### PR TITLE
Show Error if File Path does not exist

### DIFF
--- a/web/concrete/helpers/concrete/file.php
+++ b/web/concrete/helpers/concrete/file.php
@@ -84,6 +84,9 @@
 		}
 		
 		public function mapSystemPath($prefix, $filename, $createDirectories = false, $base = DIR_FILES_UPLOADED) {
+			if ($base == DIR_FILES_UPLOADED && ! is_dir($base)) {
+				trigger_error("File base path does not exist '".$base."'",E_USER_WARNING);
+			}
 			if ($prefix == null) {
 				$path = $base . '/' . $filename;
 			} else {


### PR DESCRIPTION
We had a problem where we migrated to a new server and the images were not working because a custom file location was set on the origin.
With this error it's easier to see what the reason for these disappearing images is.

However I'm not entirely sure if this is the best spot and the best way to raise this error. Any thoughts?