### PR TITLE
Enables to attach Workflows for Task/User/File permissions

### DIFF
--- a/web/concrete/tools/permissions/categories/admin.php
+++ b/web/concrete/tools/permissions/categories/admin.php
@@ -22,6 +22,15 @@ if ($p->canAccessTaskPermissions()) {
 		$pk = PermissionKey::getByID($_REQUEST['pkID']);
 		$pa = PermissionAccess::getByID($_REQUEST['paID'], $pk);
 		$pa->save($_POST);
+		$pa->clearWorkflows();
+		if (is_array($_POST['wfID'])) { 
+			foreach($_POST['wfID'] as $wfID) {
+				$wf = Workflow::getByID($wfID);
+				if (is_object($wf)) {
+					$pa->attachWorkflow($wf);
+				}
+			}
+		}
 	}
 
 	if ($_REQUEST['task'] == 'display_access_cell' && Loader::helper("validation/token")->validate('display_access_cell')) {

--- a/web/concrete/tools/permissions/categories/file.php
+++ b/web/concrete/tools/permissions/categories/file.php
@@ -35,6 +35,15 @@ if (is_object($f)) {
 			$pk->setPermissionObject($f);
 			$pa = PermissionAccess::getByID($_REQUEST['paID'], $pk);
 			$pa->save($_POST);
+			$pa->clearWorkflows();
+			if (is_array($_POST['wfID'])) { 
+				foreach($_POST['wfID'] as $wfID) {
+					$wf = Workflow::getByID($wfID);
+					if (is_object($wf)) {
+						$pa->attachWorkflow($wf);
+					}
+				}
+			}
 		}
 
 	if ($_REQUEST['task'] == 'display_access_cell' && Loader::helper("validation/token")->validate('display_access_cell')) {

--- a/web/concrete/tools/permissions/categories/user.php
+++ b/web/concrete/tools/permissions/categories/user.php
@@ -22,6 +22,15 @@ if ($p->canAccessTaskPermissions()) {
 		$pk = UserPermissionKey::getByID($_REQUEST['pkID']);
 		$pa = PermissionAccess::getByID($_REQUEST['paID'], $pk);
 		$pa->save($_POST);
+		$pa->clearWorkflows();
+		if (is_array($_POST['wfID'])) { 
+			foreach($_POST['wfID'] as $wfID) {
+				$wf = Workflow::getByID($wfID);
+				if (is_object($wf)) {
+					$pa->attachWorkflow($wf);
+				}
+			}
+		}
 	}
 
 	if ($_REQUEST['task'] == 'display_access_cell' && Loader::helper("validation/token")->validate('display_access_cell')) {


### PR DESCRIPTION
I'm working on the job that extend Workflow. It is able to attach Workflows for Page Permissions, but it is not able to attach custom Workflows for other permission categories. This request might fix this issue, but I'd like to hear the opinion from core team.