### PR TITLE
Remove redundant $db->Insert_ID call

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -515,8 +515,7 @@ class Concrete5_Model_Page extends Collection {
 		$r = $db->prepare($q);
 		
 		$res = $db->execute($r, $v);
-		$newCID = $db->Insert_ID();
-
+		
 		Loader::model('page_statistics');		
 		PageStatistics::incrementParents($newCID);
 


### PR DESCRIPTION
We use the mysqli driver for transactional support and I run into small issues with Concrete5 every now and then.  Here is the latest:

$newCID is retrieved in the original insert (line 505) and doesn't need to be overwritten.  Calling $db->Insert_ID() with the mysqli driver on that type of query (line 514) returns 0, which causes a problem with PageStatistics::incrementParents and movePageDispayOrdertoBottom().

I've submitted a couple of these changes before under NazWeb@Concrete5.org.