### PR TITLE
clear APC cache when flushing concrete5 cache

### DIFF
--- a/web/concrete/core/libraries/cache.php
+++ b/web/concrete/core/libraries/cache.php
@@ -197,6 +197,11 @@ class Concrete5_Library_Cache {
 			$cache->setOption('caching', true);
 			$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 		}
+
+		if (function_exists('apc_clear_cache')) {
+			apc_clear_cache();
+		}        
+
 		Events::fire('on_cache_flush', $cache);
 		return true;
 	}


### PR DESCRIPTION
not quite sure if this is really the way to go, but we often had caching problems not only related to concrete5 but also to APC. Especially when updating existing files we thought that there's a problem with the environment cache while in reality it was APC.