### PR TITLE
Static Block Template Issue

### DIFF
--- a/web/concrete/core/helpers/lists/states_provinces.php
+++ b/web/concrete/core/helpers/lists/states_provinces.php
@@ -95,6 +95,26 @@ class Concrete5_Helper_Lists_StatesProvinces {
 		'YT' => 'Yukon'
 	),
 
+	'NZ' => array(
+		'NORTHLAND' => 'Northland',
+		'AUCKLAND' => 'Auckland',
+		'WAIKATO' => 'Waikato',
+		'BOP' => 'Bay of Plenty',
+		'GISBORNE' => 'Gisborne',
+		'HAWKESBAY' => "Hawke's Bay",
+		'TARANAKI' => 'Taranaki',
+		'MANAWATU' => 'Manawatu-Wanganui',
+		'WELLINGTON' => 'Wellington',
+		'TASMAN' => 'Tasman',
+		'NELSON' => 'Nelson',
+		'MARLBOROUGH' => 'Marlborough',
+		'WESTCOAST' => 'West Coast',
+		'CANTERBURY' => 'Canterbury',
+		'OTAGO' => 'Otago',
+		'SOUTHLAND' => 'Southland',
+		'CHATHAM' => 'Chatham Islands'
+	),
+
 	'AU' => array(
 		'AAT' => 'Australian Antarctic Territory',
 		'ACT' => 'Australian Capital Territory',

--- a/web/concrete/core/libraries/block_view_template.php
+++ b/web/concrete/core/libraries/block_view_template.php
@@ -115,8 +115,8 @@ class Concrete5_Library_BlockViewTemplate {
 							$template = $d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename;
 							$this->baseURL = $baseStub . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle();
 							$this->basePath = $d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle();
-						} else if (is_dir($d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename)) {
-							$template = $d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename . '/' . $this->render;
+						} else if (is_dir($d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilenameWithoutDotPhp)) {
+							$template = $d . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilenameWithoutDotPhp . '/' . $this->render;
 							$this->baseURL = $baseStub . '/' . DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename;
 						}
 					}


### PR DESCRIPTION
This is perhaps a slightly esoteric one, I have a block template which is in packages/my_package/blocks/block_type/templates/my_template/view.php. Attempting to use the block in a page template statically, e.g.

```php
$search = BlockType::getByHandle('search');
$search->controller->title = 'search';
...
$search->render('templates/my_template');
```

Doesn't work because the $bFilename is being tested to see if it's a directory - which it isn't. Fix is to test $bFilenameWithoutDotPhp rather than $bFilename

See https://www.concrete5.org/developers/bugs/5-6-3-1/pacakge-block-template-not-found-when-block-rendered-statically-/