### PR TITLE
Fix log view when user id is '0' or deleted users

### DIFF
--- a/web/concrete/single_pages/dashboard/reports/logs.php
+++ b/web/concrete/single_pages/dashboard/reports/logs.php
@@ -67,12 +67,18 @@ $areEntries = count($entries) > 0 ? true : false;
                     ?></td>
                     <td valign="top"><strong><?=$ent->getType()?></strong></td>
                     <td valign="top"><strong><?php
-                    if($ent->getUserID() == NULL){
+                    $uID = $ent->getUserID();
+                    if(empty($uID)) {
                         echo t("Guest");
                     }
-                    else{
-                        $u = User::getByUserID($ent->getUserID());
-                        echo $u->getUserName();
+                    else {
+                        $u = User::getByUserID($uID);
+                        if(is_object($u)) {
+                            echo $u->getUserName();
+                        }
+                        else {
+                            echo tc('Deleted user', 'Deleted (id: %s)', $uID);
+                        }
                     }
                     ?></strong></td>
                     <td style="width: 100%"><?=$th->makenice($ent->getText())?></td>


### PR DESCRIPTION
Cherry-picked a fix from 5.7 repository.

- if a user is deleted, we call a method on a NULL: let's avoid it
- getUserID may return '0': comparing with NULL returns false
  (see http://mlocati.github.io/php-comparisions/)