### PR TITLE
block xml and php in robots.txt

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -12,3 +12,11 @@ Disallow: /page_types
 Disallow: /single_pages 
 Disallow: /tools
 Disallow: /index.php/tools
+Disallow: /blocks/*.php$
+Disallow: /blocks/*.xml$
+Disallow: /concrete/*.php$
+Disallow: /concrete/*.xml$
+Disallow: /packages/*.php$
+Disallow: /packages/*.xml$
+Disallow: /updates/*.php$
+Disallow: /updates/*.xml$


### PR DESCRIPTION
this makes sure the robots.txt of a new installation matches the one from an upgraded site https://github.com/concrete5/concrete5/pull/1886