### PR TITLE
Fix incorrect public date when composer drafts are saved

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/composer/write.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/composer/write.php
@@ -82,7 +82,9 @@ class Concrete5_Controller_Dashboard_Composer_Write extends Controller {
 					$data['cHandle'] = $handle;
 				}
 				if ($asl->allowEditDateTime()) { 
-					$data['cDatePublic'] = Loader::helper('form/date_time')->translate('cDatePublic');
+					$dt = Loader::helper('form/date_time');
+					$dh = Loader::helper('date');
+					$data['cDatePublic'] = $dh->getSystemDateTime($dt->translate('cDatePublic'));
 				}
 
 				$entry->getVersionToModify();


### PR DESCRIPTION
When composer saves a draft, it uses the "system" (server) timezone to translate the "Public Date" field. If the system timezone differs from the app or user timezone, it results in the time being saved differently than it was entered. In order to correct this, pass the resulting converted timezone through the date helper's `getSystemDateTime` function. This is how these dates are handled when saving page properties from the frontend: https://github.com/concrete5/concrete5/blob/629e95fd4ccfd63f7bd2444e8e77faa8f0b432c4/web/concrete/startup/process.php#L1036