### PR TITLE
Fix remove old page versions job

### DIFF
--- a/web/concrete/core/jobs/remove_old_page_versions.php
+++ b/web/concrete/core/jobs/remove_old_page_versions.php
@@ -40,7 +40,7 @@ class Concrete5_Job_RemoveOldPageVersions extends Job {
 			if($page instanceof Page) {
 				$pvl = new VersionList($page);
 				$pagesAffected[] = $page->getCollectionID();
-				foreach(array_slice(array_reverse($pvl->getVersionListArray()), 10) as $v) {
+				foreach(array_slice($pvl->getVersionListArray(), 10) as $v) {
 					if($v instanceof CollectionVersion && !$v->isApproved() && !$v->isMostRecent() ) {
 						@$v->delete();
 						$versionCount++;


### PR DESCRIPTION
This might be a critical issue. The remove old page versions job removes recent 10 page versions.

This is the same issue as concrete5/concrete5-5.7.0#1995 , but we have this bug in 5.6 repo since 2 years ago... :disappointed_relieved: 

392c2534e4d57076f191e381cd0da75f021e735a