### PR TITLE
Add composer type names to composer form

### DIFF
--- a/web/concrete/config/install/base/page_types.xml
+++ b/web/concrete/config/install/base/page_types.xml
@@ -6,8 +6,8 @@
         <type handle="all" name="Choose from all pages when publishing" package="" />
     </pagetypepublishtargettypes>
     <pagetypecomposercontroltypes>
-        <type handle="core_page_property" name="Built-In Properties" package="" />
-        <type handle="collection_attribute" name="Custom Attributes" package="" />
+        <type handle="core_page_property" name="Built-In Propertie" package="" />
+        <type handle="collection_attribute" name="Custom Attribute" package="" />
         <type handle="block" name="Block" package="" />
     </pagetypecomposercontroltypes>
 </concrete5-cif>

--- a/web/concrete/config/install/base/page_types.xml
+++ b/web/concrete/config/install/base/page_types.xml
@@ -6,7 +6,7 @@
         <type handle="all" name="Choose from all pages when publishing" package="" />
     </pagetypepublishtargettypes>
     <pagetypecomposercontroltypes>
-        <type handle="core_page_property" name="Built-In Propertie" package="" />
+        <type handle="core_page_property" name="Built-In Property" package="" />
         <type handle="collection_attribute" name="Custom Attribute" package="" />
         <type handle="block" name="Block" package="" />
     </pagetypecomposercontroltypes>

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -1,31 +1,44 @@
-<?
+<?php
 defined('C5_EXECUTE') or die("Access Denied.");
+/** @var $control Concrete\Core\Page\Type\Composer\FormLayoutSetControl */
 ?>
 <div class="ccm-page-type-composer-form-layout-control-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
-<div class="ccm-page-type-composer-item-control-bar">
-	<ul class="ccm-page-type-composer-item-controls">
-		<li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
-		<li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>
-		<li><a href="#" data-delete-set-control="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>"><i class="fa fa-trash-o"></i></a></li>
-	</ul>
+    <div class="ccm-page-type-composer-item-control-bar">
+        <ul class="ccm-page-type-composer-item-controls">
+            <li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
+            <li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>
+            <li><a href="#" data-delete-set-control="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>"><i class="fa fa-trash-o"></i></a></li>
+        </ul>
 
-	<div style="display: none">
-		<div data-delete-set-control-dialog="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
-			<?=t("Delete this control? This cannot be undone.")?>
-			<?=Loader::helper('validation/token')->output('delete_set_control')?>
+        <div style="display: none">
+            <div data-delete-set-control-dialog="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
+                <?=t("Delete this control? This cannot be undone.")?>
+                <?=Core::make('helper/validation/token')->output('delete_set_control')?>
 
-            <div class="dialog-buttons">
-                <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-                <button class="btn btn-danger pull-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Update Set')?></button>
+                <div class="dialog-buttons">
+                    <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+                    <button class="btn btn-danger pull-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Update Set')?></button>
+                </div>
+
             </div>
+        </div>
 
-		</div>
-	</div>
-
-<div class="ccm-page-type-composer-form-layout-control-set-control-inner">
-	<?
-	print $control->getPageTypeComposerControlDisplayLabel();
-	?>
-</div>
-</div>
+        <div class="ccm-page-type-composer-form-layout-control-set-control-inner">
+            <?php
+            $der = Concrete\Core\Page\Type\Composer\Control\Type\Type::getByID($control->getPageTypeComposerControlTypeID());
+            $pto = $control->getPageTypeComposerControlObject();
+            //var_dump($control);
+            $name = '';
+            if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
+                $name = $pto->getPageTypeComposerControlName() . ' ';
+            }
+            echo sprintf(
+                '%s - <small>%s(%s)</small>',
+                $control->getPageTypeComposerControlDisplayLabel(),
+                $name,
+                $der->getPageTypeComposerControlTypeDisplayName()
+            );
+            ?>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
This does 2 things, it adds the name of the composer control type, and the name of the composer control

it also changes the control type name to be singular (because its a type so it should be singular)

![screen shot 2015-04-23 at 12 54 08 am](https://cloud.githubusercontent.com/assets/212649/7290806/4e34cc9c-e953-11e4-810d-3b9b66e741b8.png)

for the name update we should add something to the upgrade script

(the original issue brought up by joep__ in irc, he wasn't able to tell what block types things were when they has custom names)