### PR TITLE
fix image helper resizing

### DIFF
--- a/web/concrete/core/helpers/image.php
+++ b/web/concrete/core/helpers/image.php
@@ -168,7 +168,7 @@ class Concrete5_Helper_Image {
 				} else {
 					$image->setSize($width, $height);
 					if($image->readImage($originalPath) === true) {
-						$image->thumbnailImage($width, $height, true);
+						$image->thumbnailImage($finalWidth, $finalHeight, true);
 						$imageRead = true;
 					}
 				}


### PR DESCRIPTION
I believe this along with #1895 will help address https://www.concrete5.org/developers/bugs/5-6-3-3/image-block-scale-image-setting-not-working/