### PR TITLE
'Package type' should be 'Package'

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
@@ -81,7 +81,7 @@ class Concrete5_Controller_Dashboard_Extend_Install extends Controller {
 	}
 	
 	public function package_uninstalled() {
-		$this->set('message', t('The package type has been uninstalled.'));
+		$this->set('message', t('The package has been uninstalled.'));
 	}
 
 	public function install_package($package) {


### PR DESCRIPTION
`The package type has been uninstalled`: what's a `package type`? I guess it should be just `package`