### PR TITLE
When a new user register and needs approval, email the user

### DIFF
--- a/web/concrete/controllers/single_page/register.php
+++ b/web/concrete/controllers/single_page/register.php
@@ -208,6 +208,15 @@ class Register extends PageController {
 				} else if(Config::get('concrete.user.registration.approval')) {
 					$ui = UserInfo::getByID($u->getUserID());
 					$ui->deactivate();
+					// Email to the user when he/she registered but needs approval
+					$mh = Loader::helper('mail');
+					$mh->addParameter('uEmail', $_POST['uEmail']);
+					$mh->addParameter('uHash', $uHash);
+					$mh->addParameter('site', Config::get('concrete.site'));
+					$mh->to($_POST['uEmail']);
+					$mh->load('user_notified_approval_required');
+					$mh->sendMail();
+					
 					//$this->redirect('/register', 'register_pending', $rcID);
 					$redirectMethod='register_pending';
 					$this->set('message', $this->getRegisterPendingMsg());

--- a/web/concrete/mail/user_register_approval_required_to_user.php
+++ b/web/concrete/mail/user_register_approval_required_to_user.php
@@ -1,0 +1,43 @@
+<?
+defined('C5_EXECUTE') or die("Access Denied.");
+
+$subject = $siteName.' '.t("Registration - Approval Required");
+
+/**
+ * HTML BODY START
+ */
+ob_start()
+
+?>
+<h2><?= t('Registration Approval Required') ?></h2>
+<?= t("You have registered on %s. Your account will be approved by the administrator.", $siteName) ?><br />
+<?= t('User Name') ?>: <b><?= $uName ?></b><br />
+<?= t('Email') ?>: <b><?= $uEmail ?></b><br />
+<br />
+
+<?
+
+$bodyHTML = ob_get_clean();
+/**
+ * HTML BODY END
+ *
+ * ======================
+ *
+ * PLAIN TEXT BODY START
+ */
+ob_start();
+
+?>
+<?= t('Registration Approval Required') ?>
+
+<?= t("You have registered on %s. Your account will be approved by the administrator.", $siteName) ?>
+
+<?= t('User Name') ?>: <?= $uName ?>
+<?= t('Email') ?>: <?= $uEmail ?>
+
+<?
+
+$body = ob_get_clean();
+/**
+ * PLAIN TEXT BODY END
+ */


### PR DESCRIPTION
# New Feature Request

## Current
When a new user register and needs approval, no email to the user.
He/she may consider that registration failed and try again.

## Improved
When a new user register and needs approval, email to the user that he/she has registered but needs approval by admin.
