### PR TITLE
Fix themes

### DIFF
--- a/web/concrete/src/Page/Theme/Theme.php
+++ b/web/concrete/src/Page/Theme/Theme.php
@@ -21,6 +21,7 @@ use Localization;
 /**
  * A page's theme is a pointer to a directory containing templates, CSS files and optionally PHP includes, images and JavaScript files.
  * Themes inherit down the tree when a page is added, but can also be set at the site-wide level (thereby overriding any previous choices.).
+ *
  * @package Pages and Collections
  * @subpackages Themes
  */
@@ -324,9 +325,9 @@ class Theme extends Object
      * Looks into the current CSS directory and returns a fully compiled stylesheet
      * when passed a LESS stylesheet. Also serves up custom value list values for the stylesheet if they exist.
      *
-     * @param  string $stylesheet The LESS stylesheet to compile
+     * @param string $stylesheet The LESS stylesheet to compile
      *
-     * @return string             The path to the stylesheet.
+     * @return string The path to the stylesheet.
      */
     public function getStylesheet($stylesheet)
     {
@@ -440,7 +441,7 @@ class Theme extends Object
 
     /**
      * @param string $where
-     * @param array $args
+     * @param array  $args
      *
      * @return \Concrete\Core\Page\Theme\Theme|null
      */
@@ -655,8 +656,7 @@ class Theme extends Object
             }
             try {
                 $res = static::getThemeNameAndDescription($dir, $pThemeHandle, is_object($pkg) ? $pkg->getPackageHandle() : '');
-            }
-            catch (\Exception $x) {
+            } catch (\Exception $x) {
                 if ($curLang !== 'en_US') {
                     Localization::changeLocale($curLang);
                 }
@@ -715,8 +715,8 @@ class Theme extends Object
 
     /** Returns the display name for this theme (localized and escaped accordingly to $format)
      * @param string $format = 'html'
-     *   Escape the result in html format (if $format is 'html').
-     *   If $format is 'text' or any other value, the display name won't be escaped.
+     *                       Escape the result in html format (if $format is 'html').
+     *                       If $format is 'text' or any other value, the display name won't be escaped.
      *
      * @return string
      */

--- a/web/concrete/src/Page/Theme/Theme.php
+++ b/web/concrete/src/Page/Theme/Theme.php
@@ -16,6 +16,7 @@ use Concrete\Core\Page\Theme\GridFramework\GridFramework;
 use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\StyleCustomizer\Preset;
 use Concrete\Core\StyleCustomizer\CustomCssRecord;
+use Localization;
 
 /**
  * A page's theme is a pointer to a directory containing templates, CSS files and optionally PHP includes, images and JavaScript files.
@@ -648,7 +649,22 @@ class Theme extends Object
             if ($cnt > 0) {
                 throw new \Exception(static::E_THEME_INSTALLED);
             }
-            $res = static::getThemeNameAndDescription($dir, $pThemeHandle, is_object($pkg) ? $pkg->getPackageHandle() : '');
+            $curLang = Localization::activeLocale();
+            if ($curLang !== 'en_US') {
+                Localization::changeLocale('en_US');
+            }
+            try {
+                $res = static::getThemeNameAndDescription($dir, $pThemeHandle, is_object($pkg) ? $pkg->getPackageHandle() : '');
+            }
+            catch (\Exception $x) {
+                if ($curLang !== 'en_US') {
+                    Localization::changeLocale($curLang);
+                }
+                throw $x;
+            }
+            if ($curLang !== 'en_US') {
+                Localization::changeLocale($curLang);
+            }
             if (strlen($res->pError) === 0) {
                 $pThemeName = $res->pThemeName;
                 $pThemeDescription = $res->pThemeDescription;

--- a/web/concrete/themes/elemental/description.txt
+++ b/web/concrete/themes/elemental/description.txt
@@ -1,2 +1,0 @@
-Elemental
-Elegant, spacious theme with support for blogs, portfolios, layouts and more.

--- a/web/concrete/themes/elemental/page_theme.php
+++ b/web/concrete/themes/elemental/page_theme.php
@@ -25,6 +25,16 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
 
     protected $pThemeGridFrameworkHandle = 'bootstrap3';
 
+    public function getThemeName()
+    {
+        return t('Elemental');
+    }
+
+    public function getThemeDescription()
+    {
+        return t('Elegant, spacious theme with support for blogs, portfolios, layouts and more.');
+    }
+
     public function getThemeBlockClasses()
     {
         return array(

--- a/web/concrete/themes/elemental/page_theme.php
+++ b/web/concrete/themes/elemental/page_theme.php
@@ -1,8 +1,11 @@
-<?
-namespace Concrete\Theme\Elemental;
-class PageTheme extends \Concrete\Core\Page\Theme\Theme {
+<?php
 
-	public function registerAssets() {
+namespace Concrete\Theme\Elemental;
+
+class PageTheme extends \Concrete\Core\Page\Theme\Theme
+{
+    public function registerAssets()
+    {
         //$this->providesAsset('javascript', 'bootstrap/*');
         $this->providesAsset('css', 'bootstrap/*');
         $this->providesAsset('css', 'blocks/form');
@@ -21,7 +24,7 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
         $this->requireAsset('javascript', 'picturefill');
         $this->requireAsset('javascript-conditional', 'html5-shiv');
         $this->requireAsset('javascript-conditional', 'respond');
-	}
+    }
 
     protected $pThemeGridFrameworkHandle = 'bootstrap3';
 
@@ -43,28 +46,28 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
                 'recent-blog-entry',
                 'blog-entry-list',
                 'page-list-with-buttons',
-                'block-sidebar-wrapped'
+                'block-sidebar-wrapped',
             ),
             'next_previous' => array('block-sidebar-wrapped'),
             'share_this_page' => array('block-sidebar-wrapped'),
             'content' => array(
                 'block-sidebar-wrapped',
-                'block-sidebar-padded'
+                'block-sidebar-padded',
             ),
             'date_navigation' => array('block-sidebar-padded'),
             'topic_list' => array('block-sidebar-wrapped'),
             'testimonial' => array('testimonial-bio'),
             'image' => array(
                 'image-right-tilt',
-                'image-circle'
-            )
+                'image-circle',
+            ),
         );
     }
 
     public function getThemeAreaClasses()
     {
         return array(
-            'Page Footer' => array('area-content-accent')
+            'Page Footer' => array('area-content-accent'),
         );
     }
 
@@ -82,7 +85,7 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
         return array(
             'large' => '900px',
             'medium' => '768px',
-            'small' => '0'
+            'small' => '0',
         );
     }
 
@@ -95,8 +98,7 @@ class PageTheme extends \Concrete\Core\Page\Theme\Theme {
             array('title' => t('Image Caption'), 'menuClass' => 'image-caption', 'spanClass' => 'image-caption'),
             array('title' => t('Standard Button'), 'menuClass' => '', 'spanClass' => 'btn btn-default'),
             array('title' => t('Success Button'), 'menuClass' => '', 'spanClass' => 'btn btn-success'),
-            array('title' => t('Primary Button'), 'menuClass' => '', 'spanClass' => 'btn btn-primary')
+            array('title' => t('Primary Button'), 'menuClass' => '', 'spanClass' => 'btn btn-primary'),
         );
     }
-
 }


### PR DESCRIPTION
- Elemental: move theme name and description to theme controller.
  Strings in theme controllers can be translated and developers that are inspired from Elemental will use this better approach
- When installing themes, we need to save in the DB the English name/description: they'll be translated in views