### PR TITLE
Attribute Set Handle Non-Uniquity

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1423,7 +1423,6 @@
       <unsigned/>
     </field>
     <index name="asHandle">
-        <unique/>
         <col>asHandle</col>
     </index>
     <index name="akCategoryID">

--- a/web/concrete/src/Attribute/Key/Category.php
+++ b/web/concrete/src/Attribute/Key/Category.php
@@ -255,6 +255,15 @@ class Category extends Object
         }
         return $attributeSets;
     }
+	
+	/**
+     * @param string $asHandle
+     * @return AttributeSet Returns an AttributeSet object for the current category or null if no set exists with that handle
+     */
+	public function getAttributeSetByHandle($asHandle) {
+		$attributeSet = AttributeSet::getByHandle($asHandle, $this->akCategoryID);
+		return $attributeSet;
+	}
 
     /**
      * Sets the Attribute Key Column Headers to false for all Attribute Keys in the category

--- a/web/concrete/src/Attribute/Set.php
+++ b/web/concrete/src/Attribute/Set.php
@@ -18,9 +18,16 @@ class Set extends Object {
 		}
 	}
 
-	public static function getByHandle($asHandle) {
+	public static function getByHandle($asHandle, $akCategoryID = null) {
 		$db = Loader::db();
-		$row = $db->GetRow('select asID, asHandle, pkgID, asName, akCategoryID, asIsLocked from AttributeSets where asHandle = ?', array($asHandle));
+		if($akCategoryID > 0) {
+			$row = $db->GetRow(
+				'select asID, asHandle, pkgID, asName, akCategoryID, asIsLocked from AttributeSets where asHandle = ? AND akCategoryID = ?', 
+				array($asHandle, $akCategoryID)
+			);
+		} else {
+			$row = $db->GetRow('select asID, asHandle, pkgID, asName, akCategoryID, asIsLocked from AttributeSets where asHandle = ?', array($asHandle));
+		}
 		if (isset($row['asID'])) {
 			$akc = new static();
 			$akc->setPropertiesFromArray($row);


### PR DESCRIPTION
Allows Attribute Sets to have handles that are not unique.
Adds a non-invasive way to get an Attribute Set when the ID of an
Attribute Key Category is known.

Issue #2432