### PR TITLE
Fix concrete5 legacy link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the developer repository for Concrete5.
 
 ## Version
 
-This repository contains Concrete5 version 5.7 and greater. Look for 5.6? You want [http://github.com/concrete5/concrete5-legacy](the concrete5-legacy repository).
+This repository contains Concrete5 version 5.7 and greater. Look for 5.6? You want [the concrete5-legacy repository](http://github.com/concrete5/concrete5-legacy).
 
 ## Installation
 


### PR DESCRIPTION
Congrats on pulling the bandaid off and all the new success and growth with 5.7. :beers: 
Noticed a bit of a typo in the new readme.