### PR TITLE
#2433 - added min-width: 55px; to .redactor-editor table

### DIFF
--- a/web/concrete/css/build/core/redactor/redactor.less
+++ b/web/concrete/css/build/core/redactor/redactor.less
@@ -33,6 +33,7 @@ div.ccm-panel-detail .redactor-editor, div.ui-dialog .redactor-editor {
   }
   table {
     border-collapse: collapse;
+    min-width: 55px;
     & td,
     & th {
       padding: 5px;


### PR DESCRIPTION
Make the table cells easier to select and add content to.