### PR TITLE
Fix warnings in tree nodes

### DIFF
--- a/web/concrete/src/Tree/Node/Node.php
+++ b/web/concrete/src/Tree/Node/Node.php
@@ -375,7 +375,7 @@ abstract class Node extends Object implements \Concrete\Core\Permission\ObjectIn
         return $node;
     }
 
-    public function importNode(\SimpleXMLElement $sx, $parent = false)
+    public static function importNode(\SimpleXMLElement $sx, $parent = false)
     {
         return static::add($parent);
     }

--- a/web/concrete/src/Tree/Node/Type/Category.php
+++ b/web/concrete/src/Tree/Node/Type/Category.php
@@ -79,7 +79,7 @@ abstract class Category extends TreeNode
         return $node;
     }
 
-    public function importNode(\SimpleXMLElement $sx, $parent = false)
+    public static function importNode(\SimpleXMLElement $sx, $parent = false)
     {
         return static::add((string) $sx['name'], $parent);
     }

--- a/web/concrete/src/Tree/Node/Type/Topic.php
+++ b/web/concrete/src/Tree/Node/Type/Topic.php
@@ -91,7 +91,7 @@ class Topic extends TreeNode
         return static::add((string) $sx['name'], $parent);
     }
 
-    public static function add($treeNodeTopicName, $parent = false)
+    public static function add($treeNodeTopicName = '', $parent = false)
     {
         $db = Loader::db();
         $node = parent::add($parent);

--- a/web/concrete/src/Tree/Node/Type/Topic.php
+++ b/web/concrete/src/Tree/Node/Type/Topic.php
@@ -86,7 +86,7 @@ class Topic extends TreeNode
         $this->treeNodeTopicName = $treeNodeTopicName;
     }
 
-    public function importNode(\SimpleXMLElement $sx, $parent = false)
+    public static function importNode(\SimpleXMLElement $sx, $parent = false)
     {
         return static::add((string) $sx['name'], $parent);
     }


### PR DESCRIPTION
`importNode` is called statically, it does not contain any reference to `$this` (and the method name is not the same as the class name :wink:).

I marked the first argument of `Topic::add` as optional to avoid strict warnings: see http://3v4l.org/AVeOk (like the previous code) and http://3v4l.org/Tvjqu (like the code in this PR).
The need to have static methods with compatible signatures is quite odd IMHO, BTW.