### PR TITLE
Use getAreaGridMaximumColumns to determine block container classes

### DIFF
--- a/web/concrete/elements/block_header_view.php
+++ b/web/concrete/elements/block_header_view.php
@@ -32,7 +32,7 @@ if (
     print $gf->getPageThemeGridFrameworkContainerStartHTML();
     print $gf->getPageThemeGridFrameworkRowStartHTML();
     printf('<div class="%s">', $gf->getPageThemeGridFrameworkColumnClassesForSpan(
-        $gf->getPageThemeGridFrameworkNumColumns()
+        min($a->getAreaGridMaximumColumns(), $gf->getPageThemeGridFrameworkNumColumns())
     ));
 }
 


### PR DESCRIPTION
Prevents blocks from overflowing out of an area with arGridMaximumColumns set.