### PR TITLE
Redirect "/cli" to dispatcher

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
+++ b/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
@@ -1,17 +1,18 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Seo;
 
 use Core;
-use \Concrete\Core\Page\Controller\DashboardPageController;
-use Loader;
+use Concrete\Core\Page\Controller\DashboardPageController;
 use Config;
+
 class Urls extends DashboardPageController
 {
     /**
-    * Returns the mod_rewrite rules
-    *
-    * @return string
-    */
+     * Returns the mod_rewrite rules.
+     *
+     * @return string
+     */
     public function getRewriteRules()
     {
         $strRules = '
@@ -32,10 +33,10 @@ class Urls extends DashboardPageController
     }
 
     /**
-    * Returns the .htaccess text to be copied/inserted
-    *
-    * @return string
-    */
+     * Returns the .htaccess text to be copied/inserted.
+     *
+     * @return string
+     */
     public function getHtaccessText()
     {
         $strHt = '
@@ -47,14 +48,12 @@ class Urls extends DashboardPageController
         return trim($strHt);
     }
 
-
     /**
-    * Dashboard page view
-    *
-    * @param string|bool $strStatus - Result of attempting to update rewrite rules
-    * @param boolean $blnHtu - Flag denoting if the .htaccess file was writable or not
-    * @return void
-    */
+     * Dashboard page view.
+     *
+     * @param string|bool $strStatus - Result of attempting to update rewrite rules
+     * @param bool        $blnHtu    - Flag denoting if the .htaccess file was writable or not
+     */
     public function view($strStatus = false, $blnHtu = false)
     {
         $strStatus = (string) $strStatus;
@@ -77,15 +76,11 @@ class Urls extends DashboardPageController
         }
     }
 
-
     /**
-    * Updates the .htaccess file (if writable)
-    *
-    * @return void
-    */
+     * Updates the .htaccess file (if writable).
+     */
     public function save_urls()
     {
-
         if (!$this->token->validate('save_urls')) {
             $this->error->add($this->token->getErrorMessage());
         }
@@ -95,8 +90,6 @@ class Urls extends DashboardPageController
             $blnHtu = 0;
 
             if ($this->isPost()) {
-
-
                 Config::save('concrete.seo.canonical_url', $this->post('canonical_url'));
                 Config::save('concrete.seo.canonical_ssl_url', $this->post('canonical_ssl_url'));
                 Config::save('concrete.seo.redirect_to_canonical_url', $this->post('redirect_to_canonical_url') ? 1 : 0);

--- a/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
+++ b/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
@@ -86,9 +86,6 @@ class Urls extends DashboardPageController
         }
 
         if (!$this->error->has()) {
-            $strHtText = $this->getHtaccessText();
-            $blnHtu = 0;
-
             if ($this->isPost()) {
                 Config::save('concrete.seo.canonical_url', $this->post('canonical_url'));
                 Config::save('concrete.seo.canonical_ssl_url', $this->post('canonical_ssl_url'));


### PR DESCRIPTION
Since we added cli to the webroot (and that's fine), users may have problems if they a page that should be visible as "http://www.example.com/cli".
So, we need to update the code for .htaccess.
The previous code simply compared the .htaccess data searching for the exact chunk defined by:
```
# -- concrete5 urls start --
.... 
# -- concrete5 urls end --
```
This new code takes a smarter approach: it considers the code between those two placeholders as to be automatically handled by concrete5 (this is necessary since the .htaccess code has changed and users may be come from a previous version).
