### PR TITLE
Mark Asset::process as not abstract

### DIFF
--- a/web/concrete/src/Asset/Asset.php
+++ b/web/concrete/src/Asset/Asset.php
@@ -73,8 +73,13 @@ abstract class Asset
      * @param Asset[] $assets
      *
      * @return Asset[]
+     *
+     * @abstract
      */
-    abstract public static function process($assets);
+    public static function process($assets)
+    {
+        return $assets;
+    }
 
     abstract public function __toString();
 


### PR DESCRIPTION
Abstract static methods throw an E_STRICT warning