### PR TITLE
Close logger before deleting log file

### DIFF
--- a/tests/tests/Core/Logging/LogTest.php
+++ b/tests/tests/Core/Logging/LogTest.php
@@ -68,6 +68,7 @@ class LogTest extends ConcreteDatabaseTestCase {
 
         $this->assertEquals(count($r), 1);
 
+        $sh->close();
         $contents = trim(file_get_contents(dirname(__FILE__) . '/test.log'));
         $entries = explode("\n", $contents);
 


### PR DESCRIPTION
Sometimes I get an access denied error because the log file is still open...