### PR TITLE
Strict check for false

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
@@ -143,7 +143,7 @@ class CollectionAttributeControl extends Control
             $e = \Core::make('error');
             if ($this->isFormSubmission()) {
                 $response = $ak->validateAttributeForm();
-                if ($response == false) {
+                if ($response === false) {
                     $e->add(t('The field "%s" is required', $ak->getAttributeKeyDisplayName()));
                 } else if ($response instanceof \Concrete\Core\Error\Error) {
                     $e->add($response);
@@ -154,7 +154,7 @@ class CollectionAttributeControl extends Control
                     $e->add(t('The field "%s" is required', $ak->getAttributeKeyDisplayName()));
                 } else {
                     $response = $value->validateAttributeValue();
-                    if ($response == false) {
+                    if ($response === false) {
                         $e->add(t('The field "%s" is required', $ak->getAttributeKeyDisplayName()));
                     } else if ($response instanceof \Concrete\Core\Error\Error) {
                         $e->add($response);


### PR DESCRIPTION
Fixes being unable to publish a page which has a valid file attribute that is marked as required (the validation test returns null when it passes, but null matches false in a loose comparison).

It would let you publish the page through the Composer interface, but not through the exit Edit Mode panel.