### PR TITLE
Fixes the Form Results pagination

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/reports/forms.php
+++ b/web/concrete/controllers/single_page/dashboard/reports/forms.php
@@ -172,7 +172,7 @@ class Forms extends DashboardPageController
             $answerSetCount = MiniSurvey::getAnswerCount($questionSet);
 
             //pagination 
-            $pageBaseSurvey = $pageBase . '&qsid=' . $questionSet;
+            $pageBaseSurvey = $pageBase . '?qsid=' . $questionSet;
             $paginator = Loader::helper('pagination');
             $sortBy = $_REQUEST['sortBy'];
             $paginator->init(

--- a/web/concrete/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/single_pages/dashboard/reports/forms.php
@@ -119,7 +119,7 @@ $db = Loader::db();
                             <input type="hidden" name="action" value="deleteFormAnswers"/>
                             <?php $valt->output('deleteFormAnswers') ?>
                             <div class="btn-group">
-                                <a href="<?= DIR_REL . '/index.php?cID=' . $c->getCollectionID() . '&qsid=' . $qsid ?>"
+                                <a href="<?= URL::to($c->getCollectionPath() . '?qsid=' . $qsid) ?>"
                                    class="btn btn-default btn-sm">
                                     <?= t('View Responses') ?>
                                 </a>


### PR DESCRIPTION
The Form Results pagination is broken as a side effect of the recent [BASE_URL and DIR_REL deprecation](https://github.com/concrete5/concrete5/commit/b6e5a7c3ca54bec27bb0d5e0ed731960d0e0b6a8#diff-c8650f428a9ccd91451f25949b50081fL121)

The initial query string `?cID=` was removed which invalidated the other parameters, causing it to redirect.