### PR TITLE
Normalize directory before splitting it

### DIFF
--- a/web/concrete/src/Updater/Archive.php
+++ b/web/concrete/src/Updater/Archive.php
@@ -107,6 +107,7 @@ class Archive
         }
         $dir = $this->unzip($directory);
         $dirFull = $this->getArchiveDirectory($dir);
+        $dirFull = str_replace(DIRECTORY_SEPARATOR, '/', $dirFull);
         $dirBase = substr(strrchr($dirFull, '/'), 1);
         if (file_exists($this->targetDirectory . '/' . $dirBase)) {
             throw new Exception(t('The directory %s already exists. Perhaps this item has already been installed.', $this->targetDirectory . '/' . $dirBase));


### PR DESCRIPTION
This PR *could* fix http://www.concrete5.org/developers/bugs/5-7-3-1/cant-update-or-download-add-ons/