### PR TITLE
Enables to override page cache adapters

### DIFF
--- a/web/concrete/src/Cache/Page/PageCache.php
+++ b/web/concrete/src/Cache/Page/PageCache.php
@@ -8,7 +8,6 @@ use \Page as ConcretePage;
 use \Concrete\Core\Page\View\PageView;
 use Permissions;
 use User;
-use Loader;
 use Session;
 
 abstract class PageCache {
@@ -30,7 +29,11 @@ abstract class PageCache {
 
 	public static function getLibrary() {
 		if (!PageCache::$library) {
-			$class = '\\Concrete\\Core\\Cache\\Page\\' . Loader::helper('text')->camelcase(Config::get('concrete.cache.page.adapter')) . 'PageCache';
+			$adapter = Config::get('concrete.cache.page.adapter');
+			$class = overrideable_core_class(
+				'Core\\Cache\\Page\\' . camelcase($adapter) . 'PageCache',
+				DIRNAME_CLASSES . '/Cache/Page/' . camelcase($adapter) . 'PageCache.php'
+			);
 			PageCache::$library = new $class();
 		}
 		return PageCache::$library;


### PR DESCRIPTION
Currently, page cache adapters will be loaded from concrete directory only. This change enables to add another adapters for developers.

Here is an example to use APC cache adapter.

application/config/concrete.php
```php
<?php
return array(
    'cache' => array(
        'page' => array(
            'adapter' => 'apc',
            'ttl' => 3600,
            'namespace' => 'concrete5fullpagecache'
        )
    )
);
```

application/src/Cache/Page/ApcPageCache.php
```php
<?php
namespace Application\Src\Cache\Page;

use Concrete\Core\Cache\Page\PageCache;
use Concrete\Core\Cache\Page\PageCacheRecord;
use Stash\Driver\Apc;
use Stash\Pool;
use Page as ConcretePage;
use Config;

class ApcPageCache extends PageCache
{
    static $pool;

    public function __construct()
    {
        $driver = new Apc();
        $options = array(
            'ttl'       => Config::get('concrete.cache.page.ttl'),
            'namespace' => Config::get('concrete.cache.page.namespace')
        );
        $driver->setOptions($options);

        self::$pool = new Pool($driver);
    }

    public function getRecord($mixed)
    {
        $key = $this->getCacheKey($mixed);
        if ($key) {
            $item = self::$pool->getItem($key);
            return $item->get();
        }
    }

    public function set(ConcretePage $c, $content)
    {
        $key = $this->getCacheKey($c);
        if ($key && $content) {
            $item = self::$pool->getItem($key);

            // Let other processes know that this one is rebuilding the data.
            $item->lock();

            $lifetime = $c->getCollectionFullPageCachingLifetimeValue();
            $response = new PageCacheRecord($c, $content, $lifetime);
            $item->set($response);
        }
    }

    public function purgeByRecord(\Concrete\Core\Cache\Page\PageCacheRecord $rec)
    {
        $key = $this->getCacheKey($rec);
        if ($key) {
            $item = self::$pool->getItem($key);
            $item->clear();
        }
    }

    public function purge(ConcretePage $c)
    {
        $key = $this->getCacheKey($c);
        if ($key) {
            $item = self::$pool->getItem($key);
            $item->clear();
        }
    }

    public function flush()
    {
        self::$pool->flush();
    }
}
```