### PR TITLE
Remove undefined constant DIR_FILES_CACHE

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -98,11 +98,13 @@ class Application extends Container
         Core::make('cache')->flush();
         Core::make('cache/expensive')->flush();
 
-        // flush the CSS cache
-        if (is_dir(DIR_FILES_CACHE . '/' . DIRNAME_CSS)) {
+        // Delete and re-create the cache directory
+        $cacheDir = Config::get('concrete.cache.directory');
+        if (is_dir($cacheDir)) {
             $fh = Loader::helper("file");
-            $fh->removeAll(DIR_FILES_CACHE . '/' . DIRNAME_CSS);
+            $fh->removeAll($cacheDir, true);
         }
+        $this->setupFilesystem();
 
         $pageCache = PageCache::getLibrary();
         if (is_object($pageCache)) {


### PR DESCRIPTION
`DIR_FILES_CACHE` is no more defined.
I replaced this old code with new code that completely deletes and re-create the cache directory.
In most cases this is superfluous since the cache directory should already be emptied by `Core::make('cache/expensive')->flush()`, but let's be sure to delete the cache directory anyway (since it's configurable).