### PR TITLE
check existing blocks before import

### DIFF
--- a/web/concrete/src/Backup/ContentImporter.php
+++ b/web/concrete/src/Backup/ContentImporter.php
@@ -399,11 +399,13 @@ class ContentImporter
     {
         if (isset($sx->blocktypes)) {
             foreach ($sx->blocktypes->blocktype as $bt) {
-                $pkg = static::getPackageObject($bt['package']);
-                if (is_object($pkg)) {
-                    BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg);
-                } else {
-                    BlockType::installBlockType((string) $bt['handle']);
+                if (!is_object(BlockType::getByHandle((string) $bt['handle']))) {
+                    $pkg = static::getPackageObject($bt['package']);
+                    if (is_object($pkg)) {
+                        BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg);
+                    } else {
+                        BlockType::installBlockType((string) $bt['handle']);
+                    }
                 }
             }
         }


### PR DESCRIPTION
importing fails for block types because the check for existing blocks is missing. Used to be there https://github.com/concrete5/concrete5-legacy/blob/master/web/concrete/core/libraries/content/importer.php#L307