### PR TITLE
Remove concrete.conversations.attachments_enabled

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -442,7 +442,6 @@ return array(
     'conversations'     => array(
         'attachments_pending_file_set' => 'Conversation Messages (Pending)',
         'attachments_file_set'         => 'Conversation Messages',
-        'attachments_enabled'          => true
     ),
     'icons'             => array(
         'page_template'        => array(


### PR DESCRIPTION
The used configuration key is [`conversations.attachments_enabled`](https://github.com/concrete5/concrete5/blob/cb2808c368b143585a8e91b2d9b9b68c161dd70d/web/concrete/config/conversations.php#L13) and not `concrete.conversations.attachments_enabled`