### PR TITLE
Fix config key for default email sender name

### DIFF
--- a/web/concrete/src/Mail/Service.php
+++ b/web/concrete/src/Mail/Service.php
@@ -403,7 +403,7 @@ class Service
                 }
             }
             if (!isset($from)) {
-                $from = array(Config::get('concrete.email.default.address'), Config::get('concrete.email.name'));
+                $from = array(Config::get('concrete.email.default.address'), Config::get('concrete.email.default.name'));
                 $fromStr = Config::get('concrete.email.default.address');
             }
 


### PR DESCRIPTION
The configuration key for the default sender name is `concrete.email.name` and not `concrete.email.default.name`: see the [concrete/config/concrete.php file](https://github.com/concrete5/concrete5/blob/cb2808c368b143585a8e91b2d9b9b68c161dd70d/web/concrete/config/concrete.php#L328-L330)