### PR TITLE
Use correct config value for the page size when deleting pages

### DIFF
--- a/web/concrete/tools/pages/delete.php
+++ b/web/concrete/tools/pages/delete.php
@@ -18,7 +18,7 @@ if ($_POST['task'] == 'delete_pages') {
 	if ($_POST['process']) {
 		$obj = new stdClass;
 		$js = Loader::helper('json');
-		$messages = $q->receive(Config::get('concrete.limits.sitemap_pages'));
+		$messages = $q->receive(Config::get('concrete.limits.delete_pages'));
 		foreach($messages as $key => $p) {
 			// delete the page here
 			$page = unserialize($p->body);


### PR DESCRIPTION
I may be wrong, but here we should use `'concrete.limits.delete_pages'` instead of `'concrete.limits.sitemap_pages'` (see [`concrete/config/concrete.php`](https://github.com/concrete5/concrete5/blob/cb2808c368b143585a8e91b2d9b9b68c161dd70d/web/concrete/config/concrete.php#L848))