### PR TITLE
Fix method name

### DIFF
--- a/web/concrete/src/StyleCustomizer/Style/TypeStyle.php
+++ b/web/concrete/src/StyleCustomizer/Style/TypeStyle.php
@@ -70,7 +70,7 @@ class TypeStyle extends Style {
         if ($type['underline']) {
             $tv->setTextDecoration('underline');
         } else if (isset($type['underline'])) {
-            $tv->setDecoration('none');
+            $tv->setTextDecoration('none');
         }
 
         if ($type['uppercase']) {


### PR DESCRIPTION
Throws an error when saving a type with underline option unchecked in theme customization.
`Call to undefined method Concrete\Core\StyleCustomizer\Style\Value\TypeValue::setDecoration()`