### PR TITLE
Convert all schema files to concrete5-doctrine-xml

### DIFF
--- a/web/concrete/attributes/topics/db.xml
+++ b/web/concrete/attributes/topics/db.xml
@@ -1,27 +1,32 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="atTopicSettings">
-    <field name="akID" type="I" size="10">
-      <KEY/>
-      <DEFAULT value="0"/>
-      <UNSIGNED/>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="atTopicSettings">
+    <field name="akID" type="integer" size="10">
+      <unsigned/>
+      <key/>
+      <default value="0"/>
     </field>
-    <field name="akTopicParentNodeID" type="I" size="10"/>
-    <field name="akTopicTreeID" type="I" size="10"/>
+    <field name="akTopicParentNodeID" type="integer" size="10"/>
+    <field name="akTopicTreeID" type="integer" size="10"/>
     <index name="akTopicTreeID">
-        <col>akTopicTreeID</col>
+      <col>akTopicTreeID</col>
     </index>
   </table>
+
   <table name="atSelectedTopics">
-  	<field name="avID" type="I" size="10">
-        <KEY/>
-        <UNSIGNED/>
+    <field name="avID" type="integer" size="10">
+      <unsigned/>
+      <key/>
     </field>
-  	<field name="TopicNodeID" type="I" size="10">
-        <KEY/>
+    <field name="TopicNodeID" type="integer" size="10">
+      <key/>
     </field>
-	<index name="TopicNodeID">
-		<col>TopicNodeID</col>
-	</index>
+    <index name="TopicNodeID">
+      <col>TopicNodeID</col>
+    </index>
   </table>
+
 </schema>

--- a/web/concrete/authentication/concrete/db.xml
+++ b/web/concrete/authentication/concrete/db.xml
@@ -1,20 +1,24 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="authTypeConcreteCookieMap">
-		<field name="ID" type="I">
-			<key />
-			<unsigned />
-			<autoincrement />
-		</field>
-		<field name='token' type="C" size='32' />
-		<field name="uID" type="I" size='10' />
-		<field name="validThrough" type="I" size='10' />
-		<index name="token">
-			<UNIQUE/>
-			<col>token</col>
-		</index>
-        <index name="uID">
-            <col>uID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="authTypeConcreteCookieMap">
+    <field name="ID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="token" type="string" size="32"/>
+    <field name="uID" type="integer" size="10"/>
+    <field name="validThrough" type="integer" size="10"/>
+    <index name="token">
+      <unique/>
+      <col>token</col>
+    </index>
+    <index name="uID">
+      <col>uID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/autonav/db.xml
+++ b/web/concrete/blocks/autonav/db.xml
@@ -1,45 +1,45 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btNavigation">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="orderBy" type="C" size="255">
-			<descr></descr>
-			<default value="alpha_asc" />
-		</field>
-		<field name="displayPages" type="C" size="255">
-			<descr>was enum('top','current','above','below','custom')</descr>
-			<default value="top" />
-		</field>
-		<field name="displayPagesCID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="displayPagesIncludeSelf" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="displaySubPages" type="C" size="255">
-			<descr>was enum('none','all','relevant','relevant_breadcrumb')</descr>
-			<default value="none" />
-		</field>
-		<field name="displaySubPageLevels" type="C" size="255">
-			<descr>was enum('all','none','enough','enough_plus1','custom')</descr>
-			<default value="none" />
-		</field>
-		<field name="displaySubPageLevelsNum" type="I2">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="displayUnavailablePages" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btNavigation">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="orderBy" type="string" size="255">
+      <default value="alpha_asc"/>
+    </field>
+    <field name="displayPages" type="string" size="255" comment="was enum('top','current','above','below','custom')">
+      <default value="top"/>
+    </field>
+    <field name="displayPagesCID" type="integer">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="displayPagesIncludeSelf" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="displaySubPages" type="string" size="255" comment="was enum('none','all','relevant','relevant_breadcrumb')">
+      <default value="none"/>
+    </field>
+    <field name="displaySubPageLevels" type="string" size="255" comment="was enum('all','none','enough','enough_plus1','custom')">
+      <default value="none"/>
+    </field>
+    <field name="displaySubPageLevelsNum" type="smallint">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="displayUnavailablePages" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/content/db.xml
+++ b/web/concrete/blocks/content/db.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btContentLocal">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="content" type="X2">
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btContentLocal">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="content" type="text"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_area_layout/db.xml
+++ b/web/concrete/blocks/core_area_layout/db.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreAreaLayout">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="arLayoutID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <index name="arLayoutID">
-            <col>arLayoutID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreAreaLayout">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="arLayoutID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <index name="arLayoutID">
+      <col>arLayoutID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_conversation/db.xml
+++ b/web/concrete/blocks/core_conversation/db.xml
@@ -1,58 +1,60 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreConversation">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="cnvID" type="I">
-		</field>
-		<field name="enablePosting" type="I">
-			<default value="1"/>
-		</field>
-		<field name="paginate" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="itemsPerPage" type="I2">
-			<unsigned />
-			<notnull />
-			<default value="50" />
-		</field>
-		<field name="displayMode" type="C" size="255">
-			<notnull />
-			<default value="threaded" />
-		</field>
-		<field name="orderBy" type="C" size="255">
-			<notnull />
-			<default value="date_desc" />
-		</field>
-		<field name="enableOrdering" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="enableCommentRating" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="displayPostingForm" type="C" size="255">
-			<notnull />
-			<default value="top" />
-		</field>
-		<field name="addMessageLabel" type="C" size="255">
-			<notnull />
-			<default value="" />
-		</field>
-		<field name="dateFormat" type="C" size="255">
-			<default value="default" />
-		</field>
-		<field name="customDateFormat" type="C" size="255">
-		</field>
-        <index name="cnvID">
-            <col>cnvID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreConversation">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="cnvID" type="integer"/>
+    <field name="enablePosting" type="integer">
+      <default value="1"/>
+    </field>
+    <field name="paginate" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="itemsPerPage" type="smallint">
+      <unsigned/>
+      <default value="50"/>
+      <notnull/>
+    </field>
+    <field name="displayMode" type="string" size="255">
+      <default value="threaded"/>
+      <notnull/>
+    </field>
+    <field name="orderBy" type="string" size="255">
+      <default value="date_desc"/>
+      <notnull/>
+    </field>
+    <field name="enableOrdering" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="enableCommentRating" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="displayPostingForm" type="string" size="255">
+      <default value="top"/>
+      <notnull/>
+    </field>
+    <field name="addMessageLabel" type="string" size="255">
+      <default value=""/>
+      <notnull/>
+    </field>
+    <field name="dateFormat" type="string" size="255">
+      <default value="default"/>
+    </field>
+    <field name="customDateFormat" type="string" size="255"/>
+    <index name="cnvID">
+      <col>cnvID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_conversation_message/db.xml
+++ b/web/concrete/blocks/core_conversation_message/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreConversationMessage">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="cnvMessageID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <index name="cnvMessageID">
-            <col>cnvMessageID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreConversationMessage">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="cnvMessageID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <index name="cnvMessageID">
+      <col>cnvMessageID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_gathering/db.xml
+++ b/web/concrete/blocks/core_gathering/db.xml
@@ -1,23 +1,26 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreGathering">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="gaID" type="I">
-		</field>
-		<field name="itemsPerPage" type="I2">
-			<unsigned />
-			<notnull />
-			<default value="50" />
-		</field>
-		<field name="ptID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="enablePostingFromGathering" type="I">
-			<default value="0"/>
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreGathering">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="gaID" type="integer"/>
+    <field name="itemsPerPage" type="smallint">
+      <unsigned/>
+      <default value="50"/>
+      <notnull/>
+    </field>
+    <field name="ptID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="enablePostingFromGathering" type="integer">
+      <default value="0"/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_gathering_display/db.xml
+++ b/web/concrete/blocks/core_gathering_display/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreGatheringDisplay">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="gaID" type="I">
-			<unsigned />
-			<notnull />
-		</field>
-        <index name="gaID">
-            <col>gaID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreGatheringDisplay">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <notnull/>
+    </field>
+    <field name="gaID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <index name="gaID">
+      <col>gaID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_page_type_composer_control_output/db.xml
+++ b/web/concrete/blocks/core_page_type_composer_control_output/db.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCorePageTypeComposerControlOutput">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="ptComposerOutputControlID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <index name="ptComposerOutputControlID">
-            <col>ptComposerOutputControlID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCorePageTypeComposerControlOutput">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <notnull/>
+    </field>
+    <field name="ptComposerOutputControlID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <index name="ptComposerOutputControlID">
+      <col>ptComposerOutputControlID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_scrapbook_display/db.xml
+++ b/web/concrete/blocks/core_scrapbook_display/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreScrapbookDisplay">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="bOriginalID" type="I">
-			<unsigned />
-			<notnull />
-		</field>
-		<index name="bOriginalID">
-		  <col>bOriginalID</col>
-		</index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreScrapbookDisplay">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <notnull/>
+    </field>
+    <field name="bOriginalID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <index name="bOriginalID">
+      <col>bOriginalID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/core_stack_display/db.xml
+++ b/web/concrete/blocks/core_stack_display/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btCoreStackDisplay">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="stID" type="I">
-			<unsigned />
-			<notnull />
-		</field>
-        <index name="stID">
-            <col>stID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btCoreStackDisplay">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <notnull/>
+    </field>
+    <field name="stID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <index name="stID">
+      <col>stID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/dashboard_newsflow_latest/db.xml
+++ b/web/concrete/blocks/dashboard_newsflow_latest/db.xml
@@ -1,13 +1,17 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btDashboardNewsflowLatest">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="slot" type="C" size="1">
-			<notnull />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btDashboardNewsflowLatest">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+      <notnull/>
+    </field>
+    <field name="slot" type="string" size="1">
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/date_navigation/db.xml
+++ b/web/concrete/blocks/date_navigation/db.xml
@@ -1,33 +1,35 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btDateNavigation">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-        <field name="title" type="C" size="255">
-            <notnull />
-            <default value="" />
-        </field>
-        <field name="filterByParent" type="I1">
-            <default value="0" />
-        </field>
-        <field name="redirectToResults" type="I1">
-            <default value="0" />
-        </field>
-        <field name="cParentID" type="I">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <!-- this field is where the links will direct you //-->
-        <field name="cTargetID" type="I">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="ptID" type="I2">
-            <unsigned />
-        </field>
-	</table>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btDateNavigation">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255">
+      <default value=""/>
+      <notnull/>
+    </field>
+    <field name="filterByParent" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="redirectToResults" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="cParentID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="cTargetID" type="integer" comment="this field is where the links will direct you">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="ptID" type="smallint">
+      <unsigned/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/discussion/db.xml
+++ b/web/concrete/blocks/discussion/db.xml
@@ -1,38 +1,41 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btDiscussion">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="cnvDiscussionID" type="I">
-		</field>
-		<field name="ptID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="enableNewTopics" type="I">
-			<default value="1"/>
-		</field>
-		<field name="itemsPerPage" type="I2">
-			<unsigned />
-			<notnull />
-			<default value="50" />
-		</field>
-		<field name="orderBy" type="C" size="255">
-			<notnull />
-			<default value="date_desc" />
-		</field>
-		<field name="enableOrdering" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-        <index name="cnvDiscussionID">
-            <col>cnvDiscussionID</col>
-        </index>
-        <index name="ptID">
-            <col>ptID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btDiscussion">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="cnvDiscussionID" type="integer"/>
+    <field name="ptID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="enableNewTopics" type="integer">
+      <default value="1"/>
+    </field>
+    <field name="itemsPerPage" type="smallint">
+      <unsigned/>
+      <default value="50"/>
+      <notnull/>
+    </field>
+    <field name="orderBy" type="string" size="255">
+      <default value="date_desc"/>
+      <notnull/>
+    </field>
+    <field name="enableOrdering" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <index name="cnvDiscussionID">
+      <col>cnvDiscussionID</col>
+    </index>
+    <index name="ptID">
+      <col>ptID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/external_form/db.xml
+++ b/web/concrete/blocks/external_form/db.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btExternalForm">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="filename" type="C" size="128">
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btExternalForm">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="filename" type="string" size="128"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/faq/db.xml
+++ b/web/concrete/blocks/faq/db.xml
@@ -1,28 +1,33 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-    <table name="btFaq">
-        <field name="bID" type="I">
-            <KEY/>
-            <UNSIGNED/>
-        </field>
-        <field name="blockTitle" type="C" size="255"></field>
-    </table>
-    <table name="btFaqEntries">
-        <field name="id" type="I">
-            <UNSIGNED/>
-            <key/>
-            <AUTOINCREMENT/>
-        </field>
-        <field name="bID" type="I">
-            <UNSIGNED/>
-        </field>
-        <field name="linkTitle" type="C" size="255"/>
-        <field name="title" type="C" size="255"/>
-        <field name="sortOrder" type="I"/>
-        <field name="description" type="X2"/>
-        <index name="bID">
-            <col>bID</col>
-            <col>sortOrder</col>
-        </index>
-    </table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btFaq">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="blockTitle" type="string" size="255"/>
+  </table>
+
+  <table name="btFaqEntries">
+    <field name="id" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="bID" type="integer">
+      <unsigned/>
+    </field>
+    <field name="linkTitle" type="string" size="255"/>
+    <field name="title" type="string" size="255"/>
+    <field name="sortOrder" type="integer"/>
+    <field name="description" type="text"/>
+    <index name="bID">
+      <col>bID</col>
+      <col>sortOrder</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/feature/db.xml
+++ b/web/concrete/blocks/feature/db.xml
@@ -1,18 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btFeature">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="icon" type="C" size="255">
-		</field>
-		<field name="title" type="C" size="255"></field>
-        <field name="paragraph" type="X"></field>
-		<field name="externalLink"  type="C" size="255"/>
-		<field name="internalLinkCID"  type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btFeature">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="icon" type="string" size="255"/>
+    <field name="title" type="string" size="255"/>
+    <field name="paragraph" type="text" size="65535"/>
+    <field name="externalLink" type="string" size="255"/>
+    <field name="internalLinkCID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/file/db.xml
+++ b/web/concrete/blocks/file/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btContentFile">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="fID" type="I">
-			<unsigned />
-		</field>
-		<field name="fileLinkText" type="C" size="255"/>
-		<field name="filePassword" type="C" size="255"/>
-        <index name="fID">
-            <col>fID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btContentFile">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="fID" type="integer">
+      <unsigned/>
+    </field>
+    <field name="fileLinkText" type="string" size="255"/>
+    <field name="filePassword" type="string" size="255"/>
+    <index name="fID">
+      <col>fID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/form/db.xml
+++ b/web/concrete/blocks/form/db.xml
@@ -1,143 +1,140 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	
-	<table name="btForm">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="questionSetId" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="surveyName" type="C" size="255">
-		</field>
-        <field name="submitText" type="C" size="255" >
-            <default value="Submit" />
-        </field>
-		<field name="thankyouMsg" type="X" >
-		</field> 
-		<index name="questionSetIdForeign">
-			<col>questionSetId</col>
-		</index>
-		<field name="notifyMeOnSubmission" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="recipientEmail" type="C" size="255">
-		</field>		
-		<field name="displayCaptcha" type="I">
-			<default value="1"/>
-		</field>
-		<field name="redirectCID" type="I">
-			<default value="0"/>
-		</field>      		
-		<field name="addFilesToSet" type="I">
-			<default value="0" />
-		</field>
-	</table>
-	
-	<table name="btFormQuestions"> 
-		<field name="qID" type="I">
-			<key />
-			<autoincrement />			
-			<unsigned />
-		</field>
-		<field name="msqID" type="I">
-			<unsigned />
-			<default value="0" /> 
-		</field>
-		<field name="bID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>		
-		<field name="questionSetId" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="question" type="C" size="255">
-		</field>
-		<field name="inputType" type="C" size="255">
-		</field>
-		<field name="options" type="X">
-		</field>
-		<field name="position" type="I">
-			<unsigned />
-			<default value="1000" />
-		</field>
-		<field name="width" type="I">
-			<unsigned />
-			<default value="50" />
-		</field>
-		<field name="height" type="I">
-			<unsigned />
-			<default value="3" />
-		</field>
-        <field name="defaultDate" type="C" size="255">
-            <default value="" />
-        </field>
-        <field name="required" type="I">
-			<default value="0"/>
-		</field>  
-		<index name="questionSetId">
-		  <col>questionSetId</col>
-		</index>
-		<index name="msqID">
-		  <col>msqID</col> 
-		</index>
-        <index name="bID">
-            <col>bID</col>
-            <col>questionSetId</col>
-        </index>
-	</table>
-	
-	<table name="btFormAnswerSet">
-		<field name="asID" type="I">
-			<key />
-			<autoincrement />
-			<unsigned />
-		</field>
-		<field name="questionSetId" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="created" type="T">
-			<deftimestamp />
-		</field>
-		<field name="uID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<index name="questionSetId">
-			<col>questionSetId</col>
-		</index>
-        <index name="uID">
-            <col>uID</col>
-        </index>
-	</table>
-	
-	<table name="btFormAnswers">
-		<field name="aID" type="I">
-			<key />
-			<autoincrement />
-			<unsigned />
-		</field>
-		<field name="asID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="msqID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="answer" type="C" size="255"/>
-		<field name="answerLong" type="X"/>
-        <index name="asID">
-            <col>asID</col>
-        </index>
-        <index name="msqID">
-            <col>msqID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btForm">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="questionSetId" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="surveyName" type="string" size="255"/>
+    <field name="submitText" type="string" size="255">
+      <default value="Submit"/>
+    </field>
+    <field name="thankyouMsg" type="text" size="65535"/>
+    <field name="notifyMeOnSubmission" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="recipientEmail" type="string" size="255"/>
+    <field name="displayCaptcha" type="integer">
+      <default value="1"/>
+    </field>
+    <field name="redirectCID" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="addFilesToSet" type="integer">
+      <default value="0"/>
+    </field>
+    <index name="questionSetIdForeign">
+      <col>questionSetId</col>
+    </index>
+  </table>
+
+  <table name="btFormQuestions">
+    <field name="qID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="msqID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="bID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="questionSetId" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="question" type="string" size="255"/>
+    <field name="inputType" type="string" size="255"/>
+    <field name="options" type="text" size="65535"/>
+    <field name="position" type="integer">
+      <unsigned/>
+      <default value="1000"/>
+    </field>
+    <field name="width" type="integer">
+      <unsigned/>
+      <default value="50"/>
+    </field>
+    <field name="height" type="integer">
+      <unsigned/>
+      <default value="3"/>
+    </field>
+    <field name="defaultDate" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="required" type="integer">
+      <default value="0"/>
+    </field>
+    <index name="questionSetId">
+      <col>questionSetId</col>
+    </index>
+    <index name="msqID">
+      <col>msqID</col>
+    </index>
+    <index name="bID">
+      <col>bID</col>
+      <col>questionSetId</col>
+    </index>
+  </table>
+
+  <table name="btFormAnswerSet">
+    <field name="asID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="questionSetId" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="created" type="timestamp">
+      <deftimestamp/>
+    </field>
+    <field name="uID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <index name="questionSetId">
+      <col>questionSetId</col>
+    </index>
+    <index name="uID">
+      <col>uID</col>
+    </index>
+  </table>
+
+  <table name="btFormAnswers">
+    <field name="aID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="asID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="msqID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="answer" type="string" size="255"/>
+    <field name="answerLong" type="text" size="65535"/>
+    <index name="asID">
+      <col>asID</col>
+    </index>
+    <index name="msqID">
+      <col>msqID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/google_map/db.xml
+++ b/web/concrete/blocks/google_map/db.xml
@@ -1,25 +1,29 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btGoogleMap">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="title" type="C" size="255"></field>		
-		<field name="location" type="C" size="255"></field>	
-		<field name="latitude" type="F"></field>
-		<field name="longitude" type="F"></field>	
-		<field name="zoom" type="I" size="3"></field>
-        <field name="width" type="C" size="8">
-            <default value="100%"/>
-        </field>	
-        <field name="height" type="C" size="8">
-            <default value="400px"/>
-        </field>
-            <field name="scrollwheel" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="1" />
-        </field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btGoogleMap">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255"/>
+    <field name="location" type="string" size="255"/>
+    <field name="latitude" type="float"/>
+    <field name="longitude" type="float"/>
+    <field name="zoom" type="smallint"/>
+    <field name="width" type="string" size="8">
+      <default value="100%"/>
+    </field>
+    <field name="height" type="string" size="8">
+      <default value="400px"/>
+    </field>
+    <field name="scrollwheel" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/html/db.xml
+++ b/web/concrete/blocks/html/db.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btContentLocal">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="content" type="X2">
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btContentLocal">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="content" type="text"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/image/db.xml
+++ b/web/concrete/blocks/image/db.xml
@@ -1,35 +1,39 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btContentImage">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="fID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="fOnstateID" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="maxWidth" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="maxHeight" type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="externalLink"  type="C" size="255"/>
-		<field name="internalLinkCID"  type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-		<field name="altText" type="C" size="255"/>
-        <field name="title" type="C" size="255"/>
-        <index name="fID">
-            <col>fID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btContentImage">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="fID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="fOnstateID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="maxWidth" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="maxHeight" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="externalLink" type="string" size="255"/>
+    <field name="internalLinkCID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="altText" type="string" size="255"/>
+    <field name="title" type="string" size="255"/>
+    <index name="fID">
+      <col>fID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/image_slider/db.xml
+++ b/web/concrete/blocks/image_slider/db.xml
@@ -1,21 +1,44 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-    <table name="btImageSlider">
-        <field name="bID" type="I"><KEY/><UNSIGNED/></field>
-        <field name="navigationType" type="I"><UNSIGNED /><default value="0" /></field>
-    </table>
-    <table name="btImageSliderEntries">
-        <field name="id" type="I"><UNSIGNED/><key/><AUTOINCREMENT/></field>
-        <field name="bID" type="I"><UNSIGNED /></field>
-        <field name="cID" type="I"><UNSIGNED /><default value="0" /></field>
-        <field name="fID" type="I"><UNSIGNED /><default value="0" /></field>
-		<field name="linkURL"  type="C" size="255"/>
-		<field name="internalLinkCID"  type="I">
-			<unsigned />
-			<default value="0" />
-		</field>
-        <field name="title" type="X2"></field>
-        <field name="description" type="X2"></field>
-        <field name="sortOrder" type="I"></field>
-    </table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btImageSlider">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="navigationType" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+  </table>
+
+  <table name="btImageSliderEntries">
+    <field name="id" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="bID" type="integer">
+      <unsigned/>
+    </field>
+    <field name="cID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="fID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="linkURL" type="string" size="255"/>
+    <field name="internalLinkCID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="title" type="text"/>
+    <field name="description" type="text"/>
+    <field name="sortOrder" type="integer"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/next_previous/db.xml
+++ b/web/concrete/blocks/next_previous/db.xml
@@ -1,22 +1,25 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btNextPrevious">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
 
-		<field name="nextLabel"  type="C" size="128"></field>
-		
-		<field name="previousLabel"  type="C" size="128"></field>
-		
-		<field name="parentLabel" type="C" size="128"></field>
+  <table name="btNextPrevious">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="nextLabel" type="string" size="128"/>
+    <field name="previousLabel" type="string" size="128"/>
+    <field name="parentLabel" type="string" size="128"/>
+    <field name="loopSequence" type="integer">
+      <default value="1"/>
+    </field>
+    <field name="excludeSystemPages" type="integer">
+      <default value="1"/>
+    </field>
+    <field name="orderBy" type="string" size="20">
+      <default value="display_asc"/>
+    </field>
+  </table>
 
-		<field name="loopSequence" type="I"><default value="1"/></field>
-
-		<field name="excludeSystemPages" type="I"><default value="1"/></field>
-		
-		<field name="orderBy" type="C" size="20"><default value="display_asc"/></field>
-		
-	</table>
 </schema>

--- a/web/concrete/blocks/page_attribute_display/db.xml
+++ b/web/concrete/blocks/page_attribute_display/db.xml
@@ -1,24 +1,25 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btPageAttributeDisplay">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="attributeHandle" type="C" size="255">
-		</field>
-		<field name="attributeTitleText" type="C" size="255">
-		</field>
-		<field name="displayTag" type="C" size="255">
-		</field>
-		<field name="dateFormat" type="C" size="100">
-            <default value="div" />
-		</field>
-		<field name="thumbnailHeight" type="I">
-			<unsigned />
-		</field>
-		<field name="thumbnailWidth" type="I">
-			<unsigned />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btPageAttributeDisplay">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="attributeHandle" type="string" size="255"/>
+    <field name="attributeTitleText" type="string" size="255"/>
+    <field name="displayTag" type="string" size="255"/>
+    <field name="dateFormat" type="string" size="100">
+      <default value="div"/>
+    </field>
+    <field name="thumbnailHeight" type="integer">
+      <unsigned/>
+    </field>
+    <field name="thumbnailWidth" type="integer">
+      <unsigned/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/page_list/db.xml
+++ b/web/concrete/blocks/page_list/db.xml
@@ -1,112 +1,109 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btPageList">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="num" type="I2">
-			<unsigned />
-			<notnull />
-		</field>
-		<field name="orderBy" type="C" size="32">
-			<descr>Was enum, display_asc','display_desc','chrono_asc','chrono_desc','alpha_asc','alpha_desc','score_asc','score_desc'</descr>
-		</field>
-		<field name="cParentID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="cThis" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <field name="useButtonForLink" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="buttonLinkText" type="C" size="255">
-        </field>
-        <field name="pageListTitle" type="C" size="255">
-        </field>
-		<field name="filterByRelated" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="filterByCustomTopic" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <field name="relatedTopicAttributeKeyHandle" type="C" size="255">
-        </field>
-		<field name="customTopicAttributeKeyHandle" type="C" size="255">
-		</field>
-		<field name="customTopicTreeNodeID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-        <field name="includeName" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="1" />
-        </field>
-        <field name="includeDescription" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="1" />
-        </field>
-        <field name="includeDate" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="includeAllDescendents" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="paginate" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-		<field name="displayAliases" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-        <field name="enableExternalFiltering" type="I1">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-		<field name="ptID" type="I2">
-			<unsigned />
-		</field>
-		<field name="pfID" type="I">
-			<default value="0"/>
-		</field>
-		<field name="truncateSummaries" type="I">
-			<default value="0"/>
-		</field>
-		<field name="displayFeaturedOnly" type="I1">
-			<default value="0"/>
-		</field>
-        <field name="noResultsMessage" type="C" size="255">
-        </field>
-        <field name="displayThumbnail" type="I1">
-            <default value="0"/>
-        </field>
-		<field name="truncateChars" type="I">
-			<default value="128"/>
-		</field>
-        <index name="ptID">
-            <col>ptID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btPageList">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="num" type="smallint">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <field name="orderBy" type="string" size="32" comment="Was enum, display_asc','display_desc','chrono_asc','chrono_desc','alpha_asc','alpha_desc','score_asc','score_desc'"/>
+    <field name="cParentID" type="integer">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="cThis" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="useButtonForLink" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="buttonLinkText" type="string" size="255"/>
+    <field name="pageListTitle" type="string" size="255"/>
+    <field name="filterByRelated" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="filterByCustomTopic" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="relatedTopicAttributeKeyHandle" type="string" size="255"/>
+    <field name="customTopicAttributeKeyHandle" type="string" size="255"/>
+    <field name="customTopicTreeNodeID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="includeName" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="includeDescription" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="includeDate" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="includeAllDescendents" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="paginate" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="displayAliases" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="enableExternalFiltering" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="ptID" type="smallint">
+      <unsigned/>
+    </field>
+    <field name="pfID" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="truncateSummaries" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="displayFeaturedOnly" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="noResultsMessage" type="string" size="255"/>
+    <field name="displayThumbnail" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="truncateChars" type="integer">
+      <default value="128"/>
+    </field>
+    <index name="ptID">
+      <col>ptID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/page_title/db.xml
+++ b/web/concrete/blocks/page_title/db.xml
@@ -1,15 +1,19 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btPageTitle">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="useCustomTitle" type="I">
-			<unsigned />
-			<default value="0"/>
-		</field>
-		<field name="titleText" type="C" size="255"></field>
-		<field name="formatting" type="C" size="3"></field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btPageTitle">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="useCustomTitle" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="titleText" type="string" size="255"/>
+    <field name="formatting" type="string" size="3"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/rss_displayer/db.xml
+++ b/web/concrete/blocks/rss_displayer/db.xml
@@ -1,29 +1,30 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btRssDisplay">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="title" type="C" size="255">
-		</field> 			
-		<field name="url" type="C" size="255">
-		</field> 		
-		<field name="dateFormat" type="C" size="100">
-		</field> 		
-		<field name="itemsToDisplay" type="I">
-			<unsigned />
-			<default value="5" />
-		</field>
-		<field name="showSummary" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>
-		<field name="launchInNewWindow" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="1" />
-		</field>		
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btRssDisplay">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255"/>
+    <field name="url" type="string" size="255"/>
+    <field name="dateFormat" type="string" size="100"/>
+    <field name="itemsToDisplay" type="integer">
+      <unsigned/>
+      <default value="5"/>
+    </field>
+    <field name="showSummary" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+    <field name="launchInNewWindow" type="boolean">
+      <unsigned/>
+      <default value="1"/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/search/db.xml
+++ b/web/concrete/blocks/search/db.xml
@@ -1,19 +1,18 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btSearch">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="title" type="C" size="255">
-		</field>
-		<field name="buttonText" type="C" size="128">
-		</field>
-		<field name="baseSearchPath" type="C" size="255">
-		</field>
-		<field name="postTo_cID" type="C" size="255">
-		</field>
-		<field name="resultsURL" type="C" size="255">
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btSearch">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255"/>
+    <field name="buttonText" type="string" size="128"/>
+    <field name="baseSearchPath" type="string" size="255"/>
+    <field name="postTo_cID" type="string" size="255"/>
+    <field name="resultsURL" type="string" size="255"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/share_this_page/db.xml
+++ b/web/concrete/blocks/share_this_page/db.xml
@@ -1,20 +1,23 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btShareThisPage">
-		<field name="btShareThisPageID" type="I">
-			<key />
-			<unsigned />
-            <autoincrement />
-		</field>
-		<field name="bID" type="I">
-			<unsigned />
-			<default value="0"/>
-		</field>
-        <field name="service" type="C">
-        </field>
-        <field name="displayOrder" type="I">
-            <unsigned />
-            <default value="0"/>
-        </field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btShareThisPage">
+    <field name="btShareThisPageID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="bID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="service" type="string" size="255"/>
+    <field name="displayOrder" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/social_links/db.xml
+++ b/web/concrete/blocks/social_links/db.xml
@@ -1,29 +1,33 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btSocialLinks">
-		<field name="btSocialLinkID" type="I">
-			<key />
-			<unsigned />
-            <autoincrement />
-		</field>
-		<field name="bID" type="I">
-			<unsigned />
-			<default value="0"/>
-		</field>
-        <field name="slID" type="I">
-            <unsigned />
-            <default value="0"/>
-        </field>
-        <field name="displayOrder" type="I">
-            <unsigned />
-            <default value="0"/>
-        </field>
-        <index name="bID">
-            <col>bID</col>
-            <col>displayOrder</col>
-        </index>
-        <index name="slID">
-            <col>slID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btSocialLinks">
+    <field name="btSocialLinkID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="bID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="slID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="displayOrder" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <index name="bID">
+      <col>bID</col>
+      <col>displayOrder</col>
+    </index>
+    <index name="slID">
+      <col>slID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/survey/db.xml
+++ b/web/concrete/blocks/survey/db.xml
@@ -1,71 +1,74 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btSurvey">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="question" type="C" size="255">
-			<default value=""/>
-		</field>
-		<field name="requiresRegistration" type="I">
-			<default value="0"/>
-		</field>
-	</table>
-	<table name="btSurveyOptions">
-		<field name="optionID" type="I">
-			<key/>
-			<unsigned/>
-			<autoincrement/>
-		</field>
-		<field name="bID" type="I" />	
-		<field name="optionName" type="C" size="255" />
-		<field name="displayOrder" type="I">
-			<default value="0"/>
-		</field>
-        <index name="bID">
-            <col>bID</col>
-            <col>displayOrder</col>
-        </index>
-	</table>
-	<table name="btSurveyResults">
-		<field name="resultID" type="I">
-			<key/>
-			<unsigned/>
-			<autoincrement/>
-		</field>
-		<field name="optionID" type="I">
-			<unsigned/>
-			<default value="0"/>
-		</field>
-		<field name="uID" type="I">
-			<unsigned/>
-			<default value="0"/>
-		</field>
-		<field name="bID" type="I" />	
-		<field name="cID" type="I" />	
-		<field name="ipAddress" type="C" size="128" />
-		<field name="timestamp" type="T">
-			<deftimestamp/>
-		</field>
-        <index name="optionID">
-            <col>optionID</col>
-        </index>
-        <index name="cID">
-            <col>cID</col>
-            <col>optionID</col>
-            <col>bID</col>
-        </index>
-        <index name="bID">
-            <col>bID</col>
-            <col>cID</col>
-            <col>uID</col>
-        </index>
-        <index name="uID">
-            <col>uID</col>
-        </index>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btSurvey">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="question" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="requiresRegistration" type="integer">
+      <default value="0"/>
+    </field>
+  </table>
+
+  <table name="btSurveyOptions">
+    <field name="optionID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="bID" type="integer"/>
+    <field name="optionName" type="string" size="255"/>
+    <field name="displayOrder" type="integer">
+      <default value="0"/>
+    </field>
+    <index name="bID">
+      <col>bID</col>
+      <col>displayOrder</col>
+    </index>
+  </table>
+
+  <table name="btSurveyResults">
+    <field name="resultID" type="integer">
+      <unsigned/>
+      <autoincrement/>
+      <key/>
+    </field>
+    <field name="optionID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="uID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="bID" type="integer"/>
+    <field name="cID" type="integer"/>
+    <field name="ipAddress" type="string" size="128"/>
+    <field name="timestamp" type="timestamp">
+      <deftimestamp/>
+    </field>
+    <index name="optionID">
+      <col>optionID</col>
+    </index>
+    <index name="cID">
+      <col>cID</col>
+      <col>optionID</col>
+      <col>bID</col>
+    </index>
+    <index name="bID">
+      <col>bID</col>
+      <col>cID</col>
+      <col>uID</col>
+    </index>
+    <index name="uID">
+      <col>uID</col>
+    </index>
+  </table>
+
 </schema>
-
-
-

--- a/web/concrete/blocks/switch_language/db.xml
+++ b/web/concrete/blocks/switch_language/db.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-<table name="btSwitchLanguage">
-    <field name="bID" type="I">
-      <KEY/>
-      <UNSIGNED/>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btSwitchLanguage">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
     </field>
-    <field name="label" type="C" size="255">
-      <DEFAULT value=""/>
+    <field name="label" type="string" size="255">
+      <default value=""/>
     </field>
   </table>
+
 </schema>

--- a/web/concrete/blocks/tags/db.xml
+++ b/web/concrete/blocks/tags/db.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btTags">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="title" type="C" size="255"></field>
-		<field name="targetCID" type="I"></field>
-		<field name="displayMode" type="C" size="20">
-			<default value="page"/>
-		</field>
-		<field name="cloudCount" type="I">
-			<default value="10"/>
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btTags">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255"/>
+    <field name="targetCID" type="integer"/>
+    <field name="displayMode" type="string" size="20">
+      <default value="page"/>
+    </field>
+    <field name="cloudCount" type="integer">
+      <default value="10"/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/testimonial/db.xml
+++ b/web/concrete/blocks/testimonial/db.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btTestimonial">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-        <field name="fID" type="I">
-            <unsigned />
-            <default value="0" />
-        </field>
-		<field name="name" type="C" size="255"></field>
-        <field name="position" type="C" size="255"></field>
-        <field name="company" type="C" size="255"></field>
-        <field name="companyURL" type="C" size="255"></field>
-        <field name="paragraph" type="X"></field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btTestimonial">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="fID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="name" type="string" size="255"/>
+    <field name="position" type="string" size="255"/>
+    <field name="company" type="string" size="255"/>
+    <field name="companyURL" type="string" size="255"/>
+    <field name="paragraph" type="text" size="65535"/>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/topic_list/db.xml
+++ b/web/concrete/blocks/topic_list/db.xml
@@ -8,7 +8,7 @@
       <unsigned/>
       <key/>
     </field>
-    <field name="mode" type="string" size="1">
+    <field name="mode" type="string" size="1" comment="S = Search, P = Page">
       <default value="S"/>
       <notnull/>
     </field>

--- a/web/concrete/blocks/topic_list/db.xml
+++ b/web/concrete/blocks/topic_list/db.xml
@@ -1,32 +1,35 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btTopicList">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-        <field name="mode" type="C" size="1">
-            <notnull />
-            <default value="S" />
-            <!-- S = Search, P = Page //-->
-        </field>
-        <field name="topicAttributeKeyHandle" type="C" size="255">
-            <notnull />
-            <default value="" />
-        </field>
-		<field name="topicTreeID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-		</field>
-        <field name="cParentID" type="I">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="title" type="C" size="255">
-            <notnull />
-            <default value="" />
-        </field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btTopicList">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="mode" type="string" size="1">
+      <default value="S"/>
+      <notnull/>
+    </field>
+    <field name="topicAttributeKeyHandle" type="string" size="255">
+      <default value=""/>
+      <notnull/>
+    </field>
+    <field name="topicTreeID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="cParentID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="title" type="string" size="255">
+      <default value=""/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/video/db.xml
+++ b/web/concrete/blocks/video/db.xml
@@ -1,31 +1,35 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btVideo">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-        <field name="webmfID" type="I">
-            <unsigned />
-            <default value="0" />
-        </field>
-        <field name="oggfID" type="I">
-            <unsigned />
-            <default value="0" />
-        </field>
-        <field name="posterfID" type="I">
-            <unsigned />
-            <default value="0" />
-        </field>
-        <field name="mp4fID" type="I">
-            <unsigned />
-            <default value="0" />
-        </field>
-		<field name="width" type="I">
-			<unsigned />
-		</field>
-		<field name="height" type="I">
-			<unsigned />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btVideo">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="webmfID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="oggfID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="posterfID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="mp4fID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+    </field>
+    <field name="width" type="integer">
+      <unsigned/>
+    </field>
+    <field name="height" type="integer">
+      <unsigned/>
+    </field>
+  </table>
+
 </schema>

--- a/web/concrete/blocks/youtube/db.xml
+++ b/web/concrete/blocks/youtube/db.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btYouTube">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="title" type="C" size="255"></field>		
-		<field name="videoURL" type="C" size="255"></field>
-		<field name="vHeight" type="C" size="255"></field>		
-		<field name="vWidth" type="C" size="255"></field>
-		<field name="vPlayer" type="I1">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-	</table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="btYouTube">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="title" type="string" size="255"/>
+    <field name="videoURL" type="string" size="255"/>
+    <field name="vHeight" type="string" size="255"/>
+    <field name="vWidth" type="string" size="255"/>
+    <field name="vPlayer" type="boolean">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>


### PR DESCRIPTION
Database schemas for blocks & co. automatically converted to DoctrineXML with http://concrete5.github.io/doctrine-xml/

After that automatic conversion, I manually edited the generated xml files by adding field comments.

For instance, before we had:
```xml
<table name="btDateNavigation">
   ..
  <!-- this field is where the links will direct you //-->
  <field name="cTargetID" type="I">
```
and I manually converted the xml comment as a field comment:
```xml
<table name="btDateNavigation">
   ..
  <field name="cTargetID" type="integer" comment="this field is where the links will direct you">
   ..
```

Another example: before we had
```xml
<table name="btNavigation">
  ..
  <field name="displayPages" type="C" size="255">
    <descr>was enum('top','current','above','below','custom')</descr>
   ..
```
and I manually converted `<descr>` to the comment
```xml
<table name="btNavigation">
  ..
  <field name="displayPages" type="string" size="255" comment="was enum('top','current','above','below','custom')">
   ..
```

Since before the comments were not supported, before there were no comments in mysql.
Now, with the edits above, we have field comments.

Except for these comment differences, the resulting database structure after a clean installation is exactly the same as before! :smile: 