### PR TITLE
Fix uncaught error on ConcreteTypographySelector

### DIFF
--- a/web/concrete/js/build/core/style-customizer/typography.js
+++ b/web/concrete/js/build/core/style-customizer/typography.js
@@ -266,7 +266,7 @@
 
     ConcreteTypographySelector.prototype.save = function (e) {
         var my = this;
-        my.setValue('font-family', my.fonts[my.$fontMenu.val()].css);
+        my.setValue('font-family', (my.options.fontFamily != -1) ? my.fonts[my.$fontMenu.val()].css : '');
         my.setValue('color', my.$widget.find('input[data-style-customizer-field=color]').spectrum('get'));
         my.setValue('italic', my.$widget.find('input[data-style-customizer-field=italic]').is(':checked') ? '1' : 0);
         my.setValue('underline', my.$widget.find('input[data-style-customizer-field=underline]').is(':checked') ? '1' : 0);


### PR DESCRIPTION
Typography selector fails on save if it is used without font selection.
`Uncaught TypeError: Cannot read property 'css' of undefined`

e.g. I don't want end-user to be able to choose font on links:

**styles.xml**
```
<style name="Link" variable="link" type="type" />
```

**defaults.less**
```
@link-type-color: #222;
@link-type-text-decoration: none;
```