### PR TITLE
Addition of option to force download in File block

### DIFF
--- a/web/concrete/blocks/file/add.php
+++ b/web/concrete/blocks/file/add.php
@@ -3,10 +3,14 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $al = Loader::helper('concrete/asset_library');
 ?>
 <div class="form-group">
-<?=$form->label('fID', t('File'))?>
-<?=$al->file('ccm-b-file', 'fID', t('Choose File'));?>
+	<?=$form->label('fID', t('File'))?>
+	<?=$al->file('ccm-b-file', 'fID', t('Choose File'));?>
 </div>
 <div class="form-group">
-<?=$form->label('fileLinkText', t('Link'))?>
-<?=$form->text('fileLinkText')?>
+	<?=$form->label('fileLinkText', t('Link'))?>
+	<?=$form->text('fileLinkText')?>
+</div>
+<div class="form-group">
+	<?=$form->checkbox('forceDownload', '1'); ?>
+	<?=$form->label('forceDownload', t('Force file to download')); ?>
 </div>

--- a/web/concrete/blocks/file/controller.php
+++ b/web/concrete/blocks/file/controller.php
@@ -9,7 +9,7 @@ class Controller extends BlockController {
 	protected $btCacheBlockOutput = true;
 	protected $btCacheBlockOutputOnPost = true;
 	protected $btCacheBlockOutputForRegisteredUsers = true;
-	protected $btInterfaceHeight = 250;
+	protected $btInterfaceHeight = 320;
 	protected $btTable = 'btContentFile';
 	
 	protected $btExportFileColumns = array('fID');
@@ -32,8 +32,13 @@ class Controller extends BlockController {
 	public function getSearchableContent(){
 		return $this->fileLinkText;
 	}
-	
-	public function validate($args) {
+
+    function save($args){
+		$args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+		parent::save($args);
+    }
+
+    public function validate($args) {
 		$e = Loader::helper('validation/error');
 		if ($args['fID'] < 1) {
 			$e->add(t('You must select a file.'));

--- a/web/concrete/blocks/file/db.xml
+++ b/web/concrete/blocks/file/db.xml
@@ -8,6 +8,10 @@
 		<field name="fID" type="I">
 			<unsigned />
 		</field>
+        <field name="forceDownload" type="I1">
+            <unsigned />
+            <default value="0" />
+        </field>
 		<field name="fileLinkText" type="C" size="255"/>
 		<field name="filePassword" type="C" size="255"/>
         <index name="fID">

--- a/web/concrete/blocks/file/edit.php
+++ b/web/concrete/blocks/file/edit.php
@@ -7,10 +7,14 @@
     }
 ?>
 <div class="form-group">
-<?=$form->label('fID', t('File'))?>
-<?=$al->file('ccm-b-file', 'fID', t('Choose File'), $bf);?>
+	<?=$form->label('fID', t('File'))?>
+	<?=$al->file('ccm-b-file', 'fID', t('Choose File'), $bf);?>
 </div>
 <div class="form-group">
-<?=$form->label('fileLinkText', t('Text for Linked File'))?>
-<?=$form->text('fileLinkText', $controller->getLinkText())?>
+	<?=$form->label('fileLinkText', t('Text for Linked File'))?>
+	<?=$form->text('fileLinkText', $controller->getLinkText())?>
+</div>
+<div class="form-group">
+	<?=$form->checkbox('forceDownload', '1', $forceDownload); ?>
+	<?=$form->label('forceDownload', t('Force file to download')); ?>
 </div>

--- a/web/concrete/blocks/file/view.php
+++ b/web/concrete/blocks/file/view.php
@@ -8,7 +8,7 @@ if ($fp->canViewFile()) {
 	}
 	?>
 	<div class="ccm-block-file">
-		<a href="<?= View::url('/download_file', $controller->getFileID(),$cID) ?>"><?= stripslashes($controller->getLinkText()) ?></a>
+		<a href="<?php echo ($forceDownload ? $f->getForceDownloadURL() : $f->getDownloadURL()); ?>"><?php echo stripslashes($controller->getLinkText()) ?></a>
 	</div>
 
 


### PR DESCRIPTION
This change:
- Adds the option to force a linked file to download
- Uses the newer ->getDownloadURL() call
- Increases the height of the form block interface to fit the new checkbox