### PR TITLE
Update form.php

### DIFF
--- a/web/concrete/blocks/testimonial/form.php
+++ b/web/concrete/blocks/testimonial/form.php
@@ -1,10 +1,10 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 
-<?
+<?php
 if ($fID > 0) {
     $fo = File::getByID($fID);
-    if ($fo->isError()) {
+   if (!is_object($fo)) {
         unset($fo);
     }
 }


### PR DESCRIPTION
If the Image has being deleted from the file manager, the form does not load to edit the testimonial.
I believe the isError() is deprecated.