### PR TITLE
A Block with CustomTemplate with No CSS CustomStyle not to print out ccm-custom-style-container div

### DIFF
--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -860,6 +860,61 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
         if ($this->getCustomStyleSetID() > 0 || $force) {
             $csr = StyleSet::getByID($this->getCustomStyleSetID());
             $bs = new CustomStyle($csr, $this->getBlockID(), $this->getAreaHandle());
+            $noCustomStyle = true;
+            if (is_object($bs)) {
+                if ($bs->backgroundColor) {
+                    $noCustomStyle = false;
+                } else if ($bs->backgroundImageFileID) {
+                    $noCustomStyle = false;
+                } else if ($bs->backgroundRepeat) {
+                    // no-repeat does not mean empty object
+                } else if ($bs->borderStyle) {
+                    $noCustomStyle = false;
+                } else if ($bs->borderWidth) {
+                    $noCustomStyle = false;
+                } else if ($bs->borderRadius) {
+                    $noCustomStyle = false;
+                } else if ($bs->baseFontSize) {
+                    $noCustomStyle = false;
+                } else if ($bs->alignment) {
+                    $noCustomStyle = false;
+                } else if ($bs->textColor) {
+                    $noCustomStyle = false;
+                } else if ($bs->linkColor) {
+                    $noCustomStyle = false;
+                } else if ($bs->marginTop) {
+                    $noCustomStyle = false;
+                } else if ($bs->marginBottom) {
+                    $noCustomStyle = false;
+                } else if ($bs->marginLeft) {
+                    $noCustomStyle = false;
+                } else if ($bs->marginRight) {
+                    $noCustomStyle = false;
+                } else if ($bs->paddingTop) {
+                    $noCustomStyle = false;
+                } else if ($bs->paddingBottom) {
+                    $noCustomStyle = false;
+                } else if ($bs->paddingLeft) {
+                    $noCustomStyle = false;
+                } else if ($bs->paddingRight) {
+                    $noCustomStyle = false;
+                } else if ($bs->rotate) {
+                    $noCustomStyle = false;
+                } else if ($bs->boxShadowHorizontal) {
+                    $noCustomStyle = false;
+                } else if ($bs->boxShadowVertical) {
+                    $noCustomStyle = false;
+                } else if ($bs->boxShadowBlur) {
+                    $noCustomStyle = false;
+                } else if ($bs->boxShadowSpread) {
+                    $noCustomStyle = false;
+                } else if ($bs->boxShadowColor) {
+                    $noCustomStyle = false;
+                }
+            }
+            if ($noCustomStyle) {
+                $bs = null;
+            }
             return $bs;
         }
     }


### PR DESCRIPTION
I had an exact same case as
https://www.concrete5.org/community/forums/customizing_c5/is-it-possible-to-remove-the-div-which-surrounds-all-blocks-ccm-/

## What

We usually have original design with original HTML coding.
We want the blocks to print out exactly the way how we wrote in the HTML coding.

But we have multiple coding for a particular block (e.g., Page List blocks). So we make multiple custom templates.

But we don't want the extra ccm-custom-style-container div tag to be printed out because it will break the CSS or JS.

## About my PR

I know that my PR is premature.
I should be looking where it saves the custom template.

But I was only able to track the output side and implement for my client work.

Since I'm running out of my time, I would first throw this ugly PR, so that we can start a discussion.