### PR TITLE
Allow resetting Config values

### DIFF
--- a/tests/tests/Core/Config/Repository/LiaisonTest.php
+++ b/tests/tests/Core/Config/Repository/LiaisonTest.php
@@ -100,5 +100,8 @@ class LiaisonSaver implements SaverInterface
     {
         $this->saved = "{$namespace}::{$group}.{$item}";
     }
+    public function reset($item, $environment, $group, $namespace = null)
+    {
+    }
 
 }

--- a/web/concrete/src/Config/Repository/Repository.php
+++ b/web/concrete/src/Config/Repository/Repository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Config\Repository;
 
 use Concrete\Core\Config\LoaderInterface;
@@ -6,7 +7,6 @@ use Concrete\Core\Config\SaverInterface;
 
 class Repository extends \Illuminate\Config\Repository
 {
-
     /**
      * @var SaverInterface
      */
@@ -31,7 +31,7 @@ class Repository extends \Illuminate\Config\Repository
     }
 
     /**
-     * Clear specific key
+     * Clear specific key.
      *
      * @param string $key
      */
@@ -41,10 +41,11 @@ class Repository extends \Illuminate\Config\Repository
     }
 
     /**
-     * Save a key
+     * Save a key.
      *
      * @param $key
      * @param $value
+     *
      * @return bool
      */
     public function save($key, $value)
@@ -58,6 +59,27 @@ class Repository extends \Illuminate\Config\Repository
 
             return true;
         }
+
+        return false;
+    }
+
+    /**
+     * Delete/reset a key (in case of FileSaver savers: resets the key to the default value, in case of DatabaseSaver savers: delete the value).
+     *
+     * @param string $key
+     */
+    public function reset($key)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
+        $collection = $this->getCollection($group, $namespace);
+        unset($this->items[$collection]);
+
+        if ($this->saver->reset($item, $this->environment, $group, $namespace)) {
+            $this->load($group, $namespace, $this->getCollection($group, $namespace));
+
+            return true;
+        }
+
         return false;
     }
 
@@ -67,7 +89,6 @@ class Repository extends \Illuminate\Config\Repository
      * @param  string $package
      * @param  string $hint
      * @param  string $namespace
-     * @return void
      */
     public function package($package, $hint, $namespace = null)
     {
@@ -87,7 +108,8 @@ class Repository extends \Illuminate\Config\Repository
         $this->items = array();
     }
 
-    public function clearNamespace($namespace) {
+    public function clearNamespace($namespace)
+    {
         $this->loader->clearNamespace($namespace);
     }
 
@@ -112,5 +134,4 @@ class Repository extends \Illuminate\Config\Repository
 
         return array_merge(array($namespace), $groupAndItem);
     }
-
 }

--- a/web/concrete/src/Config/Repository/Repository.php
+++ b/web/concrete/src/Config/Repository/Repository.php
@@ -75,6 +75,7 @@ class Repository extends \Illuminate\Config\Repository
         unset($this->items[$collection]);
 
         if ($this->saver->reset($item, $this->environment, $group, $namespace)) {
+            $this->clearCache();
             $this->load($group, $namespace, $this->getCollection($group, $namespace));
 
             return true;

--- a/web/concrete/src/Config/SaverInterface.php
+++ b/web/concrete/src/Config/SaverInterface.php
@@ -1,19 +1,31 @@
 <?php
+
 namespace Concrete\Core\Config;
 
 interface SaverInterface
 {
-
     /**
-     * Save config item
+     * Save config item.
      *
      * @param string $item
      * @param string $value
      * @param string $environment
      * @param string $group
      * @param string|null $namespace
+     *
      * @return bool
      */
     public function save($item, $value, $environment, $group, $namespace = null);
 
+    /**
+     * Reset a config item.
+     *
+     * @param string $item
+     * @param string $environment
+     * @param string $group
+     * @param string|null $namespace
+     *
+     * @return bool
+     */
+    public function reset($item, $environment, $group, $namespace = null);
 }


### PR DESCRIPTION
It could be handy to have a function to reset the configuration options to the default values.
So, I added a `reset` method to the `Repository` class.
- if the saver is a `FileSaver` instance, we reset the key to default value (eg to the ones in /concrete/config)
- if the saver is a `DatabaseSaver`. we delete the database record.

Please remark that this `reset` method is different to the `clear` method. For instance:
- `\Config::clear('concrete.misc.default_jpeg_image_compression')` will cause to have `null` when we call `\Config::get('concrete.misc.default_jpeg_image_compression')`
- `\Config::reset('concrete.misc.default_jpeg_image_compression')` will cause to have `80` ([that's the default value](https://github.com/concrete5/concrete5/blob/aabd6d59ed1a17a6338496812a82db05c594cf6d/web/concrete/config/concrete.php#L419)) when we call `\Config::get('concrete.misc.default_jpeg_image_compression')`
