### PR TITLE
Fix: can't override install options by config file

### DIFF
--- a/web/concrete/src/Console/Command/InstallCommand.php
+++ b/web/concrete/src/Console/Command/InstallCommand.php
@@ -45,7 +45,7 @@ class InstallCommand extends Command
             if (!is_array($configOptions)) {
                 throw new Exception('The configuration file did not returned an array.');
             }
-            $options = $options + $configOptions;
+            $options = $configOptions + $options;
         }
         if (file_exists(DIR_CONFIG_SITE.'/database.php')) {
             throw new Exception('concrete5 is already installed.');


### PR DESCRIPTION
Even if we define any options from config file, these values will be overwrited by default value.

http://php.net/manual/en/language.operators.array.php