### PR TITLE
Change default workflow page to Me

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/workflow.php
+++ b/web/concrete/controllers/single_page/dashboard/workflow.php
@@ -4,7 +4,7 @@ use \Concrete\Core\Page\Controller\DashboardPageController;
 class Workflow extends DashboardPageController {
 	
 	public function view() {
-		$this->redirect('/dashboard/workflow/workflows');
+		$this->redirect('/dashboard/workflow/me');
 	}
 	
 }


### PR DESCRIPTION
When you click the "Workflow" of right side dashboard menu, it will redirect to the "Workflow List" page.
But we would want to direct to "Waiting for Me" page instead.

This is because there may be a user who has a permission to approve the page, but not the Workflow List page.

Once you finish setting up the Workflow, you will visit Waiting For Me page more often.