### PR TITLE
Fix basic workflow assignment

### DIFF
--- a/web/concrete/src/Workflow/BasicWorkflow.php
+++ b/web/concrete/src/Workflow/BasicWorkflow.php
@@ -16,6 +16,9 @@ use Config;
 
 class BasicWorkflow extends \Concrete\Core\Workflow\Workflow
 {
+    public function getPermissionAssignmentClassName() {
+        return '\\Concrete\\Core\\Permission\\Assignment\\BasicWorkflowAssignment';
+    }
 
     public function updateDetails($post)
     {


### PR DESCRIPTION
Users can not use multiple basic workflow now, because basic workflow permission assignment class is not used.