### PR TITLE
Fix: username validation

### DIFF
--- a/web/concrete/controllers/single_page/register.php
+++ b/web/concrete/controllers/single_page/register.php
@@ -71,7 +71,7 @@ class Register extends PageController {
 			}
 
 
-			if (strlen($username) >= Config::get('concrete.user.username.minimum') && !$valc->username($username)) {
+			if (strlen($username) >= Config::get('concrete.user.username.minimum') && strlen($username) <= Config::get('concrete.user.username.maximum') && !$valc->username($username)) {
 				if(Config::get('concrete.user.username.allow_spaces')) {
 					$e->add(t('A username may only contain letters, numbers and spaces.'));
 				} else {


### PR DESCRIPTION
Very long username shows "A username may only contain letters or numbers".
This message is unnecessary.

![long_username](https://cloud.githubusercontent.com/assets/531277/8050915/1c7ac166-0eb0-11e5-8c53-281feaf278f5.png)
