### PR TITLE
Check access group search permission on dashboard

### DIFF
--- a/web/concrete/elements/group/search.php
+++ b/web/concrete/elements/group/search.php
@@ -1,5 +1,12 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?> 
 <?
+$tp = new TaskPermission();
+if (!$tp->canAccessGroupSearch()) {
+	?>
+	<p><?=t('You do not have access to the group search.')?></p>
+	<?php
+} else {
+
 $form = Loader::helper('form');
 $searchRequest = $_REQUEST;
 $result = Loader::helper('json')->encode($controller->getSearchResultObject()->getJSONObject());
@@ -132,5 +139,6 @@ $(function() {
 </div>
 
 
-
+<?php
+}
 


### PR DESCRIPTION
If you does not have access to group search, you'll get the error message:

```
An unexpected error occurred.
Call to a member function getJSONObject() on null
```