### PR TITLE
Fix class alias issue in legacy page list

### DIFF
--- a/web/concrete/src/Legacy/PageList.php
+++ b/web/concrete/src/Legacy/PageList.php
@@ -7,6 +7,7 @@ use \Concrete\Core\Permission\Access\Entity\PageOwnerEntity as PageOwnerPermissi
 use PermissionKey;
 use Permissions;
 use CollectionAttributeKey;
+use Concrete\Core\Permission\Duration as PermissionDuration;
 /**
 *
 * An object that allows a filtered list of pages to be returned.


### PR DESCRIPTION
We might have to move away from legacy pagelist, but we should fix the error first.