### PR TITLE
Normalize formatted array when saving configuration items

### DIFF
--- a/web/concrete/src/Config/Renderer.php
+++ b/web/concrete/src/Config/Renderer.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Config;
 
 class Renderer
 {
-
     protected $config = null;
 
     public function __construct(array $config)
@@ -99,5 +98,4 @@ class Renderer
 
         return $result;
     }
-
 }

--- a/web/concrete/src/Config/Renderer.php
+++ b/web/concrete/src/Config/Renderer.php
@@ -88,9 +88,16 @@ class Renderer
             }
         }
 
-        return 'array(' . $eol .
-        implode(',' . $eol, $results) . $eol .
-        ($depth ? str_repeat($spacer, $depth - 1) : '') . ')';
+        $result = 'array(' . $eol;
+        if (!empty($results)) {
+            $result .= implode(',' . $eol, $results) . ',' . $eol;
+        }
+        if ($depth > 0) {
+            $result .= str_repeat($spacer, $depth - 1);
+        }
+        $result .= ')';
+
+        return $result;
     }
 
 }


### PR DESCRIPTION
Example: previous output
```php
array(
    'detail' => 'debug',
    'display_errors' => true
)
```

new output:
```php
array(
    'detail' => 'debug',
    'display_errors' => true,
)
```

This simplifies changes (eg git)