### PR TITLE
Possibility to define the environment through an environment variable

### DIFF
--- a/web/concrete/src/Foundation/EnvironmentDetector.php
+++ b/web/concrete/src/Foundation/EnvironmentDetector.php
@@ -27,7 +27,7 @@ class EnvironmentDetector {
         }
         else
         {
-            return $this->detectWebEnvironment($environments);
+            return $this->detectVariableEnvironment($environments);
         }
     }
 
@@ -79,6 +79,21 @@ class EnvironmentDetector {
         }
         else
         {
+            return $this->detectVariableEnvironment($environments);
+        }
+    }
+
+    /**
+     * Set the application environment from environment variable.
+     *
+     * @param mixed $environments
+     * @return string
+     */
+    protected function detectVariableEnvironment($environments)
+    {
+        if (($env = $this->getEnvironmentFromVariable()) !== false) {
+            return $env;
+        } else {
             return $this->detectWebEnvironment($environments);
         }
     }
@@ -95,6 +110,16 @@ class EnvironmentDetector {
         {
             return starts_with($v, '--env');
         });
+    }
+
+    /**
+     * Gets the environment from the CONCRETE5_ENV environment variable.
+     * 
+     * @return string|bool
+     */
+    protected function getEnvironmentFromVariable()
+    {
+        return getenv('CONCRETE5_ENV');
     }
 
     /**


### PR DESCRIPTION
This adds the possibility to define the current environment through an environment variable named CONCRETE5_ENV. This allows us to control the environment on the server-level (or even in .htaccess).

We find this much convenient way than sniffing the hostname because we all basically use the same environment configs on our development machines.

I know we could already pass a closure to the method but it would be easier if we didn't have to add the same code manually for each and every project.