### PR TITLE
Fix: Message for notifing the allowed chars in username

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/add.php
+++ b/web/concrete/controllers/single_page/dashboard/users/add.php
@@ -64,7 +64,7 @@ class Add extends DashboardPageController {
 
 		if (strlen($username) >= Config::get('concrete.user.username.minimum') && !$valc->username($username)) {
 			if(Config::get('concrete.user.username.allow_spaces')) {
-				$this->error->add(t('A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'));
+				$this->error->add(t('A username may only contain letters, numbers, spaces (not at the beginning/end), dots (not at the beginning/end), underscores (not at the beginning/end).'));
 			} else {
 				$this->error->add(t('A username may only contain letters numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'));
 			}

--- a/web/concrete/controllers/single_page/register.php
+++ b/web/concrete/controllers/single_page/register.php
@@ -73,9 +73,9 @@ class Register extends PageController {
 
 			if (strlen($username) >= Config::get('concrete.user.username.minimum') && !$valc->username($username)) {
 				if(Config::get('concrete.user.username.allow_spaces')) {
-					$e->add(t('A username may only contain letters, numbers and spaces.'));
+					$e->add(t('A username may only contain letters, numbers, spaces (not at the beginning/end), dots (not at the beginning/end), underscores (not at the beginning/end).'));
 				} else {
-					$e->add(t('A username may only contain letters or numbers.'));
+					$e->add(t('A username may only contain letters, numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'));
 				}
 
 			}


### PR DESCRIPTION
Username characters

[A-Za-z0-9] ... allowed everywhere

if  concrete.user.username.allow_spaces :
  [A-Za-z0-9_. ] ... disallowed in start and end
else :
  [A-Za-z0-9_.] ... disallowed in start and end


see src\Application\Service\Validation.php L63-88