### PR TITLE
Show forbidden page intead of login form

### DIFF
--- a/web/concrete/controllers/frontend/page_forbidden.php
+++ b/web/concrete/controllers/frontend/page_forbidden.php
@@ -3,13 +3,14 @@
 namespace Concrete\Controller\Frontend;
 use Controller;
 use User;
+use Config;
 class PageForbidden extends Controller {
 	
 	protected $viewPath = '/frontend/page_forbidden';
 
 	public function view() {
 		$u = new User();
-        if (!$u->isRegistered()) { //if they are not logged in, and we show guests the login...
+        if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
 			$this->redirect('/login');
 		}
 	}

--- a/web/concrete/controllers/frontend/page_forbidden.php
+++ b/web/concrete/controllers/frontend/page_forbidden.php
@@ -1,19 +1,20 @@
-<?
+<?php
 
 namespace Concrete\Controller\Frontend;
+
 use Controller;
 use User;
 use Config;
-class PageForbidden extends Controller {
-	
-	protected $viewPath = '/frontend/page_forbidden';
 
-	public function view() {
-		$u = new User();
+class PageForbidden extends Controller
+{
+    protected $viewPath = '/frontend/page_forbidden';
+
+    public function view()
+    {
+        $u = new User();
         if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
-			$this->redirect('/login');
-		}
-	}
-
-	
+            $this->redirect('/login');
+        }
+    }
 }

--- a/web/concrete/controllers/single_page/page_forbidden.php
+++ b/web/concrete/controllers/single_page/page_forbidden.php
@@ -1,21 +1,21 @@
-<?
+<?php
 
 namespace Concrete\Controller\SinglePage;
+
 use \PageController;
 use Loader;
 use User;
 use Config;
 
-class PageForbidden extends PageController {
-	
-	protected $viewPath = '/frontend/page_forbidden';
+class PageForbidden extends PageController
+{
+    protected $viewPath = '/frontend/page_forbidden';
 
-	public function view() {
-		$u = new User();
-		if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
-			$this->redirect('/login');
-		}
-	}
-
-
+    public function view()
+    {
+        $u = new User();
+        if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
+            $this->redirect('/login');
+        }
+    }
 }

--- a/web/concrete/controllers/single_page/page_forbidden.php
+++ b/web/concrete/controllers/single_page/page_forbidden.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller\SinglePage;
 use \PageController;
 use Loader;
 use User;
+use Config;
 
 class PageForbidden extends PageController {
 	
@@ -11,7 +12,7 @@ class PageForbidden extends PageController {
 
 	public function view() {
 		$u = new User();
-		if (!$u->isRegistered()) { //if they are not logged in, and we show guests the login...
+		if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
 			$this->redirect('/login');
 		}
 	}


### PR DESCRIPTION
when a user doesn't have a permission to view that page and `concrete.permissions.forward_to_login` config value is `false`.