### PR TITLE
From conversation.banned_words to conversations.banned_words

### DIFF
--- a/web/concrete/blocks/core_conversation_message/controller.php
+++ b/web/concrete/blocks/core_conversation_message/controller.php
@@ -43,7 +43,7 @@ use \Concrete\Core\Block\BlockController;
 				$ve->add(t('Your message cannot be empty.'));
 			}
 
-			if (Config::get('conversation.banned_words') && (
+			if (Config::get('conversations.banned_words') && (
 				Loader::helper('validation/banned_words')->hasBannedWords($data['cnvMessageSubject']) ||
 				Loader::helper('validation/banned_words')->hasBannedWords($data['cnvMessageBody']))) {
 				$ve->add(t('Banned words detected.'));

--- a/web/concrete/controllers/single_page/dashboard/system/conversations/bannedwords.php
+++ b/web/concrete/controllers/single_page/dashboard/system/conversations/bannedwords.php
@@ -14,7 +14,7 @@ class BannedWords extends DashboardPageController {
 
 	public function view() {
 		$this->set('bannedWords',$this->getBannedWords());
-		$this->set('bannedListEnabled',Config::get('conversation.banned_words'));
+		$this->set('bannedListEnabled',Config::get('conversations.banned_words'));
 	}
 
 	public function getBannedWords() {
@@ -38,7 +38,7 @@ class BannedWords extends DashboardPageController {
 				BannedWord::add($bw);
 			}
 		}
-		Config::save('conversation.banned_words',!!$this->post('banned_list_enabled'));
+		Config::save('conversations.banned_words',!!$this->post('banned_list_enabled'));
 		$this->view();
 		$this->redirect('dashboard/system/conversations/bannedwords/success');
 	}

--- a/web/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
@@ -4,22 +4,21 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use ORM;
 
 class Version20150610000000 extends AbstractMigration
 {
-
     public function up(Schema $schema)
     {
         $bt = \BlockType::getByHandle('file');
         if (is_object($bt)) {
             $bt->refresh();
         }
+        if (\Config::get('conversation.banned_words')) {
+            \Config::set('conversations.banned_words', true);
+        }
     }
 
     public function down(Schema $schema)
     {
     }
-
-
 }

--- a/web/concrete/tools/conversations/add_message.php
+++ b/web/concrete/tools/conversations/add_message.php
@@ -88,7 +88,7 @@ if (Loader::helper('validation/numbers')->integer($_POST['cnvMessageParentID']) 
 	}
 }
 
-if (Config::get('conversation.banned_words') && Loader::helper('validation/banned_words')->hasBannedWords($_POST['cnvMessageBody'])) {
+if (Config::get('conversations.banned_words') && Loader::helper('validation/banned_words')->hasBannedWords($_POST['cnvMessageBody'])) {
 	$ve->add(t('Banned words detected.'));
 }
 


### PR DESCRIPTION
All the other conversations-related configuration keys use `conversations.*`, not `conversation.*`