### PR TITLE
Allow DispatcherRouteCallback class to be easily overridden or extended

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -8,7 +8,6 @@ use Concrete\Core\Foundation\ClassLoader;
 use Concrete\Core\Foundation\EnvironmentDetector;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Logging\Query\Logger;
-use Concrete\Core\Routing\DispatcherRouteCallback;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Updater\Update;
 use Concrete\Core\Url\Url;
@@ -367,7 +366,7 @@ class Application extends Container
                 Route::setRequest($request);
                 $response = Route::execute($route, $matched);
             } catch(ResourceNotFoundException $e) {
-                $callback = new DispatcherRouteCallback('dispatcher');
+				$callback = Core::make('\Concrete\Core\Routing\DispatcherRouteCallback', array('dispatcher'));
                 $response = $callback->execute($request);
             }
         }


### PR DESCRIPTION
Instantiate the `DispatcherRouteCallback` core class via the IoC container to allow it to be easily overridden or extended via application/bootstrap/app.php.

Doing so would make [this type of thing](http://www.concrete5.org/community/forums/5-7-discussion/mobile-themes-and-tablets/) easier without having to resort to [something like this](https://www.concrete5.org/documentation/how-tos/developers/override-almost-any-core-file-in-5.7/).

-Steve