### PR TITLE
Stack block type javascript

### DIFF
--- a/web/concrete/js/build/core/app/edit-mode/stack.js
+++ b/web/concrete/js/build/core/app/edit-mode/stack.js
@@ -26,12 +26,12 @@
                 dragAreaBlockID = dragAreaBlock.getId();
             }
 
-            ConcretePanelManager.exitPanelMode();
+            jQuery.fn.dialog.closeAll();
 
             var settings = {
-                cID: CCM_CID,
+                cID: elem.data('cid'),
                 arHandle: area_handle,
-                stID: elem.data('cid'),
+                stID: elem.data('sid'),
                 atask: 'add_stack',
                 ccm_token: CCM_SECURITY_TOKEN
             };
@@ -42,6 +42,7 @@
 
             $.fn.dialog.showLoader();
             $.getJSON(CCM_DISPATCHER_FILENAME, settings, function (response) {
+                $.fn.dialog.hideLoader();
                 my.handleAddResponse(response, area, dragAreaBlock);
             });
         },

--- a/web/concrete/js/build/core/app/edit-mode/stack.js
+++ b/web/concrete/js/build/core/app/edit-mode/stack.js
@@ -42,7 +42,6 @@
 
             $.fn.dialog.showLoader();
             $.getJSON(CCM_DISPATCHER_FILENAME, settings, function (response) {
-                $.fn.dialog.hideLoader();
                 my.handleAddResponse(response, area, dragAreaBlock);
             });
         },

--- a/web/concrete/views/panels/add.php
+++ b/web/concrete/views/panels/add.php
@@ -63,7 +63,8 @@ switch ($tab) {
                 ?>
                 <div class="ccm-panel-add-block-stack-item"
                      data-panel-add-block-drag-item="stack-item"
-                     data-cID="<?= intval($stack->getCollectionID()) ?>"
+                     data-cID="<?= intval($c->getCollectionID()) ?>"
+                     data-sID="<?= intval($stack->getCollectionID()) ?>"
                      data-block-type-handle="<?= t('stack') ?>"
                      data-has-add-template="no"
                      data-supports-inline-add="no"

--- a/web/concrete/views/panels/add.php
+++ b/web/concrete/views/panels/add.php
@@ -65,7 +65,7 @@ switch ($tab) {
                      data-panel-add-block-drag-item="stack-item"
                      data-cID="<?= intval($c->getCollectionID()) ?>"
                      data-sID="<?= intval($stack->getCollectionID()) ?>"
-                     data-block-type-handle="<?= t('stack') ?>"
+                     data-block-type-handle="stack"
                      data-has-add-template="no"
                      data-supports-inline-add="no"
                      data-btID="0"


### PR DESCRIPTION
This code makes the stacks block type javascript behave the same way as the javascript for a normal block type. On a custom editing page this code causes problems because:
+ CCM_ID is the ID of the current page, which is ok when editing a normal page but not when editing a collection from another page. A normal block type uses data-cid to store the destination collection ID, which for stacks was changed to the stack collection ID. Instead, I added a new attribute to store the stack collection ID and kept the same behavior for the collection ID.
+ ConcretePanelManager.exitPanelMode() is not needed here when editing a normal page because the panel will already have been closed. When used on a dashboard page it actually closes the side navigation page. In addition, a normal block type will close open dialogs, which stacks previously do not do.