### PR TITLE
Keep composer editable blocks status even after the page is duplicated

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2292,15 +2292,15 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         if ($rows && is_array($rows)) {
 	        foreach ($rows as $row) {
 		        if (is_array($row) && $row['cID']) {
-		            $db->insert('PageTypeComposerOutputBlocks', array(
-		                'cID' => $newCID,
-		                'arHandle' => $row['arHandle'],
-		                'cbDisplayOrder' => $row['cbDisplayOrder'],
-		                'ptComposerFormLayoutSetControlID' => $row['ptComposerFormLayoutSetControlID'],
-		                'bID' => $row['bID']
-		                ));
-					}
-				}
+                    $db->insert('PageTypeComposerOutputBlocks', array(
+                        'cID' => $newCID,
+                        'arHandle' => $row['arHandle'],
+                        'cbDisplayOrder' => $row['cbDisplayOrder'],
+                        'ptComposerFormLayoutSetControlID' => $row['ptComposerFormLayoutSetControlID'],
+                        'bID' => $row['bID']
+                        ));
+                    }
+                }
         }
 
         PageStatistics::incrementParents($newCID);

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2290,8 +2290,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $rows = $db->GetAll('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID, bID from PageTypeComposerOutputBlocks where cID = ?',
             array($this->cID));
         if ($rows && is_array($rows)) {
-	        foreach ($rows as $row) {
-		        if (is_array($row) && $row['cID']) {
+            foreach ($rows as $row) {
+                if (is_array($row) && $row['cID']) {
                     $db->insert('PageTypeComposerOutputBlocks', array(
                         'cID' => $newCID,
                         'arHandle' => $row['arHandle'],

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2287,8 +2287,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $res = $db->query($q, $v);
 
         // Composer specific
-        $row = $db->GetRow('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID from PageTypeComposerOutputBlocks where cID = ?',
-            array($newCID));
+        $row = $db->GetRow('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID, bID from PageTypeComposerOutputBlocks where cID = ?',
+            array($this->cID));
         if ($row && is_array($row) && $row['cID']) {
             $db->insert('PageTypeComposerOutputBlocks', array(
                 'cID' => $newCID,

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2287,16 +2287,20 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $res = $db->query($q, $v);
 
         // Composer specific
-        $row = $db->GetRow('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID, bID from PageTypeComposerOutputBlocks where cID = ?',
+        $rows = $db->GetAll('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID, bID from PageTypeComposerOutputBlocks where cID = ?',
             array($this->cID));
-        if ($row && is_array($row) && $row['cID']) {
-            $db->insert('PageTypeComposerOutputBlocks', array(
-                'cID' => $newCID,
-                'arHandle' => $row['arHandle'],
-                'cbDisplayOrder' => $row['cbDisplayOrder'],
-                'ptComposerFormLayoutSetControlID' => $row['ptComposerFormLayoutSetControlID'],
-                'bID' => $row['bID']
-                ));
+        if ($rows && is_array($rows)) {
+	        foreach ($rows as $row) {
+		        if (is_array($row) && $row['cID']) {
+		            $db->insert('PageTypeComposerOutputBlocks', array(
+		                'cID' => $newCID,
+		                'arHandle' => $row['arHandle'],
+		                'cbDisplayOrder' => $row['cbDisplayOrder'],
+		                'ptComposerFormLayoutSetControlID' => $row['ptComposerFormLayoutSetControlID'],
+		                'bID' => $row['bID']
+		                ));
+					}
+				}
         }
 
         PageStatistics::incrementParents($newCID);

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2286,6 +2286,19 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $q = 'insert into Pages (cID, ptID, cParentID, uID, cOverrideTemplatePermissions, cInheritPermissionsFromCID, cInheritPermissionsFrom, cFilename, cPointerID, cPointerExternalLink, cPointerExternalLinkNewWindow, cDisplayOrder, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
         $res = $db->query($q, $v);
 
+        // Composer specific
+        $row = $db->GetRow('select cID, arHandle, cbDisplayOrder, ptComposerFormLayoutSetControlID from PageTypeComposerOutputBlocks where cID = ?',
+            array($newCID));
+        if ($row && is_array($row) && $row['cID']) {
+            $db->insert('PageTypeComposerOutputBlocks', array(
+                'cID' => $newCID,
+                'arHandle' => $row['arHandle'],
+                'cbDisplayOrder' => $row['cbDisplayOrder'],
+                'ptComposerFormLayoutSetControlID' => $row['ptComposerFormLayoutSetControlID'],
+                'bID' => $row['bID']
+                ));
+        }
+
         PageStatistics::incrementParents($newCID);
 
         if ($res) {


### PR DESCRIPTION
## Problem

Composer the great tool to manufacture the same type of content such as news page.
Sometime, you want to copy an existing page to a new page ( such as a new press release page) to re-use some of the content.

However, when you make a copy, the composer blocks became uneditable on composer.

I think we should make it available to edit on composer on duplicated page

## Solution

I've added the query on Page::duplicate() function.

Cheers