### PR TITLE
Modify NativeFileSessionHandler to avoid open_basedir issue with default session path

### DIFF
--- a/web/concrete/src/Session/Session.php
+++ b/web/concrete/src/Session/Session.php
@@ -1,10 +1,10 @@
 <?php
 namespace Concrete\Core\Session;
 
+use Concrete\Core\Session\Storage\Handler\NativeFileSessionHandler;
 use Concrete\Core\Utility\IPAddress;
 use Config;
 use \Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
 use \Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;

--- a/web/concrete/src/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/web/concrete/src/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Concrete\Core\Session\Storage\Handler;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
+
+/**
+ * NativeFileSessionHandler.
+ *
+ * Native session handler using PHP's built in file storage, with open_basedir restriction checking.
+ *
+ * Copied from Symfony's NativeFileSessionHandler and added in some exception handling.
+ *
+ * Default PHP config usually puts the session data in a global directory which the runtime should have no access
+ * to. Those directories should be able to be warded off for security reasons using open_basedir restrictions. By
+ * testing the existence of that directory such a restriction is useless as it will always generate a fatal error.
+ */
+class NativeFileSessionHandler extends NativeSessionHandler
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string $savePath Path of directory to save session files.
+     *                         Default null will leave setting as defined by PHP.
+     *                         '/path', 'N;/path', or 'N;octal-mode;/path
+     *
+     * @see http://php.net/session.configuration.php#ini.session.save-path for further details.
+     *
+     * @throws \InvalidArgumentException On invalid $savePath
+     */
+    public function __construct($savePath = null)
+    {
+        if (null === $savePath) {
+            $savePath = ini_get('session.save_path');
+        }
+
+        $baseDir = $savePath;
+
+        if ($count = substr_count($savePath, ';')) {
+            if ($count > 2) {
+                throw new \InvalidArgumentException(sprintf('Invalid argument $savePath \'%s\'', $savePath));
+            }
+
+            // characters after last ';' are the path
+            $baseDir = ltrim(strrchr($savePath, ';'), ';');
+        }
+
+        ini_set('session.save_handler', 'files');
+
+        try {
+
+            if ($baseDir && !is_dir($baseDir)) {
+                mkdir($baseDir, 0777, true);
+            }
+
+            ini_set('session.save_path', $savePath);
+
+        } catch (\Exception $e) {
+            /*
+             * Catch any exceptions caused by open_basedir restrictions and ignore them.
+             *
+             * Not the most elegant solution but far less tedious than trying to analyze the save path.
+             *
+             * - if the exception is not open_basedir related, pass it on.
+             * - if a save path was manually specified, pass it on.
+             */
+
+            if (strpos($e->getMessage(), 'open_basedir') === false || current(func_get_args())) {
+                throw $e;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Hit the same snag with open_basedir restrictions as described in issue #2579. The trouble is with the Symfony session file storage handler checking the existence of the session path.

This is useful when a website has its own session path, but in many distributions the default session path is shared over the entire server (e.g. /var/lib/php5 in Debian, which also has its own garbage collection implementation tied in with that).

Complementing open_basedir restrictions make sure that runtime code is unable to read session data, as it has no business there from a security perspective. Turning off open_basedir restrictions on such a path will make any session data unnecessary vulnerable to things like remote file inclusion.

Also, in such a situation it is safe to assume the session path always exists, making checking it unnecessary as usually file system permissions prohibit creating a new directory in that location anyway.

--

This patch modifies the Symfony NativeFileSessionHandler by adding a little exception handling, which takes care of the open_basedir restriction only when the default session path is used. When a session path is specified through config the developer is responsible for making sure that it is within restrictions.