### PR TITLE
Add theme folder as flag source. Fix old c56 image path.

### DIFF
--- a/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
+++ b/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
@@ -24,7 +24,7 @@ class Flag
         if ($region) {
             $v = \View::getInstance();
             
-			if ($v->getThemeDirectory() != '' && file_exists(
+            if ($v->getThemeDirectory() != '' && file_exists(
                 $v->getThemeDirectory() . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png'
 			)) {
                 $icon = $v->getThemePath() . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png';

--- a/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
+++ b/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
@@ -22,10 +22,16 @@ class Flag
         }
 
         if ($region) {
-            if (file_exists(
-                DIR_BASE . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png'
+            $v = \View::getInstance();
+            
+			if ($v->getThemeDirectory() != '' && file_exists(
+                $v->getThemeDirectory() . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png'
+			)) {
+                $icon = $v->getThemePath() . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png';
+            } elseif (file_exists(
+                DIR_APPLICATION . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png'
             )) {
-                $icon = DIR_REL . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png';
+                $icon = REL_DIR_APPLICATION . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png';
             } else {
                 $icon = ASSETS_URL . '/' . DIRNAME_IMAGES . '/' . DIRNAME_IMAGES_LANGUAGES . '/' . $region . '.png';
             }


### PR DESCRIPTION
This PR allows us to add flag images in our theme folder as well.

It also fixes a bug because the old code looks in /images/countries/ for images. Although this worked for C56, it doesn't for C57. We use the DIR_APPLICATION constant to look for flag images in /application/images/countries/region.png

In sum, the script looks for these paths:
1. /application/themes/theme/images/countries/region.png
2. /application/images/countries/region.png
3. /concrete/images/countries/region.png