### PR TITLE
Remove old constants - Part 2

### DIFF
--- a/tests/tests/Block/ContentFileTranslateTest.php
+++ b/tests/tests/Block/ContentFileTranslateTest.php
@@ -28,7 +28,7 @@ class ContentFileTranslateTest extends FileStorageTestCase {
             'FileVersionLog'
         ));
         parent::setUp();
-        define('UPLOAD_FILE_EXTENSIONS_ALLOWED', '*.txt;*.jpg;*.jpeg;*.png');
+        \Config::set('concrete.upload.extensions', '*.txt;*.jpg;*.jpeg;*.png');
 
         Category::add('file');
         $number = AttributeType::add('number', 'Number');

--- a/tests/tests/Core/File/FileListTest.php
+++ b/tests/tests/Core/File/FileListTest.php
@@ -35,7 +35,7 @@ class FileListTest extends \FileStorageTestCase {
             'FileSetFiles'
         ));
         parent::setUp();
-        define('UPLOAD_FILE_EXTENSIONS_ALLOWED', '*.txt;*.jpg;*.jpeg;*.png');
+        \Config::set('concrete.upload.extensions', '*.txt;*.jpg;*.jpeg;*.png');
 
         Category::add('file');
         \Concrete\Core\Permission\Access\Entity\Type::add('file_uploader', 'File Uploader');

--- a/web/concrete/blocks/autonav/nav_item.php
+++ b/web/concrete/blocks/autonav/nav_item.php
@@ -83,7 +83,7 @@ use Loader;
 		}
 
 		/**
-		 * Gets a URL that will take the user to this particular page. Checks against URL_REWRITING, the page's path, etc..
+		 * Gets a URL that will take the user to this particular page. Checks against concrete.seo.url_rewriting, the page's path, etc..
 		 * @return string $url
 		 */
 		function getURL() {

--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -810,7 +810,7 @@ return array(
         /**
          * URL rewriting
          *
-         * Doesn't impact URL_REWRITING_ALL which is set at a lower level and
+         * Doesn't impact concrete.seo.url_rewriting_all which is set at a lower level and
          * controls whether ALL items will be rewritten.
          *
          * @var bool

--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -700,7 +700,8 @@ return array(
             'maximum'        => 128,
             'minimum'        => 5,
             'hash_portable'  => false,
-            'hash_cost_log2' => 12
+            'hash_cost_log2' => 12,
+            'legacy_salt'    => '',
         ),
         'private_messages'  => array(
             'throttle_max'          => 20,

--- a/web/concrete/single_pages/dashboard/system/basics/multilingual/view.php
+++ b/web/concrete/single_pages/dashboard/system/basics/multilingual/view.php
@@ -14,18 +14,10 @@
                 <label><?=$form->checkbox('LANGUAGE_CHOOSE_ON_LOGIN', 1, $LANGUAGE_CHOOSE_ON_LOGIN)?><?=t('Offer choice of language on login.')?></label>
             </div>
         </div>
-
-        <?
-        $args = array();
-        if (defined("LOCALE")) {
-            $args['disabled'] = 'disabled';
-        }
-        ?>
-
         <div class="form-group">
             <?=$form->label('SITE_LOCALE', t('Default Language'))?>
             <div class="checkbox">
-                <?=$form->select('SITE_LOCALE', $interfacelocales, $SITE_LOCALE, $args);?>
+                <?=$form->select('SITE_LOCALE', $interfacelocales, $SITE_LOCALE);?>
             </div>
         </div>
 

--- a/web/concrete/single_pages/dashboard/system/files/filetypes.php
+++ b/web/concrete/single_pages/dashboard/system/files/filetypes.php
@@ -7,14 +7,9 @@
         <p>
             <?=t('Only files with the following extensions will be allowed. Separate extensions with commas. Periods and spaces will be ignored.')?>
         </p>
-        <? if (UPLOAD_FILE_EXTENSIONS_CONFIGURABLE) { ?>
-            <div class="form-group">
-                <textarea name="file-access-file-types" class="form-control" rows="3"><?=$file_access_file_types?></textarea>
-            </div>
-        <? } else { ?>
-            <?=$file_access_file_types?>
-        <? } ?>
-	
+        <div class="form-group">
+            <textarea name="file-access-file-types" class="form-control" rows="3"><?=$file_access_file_types?></textarea>
+        </div>
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
                 <button class="pull-right btn btn-primary" type="submit" value="file-access-extensions"><?=t('Save')?></button>

--- a/web/concrete/single_pages/dashboard/system/mail/method/test.php
+++ b/web/concrete/single_pages/dashboard/system/mail/method/test.php
@@ -9,7 +9,7 @@ $fh = Loader::helper('form');
         <div class="col-md-6">
             <?php
             if(!Config::get('concrete.email.enabled')) {
-                ?><div class="alert alert-info"><?php echo t(/*i18n: %1$s is a configuration name, %2$s is a configuration value*/'It\'s not possible to test the settings since the mail system is disabled (the setting %1$s is set to %2$s in the configuration).', '<b>ENABLE_EMAILS</b>', '<b>false</b>'); ?></div><?php
+                ?><div class="alert alert-info"><?php echo t(/*i18n: %1$s is a configuration name, %2$s is a configuration value*/'It\'s not possible to test the settings since the mail system is disabled (the setting %1$s is set to %2$s in the configuration).', '<b>concrete.email.enabled</b>', '<b>false</b>'); ?></div><?php
             }
             else {
                 echo Loader::helper('validation/token')->output('test'); ?>

--- a/web/concrete/single_pages/dashboard/system/seo/statistics.php
+++ b/web/concrete/single_pages/dashboard/system/seo/statistics.php
@@ -5,7 +5,7 @@ $form = Loader::helper('form'); ?>
         <div class="form-group">
             <div class="checkbox">
                 <label>
-                <?=$form->checkbox('STATISTICS_TRACK_PAGE_VIEWS', 1, STATISTICS_TRACK_PAGE_VIEWS); ?>
+                <?=$form->checkbox('STATISTICS_TRACK_PAGE_VIEWS', 1, $STATISTICS_TRACK_PAGE_VIEWS); ?>
                 <span><?=t('Track page view statistics.');?></span>
                 </label>
             </div>

--- a/web/concrete/single_pages/login_oauth.php
+++ b/web/concrete/single_pages/login_oauth.php
@@ -14,7 +14,7 @@ $form = Loader::helper('form');
 <div class='row'>
 	<div class='span10 offset1'>
 		<div class="page-header">
-			<h1><?=t('Sign in to %s', SITE)?></h1>
+			<h1><?=t('Sign in to %s', Config::get('concrete.site'))?></h1>
 		</div>
 		<?php
 		if (count($activeAuths) > 1) {

--- a/web/concrete/src/Activity/Newsflow.php
+++ b/web/concrete/src/Activity/Newsflow.php
@@ -12,7 +12,7 @@ use Concrete\Core\Activity\NewsflowSlotItem;
  *
  * A class used for retrieving the latest news and updates from Concrete5. This is a singleton class that should be
  * instantiated via Newsflow::getInstance(). This object is prevented from being created if the config file has the
- * ENABLE_APP_NEWS setting set to false.
+ * 'concrete.external.news' setting set to false.
  * @package Concrete\Core\Activity
  */
 class Newsflow

--- a/web/concrete/src/File/ValidationService.php
+++ b/web/concrete/src/File/ValidationService.php
@@ -53,7 +53,7 @@ class ValidationService {
 
 	/**
 	* Parses the file extension for a given file name, checks it to see if it's in the the extension array if provided
-	* if not, it checks to see if it's in the UPLOAD_FILE_EXTENSIONS_ALLOWED constant
+	* if not, it checks to see if it's in the concrete.upload.extensions configuration option
 	* @param string $filename
 	* @param array $extensions
 	* @return boolean

--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -142,7 +142,7 @@ class User extends Object
             $r = $db->query($q, $v);
             if ($r) {
                 $row = $r->fetchRow();
-                $pw_is_valid_legacy = (defined('PASSWORD_SALT') && User::legacyEncryptPassword($password) == $row['uPassword']);
+                $pw_is_valid_legacy = (Config::get('concrete.user.password.legacy_salt') && User::legacyEncryptPassword($password) == $row['uPassword']);
                 $pw_is_valid = $pw_is_valid_legacy || $this->getUserPasswordHasher()->checkPassword($password, $row['uPassword']);
                 if ($row['uID'] && $row['uIsValidated'] === '0' && Config::get('concrete.user.registration.validate_email')) {
                     $this->loadError(USER_NON_VALIDATED);
@@ -254,7 +254,7 @@ class User extends Object
     // Use only for checking password hashes, not generating new ones to store.
     public function legacyEncryptPassword($uPassword)
     {
-        return md5($uPassword . ':' . PASSWORD_SALT);
+        return md5($uPassword . ':' . Config::get('concrete.user.password.legacy_salt'));
     }
 
     public function isActive()


### PR DESCRIPTION
See each commit message.

New configuration option introduced: `concrete.user.password.legacy_salt`