### PR TITLE
Check page cache before assets & install check

### DIFF
--- a/web/concrete/bootstrap/start.php
+++ b/web/concrete/bootstrap/start.php
@@ -168,23 +168,6 @@ $cms->setupFilesystem();
 
 /**
  * ----------------------------------------------------------------------------
- * Registries for theme paths, assets, routes and file types.
- * ----------------------------------------------------------------------------
- */
-$asset_list = AssetList::getInstance();
-
-$asset_list->registerMultiple($config->get('app.assets', array()));
-$asset_list->registerGroupMultiple($config->get('app.asset_groups', array()));
-
-Route::registerMultiple($config->get('app.routes'));
-Route::setThemesByRoutes($config->get('app.theme_paths', array()));
-
-$type_list = TypeList::getInstance();
-$type_list->defineMultiple($config->get('app.file_types', array()));
-$type_list->defineImporterAttributeMultiple($config->get('app.importer_attributes', array()));
-
-/**
- * ----------------------------------------------------------------------------
  * If we are running through the command line, we don't proceed any further
  * ----------------------------------------------------------------------------
  */
@@ -208,6 +191,34 @@ $request = Request::getInstance();
 
 /**
  * ----------------------------------------------------------------------------
+ * Check the page cache in case we need to return a result early.
+ * ----------------------------------------------------------------------------
+ */
+$response = $cms->checkPageCache($request);
+if ($response) {
+    $response->send();
+    $cms->shutdown();
+}
+
+/**
+ * ----------------------------------------------------------------------------
+ * Registries for theme paths, assets, routes and file types.
+ * ----------------------------------------------------------------------------
+ */
+$asset_list = AssetList::getInstance();
+
+$asset_list->registerMultiple($config->get('app.assets', array()));
+$asset_list->registerGroupMultiple($config->get('app.asset_groups', array()));
+
+Route::registerMultiple($config->get('app.routes'));
+Route::setThemesByRoutes($config->get('app.theme_paths', array()));
+
+$type_list = TypeList::getInstance();
+$type_list->defineMultiple($config->get('app.file_types', array()));
+$type_list->defineImporterAttributeMultiple($config->get('app.importer_attributes', array()));
+
+/**
+ * ----------------------------------------------------------------------------
  * If we haven't installed, then we need to reroute. If we have, and we're
  * on the install page, and we haven't installed, then we need to dispatch
  * early and exit.
@@ -222,17 +233,6 @@ if (!$cms->isInstalled()) {
     else {
         $response = $cms->dispatch($request);
     }
-    $response->send();
-    $cms->shutdown();
-}
-
-/**
- * ----------------------------------------------------------------------------
- * Check the page cache in case we need to return a result early.
- * ----------------------------------------------------------------------------
- */
-$response = $cms->checkPageCache($request);
-if ($response) {
     $response->send();
     $cms->shutdown();
 }


### PR DESCRIPTION
I think its safe to move the page cache check to happen before the assets and install check. Not a huge benefit but the loading times appeared to go down 10% when I tested it.

Just not sure about routes. The page cache does not apply to routes right?