### PR TITLE
Fix warnings in GlobalArea

### DIFF
--- a/web/concrete/src/Area/Area.php
+++ b/web/concrete/src/Area/Area.php
@@ -826,8 +826,11 @@ class Area extends Object implements \Concrete\Core\Permission\ObjectInterface
      *
      * @return bool
      */
-    public function display($c, $alternateBlockArray = null)
+    public function display($c = false, $alternateBlockArray = null)
     {
+        if (!$c) {
+            $c = Page::getCurrentPage();
+        }
         $v = View::getRequestInstance();
 
         if (!is_object($c) || $c->isError()) {

--- a/web/concrete/src/Area/GlobalArea.php
+++ b/web/concrete/src/Area/GlobalArea.php
@@ -118,10 +118,9 @@ class GlobalArea extends Area
         return $blocks;
     }
 
-    public function display()
+    public function display($c = false, $fake = null)
     {
-        $c = Page::getCurrentPage();
-        parent::display($c);
+        parent::display($c, null);
     }
 
     /**

--- a/web/concrete/src/Area/GlobalArea.php
+++ b/web/concrete/src/Area/GlobalArea.php
@@ -42,11 +42,13 @@ class GlobalArea extends Area
     }
 
     /**
+     * @param Page $c
+     *
      * @return int
      */
-    public function getTotalBlocksInArea()
+    public function getTotalBlocksInArea($c = false)
     {
-        $stack = $this->getGlobalAreaStackObject();
+        $stack = $this->getGlobalAreaStackObject($c);
         $ax = Area::get($stack, STACKS_AREA_NAME);
         if (is_object($ax)) {
             return $ax->getTotalBlocksInArea();
@@ -55,11 +57,15 @@ class GlobalArea extends Area
     }
 
     /**
+     * @param Page $c
+     *
      * @return Page
      */
-    protected function getGlobalAreaStackObject()
+    protected function getGlobalAreaStackObject($c = false)
     {
-        $c = Page::getCurrentPage();
+        if (!$c) {
+            $c = Page::getCurrentPage();
+        }
         $cp = new Permissions($c);
         if ($cp->canViewPageVersions()) {
             $stack = Stack::getByName($this->arHandle);


### PR DESCRIPTION
This fixes two E_STRICT warnings:
- Declaration of Concrete\Core\Area\GlobalArea::getTotalBlocksInArea() should be compatible with Concrete\Core\Area\Area::getTotalBlocksInArea($c = false)
- Declaration of Concrete\Core\Area\GlobalArea::display() should be compatible with Concrete\Core\Area\Area::display($c, $alternateBlockArray = NULL)