### PR TITLE
getRelativePathFromID: 'false' instead of error

### DIFF
--- a/web/concrete/src/File/File.php
+++ b/web/concrete/src/File/File.php
@@ -176,11 +176,17 @@ class File implements \Concrete\Core\Permission\ObjectInterface
         }
 
         $f = static::getByID($fID);
-        $path = $f->getRelativePath();
 
-        CacheLocal::set('file_relative_path', $fID, $path);
-        return $path;
+        if ($f) {
+            $path = $f->getRelativePath();
+
+            CacheLocal::set('file_relative_path', $fID, $path);
+            return $path;
+        }
+
+        return false;
     }
+
 
     protected function save()
     {


### PR DESCRIPTION
If you call 'getRelativePathFromID' for a non-existing fID, the file would evaluate to NULL, and you can't get a relative path from NULL -> this would result in a fatal error. I've added code to return 'false' in such cases instead. This kind of behavior could happen if you've transferred the database but not the files itself. The previous behavior would make the whole page inoperable/inaccessible, the new behavior doesn't.