### PR TITLE
Check task permission if the user can view group tree

### DIFF
--- a/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
+++ b/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
@@ -1,9 +1,6 @@
 <?php
 namespace Concrete\Core\Permission\Response;
 
-use User;
-use Group;
-use PermissionKey;
 use TaskPermission;
 
 class GroupTreeNodeResponse extends TreeNodeResponse

--- a/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
+++ b/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
@@ -1,10 +1,9 @@
 <?php
 namespace Concrete\Core\Permission\Response;
-use Page;
 use User;
 use Group;
 use PermissionKey;
-use Permissions;
+use TaskPermission;
 class GroupTreeNodeResponse extends TreeNodeResponse {
 
 	public function canEditTreeNodePermissions() {
@@ -12,9 +11,8 @@ class GroupTreeNodeResponse extends TreeNodeResponse {
 	}
 
 	public function canViewTreeNode() {
-		$c = Page::getByPath('/dashboard/users/groups');
-		$cp = new Permissions($c);
-		return $cp->canViewPage();
+		$tp = new TaskPermission();
+		return $tp->canAccessGroupSearch();
 	}
 
 	public function canDuplicateTreeNode() {

--- a/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
+++ b/web/concrete/src/Permission/Response/GroupTreeNodeResponse.php
@@ -1,34 +1,41 @@
 <?php
 namespace Concrete\Core\Permission\Response;
+
 use User;
 use Group;
 use PermissionKey;
 use TaskPermission;
-class GroupTreeNodeResponse extends TreeNodeResponse {
 
-	public function canEditTreeNodePermissions() {
-		return $this->validate('edit_group_permissions');
-	}
+class GroupTreeNodeResponse extends TreeNodeResponse
+{
+    public function canEditTreeNodePermissions()
+    {
+        return $this->validate('edit_group_permissions');
+    }
 
-	public function canViewTreeNode() {
-		$tp = new TaskPermission();
-		return $tp->canAccessGroupSearch();
-	}
+    public function canViewTreeNode()
+    {
+        $tp = new TaskPermission();
+        return $tp->canAccessGroupSearch();
+    }
 
-	public function canDuplicateTreeNode() {
-		return false;
-	}
+    public function canDuplicateTreeNode()
+    {
+        return false;
+    }
 
-	public function canEditTreeNode() {
-		return $this->validate('edit_group');
-	}
+    public function canEditTreeNode()
+    {
+        return $this->validate('edit_group');
+    }
 
-	public function canAddTreeSubNode() {
-		return $this->validate('add_sub_group');
-	}
+    public function canAddTreeSubNode()
+    {
+        return $this->validate('add_sub_group');
+    }
 
-	public function canDeleteTreeNode() {
-		return false;
-	}
-
+    public function canDeleteTreeNode()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
I'd like to give the permission to access to group tree to my user, but I have to change "Access Group Search" permission and the view permission of "User Groups" page. This is annoying. I believe concrete5 should check only "Access Group Search" permission.