### PR TITLE
Fix scaling of avatars fetched from Gravatar

### DIFF
--- a/web/concrete/src/Application/Service/Avatar.php
+++ b/web/concrete/src/Application/Service/Avatar.php
@@ -31,7 +31,7 @@ class Avatar
             } elseif (Config::get('concrete.user.gravatar.enabled')) {
                 return $this->get_gravatar(
                     $uo->getUserEmail(),
-                    Config::get('concrete.icons.user_avatar.width'),
+                    Config::get('concrete.icons.user_avatar.width') * $aspectRatio,
                     Config::get('concrete.user.gravatar.image_set'),
                     Config::get('concrete.user.gravatar.max_level'),
                     true,


### PR DESCRIPTION
The aspect ratio was only applied to avatars uploaded directly to concrete5, but should also be applied to avatars loaded via Gravatar.