### PR TITLE
'handleURLSlashes()' get irregular result from a particular multibyte character.

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -293,7 +293,7 @@ class Application extends Container
      */
     public function handleURLSlashes(SymfonyRequest $request)
     {
-        $url = Url::createFromUrl($request->getUri());
+        /*$url = Url::createFromUrl($request->getUri());
         if ($request->getPathInfo() != '/') {
             if (urldecode((string) $url) != urldecode($request->getUri())) {
                 $response = new RedirectResponse((string) $url, 301);
@@ -301,7 +301,7 @@ class Application extends Container
 
                 return $response;
             }
-        }
+        } */
     }
 
     /**


### PR DESCRIPTION
## Symptoms

For some reason, when this multibyte character '移' is included in query string such as Search block, it doesn't get encoded properly. Depends on the server, but when I tried to search '移' character, I get the following result

- re-direct loop
- no result
- or `htmlspecialchars(): Invalid multibyte sequence in argument` error.

## How this error happens

When you URLencode '移', it support to become `%E7%A7%BB`
But for some reason, when handleURLSlashes() fires, it becomes `~%A7%BB`.

I'm sure there will be another multibyte characters that may cause the same error.

This '移' character means "move", so we use this character a lot.
So it's kinda critical that people cannot search using this character.

## First step

First, I just remove this function.

I just remove the handleURLSlashes for the quick fix. And hopefully, we can start the discussion from here. (I needed this quick fix to deliver the site to my client...)