### PR TITLE
Fix presets managing

### DIFF
--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -153,11 +153,11 @@ return array(
         "/ccm/system/dialogs/area/design/"                                              => array('\Concrete\Controller\Dialog\Area\Design::view'),
         "/ccm/system/dialogs/area/design/reset"                                         => array('\Concrete\Controller\Dialog\Area\Design::reset'),
         "/ccm/system/dialogs/area/design/submit"                                        => array('\Concrete\Controller\Dialog\Area\Design::submit'),
+        "/ccm/system/dialogs/area/layout/presets/manage/"                               => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::view'),
+        "/ccm/system/dialogs/area/layout/presets/manage/delete"                         => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::delete'),
         "/ccm/system/dialogs/area/layout/presets/{arLayoutID}"                          => array('\Concrete\Controller\Dialog\Area\Layout\Presets::view'),
         "/ccm/system/dialogs/area/layout/presets/{arLayoutID}/submit"                   => array('\Concrete\Controller\Dialog\Area\Layout\Presets::submit'),
         "/ccm/system/dialogs/area/layout/presets/get/{cID}/{arLayoutPresetID}"                => array('\Concrete\Controller\Dialog\Area\Layout\Presets::getPresetData'),
-        "/ccm/system/dialogs/area/layout/presets/manage/"                               => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::view'),
-        "/ccm/system/dialogs/area/layout/presets/manage/delete"                         => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::delete'),
 
         "/ccm/system/dialogs/block/aliasing/"                                           => array('\Concrete\Controller\Dialog\Block\Aliasing::view'),
         "/ccm/system/dialogs/block/aliasing/submit"                                     => array('\Concrete\Controller\Dialog\Block\Aliasing::submit'),

--- a/web/concrete/controllers/dialog/area/layout/presets/manage.php
+++ b/web/concrete/controllers/dialog/area/layout/presets/manage.php
@@ -3,7 +3,7 @@ namespace Concrete\Controller\Dialog\Area\Layout\Presets;
 
 use Concrete\Controller\Dialog\Area\Layout\Presets;
 use Concrete\Core\Area\Layout\Layout;
-use Concrete\Core\Area\Layout\Preset;
+use Concrete\Core\Area\Layout\Preset\UserPreset;
 use Concrete\Core\Page\EditResponse;
 use Exception;
 
@@ -14,14 +14,14 @@ class Manage extends Presets
 
     public function view()
     {
-        $presets = Preset::getList();
+        $presets = UserPreset::getList();
         $this->set('presets', $presets);
     }
 
     public function delete()
     {
         if ($this->validateAction()) {
-            $preset = Preset::getByID($this->request->request('arLayoutPresetID'));
+            $preset = UserPreset::getByID($this->request->request('arLayoutPresetID'));
             if (!is_object($preset)) {
                 throw new Exception(t('Invalid layout preset object.'));
             }


### PR DESCRIPTION
Two errors fixed here (one per commit):
1. The route `/ccm/system/dialogs/area/layout/presets/manage` should be defined before `/ccm/system/dialogs/area/layout/presets/{arLayoutID}`, otherwise the latter gets executed before the former
2. **not sure about this** `Concrete\Core\Area\Layout\Preset` does not exist. Maybe it could be `Concrete\Core\Area\Layout\Preset\UserPreset`