### PR TITLE
Override URL Query component

### DIFF
--- a/tests/tests/Core/Url/Components/QueryTest.php
+++ b/tests/tests/Core/Url/Components/QueryTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Concrete\Tests\Core\Url\Components;
+
+use Concrete\Core\Url\Components\Query;
+
+class QueryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $query = new Query('?foo=bar');
+        $this->assertEquals('foo=bar', (string) $query);
+        
+        $query = new Query('?query=移設');
+        $this->assertEquals('query=%E7%A7%BB%E8%A8%AD', (string) $query);
+    }
+    
+    public function testToStringFromArray()
+    {
+        $query = new Query('?foo[]=a&foo[]=b&foo[]=c&bar=d');
+        $this->assertEquals('foo%5B%5D=a&foo%5B%5D=b&foo%5B%5D=c&bar=d', (string) $query);
+    }
+}

--- a/web/concrete/src/Url/Components/Query.php
+++ b/web/concrete/src/Url/Components/Query.php
@@ -20,7 +20,7 @@ class Query extends \League\Url\Components\Query
         foreach ($this->data as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $val) {
-                    $pairs[] = rawurlencode($key).'='.rawurlencode($value);
+                    $pairs[] = rawurlencode($key.'[]').'='.rawurlencode($val);
                 }
             } else {
                 $pairs[] = rawurlencode($key).'='.rawurlencode($value);

--- a/web/concrete/src/Url/Components/Query.php
+++ b/web/concrete/src/Url/Components/Query.php
@@ -1,0 +1,31 @@
+<?php
+namespace Concrete\Core\Url\Components;
+
+/**
+ * c5 specific query component for league/query
+ */
+class Query extends \League\Url\Components\Query
+{
+    /**
+     * {@inheritdoc}
+     * Why we override this method? See: {@link  https://github.com/concrete5/concrete5/pull/2626}
+     */
+    public function get()
+    {
+        if (!$this->data) {
+            return null;
+        }
+        
+        $pairs = array();
+        foreach ($this->data as $key => $value) {
+            if (is_array($value)) {
+                foreach ($value as $val) {
+                    $pairs[] = rawurlencode($key).'='.rawurlencode($value);
+                }
+            } else {
+                $pairs[] = rawurlencode($key).'='.rawurlencode($value);
+            }
+        }
+        return implode('&', $pairs);
+    }
+}

--- a/web/concrete/src/Url/Url.php
+++ b/web/concrete/src/Url/Url.php
@@ -70,7 +70,7 @@ class Url extends \League\Url\Url implements UrlInterface
             new        \League\Url\Components\Host($components['host']),
             new        \League\Url\Components\Port($components['port']),
             new \Concrete\Core\Url\Components\Path($components['path'], $trailing_slashes),
-            new       \League\Url\Components\Query($components['query']),
+            new       \Concrete\Core\Url\Components\Query($components['query']),
             new    \League\Url\Components\Fragment($components['fragment'])
         );
     }


### PR DESCRIPTION
Because league query component can not treats multibyte url queries in some cases. Detail of the issue is here: https://github.com/concrete5/concrete5/pull/2626