### PR TITLE
Faster tests

### DIFF
--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -1,27 +1,30 @@
 <?php
-class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
 
+class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
+{
     /** @var PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection */
-	private static $conn = null;
-	protected $tables = array();
+    private static $conn = null;
+    protected $tables = array();
 
-	protected function appendXML($root, $new) {
-		$node = $root->addChild($new->getName(), (string) $new);
-		foreach($new->attributes() as $attr => $value) {
-			$node->addAttribute($attr, $value);
-		}
-		foreach($new->children() as $ch) {
-			$this->appendXML($node, $ch);
-		}
-	}
+    protected function appendXML($root, $new)
+    {
+        $node = $root->addChild($new->getName(), (string) $new);
+        foreach ($new->attributes() as $attr => $value) {
+            $node->addAttribute($attr, $value);
+        }
+        foreach ($new->children() as $ch) {
+            $this->appendXML($node, $ch);
+        }
+    }
 
     protected function debug()
     {
         \Database::get()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
     }
 
-	public function getConnection() {
-	    if (self::$conn === null) {
+    public function getConnection()
+    {
+        if (self::$conn === null) {
             $config = \Config::get('database');
             $connection_config = $config['connections'][$config['default-connection']];
             $db = Database::getFactory()->createConnection(
@@ -29,92 +32,89 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
                 'host' => $connection_config['server'],
                 'user' => $connection_config['username'],
                 'password' => $connection_config['password'],
-                'database' => $connection_config['database']
+                'database' => $connection_config['database'],
             ));
             self::$conn = $this->createDefaultDBConnection($db->getWrappedConnection(), 'test');
             $this->db = $db;
-
-	    }
-	    return self::$conn;
-	}
-
-	public function getDataSet($fixtures = array()) {
-		$db = Database::get();
-		if (count($this->tables)) {
-			$partial = new SimpleXMLElement('<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5" />');
-
-			$xml = simplexml_load_file(DIR_BASE_CORE . '/config/db.xml');
-			foreach($xml->table as $t) {
-				$name = (string) $t['name'];
-				if (in_array($name, $this->tables)) {
-					$this->appendXML($partial, $t);
-				}
-			}
-
-			$schema = \Concrete\Core\Database\Schema\Schema::loadFromXMLElement($partial, $db);
-			$platform = $db->getDatabasePlatform();
-			$queries = $schema->toSql($platform);
-			foreach($queries as $query) {
-				$db->query($query);
-			}
-
-		}
-
-		if (empty($fixtures)) {
-			$fixtures = $this->fixtures;
-		}
-
-		$reflectionClass = new ReflectionClass(get_called_class());
-		$fixturePath = dirname($reflectionClass->getFilename()) . DIRECTORY_SEPARATOR . 'fixtures';
-		$compositeDs = new PHPUnit_Extensions_Database_DataSet_CompositeDataSet(array());
-
-		foreach ((array)$fixtures as $fixture) {
-			$path = $fixturePath . DIRECTORY_SEPARATOR . "$fixture.xml";
-			$ds = $this->createMySQLXMLDataSet($path);
-			$compositeDs->addDataSet($ds);
-		}
-        if(in_array('BlockTypes', $this->tables)) {
-			$xml = simplexml_load_file(DIR_BASE_CORE . '/blocks/core_scrapbook_display/db.xml');
-			$schema = \Concrete\Core\Database\Schema\Schema::loadFromXMLElement($xml, $db);
-			$platform = $db->getDatabasePlatform();
-			$queries = $schema->toSql($platform);
-			foreach($queries as $query) {
-				$db->query($query);
-			}
-
         }
-		return $compositeDs;
-	}
 
+        return self::$conn;
+    }
 
-	public function tearDown() {
-		if (count($this->tables)) {
-            if(in_array('BlockTypes', $this->tables)) {
-				$this->tables[] = 'btCoreScrapbookDisplay';
+    public function getDataSet($fixtures = array())
+    {
+        $db = Database::get();
+        if (count($this->tables)) {
+            $partial = new SimpleXMLElement('<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5" />');
+
+            $xml = simplexml_load_file(DIR_BASE_CORE . '/config/db.xml');
+            foreach ($xml->table as $t) {
+                $name = (string) $t['name'];
+                if (in_array($name, $this->tables)) {
+                    $this->appendXML($partial, $t);
+                }
             }
 
-			foreach ($this->tables as $table) {
-				// drop table
-				$conn = $this->getConnection();
-				$pdo = $conn->getConnection();
-				$pdo->exec("DROP TABLE IF EXISTS `$table`;");
-			}
-		}
+            $schema = \Concrete\Core\Database\Schema\Schema::loadFromXMLElement($partial, $db);
+            $platform = $db->getDatabasePlatform();
+            $queries = $schema->toSql($platform);
+            foreach ($queries as $query) {
+                $db->query($query);
+            }
+        }
 
-		$allTables = $this->getDataSet($this->fixtures)->getTableNames();
-		foreach ($allTables as $table) {
-			// drop table
-			$conn = $this->getConnection();
-			$pdo = $conn->getConnection();
-			$pdo->exec("DROP TABLE IF EXISTS `$table`;");
-		}
+        if (empty($fixtures)) {
+            $fixtures = $this->fixtures;
+        }
+
+        $reflectionClass = new ReflectionClass(get_called_class());
+        $fixturePath = dirname($reflectionClass->getFilename()) . DIRECTORY_SEPARATOR . 'fixtures';
+        $compositeDs = new PHPUnit_Extensions_Database_DataSet_CompositeDataSet(array());
+
+        foreach ((array) $fixtures as $fixture) {
+            $path = $fixturePath . DIRECTORY_SEPARATOR . "$fixture.xml";
+            $ds = $this->createMySQLXMLDataSet($path);
+            $compositeDs->addDataSet($ds);
+        }
+        if (in_array('BlockTypes', $this->tables)) {
+            $xml = simplexml_load_file(DIR_BASE_CORE . '/blocks/core_scrapbook_display/db.xml');
+            $schema = \Concrete\Core\Database\Schema\Schema::loadFromXMLElement($xml, $db);
+            $platform = $db->getDatabasePlatform();
+            $queries = $schema->toSql($platform);
+            foreach ($queries as $query) {
+                $db->query($query);
+            }
+        }
+
+        return $compositeDs;
+    }
+
+    public function tearDown()
+    {
+        if (count($this->tables)) {
+            if (in_array('BlockTypes', $this->tables)) {
+                $this->tables[] = 'btCoreScrapbookDisplay';
+            }
+
+            foreach ($this->tables as $table) {
+                // drop table
+                $conn = $this->getConnection();
+                $pdo = $conn->getConnection();
+                $pdo->exec("DROP TABLE IF EXISTS `$table`;");
+            }
+        }
+
+        $allTables = $this->getDataSet($this->fixtures)->getTableNames();
+        foreach ($allTables as $table) {
+            // drop table
+            $conn = $this->getConnection();
+            $pdo = $conn->getConnection();
+            $pdo->exec("DROP TABLE IF EXISTS `$table`;");
+        }
 
         $db = Loader::db();
         $db->getEntityManager()->clear();
 
         parent::tearDown();
-	}
-
-
-
+    }
 }

--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -2,7 +2,7 @@
 class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
 
     /** @var PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection */
-	private $conn = null;
+	private static $conn = null;
 	protected $tables = array();
 
 	protected function appendXML($root, $new) {
@@ -21,7 +21,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
     }
 
 	public function getConnection() {
-	    if ($this->conn === null) {
+	    if (self::$conn === null) {
             $config = \Config::get('database');
             $connection_config = $config['connections'][$config['default-connection']];
             $db = Database::getFactory()->createConnection(
@@ -31,11 +31,11 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
                 'password' => $connection_config['password'],
                 'database' => $connection_config['database']
             ));
-            $this->conn = $this->createDefaultDBConnection($db->getWrappedConnection(), 'test');
+            self::$conn = $this->createDefaultDBConnection($db->getWrappedConnection(), 'test');
             $this->db = $db;
 
 	    }
-	    return $this->conn;
+	    return self::$conn;
 	}
 
 	public function getDataSet($fixtures = array()) {
@@ -111,11 +111,6 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase {
 
         $db = Loader::db();
         $db->getEntityManager()->clear();
-		Database::purge();
-
-        if ($this->conn) {
-            $this->conn = null;
-        }
 
         parent::tearDown();
 	}


### PR DESCRIPTION
Let's avoid to open and close the database connection at every test.

This makes the whole test suite running 6x faster (from 9 minutes to 1 minute and half on my development machine).