### PR TITLE
Display last used authentication type if authentication fails

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -120,6 +120,11 @@ class Login extends PageController
                 $this->error->add($e->getMessage());
             }
         }
+
+        if (isset($at)) {
+            $this->set('lastAuthType', $at);
+        }
+
         $this->view();
     }
 

--- a/web/concrete/single_pages/login.php
+++ b/web/concrete/single_pages/login.php
@@ -201,6 +201,15 @@ $attribute_mode = (isset($required_attributes) && count($required_attributes));
                 $('div.authTypes > div').hide().filter('[data-authType="' + at + '"]').show();
                 return false;
             });
+
+            <?php
+            if (isset($lastAuthType)) {
+                ?>
+                $("ul.auth-types > li[data-handle='<?= $lastAuthType->getAuthenticationTypeHandle() ?>']")
+                    .trigger("click");
+                <?php
+            }
+            ?>
         })(jQuery);
     </script>
 </div>


### PR DESCRIPTION
If you fail to authenticate with an authentication type that is not the default the default authentication form is displayed when the page is reloaded. This makes the authentication type last used display instead.