### PR TITLE
Fix duration repetition and tests

### DIFF
--- a/tests/tests/Core/Permission/DurationTest.php
+++ b/tests/tests/Core/Permission/DurationTest.php
@@ -10,6 +10,15 @@ use Concrete\Core\Permission\Duration;
 class DurationTest extends \PHPUnit_Framework_TestCase
 {
 
+    private static function getFarYear($wanted)
+    {
+        static $limitTo32bits;
+        if (!isset($limitTo32bits)) {
+            $limitTo32bits = @strtotime('2300-01-01') === false;
+        }
+        return $limitTo32bits ? min($wanted, 2037) : $wanted;
+    }
+
     public function testDailyRecurring()
     {
         $now = strtotime('2/13/2014');
@@ -68,7 +77,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
 
         $weekly_weeekday_repetition->setRepeatEveryNum(1);
 
-        $test_time = strtotime('last saturday of december 3500');
+        $test_time = strtotime('last saturday of december '.self::getFarYear(3500));
         $test_time = strtotime('3:00:00', $test_time);
 
         $this->assertTrue($weekly_weeekday_repetition->isActive($test_time));
@@ -93,7 +102,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
         $weekly_repetition->setRepeatEveryNum(1);
 
         $dow = date('l', $now);
-        $test_time = strtotime("last {$dow} of december 3500");
+        $test_time = strtotime("last {$dow} of december ".self::getFarYear(3500));
         $test_time = strtotime('3:00:00', $test_time);
 
         $this->assertTrue($weekly_repetition->isActive($test_time));
@@ -117,7 +126,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $monthly_ldotw_repetition->isActive(
-                strtotime(date('Y-m-d 01:30:00', strtotime('last monday of march 2205')))));
+                strtotime(date('Y-m-d 01:30:00', strtotime('last monday of march '.self::getFarYear(2205))))));
 
         // -- Weekly
         $monthly_weekly_repetition = new Duration();
@@ -133,7 +142,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $monthly_weekly_repetition->isActive(
-                strtotime(date('Y-m-d 01:30:00', strtotime('second saturday of march 2205')))));
+                strtotime(date('Y-m-d 01:30:00', strtotime('second saturday of march '.self::getFarYear(2205))))));
 
         // -- Monthly
         $monthly_weekly_repetition = new Duration();

--- a/tests/tests/Core/Permission/DurationTest.php
+++ b/tests/tests/Core/Permission/DurationTest.php
@@ -202,7 +202,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
                 break;
             }
 
-            if ($window[0] !== $occurrence[0] || $window[1] !== $occurrence[1]) {
+            if ($window[0] != $occurrence[0] || $window[1] != $occurrence[1]) {
                 $all_active = false;
                 break;
             }
@@ -236,7 +236,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
                 break;
             }
 
-            if ($window[0] !== $occurrence[0] || $window[1] !== $occurrence[1]) {
+            if ($window[0] != $occurrence[0] || $window[1] != $occurrence[1]) {
                 $all_active = false;
                 break;
             }
@@ -269,7 +269,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
                 break;
             }
 
-            if ($window[0] !== $occurrence[0] || $window[1] !== $occurrence[1]) {
+            if ($window[0] != $occurrence[0] || $window[1] != $occurrence[1]) {
                 $all_active = false;
                 break;
             }
@@ -301,7 +301,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
                 break;
             }
 
-            if ($window[0] !== $occurrence[0] || $window[1] !== $occurrence[1]) {
+            if ($window[0] != $occurrence[0] || $window[1] != $occurrence[1]) {
                 $all_active = false;
                 break;
             }

--- a/tests/tests/Core/Permission/DurationTest.php
+++ b/tests/tests/Core/Permission/DurationTest.php
@@ -1,21 +1,22 @@
 <?php
+
 namespace tests\Core\Permission;
 
 use Concrete\Core\Permission\Duration;
 
 /**
  * Class DurationTest
- * Tests for `\Concrete\Core\Permission\Duration`
+ * Tests for `\Concrete\Core\Permission\Duration`.
  */
 class DurationTest extends \PHPUnit_Framework_TestCase
 {
-
     private static function getFarYear($wanted)
     {
         static $limitTo32bits;
         if (!isset($limitTo32bits)) {
             $limitTo32bits = @strtotime('2300-01-01') === false;
         }
+
         return $limitTo32bits ? min($wanted, 2037) : $wanted;
     }
 
@@ -158,7 +159,6 @@ class DurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($monthly_weekly_repetition->isActive(strtotime(date('Y-m-21 01:50:00', time()))));
     }
-
 
     public function testGenerateSingle()
     {
@@ -308,5 +308,4 @@ class DurationTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue($all_active, 'EventOccurrenceFactory generated inactive occurrences.');
     }
-
 }

--- a/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Concrete\Core\Foundation\Repetition;
 
 /**
  * Abstract repetition class
- * This class is used to define and match against various time windows
+ * This class is used to define and match against various time windows.
  *
  * @package Concrete\Core\Foundation\Repetition
  */
 abstract class AbstractRepetition implements RepetitionInterface
 {
-
     /**
      * @var string Date string of the start date/time
      */
@@ -69,10 +69,9 @@ abstract class AbstractRepetition implements RepetitionInterface
     }
 
     /**
-     * Toggle whether `start_date` is all day
+     * Toggle whether `start_date` is all day.
      *
      * @param bool $start_date_all_day
-     * @return void
      */
     public function setStartDateAllDay($start_date_all_day)
     {
@@ -88,10 +87,9 @@ abstract class AbstractRepetition implements RepetitionInterface
     }
 
     /**
-     * Toggle whether `end_date` is all day
+     * Toggle whether `end_date` is all day.
      *
      * @param bool $end_date_all_day
-     * @return void
      */
     public function setEndDateAllDay($end_date_all_day)
     {
@@ -100,6 +98,7 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     /**
      * @param int|null $now The timestamp to check against
+     *
      * @return bool
      */
     public function isActive($now = null)
@@ -133,7 +132,7 @@ abstract class AbstractRepetition implements RepetitionInterface
             if (is_object($end_date_object)) {
                 $end_time = $end_date_object->getTimestamp();
             }
-            if (!$start_date ) {
+            if (!$start_date) {
                 return null;
             }
             if ($start_date && $start_time > $now) {
@@ -210,7 +209,6 @@ abstract class AbstractRepetition implements RepetitionInterface
                                 if ($now >= $dailyTimeStart && $now <= $dailyTimeEnd) {
                                     return $this->rangeFromTime($dailyTimeStart);
                                 }
-
                             }
                         } else {
                             if ($dow <= $endDOW && $dow >= $startDOW) {
@@ -261,7 +259,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                     $month = date('m', $start_datetime->getTimestamp());
                     $wotm_timestamp = $start_datetime->getTimestamp();
                     do {
-                        $wotm++;
+                        ++$wotm;
                         $wotm_timestamp = strtotime('-1 week', $wotm_timestamp);
                     } while (date('m', $wotm_timestamp) === $month);
 
@@ -282,7 +280,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                                 $now_month = date('m', $start_datetime->getTimestamp());
                                 $wotm_timestamp = $start_datetime->getTimestamp();
                                 do {
-                                    $now_wotm++;
+                                    ++$now_wotm;
                                     $wotm_timestamp = strtotime('-1 week', $wotm_timestamp);
                                 } while (date('m', $wotm_timestamp) === $now_month);
 
@@ -316,7 +314,6 @@ abstract class AbstractRepetition implements RepetitionInterface
                     }
                     break;
             }
-
         }
 
         return null;
@@ -352,7 +349,6 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     /**
      * @param int $repeat_period [ ::REPEAT_DAILY | ::REPEAT_WEEKLY | ::REPEAT_MONTHLY ]
-     * @return void
      */
     public function setRepeatPeriod($repeat_period)
     {
@@ -368,10 +364,9 @@ abstract class AbstractRepetition implements RepetitionInterface
     }
 
     /**
-     * Set the start date
+     * Set the start date.
      *
      * @param $start_date
-     * @return void
      */
     public function setStartDate($start_date)
     {
@@ -387,10 +382,9 @@ abstract class AbstractRepetition implements RepetitionInterface
     }
 
     /**
-     * Set the end date
+     * Set the end date.
      *
      * @param $end_date
-     * @return void
      */
     public function setEndDate($end_date)
     {
@@ -402,6 +396,7 @@ abstract class AbstractRepetition implements RepetitionInterface
         if (!$end) {
             $end = $start + (strtotime($this->getEndDate()) - strtotime($this->getStartDate()));
         }
+
         return array($start, $end);
     }
 
@@ -415,7 +410,6 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     /**
      * @param $repeat_period_end
-     * @return void
      */
     public function setRepeatPeriodEnd($repeat_period_end)
     {
@@ -432,7 +426,6 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     /**
      * @param $repeat_every_num
-     * @return void
      */
     public function setRepeatEveryNum($repeat_every_num)
     {
@@ -444,12 +437,11 @@ abstract class AbstractRepetition implements RepetitionInterface
      */
     public function getRepeatPeriodWeekDays()
     {
-        return (array)$this->repeatPeriodWeekDays;
+        return (array) $this->repeatPeriodWeekDays;
     }
 
     /**
      * @param int[] $repeat_period_week_days
-     * @return void
      */
     public function setRepeatPeriodWeekDays($repeat_period_week_days)
     {
@@ -466,7 +458,6 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     /**
      * @param int $repeat_month_by [ ::MONTHLY_REPEAT_WEEKLY | ::MONTHLY_REPEAT_MONTHLY | ::MONTHLY_REPEAT_LAST_WEEKDAY ]
-     * @return void
      */
     public function setRepeatMonthBy($repeat_month_by)
     {
@@ -478,7 +469,7 @@ abstract class AbstractRepetition implements RepetitionInterface
      */
     public function getTextRepresentation()
     {
-        return (string)$this;
+        return (string) $this;
     }
 
     public function __toString()
@@ -504,7 +495,7 @@ abstract class AbstractRepetition implements RepetitionInterface
     }
 
     /**
-     * This method is deprecated, use `getRepeatEveryNum`
+     * This method is deprecated, use `getRepeatEveryNum`.
      *
      * @deprecated
      */
@@ -532,6 +523,7 @@ abstract class AbstractRepetition implements RepetitionInterface
     /**
      * @param int $start
      * @param int $end
+     *
      * @return array[]
      */
     public function activeRangesBetween($start, $end)
@@ -621,7 +613,8 @@ abstract class AbstractRepetition implements RepetitionInterface
                             if ($day_of_the_week >= $start && $day_of_the_week <= $end) {
                                 $occurrences[] = array(
                                     $day_of_the_week,
-                                    $day_of_the_week + $repetition_end - $repetition_start);
+                                    $day_of_the_week + $repetition_end - $repetition_start,
+                                );
                             }
                         }
 
@@ -655,7 +648,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                             $wotm_step = $repetition_start_datetime->getTimestamp();
 
                             do {
-                                $wotm++;
+                                ++$wotm;
                                 $wotm_step = strtotime('-1 week', $wotm_step);
                             } while (date('m', $wotm_step) === $month);
 
@@ -674,7 +667,8 @@ abstract class AbstractRepetition implements RepetitionInterface
                                     if (date('m', $occurrence_start) === date('m', $current_datetime->getTimestamp())) {
                                         $occurrences[] = array(
                                             $occurrence_start,
-                                            $occurrence_start + $repetition_end - $repetition_start);
+                                            $occurrence_start + $repetition_end - $repetition_start,
+                                        );
                                     }
                                 }
 
@@ -694,7 +688,8 @@ abstract class AbstractRepetition implements RepetitionInterface
                                 if ($occurrence_start && $occurrence_start >= $start && $occurrence_start <= $end) {
                                     $occurrences[] = array(
                                         $occurrence_start,
-                                        $occurrence_start + $repetition_end - $repetition_start);
+                                        $occurrence_start + $repetition_end - $repetition_start,
+                                    );
                                 }
 
                                 $current_datetime->add($interval);
@@ -715,7 +710,8 @@ abstract class AbstractRepetition implements RepetitionInterface
                                     if (date('m', $occurrence_start) === date('m', $current_datetime->getTimestamp())) {
                                         $occurrences[] = array(
                                             $occurrence_start,
-                                            $occurrence_start + $repetition_end - $repetition_start);
+                                            $occurrence_start + $repetition_end - $repetition_start,
+                                        );
                                     }
                                 }
 
@@ -726,7 +722,6 @@ abstract class AbstractRepetition implements RepetitionInterface
                     }
 
             }
-
         }
 
         return $occurrences;
@@ -735,6 +730,7 @@ abstract class AbstractRepetition implements RepetitionInterface
     protected function getDayString($day)
     {
         $days = array('Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday');
+
         return array_get($days, $day);
     }
 
@@ -750,6 +746,7 @@ abstract class AbstractRepetition implements RepetitionInterface
     {
         $fromUTC = new \DateTime($from->format('Y-m-d\TH:i:s+00:00'));
         $toUTC = new \DateTime($to->format('Y-m-d\TH:i:s+00:00'));
+
         return $fromUTC->diff($toUTC);
     }
 }

--- a/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -181,7 +181,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                     $now_time->setTimestamp($now);
 
                     $week_diff_start = new \DateTime();
-                    if (($days_past_sunday = date('w', $start_time->getTimestamp())) !== 0) {
+                    if (($days_past_sunday = date('w', $start_time->getTimestamp())) != 0) {
                         $week_diff_start->setTimestamp(
                             strtotime("-{$days_past_sunday} days", $start_time->getTimestamp()));
                     } else {
@@ -189,7 +189,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                     }
 
                     $week_diff_now = new \DateTime();
-                    if (($days_past_sunday = date('w', $now_time->getTimestamp())) !== 0) {
+                    if (($days_past_sunday = date('w', $now_time->getTimestamp())) != 0) {
                         $week_diff_now->setTimestamp(strtotime("-{$days_past_sunday} days", $now_time->getTimestamp()));
                     } else {
                         $week_diff_now->setTimestamp($now_time->getTimestamp());

--- a/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -252,7 +252,7 @@ abstract class AbstractRepetition implements RepetitionInterface
                         date("Y-m-01 {$start_datetime_time}", $now_datetime->getTimestamp()));
                     $normalized_start_datetime = new \DateTime(date("Y-m-01 H:i:s", $start_datetime->getTimestamp()));
 
-                    $diff = $normalized_now_datetime->diff($normalized_start_datetime);
+                    $diff = $this->dateDiffNoDST($normalized_now_datetime, $normalized_start_datetime);
                     $month_difference = $diff->m + ($diff->y * 12);
 
                     $checkTime = false;
@@ -738,4 +738,18 @@ abstract class AbstractRepetition implements RepetitionInterface
         return array_get($days, $day);
     }
 
+    /**
+     * Returns the difference between two DateTime objects without considering DST changes.
+     *
+     * @param \DateTime $from
+     * @param \DateTime $to
+     *
+     * @return \DateInterval
+     */
+    protected function dateDiffNoDST(\DateTime $from, \DateTime $to)
+    {
+        $fromUTC = new \DateTime($from->format('Y-m-d\TH:i:s+00:00'));
+        $toUTC = new \DateTime($to->format('Y-m-d\TH:i:s+00:00'));
+        return $fromUTC->diff($toUTC);
+    }
 }


### PR DESCRIPTION
A few fixes here:
- [1st commit](https://github.com/concrete5/concrete5/commit/5be058ae8532d12bec8974b44c58add684f710cc): some installations don't support timestamps with more that 32 bits (so the max timestamp allowed is `Tue, 19 Jan 2038 03:14:07 UTC`), So, let's limit the "future" year in those systems while testing
- [2nd commit](https://github.com/concrete5/concrete5/commit/f55e2e63d3137aa7b202ffdea2039b6a52fd1c98): on the systems with timestamps limited to 32bits, we sometimes have `double` timestamps instead of `int` timestamps, so we have to compare timestamps with `==`/`!=` instead of `===`/`!==` (because with the strict operators comparing `double` with `int` always fails)
- [3rd commit](https://github.com/concrete5/concrete5/commit/928e7c940b86b52ed90f68b2cfe583c4fde3be59): the `date` function returns a string, so we need to use `==`/`!=` instead of `===`/`!==`when comparing its result with integers
- [4th commit](https://github.com/concrete5/concrete5/commit/148a562c6c8f5a4f0c4fdcb6a64a6e741da6d530): if the current timezone is not `UTC` we have wrong results from `AbstractRepetition::getActiveRange()` because of time changes caused by summer time/standard time differences. So, let's calculate the date/time differences in `UTC` "coordinates"