### PR TITLE
Declare Class Properties

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Block\BlockController;
@@ -12,15 +13,14 @@ use Permissions;
  *
  * @package    Blocks
  * @subpackage Auto-Nav
+ *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @author     Jordan Lev
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
- *
  */
 class Controller extends BlockController
 {
-
     public $collection;
     public $navArray = array();
     public $cParentIDArray = array();
@@ -43,7 +43,10 @@ class Controller extends BlockController
     protected $btWrapperClass = 'ccm-ui';
     protected $btExportPageColumns = array('displayPagesCID');
 
-    function __construct($obj = null)
+    public $cID;
+    public $cParentID;
+
+    public function __construct($obj = null)
     {
         if (is_object($obj)) {
             switch (strtolower(get_class($obj))) {
@@ -100,7 +103,7 @@ class Controller extends BlockController
         return t("Auto-Nav");
     }
 
-    function save($args)
+    public function save($args)
     {
         $args['displayPagesIncludeSelf'] = $args['displayPagesIncludeSelf'] ? 1 : 0;
         $args['displayPagesCID'] = $args['displayPagesCID'] ? $args['displayPagesCID'] : 0;
@@ -109,13 +112,14 @@ class Controller extends BlockController
         parent::save($args);
     }
 
-    function getContent()
+    public function getContent()
     {
         /* our templates expect a variable not an object */
         $con = array();
         foreach ($this as $key => $value) {
             $con[$key] = $value;
         }
+
         return $con;
     }
 
@@ -131,6 +135,7 @@ class Controller extends BlockController
         while ($row = $r->fetchRow()) {
             $pages[] = Page::getByID($row['cID'], 'ACTIVE');
         }
+
         return $pages;
     }
 
@@ -207,7 +212,7 @@ class Controller extends BlockController
         //Prep all data and put it into a clean structure so markup output is as simple as possible
         $navItems = array();
         $navItemCount = count($includedNavItems);
-        for ($i = 0; $i < $navItemCount; $i++) {
+        for ($i = 0; $i < $navItemCount; ++$i) {
             $ni = $includedNavItems[$i];
             $_c = $ni->getCollectionObject();
             $current_level = $ni->getLevel();
@@ -252,7 +257,7 @@ class Controller extends BlockController
 
             //Calculate if this is the last item in its level (useful for CSS classes)
             $is_last_in_level = true;
-            for ($j = $i + 1; $j < $navItemCount; $j++) {
+            for ($j = $i + 1; $j < $navItemCount; ++$j) {
                 if ($includedNavItems[$j]->getLevel() == $current_level) {
                     //we found a subsequent item at this level (before this level "ended"), so this is NOT the last in its level
                     $is_last_in_level = false;
@@ -303,7 +308,7 @@ class Controller extends BlockController
      * It also must exist as a separate function to preserve backwards-compatibility with older autonav templates.
      * Warning: this function has side-effects -- if this gets called twice, items will be duplicated in the nav structure!
      */
-    function generateNav()
+    public function generateNav()
     {
         if (isset($this->displayPagesCID) && !Loader::helper('validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
@@ -447,23 +452,23 @@ class Controller extends BlockController
                 array_unshift($this->navArray, $ni);
             }
             */
-
         }
 
         return $this->navArray;
     }
 
     /**
-     * heh. probably should've gone the simpler route and named this getGrandparentID()
+     * heh. probably should've gone the simpler route and named this getGrandparentID().
      */
-    function getParentParentID()
+    public function getParentParentID()
     {
         // this has to be the stupidest name of a function I've ever created. sigh
         $cParentID = Page::getCollectionParentIDFromChildID($this->cParentID);
+
         return ($cParentID) ? $cParentID : 0;
     }
 
-    function getParentAtLevel($level)
+    public function getParentAtLevel($level)
     {
         // this function works in the following way
         // we go from the current collection up to the top level. Then we find the parent Id at the particular level specified, and begin our
@@ -488,10 +493,9 @@ class Controller extends BlockController
     }
 
     /** Pupulates the $cParentIDArray instance property.
-     *
      * @param int $cID The collection id.
      */
-    function populateParentIDArray($cID)
+    public function populateParentIDArray($cID)
     {
         // returns an array of collection IDs going from the top level to the current item
         $cParentID = Page::getCollectionParentIDFromChildID($cID);
@@ -505,7 +509,7 @@ class Controller extends BlockController
         }
     }
 
-    function getNavigationArray($cParentID, $orderBy, $currentLevel)
+    public function getNavigationArray($cParentID, $orderBy, $currentLevel)
     {
         // increment all items in the nav array with a greater $currentLevel
 
@@ -571,9 +575,7 @@ class Controller extends BlockController
                         $_c = $ni->getCollectionObject();
                         $object_name = $_c->getCollectionName();
                         $navObjectNames[$niRow['cID']] = $object_name;
-
                     }
-
                 }
             }
             // end while -- sort navSort
@@ -721,13 +723,11 @@ class Controller extends BlockController
                 }
             }
             // End Joshua's Huge Sorting Crap
-
         }
     }
 
     protected function displayPage($tc)
     {
-
         if ($tc->isSystemPage() && (!$this->displaySystemPages)) {
             return false;
         }
@@ -751,5 +751,4 @@ class Controller extends BlockController
     {
         return $c->getAttribute('exclude_nav');
     }
-
 }

--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -1,52 +1,62 @@
-<?
+<?php
+
 namespace Concrete\Block\Content;
-use \Concrete\Core\Block\BlockController;
-use \Concrete\Core\Editor\LinkAbstractor;
+
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Editor\LinkAbstractor;
 
 /**
- * The controller for the content block.
- *
- * @package Blocks
- * @subpackage Content
- * @author Andrew Embler <andrew@concrete5.org>
- * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
- *
- */
-	class Controller extends BlockController {
+     * The controller for the content block.
+     *
+     * @package Blocks
+     * @subpackage Content
+     *
+     * @author Andrew Embler <andrew@concrete5.org>
+     * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
+     * @license    http://www.concrete5.org/license/     MIT License
+     */
+    class Controller extends BlockController
+    {
+        protected $btTable = 'btContentLocal';
+        protected $btInterfaceWidth = "600";
+        protected $btInterfaceHeight = "465";
+        protected $btCacheBlockRecord = true;
+        protected $btCacheBlockOutput = true;
+        protected $btCacheBlockOutputOnPost = true;
+        protected $btSupportsInlineEdit = true;
+        protected $btSupportsInlineAdd = true;
+        protected $btCacheBlockOutputForRegisteredUsers = false;
+        protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
-		protected $btTable = 'btContentLocal';
-		protected $btInterfaceWidth = "600";
-		protected $btInterfaceHeight = "465";
-		protected $btCacheBlockRecord = true;
-		protected $btCacheBlockOutput = true;
-		protected $btCacheBlockOutputOnPost = true;
-		protected $btSupportsInlineEdit = true;
-		protected $btSupportsInlineAdd = true;
-		protected $btCacheBlockOutputForRegisteredUsers = false;
-		protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
+        public $content;
 
-		public function getBlockTypeDescription() {
-			return t("HTML/WYSIWYG Editor Content.");
-		}
+        public function getBlockTypeDescription()
+        {
+            return t("HTML/WYSIWYG Editor Content.");
+        }
 
-		public function getBlockTypeName() {
-			return t("Content");
-		}
+        public function getBlockTypeName()
+        {
+            return t("Content");
+        }
 
-		function getContent() {
-			return LinkAbstractor::translateFrom($this->content);
-		}
+        public function getContent()
+        {
+            return LinkAbstractor::translateFrom($this->content);
+        }
 
-		public function getSearchableContent(){
-			return $this->content;
-		}
+        public function getSearchableContent()
+        {
+            return $this->content;
+        }
 
-		function br2nl($str) {
-			$str = str_replace("\r\n", "\n", $str);
-			$str = str_replace("<br />\n", "\n", $str);
-			return $str;
-		}
+        public function br2nl($str)
+        {
+            $str = str_replace("\r\n", "\n", $str);
+            $str = str_replace("<br />\n", "\n", $str);
+
+            return $str;
+        }
 
         public function registerViewAssets($outputContent)
         {
@@ -60,34 +70,36 @@ use \Concrete\Core\Editor\LinkAbstractor;
             $this->set('content', $this->getContent());
         }
 
-		function getContentEditMode() {
-			return LinkAbstractor::translateFromEditMode($this->content);
-		}
+        public function getContentEditMode()
+        {
+            return LinkAbstractor::translateFromEditMode($this->content);
+        }
 
-		public function getImportData($blockNode) {
-			$content = $blockNode->data->record->content;
-			$content = LinkAbstractor::import($content);
-			$args = array('content' => $content);
-			return $args;
-		}
+        public function getImportData($blockNode)
+        {
+            $content = $blockNode->data->record->content;
+            $content = LinkAbstractor::import($content);
+            $args = array('content' => $content);
 
-		public function export(\SimpleXMLElement $blockNode) {
-			$data = $blockNode->addChild('data');
-			$data->addAttribute('table', $this->btTable);
-			$record = $data->addChild('record');
-			$cnode = $record->addChild('content');
-			$node = dom_import_simplexml($cnode);
-			$no = $node->ownerDocument;
-			$content = LinkAbstractor::export($this->content);
-			$cdata = $no->createCDataSection($content);
-			$node->appendChild($cdata);
-		}
+            return $args;
+        }
 
-		function save($args) {
-			$args['content'] = LinkAbstractor::translateTo($args['content']);
-			parent::save($args);
-		}
+        public function export(\SimpleXMLElement $blockNode)
+        {
+            $data = $blockNode->addChild('data');
+            $data->addAttribute('table', $this->btTable);
+            $record = $data->addChild('record');
+            $cnode = $record->addChild('content');
+            $node = dom_import_simplexml($cnode);
+            $no = $node->ownerDocument;
+            $content = LinkAbstractor::export($this->content);
+            $cdata = $no->createCDataSection($content);
+            $node->appendChild($cdata);
+        }
 
-	}
-
-?>
+        public function save($args)
+        {
+            $args['content'] = LinkAbstractor::translateTo($args['content']);
+            parent::save($args);
+        }
+    }

--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -27,6 +27,9 @@ class Controller extends BlockController
     protected $btTable = 'btCoreAreaLayout';
     protected $btIsInternal = true;
 
+    public $arLayoutID;
+    public $arLayout;
+
     public function getBlockTypeDescription()
     {
         return t("Proxy block for area layouts.");

--- a/web/concrete/blocks/core_conversation/controller.php
+++ b/web/concrete/blocks/core_conversation/controller.php
@@ -15,6 +15,7 @@ use Page;
  *
  * @package Blocks
  * @subpackage Conversation
+ *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2013 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
@@ -29,6 +30,19 @@ class Controller extends BlockController implements ConversationFeatureInterface
     protected $btFeatures = array(
         'conversation',
     );
+
+    public $cnvID;
+    public $enablePosting;
+    public $paginate;
+    public $itemsPerPage;
+    public $displayMode;
+    public $orderBy;
+    public $enableOrdering;
+    public $enableCommentRating;
+    public $displayPostingForm;
+    public $addMessageLabel;
+    public $dateFormat;
+    public $customDateFormat;
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/dashboard_newsflow_latest/controller.php
+++ b/web/concrete/blocks/dashboard_newsflow_latest/controller.php
@@ -1,57 +1,61 @@
-<?
+<?php
+
 namespace Concrete\Block\DashboardNewsflowLatest;
-use Concrete\Controller\SinglePage\Dashboard\News;
-use Loader;
-use \Concrete\Core\Block\BlockController;
-use \Concrete\Core\Activity\Newsflow;
+
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Activity\Newsflow;
 
 /**
  * @property mixed $slot
  * Class Controller
+ *
  * @package Concrete\Block\DashboardNewsflowLatest
  */
-class Controller extends BlockController {
+class Controller extends BlockController
+{
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputLifetime = 7200;
+    protected $btTable = 'btDashboardNewsflowLatest';
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btIsInternal = true;
 
-	protected $btCacheBlockRecord = true;
-	protected $btCacheBlockOutput = true;
-	protected $btCacheBlockOutputOnPost = true;
-	protected $btCacheBlockOutputLifetime = 7200;
-	protected $btTable = 'btDashboardNewsflowLatest';
-	protected $btCacheBlockOutputForRegisteredUsers = true;
-	protected $btIsInternal = true;
-	
-	public function getBlockTypeDescription() {
-		return t("Grabs the latest newsflow data from concrete5.org.");
-	}
-	
-	public function getBlockTypeName() {
-		return t("Dashboard Newsflow Latest");
-	}
+    protected $slot;
 
-    public function view() {
+    public function getBlockTypeDescription()
+    {
+        return t("Grabs the latest newsflow data from concrete5.org.");
+    }
+
+    public function getBlockTypeName()
+    {
+        return t("Dashboard Newsflow Latest");
+    }
+
+    public function view()
+    {
         $newsflow = new Newsflow();
-		// get the latest data as well
-		$slots = $newsflow->getSlotContents();
-		$this->set('slot', $slots[$this->slot]);
-		
-		// this is kind of a hack
-		if ($this->slot == 'C') { 
-			$ni = false;
-			try
-			{
-				// in case we are not connected $ni will throw an exception ...
-				$ni = $newsflow->getEditionByPath('/newsflow');
-			}
-			catch ( \Exception $e ) {}
-			if ($ni !== false) {
-				$this->set('editionTitle', $ni->getTitle());
-				$this->set('editionDescription', $ni->getDescription());
-				$this->set('editionDate', $ni->getDate());
-				$this->set('editionID', $ni->getID());
-			} else {
-			
-			}
-		}
-	}
-	
+        // get the latest data as well
+        $slots = $newsflow->getSlotContents();
+        $this->set('slot', $slots[$this->slot]);
+        $this->set('sID', $this->slot);
+
+        // this is kind of a hack
+        if ($this->slot == 'C') {
+            $ni = false;
+            try {
+                // in case we are not connected $ni will throw an exception ...
+                $ni = $newsflow->getEditionByPath('/newsflow');
+            } catch (\Exception $e) {
+            }
+            if ($ni !== false) {
+                $this->set('editionTitle', $ni->getTitle());
+                $this->set('editionDescription', $ni->getDescription());
+                $this->set('editionDate', $ni->getDate());
+                $this->set('editionID', $ni->getID());
+            } else {
+            }
+        }
+    }
 }

--- a/web/concrete/blocks/dashboard_newsflow_latest/view.php
+++ b/web/concrete/blocks/dashboard_newsflow_latest/view.php
@@ -5,6 +5,6 @@
 </div>
 <? } ?>
 
-<? if ($controller->slot == 'C') { ?>
+<? if ($sID == 'C') { ?>
 	<div class="newsflow-paging-next"><a href="javascript:void(0)" onclick="ConcreteNewsflowDialog.loadEdition('<?=$editionID?>')"><i class="fa fa-chevron-right"></i></a></div>
 <? } ?>

--- a/web/concrete/blocks/date_navigation/controller.php
+++ b/web/concrete/blocks/date_navigation/controller.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Concrete\Block\DateNavigation;
+
 defined('C5_EXECUTE') or die("Access Denied.");
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Page\PageList;
@@ -10,7 +11,6 @@ use Loader;
 
 class Controller extends BlockController
 {
-
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 400;
@@ -18,6 +18,13 @@ class Controller extends BlockController
     protected $btExportPageColumns = array('cParentID', 'cTargetID');
     protected $btExportPageTypeColumns = array('ptID');
     protected $btTable = 'btDateNavigation';
+
+    public $title;
+    public $cTargetID;
+    public $cParentID;
+    public $filterByParent;
+    public $redirectToResults;
+    public $ptID;
 
     public function getBlockTypeDescription()
     {
@@ -60,6 +67,7 @@ class Controller extends BlockController
     {
         $date = strtotime($dateArray['year'] . '-' . $dateArray['month'] . '-01');
         $srv = Core::make('helper/date');
+
         return $srv->date('F Y', $date);
     }
 
@@ -73,6 +81,7 @@ class Controller extends BlockController
                 $parameters[1] = intval($parameters[1]);
             }
         }
+
         return array($method, $parameters);
     }
 
@@ -88,7 +97,6 @@ class Controller extends BlockController
         if (isset($this->selectedYear) && isset($this->selectedMonth)) {
             return $dateArray['year'] == $this->selectedYear && $dateArray['month'] == $this->selectedMonth;
         }
-
     }
 
     public function view()

--- a/web/concrete/blocks/external_form/controller.php
+++ b/web/concrete/blocks/external_form/controller.php
@@ -1,13 +1,12 @@
 <?php
+
 namespace Concrete\Block\ExternalForm;
 
 use Concrete\Core\Block\BlockController;
-use Concrete\Core\Foundation\Object;
 use Loader;
 
 class Controller extends BlockController
 {
-
     public $helpers = array('file');
     protected $btTable = 'btExternalForm';
     protected $btInterfaceWidth = "370";
@@ -15,8 +14,10 @@ class Controller extends BlockController
     protected $btCacheBlockRecord = true;
     protected $btWrapperClass = 'ccm-ui';
 
+    public $filename;
+
     /**
-     * Used for localization. If we want to localize the name/description we have to include this
+     * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
@@ -33,12 +34,12 @@ class Controller extends BlockController
         return array('form-required' => t('You must select a form.'));
     }
 
-    function getFilename()
+    public function getFilename()
     {
         return $this->filename;
     }
 
-    function getExternalFormFilenamePath()
+    public function getExternalFormFilenamePath()
     {
         if ($this->filename) {
             if (file_exists(DIR_FILES_BLOCK_TYPES_FORMS_EXTERNAL . '/' . $this->filename)) {
@@ -61,6 +62,7 @@ class Controller extends BlockController
             if (method_exists($controller, $method)) {
                 return true;
             }
+
             return parent::isValidControllerTask($method, $parameters);
         }
     }
@@ -71,6 +73,7 @@ class Controller extends BlockController
         if (!$args['filename']) {
             $e->add(t('You must specify an external form.'));
         }
+
         return $e;
     }
 
@@ -85,21 +88,24 @@ class Controller extends BlockController
                 )
             );
             $cl->bID = $this->bID;
+
             return $cl;
-        } catch (\Exception $e) {}
+        } catch (\Exception $e) {
+        }
     }
 
     public function runAction($method, $parameters)
     {
         if (in_array($method, array('add', 'edit'))) {
             parent::runAction($method, $parameters);
+
             return;
         }
 
         $controller = $this->getController();
         if ($controller) {
             $controller->runAction($method, $parameters);
-            foreach($controller->getSets() as $key => $value) {
+            foreach ($controller->getSets() as $key => $value) {
                 $this->set($key, $value);
             }
         }
@@ -112,7 +118,6 @@ class Controller extends BlockController
 
     public function getFormList()
     {
-
         $forms = array();
         $fh = Loader::helper('file');
 
@@ -134,5 +139,4 @@ class Controller extends BlockController
     {
         $this->set('filenames', $this->getFormList());
     }
-
 }

--- a/web/concrete/blocks/faq/controller.php
+++ b/web/concrete/blocks/faq/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\Faq;
 
 use Concrete\Core\Block\BlockController;
@@ -6,7 +7,6 @@ use Loader;
 
 class Controller extends BlockController
 {
-
     protected $btTable = 'btFaq';
     protected $btExportTables = array('btFaq', 'btFaqEntries');
     protected $btInterfaceWidth = "600";
@@ -16,6 +16,8 @@ class Controller extends BlockController
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    public $blockTitle;
 
     public function getBlockTypeDescription()
     {
@@ -37,6 +39,7 @@ class Controller extends BlockController
         foreach ($r as $row) {
             $content .= $row['title'] . ' ' . $row['linkTitle'] . ' ' . $row['description'];
         }
+
         return $content;
     }
 
@@ -77,7 +80,7 @@ class Controller extends BlockController
                     $row['title'],
                     $row['linkTitle'],
                     $row['description'],
-                    $row['sortOrder']
+                    $row['sortOrder'],
                 )
             );
         }
@@ -105,11 +108,10 @@ class Controller extends BlockController
                     $args['title'][$i],
                     $args['linkTitle'][$i],
                     $args['description'][$i],
-                    $args['sortOrder'][$i]
+                    $args['sortOrder'][$i],
                 )
             );
-            $i++;
+            ++$i;
         }
     }
-
 }

--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -24,6 +24,12 @@ class Controller extends BlockController
     protected $btInterfaceHeight = 520;
     protected $btTable = 'btFeature';
 
+    public $icon;
+    public $title;
+    public $paragraph;
+    public $externalLink;
+    public $internalLinkCID;
+
     public function getBlockTypeDescription()
     {
         return t("Displays an icon, a title, and a short paragraph description.");

--- a/web/concrete/blocks/file/controller.php
+++ b/web/concrete/blocks/file/controller.php
@@ -1,70 +1,88 @@
-<?
+<?php
+
 namespace Concrete\Block\File;
+
 use Loader;
 use File;
-use \Concrete\Core\Block\BlockController;
-class Controller extends BlockController {
-	protected $btInterfaceWidth = 300;
-	protected $btCacheBlockRecord = true;
-	protected $btCacheBlockOutput = true;
-	protected $btCacheBlockOutputOnPost = true;
-	protected $btCacheBlockOutputForRegisteredUsers = true;
-	protected $btInterfaceHeight = 320;
-	protected $btTable = 'btContentFile';
-	
-	protected $btExportFileColumns = array('fID');
-	
-	/** 
-	 * Used for localization. If we want to localize the name/description we have to include this
-	 */
-	public function getBlockTypeDescription() {
-		return t("Link to files stored in the asset library.");
-	}
-	
-	public function getBlockTypeName() {
-		return t("File");
-	}
+use Concrete\Core\Block\BlockController;
 
-	public function getJavaScriptStrings() {
-		return array('file-required' => t('You must select a file.'));	
-	}
-	
-	public function getSearchableContent(){
-		return $this->fileLinkText;
-	}
+class Controller extends BlockController
+{
+    protected $btInterfaceWidth = 300;
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btInterfaceHeight = 320;
+    protected $btTable = 'btContentFile';
 
-    function save($args){
-		$args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
-		parent::save($args);
+    protected $btExportFileColumns = array('fID');
+
+    public $fID;
+    public $fileLinkText;
+    public $filePassword;
+    public $forceDownload;
+
+    /**
+     * Used for localization. If we want to localize the name/description we have to include this.
+     */
+    public function getBlockTypeDescription()
+    {
+        return t("Link to files stored in the asset library.");
     }
 
-    public function validate($args) {
-		$e = Loader::helper('validation/error');
-		if ($args['fID'] < 1) {
-			$e->add(t('You must select a file.'));
-		}
-		if (trim($args['fileLinkText']) == '') {
-			$e->add(t('You must give your file a link.'));
-		}
-		return $e;
-	}
-	
-	function getFileID() {return $this->fID;}
-	
-	function getFileObject() {
-		return File::getByID($this->fID);
-	}
-	
-	function getLinkText() {
-		if ($this->fileLinkText) {
-			return $this->fileLinkText;
-		} else {
-			$f = $this->getFileObject();
-			return $f->getTitle();
-		}
-	}
-	
-	
-	
+    public function getBlockTypeName()
+    {
+        return t("File");
+    }
+
+    public function getJavaScriptStrings()
+    {
+        return array('file-required' => t('You must select a file.'));
+    }
+
+    public function getSearchableContent()
+    {
+        return $this->fileLinkText;
+    }
+
+    public function save($args)
+    {
+        $args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+        parent::save($args);
+    }
+
+    public function validate($args)
+    {
+        $e = Loader::helper('validation/error');
+        if ($args['fID'] < 1) {
+            $e->add(t('You must select a file.'));
+        }
+        if (trim($args['fileLinkText']) == '') {
+            $e->add(t('You must give your file a link.'));
+        }
+
+        return $e;
+    }
+
+    public function getFileID()
+    {
+        return $this->fID;
+    }
+
+    public function getFileObject()
+    {
+        return File::getByID($this->fID);
+    }
+
+    public function getLinkText()
+    {
+        if ($this->fileLinkText) {
+            return $this->fileLinkText;
+        } else {
+            $f = $this->getFileObject();
+
+            return $f->getTitle();
+        }
+    }
 }
-?>

--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -29,7 +29,15 @@ class Controller extends BlockController
     protected $btCacheBlockRecord = false;
     protected $btExportTables = array('btForm', 'btFormQuestions');
     protected $btExportPageColumns = array('redirectCID');
-    protected $lastAnswerSetId = 0;
+
+    public $lastAnswerSetId = 0;
+    public $questionSetId;
+    public $surveyName;
+    public $notifyMeOnSubmission;
+    public $recipientEmail;
+    public $displayCaptcha;
+    public $redirectCID;
+    public $addFilesToSet;
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this.

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Concrete\Block\GoogleMap;
 
 use Loader;
 use Page;
-use \Concrete\Core\Block\BlockController;
+use Concrete\Core\Block\BlockController;
 use Core;
 
 class Controller extends BlockController
 {
-
     protected $btTable = 'btGoogleMap';
     protected $btInterfaceWidth = "400";
     protected $btInterfaceHeight = "320";
@@ -23,9 +23,11 @@ class Controller extends BlockController
     public $longitude = "";
     public $scrollwheel = true;
     public $zoom = 14;
+    public $width;
+    public $height;
 
     /**
-     * Used for localization. If we want to localize the name/description we have to include this
+     * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
@@ -36,7 +38,6 @@ class Controller extends BlockController
     {
         return t("Google Map");
     }
-
 
     public function validate($args)
     {
@@ -65,7 +66,7 @@ class Controller extends BlockController
 
     public function view()
     {
-		$this->set('unique_identifier', Core::make('helper/validation/identifier')->getString(18));
+        $this->set('unique_identifier', Core::make('helper/validation/identifier')->getString(18));
         $this->set('bID', $this->bID);
         $this->set('title', $this->title);
         $this->set('location', $this->location);
@@ -87,5 +88,4 @@ class Controller extends BlockController
         $args['scrollwheel'] = $data['scrollwheel'] ? 1 : 0;
         parent::save($args);
     }
-
 }

--- a/web/concrete/blocks/image/controller.php
+++ b/web/concrete/blocks/image/controller.php
@@ -24,6 +24,15 @@ class Controller extends BlockController
         'image',
     );
 
+    public $fID;
+    public $fOnstateID;
+    public $maxWidth;
+    public $maxHeight;
+    public $externalLink;
+    public $internalLinkCID;
+    public $altText;
+    public $title;
+
     /**
      * Used for localization. If we want to localize the name/description we have to include this.
      */

--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -20,6 +20,8 @@ class Controller extends BlockController
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btIgnorePageThemeGridFrameworkContainer = true;
 
+    public $navigationType;
+
     public function getBlockTypeDescription()
     {
         return t("Display your images and captions in an attractive slideshow format.");
@@ -159,7 +161,7 @@ class Controller extends BlockController
                         $internalLinkCID,
                     )
                 );
-                $i++;
+                ++$i;
             }
         }
     }

--- a/web/concrete/blocks/next_previous/controller.php
+++ b/web/concrete/blocks/next_previous/controller.php
@@ -1,135 +1,152 @@
-<?php 
+<?php
+
 namespace Concrete\Block\NextPrevious;
+
 use Loader;
 use Permissions;
 use Page;
-use \Concrete\Core\Block\BlockController;
-class Controller extends BlockController {
+use Concrete\Core\Block\BlockController;
 
-	protected $btTable = 'btNextPrevious';
-	protected $btInterfaceWidth = "430";
-	protected $btInterfaceHeight = "400"; 
-	protected $btCacheBlockRecord = true;
-	protected $btWrapperClass = 'ccm-ui';
-	/**
-	 * Used for localization. If we want to localize the name/description we have to include this
-	 */
-	public function getBlockTypeDescription() {
-		return t("Navigate through sibling pages.");
-	}
-	
-	public function getBlockTypeName() {
-		return t("Next & Previous Nav");
-	}
-	
-	public function getJavaScriptStrings() {
-		return array();
-	} 
-	
-	public function save($args) { 
-		$db = Loader::db(); 
-		
-		$args['showArrows'] = intval($args['showArrows']) ;
-		$args['loopSequence'] = intval($args['loopSequence']); 
-			
-		
-		parent::save($args);		
-	} 
-	
-	function view(){
-		
-		$nextPage=$this->getNextCollection();
-		$previousPage=$this->getPreviousCollection();
-		$parentPage=Page::getByID(Page::getCurrentPage()->getCollectionParentID());
-		
+class Controller extends BlockController
+{
+    protected $btTable = 'btNextPrevious';
+    protected $btInterfaceWidth = "430";
+    protected $btInterfaceHeight = "400";
+    protected $btCacheBlockRecord = true;
+    protected $btWrapperClass = 'ccm-ui';
+
+    public $nextLabel;
+    public $previousLabel;
+    public $parentLabel;
+    public $excludeSystemPages;
+    public $orderBy;
+    public $loopSequence;
+    public $showArrows;
+
+    /**
+     * Used for localization. If we want to localize the name/description we have to include this.
+     */
+    public function getBlockTypeDescription()
+    {
+        return t("Navigate through sibling pages.");
+    }
+
+    public function getBlockTypeName()
+    {
+        return t("Next & Previous Nav");
+    }
+
+    public function getJavaScriptStrings()
+    {
+        return array();
+    }
+
+    public function save($args)
+    {
+        $db = Loader::db();
+
+        $args['showArrows'] = intval($args['showArrows']);
+        $args['loopSequence'] = intval($args['loopSequence']);
+
+        parent::save($args);
+    }
+
+    public function view()
+    {
+        $nextPage = $this->getNextCollection();
+        $previousPage = $this->getPreviousCollection();
+        $parentPage = Page::getByID(Page::getCurrentPage()->getCollectionParentID());
+
         $nextLinkText = $this->nextLabel;
         $previousLinkText = $this->previousLabel;
         $parentLinkText = $this->parentLabel;
 
-		$this->set( 'nextCollection', $nextPage );
-		$this->set( 'previousCollection', $previousPage );
-		$this->set( 'parentCollection', $parentPage );
-		
-		$this->set( 'nextLinkText', $nextLinkText );
-		$this->set( 'previousLinkText', $previousLinkText );		
-		$this->set( 'parentLinkText', $parentLinkText );		
-	}
-	
-	function getNextCollection(){
-		$page = false;
-		$db = Loader::db();
-		$systemPages = '';
-		if ($this->excludeSystemPages) {
-			$systemPages = 'and cIsSystemPage = 0';
-		}
-		$cID = 1;
-		$currentPage = Page::getCurrentPage();
-		while ($cID > 0) {
-			if ($this->orderBy == 'display_asc') {
-				$cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
-			} else {
-				$cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
-			}
-			if ($cID > 0) {
-				$page = Page::getByID($cID, 'RECENT');
-				$currentPage = $page;
-				$cp = new Permissions($page);
-				if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
-					break;
-				} else {
-					$page = null; //avoid accidentally returning this $page if we're on last loop iteration
-				}
-			}
-		}
-		if (!is_object($page) && $this->loopSequence) {
-			$c = Page::getCurrentPage();
-			$parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');
-			if ($this->orderBy == 'display_asc') {
-				return $parent->getFirstChild('cDisplayOrder asc', $this->excludeSystemPages);
-			} else {
-				return $parent->getFirstChild('cvDatePublic asc', $this->excludeSystemPages);
-			}
-		}
-		return $page;
-	}
-	
-	function getPreviousCollection(){
-		$page = false;
-		$db = Loader::db();
-		$systemPages = '';
-		if ($this->excludeSystemPages) {
-			$systemPages = 'and cIsSystemPage = 0';
-		}
-		$cID = 1;
-		$currentPage = Page::getCurrentPage();
-		while ($cID > 0) {
-			if ($this->orderBy == 'display_asc') {
-				$cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
-			} else {
-				$cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
-			}
-			if ($cID > 0) {
-				$page = Page::getByID($cID, 'RECENT');
-				$currentPage = $page;
-				$cp = new Permissions($page);
-				if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
-					break;
-				} else {
-					$page = null; //avoid accidentally returning this $page if we're on last loop iteration
-				}
-			}
-		}
-		if (!is_object($page) && $this->loopSequence) {
-			$c = Page::getCurrentPage();
-			$parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');
-			if ($this->orderBy == 'display_asc') {
-				return $parent->getFirstChild('cDisplayOrder desc');
-			} else {
-				return $parent->getFirstChild('cvDatePublic desc');
-			}
-		}
-		
-		return $page;
-	}
-	
+        $this->set('nextCollection', $nextPage);
+        $this->set('previousCollection', $previousPage);
+        $this->set('parentCollection', $parentPage);
+
+        $this->set('nextLinkText', $nextLinkText);
+        $this->set('previousLinkText', $previousLinkText);
+        $this->set('parentLinkText', $parentLinkText);
+    }
+
+    public function getNextCollection()
+    {
+        $page = false;
+        $db = Loader::db();
+        $systemPages = '';
+        if ($this->excludeSystemPages) {
+            $systemPages = 'and cIsSystemPage = 0';
+        }
+        $cID = 1;
+        $currentPage = Page::getCurrentPage();
+        while ($cID > 0) {
+            if ($this->orderBy == 'display_asc') {
+                $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+            } else {
+                $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+            }
+            if ($cID > 0) {
+                $page = Page::getByID($cID, 'RECENT');
+                $currentPage = $page;
+                $cp = new Permissions($page);
+                if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
+                    break;
+                } else {
+                    $page = null; //avoid accidentally returning this $page if we're on last loop iteration
+                }
+            }
+        }
+        if (!is_object($page) && $this->loopSequence) {
+            $c = Page::getCurrentPage();
+            $parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');
+            if ($this->orderBy == 'display_asc') {
+                return $parent->getFirstChild('cDisplayOrder asc', $this->excludeSystemPages);
+            } else {
+                return $parent->getFirstChild('cvDatePublic asc', $this->excludeSystemPages);
+            }
+        }
+
+        return $page;
+    }
+
+    public function getPreviousCollection()
+    {
+        $page = false;
+        $db = Loader::db();
+        $systemPages = '';
+        if ($this->excludeSystemPages) {
+            $systemPages = 'and cIsSystemPage = 0';
+        }
+        $cID = 1;
+        $currentPage = Page::getCurrentPage();
+        while ($cID > 0) {
+            if ($this->orderBy == 'display_asc') {
+                $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+            } else {
+                $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+            }
+            if ($cID > 0) {
+                $page = Page::getByID($cID, 'RECENT');
+                $currentPage = $page;
+                $cp = new Permissions($page);
+                if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
+                    break;
+                } else {
+                    $page = null; //avoid accidentally returning this $page if we're on last loop iteration
+                }
+            }
+        }
+        if (!is_object($page) && $this->loopSequence) {
+            $c = Page::getCurrentPage();
+            $parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');
+            if ($this->orderBy == 'display_asc') {
+                return $parent->getFirstChild('cDisplayOrder desc');
+            } else {
+                return $parent->getFirstChild('cvDatePublic desc');
+            }
+        }
+
+        return $page;
+    }
 }

--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -1,30 +1,33 @@
 <?php
+
 namespace Concrete\Block\PageAttributeDisplay;
+
 use Concrete\Core\Block\BlockController;
-use Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
 use Concrete\Core\Attribute\Key\CollectionKey as CollectionAttributeKey;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 
 /**
  * @author Ryan Tyler
- *
  */
 class Controller extends BlockController
 {
-
     protected $btTable = 'btPageAttributeDisplay';
     protected $btInterfaceWidth = "500";
     protected $btInterfaceHeight = "365";
+
     public $dateFormat = "m/d/y h:i:a";
+    public $attributeHandle;
+    public $attributeTitleText;
+    public $displayTag;
 
     /**
-     * @var integer thumbnail height
+     * @var int thumbnail height
      */
     public $thumbnailHeight = 250;
 
     /**
-     * @var integer thumbnail width
+     * @var int thumbnail width
      */
     public $thumbnailWidth = 250;
 
@@ -75,7 +78,6 @@ class Controller extends BlockController
                     if (!is_scalar($content) && (!is_object($content) || !method_exists($content, '__toString'))) {
                         $content = $c->getAttribute($this->attributeHandle, 'displaySanitized');
                     }
-
                 }
                 break;
         }
@@ -84,16 +86,20 @@ class Controller extends BlockController
         if (!strlen(trim(strip_tags($content))) && ($c->isMasterCollection() || $is_stack)) {
             $content = $this->getPlaceHolderText($this->attributeHandle);
         }
+
         return $content;
     }
 
     /**
-     * returns a place holder for pages that are new or when editing default page types
+     * returns a place holder for pages that are new or when editing default page types.
+     *
      * @param string $handle
+     *
      * @return string
      */
     public function getPlaceHolderText($handle)
     {
+        $placeHolder = '';
         $pageValues = $this->getAvailablePageValues();
         if (in_array($handle, array_keys($pageValues))) {
             $placeHolder = $pageValues[$handle];
@@ -103,11 +109,13 @@ class Controller extends BlockController
                 $placeHolder = $attributeKey->getAttributeKeyName();
             }
         }
+
         return "[" . $placeHolder . "]";
     }
 
     /**
-     * returns the title text to display in front of the valie
+     * returns the title text to display in front of the valie.
+     *
      * @return string
      */
     public function getTitle()
@@ -133,6 +141,7 @@ class Controller extends BlockController
 
     protected function getTemplateHandle()
     {
+        $templateHandle = '';
         if (in_array($this->attributeHandle, array_keys($this->getAvailablePageValues()))) {
             switch ($this->attributeHandle) {
                 case "rpv_pageDateCreated":
@@ -148,11 +157,13 @@ class Controller extends BlockController
                 $templateHandle = $attributeType->getAttributeTypeHandle();
             }
         }
+
         return $templateHandle;
     }
 
     /**
-     * returns opening html tag
+     * returns opening html tag.
+     *
      * @return string
      */
     public function getOpenTag()
@@ -161,11 +172,13 @@ class Controller extends BlockController
         if (strlen($this->displayTag)) {
             $tag = "<" . $this->displayTag . " class=\"ccm-block-page-attribute-display-wrapper\">";
         }
+
         return $tag;
     }
 
     /**
-     * returns closing html tag
+     * returns closing html tag.
+     *
      * @return string
      */
     public function getCloseTag()
@@ -174,6 +187,7 @@ class Controller extends BlockController
         if (strlen($this->displayTag)) {
             $tag = "</" . $this->displayTag . ">";
         }
+
         return $tag;
     }
 
@@ -185,5 +199,3 @@ class Controller extends BlockController
         }
     }
 }
-
-?>

--- a/web/concrete/blocks/page_title/controller.php
+++ b/web/concrete/blocks/page_title/controller.php
@@ -20,6 +20,10 @@ class Controller extends BlockController
     protected $btTable = 'btPageTitle';
     protected $btWrapperClass = 'ccm-ui';
 
+    public $useCustomTitle;
+    public $titleText;
+    public $formatting;
+
     public function getBlockTypeDescription()
     {
         return t("Displays a Page's Title");

--- a/web/concrete/blocks/rss_displayer/controller.php
+++ b/web/concrete/blocks/rss_displayer/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\RssDisplayer;
 
 use Concrete\Core\Block\BlockController;
@@ -7,11 +8,13 @@ use Core;
 
 class Controller extends BlockController
 {
-
     public $itemsToDisplay = "5";
     public $showSummary = "1";
     public $launchInNewWindow = "1";
     public $title = "";
+    public $url;
+    public $dateFormat;
+
     protected $btTable = 'btRssDisplay';
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 550;
@@ -23,7 +26,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputLifetime = 3600;
 
     /**
-     * Used for localization. If we want to localize the name/description we have to include this
+     * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
@@ -38,8 +41,8 @@ class Controller extends BlockController
     public function getJavaScriptStrings()
     {
         return array(
-            'feed-address'   => t('Please enter a valid feed address.'),
-            'feed-num-items' => t('Please enter the number of items to display.')
+            'feed-address' => t('Please enter a valid feed address.'),
+            'feed-num-items' => t('Please enter the number of items to display.'),
         );
     }
 
@@ -53,7 +56,7 @@ class Controller extends BlockController
             ':longDate:longTime:',
             ':longDate:shortTime:',
             ':shortDate:longTime:',
-            ':shortDate:shortTime:'
+            ':shortDate:shortTime:',
         );
         $now = new \DateTime();
         $result = array();
@@ -65,7 +68,8 @@ class Controller extends BlockController
     }
 
     /**
-     * Format a \DateTime instance accordingly to $format
+     * Format a \DateTime instance accordingly to $format.
+     *
      * @param \DateTime|null $date
      * @param string|bool $format Set to true (default) to use the default format
      */
@@ -129,7 +133,7 @@ class Controller extends BlockController
                 if (($i + 1) == intval($this->itemsToDisplay)) {
                     break;
                 }
-                $i++;
+                ++$i;
             }
         } catch (\Exception $e) {
             $this->set('errorMsg', $e->getMessage());
@@ -161,7 +165,7 @@ class Controller extends BlockController
     public function getSearchableContent()
     {
         $fp = Loader::helper("feed");
-
+        $posts = array();
         try {
             $channel = $fp->load($this->url);
             $i = 0;
@@ -170,10 +174,9 @@ class Controller extends BlockController
                 if (($i + 1) == intval($this->itemsToDisplay)) {
                     break;
                 }
-                $i++;
+                ++$i;
             }
         } catch (\Exception $e) {
-
         }
 
         $searchContent = '';
@@ -183,5 +186,4 @@ class Controller extends BlockController
 
         return $searchContent;
     }
-
 }

--- a/web/concrete/blocks/search/controller.php
+++ b/web/concrete/blocks/search/controller.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Concrete\Block\Search;
 
 use Loader;
 use CollectionAttributeKey;
-use \Concrete\Core\Page\PageList;
-use \Concrete\Core\Block\BlockController;
+use Concrete\Core\Page\PageList;
+use Concrete\Core\Block\BlockController;
 use Page;
 use Core;
 
@@ -21,6 +22,8 @@ class Controller extends BlockController
     public $baseSearchPath = "";
     public $resultsURL = "";
     public $postTo_cID = "";
+    public $hText;
+    public $hHighlight;
 
     protected $hColor = '#EFE795';
 
@@ -31,8 +34,8 @@ class Controller extends BlockController
         }
 
         $this->hText = $fulltext;
-        $this->hHighlight  = $highlight;
-        $this->hText = @preg_replace('#' . preg_quote($this->hHighlight, '#') . '#ui', '<span style="background-color:'. $this->hColor .';">$0</span>', $this->hText );
+        $this->hHighlight = $highlight;
+        $this->hText = @preg_replace('#' . preg_quote($this->hHighlight, '#') . '#ui', '<span style="background-color:'. $this->hColor .';">$0</span>', $this->hText);
 
         return $this->hText;
     }
@@ -42,7 +45,7 @@ class Controller extends BlockController
         $text = @preg_replace("#\n|\r#", ' ', $fulltext);
 
         $matches = array();
-        $highlight = str_replace(array('"',"'","&quot;"),'',$highlight); // strip the quotes as they mess the regex
+        $highlight = str_replace(array('"', "'", "&quot;"), '', $highlight); // strip the quotes as they mess the regex
 
         if (!$highlight) {
             $text = Loader::helper('text')->shorten($fulltext, 180);
@@ -66,12 +69,13 @@ class Controller extends BlockController
                 if ($r) {
                     $body_string[] = $r;
                 }
-                if($body_length > 150)
+                if ($body_length > 150) {
                     break;
+                }
             }
-            if(!empty($body_string))
-
+            if (!empty($body_string)) {
                 return @implode("&hellip;<wbr>", $body_string);
+            }
         }
     }
 
@@ -81,8 +85,8 @@ class Controller extends BlockController
     }
 
     /**
-	 * Used for localization. If we want to localize the name/description we have to include this
-	 */
+     * Used for localization. If we want to localize the name/description we have to include this.
+     */
     public function getBlockTypeDescription()
     {
         return t("Add a search box to your site.");
@@ -129,7 +133,7 @@ class Controller extends BlockController
 
         //run query if display results elsewhere not set, or the cID of this page is set
         if ($this->postTo_cID == '') {
-            if ( !empty($_REQUEST['query']) || isset($_REQUEST['akID']) || isset($_REQUEST['month'])) {
+            if (!empty($_REQUEST['query']) || isset($_REQUEST['akID']) || isset($_REQUEST['month'])) {
                 $this->do_search();
             }
         }
@@ -140,25 +144,29 @@ class Controller extends BlockController
         $args['title'] = isset($data['title']) ? $data['title'] : '';
         $args['buttonText'] = isset($data['buttonText']) ? $data['buttonText'] : '';
         $args['baseSearchPath'] = isset($data['baseSearchPath']) ? $data['baseSearchPath'] : '';
-        if ( $args['baseSearchPath']=='OTHER' && intval($data['searchUnderCID'])>0 ) {
-            $customPathC = Page::getByID( intval($data['searchUnderCID']) );
-            if( !$customPathC )    $args['baseSearchPath']='';
-            else $args['baseSearchPath'] = $customPathC->getCollectionPath();
+        if ($args['baseSearchPath'] == 'OTHER' && intval($data['searchUnderCID']) > 0) {
+            $customPathC = Page::getByID(intval($data['searchUnderCID']));
+            if (!$customPathC) {
+                $args['baseSearchPath'] = '';
+            } else {
+                $args['baseSearchPath'] = $customPathC->getCollectionPath();
+            }
         }
-        if( trim($args['baseSearchPath'])=='/' || strlen(trim($args['baseSearchPath']))==0 )
-            $args['baseSearchPath']='';
+        if (trim($args['baseSearchPath']) == '/' || strlen(trim($args['baseSearchPath'])) == 0) {
+            $args['baseSearchPath'] = '';
+        }
 
-        if ( intval($data['postTo_cID'])>0 ) {
+        if (intval($data['postTo_cID']) > 0) {
             $args['postTo_cID'] = intval($data['postTo_cID']);
         } else {
             $args['postTo_cID'] = '';
         }
 
-        $args['resultsURL'] = ( $data['externalTarget']==1 && strlen($data['resultsURL'])>0 ) ? trim($data['resultsURL']) : '';
+        $args['resultsURL'] = ($data['externalTarget'] == 1 && strlen($data['resultsURL']) > 0) ? trim($data['resultsURL']) : '';
         parent::save($args);
     }
 
-    public $reservedParams=array('page=','query=','search_paths[]=','submit=','search_paths%5B%5D=' );
+    public $reservedParams = array('page=','query=','search_paths[]=','submit=','search_paths%5B%5D=');
 
     public function do_search()
     {
@@ -209,9 +217,11 @@ class Controller extends BlockController
             $ipl->filterByKeywords($_q);
         }
 
-        if ( is_array($_REQUEST['search_paths']) ) {
+        if (is_array($_REQUEST['search_paths'])) {
             foreach ($_REQUEST['search_paths'] as $path) {
-                if(!strlen($path)) continue;
+                if (!strlen($path)) {
+                    continue;
+                }
                 $ipl->filterByPath($path);
             }
         } elseif ($this->baseSearchPath != '') {
@@ -230,5 +240,4 @@ class Controller extends BlockController
         $this->set('searchList', $ipl);
         $this->set('pagination', $pagination);
     }
-
 }

--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Concrete\Block\ShareThisPage;
-use \Concrete\Core\Block\BlockController;
+
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Sharing\ShareThisPage\ServiceList;
 use Concrete\Core\Sharing\ShareThisPage\Service;
 use Database;
@@ -11,7 +12,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController
 {
-
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 400;
@@ -22,6 +22,10 @@ class Controller extends BlockController
     protected $btTable = 'btShareThisPage';
 
     protected $services = array();
+
+    public $btShareThisPageID;
+    public $service;
+    public $displayOrder;
 
     public function getBlockTypeDescription()
     {
@@ -37,7 +41,7 @@ class Controller extends BlockController
     {
         $selected = $this->getSelectedServices();
         $services = array();
-        foreach($selected as $s) {
+        foreach ($selected as $s) {
             $services[] = $s->getHandle();
         }
 
@@ -65,16 +69,17 @@ class Controller extends BlockController
         $services = $db->GetCol('select service from btShareThisPage where bID = ? order by displayOrder asc',
             array($this->bID)
         );
-        foreach($services as $service) {
+        foreach ($services as $service) {
             $this->addService($service);
         }
+
         return $this->services;
     }
 
     public function duplicate($newBlockID)
     {
         $db = Database::get();
-        foreach($this->getSelectedServices() as $service) {
+        foreach ($this->getSelectedServices() as $service) {
             $db->insert('btShareThisPage', array('bID' => $newBlockID, 'service' => $service->getHandle(), 'displayOrder' => $this->displayOrder));
         }
     }
@@ -86,28 +91,28 @@ class Controller extends BlockController
         if (count($service) == 0) {
             $e->add(t('You must choose at least one service.'));
         }
+
         return $e;
     }
 
     public function export(\SimpleXMLElement $blockNode)
     {
         $data = $blockNode->addChild('data');
-        foreach($this->getSelectedServices() as $link) {
+        foreach ($this->getSelectedServices() as $link) {
             $data->addChild('service', $link->getHandle());
         }
     }
 
     public function getImportData($blockNode)
     {
-
         $args = array();
-        foreach($blockNode->data->service as $service) {
+        foreach ($blockNode->data->service as $service) {
             $link = Service::getByHandle((string) $service);
             $args['service'][] = $link->getHandle();
         }
+
         return $args;
     }
-
 
     public function save($args)
     {
@@ -117,12 +122,12 @@ class Controller extends BlockController
 
         $statement = $db->prepare('insert into btShareThisPage (bID, service, displayOrder) values (?, ?, ?)');
         $displayOrder = 0;
-        foreach($services as $service) {
+        foreach ($services as $service) {
             $statement->bindValue(1, $this->bID);
             $statement->bindValue(2, $service);
             $statement->bindValue(3, $displayOrder);
             $statement->execute();
-            $displayOrder++;
+            ++$displayOrder;
         }
     }
 
@@ -146,5 +151,4 @@ class Controller extends BlockController
         }
         $this->set('selected', $selected);
     }
-
 }

--- a/web/concrete/blocks/survey/controller.php
+++ b/web/concrete/blocks/survey/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\Survey;
 
 use Concrete\Core\Block\BlockController;
@@ -9,14 +10,17 @@ use Core;
 
 class Controller extends BlockController
 {
-
     public $options = array();
     protected $btTable = 'btSurvey';
     protected $btInterfaceWidth = "420";
     protected $btInterfaceHeight = "400";
     protected $btExportTables = array('btSurvey', 'btSurveyOptions', 'btSurveyResults');
 
-    function __construct($obj = null)
+    public $cID;
+    public $question;
+    public $requiresRegistration;
+
+    public function __construct($obj = null)
     {
         parent::__construct($obj);
         $c = Page::getCurrentPage();
@@ -32,7 +36,7 @@ class Controller extends BlockController
             $this->options = array();
             if ($r) {
                 while ($row = $r->fetchRow()) {
-                    $opt = new Option;
+                    $opt = new Option();
                     $opt->optionID = $row['optionID'];
                     $opt->cID = $this->cID;
                     $opt->optionName = $row['optionName'];
@@ -44,7 +48,7 @@ class Controller extends BlockController
     }
 
     /**
-     * Used for localization. If we want to localize the name/description we have to include this
+     * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
@@ -56,17 +60,17 @@ class Controller extends BlockController
         return t("Survey");
     }
 
-    function getQuestion()
+    public function getQuestion()
     {
         return $this->question;
     }
 
-    function getPollOptions()
+    public function getPollOptions()
     {
         return $this->options;
     }
 
-    function delete()
+    public function delete()
     {
         $db = Loader::db();
         $v = array($this->bID);
@@ -80,7 +84,7 @@ class Controller extends BlockController
         parent::delete();
     }
 
-    function action_form_save_vote($bID = false)
+    public function action_form_save_vote($bID = false)
     {
         if ($this->bID != $bID) {
             return false;
@@ -103,7 +107,6 @@ class Controller extends BlockController
         }
 
         if (!$this->hasVoted()) {
-
             $antispam = Loader::helper('validation/antispam');
             if ($antispam->check('', 'survey_block')) { // we do a blank check which will still check IP and UserAgent's
                 $duID = 0;
@@ -114,13 +117,13 @@ class Controller extends BlockController
                 /** @var \Concrete\Core\Permission\IPService $iph */
                 $iph = Core::make('helper/validation/ip');
                 $ip = $iph->getRequestIP();
-                $ip = ($ip === false)?(''):($ip->getIp($ip::FORMAT_IP_STRING));
+                $ip = ($ip === false) ? ('') : ($ip->getIp($ip::FORMAT_IP_STRING));
                 $v = array(
                     $_REQUEST['optionID'],
                     $this->bID,
                     $duID,
                     $ip,
-                    $this->cID);
+                    $this->cID, );
                 $q = "INSERT INTO btSurveyResults (optionID, bID, uID, ipAddress, cID) VALUES (?, ?, ?, ?, ?)";
                 $db->query($q, $v);
                 setcookie("ccmPoll" . $this->bID . '-' . $this->cID, "voted", time() + 1296000, DIR_REL . '/');
@@ -129,12 +132,12 @@ class Controller extends BlockController
         }
     }
 
-    function requiresRegistration()
+    public function requiresRegistration()
     {
         return $this->requiresRegistration;
     }
 
-    function hasVoted()
+    public function hasVoted()
     {
         $u = new User();
         if ($u->isRegistered()) {
@@ -148,12 +151,12 @@ class Controller extends BlockController
         } elseif ($_COOKIE['ccmPoll' . $this->bID . '-' . $this->cID] == 'voted') {
             return true;
         }
+
         return false;
     }
 
-    function duplicate($newBID)
+    public function duplicate($newBID)
     {
-
         $db = Loader::db();
 
         foreach ($this->options as $opt) {
@@ -175,10 +178,9 @@ class Controller extends BlockController
         }
 
         return parent::duplicate($newBID);
-
     }
 
-    function save($args)
+    public function save($args)
     {
         parent::save($args);
         $db = Loader::db();
@@ -202,7 +204,7 @@ class Controller extends BlockController
                 $v1 = array($this->bID, $optionName, $displayOrder);
                 $q1 = "INSERT INTO btSurveyOptions (bID, optionName, displayOrder) VALUES (?, ?, ?)";
                 $db->query($q1, $v1);
-                $displayOrder++;
+                ++$displayOrder;
             }
         }
 
@@ -229,7 +231,7 @@ class Controller extends BlockController
         while ($row = $r->fetchRow()) {
             $options[$i]['name'] = $row['optionName'];
             $options[$i]['id'] = $row['optionID'];
-            $i++;
+            ++$i;
         }
 
         // Get chosen count for each option
@@ -244,13 +246,14 @@ class Controller extends BlockController
                 $options[$i]['amount'] = $row['count(*)'];
                 $total_results += $row['count(*)'];
             }
-            $i++;
+            ++$i;
         }
 
         if ($total_results <= 0) {
             $chart_options = '<div style="text-align: center; margin-top: 15px;">' . t(
                     'No data is available yet.') . '</div>';
             $this->set('chart_options', $chart_options);
+
             return;
         }
 
@@ -275,7 +278,7 @@ class Controller extends BlockController
             '66DD00',
             '6699FF',
             'FFFF33',
-            'FFCC33');
+            'FFCC33', );
         $percentage_value_string = '';
         foreach ($options as $option) {
             $option['amount'] /= $total_results;
@@ -287,7 +290,7 @@ class Controller extends BlockController
         $percentage_value_string = substr_replace($percentage_value_string, '', -1);
 
         // Get Google Charts API image
-        $img_src = '<img class="surveyChart" style="margin-bottom:10px;" border="" src="//chart.apis.google.com/chart?cht=p&chd=t:' . $percentage_value_string . '&chs=180x180&chco=' . join(
+        $img_src = '<img class="surveyChart" style="margin-bottom:10px;" border="" src="//chart.apis.google.com/chart?cht=p&chd=t:' . $percentage_value_string . '&chs=180x180&chco=' . implode(
                 ',',
                 $graphColors) . '" />';
         $this->set('pie_chart', $img_src);
@@ -306,10 +309,9 @@ class Controller extends BlockController
             $chart_options .= '<div class="surveySwatch" style="border-radius: 3px; margin-left: 6px; width:18px; height:18px; float:right; background:#' . $graphColors[$i - 1] . '"></div>';
             $chart_options .= '</td>';
             $chart_options .= '</tr>';
-            $i++;
+            ++$i;
         }
         $chart_options .= '</tbody></table>';
         $this->set('chart_options', $chart_options);
     }
-
 }

--- a/web/concrete/controllers/search/files.php
+++ b/web/concrete/controllers/search/files.php
@@ -23,6 +23,9 @@ class Files extends Controller
     /** @var \Concrete\Core\File\FileList */
     protected $fileList;
 
+    public $searchRequest;
+    public $result;
+
     public function __construct()
     {
         $this->searchRequest = new StickyRequest('files');

--- a/web/concrete/controllers/search/groups.php
+++ b/web/concrete/controllers/search/groups.php
@@ -14,6 +14,9 @@ class Groups extends Controller {
 
 	protected $fields = array();
 
+	public $groupList;
+	public $result;
+
 	public function __construct() {
 		$this->groupList = new GroupList();
 	}

--- a/web/concrete/controllers/search/pages.php
+++ b/web/concrete/controllers/search/pages.php
@@ -23,6 +23,9 @@ class Pages extends Controller
      */
     protected $pageList;
 
+    public $searchRequest;
+    public $result;
+
     public function __construct()
     {
         $this->searchRequest = new StickyRequest('pages');

--- a/web/concrete/controllers/search/users.php
+++ b/web/concrete/controllers/search/users.php
@@ -27,6 +27,9 @@ class Users extends Controller
      */
     protected $userList;
 
+    public $searchRequest;
+    public $result;
+
     public function __construct()
     {
         $this->searchRequest = new StickyRequest('users');

--- a/web/concrete/controllers/single_page/dashboard/workflow/me.php
+++ b/web/concrete/controllers/single_page/dashboard/workflow/me.php
@@ -9,6 +9,8 @@ use Loader;
 class Me extends DashboardPageController {
 
 	protected $wpCategoryHandleActive = 'page';
+
+	public $categories;
 	
 	public function on_start() {
 		parent::on_start();

--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -232,7 +232,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 $this->identifier = 'BLOCK_' . $obj->getBlockID();
                 $this->bID = $b->getBlockID();
                 $this->btHandle = $obj->getBlockTypeHandle();
-                $this->btCachedBlockRecord = $obj->getBlockCachedRecord();
+                $this->btCacheBlockRecord = $obj->getBlockCachedRecord();
                 $this->setBlockObject($b);
                 $this->load();
             }

--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -23,7 +23,9 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     public $blockViewRenderOverride;
     protected $record;
     protected $helpers = array('form');
+    protected $area;
     protected $block;
+    protected $bID;
     protected $btDescription = "";
     protected $btName = "";
     protected $btHandle = "";

--- a/web/concrete/src/Page/Controller/PageController.php
+++ b/web/concrete/src/Page/Controller/PageController.php
@@ -20,6 +20,10 @@ class PageController extends Controller
     protected $passThruBlocks = array();
     protected $parameters = array();
 
+    public $c;
+
+    protected $error;
+
     public function supportsPageCache()
     {
         return $this->supportsPageCache;
@@ -188,8 +192,6 @@ class PageController extends Controller
     }
 
     /**
-     * @access private
-     *
      * @param Block $b
      * @param BlockController $controller
      */


### PR DESCRIPTION
I have a __set() method in the abstract controller that throws exceptions when undeclared class properties are written.

I have started declaring them because I am bored.

I have declared basically all of them as public, because these properties are accessed in all sorts of weird ways, and im not bored enough to trace down where every property is accessed from yet. (It could also break addons).

Some of the files have also been run through php-cs-fixer.