### PR TITLE
Make new filesets public by default

### DIFF
--- a/web/concrete/elements/files/add_to_sets.php
+++ b/web/concrete/elements/files/add_to_sets.php
@@ -33,7 +33,7 @@ $sets = FileSet::getMySets();
 		<div class="form-inline">
 			<a href="#" class="icon-link"><i class="fa fa-minus-circle"></i></a>
 			<input type="text" class="form-control" name="fsNew[]">
-			<label class="checkbox-inline" ><input type="checkbox" name="fsNewShare[]" value="1" /> <span class="small"><?=t('Public Set.')?></span></label>
+			<label class="checkbox-inline" ><input type="checkbox" name="fsNewShare[]" value="1" checked /> <span class="small"><?=t('Public Set.')?></span></label>
 		</div>
 	</div>
 </script>


### PR DESCRIPTION
Make the checkbox determining if the fileset we're adding is public checked by default. 
@aembler mentioned this in #2597.