### PR TITLE
Some improvements for rendering pages manually

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -305,6 +305,9 @@ class Controller extends BlockController
      */
     function generateNav()
     {
+        // Initialize Nav Array
+        $this->navArray = array();
+        
         if (isset($this->displayPagesCID) && !Loader::helper('validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
         }

--- a/web/concrete/src/Html/Service/Seo.php
+++ b/web/concrete/src/Html/Service/Seo.php
@@ -22,7 +22,7 @@ class Seo
     public function setCustomTitle($title)
     {
         $this->hasCustomTitle = true;
-        $this->titleSegments = array();
+        $this->clearTitleSegments();
         $this->addTitleSegmentBefore($title);
         return $this;
     }
@@ -37,6 +37,11 @@ class Seo
     {
         array_unshift($this->titleSegments, $segment);
         return $this;
+    }
+    
+    public function clearTitleSegments()
+    {
+        $this->titleSegments = array();
     }
 
     public function setTitleFormat($format)

--- a/web/concrete/src/Http/ResponseAssetGroup.php
+++ b/web/concrete/src/Http/ResponseAssetGroup.php
@@ -24,8 +24,15 @@ class ResponseAssetGroup
 
     public function __construct()
     {
+        $this->init();
+    }
+    
+    public function init()
+    {
         $this->requiredAssetGroup = new AssetGroup();
         $this->providedAssetGroup = new AssetGroup();
+        $this->providedAssetGroupUnmatched = array();
+        $this->outputAssets = array();
     }
 
     /**


### PR DESCRIPTION
When rendering multiple pages programmatically(e.g. export to html), some items are duplicated because these items are shared in memory. If this request merged, we can reset these shared items.