### PR TITLE
Fix warnings in TreeType

### DIFF
--- a/web/concrete/src/Tree/TreeType.php
+++ b/web/concrete/src/Tree/TreeType.php
@@ -16,7 +16,7 @@ class TreeType extends Object {
 		return PackageList::getHandle($this->pkgID);
 	}
 
-	public function add($treeTypeHandle, $pkg = false) {
+	public static function add($treeTypeHandle, $pkg = false) {
 
 		$pkgID = 0;
 		$db = Loader::db();

--- a/web/concrete/src/Tree/TreeType.php
+++ b/web/concrete/src/Tree/TreeType.php
@@ -3,8 +3,9 @@
 namespace Concrete\Core\Tree;
 
 use Concrete\Core\Foundation\Object;
-use Loader;
 use Concrete\Core\Package\PackageList;
+use Core;
+use Database;
 
 class TreeType extends Object
 {
@@ -31,7 +32,7 @@ class TreeType extends Object
     public static function add($treeTypeHandle, $pkg = false)
     {
         $pkgID = 0;
-        $db = Loader::db();
+        $db = Database::connection();
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
@@ -47,13 +48,13 @@ class TreeType extends Object
 
     public function delete()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('delete from TreeTypes where treeTypeID = ?', array($this->treeTypeID));
     }
 
     public static function getByID($treeTypeID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from TreeTypes where treeTypeID = ?', array($treeTypeID));
         if (is_array($row) && $row['treeTypeID']) {
             $type = new self();
@@ -65,7 +66,7 @@ class TreeType extends Object
 
     public static function getByHandle($treeTypeHandle)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from TreeTypes where treeTypeHandle = ?', array($treeTypeHandle));
         if (is_array($row) && $row['treeTypeHandle']) {
             $type = new self();
@@ -77,7 +78,7 @@ class TreeType extends Object
 
     public function getTreeTypeClass()
     {
-        $txt = Loader::helper('text');
+        $txt = Core::make('helper/text');
         $className = '\\Concrete\\Core\\Tree\\Type\\' . $txt->camelcase($this->treeTypeHandle);
 
         return $className;
@@ -85,7 +86,7 @@ class TreeType extends Object
 
     public static function getListByPackage($pkg)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $list = array();
         $r = $db->Execute('select treeTypeID from TreeTypes where pkgID = ? order by treeTypeID asc', array($pkg->getPackageID()));
         while ($row = $r->FetchRow()) {

--- a/web/concrete/src/Tree/TreeType.php
+++ b/web/concrete/src/Tree/TreeType.php
@@ -1,80 +1,99 @@
 <?php
+
 namespace Concrete\Core\Tree;
-use \Concrete\Core\Foundation\Object;
+
+use Concrete\Core\Foundation\Object;
 use Loader;
-use \Concrete\Core\Package\PackageList;
-class TreeType extends Object {
+use Concrete\Core\Package\PackageList;
 
-	public function getTreeTypeID() {
-		return $this->treeTypeID;
-	}
-	public function getTreeTypeHandle() {
-		return $this->treeTypeHandle;
-	}
-	public function getPackageID() { return $this->pkgID;}
-	public function getPackageHandle() {
-		return PackageList::getHandle($this->pkgID);
-	}
+class TreeType extends Object
+{
+    public function getTreeTypeID()
+    {
+        return $this->treeTypeID;
+    }
 
-	public static function add($treeTypeHandle, $pkg = false) {
+    public function getTreeTypeHandle()
+    {
+        return $this->treeTypeHandle;
+    }
 
-		$pkgID = 0;
-		$db = Loader::db();
-		if (is_object($pkg)) {
-			$pkgID = $pkg->getPackageID();
-		}
+    public function getPackageID()
+    {
+        return $this->pkgID;
+    }
 
-		$r = $db->query("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
-			$treeTypeHandle, $pkgID
-		));
+    public function getPackageHandle()
+    {
+        return PackageList::getHandle($this->pkgID);
+    }
 
-		$treeTypeID = $db->Insert_ID();
-		return TreeType::getByID($treeTypeID);
-	}
+    public static function add($treeTypeHandle, $pkg = false)
+    {
+        $pkgID = 0;
+        $db = Loader::db();
+        if (is_object($pkg)) {
+            $pkgID = $pkg->getPackageID();
+        }
 
-	public function delete() {
-		$db = Loader::db();
-		$db->Execute('delete from TreeTypes where treeTypeID = ?', array($this->treeTypeID));
-	}
+        $r = $db->query("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
+            $treeTypeHandle, $pkgID,
+        ));
 
-	public static function getByID($treeTypeID) {
-		$db = Loader::db();
-		$row = $db->GetRow('select * from TreeTypes where treeTypeID = ?', array($treeTypeID));
-		if (is_array($row) && $row['treeTypeID']) {
-			$type = new TreeType();
-			$type->setPropertiesFromArray($row);
-			return $type;
-		}
-	}
+        $treeTypeID = $db->Insert_ID();
 
-	public static function getByHandle($treeTypeHandle) {
-		$db = Loader::db();
-		$row = $db->GetRow('select * from TreeTypes where treeTypeHandle = ?', array($treeTypeHandle));
-		if (is_array($row) && $row['treeTypeHandle']) {
-			$type = new TreeType();
-			$type->setPropertiesFromArray($row);
-			return $type;
-		}
-	}
+        return self::getByID($treeTypeID);
+    }
 
-	public function getTreeTypeClass() {
-		$txt = Loader::helper('text');
-		$className = '\\Concrete\\Core\\Tree\\Type\\' . $txt->camelcase($this->treeTypeHandle);
-		return $className;
-	}
+    public function delete()
+    {
+        $db = Loader::db();
+        $db->Execute('delete from TreeTypes where treeTypeID = ?', array($this->treeTypeID));
+    }
 
+    public static function getByID($treeTypeID)
+    {
+        $db = Loader::db();
+        $row = $db->GetRow('select * from TreeTypes where treeTypeID = ?', array($treeTypeID));
+        if (is_array($row) && $row['treeTypeID']) {
+            $type = new self();
+            $type->setPropertiesFromArray($row);
 
-	public static function getListByPackage($pkg) {
-		$db = Loader::db();
-		$list = array();
-		$r = $db->Execute('select treeTypeID from TreeTypes where pkgID = ? order by treeTypeID asc', array($pkg->getPackageID()));
-		while ($row = $r->FetchRow()) {
-			$list[] = TreeType::getByID($row['treeTypeID']);
-		}
+            return $type;
+        }
+    }
 
+    public static function getByHandle($treeTypeHandle)
+    {
+        $db = Loader::db();
+        $row = $db->GetRow('select * from TreeTypes where treeTypeHandle = ?', array($treeTypeHandle));
+        if (is_array($row) && $row['treeTypeHandle']) {
+            $type = new self();
+            $type->setPropertiesFromArray($row);
 
-		$r->Close();
-		return $list;
-	}
+            return $type;
+        }
+    }
 
+    public function getTreeTypeClass()
+    {
+        $txt = Loader::helper('text');
+        $className = '\\Concrete\\Core\\Tree\\Type\\' . $txt->camelcase($this->treeTypeHandle);
+
+        return $className;
+    }
+
+    public static function getListByPackage($pkg)
+    {
+        $db = Loader::db();
+        $list = array();
+        $r = $db->Execute('select treeTypeID from TreeTypes where pkgID = ? order by treeTypeID asc', array($pkg->getPackageID()));
+        while ($row = $r->FetchRow()) {
+            $list[] = self::getByID($row['treeTypeID']);
+        }
+
+        $r->Close();
+
+        return $list;
+    }
 }


### PR DESCRIPTION
TreeType::add is called statically: let's mark it as static.

Fixes an E_STRICT warning in PHP < 7, and an E_DEPRECATED warning in PHP 7