### PR TITLE
Fix warnings in NodeType

### DIFF
--- a/web/concrete/src/Tree/Node/NodeType.php
+++ b/web/concrete/src/Tree/Node/NodeType.php
@@ -17,7 +17,7 @@ class NodeType extends Object {
 		return PackageList::getHandle($this->pkgID);
 	}
 
-	public function add($treeNodeTypeHandle, $pkg = false) {
+	public static function add($treeNodeTypeHandle, $pkg = false) {
 
 		$pkgID = 0;
 		$db = Loader::db();

--- a/web/concrete/src/Tree/Node/NodeType.php
+++ b/web/concrete/src/Tree/Node/NodeType.php
@@ -1,78 +1,99 @@
 <?php
+
 namespace Concrete\Core\Tree\Node;
-use \Concrete\Core\Foundation\Object;
+
+use Concrete\Core\Foundation\Object;
 use Loader;
 use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
-use \Concrete\Core\Package\PackageList;
-class NodeType extends Object {
+use Concrete\Core\Package\PackageList;
 
-	public function getTreeNodeTypeID() {
-		return $this->treeNodeTypeID;
-	}
-	public function getTreeNodeTypeHandle() {
-		return $this->treeNodeTypeHandle;
-	}
-	public function getPackageID() { return $this->pkgID;}
-	public function getPackageHandle() {
-		return PackageList::getHandle($this->pkgID);
-	}
+class NodeType extends Object
+{
+    public function getTreeNodeTypeID()
+    {
+        return $this->treeNodeTypeID;
+    }
 
-	public static function add($treeNodeTypeHandle, $pkg = false) {
+    public function getTreeNodeTypeHandle()
+    {
+        return $this->treeNodeTypeHandle;
+    }
 
-		$pkgID = 0;
-		$db = Loader::db();
-		if (is_object($pkg)) {
-			$pkgID = $pkg->getPackageID();
-		}
+    public function getPackageID()
+    {
+        return $this->pkgID;
+    }
 
-		$r = $db->query("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
-			$treeNodeTypeHandle, $pkgID
-		));
+    public function getPackageHandle()
+    {
+        return PackageList::getHandle($this->pkgID);
+    }
 
-		$treeNodeTypeID = $db->Insert_ID();
-		return static::getByID($treeNodeTypeID);
-	}
+    public static function add($treeNodeTypeHandle, $pkg = false)
+    {
+        $pkgID = 0;
+        $db = Loader::db();
+        if (is_object($pkg)) {
+            $pkgID = $pkg->getPackageID();
+        }
 
-	public function delete() {
-		$db = Loader::db();
-		$db->Execute('delete from TreeNodeTypes where treeNodeTypeID = ?', array($this->treeNodeTypeID));
-	}
+        $r = $db->query("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
+            $treeNodeTypeHandle, $pkgID,
+        ));
 
-	public static function getByID($treeNodeTypeID) {
-		$db = Loader::db();
-		$row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeID = ?', array($treeNodeTypeID));
-		if (is_array($row) && $row['treeNodeTypeID']) {
-			$type = new TreeNodeType();
-			$type->setPropertiesFromArray($row);
-			return $type;
-		}
-	}
+        $treeNodeTypeID = $db->Insert_ID();
 
-	public static function getByHandle($treeNodeTypeHandle) {
-		$db = Loader::db();
-		$row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeHandle = ?', array($treeNodeTypeHandle));
-		if (is_array($row) && $row['treeNodeTypeHandle']) {
-			$type = new TreeNodeType();
-			$type->setPropertiesFromArray($row);
-			return $type;
-		}
-	}
+        return static::getByID($treeNodeTypeID);
+    }
 
-	public function getTreeNodeTypeClass() {
-		$txt = Loader::helper('text');
-		$className = '\\Concrete\\Core\\Tree\\Node\\Type\\' . $txt->camelcase($this->treeNodeTypeHandle);
-		return $className;
-	}
+    public function delete()
+    {
+        $db = Loader::db();
+        $db->Execute('delete from TreeNodeTypes where treeNodeTypeID = ?', array($this->treeNodeTypeID));
+    }
 
-	public static function getListByPackage($pkg) {
-		$db = Loader::db();
-		$list = array();
-		$r = $db->Execute('select treeNodeTypeID from TreeNodeTypes where pkgID = ? order by treeNodeTypeID asc', array($pkg->getPackageID()));
-		while ($row = $r->FetchRow()) {
-			$list[] = TreeNodeType::getByID($row['treeNodeTypeID']);
-		}
-		$r->Close();
-		return $list;
-	}
+    public static function getByID($treeNodeTypeID)
+    {
+        $db = Loader::db();
+        $row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeID = ?', array($treeNodeTypeID));
+        if (is_array($row) && $row['treeNodeTypeID']) {
+            $type = new TreeNodeType();
+            $type->setPropertiesFromArray($row);
 
+            return $type;
+        }
+    }
+
+    public static function getByHandle($treeNodeTypeHandle)
+    {
+        $db = Loader::db();
+        $row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeHandle = ?', array($treeNodeTypeHandle));
+        if (is_array($row) && $row['treeNodeTypeHandle']) {
+            $type = new TreeNodeType();
+            $type->setPropertiesFromArray($row);
+
+            return $type;
+        }
+    }
+
+    public function getTreeNodeTypeClass()
+    {
+        $txt = Loader::helper('text');
+        $className = '\\Concrete\\Core\\Tree\\Node\\Type\\' . $txt->camelcase($this->treeNodeTypeHandle);
+
+        return $className;
+    }
+
+    public static function getListByPackage($pkg)
+    {
+        $db = Loader::db();
+        $list = array();
+        $r = $db->Execute('select treeNodeTypeID from TreeNodeTypes where pkgID = ? order by treeNodeTypeID asc', array($pkg->getPackageID()));
+        while ($row = $r->FetchRow()) {
+            $list[] = TreeNodeType::getByID($row['treeNodeTypeID']);
+        }
+        $r->Close();
+
+        return $list;
+    }
 }

--- a/web/concrete/src/Tree/Node/NodeType.php
+++ b/web/concrete/src/Tree/Node/NodeType.php
@@ -3,9 +3,10 @@
 namespace Concrete\Core\Tree\Node;
 
 use Concrete\Core\Foundation\Object;
-use Loader;
 use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
 use Concrete\Core\Package\PackageList;
+use Core;
+use Database;
 
 class NodeType extends Object
 {
@@ -32,7 +33,7 @@ class NodeType extends Object
     public static function add($treeNodeTypeHandle, $pkg = false)
     {
         $pkgID = 0;
-        $db = Loader::db();
+        $db = Database::connection();
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
@@ -48,13 +49,13 @@ class NodeType extends Object
 
     public function delete()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('delete from TreeNodeTypes where treeNodeTypeID = ?', array($this->treeNodeTypeID));
     }
 
     public static function getByID($treeNodeTypeID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeID = ?', array($treeNodeTypeID));
         if (is_array($row) && $row['treeNodeTypeID']) {
             $type = new TreeNodeType();
@@ -66,7 +67,7 @@ class NodeType extends Object
 
     public static function getByHandle($treeNodeTypeHandle)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from TreeNodeTypes where treeNodeTypeHandle = ?', array($treeNodeTypeHandle));
         if (is_array($row) && $row['treeNodeTypeHandle']) {
             $type = new TreeNodeType();
@@ -78,7 +79,7 @@ class NodeType extends Object
 
     public function getTreeNodeTypeClass()
     {
-        $txt = Loader::helper('text');
+        $txt = Core::make('helper/text');
         $className = '\\Concrete\\Core\\Tree\\Node\\Type\\' . $txt->camelcase($this->treeNodeTypeHandle);
 
         return $className;
@@ -86,7 +87,7 @@ class NodeType extends Object
 
     public static function getListByPackage($pkg)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $list = array();
         $r = $db->Execute('select treeNodeTypeID from TreeNodeTypes where pkgID = ? order by treeNodeTypeID asc', array($pkg->getPackageID()));
         while ($row = $r->FetchRow()) {


### PR DESCRIPTION
NodeType::add is called statically: let's mark it as static.

Fixes an E_STRICT warning in PHP < 7, and an E_DEPRECATED warning in PHP 7