### PR TITLE
Fix warnings in UserKey

### DIFF
--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -1,362 +1,410 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
-use \Concrete\Core\Attribute\Type as AttributeType;
+
+use Concrete\Core\Attribute\Type as AttributeType;
 use Loader;
 use CacheLocal;
 use Package;
-use \Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
-use \Concrete\Core\Attribute\Value\UserValue as UserAttributeValue;
+use Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
+use Concrete\Core\Attribute\Value\UserValue as UserAttributeValue;
 
-class UserKey extends Key {
+class UserKey extends Key
+{
+    public function getIndexedSearchTable()
+    {
+        return 'UserSearchIndexAttributes';
+    }
 
-	public function getIndexedSearchTable() {
-		return 'UserSearchIndexAttributes';
-	}
+    protected $searchIndexFieldDefinition = array(
+        'columns' => array(
+            array('name' => 'uID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true)),
+        ),
+        'primary' => array('uID'),
+    );
 
-	protected $searchIndexFieldDefinition = array(
-		'columns' => array(
-			array('name' => 'uID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true))
-		),
-		'primary' => array('uID')
-	);
+    public static function getAttributes($uID, $method = 'getValue')
+    {
+        $db = Loader::db();
+        $values = $db->GetAll("select avID, akID from UserAttributeValues where uID = ?", array($uID));
+        $avl = new AttributeValueList();
+        foreach ($values as $val) {
+            $ak = static::getByID($val['akID']);
+            if (is_object($ak)) {
+                $value = $ak->getAttributeValue($val['avID'], $method);
+                $avl->addAttributeValue($ak, $value);
+            }
+        }
 
-	public static function getAttributes($uID, $method = 'getValue') {
-		$db = Loader::db();
-		$values = $db->GetAll("select avID, akID from UserAttributeValues where uID = ?", array($uID));
-		$avl = new AttributeValueList();
-		foreach($values as $val) {
-			$ak = static::getByID($val['akID']);
-			if (is_object($ak)) {
-				$value = $ak->getAttributeValue($val['avID'], $method);
-				$avl->addAttributeValue($ak, $value);
-			}
-		}
-		return $avl;
-	}
+        return $avl;
+    }
 
-	public function getAttributeKeyDisplayOrder() {return $this->displayOrder;}
+    public function getAttributeKeyDisplayOrder()
+    {
+        return $this->displayOrder;
+    }
 
+    public function load($akIdentifier, $loadBy = 'akID')
+    {
+        parent::load($akIdentifier, $loadBy);
+        if (isset($this->akID) && $this->akID) {
+            $db = Loader::db();
+            $row = $db->GetRow("select uakProfileDisplay, uakMemberListDisplay, displayOrder, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, uakIsActive from UserAttributeKeys where akID = ?", array($this->akID));
+            $this->setPropertiesFromArray($row);
+        }
+    }
 
-	public function load($akIdentifier, $loadBy = 'akID') {
-		parent::load($akIdentifier, $loadBy);
-		if (isset($this->akID) && $this->akID) {
-			$db = Loader::db();
-			$row = $db->GetRow("select uakProfileDisplay, uakMemberListDisplay, displayOrder, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, uakIsActive from UserAttributeKeys where akID = ?", array($this->akID));
-			$this->setPropertiesFromArray($row);
-		}
-	}
+    public function getAttributeValue($avID, $method = 'getValue')
+    {
+        $av = UserAttributeValue::getByID($avID);
+        $av->setAttributeKey($this);
 
-	public function getAttributeValue($avID, $method = 'getValue') {
-		$av = UserAttributeValue::getByID($avID);
-		$av->setAttributeKey($this);
-		return $av->{$method}();
-	}
+        return $av->{$method}();
+    }
 
-	public static function getByID($akID) {
-		$ak = new static();
-		$ak->load($akID);
-		if ($ak->getAttributeKeyID() > 0) {
-			return $ak;
-		}
-	}
+    public static function getByID($akID)
+    {
+        $ak = new static();
+        $ak->load($akID);
+        if ($ak->getAttributeKeyID() > 0) {
+            return $ak;
+        }
+    }
 
-	public static function getByHandle($akHandle) {
-		$ak = CacheLocal::getEntry('user_attribute_key_by_handle', $akHandle);
-		if (is_object($ak)) {
-			return $ak;
-		} else if ($ak == -1) {
-			return false;
-		}
-		$ak = -1;
-		$db = Loader::db();
+    public static function getByHandle($akHandle)
+    {
+        $ak = CacheLocal::getEntry('user_attribute_key_by_handle', $akHandle);
+        if (is_object($ak)) {
+            return $ak;
+        } elseif ($ak == -1) {
+            return false;
+        }
+        $ak = -1;
+        $db = Loader::db();
 
-		$q = "SELECT ak.akID
+        $q = "SELECT ak.akID
 			FROM AttributeKeys ak
 			INNER JOIN AttributeKeyCategories akc ON ak.akCategoryID = akc.akCategoryID
 			WHERE ak.akHandle = ?
 			AND akc.akCategoryHandle = 'user'";
-		$akID = $db->GetOne($q, array($akHandle));
-		if ($akID > 0) {
-			$ak = static::getByID($akID);
-		}
+        $akID = $db->GetOne($q, array($akHandle));
+        if ($akID > 0) {
+            $ak = static::getByID($akID);
+        }
 
-		CacheLocal::set('user_attribute_key_by_handle', $akHandle, $ak);
-		if ($ak === -1) {
-			return false;
-		}
-		return $ak;
-	}
+        CacheLocal::set('user_attribute_key_by_handle', $akHandle, $ak);
+        if ($ak === -1) {
+            return false;
+        }
 
-	public function export($axml, $exporttype = 'full') {
-		$akey = parent::export($axml, $exporttype);
-		$akey->addAttribute('profile-displayed', $this->uakProfileDisplay);
-		$akey->addAttribute('profile-editable', $this->uakProfileEdit);
-		$akey->addAttribute('profile-required',$this->uakProfileEditRequired);
-		$akey->addAttribute('register-editable', $this->uakRegisterEdit);
-		$akey->addAttribute('register-required', $this->uakRegisterEditRequired);
-		$akey->addAttribute('member-list-displayed', $this->uakMemberListDisplay);
-		return $akey;
-	}
+        return $ak;
+    }
 
-	public static function import(\SimpleXMLElement $ak) {
-		$type = AttributeType::getByHandle($ak['type']);
-		$pkg = false;
-		if ($ak['package']) {
-			$pkg = Package::getByHandle($ak['package']);
-		}
-		$akn = static::add($type, array(
-			'akHandle' => $ak['handle'],
-			'akName' => $ak['name'],
-			'akIsSearchableIndexed' => $ak['indexed'],
-			'akIsSearchable' => $ak['searchable'],
-			'uakProfileDisplay' => $ak['profile-displayed'],
-			'uakProfileEdit' => $ak['profile-editable'],
-			'uakProfileEditRequired' => $ak['profile-required'],
-			'uakRegisterEdit' => $ak['register-editable'],
-			'uakRegisterEditRequired' => $ak['register-required'],
-			'uakMemberListDisplay' => $ak['member-list-displayed']
-		), $pkg);
+    public function export($axml, $exporttype = 'full')
+    {
+        $akey = parent::export($axml, $exporttype);
+        $akey->addAttribute('profile-displayed', $this->uakProfileDisplay);
+        $akey->addAttribute('profile-editable', $this->uakProfileEdit);
+        $akey->addAttribute('profile-required', $this->uakProfileEditRequired);
+        $akey->addAttribute('register-editable', $this->uakRegisterEdit);
+        $akey->addAttribute('register-required', $this->uakRegisterEditRequired);
+        $akey->addAttribute('member-list-displayed', $this->uakMemberListDisplay);
 
-		$akn->getController()->importKey($ak);
+        return $akey;
+    }
 
-	}
+    public static function import(\SimpleXMLElement $ak)
+    {
+        $type = AttributeType::getByHandle($ak['type']);
+        $pkg = false;
+        if ($ak['package']) {
+            $pkg = Package::getByHandle($ak['package']);
+        }
+        $akn = static::add($type, array(
+            'akHandle' => $ak['handle'],
+            'akName' => $ak['name'],
+            'akIsSearchableIndexed' => $ak['indexed'],
+            'akIsSearchable' => $ak['searchable'],
+            'uakProfileDisplay' => $ak['profile-displayed'],
+            'uakProfileEdit' => $ak['profile-editable'],
+            'uakProfileEditRequired' => $ak['profile-required'],
+            'uakRegisterEdit' => $ak['register-editable'],
+            'uakRegisterEditRequired' => $ak['register-required'],
+            'uakMemberListDisplay' => $ak['member-list-displayed'],
+        ), $pkg);
 
-	public function isAttributeKeyDisplayedOnProfile() {
-		return $this->uakProfileDisplay;
-	}
-	public function isAttributeKeyEditableOnProfile() {
-		return $this->uakProfileEdit;
-	}
-	public function isAttributeKeyRequiredOnProfile() {
-		return $this->uakProfileEditRequired;
-	}
-	public function isAttributeKeyEditableOnRegister() {
-		return $this->uakRegisterEdit;
-	}
-	public function isAttributeKeyRequiredOnRegister() {
-		return $this->uakRegisterEditRequired;
-	}
+        $akn->getController()->importKey($ak);
+    }
 
-	public function isAttributeKeyDisplayedOnMemberList() {
-		return $this->uakMemberListDisplay;
-	}
+    public function isAttributeKeyDisplayedOnProfile()
+    {
+        return $this->uakProfileDisplay;
+    }
 
-	public function isAttributeKeyActive() {
-		return $this->uakIsActive;
-	}
+    public function isAttributeKeyEditableOnProfile()
+    {
+        return $this->uakProfileEdit;
+    }
 
-	public function activate() {
-		$db = Loader::db();
-		$this->refreshCache();
-		$db->Execute('update UserAttributeKeys set uakIsActive = 1 where akID = ?', array($this->akID));
-	}
+    public function isAttributeKeyRequiredOnProfile()
+    {
+        return $this->uakProfileEditRequired;
+    }
 
-	public function deactivate() {
-		$db = Loader::db();
-		$this->refreshCache();
-		$db->Execute('update UserAttributeKeys set uakIsActive = 0 where akID = ?', array($this->akID));
-	}
+    public function isAttributeKeyEditableOnRegister()
+    {
+        return $this->uakRegisterEdit;
+    }
 
-	public static function getList() {
-		$list = parent::getList('user');
-		usort($list, function($a, $b) {
-			if ($a->getAttributeKeyDisplayOrder() == $b->getAttributeKeyDisplayOrder()) {
-				return 0;
-			} else {
-				return ($a->getAttributeKeyDisplayOrder() < $b->getAttributeKeyDisplayOrder()) ? -1 : 1;
-			}
-		});
-		return $list;
-	}
+    public function isAttributeKeyRequiredOnRegister()
+    {
+        return $this->uakRegisterEditRequired;
+    }
 
-	protected function saveAttribute($uo, $value = false) {
-		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
-		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
-		// otherwise generate new IDs
-		$av = $uo->getAttributeValueObject($this, true);
-		parent::saveAttribute($av, $value);
-		$db = Loader::db();
-		$v = array($uo->getUserID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
-		$db->Replace('UserAttributeValues', array(
-			'uID' => $uo->getUserID(),
-			'akID' => $this->getAttributeKeyID(),
-			'avID' => $av->getAttributeValueID()
-		), array('uID', 'akID'));
+    public function isAttributeKeyDisplayedOnMemberList()
+    {
+        return $this->uakMemberListDisplay;
+    }
 
-		$uo->reindex();
-		unset($uo);
-	}
+    public function isAttributeKeyActive()
+    {
+        return $this->uakIsActive;
+    }
 
-	public static function add($type, $args, $pkg = false) {
+    public function activate()
+    {
+        $db = Loader::db();
+        $this->refreshCache();
+        $db->Execute('update UserAttributeKeys set uakIsActive = 1 where akID = ?', array($this->akID));
+    }
 
-		CacheLocal::delete('user_attribute_key_by_handle', $args['akHandle']);
+    public function deactivate()
+    {
+        $db = Loader::db();
+        $this->refreshCache();
+        $db->Execute('update UserAttributeKeys set uakIsActive = 0 where akID = ?', array($this->akID));
+    }
 
-		$ak = parent::add('user', $type, $args, $pkg);
+    public static function getList()
+    {
+        $list = parent::getList('user');
+        usort($list, function ($a, $b) {
+            if ($a->getAttributeKeyDisplayOrder() == $b->getAttributeKeyDisplayOrder()) {
+                return 0;
+            } else {
+                return ($a->getAttributeKeyDisplayOrder() < $b->getAttributeKeyDisplayOrder()) ? -1 : 1;
+            }
+        });
 
-		extract($args);
+        return $list;
+    }
 
-		if ($uakProfileDisplay != 1) {
-			$uakProfileDisplay = 0;
-		}
-		if ($uakMemberListDisplay != 1) {
-			$uakMemberListDisplay = 0;
-		}
-		if ($uakProfileEdit != 1) {
-			$uakProfileEdit = 0;
-		}
-		if ($uakProfileEditRequired != 1) {
-			$uakProfileEditRequired = 0;
-		}
-		if ($uakRegisterEdit != 1) {
-			$uakRegisterEdit = 0;
-		}
-		if ($uakRegisterEditRequired != 1) {
-			$uakRegisterEditRequired = 0;
-		}
+    protected function saveAttribute($uo, $value = false)
+    {
+        // We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
+        // is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
+        // otherwise generate new IDs
+        $av = $uo->getAttributeValueObject($this, true);
+        parent::saveAttribute($av, $value);
+        $db = Loader::db();
+        $v = array($uo->getUserID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
+        $db->Replace('UserAttributeValues', array(
+            'uID' => $uo->getUserID(),
+            'akID' => $this->getAttributeKeyID(),
+            'avID' => $av->getAttributeValueID(),
+        ), array('uID', 'akID'));
 
-		if (isset($uakIsActive) && (!$uakIsActive)) {
-			$uakIsActive = 0;
-		} else {
-			$uakIsActive = 1;
-		}
+        $uo->reindex();
+        unset($uo);
+    }
 
-		$db = Loader::db();
-		$displayOrder = $db->GetOne('select max(displayOrder) from UserAttributeKeys');
-		if (!$displayOrder) {
-			$displayOrder = 0;
-		}
-		$displayOrder++;
-		$v = array($ak->getAttributeKeyID(), $uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $displayOrder, $uakIsActive);
-		$db->Execute('insert into UserAttributeKeys (akID, uakProfileDisplay, uakMemberListDisplay, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, displayOrder, uakIsActive) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
+    public static function add($type, $args, $pkg = false)
+    {
+        CacheLocal::delete('user_attribute_key_by_handle', $args['akHandle']);
 
-		$nak = new static();
-		$nak->load($ak->getAttributeKeyID());
-		return $nak;
-	}
+        $ak = parent::add('user', $type, $args, $pkg);
 
-	public function update($args) {
-		$ak = parent::update($args);
+        extract($args);
 
-		extract($args);
+        if ($uakProfileDisplay != 1) {
+            $uakProfileDisplay = 0;
+        }
+        if ($uakMemberListDisplay != 1) {
+            $uakMemberListDisplay = 0;
+        }
+        if ($uakProfileEdit != 1) {
+            $uakProfileEdit = 0;
+        }
+        if ($uakProfileEditRequired != 1) {
+            $uakProfileEditRequired = 0;
+        }
+        if ($uakRegisterEdit != 1) {
+            $uakRegisterEdit = 0;
+        }
+        if ($uakRegisterEditRequired != 1) {
+            $uakRegisterEditRequired = 0;
+        }
 
-		if ($uakProfileDisplay != 1) {
-			$uakProfileDisplay = 0;
-		}
-		if ($uakMemberListDisplay != 1) {
-			$uakMemberListDisplay = 0;
-		}
-		if ($uakProfileEdit != 1) {
-			$uakProfileEdit = 0;
-		}
-		if ($uakProfileEditRequired != 1) {
-			$uakProfileEditRequired = 0;
-		}
-		if ($uakRegisterEdit != 1) {
-			$uakRegisterEdit = 0;
-		}
-		if ($uakRegisterEditRequired != 1) {
-			$uakRegisterEditRequired = 0;
-		}
-		$db = Loader::db();
-		$v = array($uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $ak->getAttributeKeyID());
-		$db->Execute('update UserAttributeKeys set uakProfileDisplay = ?, uakMemberListDisplay = ?, uakProfileEdit= ?, uakProfileEditRequired = ?, uakRegisterEdit = ?, uakRegisterEditRequired = ? where akID = ?', $v);
-	}
+        if (isset($uakIsActive) && (!$uakIsActive)) {
+            $uakIsActive = 0;
+        } else {
+            $uakIsActive = 1;
+        }
 
+        $db = Loader::db();
+        $displayOrder = $db->GetOne('select max(displayOrder) from UserAttributeKeys');
+        if (!$displayOrder) {
+            $displayOrder = 0;
+        }
+        ++$displayOrder;
+        $v = array($ak->getAttributeKeyID(), $uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $displayOrder, $uakIsActive);
+        $db->Execute('insert into UserAttributeKeys (akID, uakProfileDisplay, uakMemberListDisplay, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, displayOrder, uakIsActive) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
 
+        $nak = new static();
+        $nak->load($ak->getAttributeKeyID());
 
-	public function delete() {
-		parent::delete();
-		$db = Loader::db();
-		$db->Execute('delete from UserAttributeKeys where akID = ?', array($this->getAttributeKeyID()));
-		$r = $db->Execute('select avID from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-		while ($row = $r->FetchRow()) {
-			$db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
-		}
-		$db->Execute('delete from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-	}
+        return $nak;
+    }
 
-	public static function getColumnHeaderList() {
-		return parent::getList('user', array('akIsColumnHeader' => 1));
-	}
-	public static function getEditableList() {
-		return parent::getList('user', array('akIsEditable' => 1));
-	}
-	public static function getSearchableList() {
-		return parent::getList('user', array('akIsSearchable' => 1));
-	}
-	public static function getSearchableIndexedList() {
-		return parent::getList('user', array('akIsSearchableIndexed' => 1));
-	}
-	public static function getImporterList() {
-		return parent::getList('user', array('akIsAutoCreated' => 1));
-	}
+    public function update($args)
+    {
+        $ak = parent::update($args);
 
-	public static function getPublicProfileList() {
-		$tattribs = self::getList();
-		$attribs = array();
-		foreach($tattribs as $uak) {
-			if ((!$uak->isAttributeKeyDisplayedOnProfile()) || (!$uak->isAttributeKeyActive())) {
-				continue;
-			}
-			$attribs[] = $uak;
-		}
-		unset($tattribs);
-		return $attribs;
-	}
+        extract($args);
 
-	public static function getRegistrationList() {
-		$tattribs = self::getList();
-		$attribs = array();
-		foreach($tattribs as $uak) {
-			if ((!$uak->isAttributeKeyEditableOnRegister()) || (!$uak->isAttributeKeyActive())) {
-				continue;
-			}
-			$attribs[] = $uak;
-		}
-		unset($tattribs);
-		return $attribs;
-	}
+        if ($uakProfileDisplay != 1) {
+            $uakProfileDisplay = 0;
+        }
+        if ($uakMemberListDisplay != 1) {
+            $uakMemberListDisplay = 0;
+        }
+        if ($uakProfileEdit != 1) {
+            $uakProfileEdit = 0;
+        }
+        if ($uakProfileEditRequired != 1) {
+            $uakProfileEditRequired = 0;
+        }
+        if ($uakRegisterEdit != 1) {
+            $uakRegisterEdit = 0;
+        }
+        if ($uakRegisterEditRequired != 1) {
+            $uakRegisterEditRequired = 0;
+        }
+        $db = Loader::db();
+        $v = array($uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $ak->getAttributeKeyID());
+        $db->Execute('update UserAttributeKeys set uakProfileDisplay = ?, uakMemberListDisplay = ?, uakProfileEdit= ?, uakProfileEditRequired = ?, uakRegisterEdit = ?, uakRegisterEditRequired = ? where akID = ?', $v);
+    }
 
-	public static function getMemberListList() {
-		$tattribs = self::getList();
-		$attribs = array();
-		foreach($tattribs as $uak) {
-			if ((!$uak->isAttributeKeyDisplayedOnMemberList()) || (!$uak->isAttributeKeyActive())) {
-				continue;
-			}
-			$attribs[] = $uak;
-		}
-		unset($tattribs);
-		return $attribs;
-	}
+    public function delete()
+    {
+        parent::delete();
+        $db = Loader::db();
+        $db->Execute('delete from UserAttributeKeys where akID = ?', array($this->getAttributeKeyID()));
+        $r = $db->Execute('select avID from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        while ($row = $r->FetchRow()) {
+            $db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
+        }
+        $db->Execute('delete from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+    }
 
-	public static function getEditableInProfileList() {
-		$tattribs = self::getList();
-		$attribs = array();
-		foreach($tattribs as $uak) {
-			if ((!$uak->isAttributeKeyEditableOnProfile()) || (!$uak->isAttributeKeyActive())) {
-				continue;
-			}
-			$attribs[] = $uak;
-		}
-		unset($tattribs);
-		return $attribs;
-	}
+    public static function getColumnHeaderList()
+    {
+        return parent::getList('user', array('akIsColumnHeader' => 1));
+    }
 
-	public static function getUserAddedList() {
-		return parent::getList('user', array('akIsAutoCreated' => 0));
-	}
+    public static function getEditableList()
+    {
+        return parent::getList('user', array('akIsEditable' => 1));
+    }
 
+    public static function getSearchableList()
+    {
+        return parent::getList('user', array('akIsSearchable' => 1));
+    }
 
-	public static function updateAttributesDisplayOrder($uats) {
-		$db = Loader::db();
-		for ($i = 0; $i < count($uats); $i++) {
-			$uak = static::getByID($uats[$i]);
-			$uak->refreshCache();
-			$v = array($uats[$i]);
-			$db->query("update UserAttributeKeys set displayOrder = {$i} where akID = ?", $v);
-		}
-	}
+    public static function getSearchableIndexedList()
+    {
+        return parent::getList('user', array('akIsSearchableIndexed' => 1));
+    }
 
+    public static function getImporterList()
+    {
+        return parent::getList('user', array('akIsAutoCreated' => 1));
+    }
 
+    public static function getPublicProfileList()
+    {
+        $tattribs = self::getList();
+        $attribs = array();
+        foreach ($tattribs as $uak) {
+            if ((!$uak->isAttributeKeyDisplayedOnProfile()) || (!$uak->isAttributeKeyActive())) {
+                continue;
+            }
+            $attribs[] = $uak;
+        }
+        unset($tattribs);
+
+        return $attribs;
+    }
+
+    public static function getRegistrationList()
+    {
+        $tattribs = self::getList();
+        $attribs = array();
+        foreach ($tattribs as $uak) {
+            if ((!$uak->isAttributeKeyEditableOnRegister()) || (!$uak->isAttributeKeyActive())) {
+                continue;
+            }
+            $attribs[] = $uak;
+        }
+        unset($tattribs);
+
+        return $attribs;
+    }
+
+    public static function getMemberListList()
+    {
+        $tattribs = self::getList();
+        $attribs = array();
+        foreach ($tattribs as $uak) {
+            if ((!$uak->isAttributeKeyDisplayedOnMemberList()) || (!$uak->isAttributeKeyActive())) {
+                continue;
+            }
+            $attribs[] = $uak;
+        }
+        unset($tattribs);
+
+        return $attribs;
+    }
+
+    public static function getEditableInProfileList()
+    {
+        $tattribs = self::getList();
+        $attribs = array();
+        foreach ($tattribs as $uak) {
+            if ((!$uak->isAttributeKeyEditableOnProfile()) || (!$uak->isAttributeKeyActive())) {
+                continue;
+            }
+            $attribs[] = $uak;
+        }
+        unset($tattribs);
+
+        return $attribs;
+    }
+
+    public static function getUserAddedList()
+    {
+        return parent::getList('user', array('akIsAutoCreated' => 0));
+    }
+
+    public static function updateAttributesDisplayOrder($uats)
+    {
+        $db = Loader::db();
+        for ($i = 0; $i < count($uats); ++$i) {
+            $uak = static::getByID($uats[$i]);
+            $uak->refreshCache();
+            $v = array($uats[$i]);
+            $db->query("update UserAttributeKeys set displayOrder = {$i} where akID = ?", $v);
+        }
+    }
 }

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -87,8 +87,8 @@ class UserKey extends Key {
 		return $ak;
 	}
 
-	public function export($axml) {
-		$akey = parent::export($axml);
+	public function export($axml, $exporttype = 'full') {
+		$akey = parent::export($axml, $exporttype);
 		$akey->addAttribute('profile-displayed', $this->uakProfileDisplay);
 		$akey->addAttribute('profile-editable', $this->uakProfileEdit);
 		$akey->addAttribute('profile-required',$this->uakProfileEditRequired);

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -37,11 +37,13 @@ class UserKey extends Key {
 	public function getAttributeKeyDisplayOrder() {return $this->displayOrder;}
 
 
-	public function load($akID) {
-		parent::load($akID);
-		$db = Loader::db();
-		$row = $db->GetRow("select uakProfileDisplay, uakMemberListDisplay, displayOrder, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, uakIsActive from UserAttributeKeys where akID = ?", array($akID));
-		$this->setPropertiesFromArray($row);
+	public function load($akIdentifier, $loadBy = 'akID') {
+		parent::load($akIdentifier, $loadBy);
+		if (isset($this->akID) && $this->akID) {
+			$db = Loader::db();
+			$row = $db->GetRow("select uakProfileDisplay, uakMemberListDisplay, displayOrder, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, uakIsActive from UserAttributeKeys where akID = ?", array($this->akID));
+			$this->setPropertiesFromArray($row);
+		}
 	}
 
 	public function getAttributeValue($avID, $method = 'getValue') {

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -3,7 +3,7 @@
 namespace Concrete\Core\Attribute\Key;
 
 use Concrete\Core\Attribute\Type as AttributeType;
-use Loader;
+use Database;
 use CacheLocal;
 use Package;
 use Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
@@ -25,7 +25,7 @@ class UserKey extends Key
 
     public static function getAttributes($uID, $method = 'getValue')
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $values = $db->GetAll("select avID, akID from UserAttributeValues where uID = ?", array($uID));
         $avl = new AttributeValueList();
         foreach ($values as $val) {
@@ -48,7 +48,7 @@ class UserKey extends Key
     {
         parent::load($akIdentifier, $loadBy);
         if (isset($this->akID) && $this->akID) {
-            $db = Loader::db();
+            $db = Database::connection();
             $row = $db->GetRow("select uakProfileDisplay, uakMemberListDisplay, displayOrder, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, uakIsActive from UserAttributeKeys where akID = ?", array($this->akID));
             $this->setPropertiesFromArray($row);
         }
@@ -80,7 +80,7 @@ class UserKey extends Key
             return false;
         }
         $ak = -1;
-        $db = Loader::db();
+        $db = Database::connection();
 
         $q = "SELECT ak.akID
 			FROM AttributeKeys ak
@@ -173,14 +173,14 @@ class UserKey extends Key
 
     public function activate()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $this->refreshCache();
         $db->Execute('update UserAttributeKeys set uakIsActive = 1 where akID = ?', array($this->akID));
     }
 
     public function deactivate()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $this->refreshCache();
         $db->Execute('update UserAttributeKeys set uakIsActive = 0 where akID = ?', array($this->akID));
     }
@@ -206,7 +206,7 @@ class UserKey extends Key
         // otherwise generate new IDs
         $av = $uo->getAttributeValueObject($this, true);
         parent::saveAttribute($av, $value);
-        $db = Loader::db();
+        $db = Database::connection();
         $v = array($uo->getUserID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
         $db->Replace('UserAttributeValues', array(
             'uID' => $uo->getUserID(),
@@ -251,7 +251,7 @@ class UserKey extends Key
             $uakIsActive = 1;
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         $displayOrder = $db->GetOne('select max(displayOrder) from UserAttributeKeys');
         if (!$displayOrder) {
             $displayOrder = 0;
@@ -290,7 +290,7 @@ class UserKey extends Key
         if ($uakRegisterEditRequired != 1) {
             $uakRegisterEditRequired = 0;
         }
-        $db = Loader::db();
+        $db = Database::connection();
         $v = array($uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $ak->getAttributeKeyID());
         $db->Execute('update UserAttributeKeys set uakProfileDisplay = ?, uakMemberListDisplay = ?, uakProfileEdit= ?, uakProfileEditRequired = ?, uakRegisterEdit = ?, uakRegisterEditRequired = ? where akID = ?', $v);
     }
@@ -298,7 +298,7 @@ class UserKey extends Key
     public function delete()
     {
         parent::delete();
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('delete from UserAttributeKeys where akID = ?', array($this->getAttributeKeyID()));
         $r = $db->Execute('select avID from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
         while ($row = $r->FetchRow()) {
@@ -399,7 +399,7 @@ class UserKey extends Key
 
     public static function updateAttributesDisplayOrder($uats)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         for ($i = 0; $i < count($uats); ++$i) {
             $uak = static::getByID($uats[$i]);
             $uak->refreshCache();


### PR DESCRIPTION
This PR fixes two E_STRICT warnings in PHP < 7 (two E_WARNING in PHP 7).

BTW, there are two more declarations that should be fixed:
- [`UserKey::getList`](https://github.com/concrete5/concrete5/blob/c478b84576740cc262a36e65010147e403d427e6/web/concrete/src/Attribute/Key/UserKey.php#L158) vs [`Key::getList`](https://github.com/concrete5/concrete5/blob/c478b84576740cc262a36e65010147e403d427e6/web/concrete/src/Attribute/Key/Key.php#L216)
- [`UserKey::add`](https://github.com/concrete5/concrete5/blob/c478b84576740cc262a36e65010147e403d427e6/web/concrete/src/Attribute/Key/UserKey.php#L188) vs [`Key::add`](https://github.com/concrete5/concrete5/blob/c478b84576740cc262a36e65010147e403d427e6/web/concrete/src/Attribute/Key/Key.php#L360)

I can't see a way to make them compatible...