### PR TITLE
Search Controller Abstraction

### DIFF
--- a/web/concrete/controllers/search/files.php
+++ b/web/concrete/controllers/search/files.php
@@ -166,6 +166,11 @@ class Files extends Controller
         return $this->result;
     }
 
+    public function getListObject()
+    {
+        return $this->fileList;
+    }
+
     public function field($field)
     {
         $r = $this->getField($field);

--- a/web/concrete/controllers/search/groups.php
+++ b/web/concrete/controllers/search/groups.php
@@ -45,6 +45,10 @@ class Groups extends Controller {
 		return $this->result;
 	}
 
+	public function getListObject() {
+		return $this->groupList;
+	}
+
 	public function submit() {
 		$this->search();
 		$result = $this->result;

--- a/web/concrete/controllers/search/pages.php
+++ b/web/concrete/controllers/search/pages.php
@@ -190,6 +190,11 @@ class Pages extends Controller
         return $this->result;
     }
 
+    public function getListObject()
+    {
+        return $this->pageList;
+    }
+
     public function field($field)
     {
         $r = $this->getField($field);

--- a/web/concrete/controllers/search/users.php
+++ b/web/concrete/controllers/search/users.php
@@ -173,6 +173,11 @@ class Users extends Controller
         return $this->result;
     }
 
+    public function getListObject()
+    {
+        return $this->userList;
+    }
+
     public function field($field)
     {
         $r = $this->getField($field);


### PR DESCRIPTION
Added a getListObject function to each of the search controllers to
noninvasively facilitate abstraction. This is useful for packages that
need apply extra qualifiers to a DatabaseItemList after a search has
been performed.