### PR TITLE
Add named route url resolver

### DIFF
--- a/tests/tests/Core/Routing/URLTest.php
+++ b/tests/tests/Core/Routing/URLTest.php
@@ -95,8 +95,10 @@ class URLTest extends PHPUnit_Framework_TestCase
         $app = Core::make("app");
         Config::set('concrete.seo.redirect_to_canonical_url', true);
         Config::set('concrete.seo.canonical_url', 'https://www2.myawesomesite.com:8080');
+        Config::set('concrete.seo.canonical_ssl_url', 'https://www2.myawesomesite.com:8080');
         $request = \Concrete\Core\Http\Request::create('http://www.awesome.com/path/to/site/index.php/dashboard?bar=1&foo=1');
         $response = $app->handleCanonicalURLRedirection($request);
+
         $this->assertEquals('https://www2.myawesomesite.com:8080/path/to/site/index.php/dashboard?bar=1&foo=1', $response->getTargetUrl());
         Config::set('concrete.seo.redirect_to_canonical_url', false);
         Config::set('concrete.seo.canonical_url', null);

--- a/web/concrete/src/Routing/Router.php
+++ b/web/concrete/src/Routing/Router.php
@@ -1,12 +1,29 @@
 <?php
 namespace Concrete\Core\Routing;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
 use \Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 use Request;
 use Loader;
 
 class Router {
 
+    /**
+     * @var UrlGeneratorInterface|null
+     */
+    protected $generator;
+
+    /**
+     * @var RequestContext|null
+     */
+    protected $context;
+
+    /**
+     * @var SymfonyRouteCollection
+     */
 	protected $collection;
+
 	protected $request;
 	protected $themePaths = array();
 	public $routes = array();
@@ -14,6 +31,45 @@ class Router {
 	public function __construct() {
 		$this->collection = new SymfonyRouteCollection();
 	}
+
+    /**
+     * @return RequestContext
+     */
+    public function getContext()
+    {
+        if (!$this->context) {
+            $this->context = new RequestContext;
+            $this->context->fromRequest(\Request::getInstance());
+        }
+        return $this->context;
+    }
+
+    /**
+     * @param RequestContext $context
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @return UrlGeneratorInterface
+     */
+    public function getGenerator()
+    {
+        if (!$this->generator) {
+            $this->generator = new UrlGenerator($this->getList(), $this->getContext());
+        }
+        return $this->generator;
+    }
+
+    /**
+     * @param $generator
+     */
+    public function setGenerator(UrlGeneratorInterface $generator)
+    {
+        $this->generator = $generator;
+    }
 
 	public function getList() {
 		return $this->collection;

--- a/web/concrete/src/Url/Resolver/RouteUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/RouteUrlResolver.php
@@ -24,9 +24,12 @@ class RouteUrlResolver implements UrlResolverInterface
             $route_parameters = count($arguments) ? array_shift($arguments) : array();
 
             if (is_string($route_handle) && is_array($route_parameters)) {
-                if ($url = \Route::getGenerator()->generate($route_handle, $route_parameters, UrlGenerator::ABSOLUTE_PATH)) {
-                    $canonical = \Core::make('url/canonical');
-                    return $canonical->setPath($url);
+                if ($route = \Route::getList()->get($route_handle)) {
+                    if ($url = \Route::getGenerator()->generate($route_handle, $route_parameters, UrlGenerator::ABSOLUTE_PATH)) {
+                        $canonical = \Core::make('url/canonical');
+
+                        return $canonical->setPath($url);
+                    }
                 }
             }
         }

--- a/web/concrete/src/Url/Resolver/RouteUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/RouteUrlResolver.php
@@ -33,6 +33,8 @@ class RouteUrlResolver implements UrlResolverInterface
                 }
             }
         }
+
+        return $resolved;
     }
 
 }

--- a/web/concrete/src/Url/Resolver/RouteUrlResolver.php
+++ b/web/concrete/src/Url/Resolver/RouteUrlResolver.php
@@ -1,0 +1,35 @@
+<?php
+namespace Concrete\Core\Url\Resolver;
+
+use Concrete\Core\Url\Url;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+
+class RouteUrlResolver implements UrlResolverInterface
+{
+
+    /**
+     * Resolve url's from any type of input
+     *
+     * This method MUST either return a `\League\URL\URL` when a url is resolved
+     * or null when a url cannot be resolved.
+     *
+     * @param array $arguments A list of the arguments
+     * @param \League\URL\URLInterface $resolved
+     * @return \League\URL\URLInterface
+     */
+    public function resolve(array $arguments, $resolved = null)
+    {
+        if (count($arguments) < 3) {
+            $route_handle = array_shift($arguments);
+            $route_parameters = count($arguments) ? array_shift($arguments) : array();
+
+            if (is_string($route_handle) && is_array($route_parameters)) {
+                if ($url = \Route::getGenerator()->generate($route_handle, $route_parameters, UrlGenerator::ABSOLUTE_PATH)) {
+                    $canonical = \Core::make('url/canonical');
+                    return $canonical->setPath($url);
+                }
+            }
+        }
+    }
+
+}

--- a/web/concrete/src/Url/Url.php
+++ b/web/concrete/src/Url/Url.php
@@ -6,6 +6,7 @@ use RuntimeException;
 
 class Url extends \League\Url\Url implements UrlInterface
 {
+
     public function setPortIfNecessary($port)
     {
         if (

--- a/web/concrete/src/Url/UrlServiceProvider.php
+++ b/web/concrete/src/Url/UrlServiceProvider.php
@@ -6,6 +6,7 @@ use Concrete\Core\Url\Resolver\CanonicalUrlResolver;
 use Concrete\Core\Url\Resolver\Manager\ResolverManager;
 use Concrete\Core\Url\Resolver\PageUrlResolver;
 use Concrete\Core\Url\Resolver\PathUrlResolver;
+use Concrete\Core\Url\Resolver\RouteUrlResolver;
 
 class UrlServiceProvider extends Provider
 {
@@ -35,6 +36,7 @@ class UrlServiceProvider extends Provider
                 $path_resolver = new PathUrlResolver();
                 $manager = new ResolverManager('concrete.path', $path_resolver);
                 $manager->addResolver('concrete.page', new PageUrlResolver());
+                $manager->addResolver('concrete.route', new RouteUrlResolver());
 
                 return $manager;
             });


### PR DESCRIPTION
Here's a sample:

```php
\Route::register('/path/to/{some_var}/', function() {}, 'some_route_handle');
$url = (string) \URL::to('some_route_handle', array('some_var' => 'test')); 
// string 'http://c57.com/path/to/test' (length=27)
```

@aembler I went back and forth with adding a prefix to this. Searching the route list every time we generate a url if it matches a form factor certainly will impact performance. To fix that we can make it something like `\URL::to('route/some_route_handle')` and only search when the string starts with `route/` 