### PR TITLE
Fix warnings in CoreAreaLayoutController

### DIFF
--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -128,7 +128,7 @@ class Controller extends BlockController
         parent::save($values);
     }
 
-    public function getImportData($blockNode)
+    protected function getImportData($blockNode, $page)
     {
         $args = array();
         if (isset($blockNode->arealayout)) {

--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -128,7 +128,7 @@ class Controller extends BlockController
         parent::save($values);
     }
 
-    protected function getImportData($blockNode, $page)
+    public function getImportData($blockNode, $page)
     {
         $args = array();
         if (isset($blockNode->arealayout)) {


### PR DESCRIPTION
Make `CoreAreaLayoutController::getImportData` compatible with the parent declaration

Marking this method as static is safe since it's being called only by the parent class `BlockController` (`import` method)

EDIT: BTW there's no problem in keeping getImportData as public, no warnings is raised if the parameters are the same (see http://3v4l.org/1tC68 )