### PR TITLE
Fix warnings in Permission\Assignment\...::setPermissionObject

### DIFF
--- a/web/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/web/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -3,12 +3,12 @@
 namespace Concrete\Core\Permission\Assignment;
 
 use PermissionAccess;
-use Loader;
 use Concrete\Core\Area\Area;
 use Stack;
 use Page;
 use Concrete\Core\Area\SubArea;
 use PermissionKey;
+use Database;
 
 class AreaAssignment extends Assignment
 {
@@ -75,7 +75,7 @@ class AreaAssignment extends Assignment
 
     public function getPermissionAccessObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
 
         if ($this->permissionObjectToCheck instanceof Area) {
             $r = $db->GetOne(
@@ -116,7 +116,7 @@ class AreaAssignment extends Assignment
 
     public function clearPermissionAssignment()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $area = $this->getPermissionObject();
         $c = $area->getAreaCollectionObject();
         $db->Execute('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', array($this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()));
@@ -124,7 +124,7 @@ class AreaAssignment extends Assignment
 
     public function assignPermissionAccess(PermissionAccess $pa)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Replace(
             'AreaPermissionAssignments',
             array(

--- a/web/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/web/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -1,120 +1,141 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
+
 use PermissionAccess;
 use Loader;
-use \Concrete\Core\Area\Area;
+use Concrete\Core\Area\Area;
 use Stack;
 use Page;
-use \Concrete\Core\Area\SubArea;
+use Concrete\Core\Area\SubArea;
 use PermissionKey;
 
-class AreaAssignment extends Assignment {
+class AreaAssignment extends Assignment
+{
+    protected $area;
+    protected $permissionObjectToCheck;
+    protected $inheritedPermissions = array(
+        'view_area' => 'view_page',
+        'edit_area_contents' => 'edit_page_contents',
+        'add_layout_to_area' => 'edit_page_contents',
+        'edit_area_design' => 'edit_page_contents',
+        'edit_area_permissions' => 'edit_page_permissions',
+        'schedule_area_contents_guest_access' => 'schedule_page_contents_guest_access',
+        'delete_area_contents' => 'edit_page_contents',
+    );
 
-	protected $area;
-	protected $permissionObjectToCheck;
-	protected $inheritedPermissions = array(
-		'view_area' => 'view_page',
-		'edit_area_contents' => 'edit_page_contents',
-		'add_layout_to_area' => 'edit_page_contents',
-		'edit_area_design' => 'edit_page_contents',
-		'edit_area_permissions' => 'edit_page_permissions',
-		'schedule_area_contents_guest_access' => 'schedule_page_contents_guest_access',
-		'delete_area_contents' => 'edit_page_contents'
-	);
+    protected $blockTypeInheritedPermissions = array(
+        'add_block_to_area' => 'add_block',
+        'add_stack_to_area' => 'add_stack',
+    );
 
-	protected $blockTypeInheritedPermissions = array(
-		'add_block_to_area' => 'add_block',
-		'add_stack_to_area' => 'add_stack'
-	);
-
-	/**
-	 * @param Area $a
-	 */
-	public function setPermissionObject($a) {
-		$ax = $a;
-		if ($a->isGlobalArea()) {
-			$cx = Stack::getByName($a->getAreaHandle(), 'ACTIVE');
-			$a = Area::get($cx, STACKS_AREA_NAME);
+    /**
+     * @param Area $a
+     */
+    public function setPermissionObject($a)
+    {
+        $ax = $a;
+        if ($a->isGlobalArea()) {
+            $cx = Stack::getByName($a->getAreaHandle(), 'ACTIVE');
+            $a = Area::get($cx, STACKS_AREA_NAME);
             if (!is_object($a)) {
                 return false;
             }
-		}
+        }
 
-		if ($a instanceof SubArea && !$a->overrideCollectionPermissions()) {
-			$a = $a->getSubAreaParentPermissionsObject();
-		}
-		$this->permissionObject = $a;
+        if ($a instanceof SubArea && !$a->overrideCollectionPermissions()) {
+            $a = $a->getSubAreaParentPermissionsObject();
+        }
+        $this->permissionObject = $a;
 
-		// if the area overrides the collection permissions explicitly (with a one on the override column) we check
-		if ($a->overrideCollectionPermissions()) {
-			$this->permissionObjectToCheck = $a;
-		} else {
-			if ($a->getAreaCollectionInheritID() > 0) {
-				// in theory we're supposed to be inheriting some permissions from an area with the same handle,
-				// set on the collection id specified above (inheritid). however, if someone's come along and
-				// reverted that area to the page's permissions, there won't be any permissions, and we
-				// won't see anything. so we have to check
-				$areac = Page::getByID($a->getAreaCollectionInheritID());
-				$inheritArea = Area::get($areac, $a->getAreaHandle());
-				if (is_object($inheritArea) && $inheritArea->overrideCollectionPermissions()) {
-					// okay, so that area is still around, still has set permissions on it. So we
-					// pass our current area to our grouplist, userinfolist objects, knowing that they will
-					// smartly inherit the correct items.
-					$this->permissionObjectToCheck = $inheritArea;
-				}
-			}
+        // if the area overrides the collection permissions explicitly (with a one on the override column) we check
+        if ($a->overrideCollectionPermissions()) {
+            $this->permissionObjectToCheck = $a;
+        } else {
+            if ($a->getAreaCollectionInheritID() > 0) {
+                // in theory we're supposed to be inheriting some permissions from an area with the same handle,
+                // set on the collection id specified above (inheritid). however, if someone's come along and
+                // reverted that area to the page's permissions, there won't be any permissions, and we
+                // won't see anything. so we have to check
+                $areac = Page::getByID($a->getAreaCollectionInheritID());
+                $inheritArea = Area::get($areac, $a->getAreaHandle());
+                if (is_object($inheritArea) && $inheritArea->overrideCollectionPermissions()) {
+                    // okay, so that area is still around, still has set permissions on it. So we
+                    // pass our current area to our grouplist, userinfolist objects, knowing that they will
+                    // smartly inherit the correct items.
+                    $this->permissionObjectToCheck = $inheritArea;
+                }
+            }
 
-			if (!$this->permissionObjectToCheck) {
-				$this->permissionObjectToCheck = $a->getAreaCollectionObject();
-			}
-		}
-	}
+            if (!$this->permissionObjectToCheck) {
+                $this->permissionObjectToCheck = $a->getAreaCollectionObject();
+            }
+        }
+    }
 
-	public function getPermissionAccessObject() {
-		$db = Loader::db();
+    public function getPermissionAccessObject()
+    {
+        $db = Loader::db();
 
-		if ($this->permissionObjectToCheck instanceof Area) {
-			$r = $db->GetOne('select paID from AreaPermissionAssignments where cID = ? and arHandle = ? and pkID = ? ' . $filterString, array(
-				$this->permissionObjectToCheck->getCollectionID(), $this->permissionObjectToCheck->getAreaHandle(), $this->pk->getPermissionKeyID()
-			));
-			if ($r) {
-				return PermissionAccess::getByID($r, $this->pk, false);
-			}
-		} else if (isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
-			// this is a page
-			$pk = PermissionKey::getByHandle($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]);
-			$pk->setPermissionObject($this->permissionObjectToCheck);
-			$pae = $pk->getPermissionAccessObject();
-			return $pae;
-		} else if (isset($this->blockTypeInheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
-			$pk = PermissionKey::getByHandle($this->blockTypeInheritedPermissions[$this->pk->getPermissionKeyHandle()]);
-			$pae = $pk->getPermissionAccessObject();
-			return $pae;
-		}
+        if ($this->permissionObjectToCheck instanceof Area) {
+            $r = $db->GetOne(
+                'select paID from AreaPermissionAssignments where cID = ? and arHandle = ? and pkID = ? ' . $filterString,
+                array(
+                    $this->permissionObjectToCheck->getCollectionID(),
+                    $this->permissionObjectToCheck->getAreaHandle(),
+                    $this->pk->getPermissionKeyID(),
+                )
+            );
+            if ($r) {
+                return PermissionAccess::getByID($r, $this->pk, false);
+            }
+        } elseif (isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
+            // this is a page
+            $pk = PermissionKey::getByHandle($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]);
+            $pk->setPermissionObject($this->permissionObjectToCheck);
+            $pae = $pk->getPermissionAccessObject();
 
-		return false;
-	}
+            return $pae;
+        } elseif (isset($this->blockTypeInheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
+            $pk = PermissionKey::getByHandle($this->blockTypeInheritedPermissions[$this->pk->getPermissionKeyHandle()]);
+            $pae = $pk->getPermissionAccessObject();
 
-	public function getPermissionKeyToolsURL($task = false) {
-		$area = $this->getPermissionObject();
-		$c = $area->getAreaCollectionObject();
-		return parent::getPermissionKeyToolsURL($task) . '&cID=' . $c->getCollectionID() . '&arHandle=' . urlencode($area->getAreaHandle());
-	}
+            return $pae;
+        }
 
-	public function clearPermissionAssignment() {
-		$db = Loader::db();
-		$area = $this->getPermissionObject();
-		$c = $area->getAreaCollectionObject();
-		$db->Execute('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', array($this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()));
-	}
+        return false;
+    }
 
-	public function assignPermissionAccess(PermissionAccess $pa) {
-		$db = Loader::db();
-		$db->Replace('AreaPermissionAssignments', array('cID' => $this->getPermissionObject()->getCollectionID(),
-			'arHandle' => $this->getPermissionObject()->getAreaHandle(),
-			'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('cID', 'arHandle', 'pkID'), true);
-		$pa->markAsInUse();
-	}
+    public function getPermissionKeyToolsURL($task = false)
+    {
+        $area = $this->getPermissionObject();
+        $c = $area->getAreaCollectionObject();
 
+        return parent::getPermissionKeyToolsURL($task) . '&cID=' . $c->getCollectionID() . '&arHandle=' . urlencode($area->getAreaHandle());
+    }
 
+    public function clearPermissionAssignment()
+    {
+        $db = Loader::db();
+        $area = $this->getPermissionObject();
+        $c = $area->getAreaCollectionObject();
+        $db->Execute('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', array($this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()));
+    }
+
+    public function assignPermissionAccess(PermissionAccess $pa)
+    {
+        $db = Loader::db();
+        $db->Replace(
+            'AreaPermissionAssignments',
+            array(
+                'cID' => $this->getPermissionObject()->getCollectionID(),
+                'arHandle' => $this->getPermissionObject()->getAreaHandle(),
+                'paID' => $pa->getPermissionAccessID(),
+                'pkID' => $this->pk->getPermissionKeyID(),
+            ),
+            array('cID', 'arHandle', 'pkID'),
+            true
+        );
+        $pa->markAsInUse();
+    }
 }

--- a/web/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/web/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -27,7 +27,10 @@ class AreaAssignment extends Assignment {
 		'add_stack_to_area' => 'add_stack'
 	);
 
-	public function setPermissionObject(Area $a) {
+	/**
+	 * @param Area $a
+	 */
+	public function setPermissionObject($a) {
 		$ax = $a;
 		if ($a->isGlobalArea()) {
 			$cx = Stack::getByName($a->getAreaHandle(), 'ACTIVE');

--- a/web/concrete/src/Permission/Assignment/BlockAssignment.php
+++ b/web/concrete/src/Permission/Assignment/BlockAssignment.php
@@ -3,12 +3,12 @@
 namespace Concrete\Core\Permission\Assignment;
 
 use PermissionAccess;
-use Loader;
 use Concrete\Core\Block\Block;
 use Area;
 use Concrete\Core\Area\SubArea;
 use PermissionKey;
 use Page;
+use Database;
 
 class BlockAssignment extends Assignment
 {
@@ -74,7 +74,7 @@ class BlockAssignment extends Assignment
 
     public function getPermissionAccessObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         if ($this->permissionObjectToCheck instanceof Block) {
             $co = $this->permissionObjectToCheck->getBlockCollectionObject();
             $arHandle = $this->permissionObjectToCheck->getAreaHandle();
@@ -105,14 +105,14 @@ class BlockAssignment extends Assignment
 
     public function clearPermissionAssignment()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $co = $this->permissionObject->getBlockCollectionObject();
         $db->Execute('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
     }
 
     public function assignPermissionAccess(PermissionAccess $pa)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $co = $this->permissionObject->getBlockCollectionObject();
         $arHandle = $this->permissionObject->getAreaHandle();
         $db->Replace(

--- a/web/concrete/src/Permission/Assignment/BlockAssignment.php
+++ b/web/concrete/src/Permission/Assignment/BlockAssignment.php
@@ -34,7 +34,10 @@ class BlockAssignment extends Assignment {
 		'delete_block' => 'edit_page_contents'
 	);
 
-	public function setPermissionObject(Block $b) {
+	/**
+	 * @param Block $b
+	 */
+	public function setPermissionObject($b) {
 		$this->permissionObject = $b;
 
 		// if the area overrides the collection permissions explicitly (with a one on the override column) we check

--- a/web/concrete/src/Permission/Assignment/BlockAssignment.php
+++ b/web/concrete/src/Permission/Assignment/BlockAssignment.php
@@ -1,126 +1,141 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
+
 use PermissionAccess;
 use Loader;
-use \Concrete\Core\Block\Block;
+use Concrete\Core\Block\Block;
 use Area;
-use \Concrete\Core\Area\SubArea;
+use Concrete\Core\Area\SubArea;
 use PermissionKey;
 use Page;
 
-class BlockAssignment extends Assignment {
+class BlockAssignment extends Assignment
+{
+    protected $permissionObjectToCheck;
+    protected $inheritedAreaPermissions = array(
+        'view_block' => 'view_area',
+        'edit_block' => 'edit_area_contents',
+        'edit_block_custom_template' => 'edit_area_contents',
+        'edit_block_design' => 'edit_area_contents',
+        'edit_block_permissions' => 'edit_area_permissions',
+        'schedule_guest_access' => 'schedule_area_contents_guest_access',
+        'edit_block_name' => 'edit_area_contents',
+        'edit_block_cache_settings' => 'edit_area_contents',
+        'delete_block' => 'delete_area_contents',
+    );
+    protected $inheritedPagePermissions = array(
+        'view_block' => 'view_page',
+        'edit_block' => 'edit_page_contents',
+        'edit_block_custom_template' => 'edit_page_contents',
+        'edit_block_design' => 'edit_page_contents',
+        'edit_block_permissions' => 'edit_page_permissions',
+        'edit_block_name' => 'edit_page_contents',
+        'edit_block_cache_settings' => 'edit_page_contents',
+        'schedule_guest_access' => 'schedule_page_contents_guest_access',
+        'delete_block' => 'edit_page_contents',
+    );
 
-	protected $permissionObjectToCheck;
-	protected $inheritedAreaPermissions = array(
-		'view_block' => 'view_area',
-		'edit_block' => 'edit_area_contents',
-		'edit_block_custom_template' => 'edit_area_contents',
-		'edit_block_design' => 'edit_area_contents',
-		'edit_block_permissions' => 'edit_area_permissions',
-		'schedule_guest_access' => 'schedule_area_contents_guest_access',
-		'edit_block_name' => 'edit_area_contents',
-		'edit_block_cache_settings' => 'edit_area_contents',
-		'delete_block' => 'delete_area_contents'
-	);
-	protected $inheritedPagePermissions = array(
-		'view_block' => 'view_page',
-		'edit_block' => 'edit_page_contents',
-		'edit_block_custom_template' => 'edit_page_contents',
-		'edit_block_design' => 'edit_page_contents',
-		'edit_block_permissions' => 'edit_page_permissions',
-		'edit_block_name' => 'edit_page_contents',
-		'edit_block_cache_settings' => 'edit_page_contents',
-		'schedule_guest_access' => 'schedule_page_contents_guest_access',
-		'delete_block' => 'edit_page_contents'
-	);
+    /**
+     * @param Block $b
+     */
+    public function setPermissionObject($b)
+    {
+        $this->permissionObject = $b;
 
-	/**
-	 * @param Block $b
-	 */
-	public function setPermissionObject($b) {
-		$this->permissionObject = $b;
+        // if the area overrides the collection permissions explicitly (with a one on the override column) we check
+        if ($b->overrideAreaPermissions()) {
+            $this->permissionObjectToCheck = $b;
+        } else {
+            $a = $b->getBlockAreaObject();
+            if ($a instanceof SubArea && !$a->overrideCollectionPermissions()) {
+                $a = $a->getSubAreaParentPermissionsObject();
+            }
+            if (is_object($a)) {
+                if ($a->overrideCollectionPermissions()) {
+                    $this->permissionObjectToCheck = $a;
+                } elseif ($a->getAreaCollectionInheritID()) {
+                    $mcID = $a->getAreaCollectionInheritID();
+                    $mc = Page::getByID($mcID, 'RECENT');
+                    $ma = Area::get($mc, $a->getAreaHandle());
+                    if ($ma->overrideCollectionPermissions()) {
+                        $this->permissionObjectToCheck = $ma;
+                    } else {
+                        $this->permissionObjectToCheck = $ma->getAreaCollectionObject();
+                    }
+                } else {
+                    $this->permissionObjectToCheck = $a->getAreaCollectionObject();
+                }
+            } else {
+                $this->permissionObjectToCheck = Page::getCurrentPage();
+            }
+        }
+    }
 
-		// if the area overrides the collection permissions explicitly (with a one on the override column) we check
-		if ($b->overrideAreaPermissions()) {
-			$this->permissionObjectToCheck = $b;
-		} else {
-			$a = $b->getBlockAreaObject();
-			if ($a instanceof SubArea && !$a->overrideCollectionPermissions()) {
-				$a = $a->getSubAreaParentPermissionsObject();
-			}
-			if (is_object($a)) {
-				if ($a->overrideCollectionPermissions()) {
-					$this->permissionObjectToCheck = $a;
-				} elseif ($a->getAreaCollectionInheritID()) {
-					$mcID = $a->getAreaCollectionInheritID();
-					$mc = Page::getByID($mcID, 'RECENT');
-					$ma = Area::get($mc, $a->getAreaHandle());
-					if ($ma->overrideCollectionPermissions()) {
-						$this->permissionObjectToCheck = $ma;
-					} else {
-						$this->permissionObjectToCheck = $ma->getAreaCollectionObject();
-					}
-				} else {
-					$this->permissionObjectToCheck = $a->getAreaCollectionObject();
-				}
-			} else {
-				$this->permissionObjectToCheck = Page::getCurrentPage();
-			}
-		}
-	}
+    public function getPermissionAccessObject()
+    {
+        $db = Loader::db();
+        if ($this->permissionObjectToCheck instanceof Block) {
+            $co = $this->permissionObjectToCheck->getBlockCollectionObject();
+            $arHandle = $this->permissionObjectToCheck->getAreaHandle();
+            $paID = $db->GetOne(
+                'select paID from BlockPermissionAssignments where cID = ? and cvID = ? and bID = ? and pkID = ? ' . $filterString,
+                array(
+                    $co->getCollectionID(),
+                    $co->getVersionID(),
+                    $this->permissionObject->getBlockID(),
+                    $this->pk->getPermissionKeyID(),
+                )
+            );
+            if ($paID) {
+                $pae = PermissionAccess::getByID($paID, $this->pk, false);
+            }
+        } elseif ($this->permissionObjectToCheck instanceof Area && isset($this->inheritedAreaPermissions[$this->pk->getPermissionKeyHandle()])) {
+            $pk = PermissionKey::getByHandle($this->inheritedAreaPermissions[$this->pk->getPermissionKeyHandle()]);
+            $pk->setPermissionObject($this->permissionObjectToCheck);
+            $pae = $pk->getPermissionAccessObject();
+        } elseif ($this->permissionObjectToCheck instanceof Page && isset($this->inheritedPagePermissions[$this->pk->getPermissionKeyHandle()])) {
+            $pk = PermissionKey::getByHandle($this->inheritedPagePermissions[$this->pk->getPermissionKeyHandle()]);
+            $pk->setPermissionObject($this->permissionObjectToCheck);
+            $pae = $pk->getPermissionAccessObject();
+        }
 
-	public function getPermissionAccessObject() {
-		$db = Loader::db();
-		if ($this->permissionObjectToCheck instanceof Block) {
-			$co = $this->permissionObjectToCheck->getBlockCollectionObject();
-			$arHandle = $this->permissionObjectToCheck->getAreaHandle();
-			$paID = $db->GetOne('select paID from BlockPermissionAssignments where cID = ? and cvID = ? and bID = ? and pkID = ? ' . $filterString, array(
-				$co->getCollectionID(), $co->getVersionID(), $this->permissionObject->getBlockID(), $this->pk->getPermissionKeyID()
-			));
-			if ($paID) {
-				$pae = PermissionAccess::getByID($paID, $this->pk, false);
-			}
-		} else if ($this->permissionObjectToCheck instanceof Area && isset($this->inheritedAreaPermissions[$this->pk->getPermissionKeyHandle()])) {
+        return $pae;
+    }
 
-			$pk = PermissionKey::getByHandle($this->inheritedAreaPermissions[$this->pk->getPermissionKeyHandle()]);
-			$pk->setPermissionObject($this->permissionObjectToCheck);
-			$pae = $pk->getPermissionAccessObject();
+    public function clearPermissionAssignment()
+    {
+        $db = Loader::db();
+        $co = $this->permissionObject->getBlockCollectionObject();
+        $db->Execute('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
+    }
 
-		} else if ($this->permissionObjectToCheck instanceof Page && isset($this->inheritedPagePermissions[$this->pk->getPermissionKeyHandle()])) {
-			$pk = PermissionKey::getByHandle($this->inheritedPagePermissions[$this->pk->getPermissionKeyHandle()]);
-			$pk->setPermissionObject($this->permissionObjectToCheck);
-			$pae = $pk->getPermissionAccessObject();
+    public function assignPermissionAccess(PermissionAccess $pa)
+    {
+        $db = Loader::db();
+        $co = $this->permissionObject->getBlockCollectionObject();
+        $arHandle = $this->permissionObject->getAreaHandle();
+        $db->Replace(
+            'BlockPermissionAssignments',
+            array(
+                'cID' => $co->getCollectionID(),
+                'paID' => $pa->getPermissionAccessID(),
+                'cvID' => $co->getVersionID(),
+                'bID' => $this->permissionObject->getBlockID(),
+                'pkID' => $this->pk->getPermissionKeyID(),
+            ),
+            array('cID', 'cvID', 'bID', 'pkID'),
+            true
+        );
+        $pa->markAsInUse();
+    }
 
-		}
-		return $pae;
-	}
+    public function getPermissionKeyToolsURL($task = false)
+    {
+        $b = $this->getPermissionObject();
+        $c = $b->getBlockCollectionObject();
+        $arHandle = $b->getAreaHandle();
 
-	public function clearPermissionAssignment() {
-		$db = Loader::db();
-		$co = $this->permissionObject->getBlockCollectionObject();
-		$db->Execute('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
-	}
-
-	public function assignPermissionAccess(PermissionAccess $pa) {
-		$db = Loader::db();
-		$co = $this->permissionObject->getBlockCollectionObject();
-		$arHandle = $this->permissionObject->getAreaHandle();
-		$db->Replace('BlockPermissionAssignments', array(
-			'cID' => $co->getCollectionID(),
-			'paID' => $pa->getPermissionAccessID(),
-			'cvID' => $co->getVersionID(),
-			'bID' => $this->permissionObject->getBlockID(),
-			'pkID' => $this->pk->getPermissionKeyID()), array('cID', 'cvID', 'bID', 'pkID'), true);
-		$pa->markAsInUse();
-	}
-
-
-	public function getPermissionKeyToolsURL($task = false) {
-		$b = $this->getPermissionObject();
-		$c = $b->getBlockCollectionObject();
-		$arHandle = $b->getAreaHandle();
-		return parent::getPermissionKeyToolsURL($task) . '&cID=' . $c->getCollectionID() . '&cvID=' . $c->getVersionID() . '&bID=' . $b->getBlockID() . '&arHandle=' . urlencode($arHandle);
-	}
-
-
+        return parent::getPermissionKeyToolsURL($task) . '&cID=' . $c->getCollectionID() . '&cvID=' . $c->getVersionID() . '&bID=' . $b->getBlockID() . '&arHandle=' . urlencode($arHandle);
+    }
 }

--- a/web/concrete/src/Permission/Assignment/ConversationAssignment.php
+++ b/web/concrete/src/Permission/Assignment/ConversationAssignment.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Permission\Assignment;
 use Concrete\Core\Conversation\Message\Message;
 use PermissionAccess;
 use Conversation;
-use Loader;
+use Database;
 
 class ConversationAssignment extends Assignment
 {
@@ -31,7 +31,7 @@ class ConversationAssignment extends Assignment
             $cnvID = $this->permissionObjectToCheck->getConversationID();
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         $r = $db->GetOne(
             'select paID from ConversationPermissionAssignments where cnvID = ? and pkID = ?',
             array(
@@ -50,7 +50,7 @@ class ConversationAssignment extends Assignment
             $cnvID = $this->permissionObject->getConversationID();
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute(
             'update ConversationPermissionAssignments set paID = 0 where pkID = ? and cnvID = ?',
             array($this->pk->getPermissionKeyID(), $cnvID)
@@ -64,7 +64,7 @@ class ConversationAssignment extends Assignment
             $cnvID = $this->permissionObject->getConversationID();
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Replace(
             'ConversationPermissionAssignments',
             array(

--- a/web/concrete/src/Permission/Assignment/ConversationAssignment.php
+++ b/web/concrete/src/Permission/Assignment/ConversationAssignment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
 
 use Concrete\Core\Conversation\Message\Message;
@@ -8,7 +9,6 @@ use Loader;
 
 class ConversationAssignment extends Assignment
 {
-
     protected $permissionObjectToCheck = null;
 
     public function setPermissionObject($object)
@@ -36,9 +36,10 @@ class ConversationAssignment extends Assignment
             'select paID from ConversationPermissionAssignments where cnvID = ? and pkID = ?',
             array(
                 $cnvID,
-                $this->pk->getPermissionKeyID()
+                $this->pk->getPermissionKeyID(),
             )
         );
+
         return PermissionAccess::getByID($r, $this->pk);
     }
 
@@ -69,11 +70,11 @@ class ConversationAssignment extends Assignment
             array(
                 'cnvID' => $cnvID,
                 'paID' => $pa->getPermissionAccessID(),
-                'pkID' => $this->pk->getPermissionKeyID()
+                'pkID' => $this->pk->getPermissionKeyID(),
             ),
             array(
                 'cnvID',
-                'pkID'
+                'pkID',
             ),
             true
         );
@@ -89,5 +90,4 @@ class ConversationAssignment extends Assignment
 
         return parent::getPermissionKeyToolsURL($task) . '&cnvID=' . $cnvID;
     }
-
 }

--- a/web/concrete/src/Permission/Assignment/ConversationAssignment.php
+++ b/web/concrete/src/Permission/Assignment/ConversationAssignment.php
@@ -11,7 +11,7 @@ class ConversationAssignment extends Assignment
 
     protected $permissionObjectToCheck = null;
 
-    public function setPermissionObject($object = null)
+    public function setPermissionObject($object)
     {
         $this->permissionObject = $object;
 

--- a/web/concrete/src/Permission/Assignment/FileAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileAssignment.php
@@ -64,7 +64,10 @@ class FileAssignment extends Assignment {
 		}
 	}
 
-	public function setPermissionObject(File $f) {
+	/**
+	 * @param File $f
+	 */
+	public function setPermissionObject($f) {
 		$this->permissionObject = $f;
 
 		if ($f->overrideFileSetPermissions()) {

--- a/web/concrete/src/Permission/Assignment/FileAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileAssignment.php
@@ -4,9 +4,9 @@ namespace Concrete\Core\Permission\Assignment;
 
 use Concrete\Core\File\Set\Set;
 use PermissionAccess;
-use Loader;
 use FileSet;
 use Concrete\Core\File\File;
+use Database;
 
 class FileAssignment extends Assignment
 {
@@ -24,7 +24,7 @@ class FileAssignment extends Assignment
 
     public function getPermissionAccessObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         if ($this->permissionObjectToCheck instanceof File) {
             $r = $db->GetCol(
                 'select paID from FilePermissionAssignments where fID = ? and pkID = ?',
@@ -107,13 +107,13 @@ class FileAssignment extends Assignment
 
     public function clearPermissionAssignment()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
     }
 
     public function assignPermissionAccess(PermissionAccess $pa)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Replace('FilePermissionAssignments', array('fID' => $this->getPermissionObject()->getFileID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fID', 'pkID'), true);
         $pa->markAsInUse();
     }

--- a/web/concrete/src/Permission/Assignment/FileAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileAssignment.php
@@ -1,109 +1,125 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
+
 use Concrete\Core\File\Set\Set;
 use PermissionAccess;
 use Loader;
 use FileSet;
-use \Concrete\Core\File\File;
-class FileAssignment extends Assignment {
+use Concrete\Core\File\File;
 
-	protected $permissionObjectToCheck;
+class FileAssignment extends Assignment
+{
+    protected $permissionObjectToCheck;
 
-	protected $inheritedPermissions = array(
-		'view_file' => 'view_file_set_file',
-		'view_file_in_file_manager' => 'search_file_set',
-		'edit_file_properties' => 'edit_file_set_file_properties',
-		'edit_file_contents' => 'edit_file_set_file_contents',
-		'copy_file' => 'copy_file_set_files',
-		'edit_file_permissions' => 'edit_file_set_permissions',
-		'delete_file' => 'delete_file_set_files'
-	);
+    protected $inheritedPermissions = array(
+        'view_file' => 'view_file_set_file',
+        'view_file_in_file_manager' => 'search_file_set',
+        'edit_file_properties' => 'edit_file_set_file_properties',
+        'edit_file_contents' => 'edit_file_set_file_contents',
+        'copy_file' => 'copy_file_set_files',
+        'edit_file_permissions' => 'edit_file_set_permissions',
+        'delete_file' => 'delete_file_set_files',
+    );
 
+    public function getPermissionAccessObject()
+    {
+        $db = Loader::db();
+        if ($this->permissionObjectToCheck instanceof File) {
+            $r = $db->GetCol(
+                'select paID from FilePermissionAssignments where fID = ? and pkID = ?',
+                array(
+                    $this->permissionObject->getFileID(),
+                    $this->pk->getPermissionKeyID(),
+                )
+            );
+        } elseif (is_array($this->permissionObjectToCheck)) { // sets
+            $sets = array();
+            foreach ($this->permissionObjectToCheck as $fs) {
+                $sets[] = $fs->getFileSetID();
+            }
+            $inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
+            $r = $db->GetCol(
+                'select distinct paID from FileSetPermissionAssignments where fsID in (' . implode(',', $sets) . ') and pkID = ? ' . $filterString,
+                array(
+                    $inheritedPKID,
+                )
+            );
+        } elseif ($this->permissionObjectToCheck instanceof Set && isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
+            $inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
+            $r = $db->GetCol(
+                'select distinct paID from FileSetPermissionAssignments where fsID = ? and pkID = ?',
+                array(
+                    $this->permissionObjectToCheck->getFileSetID(),
+                    $inheritedPKID,
+                )
+            );
+        } else {
+            return false;
+        }
 
-	public function getPermissionAccessObject() {
-		$db = Loader::db();
-		if ($this->permissionObjectToCheck instanceof File) {
- 			$r = $db->GetCol('select paID from FilePermissionAssignments where fID = ? and pkID = ?', array(
- 			$this->permissionObject->getFileID(), $this->pk->getPermissionKeyID()
- 			));
- 		} else if (is_array($this->permissionObjectToCheck)) { // sets
-			$sets = array();
-			foreach($this->permissionObjectToCheck as $fs) {
-				$sets[] = $fs->getFileSetID();
-			}
-			$inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
-			$r = $db->GetCol('select distinct paID from FileSetPermissionAssignments where fsID in (' . implode(',', $sets) . ') and pkID = ? ' . $filterString, array(
-				$inheritedPKID
-			));
-		} else if ($this->permissionObjectToCheck instanceof Set && isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
-			$inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
-			$r = $db->GetCol('select distinct paID from FileSetPermissionAssignments where fsID = ? and pkID = ?', array(
-				$this->permissionObjectToCheck->getFileSetID(), $inheritedPKID
-			));
-		} else {
-			return false;
-		}
+        if (count($r) == 1) {
+            $permID = $r[0];
+        }
+        if (count($r) > 1) {
+            $permID = $r;
+        }
 
-		if (count($r) == 1) {
-			$permID = $r[0];
-		}
-		if (count($r) > 1) {
-			$permID = $r;
-		}
+        if (is_array($permID)) {
+            foreach ($permID as $paID) {
+                $pa = PermissionAccess::getByID($paID, $this->pk);
+                if (is_object($pa)) {
+                    $perms[] = $pa;
+                }
+            }
 
-		if (is_array($permID)) {
-			foreach($permID as $paID) {
-				$pa = PermissionAccess::getByID($paID, $this->pk);
-				if (is_object($pa)) {
-					$perms[] = $pa;
-				}
-			}
-			return PermissionAccess::createByMerge($perms);
-		} else {
-			return PermissionAccess::getByID($permID, $this->pk);
-		}
-	}
+            return PermissionAccess::createByMerge($perms);
+        } else {
+            return PermissionAccess::getByID($permID, $this->pk);
+        }
+    }
 
-	/**
-	 * @param File $f
-	 */
-	public function setPermissionObject($f) {
-		$this->permissionObject = $f;
+    /**
+     * @param File $f
+     */
+    public function setPermissionObject($f)
+    {
+        $this->permissionObject = $f;
 
-		if ($f->overrideFileSetPermissions()) {
-			$this->permissionObjectToCheck = $f;
-		} else {
-			$sets = $f->getFileSets();
-			$permsets = array();
-			foreach($sets as $fs) {
-				if ($fs->overrideGlobalPermissions()) {
-					$permsets[] = $fs;
-				}
-			}
-			if (count($permsets) > 0) {
-				$this->permissionObjectToCheck = $permsets;
-			} else {
-				$fs = FileSet::getGlobal();
-				$this->permissionObjectToCheck = $fs;
-			}
-		}
-	}
+        if ($f->overrideFileSetPermissions()) {
+            $this->permissionObjectToCheck = $f;
+        } else {
+            $sets = $f->getFileSets();
+            $permsets = array();
+            foreach ($sets as $fs) {
+                if ($fs->overrideGlobalPermissions()) {
+                    $permsets[] = $fs;
+                }
+            }
+            if (count($permsets) > 0) {
+                $this->permissionObjectToCheck = $permsets;
+            } else {
+                $fs = FileSet::getGlobal();
+                $this->permissionObjectToCheck = $fs;
+            }
+        }
+    }
 
+    public function clearPermissionAssignment()
+    {
+        $db = Loader::db();
+        $db->Execute('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
+    }
 
-	public function clearPermissionAssignment() {
-		$db = Loader::db();
-		$db->Execute('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
-	}
+    public function assignPermissionAccess(PermissionAccess $pa)
+    {
+        $db = Loader::db();
+        $db->Replace('FilePermissionAssignments', array('fID' => $this->getPermissionObject()->getFileID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fID', 'pkID'), true);
+        $pa->markAsInUse();
+    }
 
-	public function assignPermissionAccess(PermissionAccess $pa) {
-		$db = Loader::db();
-		$db->Replace('FilePermissionAssignments', array('fID' => $this->getPermissionObject()->getFileID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fID', 'pkID'), true);
-		$pa->markAsInUse();
-	}
-
-
-	public function getPermissionKeyToolsURL($task = false) {
-		return parent::getPermissionKeyToolsURL($task) . '&fID=' . $this->getPermissionObject()->getFileID();
-	}
-
+    public function getPermissionKeyToolsURL($task = false)
+    {
+        return parent::getPermissionKeyToolsURL($task) . '&fID=' . $this->getPermissionObject()->getFileID();
+    }
 }

--- a/web/concrete/src/Permission/Assignment/FileSetAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileSetAssignment.php
@@ -1,45 +1,57 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
+
 use PermissionAccess;
 use Concrete\Core\File\Set\Set;
 use Loader;
-class FileSetAssignment extends Assignment {
 
+class FileSetAssignment extends Assignment
+{
     /**
      * @param Set $fs
      */
-	public function setPermissionObject($fs) {
-		$this->permissionObject = $fs;
+    public function setPermissionObject($fs)
+    {
+        $this->permissionObject = $fs;
 
-		if ($fs->overrideGlobalPermissions()) {
-			$this->permissionObjectToCheck = $fs;
-		} else {
-			$fs = Set::getGlobal();
-			$this->permissionObjectToCheck = $fs;
-		}
-	}
+        if ($fs->overrideGlobalPermissions()) {
+            $this->permissionObjectToCheck = $fs;
+        } else {
+            $fs = Set::getGlobal();
+            $this->permissionObjectToCheck = $fs;
+        }
+    }
 
-	public function getPermissionAccessObject() {
-		$db = Loader::db();
- 		$r = $db->GetOne('select paID from FileSetPermissionAssignments where fsID = ? and pkID = ?', array(
- 			$this->permissionObjectToCheck->getFileSetID(), $this->pk->getPermissionKeyID()
- 		));
- 		return PermissionAccess::getByID($r, $this->pk);
-	}
+    public function getPermissionAccessObject()
+    {
+        $db = Loader::db();
+        $r = $db->GetOne(
+            'select paID from FileSetPermissionAssignments where fsID = ? and pkID = ?',
+            array(
+                $this->permissionObjectToCheck->getFileSetID(),
+                $this->pk->getPermissionKeyID(),
+            )
+        );
 
-	public function clearPermissionAssignment() {
-		$db = Loader::db();
-		$db->Execute('update FileSetPermissionAssignments set paID = 0 where pkID = ? and fsID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileSetID()));
-	}
+        return PermissionAccess::getByID($r, $this->pk);
+    }
 
-	public function assignPermissionAccess(PermissionAccess $pa) {
-		$db = Loader::db();
-		$db->Replace('FileSetPermissionAssignments', array('fsID' => $this->getPermissionObject()->getFileSetID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fsID', 'pkID'), true);
-		$pa->markAsInUse();
-	}
+    public function clearPermissionAssignment()
+    {
+        $db = Loader::db();
+        $db->Execute('update FileSetPermissionAssignments set paID = 0 where pkID = ? and fsID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileSetID()));
+    }
 
-	public function getPermissionKeyToolsURL($task = false) {
-		return parent::getPermissionKeyToolsURL($task) . '&fsID=' . $this->getPermissionObject()->getFileSetID();
-	}
+    public function assignPermissionAccess(PermissionAccess $pa)
+    {
+        $db = Loader::db();
+        $db->Replace('FileSetPermissionAssignments', array('fsID' => $this->getPermissionObject()->getFileSetID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fsID', 'pkID'), true);
+        $pa->markAsInUse();
+    }
 
+    public function getPermissionKeyToolsURL($task = false)
+    {
+        return parent::getPermissionKeyToolsURL($task) . '&fsID=' . $this->getPermissionObject()->getFileSetID();
+    }
 }

--- a/web/concrete/src/Permission/Assignment/FileSetAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileSetAssignment.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Permission\Assignment;
 
 use PermissionAccess;
 use Concrete\Core\File\Set\Set;
-use Loader;
+use Database;
 
 class FileSetAssignment extends Assignment
 {
@@ -25,7 +25,7 @@ class FileSetAssignment extends Assignment
 
     public function getPermissionAccessObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $r = $db->GetOne(
             'select paID from FileSetPermissionAssignments where fsID = ? and pkID = ?',
             array(
@@ -39,13 +39,13 @@ class FileSetAssignment extends Assignment
 
     public function clearPermissionAssignment()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('update FileSetPermissionAssignments set paID = 0 where pkID = ? and fsID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileSetID()));
     }
 
     public function assignPermissionAccess(PermissionAccess $pa)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Replace('FileSetPermissionAssignments', array('fsID' => $this->getPermissionObject()->getFileSetID(), 'paID' => $pa->getPermissionAccessID(), 'pkID' => $this->pk->getPermissionKeyID()), array('fsID', 'pkID'), true);
         $pa->markAsInUse();
     }

--- a/web/concrete/src/Permission/Assignment/FileSetAssignment.php
+++ b/web/concrete/src/Permission/Assignment/FileSetAssignment.php
@@ -5,7 +5,10 @@ use Concrete\Core\File\Set\Set;
 use Loader;
 class FileSetAssignment extends Assignment {
 
-	public function setPermissionObject(Set $fs) {
+    /**
+     * @param Set $fs
+     */
+	public function setPermissionObject($fs) {
 		$this->permissionObject = $fs;
 
 		if ($fs->overrideGlobalPermissions()) {

--- a/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
+++ b/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
@@ -11,7 +11,10 @@ class TopicTreeNodeAssignment extends TreeNodeAssignment {
 		'view_topic_tree_node' => 'view_topic_category_tree_node'
 	);
 
-	public function setPermissionObject(TopicTreeNode $node) {
+	/**
+	 * @param TopicTreeNode $node
+	 */
+	public function setPermissionObject($node) {
 		$this->permissionObject = $node;
 
 		if ($node->overrideParentTreeNodePermissions()) {

--- a/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
+++ b/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
@@ -6,7 +6,7 @@ use Concrete\Core\Tree\Node\Node;
 use PermissionAccess;
 use Concrete\Core\Tree\Node\Type\Topic as TopicTreeNode;
 use Concrete\Core\Tree\Node\Type\TopicCategory as TopicCategoryTreeNode;
-use Loader;
+use Database;
 
 class TopicTreeNodeAssignment extends TreeNodeAssignment
 {
@@ -31,7 +31,7 @@ class TopicTreeNodeAssignment extends TreeNodeAssignment
 
     public function getPermissionAccessObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         if ($this->permissionObjectToCheck instanceof TopicTreeNode) {
             $pa = parent::getPermissionAccessObject();
         } elseif ($this->permissionObjectToCheck instanceof TopicCategoryTreeNode && isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {

--- a/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
+++ b/web/concrete/src/Permission/Assignment/TopicTreeNodeAssignment.php
@@ -1,47 +1,53 @@
 <?php
+
 namespace Concrete\Core\Permission\Assignment;
+
 use Concrete\Core\Tree\Node\Node;
 use PermissionAccess;
-use \Concrete\Core\Tree\Node\Type\Topic as TopicTreeNode;
-use \Concrete\Core\Tree\Node\Type\TopicCategory as TopicCategoryTreeNode;
+use Concrete\Core\Tree\Node\Type\Topic as TopicTreeNode;
+use Concrete\Core\Tree\Node\Type\TopicCategory as TopicCategoryTreeNode;
 use Loader;
-class TopicTreeNodeAssignment extends TreeNodeAssignment {
 
-	protected $inheritedPermissions = array(
-		'view_topic_tree_node' => 'view_topic_category_tree_node'
-	);
+class TopicTreeNodeAssignment extends TreeNodeAssignment
+{
+    protected $inheritedPermissions = array(
+        'view_topic_tree_node' => 'view_topic_category_tree_node',
+    );
 
-	/**
-	 * @param TopicTreeNode $node
-	 */
-	public function setPermissionObject($node) {
-		$this->permissionObject = $node;
+    /**
+     * @param TopicTreeNode $node
+     */
+    public function setPermissionObject($node)
+    {
+        $this->permissionObject = $node;
 
-		if ($node->overrideParentTreeNodePermissions()) {
-			$this->permissionObjectToCheck = $node;
-		} else {
-			$parent = Node::getByID($node->getTreeNodePermissionsNodeID());
-			$this->permissionObjectToCheck = $parent;
-		}
-	}
+        if ($node->overrideParentTreeNodePermissions()) {
+            $this->permissionObjectToCheck = $node;
+        } else {
+            $parent = Node::getByID($node->getTreeNodePermissionsNodeID());
+            $this->permissionObjectToCheck = $parent;
+        }
+    }
 
-	public function getPermissionAccessObject() {
-		$db = Loader::db();
-		if ($this->permissionObjectToCheck instanceof TopicTreeNode) {
-			$pa = parent::getPermissionAccessObject();
- 		} else if ($this->permissionObjectToCheck instanceof TopicCategoryTreeNode && isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
-			$inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
-	 		$r = $db->GetOne('select paID from TreeNodePermissionAssignments where treeNodeID = ? and pkID = ?', array(
-	 			$this->permissionObjectToCheck->getTreeNodePermissionsNodeID(), $inheritedPKID
-	 		));
-	 		$pa = PermissionAccess::getByID($r, $this->pk);
-		} else {
-			return false;
-		}
+    public function getPermissionAccessObject()
+    {
+        $db = Loader::db();
+        if ($this->permissionObjectToCheck instanceof TopicTreeNode) {
+            $pa = parent::getPermissionAccessObject();
+        } elseif ($this->permissionObjectToCheck instanceof TopicCategoryTreeNode && isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) {
+            $inheritedPKID = $db->GetOne('select pkID from PermissionKeys where pkHandle = ?', array($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]));
+            $r = $db->GetOne(
+                'select paID from TreeNodePermissionAssignments where treeNodeID = ? and pkID = ?',
+                array(
+                    $this->permissionObjectToCheck->getTreeNodePermissionsNodeID(),
+                    $inheritedPKID,
+                )
+            );
+            $pa = PermissionAccess::getByID($r, $this->pk);
+        } else {
+            return false;
+        }
 
-		return $pa;
-
-	}
-
-
+        return $pa;
+    }
 }


### PR DESCRIPTION
Since `setPermissionObject` should have the same signature for all the derived classes, let's remove the forced type from the sub-classes declarations (sigh).