### PR TITLE
Fix warnings in ShareThisPage controller

### DIFF
--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace Concrete\Block\ShareThisPage;
-use \Concrete\Core\Block\BlockController;
+
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Sharing\ShareThisPage\ServiceList;
 use Concrete\Core\Sharing\ShareThisPage\Service;
 use Database;
@@ -11,7 +12,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController
 {
-
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 400;
@@ -37,7 +37,7 @@ class Controller extends BlockController
     {
         $selected = $this->getSelectedServices();
         $services = array();
-        foreach($selected as $s) {
+        foreach ($selected as $s) {
             $services[] = $s->getHandle();
         }
 
@@ -65,16 +65,17 @@ class Controller extends BlockController
         $services = $db->GetCol('select service from btShareThisPage where bID = ? order by displayOrder asc',
             array($this->bID)
         );
-        foreach($services as $service) {
+        foreach ($services as $service) {
             $this->addService($service);
         }
+
         return $this->services;
     }
 
     public function duplicate($newBlockID)
     {
         $db = Database::get();
-        foreach($this->getSelectedServices() as $service) {
+        foreach ($this->getSelectedServices() as $service) {
             $db->insert('btShareThisPage', array('bID' => $newBlockID, 'service' => $service->getHandle(), 'displayOrder' => $this->displayOrder));
         }
     }
@@ -85,13 +86,14 @@ class Controller extends BlockController
         if (!isset($args['service']) || empty($args['service'])) {
             $e->add(t('You must choose at least one service.'));
         }
+
         return $e;
     }
 
     public function export(\SimpleXMLElement $blockNode)
     {
         $data = $blockNode->addChild('data');
-        foreach($this->getSelectedServices() as $link) {
+        foreach ($this->getSelectedServices() as $link) {
             $data->addChild('service', $link->getHandle());
         }
     }
@@ -99,13 +101,13 @@ class Controller extends BlockController
     protected function getImportData($blockNode, $page)
     {
         $args = array();
-        foreach($blockNode->data->service as $service) {
+        foreach ($blockNode->data->service as $service) {
             $link = Service::getByHandle((string) $service);
             $args['service'][] = $link->getHandle();
         }
+
         return $args;
     }
-
 
     public function save($args)
     {
@@ -115,12 +117,12 @@ class Controller extends BlockController
 
         $statement = $db->prepare('insert into btShareThisPage (bID, service, displayOrder) values (?, ?, ?)');
         $displayOrder = 0;
-        foreach($services as $service) {
+        foreach ($services as $service) {
             $statement->bindValue(1, $this->bID);
             $statement->bindValue(2, $service);
             $statement->bindValue(3, $displayOrder);
             $statement->execute();
-            $displayOrder++;
+            ++$displayOrder;
         }
     }
 
@@ -144,5 +146,4 @@ class Controller extends BlockController
         }
         $this->set('selected', $selected);
     }
-
 }

--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -98,7 +98,7 @@ class Controller extends BlockController
         }
     }
 
-    protected function getImportData($blockNode, $page)
+    public function getImportData($blockNode, $page)
     {
         $args = array();
         foreach ($blockNode->data->service as $service) {

--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -96,9 +96,8 @@ class Controller extends BlockController
         }
     }
 
-    public function getImportData($blockNode)
+    protected function getImportData($blockNode, $page)
     {
-
         $args = array();
         foreach($blockNode->data->service as $service) {
             $link = Service::getByHandle((string) $service);

--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -79,11 +79,10 @@ class Controller extends BlockController
         }
     }
 
-    public function validate()
+    public function validate($args)
     {
         $e = Core::make('helper/validation/error');
-        $service = $this->post('service');
-        if (count($service) == 0) {
+        if (!isset($args['service']) || empty($args['service'])) {
             $e->add(t('You must choose at least one service.'));
         }
         return $e;


### PR DESCRIPTION
We can also keep getImportData as public ( see http://3v4l.org/1tC68 ), but there shouldn't be any problem in marking it as protected since it's called only by the parent class `BlockController` (`import` method)