### PR TITLE
Suppress open_basedir warnings in Concrete\Core\File\Service::isSamePath

### DIFF
--- a/web/concrete/src/File/Service/File.php
+++ b/web/concrete/src/File/Service/File.php
@@ -463,7 +463,7 @@ class File
         if ($checkFile === __FILE__) {
             $checkFile = strtolower(__FILE__);
         }
-        if (is_file($checkFile)) {
+        if (@is_file($checkFile)) {
             $same = (strcasecmp($path1, $path2) === 0) ? true : false;
         } else {
             $same = ($path1 === $path2) ? true : false;


### PR DESCRIPTION
In my environment, PHP5.5 Apache2.4 mod_fastcgi PHP_FPM, open_basedir set to sensible values I am seeing open_basedir warnings when error_reporting includes E_WARNING. This causes the sitemap to fail to load, and the file manager won't show an image if you "view" it. I logged a bug here:
https://www.concrete5.org/developers/bugs/5-7-4-2/open_basedir-issue-php-5.5-apache-2.4
The fix is very simple - just suppress errors with "@"