### PR TITLE
Re: Make console command extendable from packages

### DIFF
--- a/web/concrete/bin/concrete5.php
+++ b/web/concrete/bin/concrete5.php
@@ -10,5 +10,9 @@ $cms = require $DIR_BASE_CORE . '/bootstrap/start.php';
 if (!$cms->isRunThroughCommandLineInterface()) {
     return;
 }
+
 $app = new \Concrete\Core\Console\Application();
+$cms->instance('console', $app);
+$cms->setupPackages();
+$app->setupDefaultCommands();
 $app->run();

--- a/web/concrete/src/Console/Application.php
+++ b/web/concrete/src/Console/Application.php
@@ -13,30 +13,30 @@ class Application extends \Symfony\Component\Console\Application
     public function __construct()
     {
         parent::__construct('concrete5', \Config::get('concrete.version'));
+    }
+    
+    public function setupDefaultCommands()
+    {
         $this->add(new Command\ResetCommand());
         $this->add(new Command\InstallCommand());
         $this->add(new Command\GenerateIDESymbolsCommand());
-        $cms = Core::make('app');
-        if ($cms->isInstalled()) {
-            $cms->setupPackages();
-            $this->add(new Command\JobCommand());
-            $cn = Database::get();
-            /* @var $cn \Concrete\Core\Database\Connection\Connection */
-            $helperSet = ConsoleRunner::createHelperSet($cn->getEntityManager());
-            $this->setHelperSet($helperSet);
-            $mirationsConfiguration = new MigrationsConfiguration();
-            foreach (array(
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand(),
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand(),
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand(),
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand(),
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand(),
-                new \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand(),
-            ) as $migrationsCommand) {
-                $migrationsCommand->setMigrationConfiguration($mirationsConfiguration);
-                $this->add($migrationsCommand);
-            }
-            ConsoleRunner::addCommands($this);
+        $this->add(new Command\JobCommand());
+        $cn = Database::get();
+        /* @var $cn \Concrete\Core\Database\Connection\Connection */
+        $helperSet = ConsoleRunner::createHelperSet($cn->getEntityManager());
+        $this->setHelperSet($helperSet);
+        $mirationsConfiguration = new MigrationsConfiguration();
+        foreach (array(
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand(),
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand(),
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand(),
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand(),
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand(),
+            new \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand(),
+        ) as $migrationsCommand) {
+            $migrationsCommand->setMigrationConfiguration($mirationsConfiguration);
+            $this->add($migrationsCommand);
         }
+        ConsoleRunner::addCommands($this);
     }
 }


### PR DESCRIPTION
This PR makes console command extendable from a Package, without adding the method directly to the Package class. This is an alternative plan of #2651 

An example of package controller:

```php
<?php 
namespace Concrete\Package\CommandPackageExample;

use Concrete\Package\CommandPackageExample\Console\Command\ExampleCommand;
use Core;

class Controller extends \Concrete\Core\Package\Package
{
    protected $pkgHandle = 'command_package_example';
    protected $appVersionRequired = '5.7.4.3';
    protected $pkgVersion = '0.1';
    protected $pkgAutoloaderMapCoreExtensions = true;
    
    public function getPackageName()
    {
        return t('Command Package Example');
    }
    
    public function getPackageDescription()
    {
        return t('An example package to add console commands.');
    }

    public function on_start()
    {
        if (Core::make('app')->isRunThroughCommandLineInterface()) {
            try {
                $app = Core::make('console');
                $app->add(new ExampleCommand());
            } catch (Exception $e) {}
        }
    }
}
```