### PR TITLE
Fix failing UserPoint test

### DIFF
--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -6,6 +6,9 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     private static $conn = null;
     protected $tables = array();
 
+    protected function setUp() {
+        parent::setUp();
+    }
     protected function appendXML($root, $new)
     {
         $node = $root->addChild($new->getName(), (string) $new);
@@ -114,6 +117,8 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 
         $db = Loader::db();
         $db->getEntityManager()->clear();
+
+        \CacheLocal::flush();
 
         parent::tearDown();
     }

--- a/tests/tests/Core/User/GroupTest.php
+++ b/tests/tests/Core/User/GroupTest.php
@@ -10,12 +10,18 @@ namespace Concrete\Tests\Core\User;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
 use Concrete\Core\User\UserList;
+use Concrete\Core\Tree\Type\Group as GroupTreeType;
+use Concrete\Core\Tree\TreeType;
+use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
 
 class GroupTest extends \UserTestCase {
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
+        TreeNodeType::add('group');
+        TreeType::add('group');
+        GroupTreeType::add();
         $g1 = Group::add(
             tc("GroupName", "Guest"),
             tc("GroupDescription", "The guest group represents unregistered visitors to your site."),
@@ -68,6 +74,23 @@ class GroupTest extends \UserTestCase {
         $this->assertEquals(3, count($users1));
         $this->assertEquals(4, count($users2));
 
+    }
+
+    public function testUpdateGroup()
+    {
+        $originalGroup = Group::add('Old Group Name', 'This is the description');
+        $newGroup = $originalGroup->update('New Group Name', 'This is the new description');
+
+        $this->assertEquals('New Group Name', $newGroup->getGroupName());
+        $this->assertEquals('This is the new description', $newGroup->getGroupDescription());
+    }
+
+    public function testRescanGroupPath()
+    {
+        $originalGroup = Group::add('Old Group for Rescan', 'This is a test group');
+        $newGroup = $originalGroup->update('New Group for Rescan', 'This is a test group');
+        $newPath = $newGroup->getGroupPath();
+        $this->assertEquals('/New Group for Rescan', $newPath);
     }
 }
  

--- a/tests/tests/UserTestCase.php
+++ b/tests/tests/UserTestCase.php
@@ -3,13 +3,19 @@ use Concrete\Core\Attribute\Key\Category;
 abstract class UserTestCase extends ConcreteDatabaseTestCase {
 
     protected $fixtures = array();
-    protected $tables = array('Users', 'UserGroups', 'Groups', 'AttributeKeyCategories',
-        'TreeTypes', 'Trees',  'TreeGroupNodes', 'UserAttributeValues'); // so brutal
+    protected $tables = array(
+        'Users', 'UserGroups', 'Groups', 'AttributeKeyCategories',
+        'TreeTypes', 'TreeNodes', 'TreeNodePermissionAssignments',
+        'Packages', 'AttributeKeys', 'AttributeSetKeys', 'AttributeSets',
+        'PermissionKeyCategories', 'PermissionKeys', 'TreeNodeTypes', 'Trees',
+        'TreeGroupNodes', 'UserAttributeValues'
+    ); // so brutal
 
-    public function setUp() {
+    protected function setUp() {
         parent::setUp();
         Category::add('user');
     }
+
     protected static function createUser($uName, $uEmail)
     {
         $user = \Concrete\Core\User\UserInfo::add(

--- a/web/concrete/src/User/Group/Group.php
+++ b/web/concrete/src/User/Group/Group.php
@@ -58,7 +58,7 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
 
         $row = $db->getRow("select * from Groups where gID = ?", array($gID));
         if (isset($row['gID'])) {
-            $g = \Core::make('\Concrete\Core\User\Group\Group');
+            $g = \Core::make('Group');
             $g->setPropertiesFromArray($row);
             CacheLocal::set('group', $gID, $g);
 
@@ -198,6 +198,8 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
         }
 
         $path .= '/' . $this->gName;
+        $this->gPath = $path;
+
         $db->Execute('update Groups set gPath = ? where gID = ?', array($path, $this->gID));
     }
 


### PR DESCRIPTION
- Set `gPath` on group object after rescan
- Add addtional test for rescan group path
- Add test for `Group::updateGroup()`

- Run `parent::setUp()` as DBUnit has a setUp method that does not get
  run if this is not included
- Clear `CacheLocal` on tear down for clean state between tests
