### PR TITLE
Autonav: replace 'sibling' with 'child' for subpages

### DIFF
--- a/web/concrete/blocks/autonav/form_setup_html.php
+++ b/web/concrete/blocks/autonav/form_setup_html.php
@@ -85,7 +85,7 @@ $page_selector = Loader::helper('form/page_selector');
         </div>
 
         <div class="form-group">
-            <label for="displaySubPages"><?= t('Sibling Pages') ?></label>
+            <label for="displaySubPages"><?= t('Child Pages') ?></label>
 
             <select class='form-control' name="displaySubPages" onchange="toggleSubPageLevels(this.value);">
                 <option value="none"<? if ($info['displaySubPages'] == 'none') { ?> selected<? } ?>>


### PR DESCRIPTION
The auto-nav block currently uses 'Sibling Pages'. While I can see where this comes from (i.e. the pages can be interpreted to be siblings to the current page, where the autonav is being placed), it is a source of confusion. The concept seems better captured by calling the pages 'Child Pages', as this option reveals more sub-pages in the menu.