### PR TITLE
Autonav: properly read checkbox value for preview

### DIFF
--- a/web/concrete/blocks/autonav/auto.js
+++ b/web/concrete/blocks/autonav/auto.js
@@ -55,7 +55,7 @@ function reloadPreview(event) {
     displaySubPages = $("select[name=displaySubPages]", container).val();
     displaySubPageLevels = $("select[name=displaySubPageLevels]", container).val();
     displaySubPageLevelsNum = $("input[name=displaySubPageLevelsNum]", container).val();
-    displayUnavailablePages = $("input[name=displayUnavailablePages]", container).val();
+    displayUnavailablePages = $("input[name=displayUnavailablePages]", container).is(':checked') ? 1 : 0;
     displayPagesCID = $("input[name=displayPagesCID]", container).val();
     displayPagesIncludeSelf = displayUnavailablePages;
 


### PR DESCRIPTION
Calling the `.val()` function on a checkbox always returns the value it would submit if checked, but is not influenced by its current state. In order to actually check the value of a checkbox, `is(':checked')` can be used. To prevent having to deal with `true` and `false` as strings throughout the code, it makes sense to immediately translate this into the integers `1` and `0` respectively.