### PR TITLE
Add support for system pages to autonav block

### DIFF
--- a/web/concrete/blocks/autonav/auto.js
+++ b/web/concrete/blocks/autonav/auto.js
@@ -56,6 +56,7 @@ function reloadPreview(event) {
     displaySubPageLevels = $("select[name=displaySubPageLevels]", container).val();
     displaySubPageLevelsNum = $("input[name=displaySubPageLevelsNum]", container).val();
     displayUnavailablePages = $("input[name=displayUnavailablePages]", container).is(':checked') ? 1 : 0;
+    displaySystemPages = $("input[name=displaySystemPages]", container).is(':checked') ? 1 : 0;
     displayPagesCID = $("input[name=displayPagesCID]", container).val();
     displayPagesIncludeSelf = displayUnavailablePages;
 
@@ -78,6 +79,7 @@ function reloadPreview(event) {
         displaySubPageLevels: displaySubPageLevels,
         displaySubPageLevelsNum: displaySubPageLevelsNum,
         displayUnavailablePages: displayUnavailablePages,
+        displaySystemPages: displaySystemPages,
         displayPagesCID: displayPagesCID,
         displayPagesIncludeSelf: displayPagesIncludeSelf
     }, function (resp) {

--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -106,6 +106,7 @@ class Controller extends BlockController
         $args['displayPagesCID'] = isset($args['displayPagesCID']) && $args['displayPagesCID'] ? $args['displayPagesCID'] : 0;
         $args['displaySubPageLevelsNum'] = isset($args['displaySubPageLevelsNum']) && $args['displaySubPageLevelsNum'] > 0 ? $args['displaySubPageLevelsNum'] : 0;
         $args['displayUnavailablePages'] = isset($args['displayUnavailablePages']) && $args['displayUnavailablePages'] ? 1 : 0;
+        $args['displaySystemPages'] = isset($args['displaySystemPages']) && $args['displaySystemPages'] ? 1 : 0;
         parent::save($args);
     }
 

--- a/web/concrete/blocks/autonav/db.xml
+++ b/web/concrete/blocks/autonav/db.xml
@@ -40,6 +40,11 @@
       <default value="0"/>
       <notnull/>
     </field>
+    <field name="displaySystemPages" type="smallint">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/web/concrete/blocks/autonav/form_setup_html.php
+++ b/web/concrete/blocks/autonav/form_setup_html.php
@@ -43,6 +43,16 @@ $page_selector = Loader::helper('form/page_selector');
         </div>
 
         <div class="form-group">
+            <label for="displaySystemPages"><?php echo t('System pages') ?></label>
+            <div class="checkbox">
+                <label>
+                <?php echo $form->checkbox('displaySystemPages', 1, $info['displaySystemPages']); ?>
+                <?php echo t('Display system pages.'); ?>
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group">
             <label for="displayUnavailablePages"><?= t('Check Page Permissions') ?></label>
             <div class="checkbox">
                 <label>

--- a/web/concrete/blocks/autonav/tools/preview_pane.php
+++ b/web/concrete/blocks/autonav/tools/preview_pane.php
@@ -14,6 +14,7 @@ $bt->controller->displaySubPages = $_REQUEST['displaySubPages'];
 $bt->controller->displaySubPageLevels = $_REQUEST['displaySubPageLevels'];
 $bt->controller->displaySubPageLevelsNum = $_REQUEST['displaySubPageLevelsNum'];
 $bt->controller->displayUnavailablePages = $_REQUEST['displayUnavailablePages'];
+$bt->controller->displaySystemPages = $_REQUEST['displaySystemPages'];
 
 if ($bt->controller->displayPages == "custom") {
     $bt->controller->displayPagesCID = $_REQUEST['displayPagesCID'];


### PR DESCRIPTION
There has been a static attribute to configure the availability of system pages in the auto-nav block, but it was not configurable from the UI. This pull request adds a checkbox to the UI to enable showing of system pages (and a database field to store this value).

EDIT: as it turns out, this feature appears to have been available in 5.6. Was it removed for a specific reason, or just never fully ported?