### PR TITLE
Member page redirect to rel. location of directory

### DIFF
--- a/web/concrete/controllers/single_page/members.php
+++ b/web/concrete/controllers/single_page/members.php
@@ -4,7 +4,7 @@ use Concrete\Core\Page\Controller\PublicProfilePageController;
 class Members extends PublicProfilePageController {
 	
 	public function view() {
-        $this->redirect('/members/directory');
+        $this->redirect($this->c->cPath.'/directory');
 	}
 
 }


### PR DESCRIPTION
When moving the member page below another page (i.e. as a child page), this redirect causes a 404. By making it relative to the location of the member page, it becomes possible to move the member page.

This appears to occur on other occassions in the core as well, in various forms, such as when redirecting to the login page using `$this->redirect('/login/');`. This seems to be a bit more intricate than the situation with the member pages, though, and not as easy to resolve.