### PR TITLE
Alias for ADODB GetAssoc() method which returns a key/value array.

### DIFF
--- a/web/concrete/src/Database/Connection/Connection.php
+++ b/web/concrete/src/Database/Connection/Connection.php
@@ -147,6 +147,17 @@ class Connection extends \Doctrine\DBAL\Connection
 
     /**
      * @deprecated
+     * alias to old ADODB method
+     */
+    public function GetAssoc($q, $arguments = array())
+    {
+        $query = $this->query($q, $arguments);
+
+        return $query->fetchAll(\PDO::FETCH_KEY_PAIR);
+    }
+
+    /**
+     * @deprecated
      * Returns an associative array of all columns in a table
      */
     public function MetaColumnNames($table)


### PR DESCRIPTION
While converting a 5.6 site to 5.7 I came across an old ADODB method that hadn't been aliased yet.

Doctrine's fetchAssoc() returns
```
array(
    [0] => array(
        [id] => 1
        [name] => 'John'
    ),

    [1] => array(
        [id] => 2
        [name] => 'Bob'
    )
)
```

whereas ADODB's GetAssoc() returned
```
array(
    1 => John,
    2 => Bob
)
```