### PR TITLE
Allows areas to be changed to global areas and vice versa

### DIFF
--- a/web/concrete/src/Area/Area.php
+++ b/web/concrete/src/Area/Area.php
@@ -784,7 +784,7 @@ class Area extends Object implements \Concrete\Core\Permission\ObjectInterface
         if (!$this->arIsLoaded) {
             // replaces the current empty object with the passed object.
             $area = self::get($c, $this->arHandle);
-            if (!is_object($area)) {
+            if (!is_object($area) || get_class($area) !== get_class($this)) {
                 $area = $this->create($c, $this->arHandle);
             }
             $this->c = $c;

--- a/web/concrete/src/Area/Area.php
+++ b/web/concrete/src/Area/Area.php
@@ -489,7 +489,7 @@ class Area extends Object implements \Concrete\Core\Permission\ObjectInterface
         $db = Loader::db();
         $db->Replace(
             'Areas',
-            array('cID' => $c->getCollectionID(), 'arHandle' => $arHandle),
+            array('cID' => $c->getCollectionID(), 'arHandle' => $arHandle, 'arIsGlobal' => $this->isGlobalArea()),
             array('arHandle', 'cID'),
             true
         );


### PR DESCRIPTION
This fixes #2741 in such a way that it treats `Area` and `GlobalArea` as 2 different areas with different blocks. This does nothing to copy the blocks from the stack to the area or vice versa, it simply allows the area name to be converted back and fourth as needed. 