### PR TITLE
fixes 2444

### DIFF
--- a/web/concrete/single_pages/dashboard/view.php
+++ b/web/concrete/single_pages/dashboard/view.php
@@ -20,6 +20,9 @@ if($rowCount == 3 || $i == 0) {
             $subcats = $cat->getCollectionChildrenArray(true);
             foreach($subcats as $catID) {
                 $subcat = Page::getByID($catID, 'ACTIVE');
+                if ($subcat->getAttribute('exclude_nav')) {
+                    continue;
+                }
                 $catp = new Permissions($subcat);
                 if ($catp->canRead()) {
                     $show[] = $subcat;


### PR DESCRIPTION
exclude_nav causes dashboard pages to no longer show up in dashboard panel which implements the suggestion from #2444