### PR TITLE
clear out altField in datepicker when field is empty

### DIFF
--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -163,7 +163,10 @@ class DateTime
                     showAnim: \'fadeIn\',
                     onClose: function(dateText, inst) {
                         if(dateText == "") {
-                            $(inst.settings["altField"]).val(dateText);
+                            var altField = $(inst.settings["altField"]);
+                            if(altField.length) {
+                                altField.val(dateText);
+                            }
                         }
                     }
                 }).datepicker("setDate" , ' . $defaultDateJs . '); })</script>';
@@ -240,7 +243,10 @@ EOS;
                     showAnim: \'fadeIn\',
                     onClose: function(dateText, inst) {
                         if(dateText == "") {
-                            $(inst.settings["altField"]).val(dateText);
+                            var altField = $(inst.settings["altField"]);
+                            if(altField.length) {
+                                altField.val(dateText);
+                            }
                         }
                     }
                 }).datepicker( "setDate" , ' . $defaultDateJs . ' ); });</script>';

--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -160,7 +160,12 @@ class DateTime
                     altFormat: "yy-mm-dd",
                     altField: "#' . $id . '_dt",
                     changeYear: true,
-                    showAnim: \'fadeIn\'
+                    showAnim: \'fadeIn\',
+                    onClose: function(dateText, inst) {
+                        if(dateText == "") {
+                            $(inst.settings["altField"]).val(dateText);
+                        }
+                    }
                 }).datepicker("setDate" , ' . $defaultDateJs . '); })</script>';
         }
         // first we add a calendar input
@@ -232,7 +237,12 @@ EOS;
                     altFormat: "yy-mm-dd",
                     altField: "#' . $id . '",
                     changeYear: true,
-                    showAnim: \'fadeIn\'
+                    showAnim: \'fadeIn\',
+                    onClose: function(dateText, inst) {
+                        if(dateText == "") {
+                            $(inst.settings["altField"]).val(dateText);
+                        }
+                    }
                 }).datepicker( "setDate" , ' . $defaultDateJs . ' ); });</script>';
         }
 


### PR DESCRIPTION
This fixes #2755, basically when the overlay is closed it will check if the field is blank and if it is the value will be set to empty.

This was the solution posted at bugs.jqueryui.com/ticket/5734. Since they decided they weren't going to do anything with it I think we're going to have to handle it ourselves in concrete5.