### PR TITLE
Allow the minimum log level to be set

### DIFF
--- a/web/concrete/src/Logging/Logger.php
+++ b/web/concrete/src/Logging/Logger.php
@@ -13,9 +13,9 @@ class Logger extends MonologLogger
 
     const CHANNEL_APPLICATION = 'application';
 
-    public function __construct($channel = self::CHANNEL_APPLICATION) {
+    public function __construct($channel = self::CHANNEL_APPLICATION, $logLevel = MonologLogger::DEBUG) {
         parent::__construct($channel);
-        $this->addDatabaseHandler();
+        $this->addDatabaseHandler($logLevel);
 
         $le = new Event($this);
         Events::dispatch('on_logger_create', $le);
@@ -25,9 +25,9 @@ class Logger extends MonologLogger
      * Initially called - this sets up the log writer to use the concrete5
      * Logs database table (this is the default setting.)
      */
-    public function addDatabaseHandler()
+    public function addDatabaseHandler($logLevel = MonologLogger::DEBUG)
     {
-        $handler = new DatabaseHandler();
+        $handler = new DatabaseHandler($logLevel);
         // set a more basic formatter.
         $output = "%message%";
         $formatter = new LineFormatter($output, null, true);


### PR DESCRIPTION
Right now the logger always logs everything to the database logger. This modification might allow us to add a minimum log level configuration setting so that we're not needlessly logging granular information. Additionally, it allows people who are defining their own loggers based off the core one to specify their own default logging level. This could be extremely useful for package developers who might only want to log package warnings and higher by default, but have more granular tracing / debug information available for their package if someone wanted to turn it on.