### PR TITLE
Moves Page::getPageWrapperClass to PageView.php

### DIFF
--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -19,6 +19,7 @@ class PageView extends View
     protected $c; // page
     protected $cp;
     protected $pTemplateID;
+    protected $pTemplateObject;
     protected $customStyleMap;
 
     public function getScopeItems()
@@ -34,6 +35,7 @@ class PageView extends View
      */
     public function setCustomPageTemplate(PageTemplate $pt)
     {
+        $this->pTemplateObject = $pt;
         $this->pTemplateID = $pt->getPageTemplateID();
     }
 
@@ -44,6 +46,26 @@ class PageView extends View
     {
         $this->themeObject = $pt;
         $this->pkgHandle = $pt->getPackageHandle();
+    }
+
+    public function getPageWrapperClass()
+    {
+        if(!isset($this->pTemplateObject)) {
+            $this->pTemplateObject = $this->c->getPageTemplateObject();
+        }
+
+        $pt = $this->c->getPageTypeObject();
+        $ptm = $this->pTemplateObject;
+        
+        $classes = array('ccm-page');
+        if (is_object($pt)) {
+            $classes[] = 'page-type-'.str_replace('_', '-', $pt->getPageTypeHandle());
+        }
+        if (is_object($ptm)) {
+            $classes[] = 'page-template-'.str_replace('_', '-', $ptm->getPageTemplateHandle());
+        }
+
+        return implode(' ', $classes);
     }
 
     public function renderSinglePageByFilename($cFilename)

--- a/web/concrete/themes/elemental/elements/header_top.php
+++ b/web/concrete/themes/elemental/elements/header_top.php
@@ -21,4 +21,4 @@
 </head>
 <body>
 
-<div class="<?=$c->getPageWrapperClass()?>">
+<div class="<?=$view->getPageWrapperClass()?>">


### PR DESCRIPTION
Left Original method in place so as not to break backwards compatibility. Is there a cleaner fix for this?

Addresses #2362 