### PR TITLE
Single page render improvements

### DIFF
--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -50,23 +50,33 @@ class PageView extends View
     {
         $env = Environment::get();
         $cFilename = trim($cFilename, '/');
+
         // if we have this exact template in the theme, we use that as the outer wrapper and we don't do an inner content file
         $r = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $cFilename, $this->pkgHandle);
         if ($r->exists()) {
             $this->setViewTemplate($r->file);
         } else {
-            if (file_exists(
-                DIR_FILES_THEMES_CORE . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php')) {
+            if (file_exists(DIR_FILES_THEMES_CORE . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php')) {
                 $this->setViewTemplate(
-                    $env->getPath(DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php'));
+                    $env->getPath(
+                        DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php'
+                    )
+                );
             } else {
                 $this->setViewTemplate(
                     $env->getPath(
                         DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(),
-                        $this->pkgHandle));
+                        $this->pkgHandle
+                    )
+                );
             }
+
             $this->setInnerContentFile(
-                $env->getPath(DIRNAME_PAGES . '/' . $cFilename, $this->c->getPackageHandle()));
+                $env->getPath(
+                    DIRNAME_PAGES . '/' . $cFilename,
+                    $this->c->getPackageHandle()
+                )
+            );
         }
     }
     public function setupRender()

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -56,8 +56,9 @@ class PageView extends View
         if ($exactThemeTemplate->exists()) {
             $this->setViewTemplate($exactThemeTemplate->file);
         } else {
-            // use the outer wrapper from a core theme if one is being used
-            $coreThemeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php');
+            // use a content wrapper from themes/core if specified
+            // e.g. $this->render('your/page', 'none') would use themes/core/none.php to print the $innerContent without a wrapper
+            $coreThemeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->pkgHandle . '.php');
             if ($coreThemeTemplate->exists()) {
                 $this->setViewTemplate($coreThemeTemplate->file);
             } else {

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -64,7 +64,15 @@ class PageView extends View
             } else {
                 // check for other themes or in a package if one was specified
                 $themeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(), $this->pkgHandle);
-                $this->setViewTemplate($themeTemplate->file);
+                if ($themeTemplate->exists()) {
+                    $this->setViewTemplate($themeTemplate->file);
+                } else {
+                    // fall back to the active theme wrapper if nothing else was found
+                    $fallbackTheme = PageTheme::getByHandle($this->themeHandle);
+                    $fallbackPkgHandle = ($fallbackTheme instanceof PageTheme) ? $fallbackTheme->getPackageHandle() : $this->pkgHandle;
+                    $fallbackTemplate = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(), $fallbackPkgHandle);
+                    $this->setViewTemplate($fallbackTemplate->file);
+                }
             }
 
             // set the inner content for the theme wrapper we found
@@ -76,6 +84,7 @@ class PageView extends View
             );
         }
     }
+    
     public function setupRender()
     {
         $this->loadViewThemeObject();

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -62,7 +62,7 @@ class PageView extends View
             if ($coreThemeTemplate->exists()) {
                 $this->setViewTemplate($coreThemeTemplate->file);
             } else {
-                // check for other themes in the concrete directory, or in a package if one was specified
+                // check for other themes or in a package if one was specified
                 $themeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(), $this->pkgHandle);
                 $this->setViewTemplate($themeTemplate->file);
             }

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -52,25 +52,21 @@ class PageView extends View
         $cFilename = trim($cFilename, '/');
 
         // if we have this exact template in the theme, we use that as the outer wrapper and we don't do an inner content file
-        $r = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $cFilename, $this->pkgHandle);
-        if ($r->exists()) {
-            $this->setViewTemplate($r->file);
+        $exactThemeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $cFilename, $this->pkgHandle);
+        if ($exactThemeTemplate->exists()) {
+            $this->setViewTemplate($exactThemeTemplate->file);
         } else {
-            if (file_exists(DIR_FILES_THEMES_CORE . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php')) {
-                $this->setViewTemplate(
-                    $env->getPath(
-                        DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php'
-                    )
-                );
+            // use the outer wrapper from a core theme if one is being used
+            $coreThemeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php');
+            if ($coreThemeTemplate->exists()) {
+                $this->setViewTemplate($coreThemeTemplate->file);
             } else {
-                $this->setViewTemplate(
-                    $env->getPath(
-                        DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(),
-                        $this->pkgHandle
-                    )
-                );
+                // check for other themes in the concrete directory, or in a package if one was specified
+                $themeTemplate = $env->getRecord(DIRNAME_THEMES . '/' . $this->themeHandle . '/' . $this->controller->getThemeViewTemplate(), $this->pkgHandle);
+                $this->setViewTemplate($themeTemplate->file);
             }
 
+            // set the inner content for the theme wrapper we found
             $this->setInnerContentFile(
                 $env->getPath(
                     DIRNAME_PAGES . '/' . $cFilename,


### PR DESCRIPTION
Example class to set the scene: https://gist.github.com/mitchray/70f0a6fc3b88c2f249d7

### Backstory
* You can request to render a Single Page using `$this->render('path/go/here')`.
* It has an optional parameter for a package handle, like so: `$this->render('path/go/here', 'PACKAGE_HANDLE')`.
* THEME_HANDLE is a part of the View class and is not controlled through render(). 
* After requesting to render a Single Page, the system decides how to wrap it. This is different from setting a theme: `$this->setTheme('THEME_HANDLE')`, I just wanted to make the distinction clear as we aren't trying to explicitly give a page a certain theme.

### Previous behaviour
1. If the exact template `themes/THEME_HANDLE/fruit.php` or `packages/PACKAGE_HANDLE/themes/THEME_HANDLE/fruit.php` exists, use that as the outer wrapper and don't do an inner content file.
2. Use `concrete/themes/core/THEME_HANDLE.php` if it exists (which it never would as themes don't reside here, e.g `concrete/themes/core/elemental.php`) :-1: 
3. Use `themes/THEME_HANDLE/view.php` or `packages/PACKAGE_HANDLE/themes/THEME_HANDLE/view.php` if it exists. This is not triggered though if you are using a packaged theme and aren't specifying a package handle in your render() call (it essentially looks in `concrete/themes/THEME_HANDLE` and `application/themes/THEME_HANDLE`)
4. If none of the above conditions were met, render the $innerContent without any theme (and no C5 header/footer elements) :-1:

### New behaviour
1. Same as `#1` above
2. Use `concrete/themes/core/`**PACKAGE_HANDLE**`.php` if it exists. Now we can call `$this->render('path/go/here', `**'none'**`)` to use `concrete/themes/core/none.php` and output just the $innerContent without C5 header/footer elements :+1: 
3. Same as `#3` above
4. If none of the above conditions were met, render the $innerContent within the current theme view.php :+1: 

### Why is this useful?
* You may want to render a Single Page using the view.php file of whatever the current theme is, without hardcoding a specific theme into your controller (this is how 5.6 worked)