### PR TITLE
Output external links in page list blocks

### DIFF
--- a/web/concrete/blocks/page_list/view.php
+++ b/web/concrete/blocks/page_list/view.php
@@ -29,7 +29,7 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
         $buttonClasses = 'ccm-block-page-list-read-more';
         $entryClasses = 'ccm-block-page-list-page-entry';
 		$title = $th->entities($page->getCollectionName());
-		$url = $nh->getLinkToCollection($page);
+		$url = ($page->getCollectionPointerExternalLink() != '') ? $page->getCollectionPointerExternalLink() : $nh->getLinkToCollection($page);
 		$target = ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) ? '_blank' : $page->getAttribute('nav_target');
 		$target = empty($target) ? '_self' : $target;
 		$description = $page->getCollectionDescription();


### PR DESCRIPTION
Make page_list output external links just like autonav does. So the href will render as http://externalsite.com instead of /?cID=1234