### PR TITLE
Spectrum color picker tweaks.

### DIFF
--- a/web/concrete/css/build/core/app/inline-toolbar.less
+++ b/web/concrete/css/build/core/app/inline-toolbar.less
@@ -236,7 +236,7 @@
         width: 100%;
 
         .sp-input {
-          color: #777;
+          color: #8f969a;
           outline: 0px;
           border: 1px solid #666;
 
@@ -254,15 +254,15 @@
         width: 12px;
         height: 12px;
         top: -4px;
-        background-color: #888 !important;
         outline: none !important;
+        background-color: #fff;
         background-image: none;
 
       }
 
       a.sp-cancel {
         float: left;
-        color: #777 !important;
+        color: #8f969a !important;
         font-weight: bold;
         font-size: 12px;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -281,7 +281,7 @@
 
         button.sp-choose {
           float: right;
-          color: #777;
+          color: #8f969a !important;
           font-weight: bold;
           font-size: 12px;
           border: none !important;
@@ -291,10 +291,11 @@
           padding: 2px;
           font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
           text-transform: capitalize;
+          .box-shadow(none);
 
           &:hover {
             text-decoration: none;
-            color: #0c6;
+            color: #0c6 !important;
           }
 
           &:focus {
@@ -306,7 +307,7 @@
           }
         }
       }
-      
+
       .sp-initial {
         overflow: hidden;
         float: none;

--- a/web/concrete/css/build/core/app/inline-toolbar.less
+++ b/web/concrete/css/build/core/app/inline-toolbar.less
@@ -200,9 +200,9 @@
   background-color: rgba(0, 0, 0, 0.4);
 }
 
-div.ccm-widget-colorpicker {
+.ccm-panel-left {
 
-  &.sp-container {
+  .sp-container {
     .border-radius(4px);
     border: 0px;
     background-color: rgba(0,0,0,0.95);
@@ -229,7 +229,6 @@ div.ccm-widget-colorpicker {
       .sp-alpha {
         height: 4px;
         background-color: #232323;
-        background-image: none;
       }
 
       .sp-input-container {
@@ -237,6 +236,7 @@ div.ccm-widget-colorpicker {
         width: 100%;
 
         .sp-input {
+          color: #777;
           outline: 0px;
           border: 1px solid #666;
 
@@ -288,7 +288,7 @@ div.ccm-widget-colorpicker {
           text-shadow: none !important;
           background-color: transparent !important;
           background-image: none !important;
-          padding: 0px;
+          padding: 2px;
           font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
           text-transform: capitalize;
 
@@ -306,22 +306,15 @@ div.ccm-widget-colorpicker {
           }
         }
       }
-
+      
       .sp-initial {
-
-        span {
-          width: 172px;
-          .border-radius(4px);
-        }
+        overflow: hidden;
         float: none;
         width: 100%;
 
-        div.sp-palette-row-initial {
-          > span:first-child {
-            display: none;
-          }
+        span {
+          width: 172px;
         }
-
       }
     }
   }


### PR DESCRIPTION
* Change scope of the Customize Theme color picker to .ccm-panel-left, which ensures other uses throughout the Dashboard are not affected (see http://bgrins.github.io/spectrum/ for how it looks).
* Restore the before/after comparison (showInitial = true but the CSS was hiding it).
* Restore the checkered background in the alpha slider.
* Lighten the color value text to match the Cancal/Choose text.
* Fix alignment of the Choose text.

![spectrum_before_after](https://cloud.githubusercontent.com/assets/5735900/8867588/a557c250-320e-11e5-98b6-d209632d9f62.png)