### PR TITLE
Fix install via CLI

### DIFF
--- a/web/concrete/bin/concrete5.php
+++ b/web/concrete/bin/concrete5.php
@@ -13,6 +13,8 @@ $cms = require $DIR_BASE_CORE . '/bootstrap/start.php';
 
 $app = new \Concrete\Core\Console\Application();
 $cms->instance('console', $app);
-$cms->setupPackages();
+if ($cms->isInstalled()) {
+    $cms->setupPackages();
+}
 $app->setupDefaultCommands();
 $app->run();

--- a/web/concrete/src/Console/Application.php
+++ b/web/concrete/src/Console/Application.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Console;
 
-use Config;
 use Core;
 use Database;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
@@ -32,6 +31,9 @@ class Application extends \Symfony\Component\Console\Application
 
     public function setupDoctrineCommands()
     {
+        if (!Core::make('app')->isInstalled()) {
+            return;
+        }
         $cn = Database::connection();
         $helperSet = ConsoleRunner::createHelperSet($cn->getEntityManager());
         $this->setHelperSet($helperSet);


### PR DESCRIPTION
With the latest version of the CLI stuff, the c5:install command doesn't work since we're trying to use database-dependent stuff (but the db is not initialized before the installation).
So, let's reduce the set of available commands to those that don't require a fully installed instance.