### PR TITLE
Fixed duplicate success message on cloned blocks

### DIFF
--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -553,7 +553,7 @@ class Controller extends BlockController
                     }
                 }
                 $c = Page::getCurrentPage();
-                header("Location: ".Core::make('helper/navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."#formblock".$this->bID);
+                header("Location: ".Core::make('helper/navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."&bID=".$this->bID."#formblock".$this->bID);
                 exit;
             }
         }

--- a/web/concrete/blocks/form/view.php
+++ b/web/concrete/blocks/form/view.php
@@ -53,7 +53,7 @@ while ($questionRow = $questionsRS->fetchRow()) {
 }
 
 //Prep thank-you message
-$success = ($_GET['surveySuccess'] && $_GET['qsid'] == intval($qsID));
+$success = ($_GET['surveySuccess'] && $_GET['qsid'] == intval($qsID) && $_GET['bID'] == intval($bID));
 $thanksMsg = $survey->thankyouMsg;
 
 //Collate all errors and put them into divs


### PR DESCRIPTION
When form block is cloned on the same page and the question sets are kept the same, both blocks show the success message when a single form is submitted. Passing bID as the URL parameter helps resolve this issue.