### PR TITLE
Prevents a non-existent array in the foreach loop

### DIFF
--- a/web/concrete/elements/account/menu.php
+++ b/web/concrete/elements/account/menu.php
@@ -29,6 +29,7 @@ do {
   </button>
   <ul class="dropdown-menu pull-right" role="menu">
   <?
+  	$categories = array();
 	$children = $account->getCollectionChildrenArray(true);
 	foreach($children as $cID) {
 		$nc = Page::getByID($cID, 'ACTIVE');


### PR DESCRIPTION
In rare cases where the menu contains children, but all of them have the `exclude_nav` attribute set, this code would crash on the `foreach` loop and render the entire website unusable. By initialising the `$categories` array to an empty array instead of relying on at least one appended child, the foreach is guaranteed to execute without throwing `Exception: Invalid argument supplied for foreach()`