### PR TITLE
Make some changes for PHP7/LSP

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -32,7 +32,7 @@
         "natxet/cssmin": "dev-master",
         "tedivm/jshrink": "0.5.*",
         "michelf/php-markdown": "1.4.*@dev",
-        "filp/whoops": "1.*",
+        "filp/whoops": "dev-php7",
         "pagerfanta/pagerfanta": "1.0.2",
         "htmlawed/htmlawed": "dev-master",
         "mobiledetect/mobiledetectlib": "2.8.*",

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "af609474b82c9d267d6f6a52c87006ea",
+    "hash": "d20ff0f672bfdf1f3a7ee4edd7e6738e",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -687,7 +687,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/a4f14d3a3d397104e557ec65d1a4e43bb86e4ddf",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/78954cce4962a4655ff47c0751eb78021fbaf2cc",
                 "reference": "efb77c10dfb75485998a843154bbc44d8124c4d1",
                 "shasum": ""
             },
@@ -860,16 +860,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "1.1.3",
+            "version": "dev-php7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a85fab9a98f1f9b8ebcdbe71733f0d910e5b9adf"
+                "reference": "fe32a402b086b21360e82013e8a0355575c7c6f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a85fab9a98f1f9b8ebcdbe71733f0d910e5b9adf",
-                "reference": "a85fab9a98f1f9b8ebcdbe71733f0d910e5b9adf",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/fe32a402b086b21360e82013e8a0355575c7c6f4",
+                "reference": "fe32a402b086b21360e82013e8a0355575c7c6f4",
                 "shasum": ""
             },
             "require": {
@@ -914,7 +914,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2014-10-26 09:05:09"
+            "time": "2015-07-14 13:26:47"
         },
         {
             "name": "gettext/gettext",
@@ -1039,7 +1039,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/phpass/zipball/9590c12bf7c92f67f646d7bf2cf6384e7292cc41",
+                "url": "https://api.github.com/repos/hautelook/phpass/zipball/f0217d804225822f9bdb0d392839029b0fcb0914",
                 "reference": "9590c12bf7c92f67f646d7bf2cf6384e7292cc41",
                 "shasum": ""
             },
@@ -1083,7 +1083,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kesar/HTMLawed/zipball/9d292af5f4c288aa68f38b87f5d88c8214f5f233",
+                "url": "https://api.github.com/repos/kesar/HTMLawed/zipball/1df80388ef46f50306709c73df0f09c2643872fa",
                 "reference": "9d292af5f4c288aa68f38b87f5d88c8214f5f233",
                 "shasum": ""
             },
@@ -1516,7 +1516,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/e1aabe18173231ebcefc90e615565742fc1c7fd9",
+                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/942bf343ddc80b06b1bd43c452ffd58a1e357df6",
                 "reference": "e1aabe18173231ebcefc90e615565742fc1c7fd9",
                 "shasum": ""
             },
@@ -1743,7 +1743,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/natxet/CssMin/zipball/f076e41392b0008efb47074a133ec1d90dc8c99f",
+                "url": "https://api.github.com/repos/natxet/CssMin/zipball/4026975145f645a77e087a26e7b0a1c9209b0191",
                 "reference": "f076e41392b0008efb47074a133ec1d90dc8c99f",
                 "shasum": ""
             },
@@ -2019,7 +2019,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/utf8/zipball/ffa082111aa3cb23cf2479a17e6785ace91da982",
+                "url": "https://api.github.com/repos/tchwork/utf8/zipball/38047e4a8f64e1974f46ae6bec56aaa0357bb98d",
                 "reference": "ffa082111aa3cb23cf2479a17e6785ace91da982",
                 "shasum": ""
             },
@@ -3921,6 +3921,7 @@
         "imagine/imagine": 20,
         "natxet/cssmin": 20,
         "michelf/php-markdown": 20,
+        "filp/whoops": 20,
         "htmlawed/htmlawed": 20,
         "hautelook/phpass": 20,
         "kertz/twitteroauth": 20,

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -357,11 +357,22 @@ class Key extends Object
     /**
      * Adds an attribute key.
      */
-    protected static function add($akCategoryHandle, $type, $args, $pkg = false)
+    protected static function add($type, $args, $pkg = false)
     {
+        $txt = Core::make('helper/text');
 
-        $vn = Loader::helper('validation/numbers');
-        $txt = Loader::helper('text');
+        $fargs = func_get_args();
+        if (count($fargs) >= 4) {
+            $akCategoryHandle = $fargs[0];
+            $type = $fargs[1];
+            $args = $fargs[2];
+            $pkg = $fargs[3];
+        } else {
+            $class = get_called_class();
+            $last = array_pop(explode('\\', $class));
+            $akCategoryHandle = $txt->uncamelcase(substr($last, 0, -3)); //strip off `Key`
+        }
+
         if (!is_object($type)) {
             // The passed item is not an object. It is probably something like 'DATE'
             $type = AttributeType::getByHandle(strtolower($type));

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -375,11 +375,8 @@ class Key extends Object
         $txt = Core::make('helper/text');
 
         $fargs = func_get_args();
-        if (count($fargs) >= 4) {
-            $akCategoryHandle = $fargs[0];
-            $type = $fargs[1];
-            $args = $fargs[2];
-            $pkg = $fargs[3];
+        if (count($fargs) == 4) {
+            list($akCategoryHandle, $type, $args, $pkg) = $fargs;
         } else {
             $akCategoryHandle = self::getHandleFromClass(get_called_class());
         }

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -355,6 +355,19 @@ class Key extends Object
     }
 
     /**
+     * Takes a class name (from get_called_class() for example) and returns the handle for the class
+     *
+     * @param string $class
+     * @return string
+     */
+    protected static function getHandleFromClass($class)
+    {
+        $txt = Core::make('helper/text');
+        $last = array_pop(explode('\\', $class));
+        return $txt->uncamelcase(substr($last, 0, -3)); //strip off `Key
+    }
+
+    /**
      * Adds an attribute key.
      */
     protected static function add($type, $args, $pkg = false)
@@ -368,9 +381,7 @@ class Key extends Object
             $args = $fargs[2];
             $pkg = $fargs[3];
         } else {
-            $class = get_called_class();
-            $last = array_pop(explode('\\', $class));
-            $akCategoryHandle = $txt->uncamelcase(substr($last, 0, -3)); //strip off `Key`
+            $akCategoryHandle = self::getHandleFromClass(get_called_class());
         }
 
         if (!is_object($type)) {

--- a/web/concrete/src/Gathering/Item/FlickrFeed.php
+++ b/web/concrete/src/Gathering/Item/FlickrFeed.php
@@ -15,7 +15,7 @@ class FlickrFeed extends Item {
 		$gathering = $configuration->getGatheringObject();
 		try {
 			// we wrap this in a try because it MIGHT fail if it's a duplicate
-			$item = parent::add($gathering, $configuration->getGatheringDataSourceObject(), $post->get_date('Y-m-d H:i:s'), $post->get_title(), $post->get_link());
+			$item = parent::addItem($gathering, $configuration->getGatheringDataSourceObject(), $post->get_date('Y-m-d H:i:s'), $post->get_title(), $post->get_link());
 		} catch(Exception $e) {}
 
 		if (is_object($item)) {

--- a/web/concrete/src/Gathering/Item/Item.php
+++ b/web/concrete/src/Gathering/Item/Item.php
@@ -226,7 +226,7 @@ abstract class Item extends Object
         return $items;
     }
 
-    public static function add(
+    public static function addItem(
         Gathering $ag,
         GatheringDataSource $ags,
         $gaiPublicDateTime,

--- a/web/concrete/src/Gathering/Item/Page.php
+++ b/web/concrete/src/Gathering/Item/Page.php
@@ -25,7 +25,7 @@ class Page extends Item {
 		$gathering = $configuration->getGatheringObject();
 		try {
 			// we wrap this in a try because it MIGHT fail if it's a duplicate
-			$item = parent::add($gathering, $configuration->getGatheringDataSourceObject(), $c->getCollectionDatePublic(), $c->getCollectionName(), $c->getCollectionID());
+			$item = parent::addItem($gathering, $configuration->getGatheringDataSourceObject(), $c->getCollectionDatePublic(), $c->getCollectionName(), $c->getCollectionID());
 		} catch (Exception $e) {}
 
 		if (is_object($item)) {

--- a/web/concrete/src/Gathering/Item/RssFeed.php
+++ b/web/concrete/src/Gathering/Item/RssFeed.php
@@ -15,7 +15,7 @@ class RssFeed extends Item {
 		$gathering = $configuration->getGatheringObject();
 		try {
 			// we wrap this in a try because it MIGHT fail if it's a duplicate
-			$item = parent::add($gathering, $configuration->getGatheringDataSourceObject(), $post->get_date('Y-m-d H:i:s'), $post->get_title(), $post->get_link());
+			$item = parent::addItem($gathering, $configuration->getGatheringDataSourceObject(), $post->get_date('Y-m-d H:i:s'), $post->get_title(), $post->get_link());
 		} catch(Exception $e) {}
 
 		if (is_object($item)) {

--- a/web/concrete/src/Gathering/Item/Twitter.php
+++ b/web/concrete/src/Gathering/Item/Twitter.php
@@ -15,7 +15,7 @@ class Twitter extends Item {
 		$gathering = $configuration->getGatheringObject();
 		try {
 			// we wrap this in a try because it MIGHT fail if it's a duplicate
-			$item = parent::add($gathering, $configuration->getGatheringDataSourceObject(), date('Y-m-d H:i:s', strtotime($tweet->created_at)), $tweet->text, $tweet->id);
+			$item = parent::addItem($gathering, $configuration->getGatheringDataSourceObject(), date('Y-m-d H:i:s', strtotime($tweet->created_at)), $tweet->text, $tweet->id);
 		} catch(Exception $e) {}
 
 		if (is_object($item)) {

--- a/web/concrete/src/Workflow/Progress/PageProgress.php
+++ b/web/concrete/src/Workflow/Progress/PageProgress.php
@@ -3,14 +3,14 @@ namespace Concrete\Core\Workflow\Progress;
 use Loader;
 use Page;
 use \Concrete\Core\Workflow\Workflow;
-use \Concrete\Core\Workflow\Request\PageRequest as PageWorkflowRequest;
+use \Concrete\Core\Workflow\Request\Request as WorkflowRequest;
 
 class PageProgress extends Progress {
 
 	protected $cID;
 
-	public static function add(Workflow $wf, PageWorkflowRequest $wr) {
-		$wp = parent::add('page', $wf, $wr);
+	public static function add(Workflow $wf, WorkflowRequest $wr) {
+		$wp = parent::add($wf, $wr);
 		$db = Loader::db();
 		$db->Replace('PageWorkflowProgress', array('cID' => $wr->getRequestedPageID(), 'wpID' => $wp->getWorkflowProgressID()), array('cID', 'wpID'), true);
 		$wp->cID = $wr->getRequestedPageID();

--- a/web/concrete/src/Workflow/Progress/Progress.php
+++ b/web/concrete/src/Workflow/Progress/Progress.php
@@ -96,8 +96,14 @@ abstract class Progress extends Object
     /**
      * Creates a WorkflowProgress object (which will be assigned to a Page, File, etc... in our system.
      */
-    public static function add($wpCategoryHandle, Workflow $wf, WorkflowRequest $wr)
+    public static function add(Workflow $wf, WorkflowRequest $wr)
     {
+        $txt = Core::make('helper/text');
+
+        $class = get_called_class();
+        $last = array_pop(explode('\\', $class));
+        $wpCategoryHandle = $txt->uncamelcase(substr($last, 0, -8)); //strip off `Progress`
+
         $db = Loader::db();
         $wpDateAdded = Loader::helper('date')->getOverridableNow();
         $wpCategoryID = $db->GetOne('select wpCategoryID from WorkflowProgressCategories where wpCategoryHandle = ?', array($wpCategoryHandle));


### PR DESCRIPTION
I updated whoops to use a different branch so it works with PHP7 (still works with all previous versions of PHP)

I also changed some function signatures to adhere to LSP with backwards compatibility for the add() functions, this will work as is with the existing calls, but we should change the internal uses to get rid of the $akCategoryHandle

Due to typehints, I can't make the Workflow add() backwards compatible without removing the type hints.

I also changed the name of one of the Gathering functions because the functions that extended it had basically nothing in common with it, and this was the only clean way to deal with it.