### PR TITLE
Remove excess send() call

### DIFF
--- a/web/concrete/src/Routing/DispatcherRouteCallback.php
+++ b/web/concrete/src/Routing/DispatcherRouteCallback.php
@@ -94,7 +94,7 @@ class DispatcherRouteCallback extends RouteCallback
         }
         if (!$c->cPathFetchIsCanonical) {
             // Handle redirect URL (additional page paths)
-            return Redirect::page($c, 301)->send();
+            return Redirect::page($c, 301);
         }
 
         // maintenance mode
@@ -109,7 +109,7 @@ class DispatcherRouteCallback extends RouteCallback
         }
 
         if ($c->getCollectionPointerExternalLink() != '') {
-            return Redirect::url($c->getCollectionPointerExternalLink(), 301)->send();
+            return Redirect::url($c->getCollectionPointerExternalLink(), 301);
         }
 
         $cp = new Permissions($c);


### PR DESCRIPTION
It is not necessary to send RedirectResponse in the dispatcher, the bootstrap handles that. It fired an exception ("concrete\bootstrap\start.php:290 Call to a member function send() on a non-object") since the response was already sent by the dispatcher and the bootstrap had nothing to send.