### PR TITLE
Fix enabling/disabling display_help_system

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/basics/accessibility.php
+++ b/web/concrete/controllers/single_page/dashboard/system/basics/accessibility.php
@@ -25,7 +25,7 @@ class Accessibility extends DashboardPageController
     {
         Config::save('concrete.accessibility.toolbar_titles', !!Request::post('show_titles', false));
         Config::save('concrete.accessibility.toolbar_large_font', !!Request::post('increase_font_size', false));
-        Config::save('concrete.accessibility.display_help_system', !!Request::post('increase_font_size', false));
+        Config::save('concrete.accessibility.display_help_system', !!Request::post('display_help', false));
         $this->redirect('/dashboard/system/basics/accessibility', 'saved');
     }
 


### PR DESCRIPTION
Closes https://www.concrete5.org/developers/bugs/5-7-5rc1/re-enabling-help-after-turning-it-off-in-accessibility-menu/