### PR TITLE
Add composer type names to composer form

### DIFF
--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -16,7 +16,10 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 	</td>
 
 	<td style="width: 100%;">
-		<span class="text-muted"><?= $name ?> (<?= $der->getPageTypeComposerControlTypeDisplayName() ?>)</span>
+		<span class="text-muted"><?= $der->getPageTypeComposerControlTypeDisplayName() ?></span>
+		<? if ($name): ?>
+			<span class="text-muted">(<?= trim($name) ?>)</span>
+		<? endif ?>
 	</td>
 
 	<td style="text-align: right; min-width: 62px; white-space: nowrap;">

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -16,7 +16,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 	</td>
 
 	<td style="width: 100%;">
-		<small class="text-muted"><?= $name ?> (<?= $der->getPageTypeComposerControlTypeDisplayName() ?>)</small>
+		<span class="text-muted"><?= $name ?> (<?= $der->getPageTypeComposerControlTypeDisplayName() ?>)</span>
 	</td>
 
 	<td style="text-align: right; min-width: 62px; white-space: nowrap;">

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -11,7 +11,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 
 ?>
 <tr class="ccm-page-type-composer-form-layout-control-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
-	<td style="white-space: nowrap;">
+	<td style="white-space: nowrap; width: 20%;">
 		<?= $control->getPageTypeComposerControlDisplayLabel(); ?>
 	</td>
 

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -16,11 +16,11 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 	</td>
 
 	<td style="white-space: nowrap;">
-		<?= $der->getPageTypeComposerControlTypeDisplayName(); ?>
+		<small class="text-muted"><?= $der->getPageTypeComposerControlTypeDisplayName(); ?></small>
 	</td>
 
 	<td style="width: 100%;">
-		<?= $name; ?>
+		<small class="text-muted"><?= $name; ?></small>
 	</td>
 
 	<td style="text-align: right; min-width: 62px; white-space: nowrap;">

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -15,12 +15,8 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 		<?= $control->getPageTypeComposerControlDisplayLabel(); ?>
 	</td>
 
-	<td style="white-space: nowrap;">
-		<small class="text-muted"><?= $der->getPageTypeComposerControlTypeDisplayName(); ?></small>
-	</td>
-
 	<td style="width: 100%;">
-		<small class="text-muted"><?= $name; ?></small>
+		<small class="text-muted"><?= $name ?> (<?= $der->getPageTypeComposerControlTypeDisplayName() ?>)</small>
 	</td>
 
 	<td style="text-align: right; min-width: 62px; white-space: nowrap;">

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -22,7 +22,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 		<? endif ?>
 	</td>
 
-	<td style="text-align: right; min-width: 62px; white-space: nowrap;">
+	<td style="text-align: right; white-space: nowrap;">
 		<ul class="ccm-page-type-composer-item-controls">
 			<li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
 			<li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -1,44 +1,46 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 /** @var $control Concrete\Core\Page\Type\Composer\FormLayoutSetControl */
+
+$der = Concrete\Core\Page\Type\Composer\Control\Type\Type::getByID($control->getPageTypeComposerControlTypeID());
+$pto = $control->getPageTypeComposerControlObject();
+$name = '';
+if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
+	$name = $pto->getPageTypeComposerControlName() . ' ';
+}
+
 ?>
-<div class="ccm-page-type-composer-form-layout-control-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
-    <div class="ccm-page-type-composer-item-control-bar">
-        <ul class="ccm-page-type-composer-item-controls">
-            <li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
-            <li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>
-            <li><a href="#" data-delete-set-control="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>"><i class="fa fa-trash-o"></i></a></li>
-        </ul>
+<tr class="ccm-page-type-composer-form-layout-control-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
+	<td style="white-space: nowrap;">
+		<?= $control->getPageTypeComposerControlDisplayLabel(); ?>
+	</td>
 
-        <div style="display: none">
-            <div data-delete-set-control-dialog="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
-                <?=t("Delete this control? This cannot be undone.")?>
-                <?=Core::make('helper/validation/token')->output('delete_set_control')?>
+	<td style="white-space: nowrap;">
+		<?= $der->getPageTypeComposerControlTypeDisplayName(); ?>
+	</td>
 
-                <div class="dialog-buttons">
-                    <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-                    <button class="btn btn-danger pull-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Update Set')?></button>
-                </div>
+	<td style="width: 100%;">
+		<?= $name; ?>
+	</td>
 
-            </div>
-        </div>
+	<td style="text-align: right; width: 200px; white-space: nowrap;">
+		<ul class="ccm-page-type-composer-item-controls">
+			<li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
+			<li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>
+			<li><a href="#" data-delete-set-control="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>"><i class="fa fa-trash-o"></i></a></li>
+		</ul>
 
-        <div class="ccm-page-type-composer-form-layout-control-set-control-inner">
-            <?php
-            $der = Concrete\Core\Page\Type\Composer\Control\Type\Type::getByID($control->getPageTypeComposerControlTypeID());
-            $pto = $control->getPageTypeComposerControlObject();
-            //var_dump($control);
-            $name = '';
-            if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
-                $name = $pto->getPageTypeComposerControlName() . ' ';
-            }
-            echo sprintf(
-                '%s - <small>%s(%s)</small>',
-                $control->getPageTypeComposerControlDisplayLabel(),
-                $name,
-                $der->getPageTypeComposerControlTypeDisplayName()
-            );
-            ?>
-        </div>
-    </div>
-</div>
+		<div style="display: none">
+			<div data-delete-set-control-dialog="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
+				<?=t("Delete this control? This cannot be undone.")?>
+				<?=Core::make('helper/validation/token')->output('delete_set_control')?>
+
+				<div class="dialog-buttons">
+					<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+					<button class="btn btn-danger pull-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Update Set')?></button>
+				</div>
+
+			</div>
+		</div>
+	</td>
+</tr>

--- a/web/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/web/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -23,7 +23,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 		<?= $name; ?>
 	</td>
 
-	<td style="text-align: right; width: 200px; white-space: nowrap;">
+	<td style="text-align: right; min-width: 62px; white-space: nowrap;">
 		<ul class="ccm-page-type-composer-item-controls">
 			<li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
 			<li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -56,12 +56,6 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 				?></div>
 			</div>
 
-			<? if ($set->getPageTypeComposerFormLayoutSetDisplayDescription()): ?>
-				<div class="panel-body">
-					<p><?= $set->getPageTypeComposerFormLayoutSetDisplayDescription(); ?></p>
-				</div>
-			<? endif; ?>
-
 			<div style="display: none">
 				<div data-delete-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>">
 					<form data-delete-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('delete_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -280,16 +280,16 @@ ul.ccm-page-type-composer-item-controls a:hover {
 ul.ccm-page-type-composer-item-controls {
 	padding: 0;
 	margin: 0;
-	display: none
+	width: 45px;
 }
 
 .panel-heading:hover > .ccm-page-type-composer-item-controls,
-.ccm-page-type-composer-form-layout-control-set-control:hover .ccm-page-type-composer-item-controls {
-	display: block;
+.ccm-page-type-composer-form-layout-control-set-control:hover .ccm-page-type-composer-item-controls li {
+	display: inline-block;
 }
 
 .ccm-page-type-composer-item-controls li {
-	display: inline-block;
+	display: none;
 	list-style-type: none;
 }
 

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -280,10 +280,10 @@ ul.ccm-page-type-composer-item-controls a:hover {
 ul.ccm-page-type-composer-item-controls {
 	padding: 0;
 	margin: 0;
-	width: 45px;
+	width: 60px;
 }
 
-.panel-heading:hover > .ccm-page-type-composer-item-controls,
+.panel-heading:hover > .ccm-page-type-composer-item-controls li,
 .ccm-page-type-composer-form-layout-control-set-control:hover .ccm-page-type-composer-item-controls li {
 	display: inline-block;
 }

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -38,8 +38,8 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 
 	foreach($sets as $set) { ?>
 
-		<div class="ccm-page-type-composer-form-layout-control-set" data-page-type-composer-form-layout-control-set-id="<?=$set->getPageTypeComposerFormLayoutSetID()?>">
-			<div class="ccm-page-type-composer-item-control-bar">
+		<div class="ccm-page-type-composer-form-layout-control-set panel panel-default" data-page-type-composer-form-layout-control-set-id="<?= $set->getPageTypeComposerFormLayoutSetID()?>">
+			<div class="panel-heading">
 				<ul class="ccm-page-type-composer-item-controls">
 					<li><a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/add_control?ptComposerFormLayoutSetID=<?=$set->getPageTypeComposerFormLayoutSetID()?>" dialog-title="<?=t('Add Form Control')?>" dialog-width="640" dialog-height="400" data-command="add-form-set-control"><i class="fa fa-plus"></i></a></li>
 					<li><a href="#" data-command="move_set" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
@@ -80,14 +80,24 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 						</form>
 					</div>
 				</div>
+			</div>
 
-			</div>
-			<div class="ccm-page-type-composer-form-layout-control-set-inner">
-				<? $controls = PageTypeComposerFormLayoutSetControl::getList($set);
-				foreach($controls as $cnt) { ?>
-					<?=Loader::element('page_types/composer/form/layout_set/control', array('control' => $cnt));?>
-				<? } ?>
-			</div>
+			<table class="table" style="margin: 0; width: 100%;">
+				<thead>
+					<tr>
+						<th>Label</th>
+						<th>Type</th>
+						<th>Original Name</th>
+						<th>&nbsp;</th>
+					</tr>
+				</thead>
+				<tbody class="ccm-page-type-composer-form-layout-control-set-inner">
+					<? $controls = PageTypeComposerFormLayoutSetControl::getList($set);
+					foreach($controls as $cnt) { ?>
+						<?=Loader::element('page_types/composer/form/layout_set/control', array('control' => $cnt));?>
+					<? } ?>
+				</tbody>
+			</table>
 		</div>
 
 	<? } ?>
@@ -196,7 +206,7 @@ $(function() {
 				'value': '<?=Loader::helper("validation/token")->generate("update_set_control_display_order")?>'
 			}, {
 				'name': 'ptComposerFormLayoutSetID',
-				'value': $(this).parent().attr('data-page-type-composer-form-layout-control-set-id')
+				'value': $(this).parent().parent().attr('data-page-type-composer-form-layout-control-set-id')
 			}];
 
 			$(this).find('.ccm-page-type-composer-form-layout-control-set-control').each(function() {
@@ -238,40 +248,8 @@ div.ccm-page-type-composer-form-layout-control-set:last-child {
 	margin-bottom: 20px;
 }
 
-div.ccm-page-type-composer-item-control-bar {
-	position: relative;
-}
-
-div.ccm-page-type-composer-form-layout-control-set-control div.ccm-page-type-composer-item-control-bar {
-	background-color: #fafafa;
-	border-bottom: 1px solid #dedede;
-	padding: 4px 10px 4px 10px;
-}
-
-div.ccm-page-type-composer-form-layout-control-set-control:last-child div.ccm-page-type-composer-item-control-bar {
-	border-bottom: 0px;
-}
-
-
-div.ccm-page-type-composer-form-layout-control-set-inner {
-	border: 1px solid #eee;
-}
-
-div.ccm-page-type-composer-form-layout-control-set-name {
-	border-left: 1px solid #eee;
-	border-right: 1px solid #eee;
-	border-top: 1px solid #eee;
-	background-color: #f1f1f1;
-	padding: 4px 4px 4px 8px;
-	color: #888;
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-}
-
-ul.ccm-page-type-composer-item-controls {
-	position: absolute;
-	right: 8px;
-	top: 7px;
+.panel-heading .ccm-page-type-composer-item-controls {
+	float: right;
 }
 
 ul.ccm-page-type-composer-item-controls a {
@@ -286,15 +264,20 @@ ul.ccm-page-type-composer-item-controls a:hover {
 	text-decoration: none;
 }
 
-div.ccm-page-type-composer-item-control-bar:hover ul.ccm-page-type-composer-item-controls li {
+ul.ccm-page-type-composer-item-controls {
+	padding: 0;
+	margin: 0;
+	display: none
+}
+
+.panel-heading:hover > .ccm-page-type-composer-item-controls,
+.ccm-page-type-composer-form-layout-control-set-control:hover .ccm-page-type-composer-item-controls {
+	display: block;
+}
+
+.ccm-page-type-composer-item-controls li {
 	display: inline-block;
-}
-
-ul.ccm-page-type-composer-item-controls li {
 	list-style-type: none;
-	display: none;
 }
-
-
 
 </style>

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -100,14 +100,6 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 			if (count($controls) > 0):
 			?>
 				<table class="table table-hover" style="width: 100%;">
-					<thead>
-						<tr>
-							<th>Label</th>
-							<th>Type</th>
-							<th>Original Name</th>
-							<th>&nbsp;</th>
-						</tr>
-					</thead>
 					<tbody class="ccm-page-type-composer-form-layout-control-set-inner">
 						<? $controls = PageTypeComposerFormLayoutSetControl::getList($set);
 						foreach($controls as $cnt) {

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -214,7 +214,16 @@ $(function() {
 		items: '.ccm-page-type-composer-form-layout-control-set-control',
 		cursor: 'move',
 		axis: 'y',
-		stop: function() {
+		helper: function(e, ui) { // prevent table columns from collapsing
+			ui.addClass('active');
+			ui.children().each(function () {
+				$(this).width($(this).width());
+			});
+			return ui;
+		},
+		stop: function(e, ui) {
+			ui.item.removeClass('active');
+
 			var formData = [{
 				'name': 'token',
 				'value': '<?=Loader::helper("validation/token")->generate("update_set_control_display_order")?>'

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -133,7 +133,7 @@ var Composer = {
             success: function() {
                 jQuery.fn.dialog.hideLoader();
                 jQuery.fn.dialog.closeAll();
-                $('div[data-page-type-composer-form-layout-control-set-control-id=' + ptComposerFormLayoutSetControlID + ']').remove();
+                $('tr[data-page-type-composer-form-layout-control-set-control-id=' + ptComposerFormLayoutSetControlID + ']').remove();
             }
         });
     }

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -36,6 +36,7 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 
 <? if (count($sets) > 0) {
 
+	/* @var $set Concrete\Core\Page\Type\Composer\FormLayoutSet */
 	foreach($sets as $set) { ?>
 
 		<div class="ccm-page-type-composer-form-layout-control-set panel panel-default" data-page-type-composer-form-layout-control-set-id="<?= $set->getPageTypeComposerFormLayoutSetID()?>">
@@ -46,43 +47,56 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 					<li><a href="#" data-edit-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="fa fa-pencil"></i></a></li>
 					<li><a href="#" data-delete-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="fa fa-trash-o"></i></a></li>
 				</ul>
-				<div class="ccm-page-type-composer-form-layout-control-set-name" ><? if ($set->getPageTypeComposerFormLayoutSetDisplayName()) { ?><?=$set->getPageTypeComposerFormLayoutSetDisplayName()?><? } else { ?><?=t('(No Name)')?><? } ?></div>
-				<div style="display: none">
-					<div data-delete-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>">
-						<form data-delete-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('delete_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">
+				<div class="ccm-page-type-composer-form-layout-control-set-name" ><?
+					if ($set->getPageTypeComposerFormLayoutSetDisplayName()) {
+						echo $set->getPageTypeComposerFormLayoutSetDisplayName();
+					} else {
+						echo t('(No Name)');
+					}
+				?></div>
+			</div>
+
+			<? if ($set->getPageTypeComposerFormLayoutSetDisplayDescription()): ?>
+				<div class="panel-body">
+					<p><?= $set->getPageTypeComposerFormLayoutSetDisplayDescription(); ?></p>
+				</div>
+			<? endif; ?>
+
+			<div style="display: none">
+				<div data-delete-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>">
+					<form data-delete-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('delete_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">
 						<?=t("Delete this form layout set? This cannot be undone.")?>
 						<?=Loader::helper('validation/token')->output('delete_set')?>
-						</form>
-                        <div class="dialog-buttons">
-                            <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-                            <button class="btn btn-danger pull-right" onclick="$('form[data-delete-set-form=<?=$set->getPageTypeComposerFormLayoutSetID()?>]').submit();"><?=t('Delete Set')?></button>
-                        </div>
-
+					</form>
+					<div class="dialog-buttons">
+						<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+						<button class="btn btn-danger pull-right" onclick="$('form[data-delete-set-form=<?=$set->getPageTypeComposerFormLayoutSetID()?>]').submit();"><?=t('Delete Set')?></button>
 					</div>
-				</div>
 
-				<div style="display: none">
-					<div data-edit-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>" class="ccm-ui">
-						<form data-edit-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('update_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">
-						<div class="form-group">
-							<?=$form->label('ptComposerFormLayoutSetName', tc('Name of a set', 'Set Name'))?>
-    						<?=$form->text('ptComposerFormLayoutSetName', $set->getPageTypeComposerFormLayoutSetName())?>
-						</div>
-						<div class="form-group">
-							<?=$form->label('ptComposerFormLayoutSetDescription', tc('Description of a set', 'Set Description'))?>
-							<?=$form->textarea('ptComposerFormLayoutSetDescription', $set->getPageTypeComposerFormLayoutSetDescription())?>
-						</div>
-                        <div class="dialog-buttons">
-                            <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-                            <button class="btn btn-primary pull-right" onclick="$('form[data-edit-set-form=<?=$set->getPageTypeComposerFormLayoutSetID()?>]').submit();"><?=t('Update Set')?></button>
-                        </div>
-						<?=Loader::helper('validation/token')->output('update_set')?>
-						</form>
-					</div>
 				</div>
 			</div>
 
-			<table class="table" style="margin: 0; width: 100%;">
+			<div style="display: none">
+				<div data-edit-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>" class="ccm-ui">
+					<form data-edit-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('update_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">
+					<div class="form-group">
+						<?=$form->label('ptComposerFormLayoutSetName', tc('Name of a set', 'Set Name'))?>
+						<?=$form->text('ptComposerFormLayoutSetName', $set->getPageTypeComposerFormLayoutSetName())?>
+					</div>
+					<div class="form-group">
+						<?=$form->label('ptComposerFormLayoutSetDescription', tc('Description of a set', 'Set Description'))?>
+						<?=$form->textarea('ptComposerFormLayoutSetDescription', $set->getPageTypeComposerFormLayoutSetDescription())?>
+					</div>
+					<div class="dialog-buttons">
+						<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+						<button class="btn btn-primary pull-right" onclick="$('form[data-edit-set-form=<?=$set->getPageTypeComposerFormLayoutSetID()?>]').submit();"><?=t('Update Set')?></button>
+					</div>
+					<?=Loader::helper('validation/token')->output('update_set')?>
+					</form>
+				</div>
+			</div>
+
+			<table class="table table-hover" style="margin: 0; width: 100%;">
 				<thead>
 					<tr>
 						<th>Label</th>
@@ -278,6 +292,11 @@ ul.ccm-page-type-composer-item-controls {
 .ccm-page-type-composer-item-controls li {
 	display: inline-block;
 	list-style-type: none;
+}
+
+th, td {
+	padding-left: 15px !important;
+	padding-right: 15px !important;
 }
 
 </style>

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -72,7 +72,6 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 						<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
 						<button class="btn btn-danger pull-right" onclick="$('form[data-delete-set-form=<?=$set->getPageTypeComposerFormLayoutSetID()?>]').submit();"><?=t('Delete Set')?></button>
 					</div>
-
 				</div>
 			</div>
 
@@ -96,22 +95,27 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 				</div>
 			</div>
 
-			<table class="table table-hover" style="margin: 0; width: 100%;">
-				<thead>
-					<tr>
-						<th>Label</th>
-						<th>Type</th>
-						<th>Original Name</th>
-						<th>&nbsp;</th>
-					</tr>
-				</thead>
-				<tbody class="ccm-page-type-composer-form-layout-control-set-inner">
-					<? $controls = PageTypeComposerFormLayoutSetControl::getList($set);
-					foreach($controls as $cnt) { ?>
-						<?=Loader::element('page_types/composer/form/layout_set/control', array('control' => $cnt));?>
-					<? } ?>
-				</tbody>
-			</table>
+			<?
+			$controls = PageTypeComposerFormLayoutSetControl::getList($set);
+			if (count($controls) > 0):
+			?>
+				<table class="table table-hover" style="width: 100%;">
+					<thead>
+						<tr>
+							<th>Label</th>
+							<th>Type</th>
+							<th>Original Name</th>
+							<th>&nbsp;</th>
+						</tr>
+					</thead>
+					<tbody class="ccm-page-type-composer-form-layout-control-set-inner">
+						<? $controls = PageTypeComposerFormLayoutSetControl::getList($set);
+						foreach($controls as $cnt) {
+							echo Loader::element('page_types/composer/form/layout_set/control', array('control' => $cnt));
+						} ?>
+					</tbody>
+				</table>
+			<? endif; ?>
 		</div>
 
 	<? } ?>
@@ -246,7 +250,7 @@ $(function() {
 		}
 	});
 
-	$('div.ccm-page-type-composer-form-layout-control-set-inner').on('click', 'a[data-delete-set-control]', function() {
+	$('.ccm-page-type-composer-form-layout-control-set-inner').on('click', 'a[data-delete-set-control]', function() {
 		var ptComposerFormLayoutSetControlID = $(this).attr('data-delete-set-control');
         jQuery.fn.dialog.open({
             element: 'div[data-delete-set-control-dialog=' + ptComposerFormLayoutSetControlID + ']',

--- a/web/concrete/tools/page_types/composer/form/add_control.php
+++ b/web/concrete/tools/page_types/composer/form/add_control.php
@@ -82,7 +82,7 @@ $(function() {
 			success: function(html) {
 				jQuery.fn.dialog.hideLoader();
 				jQuery.fn.dialog.closeTop();
-				$('div[data-page-type-composer-form-layout-control-set-id=<?=$set->getPageTypeComposerFormLayoutSetID()?>] div.ccm-page-type-composer-form-layout-control-set-inner').append(html);
+				$('div[data-page-type-composer-form-layout-control-set-id=<?=$set->getPageTypeComposerFormLayoutSetID()?>] tbody.ccm-page-type-composer-form-layout-control-set-inner').append(html);
 				$('a[data-command=edit-form-set-control]').dialog();
 			}
 		});

--- a/web/concrete/tools/page_types/composer/form/edit_control.php
+++ b/web/concrete/tools/page_types/composer/form/edit_control.php
@@ -94,7 +94,8 @@ $(function() {
 			success: function(html) {
 				jQuery.fn.dialog.hideLoader();
 				jQuery.fn.dialog.closeTop();
-				$('div[data-page-type-composer-form-layout-control-set-control-id=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>]').html(html);
+				var data = $(html).html();
+				$('tr[data-page-type-composer-form-layout-control-set-control-id=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>]').html(data);
 				$('a[data-command=edit-form-set-control]').dialog();
 			}
 		});		


### PR DESCRIPTION
The culmination of discussion from PR #2316.

The columns across the different sets are now aligned.

![2015-07-28_11-41-48](https://cloud.githubusercontent.com/assets/5735900/8921776/c9610c12-351d-11e5-8454-a0f17b4117bb.png)