### PR TITLE
Adds Area Layout Caching - currently blocks full page cache

### DIFF
--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -26,6 +26,10 @@ class Controller extends BlockController
     protected $btSupportsInlineEdit = true;
     protected $btTable = 'btCoreAreaLayout';
     protected $btIsInternal = true;
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
 
     public function getBlockTypeDescription()
     {


### PR DESCRIPTION
I turned these on fairly aggressive caching, same as HTML blocks, because I don't see area layouts tied to anything dynamic.