### PR TITLE
asset group performance improvement

### DIFF
--- a/web/concrete/src/Asset/AssetGroup.php
+++ b/web/concrete/src/Asset/AssetGroup.php
@@ -19,12 +19,7 @@ class AssetGroup
      */
     public function contains(AssetPointer $ap)
     {
-        foreach ($this->assetPointers as $assetPointer) {
-            if ($assetPointer->getHandle() == $ap->getHandle() && $assetPointer->getType() == $ap->getType()) {
-                return true;
-            }
-        }
-        return false;
+        return array_key_exists($ap->getIdentifier(), $this->assetPointers);
     }
 
     /**
@@ -35,7 +30,7 @@ class AssetGroup
         $assetPointers = $item->getAssetPointers();
         foreach ($assetPointers as $assetPointer) {
             if (!$this->contains($assetPointer)) {
-                $this->assetPointers[] = $assetPointer;
+                $this->assetPointers[$assetPointer->getIdentifier()] = $assetPointer;
             }
         }
     }
@@ -56,7 +51,7 @@ class AssetGroup
     public function add(AssetPointer $ap)
     {
         if (!$this->contains($ap)) {
-            $this->assetPointers[] = $ap;
+            $this->assetPointers[$ap->getIdentifier()] = $ap;
         }
     }
 

--- a/web/concrete/src/Asset/AssetGroup.php
+++ b/web/concrete/src/Asset/AssetGroup.php
@@ -19,7 +19,7 @@ class AssetGroup
      */
     public function contains(AssetPointer $ap)
     {
-        return array_key_exists($ap->getIdentifier(), $this->assetPointers);
+        return isset($this->assetPointers[$ap->getIdentifier()]);
     }
 
     /**

--- a/web/concrete/src/Asset/AssetPointer.php
+++ b/web/concrete/src/Asset/AssetPointer.php
@@ -30,6 +30,11 @@ class AssetPointer
         return $this->assetHandle;
     }
 
+    public function getIdentifier()
+    {
+        return $this->assetType . $this->assetHandle;
+    }
+
     /**
      * @param string $assetType
      * @param string $assetHandle
@@ -47,14 +52,5 @@ class AssetPointer
     {
         $al = AssetList::getInstance();
         return $al->getAsset($this->assetType, $this->assetHandle);
-    }
-
-    /**
-     * Returns a string which uniquely identifies this asset pointer object
-     * @return string
-     */
-    public function getIdentifier()
-    {
-        return $this->getType() . $this->getHandle();
     }
 }

--- a/web/concrete/src/Asset/AssetPointer.php
+++ b/web/concrete/src/Asset/AssetPointer.php
@@ -48,4 +48,13 @@ class AssetPointer
         $al = AssetList::getInstance();
         return $al->getAsset($this->assetType, $this->assetHandle);
     }
+
+    /**
+     * Returns a string which uniquely identifies this asset pointer object
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->getType() . $this->getHandle();
+    }
 }


### PR DESCRIPTION
Created a function which returns a unique key to identify an asset pointer so that we can use it as an array index. Cuts down on thousands of iterations of the asset pointers per page load since `contains()` was being run for every asset that was added this was starting to add up