### PR TITLE
Refactored Packages to improve caching

### DIFF
--- a/web/concrete/single_pages/dashboard/extend/install.php
+++ b/web/concrete/single_pages/dashboard/extend/install.php
@@ -64,7 +64,7 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
             <table class="table table-bordered table-striped">
                 <tr>
                     <td class="ccm-marketplace-list-thumbnail"><img src="<?= $ci->getPackageIconURL($pkg); ?>" /></td>
-                    <td class="ccm-addon-list-description" style="width: 100%"><h3><?= $pkg->getPackageName(); ?> - <?= $pkg->getPackageVersion(); ?></h3><?= $pkg->getPackageDescription(); ?></td>
+                    <td class="ccm-addon-list-description" style="width: 100%"><h3><?= $pkg->getPackageName(); ?> - <?= $pkg->getPackageCurrentlyInstalledVersion(); ?></h3><?= $pkg->getPackageDescription(); ?></td>
                 </tr>
             </table>
 
@@ -345,7 +345,11 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
                     <div class="pull-left"><img style="width: 49px" src="<?= $ci->getPackageIconURL($pkg); ?>" class"media-object" /></div>
                     <div class="media-body">
                         <a href="<?= URL::to('/dashboard/extend/install', 'inspect_package', $pkg->getPackageID()); ?>" class="btn pull-right btn-sm btn-default"><?= t('Details'); ?></a>
-                        <h4 class="media-heading"><?= $pkg->getPackageName(); ?> <span class="badge badge-info" style="margin-right: 10px"><?= tc('AddonVersion', 'v.%s', $pkg->getPackageVersion()); ?></span></h4>
+                        <h4 class="media-heading"><?= $pkg->getPackageName(); ?>
+                            <span class="badge badge-info" style="margin-right: 10px">
+                                <?= tc('AddonVersion', 'v.%s', $pkg->getPackageCurrentlyInstalledVersion()); ?>
+                            </span>
+                        </h4>
                         <p><?= $pkg->getPackageDescription(); ?></p>
                     </div>
                 </div>

--- a/web/concrete/single_pages/dashboard/extend/update.php
+++ b/web/concrete/single_pages/dashboard/extend/update.php
@@ -14,7 +14,7 @@ if (Config::get('concrete.marketplace.enabled') && is_object($mi)) {
 	if ($mi->isConnected()) {
 		$pkgArray = Package::getInstalledList();
 		foreach($pkgArray as $pkg) {
-			if ($pkg->isPackageInstalled() && version_compare($pkg->getPackageVersion(), $pkg->getPackageVersionUpdateAvailable(), '<')) {
+			if ($pkg->isPackageInstalled() && version_compare($pkg->getPackageCurrentlyInstalledVersion(), $pkg->getPackageVersionUpdateAvailable(), '<')) {
 				$pkgRemote[] = $pkg;
 			}
 		}

--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -241,7 +241,7 @@ class Application extends Container
                     $cl->registerPackage($pkg);
                     // handle updates
                     if (Config::get('concrete.updates.enable_auto_update_packages')) {
-                        $pkgInstalledVersion = $p->getPackageVersion();
+                        $pkgInstalledVersion = $p->getPackageCurrentlyInstalledVersion();
                         $pkgFileVersion = $pkg->getPackageVersion();
                         if (version_compare($pkgFileVersion, $pkgInstalledVersion, '>')) {
                             $currentLocale = Localization::activeLocale();


### PR DESCRIPTION
- No longer querying for every getByHandle() or getByID() call
- slightly changed behaviour of getPackageHandle(), returns file package version when known, returns database version when not known. 
- getPackageCurrentlyInstalledVersion() now populated any time the pkgVersion is set via setPropertiesFromArray()
- DRYer code, leveraged PackageList class for package list things. More appropriate cache clearing of the PackageList (such as on package updates or uninstall) 
