### PR TITLE
Fixes bug where global blocks cache settings were ignored.

### DIFF
--- a/web/concrete/src/Cache/Page/PageCache.php
+++ b/web/concrete/src/Cache/Page/PageCache.php
@@ -114,7 +114,7 @@ abstract class PageCache {
 		}
 
 		$blocks = $c->getBlocks();
-		array_merge($c->getGlobalBlocks(), $blocks);
+		$blocks = array_merge($c->getGlobalBlocks(), $blocks);
 
 		foreach($blocks as $b) {
 			if (!$b->cacheBlockOutput()) {


### PR DESCRIPTION
Looks like the intent was to grab global blocks and merge with local, but we didn't save the resulting merged array.

Resolves #1903