### PR TITLE
Avoid static abstract function: Area\Layout\Column::getByID()

### DIFF
--- a/web/concrete/src/Area/Layout/Column.php
+++ b/web/concrete/src/Area/Layout/Column.php
@@ -6,6 +6,7 @@ use \Concrete\Core\Foundation\Object;
 use \Concrete\Core\Area\SubArea;
 use Page;
 use Area;
+use RuntimeException;
 
 abstract class Column extends Object implements ColumnInterface
 {
@@ -35,7 +36,16 @@ abstract class Column extends Object implements ColumnInterface
      */
     public $arID;
 
-    abstract static public function getByID($arLayoutColumnID);
+    /**
+     * @param int $arLayoutColumnID
+     *
+     * @abstract
+     */
+    static public function getByID($arLayoutColumnID)
+    {
+        throw new RuntimeException('This method has not yet been implemented.');
+    }
+
     abstract public function exportDetails($node);
     abstract public function getAreaLayoutColumnClass();
 

--- a/web/concrete/src/Area/Layout/Column.php
+++ b/web/concrete/src/Area/Layout/Column.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Area\Layout;
 
-use Loader;
+use Database;
 use Concrete\Core\Foundation\Object;
 use Concrete\Core\Area\SubArea;
 use Page;
@@ -54,7 +54,7 @@ abstract class Column extends Object implements ColumnInterface
      */
     protected function loadBasicInformation($arLayoutColumnID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from AreaLayoutColumns where arLayoutColumnID = ?', array($arLayoutColumnID));
         if (is_array($row) && $row['arLayoutColumnID']) {
             $this->setPropertiesFromArray($row);
@@ -119,9 +119,9 @@ abstract class Column extends Object implements ColumnInterface
      */
     protected function duplicate($newAreaLayout)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $v = array($newAreaLayout->getAreaLayoutID(), $this->arLayoutColumnIndex, $this->arLayoutColumnDisplayID);
-        $db->Execute('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', $v);
+        $db->executeQuery('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', $v);
         $newAreaLayoutColumnID = $db->Insert_ID();
 
         return $newAreaLayoutColumnID;
@@ -132,7 +132,7 @@ abstract class Column extends Object implements ColumnInterface
      */
     public function getAreaObject()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select cID, arHandle from Areas where arID = ?', array($this->arID));
         if ($row['cID'] && $row['arHandle']) {
             $c = Page::getByID($row['cID']);
@@ -207,18 +207,18 @@ abstract class Column extends Object implements ColumnInterface
      */
     public function setAreaID($arID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $this->arID = $arID;
-        $db->Execute('update AreaLayoutColumns set arID = ? where arLayoutColumnID = ?', array($arID, $this->arLayoutColumnID));
+        $db->executeQuery('update AreaLayoutColumns set arID = ? where arLayoutColumnID = ?', array($arID, $this->arLayoutColumnID));
     }
 
     public function delete()
     {
-        $db = Loader::db();
-        $db->Execute("delete from AreaLayoutColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
+        $db = Database::connection();
+        $db->executeQuery("delete from AreaLayoutColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
 
         // now we check to see if this area id is in use anywhere else. If it isn't we delete the sub area.
-        $r = $db->GetOne('select count(arLayoutColumnID) from AreaLayoutColumns where arID = ?', array($this->arID));
+        $r = $db->fetchColumn('select count(arLayoutColumnID) from AreaLayoutColumns where arID = ?', array($this->arID));
         if ($r < 1) {
             $area = $this->getAreaObject();
             if ($area instanceof SubArea) {

--- a/web/concrete/src/Area/Layout/Column.php
+++ b/web/concrete/src/Area/Layout/Column.php
@@ -1,16 +1,16 @@
 <?php
+
 namespace Concrete\Core\Area\Layout;
 
 use Loader;
-use \Concrete\Core\Foundation\Object;
-use \Concrete\Core\Area\SubArea;
+use Concrete\Core\Foundation\Object;
+use Concrete\Core\Area\SubArea;
 use Page;
 use Area;
 use RuntimeException;
 
 abstract class Column extends Object implements ColumnInterface
 {
-
     /**
      * @var Layout
      */
@@ -41,7 +41,7 @@ abstract class Column extends Object implements ColumnInterface
      *
      * @abstract
      */
-    static public function getByID($arLayoutColumnID)
+    public static function getByID($arLayoutColumnID)
     {
         throw new RuntimeException('This method has not yet been implemented.');
     }
@@ -114,6 +114,7 @@ abstract class Column extends Object implements ColumnInterface
 
     /**
      * @param Column $newAreaLayout
+     *
      * @return int
      */
     protected function duplicate($newAreaLayout)
@@ -122,6 +123,7 @@ abstract class Column extends Object implements ColumnInterface
         $v = array($newAreaLayout->getAreaLayoutID(), $this->arLayoutColumnIndex, $this->arLayoutColumnDisplayID);
         $db->Execute('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', $v);
         $newAreaLayoutColumnID = $db->Insert_ID();
+
         return $newAreaLayoutColumnID;
     }
 
@@ -135,6 +137,7 @@ abstract class Column extends Object implements ColumnInterface
         if ($row['cID'] && $row['arHandle']) {
             $c = Page::getByID($row['cID']);
             $area = Area::get($c, $row['arHandle']);
+
             return $area;
         }
     }
@@ -149,6 +152,7 @@ abstract class Column extends Object implements ColumnInterface
 
     /**
      * unique but doesn't change between version edits on a given page.
+     *
      * @return int
      */
     public function getAreaLayoutColumnDisplayID()
@@ -165,6 +169,7 @@ abstract class Column extends Object implements ColumnInterface
         $this->display($disableControls);
         $contents = ob_get_contents();
         ob_end_clean();
+
         return $contents;
     }
 
@@ -221,5 +226,4 @@ abstract class Column extends Object implements ColumnInterface
             }
         }
     }
-
 }


### PR DESCRIPTION
This fixes the following error:
```
Static function Concrete\Core\Area\Layout\Column::getByID() should not be abstract
```