### PR TITLE
Hotfix deleted files in set

### DIFF
--- a/web/concrete/src/File/Set/File.php
+++ b/web/concrete/src/File/Set/File.php
@@ -11,7 +11,7 @@ class File
     public static function getFileSetFiles(Set $fs)
     {
         $db = Loader::db();
-        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC AND EXISTS(SELECT fID FROM Files)', array($fs->getFileSetID()));
+        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? AND EXISTS(SELECT fID FROM Files) ORDER BY fsDisplayOrder ASC', array($fs->getFileSetID()));
         $files = array();
         while ($row = $r->FetchRow()) {
             $fsf = static::getByID($row['fsfID']);

--- a/web/concrete/src/File/Set/File.php
+++ b/web/concrete/src/File/Set/File.php
@@ -11,7 +11,7 @@ class File
     public static function getFileSetFiles(Set $fs)
     {
         $db = Loader::db();
-        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC', array($fs->getFileSetID()));
+        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC AND EXISTS(SELECT fID FROM Files)', array($fs->getFileSetID()));
         $files = array();
         while ($row = $r->FetchRow()) {
             $fsf = static::getByID($row['fsfID']);


### PR DESCRIPTION
When Files are added to a FileSet and deleted afterwards, there remains a record in the FileSetFiles table, linking the FileSet with a non existing File ID.
I don't exactly know why though. Looking at  https://github.com/concrete5/concrete5/blob/develop/web/concrete/src/File/File.php#L539 it seems these records should be cleared when a file is deleted. But it seems not to be so.
This Hotfix makes shure those entrys are not returned anymore when querying a FileSet for its Files.