### PR TITLE
Fix orphaning records on file delete

### DIFF
--- a/web/concrete/src/File/File.php
+++ b/web/concrete/src/File/File.php
@@ -532,14 +532,15 @@ class File implements \Concrete\Core\Permission\ObjectInterface
             $fv->delete(true);
         }
 
-        // now from the DB
-        $em = $db->getEntityManager();
-        $em->remove($this);
-        $em->flush();
         $db->Execute("delete from FileSetFiles where fID = ?", array($this->fID));
         $db->Execute("delete from FileSearchIndexAttributes where fID = ?", array($this->fID));
         $db->Execute("delete from DownloadStatistics where fID = ?", array($this->fID));
         $db->Execute("delete from FilePermissionAssignments where fID = ?", array($this->fID));
+
+        // now from the DB
+        $em = $db->getEntityManager();
+        $em->remove($this);
+        $em->flush();
     }
 
     /**

--- a/web/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
@@ -16,6 +16,12 @@ class Version20150731000000 extends AbstractMigration
             $table->setPrimaryKey(array('ID'));
         } catch(\Exception $e) {}
 
+        $db = \Database::connection();
+        $db->executeQuery("DELETE FROM FileSetFiles WHERE fID NOT IN (SELECT fID FROM Files)");
+        $db->executeQuery("DELETE FROM FileSearchIndexAttributes WHERE fID NOT IN (SELECT fID FROM Files)");
+        $db->executeQuery("DELETE FROM DownloadStatistics WHERE fID NOT IN (SELECT fID FROM Files)");
+        $db->executeQuery("DELETE FROM FilePermissionAssignments WHERE fID NOT IN (SELECT fID FROM Files)");
+
         $bt = \BlockType::getByHandle('page_list');
         if (is_object($bt)) {
             $bt->refresh();


### PR DESCRIPTION
Supersedes #2871

Assuming I'm still good to add these database deletes to the latest migration?