### PR TITLE
Fixes Bug with Search Block when resultsURL specified instead of page

### DIFF
--- a/web/concrete/blocks/search/controller.php
+++ b/web/concrete/blocks/search/controller.php
@@ -130,7 +130,7 @@ class Controller extends BlockController
         $this->set('resultTargetURL', $resultsURL);
 
         //run query if display results elsewhere not set, or the cID of this page is set
-        if ($this->postTo_cID == '') {
+        if ($this->postTo_cID == '' && $this->resultsURL == '') {
             if (!empty($_REQUEST['query']) || isset($_REQUEST['akID']) || isset($_REQUEST['month'])) {
                 $this->do_search();
             }


### PR DESCRIPTION
Inconsistent results between setting page, or setting the results URL. See http://screencast.com/t/FWrwd4kwJd for demonstration.