### PR TITLE
Reverts Content Block to be cached for registered users.

### DIFF
--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -25,7 +25,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btSupportsInlineEdit = true;
     protected $btSupportsInlineAdd = true;
-    protected $btCacheBlockOutputForRegisteredUsers = false;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
     public function getBlockTypeDescription()


### PR DESCRIPTION
I see this was changed in a https://github.com/concrete5/concrete5/commit/607f6516b832a79e67d7e115abf9e3ed382f25aa - but I don't see any reason for it?