### PR TITLE
Normalize registerViewAssets for blocks

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -3,8 +3,8 @@
 namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Block\BlockController;
-use Loader;
 use Core;
+use Database;
 use Page;
 use Permissions;
 
@@ -124,7 +124,7 @@ class Controller extends BlockController
     {
 
         // a quickie
-        $db = Loader::db();
+        $db = Database::connection();
         $r = $db->query(
                 "select cID from Pages where cParentID = ? order by cDisplayOrder asc",
                 array($c->getCollectionID()));
@@ -223,7 +223,7 @@ class Controller extends BlockController
             if ($_c->getAttribute('replace_link_with_first_in_nav')) {
                 $subPage = $_c->getFirstChild(); //Note: could be a rare bug here if first child was excluded, but this is so unlikely (and can be solved by moving it in the sitemap) that it's not worth the trouble to check
                 if ($subPage instanceof Page) {
-                    $pageLink = Loader::helper('navigation')->getLinkToCollection(
+                    $pageLink = Core::make('helper/navigation')->getLinkToCollection(
                                       $subPage); //We could optimize by instantiating the navigation helper outside the loop, but this is such an infrequent attribute that I prefer code clarity over performance in this case
                 }
             }
@@ -310,11 +310,11 @@ class Controller extends BlockController
         // Initialize Nav Array
         $this->navArray = array();
 
-        if (isset($this->displayPagesCID) && !Loader::helper('validation/numbers')->integer($this->displayPagesCID)) {
+        if (isset($this->displayPagesCID) && !Core::make('helper/validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         // now we proceed, with information obtained either from the database, or passed manually from
         $orderBy = "";
         /*switch($this->orderBy) {
@@ -428,7 +428,7 @@ class Controller extends BlockController
                 $niRow['cvName'] = $tc1->getCollectionName();
                 $niRow['cID'] = HOME_CID;
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
-                $niRow['cPath'] = Loader::helper('navigation')->getLinkToCollection($tc1);
+                $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc1);
 
                 $ni = new NavItem($niRow, 0);
                 $ni->setCollectionObject($tc1);
@@ -519,7 +519,7 @@ class Controller extends BlockController
             }
         }
 
-        $db = Loader::db();
+        $db = Database::connection();
         $navSort = $this->navSort;
         $sorted_array = $this->sorted_array;
         $navObjectNames = $this->navObjectNames;
@@ -561,7 +561,7 @@ class Controller extends BlockController
                         $niRow['cvName'] = $tc->getCollectionName();
                         $niRow['cID'] = $row['cID'];
                         $niRow['cvDescription'] = $tc->getCollectionDescription();
-                        $niRow['cPath'] = Loader::helper('navigation')->getLinkToCollection($tc);
+                        $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc);
                         $niRow['cPointerExternalLink'] = $tc->getCollectionPointerExternalLink();
                         $niRow['cPointerExternalLinkNewWindow'] = $tc->openCollectionPointerExternalLinkInNewWindow();
                         $dateKey = strtotime($tc->getCollectionDatePublic());

--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -72,7 +72,7 @@ class Controller extends BlockController
         parent::__construct($obj);
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         if (is_object($this->block) && $this->block->getBlockFilename() == 'responsive_header_navigation') {
             // this isn't great but it's the only way to do this and still make block

--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Block\BlockController;
@@ -12,15 +13,14 @@ use Permissions;
  *
  * @package    Blocks
  * @subpackage Auto-Nav
+ *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @author     Jordan Lev
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
- *
  */
 class Controller extends BlockController
 {
-
     public $collection;
     public $navArray = array();
     public $cParentIDArray = array();
@@ -43,7 +43,7 @@ class Controller extends BlockController
     protected $btWrapperClass = 'ccm-ui';
     protected $btExportPageColumns = array('displayPagesCID');
 
-    function __construct($obj = null)
+    public function __construct($obj = null)
     {
         if (is_object($obj)) {
             switch (strtolower(get_class($obj))) {
@@ -100,7 +100,7 @@ class Controller extends BlockController
         return t("Auto-Nav");
     }
 
-    function save($args)
+    public function save($args)
     {
         $args['displayPagesIncludeSelf'] = $args['displayPagesIncludeSelf'] ? 1 : 0;
         $args['displayPagesCID'] = $args['displayPagesCID'] ? $args['displayPagesCID'] : 0;
@@ -109,13 +109,14 @@ class Controller extends BlockController
         parent::save($args);
     }
 
-    function getContent()
+    public function getContent()
     {
         /* our templates expect a variable not an object */
         $con = array();
         foreach ($this as $key => $value) {
             $con[$key] = $value;
         }
+
         return $con;
     }
 
@@ -131,6 +132,7 @@ class Controller extends BlockController
         while ($row = $r->fetchRow()) {
             $pages[] = Page::getByID($row['cID'], 'ACTIVE');
         }
+
         return $pages;
     }
 
@@ -207,7 +209,7 @@ class Controller extends BlockController
         //Prep all data and put it into a clean structure so markup output is as simple as possible
         $navItems = array();
         $navItemCount = count($includedNavItems);
-        for ($i = 0; $i < $navItemCount; $i++) {
+        for ($i = 0; $i < $navItemCount; ++$i) {
             $ni = $includedNavItems[$i];
             $_c = $ni->getCollectionObject();
             $current_level = $ni->getLevel();
@@ -252,7 +254,7 @@ class Controller extends BlockController
 
             //Calculate if this is the last item in its level (useful for CSS classes)
             $is_last_in_level = true;
-            for ($j = $i + 1; $j < $navItemCount; $j++) {
+            for ($j = $i + 1; $j < $navItemCount; ++$j) {
                 if ($includedNavItems[$j]->getLevel() == $current_level) {
                     //we found a subsequent item at this level (before this level "ended"), so this is NOT the last in its level
                     $is_last_in_level = false;
@@ -303,11 +305,11 @@ class Controller extends BlockController
      * It also must exist as a separate function to preserve backwards-compatibility with older autonav templates.
      * Warning: this function has side-effects -- if this gets called twice, items will be duplicated in the nav structure!
      */
-    function generateNav()
+    public function generateNav()
     {
         // Initialize Nav Array
         $this->navArray = array();
-        
+
         if (isset($this->displayPagesCID) && !Loader::helper('validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
         }
@@ -450,23 +452,23 @@ class Controller extends BlockController
                 array_unshift($this->navArray, $ni);
             }
             */
-
         }
 
         return $this->navArray;
     }
 
     /**
-     * heh. probably should've gone the simpler route and named this getGrandparentID()
+     * heh. probably should've gone the simpler route and named this getGrandparentID().
      */
-    function getParentParentID()
+    public function getParentParentID()
     {
         // this has to be the stupidest name of a function I've ever created. sigh
         $cParentID = Page::getCollectionParentIDFromChildID($this->cParentID);
+
         return ($cParentID) ? $cParentID : 0;
     }
 
-    function getParentAtLevel($level)
+    public function getParentAtLevel($level)
     {
         // this function works in the following way
         // we go from the current collection up to the top level. Then we find the parent Id at the particular level specified, and begin our
@@ -491,10 +493,9 @@ class Controller extends BlockController
     }
 
     /** Pupulates the $cParentIDArray instance property.
-     *
      * @param int $cID The collection id.
      */
-    function populateParentIDArray($cID)
+    public function populateParentIDArray($cID)
     {
         // returns an array of collection IDs going from the top level to the current item
         $cParentID = Page::getCollectionParentIDFromChildID($cID);
@@ -508,7 +509,7 @@ class Controller extends BlockController
         }
     }
 
-    function getNavigationArray($cParentID, $orderBy, $currentLevel)
+    public function getNavigationArray($cParentID, $orderBy, $currentLevel)
     {
         // increment all items in the nav array with a greater $currentLevel
 
@@ -574,9 +575,7 @@ class Controller extends BlockController
                         $_c = $ni->getCollectionObject();
                         $object_name = $_c->getCollectionName();
                         $navObjectNames[$niRow['cID']] = $object_name;
-
                     }
-
                 }
             }
             // end while -- sort navSort
@@ -724,13 +723,11 @@ class Controller extends BlockController
                 }
             }
             // End Joshua's Huge Sorting Crap
-
         }
     }
 
     protected function displayPage($tc)
     {
-
         if ($tc->isSystemPage() && (!$this->displaySystemPages)) {
             return false;
         }
@@ -754,5 +751,4 @@ class Controller extends BlockController
     {
         return $c->getAttribute('exclude_nav');
     }
-
 }

--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -56,7 +56,7 @@ class Controller extends BlockController
         return $str;
     }
 
-    public function registerViewAssets($outputContent)
+    public function registerViewAssets($outputContent = '')
     {
         if (preg_match('/data-concrete5-link-lightbox/i', $outputContent)) {
             $this->requireAsset('core/lightbox');

--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -6,7 +6,8 @@ use Concrete\Core\Area\Layout\CustomLayout;
 use Concrete\Core\Area\Layout\PresetLayout;
 use Concrete\Core\Area\Layout\ThemeGridLayout;
 use Concrete\Core\Area\SubArea;
-use Loader;
+use Core;
+use Database;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Area\Layout\Layout as AreaLayout;
 use Concrete\Core\Area\Layout\Preset\Preset as AreaLayoutPreset;
@@ -43,7 +44,7 @@ class Controller extends BlockController
 
     public function duplicate($newBID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         parent::duplicate($newBID);
         $ar = AreaLayout::getByID($this->arLayoutID);
         $nr = $ar->duplicate();
@@ -83,7 +84,7 @@ class Controller extends BlockController
 
     public function save($post)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $arLayoutID = $db->GetOne('select arLayoutID from btCoreAreaLayout where bID = ?', array($this->bID));
         if (!$arLayoutID) {
             $arLayout = $this->addFromPost($post);
@@ -266,7 +267,7 @@ class Controller extends BlockController
 
     public function edit()
     {
-        $this->addHeaderItem(Loader::helper('html')->javascript('layouts.js'));
+        $this->addHeaderItem(Core::make('helper/html')->javascript('layouts.js'));
         $this->view();
         // since we set a render override in view() we have to explicitly declare edit
         if ($this->arLayout->isAreaLayoutUsingThemeGridFramework()) {
@@ -297,7 +298,7 @@ class Controller extends BlockController
 
     public function add()
     {
-        $this->addHeaderItem(Loader::helper('html')->javascript('layouts.js'));
+        $this->addHeaderItem(Core::make('helper/html')->javascript('layouts.js'));
         $maxColumns = 12; // normally
         // now we check our active theme and see if it has other plans
         $c = Page::getCurrentPage();

--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -37,7 +37,7 @@ class Controller extends BlockController
         return t("Area Layout");
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         if (is_object($this->block) && $this->block->getBlockFilename() == 'parallax') {
             $this->requireAsset('javascript', 'jquery');

--- a/web/concrete/blocks/core_area_layout/controller.php
+++ b/web/concrete/blocks/core_area_layout/controller.php
@@ -1,27 +1,23 @@
-<?
+<?php
+
 namespace Concrete\Block\CoreAreaLayout;
 
 use Concrete\Core\Area\Layout\CustomLayout;
 use Concrete\Core\Area\Layout\PresetLayout;
 use Concrete\Core\Area\Layout\ThemeGridLayout;
 use Concrete\Core\Area\SubArea;
-use Concrete\Core\Block\CustomStyle;
-use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Loader;
-use \Concrete\Core\Block\BlockController;
-use \Concrete\Core\Area\Layout\Layout as AreaLayout;
-use \Concrete\Core\Area\Layout\Preset\Preset as AreaLayoutPreset;
-use \Concrete\Core\Area\Layout\CustomLayout as CustomAreaLayout;
-use \Concrete\Core\Area\Layout\ThemeGridLayout as ThemeGridAreaLayout;
-use \Concrete\Core\Asset\CssAsset;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Area\Layout\Layout as AreaLayout;
+use Concrete\Core\Area\Layout\Preset\Preset as AreaLayoutPreset;
+use Concrete\Core\Area\Layout\CustomLayout as CustomAreaLayout;
+use Concrete\Core\Area\Layout\ThemeGridLayout as ThemeGridAreaLayout;
+use Concrete\Core\Asset\CssAsset;
 use URL;
 use Page;
-use Permissions;
 
 class Controller extends BlockController
 {
-
     protected $btSupportsInlineAdd = true;
     protected $btSupportsInlineEdit = true;
     protected $btTable = 'btCoreAreaLayout';
@@ -45,7 +41,6 @@ class Controller extends BlockController
         }
     }
 
-
     public function duplicate($newBID)
     {
         $db = Loader::db();
@@ -66,6 +61,7 @@ class Controller extends BlockController
             if (is_object($b)) {
                 $arLayout->setBlockObject($b);
             }
+
             return $arLayout;
         }
     }
@@ -92,7 +88,6 @@ class Controller extends BlockController
         if (!$arLayoutID) {
             $arLayout = $this->addFromPost($post);
         } else {
-
             $arLayout = AreaLayout::getByID($arLayoutID);
             if ($arLayout instanceof PresetLayout) {
                 return;
@@ -100,14 +95,13 @@ class Controller extends BlockController
             // save spacing
             if ($arLayout->isAreaLayoutUsingThemeGridFramework()) {
                 $columns = $arLayout->getAreaLayoutColumns();
-                for ($i = 0; $i < count($columns); $i++) {
+                for ($i = 0; $i < count($columns); ++$i) {
                     $col = $columns[$i];
                     $span = ($post['span'][$i]) ? $post['span'][$i] : 0;
                     $offset = ($post['offset'][$i]) ? $post['offset'][$i] : 0;
                     $col->setAreaLayoutColumnSpan($span);
                     $col->setAreaLayoutColumnOffset($offset);
                 }
-
             } else {
                 $arLayout->setAreaLayoutColumnSpacing($post['spacing']);
                 if ($post['isautomated']) {
@@ -115,7 +109,7 @@ class Controller extends BlockController
                 } else {
                     $arLayout->enableAreaLayoutCustomColumnWidths();
                     $columns = $arLayout->getAreaLayoutColumns();
-                    for ($i = 0; $i < count($columns); $i++) {
+                    for ($i = 0; $i < count($columns); ++$i) {
                         $col = $columns[$i];
                         $width = ($post['width'][$i]) ? $post['width'][$i] : 0;
                         $col->setAreaLayoutColumnWidth($width);
@@ -134,7 +128,7 @@ class Controller extends BlockController
         if (isset($blockNode->arealayout)) {
             $type = (string) $blockNode->arealayout['type'];
             $node = $blockNode->arealayout;
-            switch($type) {
+            switch ($type) {
                 case 'theme-grid':
                     $args['gridType'] = 'TG';
                     $args['arLayoutMaxColumns'] = (string) $node['columns'];
@@ -142,10 +136,10 @@ class Controller extends BlockController
                     $args['offset'] = array();
                     $args['span'] = array();
                     $i = 0;
-                    foreach($node->columns->column as $column) {
+                    foreach ($node->columns->column as $column) {
                         $args['span'][$i] = intval($column['span']);
                         $args['offset'][$i] = intval($column['offset']);
-                        $i++;
+                        ++$i;
                     }
                     break;
                 case 'custom':
@@ -159,13 +153,14 @@ class Controller extends BlockController
                     }
                     $args['width'] = array();
                     $i = 0;
-                    foreach($node->columns->column as $column) {
+                    foreach ($node->columns->column as $column) {
                         $args['width'][$i] = intval($column['width']);
-                        $i++;
+                        ++$i;
                     }
                     break;
             }
         }
+
         return $args;
     }
 
@@ -180,21 +175,21 @@ class Controller extends BlockController
         $page = $b->getBlockCollectionObject();
 
         $i = 0;
-        foreach($blockNode->arealayout->columns->column as $columnNode) {
+        foreach ($blockNode->arealayout->columns->column as $columnNode) {
             $column = $columns[$i];
             $as = new SubArea($column->getAreaLayoutColumnDisplayID(), $layoutArea->getAreaHandle(), $layoutArea->getAreaID());
             $as->load($page);
             $column->setAreaID($as->getAreaID());
             $area = $column->getAreaObject();
-            foreach($columnNode->block as $bx) {
+            foreach ($columnNode->block as $bx) {
                 $bt = \BlockType::getByHandle($bx['type']);
-                if(!is_object($bt)) {
+                if (!is_object($bt)) {
                     throw new \Exception(t('Invalid block type handle: %s', strval($bx['type'])));
                 }
                 $btc = $bt->getController();
                 $btc->import($page, $area->getAreaHandle(), $bx);
             }
-            $i++;
+            ++$i;
         }
     }
 
@@ -205,7 +200,7 @@ class Controller extends BlockController
             case 'TG':
                 $arLayout = ThemeGridAreaLayout::add();
                 $arLayout->setAreaLayoutMaxColumns($post['arLayoutMaxColumns']);
-                for ($i = 0; $i < $post['themeGridColumns']; $i++) {
+                for ($i = 0; $i < $post['themeGridColumns']; ++$i) {
                     $span = ($post['span'][$i]) ? $post['span'][$i] : 0;
                     $offset = ($post['offset'][$i]) ? $post['offset'][$i] : 0;
                     $column = $arLayout->addLayoutColumn();
@@ -220,7 +215,7 @@ class Controller extends BlockController
                     $iscustom = 0;
                 }
                 $arLayout = CustomAreaLayout::add($post['spacing'], $iscustom);
-                for ($i = 0; $i < $post['columns']; $i++) {
+                for ($i = 0; $i < $post['columns']; ++$i) {
                     $width = ($post['width'][$i]) ? $post['width'][$i] : 0;
                     $column = $arLayout->addLayoutColumn();
                     $column->setAreaLayoutColumnWidth($width);
@@ -229,11 +224,12 @@ class Controller extends BlockController
             default: // a preset
                 $arLayoutPreset = AreaLayoutPreset::getByID($post['arLayoutPresetID']);
                 $arLayout = PresetLayout::add($arLayoutPreset);
-                foreach($arLayoutPreset->getColumns() as $column) {
+                foreach ($arLayoutPreset->getColumns() as $column) {
                     $arLayout->addLayoutColumn();
                 }
                 break;
         }
+
         return $arLayout;
     }
 
@@ -284,7 +280,7 @@ class Controller extends BlockController
             $this->set('themeGridMaxColumns', $this->arLayout->getAreaLayoutMaxColumns());
             $this->set('themeGridName', $gf->getPageThemeGridFrameworkName());
             $this->render("edit_grid");
-        } else if ($this->arLayout instanceof CustomLayout) {
+        } elseif ($this->arLayout instanceof CustomLayout) {
             $this->set('enableThemeGrid', false);
             $this->set('spacing', $this->arLayout->getAreaLayoutSpacing());
             $this->set('iscustom', $this->arLayout->hasAreaLayoutCustomColumnWidths());
@@ -297,7 +293,6 @@ class Controller extends BlockController
         }
         $this->set('columnsNum', count($this->arLayout->getAreaLayoutColumns()));
         $this->requireAsset('core/style-customizer');
-
     }
 
     public function add()
@@ -323,6 +318,4 @@ class Controller extends BlockController
         $this->set('maxColumns', $maxColumns);
         $this->requireAsset('core/style-customizer');
     }
-
-
 }

--- a/web/concrete/blocks/core_conversation/controller.php
+++ b/web/concrete/blocks/core_conversation/controller.php
@@ -103,7 +103,7 @@ class Controller extends BlockController implements ConversationFeatureInterface
         $this->set('notificationUsers', $conversation->getConversationSubscribedUsers());
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('core/conversation');
         $this->requireAsset('core/lightbox');

--- a/web/concrete/blocks/core_gathering/controller.php
+++ b/web/concrete/blocks/core_gathering/controller.php
@@ -1,193 +1,202 @@
-<?
+<?php
+
 namespace Concrete\Block\CoreGathering;
+
 use Loader;
-use \Concrete\Core\Gathering\Gathering;
-use \Concrete\Core\Block\BlockController;
-class Controller extends BlockController {
+use Concrete\Core\Gathering\Gathering;
+use Concrete\Core\Block\BlockController;
 
-		protected $btCacheBlockRecord = true;
-		protected $btTable = 'btCoreGathering';
-		protected $btSupportsInlineEdit = true;
+class Controller extends BlockController
+{
+    protected $btCacheBlockRecord = true;
+    protected $btTable = 'btCoreGathering';
+    protected $btSupportsInlineEdit = true;
 
-		public function getBlockTypeDescription() {
-			return t("Displays pages and data in list or grids.");
-		}
-		
-		public function getBlockTypeName() {
-			return t("Gathering");
-		}
+    public function getBlockTypeDescription()
+    {
+        return t("Displays pages and data in list or grids.");
+    }
 
-		public function duplicate($newBID) {
-			$ni = parent::duplicate($newBID);
-			$ag = Gathering::getByID($this->gaID);
-			$nr = $ag->duplicate();
-			$db = Loader::db();
-			$db->Execute('update btCoreGathering set gaID = ? where bID = ?', array($nr->getGatheringID(), $ni->bID));
-		}
+    public function getBlockTypeName()
+    {
+        return t("Gathering");
+    }
 
-		protected function setupForm() {
-			$gathering = false;
-			$activeSources = array();
-			if ($this->gaID) {
-				$gathering = Gathering::getByID($this->gaID);
-				$activeSources = $gathering->getConfiguredGatheringDataSources();
-			}
-			$availableSources = GatheringDataSource::getList();
-			$this->set('availableSources', $availableSources);
-			$this->set('activeSources', $activeSources);
-			$this->set('gathering', $gathering);
-		}
+    public function duplicate($newBID)
+    {
+        $ni = parent::duplicate($newBID);
+        $ag = Gathering::getByID($this->gaID);
+        $nr = $ag->duplicate();
+        $db = Loader::db();
+        $db->Execute('update btCoreGathering set gaID = ? where bID = ?', array($nr->getGatheringID(), $ni->bID));
+    }
 
-		public function getGatheringObject() {
-			if (!isset($this->gathering)) {
-				// i don't know why this->cnvid isn't sticky in some cases, leading us to query
-				// every damn time
-				$db = Loader::db();
-				$agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
-				$this->gathering = Gathering::getByID($agID);
-			}
-			return $this->gathering;
-		}
+    protected function setupForm()
+    {
+        $gathering = false;
+        $activeSources = array();
+        if ($this->gaID) {
+            $gathering = Gathering::getByID($this->gaID);
+            $activeSources = $gathering->getConfiguredGatheringDataSources();
+        }
+        $availableSources = GatheringDataSource::getList();
+        $this->set('availableSources', $availableSources);
+        $this->set('activeSources', $activeSources);
+        $this->set('gathering', $gathering);
+    }
 
-		public function add() {
-			$this->setupForm();
-		}
-
-		public function edit() {
-			$this->setupForm();
-			$this->view();
-		}
-
-		public function action_post() {
-			// happens through ajax
-			$pagetype = PageType::getByID($this->ptID);
-			if (is_object($pagetype) && $this->enablePostingFromGathering) {
-				$ccp = new Permissions($pagetype);
-				if ($ccp->canEditPageTypeInComposer()) {
-
-					$ct = PageType::getByID($this->post('ptComposerPageTypeID'));
-					$availablePageTypes = $pagetype->getComposerPageTypeObjects();
-
-					if (!is_object($ct) && count($availablePageTypes) == 1) {
-						$ct = $availablePageTypes[0];
-					}
-
-					$c = Page::getCurrentPage();
-					$e = $pagetype->validatePublishRequest($ct, $c);
-					$r = new PageTypePublishResponse($e);
-					if (!$e->has()) {
-						$d = $pagetype->createDraft($ct);
-						$d->setPageDraftTargetParentPageID($c->getCollectionID());
-						$d->saveForm();
-						$d->publish();
-						$nc = Page::getByID($d->getCollectionID(), 'RECENT');
-						$link = Loader::helper('navigation')->getLinkToCollection($nc, true);
-						$r->setRedirectURL($link);
-					}
-					$r->outputJSON();
-				}
-			}
-			exit;
-		}
-
-
-		public function save($args) {
-			$db = Loader::db();
-			$agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
-			if (!$agID) {
-				$ag = Gathering::add();
-				$task = 'add';
-			} else {
-				$ag = Gathering::getByID($agID);
-				$task = 'edit';
-			}
-
-			$tab = $args['tab'];
-			if (!is_array($tab)) {
-				$tab = array();
-			}
-			if ($task == 'add' || in_array('sources', $tab)) {
-				$ag->clearConfiguredGatheringDataSources();
-				$sources = $this->post('gasID');
-				foreach($sources as $key => $gasID) {
-					$key = (string) $key; // because PHP is stupid
-					if ($key != '_gas_') {
-						$ags = GatheringDataSource::getByID($gasID);
-						$ags->setOptionFormKey($key);
-						$post = $ags->getOptionFormRequestData();
-						$agc = $ags->configure($ag, $post);	
-					}
-				}
-				$ag->generateGatheringItems();
-			}
-
-
-			$itemsPerPage = intval($args['itemsPerPage']);
-			$values = array(
-				'gaID' => $ag->getGatheringID()
-			);
-
-			if (in_array('output', $tab)) {
-				$values['itemsPerPage'] = $itemsPerPage;
-			} else {
-				$values['itemsPerPage'] = $this->itemsPerPage;
-			}
-
-			if (in_array('posting', $tab)) {
-				$ptID = 0;
-				if ($args['enablePostingFromGathering']) {
-					$values['enablePostingFromGathering'] = 1;
-					if ($args['ptID']) {
-						$ptID = $args['ptID'];
-					}
-				} else {
-					$values['enablePostingFromGathering'] = 0;
-				}
-				$values['ptID'] = $ptID;	
-			} else {
-				$values['ptID'] = $this->ptID;	
-				$values['enablePostingFromGathering'] = $this->enablePostingFromGathering;	
-			}
-			parent::save($values);
-
-		}
-
-		public function delete() {
-			parent::delete();
-			if ($this->gaID) {
-				$gathering = Gathering::getByID($this->gaID);
-				if (is_object($gathering)) {
-					$gathering->delete();
-				}
-			}
-		}
-
-        public function registerViewAssets($outputContent = '')
-        {
-            $this->requireAsset('core/gathering');
+    public function getGatheringObject()
+    {
+        if (!isset($this->gathering)) {
+            // i don't know why this->cnvid isn't sticky in some cases, leading us to query
+                // every damn time
+                $db = Loader::db();
+            $agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
+            $this->gathering = Gathering::getByID($agID);
         }
 
-		public function view() {
-			if ($this->gaID) {
-				$gathering = Gathering::getByID($this->gaID);
-				if (is_object($gathering)) {
-					Loader::helper('overlay')->init(false);
-					if ($this->enablePostingFromGathering && $this->ptID) {
-						$pt = PageType::getByID($this->ptID);
-						Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
-						$p = new Permissions($pt);
-						if ($p->canEditPageTypeInComposer()) {
-							$this->set('pagetype', $pt);
-						}
-					}		
-					$list = new GatheringItemList($gathering);
-					$list->sortByDateDescending();
-					$list->setItemsPerPage($this->itemsPerPage);
-					$this->set('gathering', $gathering);
-					$this->set('itemList', $list);
-				}
-			}
-		}
+        return $this->gathering;
+    }
 
-	}
+    public function add()
+    {
+        $this->setupForm();
+    }
 
+    public function edit()
+    {
+        $this->setupForm();
+        $this->view();
+    }
+
+    public function action_post()
+    {
+        // happens through ajax
+            $pagetype = PageType::getByID($this->ptID);
+        if (is_object($pagetype) && $this->enablePostingFromGathering) {
+            $ccp = new Permissions($pagetype);
+            if ($ccp->canEditPageTypeInComposer()) {
+                $ct = PageType::getByID($this->post('ptComposerPageTypeID'));
+                $availablePageTypes = $pagetype->getComposerPageTypeObjects();
+
+                if (!is_object($ct) && count($availablePageTypes) == 1) {
+                    $ct = $availablePageTypes[0];
+                }
+
+                $c = Page::getCurrentPage();
+                $e = $pagetype->validatePublishRequest($ct, $c);
+                $r = new PageTypePublishResponse($e);
+                if (!$e->has()) {
+                    $d = $pagetype->createDraft($ct);
+                    $d->setPageDraftTargetParentPageID($c->getCollectionID());
+                    $d->saveForm();
+                    $d->publish();
+                    $nc = Page::getByID($d->getCollectionID(), 'RECENT');
+                    $link = Loader::helper('navigation')->getLinkToCollection($nc, true);
+                    $r->setRedirectURL($link);
+                }
+                $r->outputJSON();
+            }
+        }
+        exit;
+    }
+
+    public function save($args)
+    {
+        $db = Loader::db();
+        $agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
+        if (!$agID) {
+            $ag = Gathering::add();
+            $task = 'add';
+        } else {
+            $ag = Gathering::getByID($agID);
+            $task = 'edit';
+        }
+
+        $tab = $args['tab'];
+        if (!is_array($tab)) {
+            $tab = array();
+        }
+        if ($task == 'add' || in_array('sources', $tab)) {
+            $ag->clearConfiguredGatheringDataSources();
+            $sources = $this->post('gasID');
+            foreach ($sources as $key => $gasID) {
+                $key = (string) $key; // because PHP is stupid
+                    if ($key != '_gas_') {
+                        $ags = GatheringDataSource::getByID($gasID);
+                        $ags->setOptionFormKey($key);
+                        $post = $ags->getOptionFormRequestData();
+                        $agc = $ags->configure($ag, $post);
+                    }
+            }
+            $ag->generateGatheringItems();
+        }
+
+        $itemsPerPage = intval($args['itemsPerPage']);
+        $values = array(
+            'gaID' => $ag->getGatheringID(),
+        );
+
+        if (in_array('output', $tab)) {
+            $values['itemsPerPage'] = $itemsPerPage;
+        } else {
+            $values['itemsPerPage'] = $this->itemsPerPage;
+        }
+
+        if (in_array('posting', $tab)) {
+            $ptID = 0;
+            if ($args['enablePostingFromGathering']) {
+                $values['enablePostingFromGathering'] = 1;
+                if ($args['ptID']) {
+                    $ptID = $args['ptID'];
+                }
+            } else {
+                $values['enablePostingFromGathering'] = 0;
+            }
+            $values['ptID'] = $ptID;
+        } else {
+            $values['ptID'] = $this->ptID;
+            $values['enablePostingFromGathering'] = $this->enablePostingFromGathering;
+        }
+        parent::save($values);
+    }
+
+    public function delete()
+    {
+        parent::delete();
+        if ($this->gaID) {
+            $gathering = Gathering::getByID($this->gaID);
+            if (is_object($gathering)) {
+                $gathering->delete();
+            }
+        }
+    }
+
+    public function registerViewAssets($outputContent = '')
+    {
+        $this->requireAsset('core/gathering');
+    }
+
+    public function view()
+    {
+        if ($this->gaID) {
+            $gathering = Gathering::getByID($this->gaID);
+            if (is_object($gathering)) {
+                Loader::helper('overlay')->init(false);
+                if ($this->enablePostingFromGathering && $this->ptID) {
+                    $pt = PageType::getByID($this->ptID);
+                    Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
+                    $p = new Permissions($pt);
+                    if ($p->canEditPageTypeInComposer()) {
+                        $this->set('pagetype', $pt);
+                    }
+                }
+                $list = new GatheringItemList($gathering);
+                $list->sortByDateDescending();
+                $list->setItemsPerPage($this->itemsPerPage);
+                $this->set('gathering', $gathering);
+                $this->set('itemList', $list);
+            }
+        }
+    }
+}

--- a/web/concrete/blocks/core_gathering/controller.php
+++ b/web/concrete/blocks/core_gathering/controller.php
@@ -162,7 +162,7 @@ class Controller extends BlockController {
 			}
 		}
 
-        public function registerViewAssets()
+        public function registerViewAssets($outputContent = '')
         {
             $this->requireAsset('core/gathering');
         }

--- a/web/concrete/blocks/core_gathering/controller.php
+++ b/web/concrete/blocks/core_gathering/controller.php
@@ -2,9 +2,9 @@
 
 namespace Concrete\Block\CoreGathering;
 
-use Loader;
 use Concrete\Core\Gathering\Gathering;
 use Concrete\Core\Block\BlockController;
+use Database;
 
 class Controller extends BlockController
 {
@@ -27,7 +27,7 @@ class Controller extends BlockController
         $ni = parent::duplicate($newBID);
         $ag = Gathering::getByID($this->gaID);
         $nr = $ag->duplicate();
-        $db = Loader::db();
+        $db = Database::connection();
         $db->Execute('update btCoreGathering set gaID = ? where bID = ?', array($nr->getGatheringID(), $ni->bID));
     }
 
@@ -49,8 +49,8 @@ class Controller extends BlockController
     {
         if (!isset($this->gathering)) {
             // i don't know why this->cnvid isn't sticky in some cases, leading us to query
-                // every damn time
-                $db = Loader::db();
+            // every damn time
+            $db = Database::connection();
             $agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
             $this->gathering = Gathering::getByID($agID);
         }
@@ -92,7 +92,7 @@ class Controller extends BlockController
                     $d->saveForm();
                     $d->publish();
                     $nc = Page::getByID($d->getCollectionID(), 'RECENT');
-                    $link = Loader::helper('navigation')->getLinkToCollection($nc, true);
+                    $link = Core::make('helper/navigation')->getLinkToCollection($nc, true);
                     $r->setRedirectURL($link);
                 }
                 $r->outputJSON();
@@ -103,7 +103,7 @@ class Controller extends BlockController
 
     public function save($args)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $agID = $db->GetOne('select gaID from btCoreGathering where bID = ?', array($this->bID));
         if (!$agID) {
             $ag = Gathering::add();
@@ -182,10 +182,10 @@ class Controller extends BlockController
         if ($this->gaID) {
             $gathering = Gathering::getByID($this->gaID);
             if (is_object($gathering)) {
-                Loader::helper('overlay')->init(false);
+                Core::make('helper/overlay')->init(false);
                 if ($this->enablePostingFromGathering && $this->ptID) {
                     $pt = PageType::getByID($this->ptID);
-                    Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
+                    Core::make('helper/concrete/composer')->addAssetsToRequest($pt, $this);
                     $p = new Permissions($pt);
                     if ($p->canEditPageTypeInComposer()) {
                         $this->set('pagetype', $pt);

--- a/web/concrete/blocks/core_gathering_display/controller.php
+++ b/web/concrete/blocks/core_gathering_display/controller.php
@@ -1,45 +1,49 @@
-<?
+<?php
+
 namespace Concrete\Block\CoreGatheringDisplay;
+
 use Loader;
-use \Concrete\Core\Block\BlockController;
+use Concrete\Core\Block\BlockController;
+
 /**
  * Displays an gathering stand-alone in a page.
  *
  * @package Blocks
  * @subpackage Core Gathering Display
+ *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2013 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
- *
  */
-	
-	class Controller extends BlockController {
+class Controller extends BlockController
+{
+    protected $btCacheBlockRecord = true;
+    protected $btTable = 'btCoreGatheringDisplay';
+    protected $btIsInternal = true;
+    public function getBlockTypeDescription()
+    {
+        return t("Proxy block for gathering items added to areas.");
+    }
 
-		protected $btCacheBlockRecord = true;
-		protected $btTable = 'btCoreGatheringDisplay';
-		protected $btIsInternal = true;		
-		public function getBlockTypeDescription() {
-			return t("Proxy block for gathering items added to areas.");
-		}
-		
-		public function getBlockTypeName() {
-			return t("Gathering Display");
-		}
+    public function getBlockTypeName()
+    {
+        return t("Gathering Display");
+    }
 
-        public function registerViewAssets($outputContent = '')
-        {
-            $this->requireAsset('core/gathering');
+    public function registerViewAssets($outputContent = '')
+    {
+        $this->requireAsset('core/gathering');
+    }
+
+    public function view()
+    {
+        Loader::helper('overlay')->init(false);
+        $gathering = Gathering::getByID($this->gaID);
+        if (is_object($gathering)) {
+            $list = new GatheringItemList($gathering);
+            $list->sortByDateDescending();
+            $this->set('gathering', $gathering);
+            $this->set('itemList', $list);
         }
-
-        public function view() {
-			Loader::helper('overlay')->init(false);
-			$gathering = Gathering::getByID($this->gaID);
-			if (is_object($gathering)) {
-				$list = new GatheringItemList($gathering);
-				$list->sortByDateDescending();
-				$this->set('gathering', $gathering);
-				$this->set('itemList', $list);
-			}
-		}
-		
-	}
+    }
+}

--- a/web/concrete/blocks/core_gathering_display/controller.php
+++ b/web/concrete/blocks/core_gathering_display/controller.php
@@ -2,8 +2,8 @@
 
 namespace Concrete\Block\CoreGatheringDisplay;
 
-use Loader;
 use Concrete\Core\Block\BlockController;
+use Core;
 
 /**
  * Displays an gathering stand-alone in a page.
@@ -37,7 +37,7 @@ class Controller extends BlockController
 
     public function view()
     {
-        Loader::helper('overlay')->init(false);
+        Core::make('helper/overlay')->init(false);
         $gathering = Gathering::getByID($this->gaID);
         if (is_object($gathering)) {
             $list = new GatheringItemList($gathering);

--- a/web/concrete/blocks/core_gathering_display/controller.php
+++ b/web/concrete/blocks/core_gathering_display/controller.php
@@ -26,7 +26,7 @@ use \Concrete\Core\Block\BlockController;
 			return t("Gathering Display");
 		}
 
-        public function registerViewAssets()
+        public function registerViewAssets($outputContent = '')
         {
             $this->requireAsset('core/gathering');
         }

--- a/web/concrete/blocks/discussion/controller.php
+++ b/web/concrete/blocks/discussion/controller.php
@@ -23,7 +23,7 @@ class Controller extends BlockController {
 		return $this->discussion;
 	}
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('core/conversation');
         $this->requireAsset('css', 'core/frontend/pagination');

--- a/web/concrete/blocks/discussion/controller.php
+++ b/web/concrete/blocks/discussion/controller.php
@@ -2,8 +2,9 @@
 
 namespace Concrete\Block\Discussion;
 
-use Loader;
 use Concrete\Core\Block\BlockController;
+use Core;
+use Database;
 
 class Controller extends BlockController
 {
@@ -23,7 +24,7 @@ class Controller extends BlockController
     public function getConversationDiscussionObject()
     {
         if (!isset($this->discussion)) {
-            $db = Loader::db();
+            $db = Database::connection();
             $cnvDiscussionID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
             $this->discussion = ConversationDiscussion::getByID($cnvDiscussionID);
         }
@@ -45,7 +46,7 @@ class Controller extends BlockController
             if ($this->enableNewTopics && $this->ptID) {
                 $pt = PageType::getByID($this->ptID);
                 $this->set('pagetype', $pt);
-                Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
+                Core::make('helper/concrete/composer')->addAssetsToRequest($pt, $this);
             }
 
             $c = Page::getCurrentPage();
@@ -93,7 +94,7 @@ class Controller extends BlockController
                     $d->saveForm();
                     $d->publish();
                     $nc = Page::getByID($d->getCollectionID(), 'RECENT');
-                    $link = Loader::helper('navigation')->getLinkToCollection($nc, true);
+                    $link = Core::make('helper/navigation')->getLinkToCollection($nc, true);
                     $r->setRedirectURL($link);
                 }
                 $r->outputJSON();
@@ -104,7 +105,7 @@ class Controller extends BlockController
 
     public function save($post)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $cnvID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
         if (!$cnvID) {
             $c = Page::getCurrentPage();

--- a/web/concrete/blocks/discussion/controller.php
+++ b/web/concrete/blocks/discussion/controller.php
@@ -1,27 +1,35 @@
-<?
+<?php
+
 namespace Concrete\Block\Discussion;
+
 use Loader;
-use \Concrete\Core\Block\BlockController;
-class Controller extends BlockController {
-	protected $btCacheBlockRecord = true;
-	protected $btTable = 'btDiscussion';
+use Concrete\Core\Block\BlockController;
 
-	public function getBlockTypeDescription() {
-		return t("Places a discussion a page.");
-	}
+class Controller extends BlockController
+{
+    protected $btCacheBlockRecord = true;
+    protected $btTable = 'btDiscussion';
 
-	public function getBlockTypeName() {
-		return t("Discussion");
-	}
+    public function getBlockTypeDescription()
+    {
+        return t("Places a discussion a page.");
+    }
 
-	public function getConversationDiscussionObject() {
-		if (!isset($this->discussion)) {
-			$db = Loader::db();
-			$cnvDiscussionID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
-			$this->discussion = ConversationDiscussion::getByID($cnvDiscussionID);
-		}
-		return $this->discussion;
-	}
+    public function getBlockTypeName()
+    {
+        return t("Discussion");
+    }
+
+    public function getConversationDiscussionObject()
+    {
+        if (!isset($this->discussion)) {
+            $db = Loader::db();
+            $cnvDiscussionID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
+            $this->discussion = ConversationDiscussion::getByID($cnvDiscussionID);
+        }
+
+        return $this->discussion;
+    }
 
     public function registerViewAssets($outputContent = '')
     {
@@ -29,87 +37,88 @@ class Controller extends BlockController {
         $this->requireAsset('css', 'core/frontend/pagination');
     }
 
-    public function view() {
-		$discussion = $this->getConversationDiscussionObject();
-		if (is_object($discussion)) {
-			$this->set('discussion', $discussion);
-			if ($this->enableNewTopics && $this->ptID) {
-				$pt = PageType::getByID($this->ptID);
-				$this->set('pagetype', $pt);
-				Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
-			}
+    public function view()
+    {
+        $discussion = $this->getConversationDiscussionObject();
+        if (is_object($discussion)) {
+            $this->set('discussion', $discussion);
+            if ($this->enableNewTopics && $this->ptID) {
+                $pt = PageType::getByID($this->ptID);
+                $this->set('pagetype', $pt);
+                Loader::helper('concrete/composer')->addAssetsToRequest($pt, $this);
+            }
 
-			$c = Page::getCurrentPage();
-			$dl = new ConversationDiscussionList($c);
-			$orderBy = $this->orderBy;
-			if (in_array($_REQUEST['orderBy'], array('replies', 'date', 'date_last_message')) && $this->enableOrdering) {
-				$orderBy = $_REQUEST['orderBy'];
-			}
-			switch($orderBy) {
-				case 'replies':
-					$dl->sortByTotalReplies();
-					break;
-				case 'date':
-					$dl->sortByPublicDateDescending();
-					break;
-				default: //date_last_message
-					$dl->sortByConversationDateLastMessage();
-					break;
-			}
-			if ($this->itemsPerPage > 0) {
-				$dl->setItemsPerPage($this->itemsPerPage);
-			}
-			$pages = $dl->getPage();
-			$this->set('reqOrderBy', $orderBy);
-			$this->set('topics', $pages);
-			$this->set('list', $dl);
+            $c = Page::getCurrentPage();
+            $dl = new ConversationDiscussionList($c);
+            $orderBy = $this->orderBy;
+            if (in_array($_REQUEST['orderBy'], array('replies', 'date', 'date_last_message')) && $this->enableOrdering) {
+                $orderBy = $_REQUEST['orderBy'];
+            }
+            switch ($orderBy) {
+                case 'replies':
+                    $dl->sortByTotalReplies();
+                    break;
+                case 'date':
+                    $dl->sortByPublicDateDescending();
+                    break;
+                default: //date_last_message
+                    $dl->sortByConversationDateLastMessage();
+                    break;
+            }
+            if ($this->itemsPerPage > 0) {
+                $dl->setItemsPerPage($this->itemsPerPage);
+            }
+            $pages = $dl->getPage();
+            $this->set('reqOrderBy', $orderBy);
+            $this->set('topics', $pages);
+            $this->set('list', $dl);
+        }
+    }
 
-		}
-	}
+    public function action_post()
+    {
+        // happens through ajax
+        $pagetype = PageType::getByID($this->ptID);
+        if (is_object($pagetype) && $this->enableNewTopics) {
+            $ccp = new Permissions($pagetype);
+            if ($ccp->canAddPageType()) {
+                $pagetypes = $pagetype->getPageTypeComposerPageTypeObjects();
+                $ctTopic = $pagetypes[0];
+                $c = Page::getCurrentPage();
+                $e = $pagetype->validatePublishRequest($ctTopic, $c);
+                $r = new PageTypePublishResponse($e);
+                if (!$e->has()) {
+                    $d = $pagetype->createDraft($ctTopic);
+                    $d->setPageDraftTargetParentPageID($c->getCollectionID());
+                    $d->saveForm();
+                    $d->publish();
+                    $nc = Page::getByID($d->getCollectionID(), 'RECENT');
+                    $link = Loader::helper('navigation')->getLinkToCollection($nc, true);
+                    $r->setRedirectURL($link);
+                }
+                $r->outputJSON();
+            }
+        }
+        exit;
+    }
 
-	public function action_post() {
-		// happens through ajax
-		$pagetype = PageType::getByID($this->ptID);
-		if (is_object($pagetype) && $this->enableNewTopics) {
-			$ccp = new Permissions($pagetype);
-			if ($ccp->canAddPageType()) {
-				$pagetypes = $pagetype->getPageTypeComposerPageTypeObjects();
-				$ctTopic = $pagetypes[0];
-				$c = Page::getCurrentPage();
-				$e = $pagetype->validatePublishRequest($ctTopic, $c);
-				$r = new PageTypePublishResponse($e);
-				if (!$e->has()) {
-					$d = $pagetype->createDraft($ctTopic);
-					$d->setPageDraftTargetParentPageID($c->getCollectionID());
-					$d->saveForm();
-					$d->publish();
-					$nc = Page::getByID($d->getCollectionID(), 'RECENT');
-					$link = Loader::helper('navigation')->getLinkToCollection($nc, true);
-					$r->setRedirectURL($link);
-				}
-				$r->outputJSON();
-			}
-		}
-		exit;
-	}
-
-	public function save($post) {
-		$db = Loader::db();
-		$cnvID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
-		if (!$cnvID) {
-			$c = Page::getCurrentPage();
-			$discussion = ConversationDiscussion::add($c);
-		} else {
-			$discussion = ConversationDiscussion::getByID($cnvID);
-		}
-		$values = $post;
-		$ptID = 0;
-		if ($post['ptID']) {
-			$ptID = $post['ptID'];
-		}
-		$values['ptID'] = $ptID;
-		$values['cnvDiscussionID'] = $discussion->getConversationDiscussionID();
-		parent::save($values);
-	}
-
+    public function save($post)
+    {
+        $db = Loader::db();
+        $cnvID = $db->GetOne('select cnvDiscussionID from btDiscussion where bID = ?', array($this->bID));
+        if (!$cnvID) {
+            $c = Page::getCurrentPage();
+            $discussion = ConversationDiscussion::add($c);
+        } else {
+            $discussion = ConversationDiscussion::getByID($cnvID);
+        }
+        $values = $post;
+        $ptID = 0;
+        if ($post['ptID']) {
+            $ptID = $post['ptID'];
+        }
+        $values['ptID'] = $ptID;
+        $values['cnvDiscussionID'] = $discussion->getConversationDiscussionID();
+        parent::save($values);
+    }
 }

--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -51,7 +51,7 @@ class Controller extends BlockController
         }
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('css', 'font-awesome');
         if (is_object($this->block) && $this->block->getBlockFilename() == 'hover_description') {

--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -3,14 +3,12 @@
 namespace Concrete\Block\Feature;
 
 use Page;
-use Loader;
-
-defined('C5_EXECUTE') or die("Access Denied.");
-
 use Concrete\Core\Block\BlockController;
 use Less_Parser;
 use Less_Tree_Rule;
 use Core;
+
+defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController
 {
@@ -42,7 +40,7 @@ class Controller extends BlockController
             if (!empty($this->internalLinkCID)) {
                 $linkToC = Page::getByID($this->internalLinkCID);
 
-                return (empty($linkToC) || $linkToC->error) ? '' : Loader::helper('navigation')->getLinkToCollection(
+                return (empty($linkToC) || $linkToC->error) ? '' : Core::make('helper/navigation')->getLinkToCollection(
                     $linkToC
                 );
             } else {

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -53,7 +53,7 @@ class Controller extends BlockController
         }
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('javascript', 'jquery');
         $this->addFooterItem(

--- a/web/concrete/blocks/image/controller.php
+++ b/web/concrete/blocks/image/controller.php
@@ -37,7 +37,7 @@ class Controller extends BlockController
         return t("Image");
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         // Ensure we have JQuery if we have an onState image
         if (is_object($this->getFileOnstateObject())) {

--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -159,7 +159,7 @@ class Controller extends BlockController
                         $internalLinkCID,
                     )
                 );
-                $i++;
+                ++$i;
             }
         }
     }

--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -67,7 +67,7 @@ class Controller extends BlockController
         $this->edit();
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('javascript', 'jquery');
     }

--- a/web/concrete/blocks/share_this_page/controller.php
+++ b/web/concrete/blocks/share_this_page/controller.php
@@ -132,7 +132,7 @@ class Controller extends BlockController
         $db->delete('btShareThisPage', array('bID' => $this->bID));
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('css', 'font-awesome');
     }

--- a/web/concrete/blocks/social_links/controller.php
+++ b/web/concrete/blocks/social_links/controller.php
@@ -135,7 +135,7 @@ class Controller extends BlockController
         $this->set('links', $links);
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('css', 'font-awesome');
     }

--- a/web/concrete/blocks/video/controller.php
+++ b/web/concrete/blocks/video/controller.php
@@ -62,7 +62,7 @@ class Controller extends BlockController {
 		parent::save($args);
 	}
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('swfobject');
     }

--- a/web/concrete/blocks/video/controller.php
+++ b/web/concrete/blocks/video/controller.php
@@ -1,91 +1,110 @@
-<?
+<?php
+
 namespace Concrete\Block\Video;
-use Loader;
+
 use File;
-use \Concrete\Core\Block\BlockController;
-class Controller extends BlockController {
+use Concrete\Core\Block\BlockController;
 
-	protected $btInterfaceWidth = 320;
-	protected $btInterfaceHeight = 270;
-	protected $btTable = 'btVideo';
-	protected $btCacheBlockRecord = true;
-	protected $btCacheBlockOutput = true;
-	protected $btCacheBlockOutputOnPost = true;
-	protected $btCacheBlockOutputForRegisteredUsers = false;
-	protected $btExportFileColumns = array('fID');
-	protected $btWrapperClass = 'ccm-ui';
-	
-	public $width  = '';
-	public $height = '';
-	public $fID = 0;
-	
-	/** 
-	 * Used for localization. If we want to localize the name/description we have to include this
-	 */
-	public function getBlockTypeDescription() {
-		return t("Embeds uploaded video into a web page. Supports WebM, Ogg, and Quicktime/MPEG4 formats.");
-	}
-	
-	public function getBlockTypeName() {
-		return t("Video Player");
-	}
+class Controller extends BlockController
+{
+    protected $btInterfaceWidth = 320;
+    protected $btInterfaceHeight = 270;
+    protected $btTable = 'btVideo';
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = false;
+    protected $btExportFileColumns = array('fID');
+    protected $btWrapperClass = 'ccm-ui';
 
-	function getMp4FileID() {return $this->mp4fID;}
-    function getWebmFileID() {return $this->webmfID;}
-    function getOggFileID() {return $this->oggfID;}
-    function getPosterFileID() {return $this->posterfID;}
+    public $width = '';
+    public $height = '';
+    public $fID = 0;
 
-	function getMp4FileObject() {
-		return File::getByID($this->mp4fID);
-	}
+    /** 
+     * Used for localization. If we want to localize the name/description we have to include this.
+     */
+    public function getBlockTypeDescription()
+    {
+        return t("Embeds uploaded video into a web page. Supports WebM, Ogg, and Quicktime/MPEG4 formats.");
+    }
 
-    function getOggFileObject() {
+    public function getBlockTypeName()
+    {
+        return t("Video Player");
+    }
+
+    public function getMp4FileID()
+    {
+        return $this->mp4fID;
+    }
+    public function getWebmFileID()
+    {
+        return $this->webmfID;
+    }
+    public function getOggFileID()
+    {
+        return $this->oggfID;
+    }
+    public function getPosterFileID()
+    {
+        return $this->posterfID;
+    }
+
+    public function getMp4FileObject()
+    {
+        return File::getByID($this->mp4fID);
+    }
+
+    public function getOggFileObject()
+    {
         return File::getByID($this->oggfID);
     }
 
-    function getWebmFileObject() {
+    public function getWebmFileObject()
+    {
         return File::getByID($this->webmfID);
     }
 
-    function getPosterFileObject(){
+    public function getPosterFileObject()
+    {
         return File::getByID($this->posterfID);
     }
 
-	function save($data) { 
-		$args['webmfID']    = (intval($data['webmfID'])>0 ? intval($data['webmfID']) : 0);
-        $args['oggfID']    = (intval($data['oggfID']) > 0 ? intval($data['oggfID']) : 0);
-        $args['mp4fID']    = (intval($data['mp4fID'])>0 ? intval($data['mp4fID']) : 0);
-        $args['posterfID']    = (intval($data['posterfID'])>0 ? intval($data['posterfID']) : 0);
-        $args['width']  = (intval($data['width'])>0)  ? intval($data['width'])  : 425;
-		$args['height'] = (intval($data['height'])>0) ? intval($data['height']) : 334;		
-		
-		parent::save($args);
-	}
+    public function save($data)
+    {
+        $args['webmfID'] = (intval($data['webmfID']) > 0 ? intval($data['webmfID']) : 0);
+        $args['oggfID'] = (intval($data['oggfID']) > 0 ? intval($data['oggfID']) : 0);
+        $args['mp4fID'] = (intval($data['mp4fID']) > 0 ? intval($data['mp4fID']) : 0);
+        $args['posterfID'] = (intval($data['posterfID']) > 0 ? intval($data['posterfID']) : 0);
+        $args['width'] = (intval($data['width']) > 0)  ? intval($data['width'])  : 425;
+        $args['height'] = (intval($data['height']) > 0) ? intval($data['height']) : 334;
+
+        parent::save($args);
+    }
 
     public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('swfobject');
     }
 
-	public function view() {
+    public function view()
+    {
         $mp4File = $this->getMp4FileObject();
         $webmFile = $this->getWebmFileObject();
         $posterFile = $this->getPosterFileObject();
         $oggFile = $this->getOggFileObject();
-        if(is_object($posterFile)) {
+        if (is_object($posterFile)) {
             $this->set('posterURL', $posterFile->getURL());
         }
-        if(is_object($mp4File)) {
+        if (is_object($mp4File)) {
             $this->set('mp4URL', $mp4File->getURL());
         }
-        if(is_object($webmFile)) {
+        if (is_object($webmFile)) {
             $this->set('webmURL', $webmFile->getURL());
         }
-        if(is_object($oggFile)) {
+        if (is_object($oggFile)) {
             $this->set('oggURL', $oggFile->getURL());
         }
-	}
-
+    }
 }
-
-?>

--- a/web/concrete/blocks/youtube/controller.php
+++ b/web/concrete/blocks/youtube/controller.php
@@ -41,7 +41,7 @@ class Controller extends BlockController
         }
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('swfobject');
     }

--- a/web/concrete/blocks/youtube/controller.php
+++ b/web/concrete/blocks/youtube/controller.php
@@ -1,7 +1,8 @@
-<?
+<?php
+
 namespace Concrete\Block\Youtube;
-use Loader;
-use \Concrete\Core\Block\BlockController;
+
+use Concrete\Core\Block\BlockController;
 
 class Controller extends BlockController
 {
@@ -21,7 +22,7 @@ class Controller extends BlockController
     public $mode = "youtube";
 
     /**
-     * Used for localization. If we want to localize the name/description we have to include this
+     * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
@@ -66,5 +67,4 @@ class Controller extends BlockController
         $args['vPlayer'] = ($data['vPlayer'] == 1) ? 1 : 0;
         parent::save($args);
     }
-
 }

--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -12,8 +12,8 @@ use Concrete\Core\Legacy\BlockRecord;
 use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Config;
+use Database;
 use Events;
-use Loader;
 use Package;
 use Page;
 
@@ -142,7 +142,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     {
         //$argsMerged = array_merge($_POST, $args);
         if ($this->btTable) {
-            $db = Loader::db();
+            $db = Database::connection();
             $columns = $db->MetaColumnNames($this->btTable);
             $this->record = new BlockRecord($this->btTable);
             $this->record->bID = $this->bID;
@@ -154,7 +154,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             $this->record->Replace();
             if ($this->cacheBlockRecord() && Config::get('concrete.cache.blocks')) {
                 $record = base64_encode(serialize($this->record));
-                $db = Loader::db();
+                $db = Database::connection();
                 $db->Execute('update Blocks set btCachedBlockRecord = ? where bID = ?', array($record, $this->bID));
             }
         }
@@ -262,7 +262,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 if ($this->btCacheBlockRecord && Config::get('concrete.cache.blocks')) {
                     // this is the first time we're loading
                     $record = base64_encode(serialize($this->record));
-                    $db = Loader::db();
+                    $db = Database::connection();
                     $db->Execute('update Blocks set btCachedBlockRecord = ? where bID = ?', array($record, $this->bID));
                 }
             }
@@ -304,7 +304,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         if (isset($this->btExportTables)) {
             $tables = $this->btExportTables;
         }
-        $db = Loader::db();
+        $db = Database::connection();
 
         foreach ($tables as $tbl) {
             if (!$tbl) {
@@ -347,7 +347,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
 
     public function import($page, $arHandle, \SimpleXMLElement $blockNode)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         // handle the adodb stuff
         $args = $this->getImportData($blockNode, $page);
         $blockData = array();

--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -576,7 +576,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         }
     }
 
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
     }
 


### PR DESCRIPTION
This fixes this warning:
```
Declaration of Concrete\Block\Content\Controller::registerViewAssets()
should be compatible with Concrete\Core\Block\BlockController::registerViewAssets()
```

The problem here is that `registerViewAssets` for the Content block needs the `$outputContent` parameter, but all the other blocks (and the base class) don't have that parameter.

We should change all these methods to
```php
public function registerViewAssets($outputContent)
```
but that would break existing 3rd party blocks.
The only solution I can see is the one implemented in this PR:
```php
public function registerViewAssets($outputContent = '')
```
