### PR TITLE
Remove User\Point\Action::addDetailedEntry

### DIFF
--- a/web/concrete/src/User/Point/Action/Action.php
+++ b/web/concrete/src/User/Point/Action/Action.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\User\Point\Action;
 
-use Loader;
+use Database;
 use Environment;
 use Concrete\Core\Package\PackageList;
 use Group;
@@ -21,14 +21,14 @@ class Action
 
     public function load($upaID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->GetRow('select * from UserPointActions where upaID = ?', array($upaID));
         $this->setDataFromArray($row);
     }
 
     public function delete()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $db->delete('UserPointActions', array('upaID' => $this->upaID));
     }
 
@@ -39,7 +39,7 @@ class Action
      */
     public static function getByID($upaID)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->getRow("SELECT * FROM UserPointActions WHERE upaID = ?", array($upaID));
         if ($row['upaID']) {
             $upa = static::getClass($row);
@@ -53,7 +53,7 @@ class Action
     {
         $standardClass = '\\Concrete\Core\\User\\Point\\Action\\Action';
         if ($row['upaHasCustomClass']) {
-            $handleClass = \Loader::helper('text')->camelcase($row['upaHandle']) . 'Action';
+            $handleClass = Core::make('helper/text')->camelcase($row['upaHandle']) . 'Action';
             $pkgHandle = PackageList::getHandle($row['pkgID']);
             $customClass = overrideable_core_class(
                 'Core\\User\\Point\\Action\\' . $handleClass,
@@ -79,7 +79,7 @@ class Action
      */
     public static function getListByPackage($pkg)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $upaIDs = $db->GetCol('select upaID from UserPointActions where pkgID = ? order by upaName asc', array($pkg->getPackageID()));
         $actions = array();
         foreach ($upaIDs as $upaID) {
@@ -99,7 +99,7 @@ class Action
      */
     public static function getByHandle($upaHandle)
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $row = $db->getRow("SELECT * FROM UserPointActions WHERE upaHandle = ?", array($upaHandle));
         if ($row['upaID']) {
             $upa = static::getClass($row);
@@ -294,7 +294,7 @@ class Action
 
     public function save()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         if ($this->upaID) {
             $db->update('UserPointActions', array(
                 'upaHandle' => $this->upaHandle,

--- a/web/concrete/src/User/Point/Action/Action.php
+++ b/web/concrete/src/User/Point/Action/Action.php
@@ -230,11 +230,6 @@ class Action {
 		return Group::getByID($this->getUserPointActionBadgeGroupID());
 	}
 
-	public function addDetailedEntry($user, ActionDescription $descr, $points = false, $date = null)
-	{
-		$this->addEntry($user, $descr, $points, $date);
-	}
-
 	public function addEntry($user, ActionDescription $descr, $points = false, $date = null)
 	{
 		if (!$this->isUserPointActionActive()) {

--- a/web/concrete/src/User/Point/Action/Action.php
+++ b/web/concrete/src/User/Point/Action/Action.php
@@ -1,309 +1,318 @@
 <?php
+
 namespace Concrete\Core\User\Point\Action;
+
 use Loader;
 use Environment;
-use \Concrete\Core\Package\PackageList;
+use Concrete\Core\Package\PackageList;
 use Group;
 use Core;
 use User;
 use UserInfo;
-use \Concrete\Core\User\Point\Entry as UserPointEntry;
+use Concrete\Core\User\Point\Entry as UserPointEntry;
 
-class Action {
+class Action
+{
+    public $upaID;
+    public $upaHandle;
+    public $upaName;
+    public $upaDefaultPoints;
+    public $gBadgeID;
 
-	public $upaID;
-	public $upaHandle;
-	public $upaName;
-	public $upaDefaultPoints;
-	public $gBadgeID;
+    public function load($upaID)
+    {
+        $db = Loader::db();
+        $row = $db->GetRow('select * from UserPointActions where upaID = ?', array($upaID));
+        $this->setDataFromArray($row);
+    }
 
-	public function load($upaID)
-	{
-		$db = Loader::db();
-		$row = $db->GetRow('select * from UserPointActions where upaID = ?', array($upaID));
-		$this->setDataFromArray($row);
-	}
+    public function delete()
+    {
+        $db = Loader::db();
+        $db->delete('UserPointActions', array('upaID' => $this->upaID));
+    }
 
-	public function delete()
-	{
-		$db = Loader::db();
-		$db->delete('UserPointActions', array('upaID' => $this->upaID));
+    /**
+     * @param $upaID
+     *
+     * @return UserPointAction
+     */
+    public static function getByID($upaID)
+    {
+        $db = Loader::db();
+        $row = $db->getRow("SELECT * FROM UserPointActions WHERE upaID = ?", array($upaID));
+        if ($row['upaID']) {
+            $upa = static::getClass($row);
+            $upa->setDataFromArray($row);
 
-	}
+            return $upa;
+        }
+    }
 
-	/**
-	 * @param $upaID
-	 * @return UserPointAction
-	 */
-	public static function getByID($upaID)
-	{
-		$db = Loader::db();
-		$row = $db->getRow("SELECT * FROM UserPointActions WHERE upaID = ?",array($upaID));
-		if ($row['upaID']) {
-			$upa = static::getClass($row);
-			$upa->setDataFromArray($row);
-			return $upa;
-		}
-	}
+    protected static function getClass($row)
+    {
+        $standardClass = '\\Concrete\Core\\User\\Point\\Action\\Action';
+        if ($row['upaHasCustomClass']) {
+            $handleClass = \Loader::helper('text')->camelcase($row['upaHandle']) . 'Action';
+            $pkgHandle = PackageList::getHandle($row['pkgID']);
+            $customClass = overrideable_core_class(
+                'Core\\User\\Point\\Action\\' . $handleClass,
+                DIRNAME_CLASSES . '/User/Point/Action/' . $handleClass . '.php',
+                $pkgHandle
+            );
+            try {
+                $upa = Core::make($customClass);
+            } catch (\ReflectionException $e) {
+                $upa = Core::make($standardClass);
+            }
+        } else {
+            $upa = Core::make($standardClass);
+        }
 
-	protected static function getClass($row)
-	{
-		$standardClass = '\\Concrete\Core\\User\\Point\\Action\\Action';
-		if ($row['upaHasCustomClass']) {
-			$handleClass = \Loader::helper('text')->camelcase($row['upaHandle']) . 'Action';
-			$pkgHandle = PackageList::getHandle($row['pkgID']);
-			$customClass = overrideable_core_class(
-				'Core\\User\\Point\\Action\\' . $handleClass,
-				DIRNAME_CLASSES . '/User/Point/Action/' . $handleClass . '.php',
-				$pkgHandle
-			);
-			try {
-				$upa = Core::make($customClass);
-			} catch (\ReflectionException $e) {
-				$upa = Core::make($standardClass);
-			}
-		} else {
-			$upa = Core::make($standardClass);
-		}
-		return $upa;
-	}
+        return $upa;
+    }
 
+    /**
+     * @param \Package $pkg
+     *
+     * @return array
+     */
+    public static function getListByPackage($pkg)
+    {
+        $db = Loader::db();
+        $upaIDs = $db->GetCol('select upaID from UserPointActions where pkgID = ? order by upaName asc', array($pkg->getPackageID()));
+        $actions = array();
+        foreach ($upaIDs as $upaID) {
+            $action = static::getByID($upaID);
+            if (is_object($action)) {
+                $actions[] = $action;
+            }
+        }
 
-	/**
-	 * @param \Package $pkg
-	 * @return array
- 	 */
-	public static function getListByPackage($pkg)
-	{
-		$db = Loader::db();
-		$upaIDs = $db->GetCol('select upaID from UserPointActions where pkgID = ? order by upaName asc', array($pkg->getPackageID()));
-		$actions = array();
-		foreach($upaIDs as $upaID) {
-			$action = static::getByID($upaID);
-			if (is_object($action)) {
-				$actions[] = $action;
-			}
-		}
-		return $actions;
-	}
+        return $actions;
+    }
 
-	/**
-	 * @param $upaHandle
-	 * @return UserPointAction
-	*/
-	public static function getByHandle($upaHandle)
-	{
-		$db = Loader::db();
-		$row = $db->getRow("SELECT * FROM UserPointActions WHERE upaHandle = ?",array($upaHandle));
-		if ($row['upaID']) {
-			$upa = static::getClass($row);
-			$upa->setDataFromArray($row);
-			return $upa;
-		}
-	}
+    /**
+     * @param $upaHandle
+     *
+     * @return UserPointAction
+     */
+    public static function getByHandle($upaHandle)
+    {
+        $db = Loader::db();
+        $row = $db->getRow("SELECT * FROM UserPointActions WHERE upaHandle = ?", array($upaHandle));
+        if ($row['upaID']) {
+            $upa = static::getClass($row);
+            $upa->setDataFromArray($row);
 
-	public static function add($upaHandle, $upaName, $upaDefaultPoints, $group, $upaIsActive = true, $pkg = false)
-	{
-		$upa = new static();
-		$upa->upaHandle = $upaHandle;
-		$upa->upaName = $upaName;
-		$upa->upaDefaultPoints = $upaDefaultPoints;
-		$upa->gBadgeID = 0;
-		$upa->upaHasCustomClass = 0;
-		$upa->upaIsActive = $upaIsActive;
-		if (!$upaIsActive) {
-			$up->upaIsActive = 0;
-		}
+            return $upa;
+        }
+    }
 
-		if (is_object($group)){
-			$upa->gBadgeID = $group->getGroupID();
-		}
-		$upa->pkgID = 0;
-		$pkgHandle = false;
-		if (is_object($pkg)) {
-			$upa->pkgID = $pkg->getPackageID();
-			$pkgHandle = $pkg->getPackageHandle();
-		}
+    public static function add($upaHandle, $upaName, $upaDefaultPoints, $group, $upaIsActive = true, $pkg = false)
+    {
+        $upa = new static();
+        $upa->upaHandle = $upaHandle;
+        $upa->upaName = $upaName;
+        $upa->upaDefaultPoints = $upaDefaultPoints;
+        $upa->gBadgeID = 0;
+        $upa->upaHasCustomClass = 0;
+        $upa->upaIsActive = $upaIsActive;
+        if (!$upaIsActive) {
+            $up->upaIsActive = 0;
+        }
 
-		$env = Environment::get();
-		$upaHandleCamel = \Core::make("helper/text")->camelcase($upaHandle);
-		$r = $env->getRecord(DIRNAME_CLASSES . '/User/Point/Action/' . $upaHandleCamel . 'Action.php', $pkgHandle);
-		if ($r->exists()) {
-			$upa->upaHasCustomClass = 1;
-		}
-		$upa->save();
-	}
+        if (is_object($group)) {
+            $upa->gBadgeID = $group->getGroupID();
+        }
+        $upa->pkgID = 0;
+        $pkgHandle = false;
+        if (is_object($pkg)) {
+            $upa->pkgID = $pkg->getPackageID();
+            $pkgHandle = $pkg->getPackageHandle();
+        }
 
-	/**
-	 * @param array $data
-	 * @return boolean
-	 */
-	protected function setDataFromArray($data)
-	{
-		if(is_array($data) && count($data)) {
-			$this->upaID = $data['upaID'];
-			$this->upaHandle = $data['upaHandle'];
-			$this->upaName = $data['upaName'];
-			$this->upaDefaultPoints = $data['upaDefaultPoints'];
-			$this->upaHasCustomClass = $data['upaHasCustomClass'];
-			$this->gBadgeID = $data['gBadgeID'];
-			$this->upaIsActive = $data['upaIsActive'];
-			return true;
-		} else {
-			return false;
-		}
-	}
+        $env = Environment::get();
+        $upaHandleCamel = \Core::make("helper/text")->camelcase($upaHandle);
+        $r = $env->getRecord(DIRNAME_CLASSES . '/User/Point/Action/' . $upaHandleCamel . 'Action.php', $pkgHandle);
+        if ($r->exists()) {
+            $upa->upaHasCustomClass = 1;
+        }
+        $upa->save();
+    }
 
-	public function getAttributeNames()
-	{
-    	return array('upaID', 'upaHandle', 'upaName', 'upaDefaultPoints', 'gBadgeID', 'upaIsActive');
-	}
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected function setDataFromArray($data)
+    {
+        if (is_array($data) && count($data)) {
+            $this->upaID = $data['upaID'];
+            $this->upaHandle = $data['upaHandle'];
+            $this->upaName = $data['upaName'];
+            $this->upaDefaultPoints = $data['upaDefaultPoints'];
+            $this->upaHasCustomClass = $data['upaHasCustomClass'];
+            $this->gBadgeID = $data['gBadgeID'];
+            $this->upaIsActive = $data['upaIsActive'];
 
-	/**
-	 * @return boolean
-	 */
-	public function hasCustomClass()
-	{
-		return $this->upaHasCustomClass ? true : false;
-	}
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	public function getPackageHandle()
-	{
-		return PackageList::getHandle($this->pkgID);
-	}
+    public function getAttributeNames()
+    {
+        return array('upaID', 'upaHandle', 'upaName', 'upaDefaultPoints', 'gBadgeID', 'upaIsActive');
+    }
 
-	public function getPackageID()
-	{
-		return $this->pkgID;
-	}
+    /**
+     * @return bool
+     */
+    public function hasCustomClass()
+    {
+        return $this->upaHasCustomClass ? true : false;
+    }
 
-	/**
-	 * @return string
-	*/
-	public function getUserPointActionHandle()
-	{
-		return $this->upaHandle;
-	}
+    public function getPackageHandle()
+    {
+        return PackageList::getHandle($this->pkgID);
+    }
 
-	/**
-	 * @return string
-	*/
-	public function getUserPointActionName()
-	{
-		return $this->upaName;
-	}
+    public function getPackageID()
+    {
+        return $this->pkgID;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function getUserPointActionID()
-	{
-		return $this->upaID;
-	}
+    /**
+     * @return string
+     */
+    public function getUserPointActionHandle()
+    {
+        return $this->upaHandle;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function getUserPointActionDefaultPoints()
-	{
-		return $this->upaDefaultPoints;
-	}
+    /**
+     * @return string
+     */
+    public function getUserPointActionName()
+    {
+        return $this->upaName;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function getUserPointActionBadgeGroupID()
-	{
-		return $this->gBadgeID;
-	}
+    /**
+     * @return int
+     */
+    public function getUserPointActionID()
+    {
+        return $this->upaID;
+    }
 
-	public function isUserPointActionActive()
-	{
-		return $this->upaIsActive;
-	}
+    /**
+     * @return int
+     */
+    public function getUserPointActionDefaultPoints()
+    {
+        return $this->upaDefaultPoints;
+    }
 
-	/**
-	 * @return Group
-	*/
-	public function getUserPointActionBadgeGroupObject()
-	{
-		return Group::getByID($this->getUserPointActionBadgeGroupID());
-	}
+    /**
+     * @return int
+     */
+    public function getUserPointActionBadgeGroupID()
+    {
+        return $this->gBadgeID;
+    }
 
-	public function addEntry($user, ActionDescription $descr, $points = false, $date = null)
-	{
-		if (!$this->isUserPointActionActive()) {
-			return false;
-		}
+    public function isUserPointActionActive()
+    {
+        return $this->upaIsActive;
+    }
 
-		if(is_object($user)) {
-			$user = UserInfo::getByID($user->getUserID());
-			$uID = $user->getUserID();
-		} else {
-			$uID = $user;
-		}
+    /**
+     * @return Group
+     */
+    public function getUserPointActionBadgeGroupObject()
+    {
+        return Group::getByID($this->getUserPointActionBadgeGroupID());
+    }
 
-		if(!isset($uID) || $uID <= 0) {
-			return false;
-		}
+    public function addEntry($user, ActionDescription $descr, $points = false, $date = null)
+    {
+        if (!$this->isUserPointActionActive()) {
+            return false;
+        }
 
-		$g = $this->getUserPointActionBadgeGroupObject();
-		if($g instanceof Group) {
-			if ($user instanceof UserInfo) {
-				$user = User::getByUserID($user->getUserID());
-			}
-			$user->enterGroup($g);
-		}
+        if (is_object($user)) {
+            $user = UserInfo::getByID($user->getUserID());
+            $uID = $user->getUserID();
+        } else {
+            $uID = $user;
+        }
 
-		if ($date == null) {
-			$date = date('Y-m-d H:i:s');
-		}
+        if (!isset($uID) || $uID <= 0) {
+            return false;
+        }
 
-		if($points === false) {
-			$points = $this->getUserPointActionDefaultPoints();
-		}
+        $g = $this->getUserPointActionBadgeGroupObject();
+        if ($g instanceof Group) {
+            if ($user instanceof UserInfo) {
+                $user = User::getByUserID($user->getUserID());
+            }
+            $user->enterGroup($g);
+        }
 
-		try {
-			$upe = new UserPointEntry();
-			$upe->upuID = $uID;
-			$upe->upaID = $this->upaID;
-			$upe->upPoints = $points;
-			$upe->timestamp = $date;
-			$descr = serialize($descr);
-			$upe->object = $descr;
-			$upe->save();
-			return $upe;
-		} catch(Exception $e) {
-			Log::addEntry(t("Error saving user point record: %s", $e->getMessage()),'exceptions');
-			return false;
-		}
+        if ($date == null) {
+            $date = date('Y-m-d H:i:s');
+        }
 
-		return true;
-	}
+        if ($points === false) {
+            $points = $this->getUserPointActionDefaultPoints();
+        }
 
-	public function save()
-	{
-		$db = Loader::db();
-		if($this->upaID) {
-    		$db->update('UserPointActions', array(
-    			'upaHandle' => $this->upaHandle,
-    			'upaName' => $this->upaName,
-    			'upaDefaultPoints' => $this->upaDefaultPoints,
-    			'upaHasCustomClass' => $this->upaHasCustomClass,
-    			'upaIsActive' => $this->upaIsActive,
-    			'gBadgeID' => $this->gBadgeID
-    		), array("upaID" => $this->upaID));
-		} else {
-    		$res = $db->insert('UserPointActions', array(
-    		    'upaHandle' => $this->upaHandle,
-    			'upaName' => $this->upaName,
-    			'upaDefaultPoints' => $this->upaDefaultPoints,
-    			'upaHasCustomClass' => $this->upaHasCustomClass,
-    			'upaIsActive' => $this->upaIsActive,
-    			'gBadgeID' => $this->gBadgeID
-    		));
+        try {
+            $upe = new UserPointEntry();
+            $upe->upuID = $uID;
+            $upe->upaID = $this->upaID;
+            $upe->upPoints = $points;
+            $upe->timestamp = $date;
+            $descr = serialize($descr);
+            $upe->object = $descr;
+            $upe->save();
 
-		}
+            return $upe;
+        } catch (Exception $e) {
+            Log::addEntry(t("Error saving user point record: %s", $e->getMessage()), 'exceptions');
 
-	}
+            return false;
+        }
+
+        return true;
+    }
+
+    public function save()
+    {
+        $db = Loader::db();
+        if ($this->upaID) {
+            $db->update('UserPointActions', array(
+                'upaHandle' => $this->upaHandle,
+                'upaName' => $this->upaName,
+                'upaDefaultPoints' => $this->upaDefaultPoints,
+                'upaHasCustomClass' => $this->upaHasCustomClass,
+                'upaIsActive' => $this->upaIsActive,
+                'gBadgeID' => $this->gBadgeID,
+            ), array("upaID" => $this->upaID));
+        } else {
+            $res = $db->insert('UserPointActions', array(
+                'upaHandle' => $this->upaHandle,
+                'upaName' => $this->upaName,
+                'upaDefaultPoints' => $this->upaDefaultPoints,
+                'upaHasCustomClass' => $this->upaHasCustomClass,
+                'upaIsActive' => $this->upaIsActive,
+                'gBadgeID' => $this->gBadgeID,
+            ));
+        }
+    }
 }

--- a/web/concrete/src/User/Point/Action/WonBadgeAction.php
+++ b/web/concrete/src/User/Point/Action/WonBadgeAction.php
@@ -1,15 +1,13 @@
 <?php
+
 namespace Concrete\Core\User\Point\Action;
 
 class WonBadgeAction extends Action
 {
-
-
     public function addDetailedEntry($user, $group)
     {
         $obj = new WonBadgeActionDescription();
         $obj->setBadgeGroupID($group->getGroupID());
         $entry = self::addEntry($user, $obj, $group->getGroupBadgeCommunityPointValue());
     }
-
 }


### PR DESCRIPTION
[`User\Point\Action::addDetailedEntry`](https://github.com/concrete5/concrete5/blob/a1cd4262f88badeb4e35fc231236f2aa82ece8d3/web/concrete/src/User/Point/Action/Action.php#L233) is just an alias of [`User\Point\Action::addEntry`](https://github.com/concrete5/concrete5/blob/a1cd4262f88badeb4e35fc231236f2aa82ece8d3/web/concrete/src/User/Point/Action/Action.php#L238), it's not called anywhere from the core (the only call to a `addDetailedEntry` method is [here](https://github.com/concrete5/concrete5/blob/a1cd4262f88badeb4e35fc231236f2aa82ece8d3/web/concrete/src/User/User.php#L513)), and it clashes with the definition of [`User\Point\Action\WonBadgeAction::addDetailedEntry`](https://github.com/concrete5/concrete5/blob/a1cd4262f88badeb4e35fc231236f2aa82ece8d3/web/concrete/src/User/Point/Action/WonBadgeAction.php#L8), so let's remove it.

This fixes this warning:
```
Declaration of Concrete\Core\User\Point\Action\WonBadgeAction::addDetailedEntry()
should be compatible with
Concrete\Core\User\Point\Action\Action::addDetailedEntry($user, Concrete\Core\User\Point\Action\ActionDescription $descr, $points = false, $date = NULL)
```