### PR TITLE
Notice error fixes

### DIFF
--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -5,6 +5,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     /** @var PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection */
     private static $conn = null;
     protected $tables = array();
+    protected $fixtures = array();
 
     /*
     protected function setUp() {

--- a/tests/tests/Core/Database/DatabaseTest.php
+++ b/tests/tests/Core/Database/DatabaseTest.php
@@ -28,7 +28,7 @@ class DatabaseTest extends ConcreteDatabaseTestcase
                 'database' => md5(rand()),
                 'user'     => md5(rand()),
                 'password' => md5(rand()),
-                'host'     => DB_SERVER
+                'host'     => 'DB_SERVER'
             ));
 
         try {

--- a/tests/tests/bootstrap.php
+++ b/tests/tests/bootstrap.php
@@ -51,6 +51,11 @@ $r = new \Concrete\Core\Http\Request(
  */
 $cms = require $DIR_BASE_CORE . '/bootstrap/start.php';
 
+/**
+ * Test more strictly than core settings
+ */
+error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
+
 
 class TestConfigRepository extends Repository {
 

--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -102,10 +102,10 @@ class Controller extends BlockController
 
     function save($args)
     {
-        $args['displayPagesIncludeSelf'] = $args['displayPagesIncludeSelf'] ? 1 : 0;
-        $args['displayPagesCID'] = $args['displayPagesCID'] ? $args['displayPagesCID'] : 0;
-        $args['displaySubPageLevelsNum'] = $args['displaySubPageLevelsNum'] > 0 ? $args['displaySubPageLevelsNum'] : 0;
-        $args['displayUnavailablePages'] = $args['displayUnavailablePages'] ? 1 : 0;
+        $args['displayPagesIncludeSelf'] = isset($args['displayPagesIncludeSelf']) && $args['displayPagesIncludeSelf'] ? 1 : 0;
+        $args['displayPagesCID'] = isset($args['displayPagesCID']) && $args['displayPagesCID'] ? $args['displayPagesCID'] : 0;
+        $args['displaySubPageLevelsNum'] = isset($args['displaySubPageLevelsNum']) && $args['displaySubPageLevelsNum'] > 0 ? $args['displaySubPageLevelsNum'] : 0;
+        $args['displayUnavailablePages'] = isset($args['displayUnavailablePages']) && $args['displayUnavailablePages'] ? 1 : 0;
         parent::save($args);
     }
 

--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -27,7 +27,6 @@ class Controller extends BlockController
     protected $btSupportsInlineAdd = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
-    public $content;
 
     public function getBlockTypeDescription()
     {
@@ -98,7 +97,9 @@ class Controller extends BlockController
 
     public function save($args)
     {
-        $args['content'] = LinkAbstractor::translateTo($args['content']);
+        if(isset($args['content'])) {
+            $args['content'] = LinkAbstractor::translateTo($args['content']);
+        }
         parent::save($args);
     }
 }

--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -27,6 +27,7 @@ class Controller extends BlockController
     protected $btSupportsInlineAdd = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
+    public $content;
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -179,6 +179,26 @@ class Controller extends BlockController
             $data['addFilesToSet'] = 0;
         }
 
+        if (!isset($data['surveyName'])) {
+            $data['surveyName'] = '';
+        }
+
+        if (!isset($data['submitText'])) {
+            $data['submitText'] = '';
+        }
+
+        if (!isset($data['notifyMeOnSubmission'])) {
+            $data['notifyMeOnSubmission'] = 0;
+        }
+
+        if (!isset($data['thankyouMsg'])) {
+            $data['thankyouMsg'] = '';
+        }
+
+        if (!isset($data['displayCaptcha'])) {
+            $data['displayCaptcha'] = 0;
+        }
+
         $v = array($data['qsID'], $data['surveyName'], $data['submitText'], intval($data['notifyMeOnSubmission']), $data['recipientEmail'], $data['thankyouMsg'], intval($data['displayCaptcha']), intval($data['redirectCID']), intval($data['addFilesToSet']), intval($this->bID));
 
         //is it new?

--- a/web/concrete/blocks/form/view.php
+++ b/web/concrete/blocks/form/view.php
@@ -53,13 +53,13 @@ while ($questionRow = $questionsRS->fetchRow()) {
 }
 
 //Prep thank-you message
-$success = ($_GET['surveySuccess'] && $_GET['qsid'] == intval($qsID));
+$success = (\Request::request('surveySuccess') && \Request::request('qsid') == intval($qsID));
 $thanksMsg = $survey->thankyouMsg;
 
 //Collate all errors and put them into divs
-$errorHeader = $formResponse;
-$errors = is_array($errors) ? $errors : array();
-if ($invalidIP) {
+$errorHeader = isset($formResponse) ? $formResponse : null;
+$errors = isset($errors) && is_array($errors) ? $errors : array();
+if (isset($invalidIP) && $invalidIP) {
 	$errors[] = $invalidIP;
 }
 $errorDivs = '';
@@ -130,7 +130,7 @@ $captcha = $surveyBlockInfo['displayCaptcha'] ? Loader::helper('validation/captc
 	</div>
 
 	<input name="qsID" type="hidden" value="<?php  echo $qsID; ?>" />
-	<input name="pURI" type="hidden" value="<?php  echo $pURI; ?>" />
+	<input name="pURI" type="hidden" value="<?php  echo isset($pURI) ? $pURI : ''; ?>" />
 	
 </form>
 </div><!-- .formblock -->

--- a/web/concrete/src/Attribute/Type.php
+++ b/web/concrete/src/Attribute/Type.php
@@ -19,6 +19,7 @@ class Type extends Object
     public $atHandle;
 
     protected $atID;
+    protected $pkgID;
 
     public function getAttributeTypeID()
     {

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -28,6 +28,7 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
     protected $proxyBlock = false;
     protected $bActionCID;
     protected $cacheSettings;
+    protected $a;
 
     protected $bFilename;
 

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -28,7 +28,7 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
     protected $proxyBlock = false;
     protected $bActionCID;
     protected $cacheSettings;
-    protected $a;
+    public $a;
 
     protected $bFilename;
 

--- a/web/concrete/src/File/FileList.php
+++ b/web/concrete/src/File/FileList.php
@@ -58,7 +58,7 @@ class FileList extends DatabaseItemList implements PermissionableListItemInterfa
     public function getTotalResults()
     {
         $u = new \User();
-        if ($this->permissionsChecker == -1) {
+        if ($this->permissionsChecker === -1) {
             $query = $this->deliverQueryObject();
             return $query->select('count(distinct f.fID)')->setMaxResults(1)->execute()->fetchColumn();
         } else {
@@ -69,7 +69,7 @@ class FileList extends DatabaseItemList implements PermissionableListItemInterfa
     protected function createPaginationObject()
     {
         $u = new \User();
-        if ($this->permissionsChecker == -1) {
+        if ($this->permissionsChecker === -1) {
             $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
                 $query->select('count(distinct f.fID)')->setMaxResults(1);
             });

--- a/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -60,7 +60,9 @@ class LocalConfiguration extends Configuration implements ConfigurationInterface
     {
         $data = $req->get('fslType');
         $this->path = rtrim($data['path'], '/');
-        $this->relativePath = rtrim($data['relativePath'], '/');
+        if (isset($data['relativePath'])) {
+            $this->relativePath = rtrim($data['relativePath'], '/');
+        }
     }
 
     /**

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -161,7 +161,7 @@ class Form
         }
 
         $checked = false;
-        if ($isChecked && (!isset($_REQUEST[$_field])) && ($_SERVER['REQUEST_METHOD'] != 'POST')) {
+        if ($isChecked && \Request::request($_field) === null && !\Request::isPost()) {
             $checked = true;
         } else {
             $requestValue = $this->getRequestValue($key);
@@ -435,14 +435,17 @@ class Form
         if (is_array($requestValue) && isset($requestValue[0]) && is_string($requestValue[0])) {
             $selectedValue = (string) $requestValue[0];
         } elseif ($requestValue !== false) {
-            $selectedValue = (string) $requestValue;
+            if (!is_array($requestValue)) {
+                $selectedValue = (string)$requestValue;
+            } else {
+                $selectedValue = '';
+            }
         }
         if (substr($key, -2) == '[]') {
             $_key = substr($key, 0, -2);
             $id = $_key . $this->selectIndex;
             $this->selectIndex++;
         } else {
-            $_key = $key;
             $id = $key;
         }
         $str = '<select id="' . $id . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>';

--- a/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/web/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -539,6 +539,7 @@ abstract class AbstractRepetition implements RepetitionInterface
 
         $repetition_start = $dh->toDateTime($start_date)->getTimestamp();
         $repetition_end = $dh->toDateTime($end_date)->getTimestamp();
+        $repetition_final = null;
 
         $period_end = $dh->toDateTime($this->getRepeatPeriodEnd());
         if (is_object($period_end)) {

--- a/web/concrete/src/Http/RequestBase.php
+++ b/web/concrete/src/Http/RequestBase.php
@@ -205,6 +205,6 @@ class RequestBase extends SymfonyRequest
      */
     public static function isPost()
     {
-        return $_SERVER['REQUEST_METHOD'] == 'POST';
+        return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'POST';
     }
 }

--- a/web/concrete/src/Logging/Handler/DatabaseHandler.php
+++ b/web/concrete/src/Logging/Handler/DatabaseHandler.php
@@ -9,6 +9,7 @@ use User;
 
 class DatabaseHandler extends AbstractProcessingHandler
 {
+    protected $initialized;
     private $statement;
 
     protected function write(array $record)

--- a/web/concrete/src/Mail/Service.php
+++ b/web/concrete/src/Mail/Service.php
@@ -264,7 +264,7 @@ class Service
             $v = $arr[$i];
             if (isset($v[1])) {
                 $str .= '"'.$v[1].'" <'.$v[0].'>';
-            } else {
+            } elseif (isset($v[0])) {
                 $str .= $v[0];
             }
             if (($i + 1) < count($arr)) {

--- a/web/concrete/src/Page/Collection/Collection.php
+++ b/web/concrete/src/Page/Collection/Collection.php
@@ -29,6 +29,11 @@ use User;
 class Collection extends Object
 {
     public $cID;
+    protected $vObj;
+    protected $cHandle;
+    protected $cDateAdded;
+    protected $cDateModified;
+
     protected $attributes = array();
 
     /* version specific stuff */
@@ -214,7 +219,7 @@ class Collection extends Object
             // otherwise, we have to clone this version of the collection entirely,
             // and return that collection.
 
-            $nc = $this->cloneVersion($versionComments);
+            $nc = $this->cloneVersion(null);
 
             return $nc;
         }
@@ -765,7 +770,7 @@ class Collection extends Object
      * @return Collection
      */
 
-    public function rescanDisplayOrder($areaName)
+    public function rescanDisplayOrder($arHandle)
     {
         // this collection function fixes the display order properties for all the blocks within the collection/area. We select all the items
         // order by display order, and fix the sequence
@@ -773,14 +778,16 @@ class Collection extends Object
         $db = Loader::db();
         $cID = $this->cID;
         $cvID = $this->vObj->cvID;
-        $q = "select bID from CollectionVersionBlocks where cID = '$cID' and cvID = '{$cvID}' and arHandle='$arHandle' order by cbDisplayOrder asc";
-        $r = $db->query($q);
+        $args = array($cID, $cvID, $arHandle);
+        $q = "select bID from CollectionVersionBlocks where cID = ? and cvID = ? and arHandle=? order by cbDisplayOrder asc";
+        $r = $db->query($q, $args);
 
         if ($r) {
             $displayOrder = 0;
             while ($row = $r->fetchRow()) {
-                $q = "update CollectionVersionBlocks set cbDisplayOrder = '$displayOrder' where cID = '$cID' and cvID = '{$cvID}' and arHandle = '$arHandle' and bID = '{$row['bID']}'";
-                $r2 = $db->query($q);
+                $args = array($displayOrder, $cID, $cvID, $arHandle, $row['bID']);
+                $q = "update CollectionVersionBlocks set cbDisplayOrder = ? where cID = ? and cvID = ? and arHandle = ? and bID = ?";
+                $db->query($q, $args);
                 $displayOrder++;
             }
             $r->free();

--- a/web/concrete/src/Page/Theme/Theme.php
+++ b/web/concrete/src/Page/Theme/Theme.php
@@ -35,6 +35,7 @@ class Theme extends Object
     protected $pThemeHandle;
     protected $pThemeURL;
     protected $pThemeIsPreview = false;
+    protected $pkgID;
 
     const E_THEME_INSTALLED = 1;
     const THEME_EXTENSION = '.php';

--- a/web/concrete/src/Page/Type/PublishTarget/Type/Type.php
+++ b/web/concrete/src/Page/Type/PublishTarget/Type/Type.php
@@ -87,7 +87,7 @@ abstract class Type extends Object
         $r = $db->GetRow(
             'select ptPublishTargetTypeID, ptPublishTargetTypeHandle, ptPublishTargetTypeName, pkgID from PageTypePublishTargetTypes where ptPublishTargetTypeHandle = ?', array($ptPublishTargetTypeHandle)
         );
-        if (is_array($r) && $r['ptPublishTargetTypeHandle']) {
+        if (is_array($r) && isset($r['ptPublishTargetTypeHandle'])) {
             $txt = Loader::helper('text');
             $class = overrideable_core_class('Core\\Page\\Type\\PublishTarget\\Type\\'
                 . $txt->camelcase($r['ptPublishTargetTypeHandle']) . 'Type', DIRNAME_CLASSES . '/Page/Type/PublishTarget/Type/'

--- a/web/concrete/src/StyleCustomizer/Style/ColorStyle.php
+++ b/web/concrete/src/StyleCustomizer/Style/ColorStyle.php
@@ -92,7 +92,7 @@ class ColorStyle extends Style {
     public function getValuesFromVariables($rules = array()) {
         $values = array();
         foreach($rules as $rule) {
-            if (preg_match('/@(.+)\-color/i', $rule->name, $matches)) {
+            if (preg_match('/@(.+)\-color/i',  isset($rule->name) ? $rule->name : '', $matches)) {
                 $value = $rule->value->value[0]->value[0];
                 $cv = static::parse($value, $matches[1]);
                 if (is_object($cv)) {

--- a/web/concrete/src/StyleCustomizer/Style/ImageStyle.php
+++ b/web/concrete/src/StyleCustomizer/Style/ImageStyle.php
@@ -56,7 +56,7 @@ class ImageStyle extends Style
     {
         $values = array();
         foreach ($rules as $rule) {
-            if (preg_match('/@(.+)\-image/i', $rule->name, $matches)) {
+            if (preg_match('/@(.+)\-image/i', isset($rule->name) ? $rule->name : '', $matches)) {
                 $entryURI = $rule->value->value[0]->value[0]->currentFileInfo['entryUri'];
                 $value = $rule->value->value[0]->value[0]->value;
                 if ($entryURI) {

--- a/web/concrete/src/StyleCustomizer/Style/SizeStyle.php
+++ b/web/concrete/src/StyleCustomizer/Style/SizeStyle.php
@@ -48,7 +48,7 @@ class SizeStyle extends Style {
     public function getValuesFromVariables($rules = array()) {
         $values = array();
         foreach($rules as $rule) {
-            if (preg_match('/@(.+)\-size/i', $rule->name, $matches)) {
+            if (preg_match('/@(.+)\-size/i',  isset($rule->name) ? $rule->name : '', $matches)) {
                 $value = $rule->value->value[0]->value[0];
                 $sv = static::parse($value, $matches[1]);
                 if (is_object($sv)) {

--- a/web/concrete/src/StyleCustomizer/Style/TypeStyle.php
+++ b/web/concrete/src/StyleCustomizer/Style/TypeStyle.php
@@ -129,44 +129,45 @@ class TypeStyle extends Style {
         $values = array();
 
         foreach($rules as $rule) {
-            if (preg_match('/@(.+)\-type-font-family/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            $ruleName=  isset($rule->name) ? $rule->name : '';
+            if (preg_match('/@(.+)\-type-font-family/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0]->value;
                 $values[$matches[1]]->setFontFamily($value);
             }
-            if (preg_match('/@(.+)\-type-font-weight/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-font-weight/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0]->value;
                 $values[$matches[1]]->setFontWeight($value);
             }
-            if (preg_match('/@(.+)\-type-text-decoration/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-text-decoration/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0]->value;
                 $values[$matches[1]]->setTextDecoration($value);
             }
 
-            if (preg_match('/@(.+)\-type-text-transform/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-text-transform/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0]->value;
                 $values[$matches[1]]->setTextTransform($value);
             }
-            if (preg_match('/@(.+)\-type-font-style/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-font-style/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0]->value;
                 $values[$matches[1]]->setFontStyle($value);
             }
-            if (preg_match('/@(.+)\-type-color/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-color/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
@@ -176,8 +177,8 @@ class TypeStyle extends Style {
                 }
             }
 
-            if (preg_match('/@(.+)\-type-font-size/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-font-size/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
@@ -187,8 +188,8 @@ class TypeStyle extends Style {
                 }
             }
 
-            if (preg_match('/@(.+)\-type-letter-spacing/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-letter-spacing/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
@@ -198,8 +199,8 @@ class TypeStyle extends Style {
                 }
             }
 
-            if (preg_match('/@(.+)\-type-line-height/i', $rule->name, $matches)) {
-                if (!$values[$matches[1]]) {
+            if (preg_match('/@(.+)\-type-line-height/i', $ruleName, $matches)) {
+                if (!isset($values[$matches[1]])) {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];

--- a/web/concrete/src/StyleCustomizer/Style/ValueList.php
+++ b/web/concrete/src/StyleCustomizer/Style/ValueList.php
@@ -47,7 +47,7 @@ class ValueList {
 
         // load required preset variables.
         foreach($rules as $rule) {
-            if (preg_match('/@preset-fonts-file/i', $rule->name, $matches)) {
+            if (preg_match('/@preset-fonts-file/i', isset($rule->name) ? $rule->name : '', $matches)) {
                 $value = $rule->value->value[0]->value[0]->value;
                 $bv = new BasicValue('preset-fonts-file');
                 $bv->setValue($value);

--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -513,7 +513,7 @@ class User extends Object
                         $action->addDetailedEntry($this, $g);
                     }
 
-                    $mh = Loader::helper('mail');
+                    $mh = Core::make('mail');
                     $ui = CoreUserInfo::getByID($this->getUserID());
                     $mh->addParameter('badgeName', $g->getGroupDisplayName(false));
                     $mh->addParameter('uDisplayName', $ui->getUserDisplayName());

--- a/web/concrete/src/User/UserInfo.php
+++ b/web/concrete/src/User/UserInfo.php
@@ -194,7 +194,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
         $uDateAdded = $dh->getOverridableNow();
         $hasher = new PasswordHash(Config::get('concrete.user.password.hash_cost_log2'), Config::get('concrete.user.password.hash_portable'));
 
-        if ($data['uIsValidated'] == 1) {
+        if (isset($data['uIsValidated']) && $data['uIsValidated'] == 1) {
             $uIsValidated = 1;
         } elseif (isset($data['uIsValidated']) && $data['uIsValidated'] == 0) {
             $uIsValidated = 0;
@@ -208,9 +208,10 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
             $uIsFullRecord = 1;
         }
 
-        $password_to_insert = $data['uPassword'];
+        $password_to_insert = isset($data['uPassword']) ? $data['uPassword'] : null;
         $hash = $hasher->HashPassword($password_to_insert);
 
+        $uDefaultLanguage = null;
         if (isset($data['uDefaultLanguage']) && $data['uDefaultLanguage'] != '') {
             $uDefaultLanguage = $data['uDefaultLanguage'];
         }
@@ -232,7 +233,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
 
                 // run any internal event we have for user add
                 $ue = new \Concrete\Core\User\Event\UserInfoWithPassword($ui);
-                $ue->setUserPassword($data['uPassword']);
+                $ue->setUserPassword($password_to_insert);
                 Events::dispatch('on_user_add', $ue);
             }
 
@@ -408,7 +409,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
 
         // send the email notification
         if ($recipient->getAttribute('profile_private_messages_notification_enabled')) {
-            $mh = Core::make('helper/mail');
+            $mh = Core::make('mail');
             $mh->addParameter('msgSubject', $subject);
             $mh->addParameter('msgBody', $text);
             $mh->addParameter('msgAuthor', $this->getUserName());


### PR DESCRIPTION
This fixes all notice errors presented by the phpunit tests. There are quite a few files touched but most touches are very minor so I left them in only a couple commits. If this needs split up in some way say the word and I'll make it so.

Additionally....

- Fixes an Error, which if it wasn't an error would pose a SQL injection vulnerability, which is also fixed.
- Will most likely conflict with PR #2884 in regard to web/concrete/src/Page/Type/PublishTarget/Type/Type.php. PR #2884 changes will superscede the isset change presented in this PR, it's only there to prevent unit test failures.
-  tests/tests/bootstrap.php has been modified so that unit tests going forward will show `E_NOTICE` messages.