### PR TITLE
Fixed scrollbar not reappearing after file upload

### DIFF
--- a/web/concrete/js/build/core/app/search/base.js
+++ b/web/concrete/js/build/core/app/search/base.js
@@ -197,7 +197,10 @@
 
 	ConcreteAjaxSearch.prototype.refreshResults = function() {
 		var cs = this;
-		cs.$element.find('form[data-search-form]').trigger('submit');
+		
+		if ($.contains(document, cs.$element)) {
+			cs.$element.find('form[data-search-form]').trigger('submit');
+		}
 	}
 
 	ConcreteAjaxSearch.prototype.setupSearch = function() {

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -99,6 +99,10 @@
                         my._launchUploadCompleteDialog(files);
                         files = [];
                     }
+                },
+                always: function()
+                {
+                    $('#ccm-file-upload-progress-wrapper').remove();
                 }
             };
 


### PR DESCRIPTION
This was a fun one.

The file upload progress bar is in a dialog class. That prevented the pre-dialog close function from ever running the last dialog closing code, which removes the overflow hidden on the body element. So, if you uploaded a file the scroll bar would never come back.

That change caused the browser the redirect to the search results' json page anytime you selected the uploaded file from the success dialog. Eventually discovered this is because refresh was triggering submit on an element no longer in the document.