### PR TITLE
Change maxMessages value

### DIFF
--- a/web/concrete/src/Job/QueueableJob.php
+++ b/web/concrete/src/Job/QueueableJob.php
@@ -75,7 +75,7 @@ abstract class QueueableJob extends AbstractJob {
 		$q = $this->markStarted();
 		$this->start($q);
 		try {
-			$messages = $q->receive(999999999999);
+			$messages = $q->receive(PHP_INT_MAX);
 			foreach($messages as $key => $p) {
 				$this->processQueueItem($p);
 				$q->deleteMessage($p);


### PR DESCRIPTION
The value '999999999999' caused errors in 'vendor/zend-queue/library/ZendQueue/Queue.php' on some systems as it was typed as 'double' instead of integer. Changed it to be the max integer value for the current version and platform that the system is running on.