### PR TITLE
Add ApproverUserName to Version list

### DIFF
--- a/web/concrete/src/Page/Collection/Version/EditResponse.php
+++ b/web/concrete/src/Page/Collection/Version/EditResponse.php
@@ -46,6 +46,7 @@ class EditResponse extends PageEditResponse
             $obj->cpCanDeletePageVersions = $cpCanDeletePageVersions;
             $obj->cvDateVersionCreated = $dateHelper->formatDateTime($v->getVersionDateCreated()); 
             $obj->cvAuthorUserName = $v->getVersionAuthorUserName();
+            $obj->cvApproverUserName = $v->getVersionApproverUserName();
             $obj->cvComments = $v->getVersionComments();
             $versions[] = $obj;
         }

--- a/web/concrete/views/panels/page/versions.php
+++ b/web/concrete/views/panels/page/versions.php
@@ -16,9 +16,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		<td><span class="ccm-panel-page-versions-version-id"><%-cvID%></span></td>
 		<td class="ccm-panel-page-versions-details">
 			<p><span class="ccm-panel-page-versions-version-timestamp"><%-cvDateVersionCreated%></span></p>
-			<p><%-cvAuthorUserName%></p>
+			<p><?=t('Edit by')?> <%-cvAuthorUserName%></p>
 			<% if (cvComments) { %>
 				<p><small><%-cvComments%></small></p>
+			<% } %>
+			<% if (cvIsApproved == 1) { %>
+				<p><?=t('Approved by')?> <%-cvApproverUserName%></p>
 			<% } %>
 		</td>
 		<td>


### PR DESCRIPTION
A several clients who are using workflow mentioned that Version list doesn't show who approved the version like 5.6.x.

So although there is some design issue. I've added the `Approved by` to the list.

What do you guys think?
We may want to adjust the design and CSS a bit.


Here are the screenshot

### Screenshot: Page Panel

![approved_pagepanel](https://cloud.githubusercontent.com/assets/485751/9191343/08df8e0e-403b-11e5-8789-58ff3fe2ded5.png)

### Screenshot: Fullsite Map

![approved_fullsitemap](https://cloud.githubusercontent.com/assets/485751/9191346/0f1f6b5e-403b-11e5-979f-19fbe075c041.png)
