### PR TITLE
Add Models directory to package autoloading

### DIFF
--- a/web/concrete/src/Foundation/ClassLoader.php
+++ b/web/concrete/src/Foundation/ClassLoader.php
@@ -121,6 +121,7 @@ class ClassLoader
         $symfonyLoader->addPrefix(NAMESPACE_SEGMENT_VENDOR . '\\Package\\' . camelcase($pkgHandle) . '\\Controller\\PageType', DIR_PACKAGES . '/' . $pkgHandle . '/' . DIRNAME_CONTROLLERS . '/' . DIRNAME_PAGE_TYPES);
         $symfonyLoader->addPrefix(NAMESPACE_SEGMENT_VENDOR . '\\Package\\' . camelcase($pkgHandle) . '\\Controller', DIR_PACKAGES . '/' . $pkgHandle . '/' . DIRNAME_CONTROLLERS);
         $symfonyLoader->addPrefix(NAMESPACE_SEGMENT_VENDOR . '\\Package\\' . camelcase($pkgHandle) . '\\Job', DIR_PACKAGES . '/' . $pkgHandle . '/' . DIRNAME_JOBS);
+        $symfonyLoader->addPrefix(NAMESPACE_SEGMENT_VENDOR . '\\Package\\' . camelcase($pkgHandle) . '\\Models', DIR_PACKAGES . '/' . $pkgHandle . '/' . DIRNAME_MODELS);
 
         $strictLoader = new SymfonyClassLoader();
         $loaders = $pkg->getPackageAutoloaderRegistries();


### PR DESCRIPTION
This pull request is a bug fix for a problem introduced in 5.7.5.

Concrete 5.7.5 removed the legacy loader in 409587e0. Unfortunately, the `Models` directory in a package relied on this legacy loading mechanism in the package directory. The consequence is that all models in the `Models` directory are not loaded anymore.

The pull request explicitly adds the `Models` directory to the package autoloading.