### PR TITLE
Error when the ccm_paging_p query parameter is not a number

### DIFF
--- a/web/concrete/src/Search/ItemList/ItemList.php
+++ b/web/concrete/src/Search/ItemList/ItemList.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Search\ItemList;
 
 use Concrete\Core\Search\StickyRequest;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
+use Pagerfanta\Exception\LessThan1CurrentPageException;
 
 abstract class ItemList
 {
@@ -175,6 +176,8 @@ abstract class ItemList
             $page = intval($query->get($this->getQueryPaginationPageParameter()));
             try {
                 $pagination->setCurrentPage($page);
+            } catch (LessThan1CurrentPageException $e) {
+                $pagination->setCurrentPage(1);
             } catch (OutOfRangeCurrentPageException $e) {
                 $pagination->setCurrentPage(1);
             }


### PR DESCRIPTION
When the ccm_paging_p query parameter is not a number, such as 'a', an error is thrown. Instead, this assumes that it should show page 1.

This works similar to when the OutOfRangeCurrentPageException is thrown.