### PR TITLE
Add column ids

### DIFF
--- a/tests/tests/Core/Area/AreaLayoutPresetTest.php
+++ b/tests/tests/Core/Area/AreaLayoutPresetTest.php
@@ -177,7 +177,7 @@ class AreaLayoutPresetTest extends PageTestCase
         $this->assertInstanceOf('\Concrete\Core\Area\Layout\Preset\Preset', $presets[1]);
 
         $columns = $presets[1]->getColumns();
-        $this->assertEquals('<div class="ccm-layout-column"><div class="ccm-layout-column-inner" id="ccm-layout-column-4"></div></div>', (string) $columns[0]->getColumnHtmlObject());
+        $this->assertEquals('<div class="ccm-layout-column" id="ccm-layout-column-4"><div class="ccm-layout-column-inner"></div></div>', (string) $columns[0]->getColumnHtmlObject());
 
 
     }

--- a/tests/tests/Core/Area/AreaLayoutPresetTest.php
+++ b/tests/tests/Core/Area/AreaLayoutPresetTest.php
@@ -177,7 +177,7 @@ class AreaLayoutPresetTest extends PageTestCase
         $this->assertInstanceOf('\Concrete\Core\Area\Layout\Preset\Preset', $presets[1]);
 
         $columns = $presets[1]->getColumns();
-        $this->assertEquals('<div class="ccm-layout-column"><div class="ccm-layout-column-inner"></div></div>', (string) $columns[0]->getColumnHtmlObject());
+        $this->assertEquals('<div class="ccm-layout-column"><div class="ccm-layout-column-inner" id="ccm-layout-column-4"></div></div>', (string) $columns[0]->getColumnHtmlObject());
 
 
     }

--- a/web/concrete/src/Area/Layout/CustomColumn.php
+++ b/web/concrete/src/Area/Layout/CustomColumn.php
@@ -58,7 +58,7 @@ class CustomColumn extends Column
     protected function getColumnElement($contents)
     {
         $element = new Element('div');
-        $element->addClass($this->getAreaLayoutColumnClass());
+        $element->addClass($this->getAreaLayoutColumnClass())->id('ccm-layout-column-'.$this->arLayoutColumnID);
         $inner = new Element('div');
         $inner->addClass('ccm-layout-column-inner');
         $inner->setValue($contents);


### PR DESCRIPTION
Column ids are missing since 5.7.5.
Columns with a custom width don't work without this.