### PR TITLE
add additional screen information to Mobile Device Preview

### DIFF
--- a/web/concrete/views/panels/page/devices.php
+++ b/web/concrete/views/panels/page/devices.php
@@ -85,7 +85,15 @@ use Concrete\Core\Device\Device;
                                     </div>
                                 </div>
                                 <div class="ccm-panel-device-resolution">
-                                    <?= h($device->getWidth()) ?> x <?= h($device->getHeight()) ?>
+                                    <?php
+                                    $deviceWidth = h($device->getWidth());
+                                    $deviceHeight = h($device->getHeight());
+                                    $pixelRatio = h($device->getPixelRatio());
+                                    $displayedWidth = floor($device->getWidth() / $device->getPixelRatio());
+                                    $displayedHeight = floor($device->getHeight() / $device->getPixelRatio());
+
+                                    echo "$deviceWidth x  $deviceHeight @{$pixelRatio}x ($displayedWidth x $displayedHeight)";
+                                    ?>
                                 </div>
                             </a>
                         </li>

--- a/web/concrete/views/panels/page/devices.php
+++ b/web/concrete/views/panels/page/devices.php
@@ -85,17 +85,7 @@ use Concrete\Core\Device\Device;
                                     </div>
                                 </div>
                                 <div class="ccm-panel-device-resolution">
-                                    <?php echo t('Device Screen Pixels: ') . h($device->getWidth()) . ' x ' . h($device->getHeight()); ?>
-                                </div>
-                                <div class="ccm-panel-device-resolution">
-                                    <?php echo t('Screen Pixel Ratio: ') . h($device->getPixelRatio()); ?>
-                                </div>
-                                <div class="ccm-panel-device-resolution">
-                                    <?php
-                                    $displayedWidth = floor($device->getWidth() / $device->getPixelRatio());
-                                    $displayedHeight = floor($device->getHeight() / $device->getPixelRatio());
-                                    ?>
-                                    <?php echo t('Displayed Screen Pixels: ') . h($displayedWidth) . ' x ' . h($displayedHeight); ?>
+                                    <?= h($device->getWidth()) ?> x <?= h($device->getHeight()) ?>
                                 </div>
                             </a>
                         </li>

--- a/web/concrete/views/panels/page/devices.php
+++ b/web/concrete/views/panels/page/devices.php
@@ -85,7 +85,17 @@ use Concrete\Core\Device\Device;
                                     </div>
                                 </div>
                                 <div class="ccm-panel-device-resolution">
-                                    <?= h($device->getWidth()) ?> x <?= h($device->getHeight()) ?>
+                                    <?php echo t('Device Screen Pixels: ') . h($device->getWidth()) . ' x ' . h($device->getHeight()); ?>
+                                </div>
+                                <div class="ccm-panel-device-resolution">
+                                    <?php echo t('Screen Pixel Ratio: ') . h($device->getPixelRatio()); ?>
+                                </div>
+                                <div class="ccm-panel-device-resolution">
+                                    <?php
+                                    $displayedWidth = floor($device->getWidth() / $device->getPixelRatio());
+                                    $displayedHeight = floor($device->getHeight() / $device->getPixelRatio());
+                                    ?>
+                                    <?php echo t('Displayed Screen Pixels: ') . h($displayedWidth) . ' x ' . h($displayedHeight); ?>
                                 </div>
                             </a>
                         </li>


### PR DESCRIPTION
Add Device Screen Pixels, Screen Pixel Ratio, and Displayed Screen Pixels information to Mobile Device Preview items.

This pull request was based on a discussion in the forum.

"Also, although the iPhone 6 plus and Galaxy s5 are marked with the same screen size of 1920x1080 they don't actually have the same size so it might be better to also mention what size we're actually getting on screen. I think it's something like 340x640 for the samsung. That would be useful when trying to set breakpoints."
http://www.concrete5.org/community/forums/customizing_c5/5.7.5-release-candidate-1-now-available/#755709

**Current**

![before](https://cloud.githubusercontent.com/assets/10898145/9381771/54e1546c-4708-11e5-8240-ebfa76144c9e.png)

**Pull Request Changes**

![after](https://cloud.githubusercontent.com/assets/10898145/9381780/76147768-4708-11e5-90dd-cbc24464315d.png)