### PR TITLE
Add config option for cURL timeout, #2934

### DIFF
--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -1026,6 +1026,7 @@ return array(
         )
     ),
     'curl' => array(
-        'verifyPeer' => true
+        'verifyPeer' => true,
+        'connectionTimeout' => 5
     )
 );

--- a/web/concrete/src/File/Service/File.php
+++ b/web/concrete/src/File/Service/File.php
@@ -302,7 +302,7 @@ class File
      *
      * @return string|bool Returns false in case of failure
      */
-    public function getContents($file, $timeout = 5)
+    public function getContents($file, $timeout = null)
     {
         $url = @parse_url($file);
         if (isset($url['scheme']) && isset($url['host'])) {
@@ -321,6 +321,10 @@ class File
                             CURLOPT_PROXYUSERPWD,
                             Config::get('concrete.proxy.user') . ':' . Config::get('concrete.proxy.password'));
                     }
+                }
+
+                if ($timeout === null) {
+                    $timeout = Config::get('app.curl.connectionTimeout');
                 }
 
                 curl_setopt($curl_handle, CURLOPT_URL, $file);


### PR DESCRIPTION
Allow connection timeout to be configured with a global default for use when it is called without a second parameter from core files, Refs issue #2934