### PR TITLE
Fix localization of AM/PM

### DIFF
--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -139,7 +139,7 @@ class DateTime
             }
             $html .= '>';
             // This prints out the translation of "AM" in the current language
-            $html .= $dh->date('A', mktime(1));
+            $html .= $dh->date('A', mktime(1), 'app');
             $html .= '</option>';
             $html .= '<option value="PM" ';
             if ($timeAMPM == 'PM') {
@@ -147,7 +147,7 @@ class DateTime
             }
             $html .= '>';
             // This prints out the translation of "PM" in the current language
-            $html .= $dh->date('A', mktime(13));
+            $html .= $dh->date('A', mktime(13), 'app');
             $html .= '</option>';
             $html .= '</select>';
         }


### PR DESCRIPTION
Fix for #2922

Let's use the 'app' timezone (it's the default for PHP - it' set in [concrete/bootstrap/start.php](https://github.com/concrete5/concrete5/blob/5.7.5.1/web/concrete/bootstrap/start.php#L119))