### PR TITLE
removed hacky string replacement in form view

### DIFF
--- a/web/concrete/blocks/form/view.php
+++ b/web/concrete/blocks/form/view.php
@@ -29,7 +29,7 @@ while ($questionRow = $questionsRS->fetchRow()) {
 		$question['type'] = $questionRow['inputType'];
 	}
 
-    $question['labelFor'] = 'for="Question' . $questionRow['msqID'] . '"';
+    	$question['labelFor'] = 'for="Question' . $questionRow['msqID'] . '"';
 	
 	//Remove hardcoded style on textareas
 	if ($question['type'] == 'textarea') {

--- a/web/concrete/blocks/form/view.php
+++ b/web/concrete/blocks/form/view.php
@@ -28,21 +28,8 @@ while ($questionRow = $questionsRS->fetchRow()) {
 	} else {
 		$question['type'] = $questionRow['inputType'];
 	}
-	
-	//Construct label "for" (and misc. hackery for checkboxlist / radio lists)
-	if ($question['type'] == 'checkboxlist') {
-		$question['input'] = str_replace('<div class="checkboxPair">', '<div class="checkboxPair"><label>', $question['input']);
-		$question['input'] = str_replace("</div>\n", "</label></div>\n", $question['input']); //include linebreak in find/replace string so we don't replace the very last closing </div> (the one that closes the "checkboxList" wrapper div that's around this whole question)
-	} else if ($question['type'] == 'radios') {
-		//Put labels around each radio items (super hacky string replacement -- this might break in future versions of C5)
-		$question['input'] = str_replace('<div class="radioPair">', '<div class="radioPair"><label>', $question['input']);
-		$question['input'] = str_replace('</div>', '</label></div>', $question['input']);
-		
-		//Make radioList wrapper consistent with checkboxList wrapper
-		$question['input'] = "<div class=\"radioList\">\n{$question['input']}\n</div>\n";
-	} else {
-		$question['labelFor'] = 'for="Question' . $questionRow['msqID'] . '"';
-	}
+
+    $question['labelFor'] = 'for="Question' . $questionRow['msqID'] . '"';
 	
 	//Remove hardcoded style on textareas
 	if ($question['type'] == 'textarea') {


### PR DESCRIPTION
these string replacement broke as the commentor predicted at some point.

The lables now come from within the question['input'] which makes this code unnecessary and just leads to a stray ```</label>``` tag being output with every radio field in a form Block.