### PR TITLE
Removal of meta_keywords from SEO attribute group and Bulk SEO Updater

### DIFF
--- a/web/concrete/config/install/base/attributes.xml
+++ b/web/concrete/config/install/base/attributes.xml
@@ -125,7 +125,6 @@
         <attributeset handle="seo" name="SEO" package="" locked="0" category="collection">
             <attributekey handle="meta_title"/>
             <attributekey handle="meta_description"/>
-            <attributekey handle="meta_keywords"/>
             <attributekey handle="header_extra_content"/>
             <attributekey handle="exclude_sitemapxml"/>
         </attributeset>

--- a/web/concrete/controllers/single_page/dashboard/system/seo/bulk.php
+++ b/web/concrete/controllers/single_page/dashboard/system/seo/bulk.php
@@ -39,7 +39,6 @@ class Bulk extends DashboardPageController {
 		if (trim(htmlspecialchars($c->getCollectionDescription(), ENT_COMPAT, APP_CHARSET)) != trim($this->post('meta_description')) && $this->post('meta_description'))  {
         	$c->setAttribute('meta_description', trim($this->post('meta_description')));
 		}
-    	$c->setAttribute('meta_keywords',$this->post('meta_keywords'));
         $cHandle = $this->post('collection_handle');
         $c->update(array('cHandle'=>$cHandle));
         $c->rescanCollectionPath();
@@ -97,12 +96,6 @@ class Bulk extends DashboardPageController {
 
 		if ($req['ptID']) {
 			$pageList->filterByPageTypeID($req['ptID']);
-		}
-
-		if ($_REQUEST['noKeywords'] == 1){
-			$pageList->filter('CollectionSearchIndexAttributes.ak_meta_keywords', NULL ,'=');
-			$this->set('keywordCheck', true);
-			$parentDialogOpen = 1;
 		}
 
 		if ($_REQUEST['noDescription'] == 1){

--- a/web/concrete/single_pages/dashboard/system/seo/bulk.php
+++ b/web/concrete/single_pages/dashboard/system/seo/bulk.php
@@ -108,9 +108,6 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
                         <div class="checkbox">
                             <label> <?php echo $form->checkbox('noDescription', 1, $descCheck);  ?><?=t('No Meta Description'); ?></label>
                         </div>
-                        <div class="checkbox">
-                            <label> <?php echo $form->checkbox('noKeywords', 1, $keywordCheck);  ?><?=t('No Meta Keywords'); ?></label>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -161,10 +158,6 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
                             echo $form->textarea('meta_description', $cobj->getAttribute('meta_description') ? $cobj->getAttribute('meta_description') : $autoDesc, $descInfo);
                             echo $descInfo[style] ? '<span class="help-inline">' . t('Default value. Click to edit.') . '</span>' : '';
                             ?>
-                        </div>
-                        <div class="form-group">
-                            <label><?php echo t('Meta Keywords'); ?></label>
-                            <?php echo $form->textarea('meta_keywords', $cobj->getAttribute('meta_keywords'), array('title' => $cID)); ?>
                         </div>
                         <? if ($cobj->getCollectionID() != HOME_CID) { ?>
 
@@ -217,7 +210,6 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
                 data.cID = iterator;
                 data.meta_title = $('.ccm-seoRow-'+iterator+' input[name="meta_title"].hasChanged').val();
                 data.meta_description = $('.ccm-seoRow-'+iterator+' textarea[name="meta_description"]').val();
-                data.meta_keywords = $('.ccm-seoRow-'+iterator+' textarea[name="meta_keywords"]').val();
                 data.collection_handle = $('.ccm-seoRow-'+iterator+' input[name="collection_handle"]').val();
 
                 $.ajax({


### PR DESCRIPTION
This addresses #2951 

It doesn't remove the meta_keywords attribute (as it's used for dashboard page searching), but it simply removes it from the SEO attribute group and from the Bulk SEO Update dashboard page

If someone did still want to use the attribute for some reason (intranet, custom search engine), they can still add the attribute back to the group and use it as normal.