### PR TITLE
no http:// in canonical URL bug

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
+++ b/web/concrete/controllers/single_page/dashboard/system/seo/urls.php
@@ -88,6 +88,14 @@ RewriteRule . ' . DISPATCHER_FILENAME .' [L]
             $this->error->add($this->token->getErrorMessage());
         }
 
+        if ($this->post('canonical_url') && strpos(strtolower($this->post('canonical_url')), 'http://') !== 0) {
+            $this->error->add(t('The canonical URL provided must start with "http://".'));
+        }
+
+        if ($this->post('canonical_ssl_url') && strpos(strtolower($this->post('canonical_ssl_url')), 'https://') !== 0) {
+            $this->error->add(t('The SSL canonical URL provided must start with "https://".'));
+        }
+        
         if (!$this->error->has()) {
             $strHtText = (string) $this->getHtaccessText();
             $blnHtu = 0;


### PR DESCRIPTION
Having a canonical URL not starting with http:// breaks everything. This modification throws an error in that case. Same with SSL canonical URL and https://

Franz suggested a pull request for this problem: http://www.concrete5.org/developers/pro-accounts/community-leaders-area/community-leaders-discussion/help-canonical-url-without-http-broke-complete-site-even-backend/

Here's Franz comment: http://www.concrete5.org/developers/pro-accounts/community-leaders-area/community-leaders-discussion/help-canonical-url-without-http-broke-complete-site-even-backend/#766489