### PR TITLE
Show an alert if the database version and site version don't match

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -353,15 +353,27 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
 
     <?
     print $dh->getIntelligentSearchMenu();
-    ?>
 
-    <? if ($pageInUseBySomeoneElse) { ?>
+   	$upg = new \Permissions();
+	if (\Config::get('concrete.version') !== \Config::get('concrete.version_installed') && $upg->canUpgrade()) {
+        echo \Core::make('helper/concrete/ui')->notify(
+            array(
+                'title'   => t('Upgrade Required!'),
+                'message' => t('Your site has a required upgrade available.') .
+                    '<p>' . t('Click below to begin the upgrade.') . '</p>',
+                'type'    => 'danger',
+                'icon'    => 'exclamation',
+                'buttons' => array(sprintf('<a class="btn btn-primary" href="%s">%s</a>', URL::to('/ccm/system/upgrade'), t('Upgrade')))
+            ));
+	}
+
+   if ($pageInUseBySomeoneElse) { ?>
         <?= Loader::helper('concrete/ui')->notify(
             array(
                 'title'   => t('Editing Unavailable.'),
                 'message' => t("%s is currently editing this page.", $c->getCollectionCheckedOutUserName()),
                 'type'    => 'info',
-                'icon'    => 'exclamation-sign'
+                'icon'    => 'exclamation'
             )) ?>
     <? } else { ?>
 

--- a/web/concrete/themes/dashboard/elements/footer.php
+++ b/web/concrete/themes/dashboard/elements/footer.php
@@ -7,6 +7,20 @@ if (\Request::getInstance()->get('_ccm_dashboard_external')) {
 </div>
 
 <? Loader::element('footer_required', array('disableTrackingCode' => true)); ?>
+<?php
+$upg = new \Permissions();
+if (\Config::get('concrete.version') !== \Config::get('concrete.version_installed') && $upg->canUpgrade()) {
+    echo \Core::make('helper/concrete/ui')->notify(
+        array(
+            'title'   => t('Upgrade Required!'),
+            'message' => t('Your site has a required upgrade available.') .
+                '<p>' . t('Click below to begin the upgrade.') . '</p>',
+            'type'    => 'danger',
+            'icon'    => 'exclamation',
+            'buttons' => array(sprintf('<a class="btn btn-primary" href="%s">%s</a>', URL::to('/ccm/system/upgrade'), t('Upgrade')))
+        ));
+}
+?>
 <script type="text/javascript">
 	ConcretePanelManager.register({'overlay': false, 'identifier': 'dashboard', 'position': 'right', url: '<?=URL::to("/ccm/system/panels/dashboard")?>'});
 	ConcretePanelManager.register({'identifier': 'sitemap', 'position': 'right', url: '<?=URL::to("/ccm/system/panels/sitemap")?>'});


### PR DESCRIPTION
Fixes #2068

This is the conditional used to display the error:

```
$upg = new \Permissions();
if (\Config::get('concrete.version') !== \Config::get('concrete.version_installed') && $upg->canUpgrade()) {
```

Should be pretty safe.
![image](https://cloud.githubusercontent.com/assets/212649/9670636/64f6fa9c-525b-11e5-9482-e3c6fe9ef8ea.png)
