### PR TITLE
Check overrides on menu items directories

### DIFF
--- a/web/concrete/src/Foundation/Environment.php
+++ b/web/concrete/src/Foundation/Environment.php
@@ -93,6 +93,7 @@ class Environment
             DIR_APPLICATION.'/'.DIRNAME_PAGE_TEMPLATES,
             DIR_APPLICATION.'/'.DIRNAME_VIEWS,
             DIR_APPLICATION.'/'.DIRNAME_CLASSES,
+            DIR_APPLICATION.'/'.DIRNAME_MENU_ITEMS,
         );
         foreach ($check as $loc) {
             if (is_dir($loc)) {


### PR DESCRIPTION
We can add view.js/view.css to menu items, but `Environment` class doesn't check menu items directories.