### PR TITLE
Handle EditModeBlockMove event, show Approval Button

### DIFF
--- a/web/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/web/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -168,6 +168,11 @@ if ($controller->getTask() == 'view_details') {
                 });
             });
 
+            ConcreteEvent.on('EditModeBlockMove', function(event, data) {
+                showApprovalButton();
+                Concrete.getEditMode().scanBlocks();
+            });
+
             $('a[data-dialog=delete-stack]').on('click', function() {
                 jQuery.fn.dialog.open({
                     element: '#ccm-dialog-delete-stack',


### PR DESCRIPTION
dashboard/blocks/stacks
EditModeBlockMove event handler seems to be missing.
With this, the Approve button will show when blocks were moved.