### PR TITLE
Updated Pagelist so that it allows the user to decide the instance to return

### DIFF
--- a/web/concrete/src/Page/PageList.php
+++ b/web/concrete/src/Page/PageList.php
@@ -175,12 +175,21 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
     }
 
     /**
+     * The class that will be returned by the getResult function
+     * @return string
+     */
+    public function getPageClass()
+    {
+        return '\\Concrete\\Core\\Page\\Page';
+    }
+
+    /**
      * @param $queryRow
      * @return \Concrete\Core\File\File
      */
     public function getResult($queryRow)
     {
-        $c = ConcretePage::getByID($queryRow['cID'], 'ACTIVE');
+        $c = ConcretePage::getByID($queryRow['cID'], 'ACTIVE', $this->getPageClass());
         if (is_object($c) && $this->checkPermissions($c)) {
             if ($this->pageVersionToRetrieve == self::PAGE_VERSION_RECENT) {
                 $cp = new \Permissions($c);


### PR DESCRIPTION
This allows to define your own model to return in the PageList.

In their PageList repository, users can define the class of their own Page Model to return.

Example:
```php
// application/src/Models/car.php

namespace Application\Src\Models;

use Concrete\Core\Page\Page as ConcretePage;
use Concrete\Core\User\User;
use Exception;

class Car extends ConcretePage {

    public function isPurchasedByCurrentUser() {
        if( !User::isLoggedIn() ) {
            return false;
        }
        $user = new User();
        $user->getUserID();

        return $this->isPurchasedBy( $user );
    }

    public function isPurchasedBy( User $user ) {
        throw new Exception( 'Implement relationship with user and bought cars' );
    }

}

```

```php
// application/src/Repositories/cars.php

namespace Application\Src\Repositories;

use Application\Src\Models\Car;
use Concrete\Core\Page\PageList;
use Concrete\Core\Search\StickyRequest;

class CarsRepository extends PageList {

    public function __construct( StickyRequest $req = null ) {
        parent::__construct( $req );
        $this->filterByPageTypeHandle( 'car' );
    }

    public function getPageClass() {
        return '\\Application\\Src\\Models\\Car';
    }

}

```

```php
// application/controllers/single_page/cars.php

namespace Application\Controller\SinglePage;

use Application\Src\Repositories\CarsRepository;
use Concrete\Core\Page\Controller\PageController;

class Cars extends PageController {
    protected $itemsPerPage = 6;
    /**
     * @var CarsRepository
     */
    private $cars;

    /**
     * @param \Concrete\Core\Page\Page $c
     * @param CarsRepository $cars
     */
    public function __construct(
        \Concrete\Core\Page\Page $c,
        CarsRepository $cars
    ) {
        parent::__construct( $c );
        $this->cars  = $cars;
    }

    public function view() {
        $paginator = $this->cars->getPagination();
        /** @var \Application\Src\Models\Car[] $cars **/
        $cars = $paginator->getCurrentPageResults();
        // the view can now use $someCar->isPurchasedByCurrentUser();

        $this->set( 'paginator', $paginator );
        $this->set( 'cars', $cars );

    }

}


```

Could it be useful?

The performances might be slower, since the Page::getById uses a cache key based on the class to return.
Nonetheless, I think it could be cool :D

Thanks for your time and your work!