### PR TITLE
Bug Fix: minor: members/profile page assumes User Profile enabled.

### DIFF
--- a/web/concrete/single_pages/account/messages/inbox.php
+++ b/web/concrete/single_pages/account/messages/inbox.php
@@ -19,8 +19,13 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
 			), false)?>
 
     		<div id="ccm-private-message-detail">
+			<? if (\Config::get('concrete.user.profiles_enabled')) { ?>
 				<a href="<?=$view->url('/members/profile', 'view', $msg->getMessageRelevantUserID())?>"><?=$av->outputUserAvatar($msg->getMessageRelevantUserObject())?></a>
 				<a href="<?=$view->url('/members/profile', 'view', $msg->getMessageRelevantUserID())?>"><?=$msg->getMessageRelevantUserName()?></a>
+			<? } else { ?>
+				<?=$av->outputUserAvatar($msg->getMessageRelevantUserObject())?>
+				<?=$msg->getMessageRelevantUserName()?>
+			<? } ?>
 
 				<div id="ccm-private-message-actions">
 


### PR DESCRIPTION
Current
----------
links to the members/profile all the time.

Desirable
------------
links to the members/profile when User Profile enabled.

Description
---------------
When User Profile is disabled, links to the members/profile page is useless.
Clicking these links will lead you to "PAGE NOT FOUND."
