### PR TITLE
add multilingual permissions to edit permissions

### DIFF
--- a/web/concrete/controllers/panel/detail/page/permissions.php
+++ b/web/concrete/controllers/panel/detail/page/permissions.php
@@ -101,6 +101,7 @@ class Permissions extends BackendInterfacePageController {
 				'edit_page_properties',
 				'edit_page_contents',
 				'edit_page_speed_settings',
+				'edit_page_multilingual_settings',
 				'edit_page_theme',
 				'edit_page_page_type',
 				'edit_page_template',

--- a/web/concrete/controllers/single_page/dashboard/system/permissions/site.php
+++ b/web/concrete/controllers/single_page/dashboard/system/permissions/site.php
@@ -94,6 +94,7 @@ class Site extends DashboardPageController {
 					'edit_page_properties',
 					'edit_page_contents',
 					'edit_page_speed_settings',
+					'edit_page_multilingual_settings',
 					'edit_page_theme',
 					'edit_page_page_type',
 					'edit_page_template',

--- a/web/concrete/src/Package/StartingPointPackage.php
+++ b/web/concrete/src/Package/StartingPointPackage.php
@@ -477,6 +477,7 @@ class StartingPointPackage extends BasePackage
                 'edit_page_properties',
                 'edit_page_contents',
                 'edit_page_speed_settings',
+                'edit_page_multilingual_settings',
                 'edit_page_theme',
                 'edit_page_template',
                 'edit_page_page_type',

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -562,6 +562,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $pkHandles[] = 'view_page_versions';
             $pkHandles[] = 'edit_page_properties';
             $pkHandles[] = 'edit_page_contents';
+            $pkHandles[] = 'edit_page_multilingual_settings';
             $pkHandles[] = 'approve_page_versions';
             $pkHandles[] = 'move_or_copy_page';
             $pkHandles[] = 'preview_page_as_user';


### PR DESCRIPTION
When I don't use the advanced permission mode I can only see the language switch in the toolbar when I use the admin group created by the starting point. When I create my own group I simply can't use it.

I had to add the permission keys listed in this PR. I'm not sure it's supposed to be like that, but having a way to see the language switch is pretty helpful.