### PR TITLE
fixed layout breaking on sub-pixel width of container

### DIFF
--- a/web/concrete/js/build/core/layouts.js
+++ b/web/concrete/js/build/core/layouts.js
@@ -588,7 +588,7 @@
 
         var breaks = [],
             sw = 0,
-            tw = this.$slider.width(),
+            tw = Math.floor(this.$slider.width()),
             $columns = this.$element.find('.ccm-layout-column'),
             i;
 


### PR DESCRIPTION
in case the parent container width was not an integer, the free-form
layout broke the columns into two separate rows because the width was
set too large.