### PR TITLE
activate inline datepicker parameter in attributes search method

### DIFF
--- a/web/concrete/attributes/date_time/controller.php
+++ b/web/concrete/attributes/date_time/controller.php
@@ -149,9 +149,9 @@ class Controller extends AttributeTypeController
     public function search()
     {
         $dt = Loader::helper('form/date_time');
-        $html = $dt->date($this->field('from'), $this->request('from'), false);
+        $html = $dt->date($this->field('from'), $this->request('from'), true);
         $html .= ' ' . t('to') . ' ';
-        $html .= $dt->date($this->field('to'), $this->request('to'), false);
+        $html .= $dt->date($this->field('to'), $this->request('to'), true);
         print $html;
     }
 


### PR DESCRIPTION
I've alredy posted the Issue here:
http://www.concrete5.org/developers/bugs/5-7-5-2/date-attributes-search-method-doesnt-work/

Since it's a minor code change i took the liberty of creating a PR.