### PR TITLE
Redactor Plugins Rephrase

### DIFF
--- a/web/concrete/single_pages/dashboard/system/basics/editor.php
+++ b/web/concrete/single_pages/dashboard/system/basics/editor.php
@@ -15,7 +15,7 @@
 		</div>
 	</fieldset>
 	<fieldset>
-		<p class="lead"><?=t('Redactor Plugins')?></p>
+		<p class="lead"><?=t('Editor Plugins')?></p>
 		<? foreach($plugins as $key => $plugin) { ?>
 		<div class="checkbox">
 			<label>


### PR DESCRIPTION
The Editor Plugins phrase should be generic so that if someone overrides the editor it's not incorrect