### PR TITLE
return ValueList from separate method to be able to inject custom values

### DIFF
--- a/web/concrete/src/Page/Theme/Theme.php
+++ b/web/concrete/src/Page/Theme/Theme.php
@@ -333,10 +333,9 @@ class Theme extends Object
     public function getStylesheet($stylesheet)
     {
         $stylesheet = $this->getStylesheetObject($stylesheet);
-        $style = $this->getThemeCustomStyleObject();
-        if (is_object($style)) {
-            $scl = $style->getValueList();
-            $stylesheet->setValueList($scl);
+        $styleValues = $this->getThemeCustomStyleObjectValues();
+        if (!is_null($styleValues)) {
+            $stylesheet->setValueList($styleValues);
         }
         if (!$this->isThemePreviewRequest()) {
             if (!$stylesheet->outputFileExists() || !Config::get('concrete.cache.theme_css')) {
@@ -367,6 +366,19 @@ class Theme extends Object
 
             return $o;
         }
+    }
+
+    /**
+     * Returns the value list of the custom style object if one exists.
+     * @return ValueList
+     */
+    public function getThemeCustomStyleObjectValues()
+    {
+        $style = $this->getThemeCustomStyleObject();
+        if (is_object($style)) {
+            return $style->getValueList();
+        }
+        return null;
     }
 
     public function setCustomStyleObject(


### PR DESCRIPTION
By extracting this part of the method we can easily override the result of ValueList in our page theme controller. This would offer the possibility to add custom values from our PHP code.

Creating a variable `my-color` would work with this:

```php
    public function getThemeCustomStyleObjectValues()
    {
        $valueList = parent::getThemeCustomStyleObjectValues();

        $myColor = new \Concrete\Core\StyleCustomizer\Style\Value\ColorValue('my');
        $myColor->setAlpha(0.5);
        $myColor->setRed(111);
        $myColor->setBlue(222);
        $myColor->setGreen(33);

        $valueList->addValue($myColor);

        return $valueList;
    }
```