### PR TITLE
escape selector when initializing color picker

### DIFF
--- a/web/concrete/src/Form/Service/Widget/Color.php
+++ b/web/concrete/src/Form/Service/Widget/Color.php
@@ -41,7 +41,7 @@ class Color
 
         print "<input type=\"text\" name=\"{$inputName}\" value=\"{$value}\" id=\"ccm-colorpicker-{$inputName}\" />";
         print "<script type=\"text/javascript\">";
-        print "$(function () { $('#ccm-colorpicker-{$inputName}').spectrum({$strOptions}); })";
+        print "$(function () { var colorPickerSelector = '#ccm-colorpicker-{$inputName}'.replace( /(:|\\.|\\[|\\]|,)/g, \"\\\\$1\" ); $(colorPickerSelector).spectrum({$strOptions}); })";
         print "</script>";
     }
 


### PR DESCRIPTION
when I tried to initialize a colorpicker with an attribue name `akID[234]` I don't get a colorpicker because `[` and `]`  need to be escaped.