### PR TITLE
Remove banning on failed registrations

### DIFF
--- a/web/concrete/controllers/single_page/register.php
+++ b/web/concrete/controllers/single_page/register.php
@@ -205,7 +205,6 @@ class Register extends PageController {
 					// Email to the user when he/she registered but needs approval
 					$mh = Loader::helper('mail');
 					$mh->addParameter('uEmail', $_POST['uEmail']);
-					$mh->addParameter('uHash', $uHash);
 					$mh->addParameter('site', Config::get('concrete.site'));
 					$mh->to($_POST['uEmail']);
 					$mh->load('user_register_approval_required_to_user');
@@ -229,10 +228,6 @@ class Register extends PageController {
 					$this->redirect('/register', $redirectMethod, $rcID);
 			}
 		} else {
-			$ip->logSignupRequest();
-			if ($ip->signupRequestThreshholdReached()) {
-				$ip->createIPBan();
-			}
 			$this->set('error', $e);
 		}
 	}


### PR DESCRIPTION
Prevent registration failures from causing a ban and remove undefined variable that wasn't used in mail template. For example, if you try and register and can't get your password to match or meet requirements a few times, this shouldn't be cause for a ban.