### PR TITLE
Modified the tests readme

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,20 +22,20 @@ Do __NOT__ link to a production version because it's possible that some files or
 For example
 
 	cd tests
-	phpunit tests
-    
+	phpunit
+
 Expected output is something like
 
 	PHPUnit 3.7.28 by Sebastian Bergmann.
-	
+
 	Configuration read from .../tests/phpunit.xml
-	
+
 	....................IIIIIII.IIIIIIIII..IIIIIIIII.IIIII.IIIIIIII  63 / 177 ( 35%)
 	II.IIII.IIIIIIIIIII.IIIII.IIIIIII.II....II..II.........IIIIIIII 126 / 177 ( 71%)
 	IIIIIIIIII.........................................
-	
+
 	Time: 12.2 seconds, Memory: 29.25Mb
-	
+
 	OK, but incomplete or skipped tests!
 	Tests: 177, Assertions: 457, Incomplete: 91.
 


### PR DESCRIPTION
Instead of suggesting running the whole tests folder (with the `old` tests), only suggest to run the defined test suites.