### PR TITLE
LSP fixes

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/files/attributes.php
+++ b/web/concrete/controllers/single_page/dashboard/files/attributes.php
@@ -46,7 +46,7 @@ class Attributes extends DashboardPageController {
 	public function on_start() {
 		parent::on_start();
 		$this->set('category', AttributeKeyCategory::getByHandle('file'));
-		$otypes = AttributeType::getList('file');
+		$otypes = AttributeType::getAttributeTypeList('file');
 		$types = array();
 		foreach($otypes as $at) {
 			$types[$at->getAttributeTypeID()] = $at->getAttributeTypeDisplayName();

--- a/web/concrete/controllers/single_page/dashboard/pages/attributes.php
+++ b/web/concrete/controllers/single_page/dashboard/pages/attributes.php
@@ -25,7 +25,7 @@ class Attributes extends DashboardPageController {
 	public function on_start() {
 		parent::on_start();
 		$this->set('category', AttributeKeyCategory::getByHandle('collection'));
-		$otypes = AttributeType::getList('collection');
+		$otypes = AttributeType::getAttributeTypeList('collection');
 		$types = array();
 		foreach($otypes as $at) {
 			$types[$at->getAttributeTypeID()] = $at->getAttributeTypeDisplayName();

--- a/web/concrete/controllers/single_page/dashboard/users/attributes.php
+++ b/web/concrete/controllers/single_page/dashboard/users/attributes.php
@@ -35,7 +35,7 @@ class Attributes extends DashboardPageController {
 	public function on_start() {
         parent::on_start();
         $this->set('category', AttributeKeyCategory::getByHandle('user'));
-		$otypes = AttributeType::getList('user');
+		$otypes = AttributeType::getAttributeTypeList('user');
 		$types = array();
 		foreach($otypes as $at) {
 			$types[$at->getAttributeTypeID()] = $at->getAttributeTypeDisplayName();

--- a/web/concrete/single_pages/dashboard/system/attributes/sets.php
+++ b/web/concrete/single_pages/dashboard/system/attributes/sets.php
@@ -74,7 +74,7 @@ $txt = Loader::helper('text');?>
 
                     <?php
                     $cat = AttributeKeyCategory::getByID($set->getAttributeSetKeyCategoryID());
-                    $list = AttributeKey::getList($cat->getAttributeKeyCategoryHandle());
+                    $list = AttributeKey::get($cat->getAttributeKeyCategoryHandle());
                     $unassigned = $cat->getUnassignedAttributeKeys();
                     if (count($list) > 0) { ?>
 

--- a/web/concrete/single_pages/dashboard/system/attributes/sets.php
+++ b/web/concrete/single_pages/dashboard/system/attributes/sets.php
@@ -74,7 +74,7 @@ $txt = Loader::helper('text');?>
 
                     <?php
                     $cat = AttributeKeyCategory::getByID($set->getAttributeSetKeyCategoryID());
-                    $list = AttributeKey::get($cat->getAttributeKeyCategoryHandle());
+                    $list = AttributeKey::getAttributeKeyList($cat->getAttributeKeyCategoryHandle());
                     $unassigned = $cat->getUnassignedAttributeKeys();
                     if (count($list) > 0) { ?>
 

--- a/web/concrete/single_pages/dashboard/system/attributes/types.php
+++ b/web/concrete/single_pages/dashboard/system/attributes/types.php
@@ -2,7 +2,7 @@
 use \Concrete\Core\Attribute\Type as AttributeType;
 use \Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
 use \Concrete\Core\Attribute\PendingType as PendingAttributeType;
-$types = AttributeType::getList();
+$types = AttributeType::getAttributeTypeList();
 $categories = AttributeKeyCategory::getList();
 $txt = Loader::helper('text');
 $form = Loader::helper('form');

--- a/web/concrete/src/Attribute/Key/Category.php
+++ b/web/concrete/src/Attribute/Key/Category.php
@@ -385,11 +385,12 @@ class Category extends Object
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
-        Database::connection()->executeQuery(
+        $db = Database::connection();
+        $db->executeQuery(
             'INSERT INTO AttributeKeyCategories (akCategoryHandle, akCategoryAllowSets, pkgID) values (?, ?, ?)',
             array($akCategoryHandle, $akCategoryAllowSets, $pkgID)
         );
-        $id = Database::connection()->lastInsertId();
+        $id = $db->lastInsertId();
         $txt = Core::make('helper/text');
         $prefix = ($pkgID > 0) ? $pkg->getPackageHandle() : false;
         $class = core_class('Core\\Attribute\\Key\\' . $txt->camelcase($akCategoryHandle) . 'Key', $prefix);

--- a/web/concrete/src/Attribute/Key/Category.php
+++ b/web/concrete/src/Attribute/Key/Category.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
 
 use Core;
-use \Concrete\Core\Foundation\Object;
-use \Concrete\Core\Attribute\Set as AttributeSet;
-use \Concrete\Core\Package\PackageList;
+use Concrete\Core\Foundation\Object;
+use Concrete\Core\Attribute\Set as AttributeSet;
+use Concrete\Core\Package\PackageList;
 use Database;
 
 class Category extends Object
 {
-
     protected $akCategoryID;
     protected $akCategoryHandle;
     protected $akCategoryAllowSets;
@@ -18,7 +18,6 @@ class Category extends Object
     const ASET_ALLOW_NONE = 0;
     const ASET_ALLOW_SINGLE = 1;
     const ASET_ALLOW_MULTIPLE = 2;
-
 
     /**
      * @return int The attribute category unique numeric identifier
@@ -63,6 +62,7 @@ class Category extends Object
 
     /**
      * @param int $akCategoryID
+     *
      * @return self|null Returns an AttributeKeyCategory object for the given ID or null if no category exists with that ID
      */
     public static function getByID($akCategoryID)
@@ -78,13 +78,16 @@ class Category extends Object
             /** @var self $akc */
             $akc = new static();
             $akc->setPropertiesFromArray($row);
+
             return $akc;
         }
+
         return null;
     }
 
     /**
      * @param string $akCategoryHandle
+     *
      * @return self|null Returns an AttributeKeyCategory object for the given category handle or null if no category exists with that handle
      */
     public static function getByHandle($akCategoryHandle)
@@ -100,18 +103,22 @@ class Category extends Object
             /** @var self $akc */
             $akc = new static();
             $akc->setPropertiesFromArray($row);
+
             return $akc;
         }
+
         return null;
     }
 
     /**
      * @param string $akHandle
+     *
      * @return bool Returns true if the handle already is in use for the category, false if is not yet in use
      */
     public function handleExists($akHandle)
     {
         $db = Database::connection();
+
         return $db->fetchColumn(
             'select count(akID) from AttributeKeys where akHandle = ? and akCategoryID = ?',
             array($akHandle, $this->akCategoryID)
@@ -119,7 +126,7 @@ class Category extends Object
     }
 
     /**
-     * This function appends a list of attribute categories to the supplied SimpleXMLElement node
+     * This function appends a list of attribute categories to the supplied SimpleXMLElement node.
      *
      * @param \SimpleXMLElement $xml
      */
@@ -137,6 +144,7 @@ class Category extends Object
 
     /**
      * @param string $akHandle
+     *
      * @return Key|false Returns an attribute key for the matching handle,
      * false if no key exists for the category with the given handle
      */
@@ -149,16 +157,17 @@ class Category extends Object
         $ak = call_user_func(
             array(
                 $className,
-                'getByHandle'
+                'getByHandle',
             ),
             $akHandle
         );
+
         return $ak;
     }
 
-
     /**
      * @param int $akID
+     *
      * @return Key|false Returns an attribute key for the matching ID,
      * false if no key exists for the category with the given ID
      */
@@ -171,10 +180,11 @@ class Category extends Object
         $ak = call_user_func(
             array(
                 $className,
-                'getByID'
+                'getByID',
             ),
             $akID
         );
+
         return $ak;
     }
 
@@ -194,14 +204,16 @@ class Category extends Object
             WHERE asID IS NULL AND akIsInternal = 0 AND akCategoryID = ?',
             array($this->akCategoryID)
         );
-        foreach($unassignedAttributeKeys AS $row) {
+        foreach ($unassignedAttributeKeys as $row) {
             $keys[] = $cat->getAttributeKeyByID($row['akID']);
         }
+
         return $keys;
     }
 
     /**
      * @param \Package $pkg A Concrete5 Package object
+     *
      * @return array
      */
     public static function getListByPackage($pkg)
@@ -214,14 +226,15 @@ class Category extends Object
             ORDER BY akCategoryID ASC',
             array($pkg->getPackageID())
         );
-        foreach($categories AS $cat) {
+        foreach ($categories as $cat) {
             $list[] = static::getByID($cat['akCategoryID']);
         }
+
         return $list;
     }
 
     /**
-     * This function will set the setting which determines if the category allows for sets or not
+     * This function will set the setting which determines if the category allows for sets or not.
      *
      * @param int $val This value should be one of the Category::ASET_ALLOW_* constants
      */
@@ -249,24 +262,27 @@ class Category extends Object
             array($this->akCategoryID)
         );
         $attributeSets = array();
-        foreach($sets AS $set) {
-
+        foreach ($sets as $set) {
             $attributeSets[] = AttributeSet::getByID($set['asID']);
         }
+
         return $attributeSets;
     }
-	
-	/**
-     * @param string $asHandle
-     * @return AttributeSet Returns an AttributeSet object for the current category or null if no set exists with that handle
-     */
-	public function getAttributeSetByHandle($asHandle) {
-		$attributeSet = AttributeSet::getByHandle($asHandle, $this->akCategoryID);
-		return $attributeSet;
-	}
 
     /**
-     * Sets the Attribute Key Column Headers to false for all Attribute Keys in the category
+     * @param string $asHandle
+     *
+     * @return AttributeSet Returns an AttributeSet object for the current category or null if no set exists with that handle
+     */
+    public function getAttributeSetByHandle($asHandle)
+    {
+        $attributeSet = AttributeSet::getByHandle($asHandle, $this->akCategoryID);
+
+        return $attributeSet;
+    }
+
+    /**
+     * Sets the Attribute Key Column Headers to false for all Attribute Keys in the category.
      */
     public function clearAttributeKeyCategoryColumnHeaders()
     {
@@ -279,7 +295,7 @@ class Category extends Object
     }
 
     /**
-     * Associates the given attribute type with the current attribute category
+     * Associates the given attribute type with the current attribute category.
      *
      * @param \Concrete\Core\Attribute\Type $at
      */
@@ -295,6 +311,7 @@ class Category extends Object
 
     /**
      * @param \Concrete\Core\Attribute\Type $at An attribute type object
+     *
      * @return bool True if the attribute type is associated with the current attribute category, false if not
      */
     public function hasAttributeKeyTypeAssociated($at)
@@ -305,11 +322,12 @@ class Category extends Object
             WHERE atID = ? AND akCategoryID = ?',
             array($at->getAttributeTypeID(), $this->akCategoryID)
         );
+
         return $atCount > 0;
     }
 
     /**
-     * Removes all associated attribute types from the current category
+     * Removes all associated attribute types from the current category.
      */
     public function clearAttributeKeyCategoryTypes()
     {
@@ -322,7 +340,7 @@ class Category extends Object
     /**
      * Removes the attribute category and the association records for category types. Additionally, this will
      * unset any Category Column Headers from attribute keys where these were set for this category and will rescan
-     * the set display order
+     * the set display order.
      *
      * This function will not remove attribute types or keys, only the associations to these.
      */
@@ -347,9 +365,10 @@ class Category extends Object
             'SELECT akCategoryID
             FROM AttributeKeyCategories
             ORDER BY akCategoryID ASC');
-        foreach($categoryIDs AS $catID) {
+        foreach ($categoryIDs as $catID) {
             $cats[] = static::getByID($catID['akCategoryID']);
         }
+
         return $cats;
     }
 
@@ -357,6 +376,7 @@ class Category extends Object
      * @param string $akCategoryHandle The handle string for the category
      * @param int $akCategoryAllowSets This should be an attribute Category::ASET_ALLOW_* constant
      * @param bool|\Package $pkg The package object that the category belongs to, false if it does not belong to a package
+     *
      * @return self|null Returns the category object if it was added successfully, or null if it failed to be added
      */
     public static function add($akCategoryHandle, $akCategoryAllowSets = 0, $pkg = false)
@@ -374,7 +394,7 @@ class Category extends Object
         $prefix = ($pkgID > 0) ? $pkg->getPackageHandle() : false;
         $class = core_class('Core\\Attribute\\Key\\' . $txt->camelcase($akCategoryHandle) . 'Key', $prefix);
         /** @var \Concrete\Core\Attribute\Key\Key $obj This is really a specific category key object*/
-        $obj = new $class;
+        $obj = new $class();
         $obj->createIndexedSearchTable();
 
         return static::getByID($id);
@@ -385,6 +405,7 @@ class Category extends Object
      * @param string $asName The attribute set name
      * @param bool|\Package $pkg The package object to associate the set with or false if it does not belong to a package
      * @param int $asIsLocked
+     *
      * @return null|AttributeSet Returns the AttribueSet object if it was created successfully, null if it could not be
      * created (usually due to the category not allowing sets)
      */
@@ -407,7 +428,7 @@ class Category extends Object
                     'SELECt MAX(asDisplayOrder) FROM AttributeSets WHERE akCategoryID = ?',
                     array($this->akCategoryID)
                 );
-                $asDisplayOrder++;
+                ++$asDisplayOrder;
             }
 
             $db->executeQuery(
@@ -419,8 +440,10 @@ class Category extends Object
             $id = $db->lastInsertId();
 
             $as = AttributeSet::getByID($id);
+
             return $as;
         }
+
         return null;
     }
 
@@ -439,30 +462,29 @@ class Category extends Object
             array($this->getAttributeKeyCategoryID())
         );
         $displayOrder = 0;
-        foreach($categoryAttributeSetIDs AS $setID) {
+        foreach ($categoryAttributeSetIDs as $setID) {
             $db->executeQuery(
                 'UPDATE AttributeSetKeys SET displayOrder = ? WHERE asID = ?',
                 array($displayOrder, $setID['asID'])
             );
-            $displayOrder++;
+            ++$displayOrder;
         }
     }
 
     /**
      * This takes in array of attribute set ID's and reorders those ID's starting from 0 based on the order of the
-     * array provided
+     * array provided.
      *
      * @param array $asIDs An array of Attribute Set ID's to be re-ordered starting at
      */
     public function updateAttributeSetDisplayOrder($asIDs)
     {
         $db = Database::connection();
-        for ($i = 0; $i < count($asIDs); $i++) {
+        for ($i = 0; $i < count($asIDs); ++$i) {
             $db->executeQuery(
                 "UPDATE AttributeSets SET asDisplayOrder = {$i} WHERE akCategoryID = ? AND asID = ?",
                 array($this->getAttributeKeyCategoryID(), $asIDs[$i])
             );
         }
     }
-
 }

--- a/web/concrete/src/Attribute/Key/CollectionKey.php
+++ b/web/concrete/src/Attribute/Key/CollectionKey.php
@@ -1,141 +1,157 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
+
 use Loader;
-use Package;
 use CacheLocal;
-use \Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
-use \Concrete\Core\Attribute\Value\CollectionValue as CollectionAttributeValue;
+use Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
+use Concrete\Core\Attribute\Value\CollectionValue as CollectionAttributeValue;
 
-class CollectionKey extends Key {
+class CollectionKey extends Key
+{
+    public function getIndexedSearchTable()
+    {
+        return 'CollectionSearchIndexAttributes';
+    }
 
-	public function getIndexedSearchTable() {
-		return 'CollectionSearchIndexAttributes';
-	}
-
-	protected $searchIndexFieldDefinition = array(
-		'columns' => array(
-			array('name' => 'cID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true))
-		),
-		'primary' => array('cID')
-	);
+    protected $searchIndexFieldDefinition = array(
+        'columns' => array(
+            array('name' => 'cID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true)),
+        ),
+        'primary' => array('cID'),
+    );
 
     /**
-    * Returns an attribute value list of attributes and values (duh) which a collection version can store
-    * against its object.
-    * @return AttributeValueList
-    */
-    public static function getAttributes($cID, $cvID, $method = 'getValue') {
+     * Returns an attribute value list of attributes and values (duh) which a collection version can store
+     * against its object.
+     *
+     * @return AttributeValueList
+     */
+    public static function getAttributes($cID, $cvID, $method = 'getValue')
+    {
         $db = Loader::db();
         $values = $db->GetAll("select akID, avID from CollectionAttributeValues where cID = ? and cvID = ?", array($cID, $cvID));
         $avl = new AttributeValueList();
-        foreach($values as $val) {
+        foreach ($values as $val) {
             $ak = static::getByID($val['akID']);
             if (is_object($ak)) {
                 $value = $ak->getAttributeValue($val['avID'], $method);
                 $avl->addAttributeValue($ak, $value);
             }
         }
+
         return $avl;
     }
 
-	public static function getColumnHeaderList() {
-		return parent::getList('collection', array('akIsColumnHeader' => 1));
-	}
-	public static function getSearchableIndexedList() {
-		return parent::getList('collection', array('akIsSearchableIndexed' => 1));
-	}
+    public static function getColumnHeaderList()
+    {
+        return parent::getList('collection', array('akIsColumnHeader' => 1));
+    }
+    public static function getSearchableIndexedList()
+    {
+        return parent::getList('collection', array('akIsSearchableIndexed' => 1));
+    }
 
-	public static function getSearchableList() {
-		return parent::getList('collection', array('akIsSearchable' => 1));
-	}
+    public static function getSearchableList()
+    {
+        return parent::getList('collection', array('akIsSearchable' => 1));
+    }
 
-	public function getAttributeValue($avID, $method = 'getValue') {
-		$av = CollectionAttributeValue::getByID($avID);
-		if (is_object($av)) {
-			$av->setAttributeKey($this);
-			$value = $av->{$method}();
-			$av->__destruct();
-			unset($av);
-			return $value;
-		}
-	}
+    public function getAttributeValue($avID, $method = 'getValue')
+    {
+        $av = CollectionAttributeValue::getByID($avID);
+        if (is_object($av)) {
+            $av->setAttributeKey($this);
+            $value = $av->{$method}();
+            $av->__destruct();
+            unset($av);
 
-	public static function getByID($akID) {
-		$ak = new static();
-		$ak->load($akID);
-		if ($ak->getAttributeKeyID() > 0) {
-			return $ak;
-		}
-	}
+            return $value;
+        }
+    }
 
-	public static function getByHandle($akHandle) {
-		$ak = CacheLocal::getEntry('collection_attribute_key_by_handle', $akHandle);
-		if (is_object($ak)) {
-			return $ak;
-		} else if ($ak == -1) {
-			return false;
-		}
+    public static function getByID($akID)
+    {
+        $ak = new static();
+        $ak->load($akID);
+        if ($ak->getAttributeKeyID() > 0) {
+            return $ak;
+        }
+    }
 
-		$ak = new static();
-		$ak->load($akHandle, 'akHandle');
-		if ($ak->getAttributeKeyID() < 1) {
-			$ak = -1;
-		}
+    public static function getByHandle($akHandle)
+    {
+        $ak = CacheLocal::getEntry('collection_attribute_key_by_handle', $akHandle);
+        if (is_object($ak)) {
+            return $ak;
+        } elseif ($ak == -1) {
+            return false;
+        }
 
-		CacheLocal::set('collection_attribute_key_by_handle', $akHandle, $ak);
+        $ak = new static();
+        $ak->load($akHandle, 'akHandle');
+        if ($ak->getAttributeKeyID() < 1) {
+            $ak = -1;
+        }
 
-		if ($ak === -1) {
-			return false;
-		}
+        CacheLocal::set('collection_attribute_key_by_handle', $akHandle, $ak);
 
-		return $ak;
-	}
+        if ($ak === -1) {
+            return false;
+        }
 
-	public static function getList() {
-		return parent::getList('collection');
-	}
+        return $ak;
+    }
 
-	protected function saveAttribute($nvc, $value = false) {
-		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
-		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
-		// otherwise generate new IDs
-		$av = $nvc->getAttributeValueObject($this, true);
-		parent::saveAttribute($av, $value);
-		$db = Loader::db();
-		$v = array($nvc->getCollectionID(), $nvc->getVersionID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
-		$db->Replace('CollectionAttributeValues', array(
-			'cID' => $nvc->getCollectionID(),
-			'cvID' => $nvc->getVersionID(),
-			'akID' => $this->getAttributeKeyID(),
-			'avID' => $av->getAttributeValueID()
-		), array('cID', 'cvID', 'akID'));
-		unset($av);
-	}
+    public static function getList()
+    {
+        return parent::getList('collection');
+    }
 
-	public static function add($at, $args, $pkg = false) {
+    protected function saveAttribute($nvc, $value = false)
+    {
+        // We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
+        // is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
+        // otherwise generate new IDs
+        $av = $nvc->getAttributeValueObject($this, true);
+        parent::saveAttribute($av, $value);
+        $db = Loader::db();
+        $v = array($nvc->getCollectionID(), $nvc->getVersionID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
+        $db->Replace('CollectionAttributeValues', array(
+            'cID' => $nvc->getCollectionID(),
+            'cvID' => $nvc->getVersionID(),
+            'akID' => $this->getAttributeKeyID(),
+            'avID' => $av->getAttributeValueID(),
+        ), array('cID', 'cvID', 'akID'));
+        unset($av);
+    }
 
-		// legacy check
-		$fargs = func_get_args();
-		if (count($fargs) >= 5) {
-			$at = $fargs[4];
-			$pkg = false;
-			$args = array('akHandle' => $fargs[0], 'akName' => $fargs[1], 'akIsSearchable' => $fargs[2]);
-		}
+    public static function add($at, $args, $pkg = false)
+    {
 
-		CacheLocal::delete('collection_attribute_key_by_handle', $args['akHandle']);
+        // legacy check
+        $fargs = func_get_args();
+        if (count($fargs) >= 5) {
+            $at = $fargs[4];
+            $pkg = false;
+            $args = array('akHandle' => $fargs[0], 'akName' => $fargs[1], 'akIsSearchable' => $fargs[2]);
+        }
 
-		$ak = parent::add('collection', $at, $args, $pkg);
-		return $ak;
-	}
+        CacheLocal::delete('collection_attribute_key_by_handle', $args['akHandle']);
 
-	public function delete() {
-		parent::delete();
-		$db = Loader::db();
-		$r = $db->Execute('select avID from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-		while ($row = $r->FetchRow()) {
-			$db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
-		}
-		$db->Execute('delete from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-	}
+        $ak = parent::add('collection', $at, $args, $pkg);
 
+        return $ak;
+    }
+
+    public function delete()
+    {
+        parent::delete();
+        $db = Loader::db();
+        $r = $db->Execute('select avID from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        while ($row = $r->FetchRow()) {
+            $db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
+        }
+        $db->Execute('delete from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+    }
 }

--- a/web/concrete/src/Attribute/Key/CollectionKey.php
+++ b/web/concrete/src/Attribute/Key/CollectionKey.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Attribute\Key;
 
-use Loader;
+use Database;
 use CacheLocal;
 use Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
 use Concrete\Core\Attribute\Value\CollectionValue as CollectionAttributeValue;
@@ -29,8 +29,8 @@ class CollectionKey extends Key
      */
     public static function getAttributes($cID, $cvID, $method = 'getValue')
     {
-        $db = Loader::db();
-        $values = $db->GetAll("select akID, avID from CollectionAttributeValues where cID = ? and cvID = ?", array($cID, $cvID));
+        $db = Database::connection();
+        $values = $db->fetchAll("select akID, avID from CollectionAttributeValues where cID = ? and cvID = ?", array($cID, $cvID));
         $avl = new AttributeValueList();
         foreach ($values as $val) {
             $ak = static::getByID($val['akID']);
@@ -115,7 +115,7 @@ class CollectionKey extends Key
         // otherwise generate new IDs
         $av = $nvc->getAttributeValueObject($this, true);
         parent::saveAttribute($av, $value);
-        $db = Loader::db();
+        $db = Database::connection();
         $v = array($nvc->getCollectionID(), $nvc->getVersionID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
         $db->Replace('CollectionAttributeValues', array(
             'cID' => $nvc->getCollectionID(),
@@ -147,11 +147,11 @@ class CollectionKey extends Key
     public function delete()
     {
         parent::delete();
-        $db = Loader::db();
-        $r = $db->Execute('select avID from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        $db = Database::connection();
+        $r = $db->executeQuery('select avID from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
         while ($row = $r->FetchRow()) {
-            $db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
+            $db->executeQuery('delete from AttributeValues where avID = ?', array($row['avID']));
         }
-        $db->Execute('delete from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        $db->executeQuery('delete from CollectionAttributeValues where akID = ?', array($this->getAttributeKeyID()));
     }
 }

--- a/web/concrete/src/Attribute/Key/CollectionKey.php
+++ b/web/concrete/src/Attribute/Key/CollectionKey.php
@@ -140,7 +140,7 @@ class CollectionKey extends Key
 
         CacheLocal::delete('collection_attribute_key_by_handle', $args['akHandle']);
 
-        $ak = parent::add('collection', $at, $args, $pkg);
+        $ak = parent::addAttributeKey('collection', $at, $args, $pkg);
 
         return $ak;
     }

--- a/web/concrete/src/Attribute/Key/CollectionKey.php
+++ b/web/concrete/src/Attribute/Key/CollectionKey.php
@@ -45,16 +45,16 @@ class CollectionKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::getList('collection', array('akIsColumnHeader' => 1));
+        return parent::get('collection', array('akIsColumnHeader' => 1));
     }
     public static function getSearchableIndexedList()
     {
-        return parent::getList('collection', array('akIsSearchableIndexed' => 1));
+        return parent::get('collection', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getSearchableList()
     {
-        return parent::getList('collection', array('akIsSearchable' => 1));
+        return parent::get('collection', array('akIsSearchable' => 1));
     }
 
     public function getAttributeValue($avID, $method = 'getValue')
@@ -105,7 +105,7 @@ class CollectionKey extends Key
 
     public static function getList()
     {
-        return parent::getList('collection');
+        return parent::get('collection');
     }
 
     protected function saveAttribute($nvc, $value = false)

--- a/web/concrete/src/Attribute/Key/CollectionKey.php
+++ b/web/concrete/src/Attribute/Key/CollectionKey.php
@@ -45,16 +45,17 @@ class CollectionKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::get('collection', array('akIsColumnHeader' => 1));
+        return parent::getAttributeKeyList('collection', array('akIsColumnHeader' => 1));
     }
+
     public static function getSearchableIndexedList()
     {
-        return parent::get('collection', array('akIsSearchableIndexed' => 1));
+        return parent::getAttributeKeyList('collection', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getSearchableList()
     {
-        return parent::get('collection', array('akIsSearchable' => 1));
+        return parent::getAttributeKeyList('collection', array('akIsSearchable' => 1));
     }
 
     public function getAttributeValue($avID, $method = 'getValue')
@@ -105,7 +106,7 @@ class CollectionKey extends Key
 
     public static function getList()
     {
-        return parent::get('collection');
+        return parent::getAttributeKeyList('collection');
     }
 
     protected function saveAttribute($nvc, $value = false)

--- a/web/concrete/src/Attribute/Key/FileKey.php
+++ b/web/concrete/src/Attribute/Key/FileKey.php
@@ -1,178 +1,197 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
+
 use Loader;
-use Package;
 use CacheLocal;
-use \Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
-use \Concrete\Core\Attribute\Value\FileValue as FileAttributeValue;
-use \Concrete\Core\File\Type\TypeList as FileTypeList;
-use \Concrete\Core\Attribute\Type as AttributeType;
+use Concrete\Core\Attribute\Value\ValueList as AttributeValueList;
+use Concrete\Core\Attribute\Value\FileValue as FileAttributeValue;
+use Concrete\Core\File\Type\TypeList as FileTypeList;
+use Concrete\Core\Attribute\Type as AttributeType;
 use File;
 use FileVersion;
-class FileKey extends Key {
 
-	public function getIndexedSearchTable() {
-		return 'FileSearchIndexAttributes';
-	}
+class FileKey extends Key
+{
+    public function getIndexedSearchTable()
+    {
+        return 'FileSearchIndexAttributes';
+    }
 
-	protected $searchIndexFieldDefinition = array(
-		'columns' => array(
-			array('name' => 'fID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true))
-		),
-		'primary' => array('fID')
-	);
+    protected $searchIndexFieldDefinition = array(
+        'columns' => array(
+            array('name' => 'fID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true)),
+        ),
+        'primary' => array('fID'),
+    );
 
-	/**
-	 * Returns an attribute value list of attributes and values (duh) which a collection version can store
-	 * against its object.
-	 * @return AttributeValueList
-	 */
-	public static function getAttributes($fID, $fvID, $method = 'getValue') {
-		$db = Loader::db();
-		$values = $db->GetAll("select akID, avID from FileAttributeValues where fID = ? and fvID = ?", array($fID, $fvID));
-		$avl = new AttributeValueList();
-		foreach($values as $val) {
-			$ak = static::getByID($val['akID']);
-			if (is_object($ak)) {
-				$value = $ak->getAttributeValue($val['avID'], $method);
-				$avl->addAttributeValue($ak, $value);
-			}
-		}
-		return $avl;
-	}
+    /**
+     * Returns an attribute value list of attributes and values (duh) which a collection version can store
+     * against its object.
+     *
+     * @return AttributeValueList
+     */
+    public static function getAttributes($fID, $fvID, $method = 'getValue')
+    {
+        $db = Loader::db();
+        $values = $db->GetAll("select akID, avID from FileAttributeValues where fID = ? and fvID = ?", array($fID, $fvID));
+        $avl = new AttributeValueList();
+        foreach ($values as $val) {
+            $ak = static::getByID($val['akID']);
+            if (is_object($ak)) {
+                $value = $ak->getAttributeValue($val['avID'], $method);
+                $avl->addAttributeValue($ak, $value);
+            }
+        }
 
-	public function getAttributeValue($avID, $method = 'getValue') {
-		$av = FileAttributeValue::getByID($avID);
-		if (is_object($av)) {
-			$av->setAttributeKey($this);
-			return $av->{$method}();
-		}
-	}
+        return $avl;
+    }
 
-	public static function getByHandle($akHandle) {
-		$ak = CacheLocal::getEntry('file_attribute_key_by_handle', $akHandle);
-		if (is_object($ak)) {
-			return $ak;
-		} else if ($ak == -1) {
-			return false;
-		}
+    public function getAttributeValue($avID, $method = 'getValue')
+    {
+        $av = FileAttributeValue::getByID($avID);
+        if (is_object($av)) {
+            $av->setAttributeKey($this);
 
-		$ak = -1;
-		$db = Loader::db();
-		$q = "SELECT ak.akID FROM AttributeKeys ak INNER JOIN AttributeKeyCategories akc ON ak.akCategoryID = akc.akCategoryID  WHERE ak.akHandle = ? AND akc.akCategoryHandle = 'file'";
-		$akID = $db->GetOne($q, array($akHandle));
-		if ($akID > 0) {
-			$ak = self::getByID($akID);
-		} else {
-			 // else we check to see if it's listed in the initial registry
-			 $ia = FileTypeList::getImporterAttribute($akHandle);
-			 if (is_object($ia)) {
-			 	// we create this attribute and return it.
-			 	$at = AttributeType::getByHandle($ia->akType);
-				$args = array(
-					'akHandle' => $akHandle,
-					'akName' => $ia->akName,
-					'akIsSearchable' => 1,
-					'akIsAutoCreated' => 1,
-					'akIsEditable' => $ia->akIsEditable
-				);
-			 	$ak = static::add($at, $args);
-			 }
-		}
-		CacheLocal::set('file_attribute_key_by_handle', $akHandle, $ak);
-		if ($ak === -1) {
-			return false;
-		}
-		return $ak;
-	}
+            return $av->{$method}();
+        }
+    }
 
-	public static function getByID($akID) {
-		$ak = new static();
-		$ak->load($akID);
-		if ($ak->getAttributeKeyID() > 0) {
-			return $ak;
-		}
-	}
+    public static function getByHandle($akHandle)
+    {
+        $ak = CacheLocal::getEntry('file_attribute_key_by_handle', $akHandle);
+        if (is_object($ak)) {
+            return $ak;
+        } elseif ($ak == -1) {
+            return false;
+        }
 
+        $ak = -1;
+        $db = Loader::db();
+        $q = "SELECT ak.akID FROM AttributeKeys ak INNER JOIN AttributeKeyCategories akc ON ak.akCategoryID = akc.akCategoryID  WHERE ak.akHandle = ? AND akc.akCategoryHandle = 'file'";
+        $akID = $db->GetOne($q, array($akHandle));
+        if ($akID > 0) {
+            $ak = self::getByID($akID);
+        } else {
+            // else we check to see if it's listed in the initial registry
+             $ia = FileTypeList::getImporterAttribute($akHandle);
+            if (is_object($ia)) {
+                // we create this attribute and return it.
+                $at = AttributeType::getByHandle($ia->akType);
+                $args = array(
+                    'akHandle' => $akHandle,
+                    'akName' => $ia->akName,
+                    'akIsSearchable' => 1,
+                    'akIsAutoCreated' => 1,
+                    'akIsEditable' => $ia->akIsEditable,
+                );
+                $ak = static::add($at, $args);
+            }
+        }
+        CacheLocal::set('file_attribute_key_by_handle', $akHandle, $ak);
+        if ($ak === -1) {
+            return false;
+        }
 
-	public static function getList() {
-		return parent::getList('file');
-	}
+        return $ak;
+    }
 
-	public static function getSearchableList() {
-		return parent::getList('file', array('akIsSearchable' => 1));
-	}
-	public static function getSearchableIndexedList() {
-		return parent::getList('file', array('akIsSearchableIndexed' => 1));
-	}
+    public static function getByID($akID)
+    {
+        $ak = new static();
+        $ak->load($akID);
+        if ($ak->getAttributeKeyID() > 0) {
+            return $ak;
+        }
+    }
 
-	public static function getImporterList($fv = false) {
-		$list = parent::getList('file', array('akIsAutoCreated' => 1));
-		if ($fv == false) {
-			return $list;
-		}
-		$list2 = array();
-		$db = Loader::db();
-		foreach($list as $l) {
-			$r = $db->GetOne('select count(akID) from FileAttributeValues where fID = ? and fvID = ? and akID = ?', array($fv->getFileID(), $fv->getFileVersionID(), $l->getAttributeKeyID()));
-			if ($r > 0) {
-				$list2[] = $l;
-			}
-		}
-		return $list2;
-	}
+    public static function getList()
+    {
+        return parent::getList('file');
+    }
 
-	public static function getUserAddedList() {
-		return parent::getList('file', array('akIsAutoCreated' => 0));
-	}
+    public static function getSearchableList()
+    {
+        return parent::getList('file', array('akIsSearchable' => 1));
+    }
+    public static function getSearchableIndexedList()
+    {
+        return parent::getList('file', array('akIsSearchableIndexed' => 1));
+    }
 
-	/**
-	 * @access private
-	 */
-	public static function get($akID) {
-		return static::getByID($akID);
-	}
+    public static function getImporterList($fv = false)
+    {
+        $list = parent::getList('file', array('akIsAutoCreated' => 1));
+        if ($fv == false) {
+            return $list;
+        }
+        $list2 = array();
+        $db = Loader::db();
+        foreach ($list as $l) {
+            $r = $db->GetOne('select count(akID) from FileAttributeValues where fID = ? and fvID = ? and akID = ?', array($fv->getFileID(), $fv->getFileVersionID(), $l->getAttributeKeyID()));
+            if ($r > 0) {
+                $list2[] = $l;
+            }
+        }
 
-	protected function saveAttribute($f, $value = false) {
-		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
-		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
-		// otherwise generate new IDs
-		$av = $f->getAttributeValueObject($this, true);
-		parent::saveAttribute($av, $value);
-		$db = Loader::db();
-		$db->Replace('FileAttributeValues', array(
-			'fID' => $f->getFileID(),
-			'fvID' => $f->getFileVersionID(),
-			'akID' => $this->getAttributeKeyID(),
-			'avID' => $av->getAttributeValueID()
-		), array('fID', 'fvID', 'akID'));
-		$f->logVersionUpdate(FileVersion::UT_EXTENDED_ATTRIBUTE, $this->getAttributeKeyID());
-		$fo = $f->getFile();
-		$fo->reindex();
-		unset($av);
-		unset($fo);
-		unset($f);
-	}
+        return $list2;
+    }
 
-	public static function add($at, $args, $pkg = false) {
-		CacheLocal::delete('file_attribute_key_by_handle', $args['akHandle']);
-		$ak = parent::add('file', $at, $args, $pkg);
-		return $ak;
-	}
+    public static function getUserAddedList()
+    {
+        return parent::getList('file', array('akIsAutoCreated' => 0));
+    }
 
-	public static function getColumnHeaderList() {
-		return parent::getList('file', array('akIsColumnHeader' => 1));
-	}
+    /**
+     */
+    public static function get($akID)
+    {
+        return static::getByID($akID);
+    }
 
+    protected function saveAttribute($f, $value = false)
+    {
+        // We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
+        // is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
+        // otherwise generate new IDs
+        $av = $f->getAttributeValueObject($this, true);
+        parent::saveAttribute($av, $value);
+        $db = Loader::db();
+        $db->Replace('FileAttributeValues', array(
+            'fID' => $f->getFileID(),
+            'fvID' => $f->getFileVersionID(),
+            'akID' => $this->getAttributeKeyID(),
+            'avID' => $av->getAttributeValueID(),
+        ), array('fID', 'fvID', 'akID'));
+        $f->logVersionUpdate(FileVersion::UT_EXTENDED_ATTRIBUTE, $this->getAttributeKeyID());
+        $fo = $f->getFile();
+        $fo->reindex();
+        unset($av);
+        unset($fo);
+        unset($f);
+    }
 
-	public function delete() {
-		parent::delete();
-		$db = Loader::db();
-		$r = $db->Execute('select avID from FileAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-		while ($row = $r->FetchRow()) {
-			$db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
-		}
-		$db->Execute('delete from FileAttributeValues where akID = ?', array($this->getAttributeKeyID()));
-	}
+    public static function add($at, $args, $pkg = false)
+    {
+        CacheLocal::delete('file_attribute_key_by_handle', $args['akHandle']);
+        $ak = parent::add('file', $at, $args, $pkg);
 
+        return $ak;
+    }
+
+    public static function getColumnHeaderList()
+    {
+        return parent::getList('file', array('akIsColumnHeader' => 1));
+    }
+
+    public function delete()
+    {
+        parent::delete();
+        $db = Loader::db();
+        $r = $db->Execute('select avID from FileAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        while ($row = $r->FetchRow()) {
+            $db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
+        }
+        $db->Execute('delete from FileAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+    }
 }

--- a/web/concrete/src/Attribute/Key/FileKey.php
+++ b/web/concrete/src/Attribute/Key/FileKey.php
@@ -107,21 +107,22 @@ class FileKey extends Key
 
     public static function getList()
     {
-        return parent::get('file');
+        return parent::getAttributeKeyList('file');
     }
 
     public static function getSearchableList()
     {
-        return parent::get('file', array('akIsSearchable' => 1));
+        return parent::getAttributeKeyList('file', array('akIsSearchable' => 1));
     }
+
     public static function getSearchableIndexedList()
     {
-        return parent::get('file', array('akIsSearchableIndexed' => 1));
+        return parent::getAttributeKeyList('file', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getImporterList($fv = false)
     {
-        $list = parent::get('file', array('akIsAutoCreated' => 1));
+        $list = parent::getAttributeKeyList('file', array('akIsAutoCreated' => 1));
         if ($fv == false) {
             return $list;
         }
@@ -139,7 +140,7 @@ class FileKey extends Key
 
     public static function getUserAddedList()
     {
-        return parent::get('file', array('akIsAutoCreated' => 0));
+        return parent::getAttributeKeyList('file', array('akIsAutoCreated' => 0));
     }
 
     /**
@@ -181,7 +182,7 @@ class FileKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::get('file', array('akIsColumnHeader' => 1));
+        return parent::getAttributeKeyList('file', array('akIsColumnHeader' => 1));
     }
 
     public function delete()

--- a/web/concrete/src/Attribute/Key/FileKey.php
+++ b/web/concrete/src/Attribute/Key/FileKey.php
@@ -107,21 +107,21 @@ class FileKey extends Key
 
     public static function getList()
     {
-        return parent::getList('file');
+        return parent::get('file');
     }
 
     public static function getSearchableList()
     {
-        return parent::getList('file', array('akIsSearchable' => 1));
+        return parent::get('file', array('akIsSearchable' => 1));
     }
     public static function getSearchableIndexedList()
     {
-        return parent::getList('file', array('akIsSearchableIndexed' => 1));
+        return parent::get('file', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getImporterList($fv = false)
     {
-        $list = parent::getList('file', array('akIsAutoCreated' => 1));
+        $list = parent::get('file', array('akIsAutoCreated' => 1));
         if ($fv == false) {
             return $list;
         }
@@ -139,7 +139,7 @@ class FileKey extends Key
 
     public static function getUserAddedList()
     {
-        return parent::getList('file', array('akIsAutoCreated' => 0));
+        return parent::get('file', array('akIsAutoCreated' => 0));
     }
 
     /**
@@ -181,7 +181,7 @@ class FileKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::getList('file', array('akIsColumnHeader' => 1));
+        return parent::get('file', array('akIsColumnHeader' => 1));
     }
 
     public function delete()

--- a/web/concrete/src/Attribute/Key/FileKey.php
+++ b/web/concrete/src/Attribute/Key/FileKey.php
@@ -175,7 +175,7 @@ class FileKey extends Key
     public static function add($at, $args, $pkg = false)
     {
         CacheLocal::delete('file_attribute_key_by_handle', $args['akHandle']);
-        $ak = parent::add('file', $at, $args, $pkg);
+        $ak = parent::addAttributeKey('file', $at, $args, $pkg);
 
         return $ak;
     }

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -21,6 +21,7 @@ use Whoops\Exception\ErrorException;
  * Base class for attribute keys.
  * 
  * @method static Key[] getList(string $akCategoryHandle, $filters = array()) Deprecated method. Use Key::getAttributeKeyList instead.
+ * @method static Key|null add(string $akCategoryHandle, AttributeType|string$type, array $args, \Concrete\Core\Package\Package|false $pkg = false) Deprecated method. Use Key::addAttributeKey instead.
  */
 class Key extends Object
 {
@@ -221,6 +222,9 @@ class Key extends Object
         if (strcasecmp($name, 'getList') === 0) {
             return call_user_func_array('self::getAttributeKeyList', $arguments);
         }
+        if (strcasecmp($name, 'add') === 0) {
+            return call_user_func_array('self::addAttributeKey', $arguments);
+        }
         trigger_error("Call to undefined method ".__CLASS__."::$name()", E_USER_ERROR);
     }
 
@@ -351,7 +355,7 @@ class Key extends Object
             array($ak['handle'], $akc->getAttributeKeyCategoryID()));
 
         if (!$akID) {
-            $akn = self::add(
+            $akn = self::addAttributeKey(
                 $akCategoryHandle,
                 $type,
                 array(
@@ -371,7 +375,7 @@ class Key extends Object
     /**
      * Adds an attribute key.
      */
-    protected static function add($akCategoryHandle, $type, $args, $pkg = false)
+    protected static function addAttributeKey($akCategoryHandle, $type, $args, $pkg = false)
     {
         $vn = Core::make('helper/validation/numbers');
         $txt = Core::make('helper/text');

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -17,6 +17,11 @@ use Concrete\Core\Package\PackageList;
 use Concrete\Core\Attribute\Value\CollectionValue;
 use Whoops\Exception\ErrorException;
 
+/**
+ * Base class for attribute keys.
+ * 
+ * @method static Key[] getList(string $akCategoryHandle, $filters = array()) Deprecated method. Use Key::getAttributeKeyList instead.
+ */
 class Key extends Object
 {
     protected $akID;
@@ -211,7 +216,7 @@ class Key extends Object
         return $this->getAttributeType();
     }
 
-    public static function __callstatic($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
         if (strcasecmp($name, 'getList') === 0) {
             return call_user_func_array('self::getAttributeKeyList', $arguments);

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -1,26 +1,25 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
 
-use \Concrete\Core\Foundation\Object;
-use \Concrete\Core\Attribute\Type as AttributeType;
-use \Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
-use \Concrete\Core\Database\Schema\Schema;
+use Concrete\Core\Foundation\Object;
+use Concrete\Core\Attribute\Type as AttributeType;
+use Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
+use Concrete\Core\Database\Schema\Schema;
 use Gettext\Translations;
 use Loader;
 use Package;
-use CacheLocal;
 use Core;
 use User;
 use Database;
 use AttributeSet;
-use \Concrete\Core\Attribute\Value\Value as AttributeValue;
-use \Concrete\Core\Package\PackageList;
+use Concrete\Core\Attribute\Value\Value as AttributeValue;
+use Concrete\Core\Package\PackageList;
 use Concrete\Core\Attribute\Value\CollectionValue;
 use Whoops\Exception\ErrorException;
 
 class Key extends Object
 {
-
     protected $akID;
 
     public function getIndexedSearchTable()
@@ -34,7 +33,7 @@ class Key extends Object
     }
 
     /**
-     * Returns the name for this attribute key
+     * Returns the name for this attribute key.
      */
     public function getAttributeKeyName()
     {
@@ -45,6 +44,7 @@ class Key extends Object
      * @param string $format = 'html'
      *    Escape the result in html format (if $format is 'html').
      *    If $format is 'text' or any other value, the display name won't be escaped.
+     *
      * @return string
      */
     public function getAttributeKeyDisplayName($format = 'html')
@@ -60,7 +60,7 @@ class Key extends Object
     }
 
     /**
-     * Returns the handle for this attribute key
+     * Returns the handle for this attribute key.
      */
     public function getAttributeKeyHandle()
     {
@@ -68,16 +68,15 @@ class Key extends Object
     }
 
     /**
-     * Deprecated. Going to be replaced by front end display name
+     * Deprecated. Going to be replaced by front end display name.
      */
     public function getAttributeKeyDisplayHandle()
     {
         return Loader::helper('text')->unhandle($this->akHandle);
     }
 
-
     /**
-     * Returns the ID for this attribute key
+     * Returns the ID for this attribute key.
      */
     public function getAttributeKeyID()
     {
@@ -90,7 +89,7 @@ class Key extends Object
     }
 
     /**
-     * Returns whether the attribute key is searchable
+     * Returns whether the attribute key is searchable.
      */
     public function isAttributeKeySearchable()
     {
@@ -98,7 +97,7 @@ class Key extends Object
     }
 
     /**
-     * Returns whether the attribute key is internal
+     * Returns whether the attribute key is internal.
      */
     public function isAttributeKeyInternal()
     {
@@ -141,11 +140,12 @@ class Key extends Object
     {
         $class = explode('\\', get_class($this));
         $start = Loader::helper('text')->uncamelcase($class[count($class) - 1]);
+
         return substr($start, 0, strpos($start, '_key'));
     }
 
     /**
-     * Loads the required attribute fields for this instantiated attribute
+     * Loads the required attribute fields for this instantiated attribute.
      */
     protected function load($akIdentifier, $loadBy = 'akID')
     {
@@ -191,7 +191,7 @@ class Key extends Object
     }
 
     /**
-     * Returns an attribute type object
+     * Returns an attribute type object.
      */
     public function getAttributeType()
     {
@@ -199,7 +199,7 @@ class Key extends Object
     }
 
     /**
-     * Returns the attribute type handle
+     * Returns the attribute type handle.
      */
     public function getAttributeTypeHandle()
     {
@@ -213,7 +213,7 @@ class Key extends Object
     }
 
     /**
-     * Returns a list of all attributes of this category
+     * Returns a list of all attributes of this category.
      */
     public static function getList($akCategoryHandle, $filters = array())
     {
@@ -348,7 +348,7 @@ class Key extends Object
                     'akIsInternal' => $akIsInternal,
                     'akIsSearchableIndexed' => $ak['indexed'],
                     'akIsAutoCreated' => 1,
-                    'akIsSearchable' => $ak['searchable']
+                    'akIsSearchable' => $ak['searchable'],
                 ),
                 $pkg
             );
@@ -361,7 +361,6 @@ class Key extends Object
      */
     protected static function add($akCategoryHandle, $type, $args, $pkg = false)
     {
-
         $vn = Loader::helper('validation/numbers');
         $txt = Loader::helper('text');
         if (!is_object($type)) {
@@ -389,7 +388,6 @@ class Key extends Object
         if (!isset($akName)) {
             throw new ErrorException('No Attribute Key name set.');
         }
-
 
         if (isset($akIsSearchable) && $akIsSearchable != 0) {
             $_akIsSearchable = 1;
@@ -422,7 +420,7 @@ class Key extends Object
             $_akIsEditable,
             $atID,
             $akCategoryID,
-            $pkgID
+            $pkgID,
         );
         $r = $db->query(
             "insert into AttributeKeys (akHandle, akName, akIsSearchable, akIsSearchableIndexed, akIsInternal, akIsAutoCreated, akIsEditable, atID, akCategoryID, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -463,7 +461,6 @@ class Key extends Object
 
     public function refreshCache()
     {
-
     }
 
     /**
@@ -530,7 +527,7 @@ class Key extends Object
     }
 
     /**
-     * Duplicates an attribute key
+     * Duplicates an attribute key.
      */
     public function duplicate($args = array())
     {
@@ -644,7 +641,7 @@ class Key extends Object
                 $fields[] = array(
                     'name' => 'ak_' . $this->akHandle,
                     'type' => $definition['type'],
-                    'options' => $definition['options']
+                    'options' => $definition['options'],
                 );
             }
         } else {
@@ -653,7 +650,7 @@ class Key extends Object
                     $fields[] = array(
                         'name' => 'ak_' . $this->akHandle . '_' . $name,
                         'type' => $column['type'],
-                        'options' => $column['options']
+                        'options' => $column['options'],
                     );
                 }
             }
@@ -693,7 +690,6 @@ class Key extends Object
         $db->Execute('delete from AttributeSetKeys where akID = ?', array($this->getAttributeKeyID()));
 
         if ($this->getIndexedSearchTable()) {
-
             $definition = $cnt->getSearchIndexFieldDefinition();
             $prefix = $this->akHandle;
             $sm = $db->getSchemaManager();
@@ -724,7 +720,6 @@ class Key extends Object
                 }
             }
         }
-
     }
 
     public function getAttributeValueIDList()
@@ -741,7 +736,7 @@ class Key extends Object
     }
 
     /**
-     * Adds a generic attribute record (with this type) to the AttributeValues table
+     * Adds a generic attribute record (with this type) to the AttributeValues table.
      */
     public function addAttributeValue()
     {
@@ -795,7 +790,7 @@ class Key extends Object
      * NOTE: this code is screwy because all code ever written that EXTENDS this code creates an attribute value object and passes it in, like
      * this code implies. But if you call this code directly it passes the object that you're messing with (Page, User, etc...) in as the $attributeValue
      * object, which is obviously not right. So we're going to do a little procedural if/then checks in this to ensure we're passing the right
-     * stuff
+     * stuff.
      *
      * @param CollectionValue|mixed $mixed
      * @param mixed $passedValue
@@ -826,11 +821,11 @@ class Key extends Object
 
     public function __destruct()
     {
-
     }
 
     /**
      * Validates the request object to see if the current request fulfills the "requirement" portion of an attribute.
+     *
      * @return bool|\Concrete\Core\Error\Error
      */
     public function validateAttributeForm()
@@ -918,7 +913,7 @@ class Key extends Object
     }
 
     /**
-     * Returns the handle for this attribute key
+     * Returns the handle for this attribute key.
      */
     public function getKeyHandle()
     {
@@ -926,7 +921,7 @@ class Key extends Object
     }
 
     /**
-     * Returns the ID for this attribute key
+     * Returns the ID for this attribute key.
      */
     public function getKeyID()
     {
@@ -942,7 +937,7 @@ class Key extends Object
             $key = static::getInstanceByID($row['akID']);
             $translations->insert('AttributeKeyName', $key->getAttributeKeyName());
         }
+
         return $translations;
     }
-
 }

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -181,7 +181,7 @@ class Key extends Object
     public static function getInstanceByID($akID)
     {
         $db = Database::connection();
-        $akCategoryID = $db->fetchColumn('select akCategoryID from AttributeKeys where akID = ?', (array)$akID);
+        $akCategoryID = $db->fetchColumn('select akCategoryID from AttributeKeys where akID = ?', (array) $akID);
         if ($akCategoryID > 0) {
             $akc = AttributeKeyCategory::getByID($akCategoryID);
 
@@ -211,10 +211,10 @@ class Key extends Object
         return $this->getAttributeType();
     }
 
-    public static function __callstatic($name , $arguments)
+    public static function __callstatic($name, $arguments)
     {
         if (strcasecmp($name, 'getList') === 0) {
-            return call_user_func_array("self::get", $arguments);
+            return call_user_func_array('self::getAttributeKeyList', $arguments);
         }
         trigger_error("Call to undefined method ".__CLASS__."::$name()", E_USER_ERROR);
     }
@@ -222,7 +222,7 @@ class Key extends Object
     /**
      * Returns a list of all attributes of this category.
      */
-    public static function get($akCategoryHandle, $filters = array())
+    public static function getAttributeKeyList($akCategoryHandle, $filters = array())
     {
         $db = Database::connection();
         $pkgHandle = $db->fetchColumn(
@@ -279,7 +279,7 @@ class Key extends Object
         $categories = AttributeKeyCategory::getList();
         $axml = $xml->addChild('attributekeys');
         foreach ($categories as $cat) {
-            $attributes = static::get($cat->getAttributeKeyCategoryHandle());
+            $attributes = static::getAttributeKeyList($cat->getAttributeKeyCategoryHandle());
             foreach ($attributes as $at) {
                 $at->export($axml);
             }
@@ -938,7 +938,7 @@ class Key extends Object
     public static function exportTranslations()
     {
         $translations = new Translations();
-        $db = \Database::get();
+        $db = Database::get();
         $r = $db->executeQuery('select akID from AttributeKeys order by akID asc', array());
         while ($row = $r->FetchRow()) {
             $key = static::getInstanceByID($row['akID']);

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -211,10 +211,18 @@ class Key extends Object
         return $this->getAttributeType();
     }
 
+    public static function __callstatic($name , $arguments)
+    {
+        if (strcasecmp($name, 'getList') === 0) {
+            return call_user_func_array("self::get", $arguments);
+        }
+        trigger_error("Call to undefined method ".__CLASS__."::$name()");
+    }
+
     /**
      * Returns a list of all attributes of this category.
      */
-    public static function getList($akCategoryHandle, $filters = array())
+    public static function get($akCategoryHandle, $filters = array())
     {
         $db = Database::connection();
         $pkgHandle = $db->fetchColumn(
@@ -271,7 +279,7 @@ class Key extends Object
         $categories = AttributeKeyCategory::getList();
         $axml = $xml->addChild('attributekeys');
         foreach ($categories as $cat) {
-            $attributes = static::getList($cat->getAttributeKeyCategoryHandle());
+            $attributes = static::get($cat->getAttributeKeyCategoryHandle());
             foreach ($attributes as $at) {
                 $at->export($axml);
             }

--- a/web/concrete/src/Attribute/Key/Key.php
+++ b/web/concrete/src/Attribute/Key/Key.php
@@ -216,7 +216,7 @@ class Key extends Object
         if (strcasecmp($name, 'getList') === 0) {
             return call_user_func_array("self::get", $arguments);
         }
-        trigger_error("Call to undefined method ".__CLASS__."::$name()");
+        trigger_error("Call to undefined method ".__CLASS__."::$name()", E_USER_ERROR);
     }
 
     /**

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -187,7 +187,7 @@ class UserKey extends Key
 
     public static function getList()
     {
-        $list = parent::get('user');
+        $list = parent::getAttributeKeyList('user');
         usort($list, function ($a, $b) {
             if ($a->getAttributeKeyDisplayOrder() == $b->getAttributeKeyDisplayOrder()) {
                 return 0;
@@ -309,27 +309,27 @@ class UserKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::get('user', array('akIsColumnHeader' => 1));
+        return parent::getAttributeKeyList('user', array('akIsColumnHeader' => 1));
     }
 
     public static function getEditableList()
     {
-        return parent::get('user', array('akIsEditable' => 1));
+        return parent::getAttributeKeyList('user', array('akIsEditable' => 1));
     }
 
     public static function getSearchableList()
     {
-        return parent::get('user', array('akIsSearchable' => 1));
+        return parent::getAttributeKeyList('user', array('akIsSearchable' => 1));
     }
 
     public static function getSearchableIndexedList()
     {
-        return parent::get('user', array('akIsSearchableIndexed' => 1));
+        return parent::getAttributeKeyList('user', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getImporterList()
     {
-        return parent::get('user', array('akIsAutoCreated' => 1));
+        return parent::getAttributeKeyList('user', array('akIsAutoCreated' => 1));
     }
 
     public static function getPublicProfileList()
@@ -394,7 +394,7 @@ class UserKey extends Key
 
     public static function getUserAddedList()
     {
-        return parent::get('user', array('akIsAutoCreated' => 0));
+        return parent::getAttributeKeyList('user', array('akIsAutoCreated' => 0));
     }
 
     public static function updateAttributesDisplayOrder($uats)

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -26,7 +26,7 @@ class UserKey extends Key
     public static function getAttributes($uID, $method = 'getValue')
     {
         $db = Database::connection();
-        $values = $db->GetAll("select avID, akID from UserAttributeValues where uID = ?", array($uID));
+        $values = $db->fetchAll("select avID, akID from UserAttributeValues where uID = ?", array($uID));
         $avl = new AttributeValueList();
         foreach ($values as $val) {
             $ak = static::getByID($val['akID']);
@@ -87,7 +87,7 @@ class UserKey extends Key
 			INNER JOIN AttributeKeyCategories akc ON ak.akCategoryID = akc.akCategoryID
 			WHERE ak.akHandle = ?
 			AND akc.akCategoryHandle = 'user'";
-        $akID = $db->GetOne($q, array($akHandle));
+        $akID = $db->fetchColumn($q, array($akHandle));
         if ($akID > 0) {
             $ak = static::getByID($akID);
         }
@@ -175,14 +175,14 @@ class UserKey extends Key
     {
         $db = Database::connection();
         $this->refreshCache();
-        $db->Execute('update UserAttributeKeys set uakIsActive = 1 where akID = ?', array($this->akID));
+        $db->executeQuery('update UserAttributeKeys set uakIsActive = 1 where akID = ?', array($this->akID));
     }
 
     public function deactivate()
     {
         $db = Database::connection();
         $this->refreshCache();
-        $db->Execute('update UserAttributeKeys set uakIsActive = 0 where akID = ?', array($this->akID));
+        $db->executeQuery('update UserAttributeKeys set uakIsActive = 0 where akID = ?', array($this->akID));
     }
 
     public static function getList()
@@ -252,13 +252,13 @@ class UserKey extends Key
         }
 
         $db = Database::connection();
-        $displayOrder = $db->GetOne('select max(displayOrder) from UserAttributeKeys');
+        $displayOrder = $db->fetchColumn('select max(displayOrder) from UserAttributeKeys');
         if (!$displayOrder) {
             $displayOrder = 0;
         }
         ++$displayOrder;
         $v = array($ak->getAttributeKeyID(), $uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $displayOrder, $uakIsActive);
-        $db->Execute('insert into UserAttributeKeys (akID, uakProfileDisplay, uakMemberListDisplay, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, displayOrder, uakIsActive) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
+        $db->executeQuery('insert into UserAttributeKeys (akID, uakProfileDisplay, uakMemberListDisplay, uakProfileEdit, uakProfileEditRequired, uakRegisterEdit, uakRegisterEditRequired, displayOrder, uakIsActive) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
 
         $nak = new static();
         $nak->load($ak->getAttributeKeyID());
@@ -292,19 +292,19 @@ class UserKey extends Key
         }
         $db = Database::connection();
         $v = array($uakProfileDisplay, $uakMemberListDisplay, $uakProfileEdit, $uakProfileEditRequired, $uakRegisterEdit, $uakRegisterEditRequired, $ak->getAttributeKeyID());
-        $db->Execute('update UserAttributeKeys set uakProfileDisplay = ?, uakMemberListDisplay = ?, uakProfileEdit= ?, uakProfileEditRequired = ?, uakRegisterEdit = ?, uakRegisterEditRequired = ? where akID = ?', $v);
+        $db->executeQuery('update UserAttributeKeys set uakProfileDisplay = ?, uakMemberListDisplay = ?, uakProfileEdit= ?, uakProfileEditRequired = ?, uakRegisterEdit = ?, uakRegisterEditRequired = ? where akID = ?', $v);
     }
 
     public function delete()
     {
         parent::delete();
         $db = Database::connection();
-        $db->Execute('delete from UserAttributeKeys where akID = ?', array($this->getAttributeKeyID()));
-        $r = $db->Execute('select avID from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        $db->executeQuery('delete from UserAttributeKeys where akID = ?', array($this->getAttributeKeyID()));
+        $r = $db->executeQuery('select avID from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
         while ($row = $r->FetchRow()) {
-            $db->Execute('delete from AttributeValues where avID = ?', array($row['avID']));
+            $db->executeQuery('delete from AttributeValues where avID = ?', array($row['avID']));
         }
-        $db->Execute('delete from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
+        $db->executeQuery('delete from UserAttributeValues where akID = ?', array($this->getAttributeKeyID()));
     }
 
     public static function getColumnHeaderList()
@@ -404,7 +404,7 @@ class UserKey extends Key
             $uak = static::getByID($uats[$i]);
             $uak->refreshCache();
             $v = array($uats[$i]);
-            $db->query("update UserAttributeKeys set displayOrder = {$i} where akID = ?", $v);
+            $db->executeQuery("update UserAttributeKeys set displayOrder = {$i} where akID = ?", $v);
         }
     }
 }

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -187,7 +187,7 @@ class UserKey extends Key
 
     public static function getList()
     {
-        $list = parent::getList('user');
+        $list = parent::get('user');
         usort($list, function ($a, $b) {
             if ($a->getAttributeKeyDisplayOrder() == $b->getAttributeKeyDisplayOrder()) {
                 return 0;
@@ -309,27 +309,27 @@ class UserKey extends Key
 
     public static function getColumnHeaderList()
     {
-        return parent::getList('user', array('akIsColumnHeader' => 1));
+        return parent::get('user', array('akIsColumnHeader' => 1));
     }
 
     public static function getEditableList()
     {
-        return parent::getList('user', array('akIsEditable' => 1));
+        return parent::get('user', array('akIsEditable' => 1));
     }
 
     public static function getSearchableList()
     {
-        return parent::getList('user', array('akIsSearchable' => 1));
+        return parent::get('user', array('akIsSearchable' => 1));
     }
 
     public static function getSearchableIndexedList()
     {
-        return parent::getList('user', array('akIsSearchableIndexed' => 1));
+        return parent::get('user', array('akIsSearchableIndexed' => 1));
     }
 
     public static function getImporterList()
     {
-        return parent::getList('user', array('akIsAutoCreated' => 1));
+        return parent::get('user', array('akIsAutoCreated' => 1));
     }
 
     public static function getPublicProfileList()
@@ -394,7 +394,7 @@ class UserKey extends Key
 
     public static function getUserAddedList()
     {
-        return parent::getList('user', array('akIsAutoCreated' => 0));
+        return parent::get('user', array('akIsAutoCreated' => 0));
     }
 
     public static function updateAttributesDisplayOrder($uats)

--- a/web/concrete/src/Attribute/Key/UserKey.php
+++ b/web/concrete/src/Attribute/Key/UserKey.php
@@ -222,7 +222,7 @@ class UserKey extends Key
     {
         CacheLocal::delete('user_attribute_key_by_handle', $args['akHandle']);
 
-        $ak = parent::add('user', $type, $args, $pkg);
+        $ak = parent::addAttributeKey('user', $type, $args, $pkg);
 
         extract($args);
 

--- a/web/concrete/src/Attribute/PendingType.php
+++ b/web/concrete/src/Attribute/PendingType.php
@@ -1,39 +1,47 @@
 <?php
+
 namespace Concrete\Core\Attribute;
-use \Concrete\Core\Foundation\Object;
+
 use Loader;
-class PendingType extends Type {
 
-	public static function getList() {
-		$db = Loader::db();
-		$atHandles = $db->GetCol("select atHandle from AttributeTypes");
+class PendingType extends Type
+{
 
-		$dh = Loader::helper('file');
-		$available = array();
-		if (is_dir(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES)) {
-			$contents = $dh->getDirectoryContents(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES);
-			foreach($contents as $atHandle) {
-				if (!in_array($atHandle, $atHandles)) {
-					$available[] = static::getByHandle($atHandle);
-				}
-			}
-		}
-		return $available;
-	}
+    public static function getList()
+    {
+        $db = Loader::db();
+        $atHandles = $db->GetCol("select atHandle from AttributeTypes");
 
-	public static function getByHandle($atHandle) {
-		$th = Loader::helper('text');
-		if (file_exists(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES . '/' .  $atHandle)) {
-			$at = new static();
-			$at->atID = 0;
-			$at->atHandle = $atHandle;
-			$at->atName = $th->unhandle($atHandle);
-			return $at;
-		}
-	}
+        $dh = Loader::helper('file');
+        $available = array();
+        if (is_dir(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES)) {
+            $contents = $dh->getDirectoryContents(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES);
+            foreach ($contents as $atHandle) {
+                if (!in_array($atHandle, $atHandles)) {
+                    $available[] = static::getByHandle($atHandle);
+                }
+            }
+        }
 
-	public function install() {
-		parent::add($this->atHandle, $this->atName);
-	}
+        return $available;
+    }
+
+    public static function getByHandle($atHandle)
+    {
+        $th = Loader::helper('text');
+        if (file_exists(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES . '/' .  $atHandle)) {
+            $at = new static();
+            $at->atID = 0;
+            $at->atHandle = $atHandle;
+            $at->atName = $th->unhandle($atHandle);
+
+            return $at;
+        }
+    }
+
+    public function install()
+    {
+        parent::add($this->atHandle, $this->atName);
+    }
 
 }

--- a/web/concrete/src/Attribute/PendingType.php
+++ b/web/concrete/src/Attribute/PendingType.php
@@ -2,14 +2,15 @@
 
 namespace Concrete\Core\Attribute;
 
-use Loader;
+use Core;
+use Database;
 
 class PendingType extends Type
 {
 
     public static function getList()
     {
-        $db = Loader::db();
+        $db = Database::connection();
         $atHandles = $db->GetCol("select atHandle from AttributeTypes");
 
         $dh = Loader::helper('file');
@@ -28,7 +29,7 @@ class PendingType extends Type
 
     public static function getByHandle($atHandle)
     {
-        $th = Loader::helper('text');
+        $th = Core::make('helper/text');
         if (file_exists(DIR_APPLICATION . '/' . DIRNAME_ATTRIBUTES . '/' .  $atHandle)) {
             $at = new static();
             $at->atID = 0;

--- a/web/concrete/src/Attribute/Type.php
+++ b/web/concrete/src/Attribute/Type.php
@@ -125,7 +125,6 @@ class Type extends Object
         if (method_exists($this->controller, 'deleteType')) {
             $this->controller->deleteType();
         }
-
         $db->Execute("delete from AttributeTypes where atID = ?", array($this->atID));
         $db->Execute("delete from AttributeTypeCategories where atID = ?", array($this->atID));
     }
@@ -169,7 +168,6 @@ class Type extends Object
 
     public static function getByHandle($atHandle)
     {
-
         // Handle legacy handles
         switch ($atHandle) {
             case 'date':

--- a/web/concrete/src/Attribute/Type.php
+++ b/web/concrete/src/Attribute/Type.php
@@ -11,6 +11,11 @@ use Environment;
 use Package;
 use Core;
 
+/**
+ * Base class for attribute types.
+ *
+ * @method static Type[] getList(string|false $akCategoryHandle) Deprecated method. Use Key::getAttributeTypeList instead.
+ */
 class Type extends Object
 {
     /** @var  \Concrete\Core\Attribute\Controller */
@@ -76,7 +81,15 @@ class Type extends Object
         unset($this->controller);
     }
 
-    public static function getList($akCategoryHandle = false)
+    public static function __callStatic($name, $arguments)
+    {
+        if (strcasecmp($name, 'getList') === 0) {
+            return call_user_func_array('self::getAttributeTypeList', $arguments);
+        }
+        trigger_error("Call to undefined method ".__CLASS__."::$name()", E_USER_ERROR);
+    }
+
+    public static function getAttributeTypeList($akCategoryHandle = false)
     {
         $db = Database::get();
         $list = array();
@@ -99,7 +112,7 @@ class Type extends Object
 
     public static function exportList($xml)
     {
-        $attribs = static::getList();
+        $attribs = static::getAttributeTypeList();
         $db = Database::get();
         $axml = $xml->addChild('attributetypes');
         foreach ($attribs as $at) {
@@ -289,7 +302,7 @@ class Type extends Object
     public static function exportTranslations()
     {
         $translations = new Translations();
-        $attribs = static::getList();
+        $attribs = static::getAttributeTypeList();
         foreach ($attribs as $type) {
             $translations->insert('AttributeTypeName', $type->getAttributeTypeName());
         }

--- a/web/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
@@ -13,7 +13,7 @@ class CollectionAttributeType extends Type
     public function getPageTypeComposerControlObjects()
     {
         $objects = array();
-        $keys = AttributeKey::getList('collection');
+        $keys = AttributeKey::get('collection');
 
         foreach ($keys as $ak) {
             $ac = new CollectionAttributeControl();


### PR DESCRIPTION
We have still a few LSP collisions (see #2714 )... What about fixing them so that concrete5 can run on the upcoming PHP 7? :wink:

Let's start with `Attribute\Key::getList`: it conlflicts with the `getList` methods implemented in the child classes (eg  `UserKey`).

With this pull request I'm suggesting to rename `Attribute\Key::getList` to `Attribute\Key::get` (someone can think of better name?), while keeping a backward compatibility by using `__callStatic`.

