### PR TITLE
Allow PageLists to be filtered by multiple select attributes

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -537,9 +537,9 @@ class Controller extends AttributeTypeController
             $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
             $qb = $list->getQueryObject();
             $qb->andWhere(
-                $qb->expr()->like($column, ':optionValue')
+	            $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
             );
-            $qb->setParameter('optionValue', "%\n" . $option->getSelectAttributeOptionValue() . "\n%");
+	        $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $option->getSelectAttributeOptionValue() . "\n%");
         }
     }
 


### PR DESCRIPTION
Fix for 
http://www.concrete5.org/developers/bugs/5-7-5-2/can-not-filter-by-more-then-one-attribute

Your contribution guidelines don't say anything about which branch I should base my fix off, or which branch to create the pull request into, so this fix was pulled from master, and my pull request is into develop. Hope that's OK - if not, let me know and I can easily create a new pull request using different branches.