### PR TITLE
Core::make() parameters must be array

### DIFF
--- a/web/concrete/src/Updater/Update.php
+++ b/web/concrete/src/Updater/Update.php
@@ -179,7 +179,7 @@ class Update
         $cms->clearCaches();
 
         $em = ORM::entityManager('core');
-        $dbm = Core::make('database/structure', $em);
+        $dbm = Core::make('database/structure', array($em));
         $dbm->destroyProxyClasses('ConcreteCore');
         $dbm->generateProxyClasses();
 


### PR DESCRIPTION
Avoids error on upgrade from 5.7.5.2 -> 5.7.5.3.