### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Try to autodetect as fallback
+* text=auto
+
+# Shorthand for text files with whitespace error config
+[attr]normalizetext   text eol=lf whitespace=trailing-space,tab-in-indent,tabwidth=4
+
+#
+# Text files
+#
+*.conf text
+*.css normalizetext
+*.json normalizetext
+*.yml normalizetext
+*.yaml normalizetext
+*.scss normalizetext
+*.sass normalizetext
+*.html normalizetext diff=html
+*.js normalizetext
+*.md normalizetext
+*.php normalizetext diff=php
+*.sql normalizetext
+*.tpl normalizetext
+*.txt normalizetext
+*.xml normalizetext
+
+#
+# Binary files
+#
+*.bz2 binary
+*.gif binary
+*.ico binary
+*.jar binary
+*.jpeg binary
+*.jpg binary
+*.otf binary
+*.png binary
+*.tar.* binary
+*.ttf binary
+*.TTF binary
+*.woff binary


### PR DESCRIPTION
Gitattributes allow to better control line endings and whitespace errors in git commits by warning about them.