### PR TITLE
Allow multiple node selection in group tree

### DIFF
--- a/web/concrete/js/build/core/groups.js
+++ b/web/concrete/js/build/core/groups.js
@@ -95,7 +95,7 @@
 					my.reloadNode(node);
 				},
                 onSelect: options.onSelect,
-				selectMode: 1,
+				selectMode: options.chooseNodeInForm === 'multiple' ? 3 : 1, // allow multi-select for checkboxes
 				checkbox: checkbox,
 				classNames: classNames,
 				minExpandLevel: options.minimumExpandLevel,


### PR DESCRIPTION
When checkboxes are enabled, allow more than one group node to be selected in the tree.

-Steve
