### PR TITLE
Fixes #3061 by moving __construct logic to on_start

### DIFF
--- a/web/concrete/blocks/survey/controller.php
+++ b/web/concrete/blocks/survey/controller.php
@@ -16,11 +16,10 @@ class Controller extends BlockController
     protected $btInterfaceHeight = "400";
     protected $btExportTables = array('btSurvey', 'btSurveyOptions', 'btSurveyResults');
 
-    public function __construct($obj = null)
+    public function on_start()
     {
         $this->cID = null;
-        $this->bID = null;
-        parent::__construct($obj);
+
         $c = Page::getCurrentPage();
 
         if (is_object($c)) {


### PR DESCRIPTION
Fix was very easy... which makes me wonder why it was built this way in the first place? Is there something I'm missing, or just an oversight?

https://drive.google.com/open?id=0BxDKN4uzSheoUzlfeXgxczlHWEU