### PR TITLE
Add print as a new service

### DIFF
--- a/web/concrete/src/Sharing/ShareThisPage/Service.php
+++ b/web/concrete/src/Sharing/ShareThisPage/Service.php
@@ -38,6 +38,8 @@ class Service extends SocialNetworkService
                     return "https://plus.google.com/share?url=$url";
                 case 'reddit':
                     return "https://www.reddit.com/submit?url={$url}";
+                case 'print':
+                    return "javascript:window.print();";
                 case 'email':
                     $body = rawurlencode(t("Check out this article on %s:\n\n%s\n%s", Config::get('concrete.site'), $c->getCollectionName(), urldecode($url)));
                     $subject = rawurlencode(t('Thought you\'d enjoy this article.'));

--- a/web/concrete/src/Sharing/ShareThisPage/ServiceList.php
+++ b/web/concrete/src/Sharing/ShareThisPage/ServiceList.php
@@ -11,6 +11,7 @@ class ServiceList
             array('reddit', 'Reddit', 'reddit'),
             array('pinterest', 'Pinterest', 'pinterest'),
             array('google_plus', 'Google Plus', 'google-plus'),
+            array('print', t('Print'), 'print'),
             array('email', 'Email', 'envelope')
         );
     }


### PR DESCRIPTION
Even though `print` is not an actual service it seems logical to have it as an option in `Share This Page` -block.