### PR TITLE
display no date in date widget for `null`

### DIFF
--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -87,7 +87,7 @@ class DateTime
                 $timeHour = 12;
             }
         }
-        if ($value === '') {
+        if ($value == '') {
             $defaultDateJs = '""';
         } else {
             $defaultDateJs = "new Date($dateYear, $dateMonth - 1, $dateDay)";
@@ -219,7 +219,7 @@ EOS;
             $timestamp = empty($_REQUEST[$field]) ? false : @strtotime($_REQUEST[$field]);
         } elseif ($value) {
             $timestamp = @strtotime($value);
-        } elseif ($value === '') {
+        } elseif ($value == '') {
             $timestamp = false;
         } else {
             // Today (in the user's timezone)


### PR DESCRIPTION
This call shows todays date:

`Loader::helper('form/date_time')->date('date', null);`

In my opinion this should display an empty field.

This happens for date/time attributes and thus makes it impossible to have a value of "no-date".