### PR TITLE
display no date in date widget for `null` - alternative

### DIFF
--- a/web/concrete/attributes/date_time/controller.php
+++ b/web/concrete/attributes/date_time/controller.php
@@ -81,11 +81,11 @@ class Controller extends AttributeTypeController
                 break;
             case 'date':
                 $this->requireAsset('jquery/ui');
-                print $dt->date($this->field('value'), $caValue);
+                print $dt->date($this->field('value'), $caValue == null ? '' : $caValue);
                 break;
             default:
                 $this->requireAsset('jquery/ui');
-                print $dt->datetime($this->field('value'), $caValue);
+                print $dt->datetime($this->field('value'), $caValue == null ? '' : $caValue);
                 break;
         }
     }


### PR DESCRIPTION
an alternative approach for https://github.com/concrete5/concrete5/pull/3119