### PR TITLE
Fix #2966

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
@@ -9,8 +9,12 @@ class DateTimeCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('date_time');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'Public Date/Time'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/date_time/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'Public Date/Time');
     }
 
     public function publishToPage(Page $c, $data, $controls)

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -10,8 +10,12 @@ class DescriptionCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('description');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'Description'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/textarea/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'Description');
     }
 
     public function publishToPage(Page $c, $data, $controls)

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -12,8 +12,12 @@ class NameCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('name');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'Page Name'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'Page Name');
     }
 
     public function publishToPage(Page $c, $data, $controls)

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
@@ -8,8 +8,12 @@ class PageTemplateCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('page_template');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'Page Template'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/select/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'Page Template');
     }
 
     public function pageTypeComposerFormControlSupportsValidation()

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
@@ -6,8 +6,12 @@ class PublishTargetCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('publish_target');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'Page Location'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/image_file/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'Page Location');
     }
 
     public function pageTypeComposerFormControlSupportsValidation()

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -9,8 +9,12 @@ class UrlSlugCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('url_slug');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'URL Slug'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'URL Slug');
     }
 
     public function publishToPage(Page $c, $data, $controls)

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
@@ -11,8 +11,12 @@ class UserCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('user');
-        $this->setPageTypeComposerControlName(tc('PageTypeComposerControlName', 'User'));
         $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+    }
+
+    public function getPageTypeComposerControlName()
+    {
+        return tc('PageTypeComposerControlName', 'User');
     }
 
     public function publishToPage(Page $c, $data, $controls)


### PR DESCRIPTION
This fixes #2966.

Instead of the `__wakeup()` approach discussed in the thread, I have instead just overridden the `getPageTypeComposerControlName()`. I think this is a better approach as this way we don't need to have the `setPageTypeComposerControlName()` in two places.

Maybe it should also be discussed if there is any reason for the `setPageTypeComposerControlName()` method in the first place. Could we perhaps deprecate that?