### PR TITLE
Enlarge textarea for tracking code

### DIFF
--- a/web/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/web/concrete/single_pages/dashboard/system/seo/codes.php
@@ -7,7 +7,7 @@
         	<div class="form-group">
         		<?=$form->label('tracking_code', t('Tracking Codes'))?>
         		<div class="input">
-        			<?=$form->textarea('tracking_code', $tracking_code, array('class' => 'xxlarge', 'rows' => 4, 'cols' => 50))?>
+        			<?=$form->textarea('tracking_code', $tracking_code, array('class' => 'xxlarge', 'rows' => 12, 'cols' => 50))?>
         			<span class="help-block"><?=t('Any HTML you paste here will be inserted at either the bottom or top of every page in your website automatically.')?></span>
         		</div>
         	</div>


### PR DESCRIPTION
Textarea for tracking codes is so small that I always resize it. Let's make it a little bigger by default.