### PR TITLE
Attribute constructor problem

### DIFF
--- a/web/concrete/src/Attribute/Controller.php
+++ b/web/concrete/src/Attribute/Controller.php
@@ -111,11 +111,13 @@ class Controller extends AbstractController
     /**
      * @param \Concrete\Core\Attribute\Type $attributeType
      */
-    public function __construct($attributeType)
+    public function __construct($attributeType = null)
     {
-        $this->identifier = $attributeType->getAttributeTypeID();
-        $this->attributeType = $attributeType;
-        $this->set('controller', $this);
+        if ($attributeType) {
+            $this->identifier = $attributeType->getAttributeTypeID();
+            $this->attributeType = $attributeType;
+            $this->set('controller', $this);
+        }
     }
 
     public function post($field = false, $defaultValue = null)


### PR DESCRIPTION
Problem:
Adding an attribute type works fine, but when using the https://www.concrete5.org/marketplace/addons/exchangecore-developer-tools/ add-on, generating symbol files, it breaks on the attribute type constructor:
![afbeelding 1](https://cloud.githubusercontent.com/assets/11035118/11318842/fcc40bae-9062-11e5-9a5b-7b74c9e8ef9f.jpg)

I know...this maybe should be addressed to the addon author, but the actual problem lies in the MetadataGenerator (Concrete\Core\Support\Symbol), I narrowed it down to line 23:
                     $class = Core::make($name);
I didn't dig any further but probably here the constructor gets called without a parameter.

I also got the same error when trying to get an ajax call to an action_handler working for an attribute.

