### PR TITLE
In `filterByAttribute` don't convert option values' special characters to…

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -601,7 +601,7 @@ class Controller extends AttributeTypeController
             $qb->andWhere(
 	            $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
             );
-	        $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $option->getSelectAttributeOptionValue() . "\n%");
+	        $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $option->getSelectAttributeOptionValue(false) . "\n%");
         }
     }
 


### PR DESCRIPTION
… HTML entities. When filtering a page list using a select attribute option with special characters (ie. &) it will always return zero results. The input will be "Foo & Bar", but the filter applied to the query will be "Foo &amp; Bar". 