### PR TITLE
encode array when exporting attribute

### DIFF
--- a/web/concrete/src/Attribute/Controller.php
+++ b/web/concrete/src/Attribute/Controller.php
@@ -67,6 +67,10 @@ class Controller extends AbstractController
             $val = (string) $val;
         }
 
+        if (is_array($val)) {
+            $val = json_encode($val);
+        }
+
         $cnode = $akv->addChild('value');
         $node = dom_import_simplexml($cnode);
         $no = $node->ownerDocument;


### PR DESCRIPTION
some attributes return an array when you call `getValue`. This ensures that the export process doesn't process. It will most likely not work when importing, but that's a problem of the attribute..