### PR TITLE
Update google map api urls

### DIFF
--- a/web/concrete/blocks/google_map/auto.js
+++ b/web/concrete/blocks/google_map/auto.js
@@ -7,7 +7,7 @@
         
         init: function () {
             if (!window.C5GMaps.isMapsPresent()) {
-                $('head').append($(unescape("%3Cscript src='https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&sensor=false&callback=window.C5GMaps.setupAutocomplete' type='text/javascript'%3E%3C/script%3E")));
+                $('head').append($(unescape("%3Cscript src='https://maps.googleapis.com/maps/api/js?libraries=places&callback=window.C5GMaps.setupAutocomplete' type='text/javascript'%3E%3C/script%3E")));
             } else {
                 window.C5GMaps.setupAutocomplete();
             }

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -57,7 +57,7 @@ class Controller extends BlockController
     {
         $this->requireAsset('javascript', 'jquery');
         $this->addFooterItem(
-            '<script async defer src="https://maps.googleapis.com/maps/api/js"></script>'
+            '<script defer src="https://maps.googleapis.com/maps/api/js"></script>'
         );
     }
 

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -57,7 +57,7 @@ class Controller extends BlockController
     {
         $this->requireAsset('javascript', 'jquery');
         $this->addFooterItem(
-            '<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>'
+            '<script async defer src="https://maps.googleapis.com/maps/api/js"></script>'
         );
     }
 


### PR DESCRIPTION
An update to use the latest google maps api url, adding defer and sticking to https. This is really just to keep it up to date.

(I'm still getting errors/warnings in the console about the api being loaded twice when editing a block, couldn't work out how to resolve that, but it doesn't actually cause issues.)