### PR TITLE
Packages handling via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Development branch
+
+## Feature Updates
+* Added two new console commands to install and remove packages (thanks mlocati)
+
+
 # 5.7.5.3
 
 ## Behavioral Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Development branch
 
 ## Feature Updates
-* Added two new console commands to install and remove packages (thanks mlocati)
+* Added new console commands to install, update and remove packages (thanks mlocati)
 
 
 # 5.7.5.3

--- a/web/concrete/src/Console/Application.php
+++ b/web/concrete/src/Console/Application.php
@@ -20,6 +20,8 @@ class Application extends \Symfony\Component\Console\Application
         $this->add(new Command\InstallCommand());
         $this->add(new Command\ClearCacheCommand());
         $this->add(new Command\GenerateIDESymbolsCommand());
+        $this->add(new Command\InstallPackageCommand());
+        $this->add(new Command\UninstallPackageCommand());
         $this->setupRestrictedCommands();
         $this->setupDoctrineCommands();
     }

--- a/web/concrete/src/Console/Application.php
+++ b/web/concrete/src/Console/Application.php
@@ -22,6 +22,7 @@ class Application extends \Symfony\Component\Console\Application
         $this->add(new Command\GenerateIDESymbolsCommand());
         $this->add(new Command\InstallPackageCommand());
         $this->add(new Command\UninstallPackageCommand());
+        $this->add(new Command\UpdatePackageCommand());
         $this->setupRestrictedCommands();
         $this->setupDoctrineCommands();
     }

--- a/web/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/web/concrete/src/Console/Command/InstallPackageCommand.php
@@ -30,13 +30,23 @@ class InstallPackageCommand extends Command
             foreach ($input->getArgument('package-options') as $keyValuePair) {
                 list($key, $value) = explode('=', $keyValuePair, 2);
                 $key = trim($key);
+                if (substr($key, -2) === '[]') {
+                    $isArray = true;
+                    $key = rtrim(substr($key, 0, -2));
+                } else {
+                    $isArray = false;
+                }
                 if ($key === '' || !isset($value)) {
                     throw new Exception(sprintf("Unable to parse the package option '%s': it must be in the form of key=value", $keyValuePair));
                 }
                 if (isset($packageOptions[$key])) {
-                    throw new Exception(sprintf("Duplicated package option '%s'", $key));
+                    if (!($isArray && is_array($packageOptions[$key]))) {
+                        throw new Exception(sprintf("Duplicated package option '%s'", $key));
+                    }
+                    $packageOptions[$key][] = $value;
+                } else {
+                    $packageOptions[$key] = $isArray ? ((array) $value) : $value;
                 }
-                $packageOptions[$key] = $value;
             }
 
             $output->write("Looking for package '$pkgHandle'... ");

--- a/web/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/web/concrete/src/Console/Command/InstallPackageCommand.php
@@ -1,0 +1,82 @@
+<?php
+namespace Concrete\Core\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Package;
+use Exception;
+
+class InstallPackageCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('c5:package-install')
+            ->addOption('full-content-swap', null, InputOption::VALUE_NONE, 'If this option is specified a full content swap will be performed (if the package supports it)')
+            ->setDescription('Install a concrete5 package')
+            ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
+            ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $pkgHandle = $input->getArgument('package');
+            $packageOptions = array();
+            foreach ($input->getArgument('package-options') as $keyValuePair) {
+                list($key, $value) = explode('=', $keyValuePair, 2);
+                $key = trim($key);
+                if ($key === '' || !isset($value)) {
+                    throw new Exception(sprintf("Unable to parse the package option '%s': it must be in the form of key=value", $keyValuePair));
+                }
+                if (isset($packageOptions[$key])) {
+                    throw new Exception(sprintf("Duplicated package option '%s'", $key));
+                }
+                $packageOptions[$key] = $value;
+            }
+
+            $output->write("Looking for package '$pkgHandle'... ");
+            foreach (Package::getInstalledList() as $installed) {
+                if ($installed->getPackageHandle() === $pkgHandle) {
+                    throw new Exception(sprintf("The package '%s' (%s) is already installed", $pkgHandle, $installed->getPackageName()));
+                }
+            }
+            $pkg = null;
+            foreach (Package::getAvailablePackages() as $available) {
+                if ($available->getPackageHandle() === $pkgHandle) {
+                    $pkg = $available;
+                    break;
+                }
+            }
+            if ($pkg === null) {
+                throw new Exception(sprintf("No package with handle '%s' was found", $pkgHandle));
+            }
+            $output->writeln(sprintf('found (%s).', $pkg->getPackageName()));
+
+            $output->write('Checking preconditions... ');
+            $test = Package::testForInstall($pkgHandle);
+            if ($test !== true) {
+                throw new Exception(implode("\n", Package::mapError($r)));
+            }
+            $output->writeln('good.');
+
+            $output->write('Installing package... ');
+            $pkgInstalled = $pkg->install($packageOptions);
+            $output->writeln('done.');
+
+            if ($pkg->allowsFullContentSwap() && $input->getOption('full-content-swap')) {
+                $output->write('Performing full content swap... ');
+                $pkg->swapContent(array());
+                $output->writeln('done.');
+            }
+        } catch (Exception $x) {
+            $output->writeln($x->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/web/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/web/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -1,0 +1,68 @@
+<?php
+namespace Concrete\Core\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Package;
+use Exception;
+
+class UninstallPackageCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('c5:package-uninstall')
+            ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
+            ->addOption('full-content-swap', null, InputOption::VALUE_NONE, 'If this option is specified a full content swap will be performed (if the package supports it)')
+            ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')
+            ->setDescription('Uninstall a concrete5 package')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $pkgHandle = $input->getArgument('package');
+
+            $output->write("Looking for package '$pkgHandle'... ");
+            $pkg = null;
+            foreach (Package::getInstalledList() as $installed) {
+                if ($installed->getPackageHandle() === $pkgHandle) {
+                    $pkg = $installed;
+                    break;
+                }
+            }
+            if ($pkg === null) {
+                throw new Exception(sprintf("No package with handle '%s' is installed", $pkgHandle));
+            }
+            $output->writeln(sprintf('found (%s).', $pkg->getPackageName()));
+
+            $output->write('Checking preconditions... ');
+            $test = $pkg->testForUninstall();
+            if ($test !== true) {
+                throw new Exception(implode("\n", Package::mapError($test)));
+            }
+            $output->writeln('good.');
+
+            $output->write('Uninstalling package... ');
+            $pkg->uninstall();
+            $output->writeln('done.');
+
+            if ($input->getOption('trash')) {
+                $output->write('Moving package to trash... ');
+                $r = $pkg->backup();
+                if (is_array($r)) {
+                    throw new Exception(implode("\n", Package::mapError($r)));
+                }
+                $output->writeln('done.');
+            }
+        } catch (Exception $x) {
+            $output->writeln($x->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/web/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/web/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Package;
@@ -14,7 +15,8 @@ class UpdatePackageCommand extends Command
     {
         $this
             ->setName('c5:package-update')
-            ->addArgument('package', InputArgument::OPTIONAL, 'The handle of the package to be updated. If omitted then all the packages will be updated')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Update all the installed packages')
+            ->addArgument('package', InputArgument::OPTIONAL, 'The handle of the package to be updated')
             ->setDescription('Update a concrete5 package')
         ;
     }
@@ -24,7 +26,10 @@ class UpdatePackageCommand extends Command
         $rc = 0;
         try {
             $pkgHandle = $input->getArgument('package');
-            if ($pkgHandle === null) {
+            if ($input->getOption('all')) {
+                if ($pkgHandle !== null) {
+                    throw new Exception('If you use the --all option you can\'t specify a package handle.');
+                }
                 $updatablePackages = Package::getLocalUpgradeablePackages();
                 if (empty($updatablePackaeges)) {
                     $output->writeln("No package needs to be updated.");
@@ -38,6 +43,8 @@ class UpdatePackageCommand extends Command
                         }
                     }
                 }
+            } elseif ($pkgHandle === null) {
+                throw new Exception('No package handle specified and the --all option has not been specified.');
             } else {
                 $this->updatePackage($pkgHandle, $output);
             }

--- a/web/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/web/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -1,0 +1,69 @@
+<?php
+namespace Concrete\Core\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Package;
+use Exception;
+
+class UpdatePackageCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('c5:package-update')
+            ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be updated')
+            ->setDescription('Update a concrete5 package')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $pkgHandle = $input->getArgument('package');
+
+            $output->write("Looking for updatable package '$pkgHandle'... ");
+            $pkg = null;
+            foreach (Package::getInstalledList() as $installed) {
+                if ($installed->getPackageHandle() === $pkgHandle) {
+                    $pkg = $installed;
+                    break;
+                }
+            }
+            if ($pkg === null) {
+                throw new Exception(sprintf("No package with handle '%s' is installed", $pkgHandle));
+            }
+            $output->writeln(sprintf('found (%s).', $pkg->getPackageName()));
+
+            $output->write('Checking preconditions... ');
+            $upPkg = null;
+            foreach (Package::getLocalUpgradeablePackages() as $updatable) {
+                if ($updatable->getPackageHandle() === $pkgHandle) {
+                    $upPkg = $updatable;
+                    break;
+                }
+            }
+            if ($upPkg === null) {
+                $output->writeln(sprintf("the package is already up-to-date (v%s)", $pkg->getPackageVersion()));
+
+                return;
+            }
+            $test = Package::testForInstall($pkgHandle, false);
+            if ($test !== true) {
+                throw new Exception(implode("\n", Package::mapError($r)));
+            }
+            $output->writeln('good.');
+
+            $output->write(sprintf('Updating from v%s to v%s...', $upPkg->getPackageCurrentlyInstalledVersion(), $upPkg->getPackageVersion()));
+            $pkg->upgradeCoreData();
+            $pkg->upgrade();
+            $output->writeln('done.');
+        } catch (Exception $x) {
+            $output->writeln($x->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -950,21 +950,25 @@ class Package extends Object
      *
      * @return array
      */
-    public function mapError($testResults)
+    public static function mapError($testResults)
     {
-        $errorText[self::E_PACKAGE_INSTALLED] = t("You've already installed that package.");
-        $errorText[self::E_PACKAGE_NOT_FOUND] = t("Invalid Package.");
-        $errorText[self::E_PACKAGE_VERSION] = t("This package requires concrete5 version %s or greater.");
-        $errorText[self::E_PACKAGE_DOWNLOAD] = t("An error occurred while downloading the package.");
-        $errorText[self::E_PACKAGE_SAVE] = t("concrete5 was not able to save the package after download.");
-        $errorText[self::E_PACKAGE_UNZIP] = t('An error occurred while trying to unzip the package.');
-        $errorText[self::E_PACKAGE_INSTALL] = t('An error occurred while trying to install the package.');
-        $errorText[self::E_PACKAGE_MIGRATE_BACKUP] = t(
-            'Unable to backup old package directory to %s',
-            \Config::get('concrete.misc.package_backup_directory')
+        $errorText = array(
+            self::E_PACKAGE_INSTALLED => t("You've already installed that package."),
+            self::E_PACKAGE_NOT_FOUND => t("Invalid Package."),
+            self::E_PACKAGE_VERSION => t("This package requires concrete5 version %s or greater."),
+            self::E_PACKAGE_DOWNLOAD => t("An error occurred while downloading the package."),
+            self::E_PACKAGE_SAVE => t("concrete5 was not able to save the package after download."),
+            self::E_PACKAGE_UNZIP => t('An error occurred while trying to unzip the package.'),
+            self::E_PACKAGE_INSTALL => t('An error occurred while trying to install the package.'),
+            self::E_PACKAGE_MIGRATE_BACKUP => t(
+                'Unable to backup old package directory to %s',
+                \Config::get('concrete.misc.package_backup_directory')
+            ),
+            self::E_PACKAGE_INVALID_APP_VERSION => t(
+                'This package isn\'t currently available for this version of concrete5. Please contact the maintainer of this package for assistance.'
+            ),
+            self::E_PACKAGE_THEME_ACTIVE => t('This package contains the active site theme, please change the theme before uninstalling.'),
         );
-        $errorText[self::E_PACKAGE_INVALID_APP_VERSION] = t(
-            'This package isn\'t currently available for this version of concrete5. Please contact the maintainer of this package for assistance.');
 
         $testResultsText = array();
         foreach ($testResults as $result) {

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -60,13 +60,12 @@ use SinglePage;
  * @property string $pkgName Installed name of package
  * @property string $pkgHandle Installed handle of package. This should be provided by the ending package.
  * @property string $pkgDescription Installed description of package
- * @property boolean $pkgIsInstalled True if package is installed
+ * @property bool $pkgIsInstalled True if package is installed
  * @property string $pkgVersion Version of package installed
  * @property string $pkgAvailableVersion
  */
 class Package extends Object
 {
-
     const E_PACKAGE_NOT_FOUND = 1;
     const E_PACKAGE_INSTALLED = 2;
     const E_PACKAGE_VERSION = 3;
@@ -104,6 +103,7 @@ class Package extends Object
     /** Returns the display name of a category of package items (localized and escaped accordingly to $format)
      * @param string $categoryHandle The category handle
      * @param string $format         = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
+     *
      * @return string
      */
     public static function getPackageItemsCategoryDisplayName($categoryHandle, $format = 'html')
@@ -180,8 +180,10 @@ class Package extends Object
     }
 
     /**
-     * Returns the name of an object belonging to a package
+     * Returns the name of an object belonging to a package.
+     *
      * @param $item
+     *
      * @return string
      */
     public static function getItemName($item)
@@ -266,9 +268,11 @@ class Package extends Object
 
     /**
      * This is the pre-test routine that packages run through before they are installed. Any errors that come here are
-     * to be returned in the form of an array so we can show the user. If it's all good we return true
+     * to be returned in the form of an array so we can show the user. If it's all good we return true.
+     *
      * @param string $package Package handle
      * @param bool $testForAlreadyInstalled
+     *
      * @return array|bool Returns an array of errors or true if the package can be installed
      */
     public static function testForInstall($package, $testForAlreadyInstalled = true)
@@ -284,23 +288,23 @@ class Package extends Object
         if ((!is_dir(DIR_PACKAGES . '/' . $package) && (!is_dir(
                     DIR_PACKAGES_CORE . '/' . $package))) || $package == ''
         ) {
-            $errors[] = Package::E_PACKAGE_NOT_FOUND;
+            $errors[] = self::E_PACKAGE_NOT_FOUND;
         } elseif ($pkg instanceof BrokenPackage) {
-            $errors[] = Package::E_PACKAGE_NOT_FOUND;
+            $errors[] = self::E_PACKAGE_NOT_FOUND;
         }
 
         // Step 2 - check to see if the user has already installed a package w/this handle
         if ($testForAlreadyInstalled) {
             $cnt = $db->getOne("SELECT count(*) FROM Packages WHERE pkgHandle = ?", array($package));
             if ($cnt > 0) {
-                $errors[] = Package::E_PACKAGE_INSTALLED;
+                $errors[] = self::E_PACKAGE_INSTALLED;
             }
         }
 
         if (count($errors) == 0) {
             // test minimum application version requirement
             if (version_compare(APP_VERSION, $pkg->getApplicationVersionRequired(), '<')) {
-                $errors[] = array(Package::E_PACKAGE_VERSION, $pkg->getApplicationVersionRequired());
+                $errors[] = array(self::E_PACKAGE_VERSION, $pkg->getApplicationVersionRequired());
             }
         }
 
@@ -312,8 +316,10 @@ class Package extends Object
     }
 
     /**
-     * Returns a package's class
+     * Returns a package's class.
+     *
      * @param string $pkgHandle Handle of package
+     *
      * @return Package
      */
     public static function getClass($pkgHandle)
@@ -341,7 +347,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the version of concrete5 required by the package
+     * Returns the version of concrete5 required by the package.
+     *
      * @return string
      */
     public function getApplicationVersionRequired()
@@ -350,9 +357,10 @@ class Package extends Object
     }
 
     /**
-     * returns a Package object for the given package handle, null if not found
+     * returns a Package object for the given package handle, null if not found.
      *
      * @param string $pkgHandle
+     *
      * @return Package
      */
     public static function getByHandle($pkgHandle)
@@ -361,7 +369,7 @@ class Package extends Object
         $row = $db->GetRow("SELECT * FROM Packages WHERE pkgHandle = ?", array($pkgHandle));
         if ($row) {
             $pkg = static::getClass($row['pkgHandle']);
-            if ($pkg instanceof Package) {
+            if ($pkg instanceof self) {
                 $pkg->setPropertiesFromArray($row);
             }
 
@@ -373,12 +381,13 @@ class Package extends Object
 
     /**
      * Returns an array of packages that have newer versions in the local packages directory
-     * than those which are in the Packages table. This means they're ready to be upgraded
+     * than those which are in the Packages table. This means they're ready to be upgraded.
+     *
      * @return Package[]
      */
     public static function getLocalUpgradeablePackages()
     {
-        $packages = Package::getAvailablePackages(false);
+        $packages = self::getAvailablePackages(false);
         $upgradeables = array();
         $db = Database::getActiveConnection();
         foreach ($packages as $p) {
@@ -397,8 +406,10 @@ class Package extends Object
     }
 
     /**
-     * Returns all available packages
+     * Returns all available packages.
+     *
      * @param bool $filterInstalled True to only return installed packages
+     *
      * @return Package[]
      */
     public static function getAvailablePackages($filterInstalled = true)
@@ -437,7 +448,8 @@ class Package extends Object
     }
 
     /**
-     * Returns all installed package handles
+     * Returns all installed package handles.
+     *
      * @return string[]
      */
     public static function getInstalledHandles()
@@ -448,12 +460,13 @@ class Package extends Object
     }
 
     /**
-     * Finds all packages that have an upgraded version available in the marketplace
+     * Finds all packages that have an upgraded version available in the marketplace.
+     *
      * @return Package[]
      */
     public static function getRemotelyUpgradeablePackages()
     {
-        $packages = Package::getInstalledList();
+        $packages = self::getInstalledList();
         $upgradeables = array();
         $db = Database::getActiveConnection();
         foreach ($packages as $p) {
@@ -466,7 +479,8 @@ class Package extends Object
     }
 
     /**
-     * Returns an array of all installed packages
+     * Returns an array of all installed packages.
+     *
      * @return Package[]
      */
     public static function getInstalledList()
@@ -475,7 +489,7 @@ class Package extends Object
         $r = $db->query("SELECT * FROM Packages WHERE pkgIsInstalled = 1 ORDER BY pkgDateInstalled ASC");
         $pkgArray = array();
         while ($row = $r->fetchRow()) {
-            $pkg = new Package();
+            $pkg = new self();
             $pkg->setPropertiesFromArray($row);
 
             $pkgArray[] = $pkg;
@@ -485,7 +499,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the path to the package's folder, relative to the install path
+     * Returns the path to the package's folder, relative to the install path.
+     *
      * @return string
      */
     public function getRelativePath()
@@ -497,7 +512,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the package handle
+     * Returns the package handle.
+     *
      * @return string
      */
     public function getPackageHandle()
@@ -506,7 +522,7 @@ class Package extends Object
     }
 
     /**
-     * Gets the date the package was added to the system,
+     * Gets the date the package was added to the system.
      *
      * @return string date formatted like: 2009-01-01 00:00:00
      */
@@ -521,8 +537,9 @@ class Package extends Object
     }
 
     /**
-     * Returns true if the package is installed, false if not
-     * @return boolean
+     * Returns true if the package is installed, false if not.
+     *
+     * @return bool
      */
     public function isPackageInstalled()
     {
@@ -531,6 +548,7 @@ class Package extends Object
 
     /**
      * Gets the contents of the package's CHANGELOG file. If no changelog is available an empty string is returned.
+     *
      * @return string
      */
     public function getChangelogContents()
@@ -556,6 +574,7 @@ class Package extends Object
     /**
      * Returns the currently installed package version.
      * NOTE: This function only returns a value if getLocalUpgradeablePackages() has been called first!
+     *
      * @return string
      */
     public function getPackageCurrentlyInstalledVersion()
@@ -572,7 +591,8 @@ class Package extends Object
     }
 
     /**
-     * Returns custom autoloader prefixes registered by the class loader
+     * Returns custom autoloader prefixes registered by the class loader.
+     *
      * @return array Keys represent the namespace, not relative to the package's namespace. Values are the path, and are relative to the package directory.
      */
     public function getPackageAutoloaderRegistries()
@@ -581,7 +601,8 @@ class Package extends Object
     }
 
     /**
-     * Returns true if the package has a post install screen
+     * Returns true if the package has a post install screen.
+     *
      * @return bool
      */
     public function hasInstallPostScreen()
@@ -591,7 +612,8 @@ class Package extends Object
     }
 
     /**
-     * Returns true if the package has an install options screen
+     * Returns true if the package has an install options screen.
+     *
      * @return bool
      */
     public function showInstallOptionsScreen()
@@ -610,7 +632,7 @@ class Package extends Object
     }
 
     /**
-     * Loads package translation files into zend translate
+     * Loads package translation files into zend translate.
      *
      * @param string                                  $locale    = null The identifier of the locale to activate (used to build the language file path). If empty we'll use currently active locale.
      * @param \Zend\I18n\Translator\Translator|string $translate = 'current' The Zend Translator instance that holds the translations (set to 'current' to use the current one)
@@ -742,7 +764,8 @@ class Package extends Object
     }
 
     /**
-     * Returns an array of package items (e.g. blocks, themes)
+     * Returns an array of package items (e.g. blocks, themes).
+     *
      * @return array
      */
     public function getPackageItems()
@@ -793,7 +816,7 @@ class Package extends Object
     /**
      * Destroys all the existing proxy classes for this package.
      *
-     * @return boolean
+     * @return bool
      */
     protected function destroyProxyClasses()
     {
@@ -802,6 +825,7 @@ class Package extends Object
         if (is_object($cache = $config->getMetadataCacheImpl())) {
             $cache->flushAll();
         }
+
         return $dbm->destroyProxyClasses('ConcretePackage' . camelcase($this->getPackageHandle()) . 'Src');
     }
 
@@ -815,6 +839,7 @@ class Package extends Object
         if (!isset($this->databaseStructureManager)) {
             $this->databaseStructureManager = Core::make('database/structure', $this->getEntityManager());
         }
+
         return $this->databaseStructureManager;
     }
 
@@ -837,7 +862,8 @@ class Package extends Object
     }
 
     /**
-     * Removes any existing pages, files, stacks, block and page types and installs content from the package
+     * Removes any existing pages, files, stacks, block and page types and installs content from the package.
+     *
      * @param $options
      */
     public function swapContent($options)
@@ -876,7 +902,6 @@ class Package extends Object
 
             // now we add in any files that this package has
             if (is_dir($this->getPackagePath() . '/content_files')) {
-
                 $ch = new ContentImporter();
                 $computeThumbnails = true;
                 if ($this->contentProvidesFileThumbnails()) {
@@ -910,7 +935,7 @@ class Package extends Object
 
     /**
      * Returns a path to where the packages files are located.
-     * @access public
+     *
      * @return string $path
      */
     public function contentProvidesFileThumbnails()
@@ -919,24 +944,26 @@ class Package extends Object
     }
 
     /**
-     * Converts package install test errors to human-readable strings
+     * Converts package install test errors to human-readable strings.
+     *
      * @param $testResults Package install test errors
+     *
      * @return array
      */
     public function mapError($testResults)
     {
-        $errorText[Package::E_PACKAGE_INSTALLED] = t("You've already installed that package.");
-        $errorText[Package::E_PACKAGE_NOT_FOUND] = t("Invalid Package.");
-        $errorText[Package::E_PACKAGE_VERSION] = t("This package requires concrete5 version %s or greater.");
-        $errorText[Package::E_PACKAGE_DOWNLOAD] = t("An error occurred while downloading the package.");
-        $errorText[Package::E_PACKAGE_SAVE] = t("concrete5 was not able to save the package after download.");
-        $errorText[Package::E_PACKAGE_UNZIP] = t('An error occurred while trying to unzip the package.');
-        $errorText[Package::E_PACKAGE_INSTALL] = t('An error occurred while trying to install the package.');
-        $errorText[Package::E_PACKAGE_MIGRATE_BACKUP] = t(
+        $errorText[self::E_PACKAGE_INSTALLED] = t("You've already installed that package.");
+        $errorText[self::E_PACKAGE_NOT_FOUND] = t("Invalid Package.");
+        $errorText[self::E_PACKAGE_VERSION] = t("This package requires concrete5 version %s or greater.");
+        $errorText[self::E_PACKAGE_DOWNLOAD] = t("An error occurred while downloading the package.");
+        $errorText[self::E_PACKAGE_SAVE] = t("concrete5 was not able to save the package after download.");
+        $errorText[self::E_PACKAGE_UNZIP] = t('An error occurred while trying to unzip the package.');
+        $errorText[self::E_PACKAGE_INSTALL] = t('An error occurred while trying to install the package.');
+        $errorText[self::E_PACKAGE_MIGRATE_BACKUP] = t(
             'Unable to backup old package directory to %s',
             \Config::get('concrete.misc.package_backup_directory')
         );
-        $errorText[Package::E_PACKAGE_INVALID_APP_VERSION] = t(
+        $errorText[self::E_PACKAGE_INVALID_APP_VERSION] = t(
             'This package isn\'t currently available for this version of concrete5. Please contact the maintainer of this package for assistance.');
 
         $testResultsText = array();
@@ -956,7 +983,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the directory containing package entities
+     * Returns the directory containing package entities.
+     *
      * @return string
      */
     public function getPackageEntitiesPath()
@@ -965,7 +993,7 @@ class Package extends Object
     }
 
     /**
-     * Called to enable package specific configuration
+     * Called to enable package specific configuration.
      */
     public function registerConfigNamespace()
     {
@@ -973,7 +1001,7 @@ class Package extends Object
     }
 
     /**
-     * Get the standard database config liaison
+     * Get the standard database config liaison.
      *
      * @return \Concrete\Core\Config\Repository\Liaison
      */
@@ -983,7 +1011,8 @@ class Package extends Object
     }
 
     /**
-     * Get the standard database config liaison
+     * Get the standard database config liaison.
+     *
      * @return \Concrete\Core\Config\Repository\Liaison
      */
     public function getDatabaseConfig()
@@ -996,7 +1025,8 @@ class Package extends Object
     }
 
     /**
-     * Get the standard filesystem config liaison
+     * Get the standard filesystem config liaison.
+     *
      * @return \Concrete\Core\Config\Repository\Liaison
      */
     public function getFileConfig()
@@ -1011,6 +1041,7 @@ class Package extends Object
     /**
      * Installs the package info row and installs the database. Packages installing additional content should override this method, call the parent method,
      * and use the resulting package object for further installs.
+     *
      * @return Package
      */
     public function install()
@@ -1024,12 +1055,12 @@ class Package extends Object
             $this->getPackageVersion(),
             $this->getPackageHandle(),
             1,
-            $dh->getOverridableNow());
+            $dh->getOverridableNow(), );
         $db->query(
             "INSERT INTO Packages (pkgName, pkgDescription, pkgVersion, pkgHandle, pkgIsInstalled, pkgDateInstalled) VALUES (?, ?, ?, ?, ?, ?)",
             $v);
 
-        $pkg = Package::getByID($db->lastInsertId());
+        $pkg = self::getByID($db->lastInsertId());
         ClassLoader::getInstance()->registerPackage($pkg);
         $pkg->installDatabase();
 
@@ -1041,7 +1072,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the translated name of the package
+     * Returns the translated name of the package.
+     *
      * @return string
      */
     public function getPackageName()
@@ -1050,7 +1082,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the translated package description
+     * Returns the translated package description.
+     *
      * @return string
      */
     public function getPackageDescription()
@@ -1059,7 +1092,8 @@ class Package extends Object
     }
 
     /**
-     * Returns the installed package version
+     * Returns the installed package version.
+     *
      * @return string
      */
     public function getPackageVersion()
@@ -1068,8 +1102,10 @@ class Package extends Object
     }
 
     /**
-     * returns a Package object for the given package id, null if not found
+     * Returns a Package object for the given package id, null if not found.
+     *
      * @param int $pkgID
+     *
      * @return Package
      */
     public static function getByID($pkgID)
@@ -1078,7 +1114,7 @@ class Package extends Object
         $row = $db->GetRow("SELECT * FROM Packages WHERE pkgID = ?", array($pkgID));
         if ($row) {
             $pkg = static::getClass($row['pkgHandle']);
-            if ($pkg instanceof Package) {
+            if ($pkg instanceof self) {
                 $pkg->setPropertiesFromArray($row);
 
                 return $pkg;
@@ -1091,14 +1127,12 @@ class Package extends Object
     /**
      * Installs the packages database through doctrine entities and db.xml
      * database definitions.
-     *
-     * @return void
      */
     public function installDatabase()
     {
         $this->installEntitiesDatabase();
 
-        Package::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB);
+        self::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB);
     }
 
     public function installEntitiesDatabase()
@@ -1112,9 +1146,12 @@ class Package extends Object
     }
 
     /**
-     * Installs a package's database from an XML file
+     * Installs a package's database from an XML file.
+     *
      * @param string $xmlFile Path to the database XML file
+     *
      * @return bool|\stdClass Returns false if the XML file could not be found
+     *
      * @throws \Doctrine\DBAL\ConnectionException
      */
     public static function installDB($xmlFile)
@@ -1136,31 +1173,33 @@ class Package extends Object
         unset($schema);
         unset($platform);
         /*
-		$schema = Database::getADOSChema();
-		$sql = $schema->ParseSchema($xmlFile);
-		$db->IgnoreErrors($handler);
-		if (!$sql) {
-			$result->message = $db->ErrorMsg();
-			return $result;
-		}
-		$r = $schema->ExecuteSchema();
-		if ($dbLayerErrorMessage != '') {
-			$result->message = $dbLayerErrorMessage;
-			return $result;
-		} if (!$r) {
-			$result->message = $db->ErrorMsg();
-			return $result;
-		}
-		$result->result = true;
-		$db->CacheFlush();
-		*/
+        $schema = Database::getADOSChema();
+        $sql = $schema->ParseSchema($xmlFile);
+        $db->IgnoreErrors($handler);
+        if (!$sql) {
+            $result->message = $db->ErrorMsg();
+            return $result;
+        }
+        $r = $schema->ExecuteSchema();
+        if ($dbLayerErrorMessage != '') {
+            $result->message = $dbLayerErrorMessage;
+            return $result;
+        } if (!$r) {
+            $result->message = $db->ErrorMsg();
+            return $result;
+        }
+        $result->result = true;
+        $db->CacheFlush();
+        */
         $result = new \stdClass();
         $result->result = false;
+
         return $result;
     }
 
     /**
-     * Updates the available package number in the database
+     * Updates the available package number in the database.
+     *
      * @param string $vNum New version number
      */
     public function updateAvailableVersionNumber($vNum)
@@ -1171,8 +1210,9 @@ class Package extends Object
     }
 
     /**
-     * Returns the package ID
-     * @return integer
+     * Returns the package ID.
+     *
+     * @return int
      */
     public function getPackageID()
     {
@@ -1180,18 +1220,18 @@ class Package extends Object
     }
 
     /**
-     * Updates a package's name, description, version and ID using the current class properties
+     * Updates a package's name, description, version and ID using the current class properties.
      */
     public function upgradeCoreData()
     {
         $db = Database::getActiveConnection();
         $p1 = static::getClass($this->getPackageHandle());
-        if ($p1 instanceof Package) {
+        if ($p1 instanceof self) {
             $v = array(
                 $p1->getPackageName(),
                 $p1->getPackageDescription(),
                 $p1->getPackageVersion(),
-                $this->getPackageID());
+                $this->getPackageID(), );
             $db->query("update Packages set pkgName = ?, pkgDescription = ?, pkgVersion = ? where pkgID = ?", $v);
         }
     }
@@ -1214,7 +1254,8 @@ class Package extends Object
     }
 
     /**
-     * Updates a package's database using entities and a db.xml
+     * Updates a package's database using entities and a db.xml.
+     *
      * @throws \Doctrine\DBAL\ConnectionException
      * @throws \Exception
      */
@@ -1261,7 +1302,7 @@ class Package extends Object
             $trashName = $trash . '/' . $this->pkgHandle . '_' . date('YmdHis');
             $ret = rename(DIR_PACKAGES . '/' . $this->pkgHandle, $trashName);
             if (!$ret) {
-                return array(Package::E_PACKAGE_MIGRATE_BACKUP);
+                return array(self::E_PACKAGE_MIGRATE_BACKUP);
             } else {
                 $this->backedUpFname = $trashName;
             }
@@ -1270,7 +1311,7 @@ class Package extends Object
 
     /**
      * if a package was just backed up by this instance of the package object and the packages/package handle directory doesn't exist, this will restore the
-     * package from the trash
+     * package from the trash.
      */
     public function restore()
     {

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -919,18 +919,28 @@ class Package extends Object
         }
     }
 
+    /**
+     * @param array $options
+     *
+     * @return bool
+     */
     protected function validateClearSiteContents($options)
     {
-        $u = new \User();
-        if ($u->isSuperUser()) {
-            // this can ONLY be used through the post. We will use the token to ensure that
-            $valt = Core::make('helper/validation/token');
-            if ($valt->validate('install_options_selected', $options['ccm_token'])) {
-                return true;
+        if (Core::make('application')->isRunThroughCommandLineInterface()) {
+            $result = true;
+        } else {
+            $result = false;
+            $u = new \User();
+            if ($u->isSuperUser()) {
+                // this can ONLY be used through the post. We will use the token to ensure that
+                $valt = Core::make('helper/validation/token');
+                if ($valt->validate('install_options_selected', $options['ccm_token'])) {
+                    $result = true;
+                }
             }
         }
 
-        return false;
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Two new commands here:

### Install a package
`c5:package-install [--full-content-swap] <packageHandle> [packageOption1=value1 [packageOption2=value2...]]`

Where:
- `--full-content-swap` enables full contents swap (if package supports it)
- `packageHandle` is the handle of the package to install
- `[packageOption1=value1 [packageOption2=value2...]]` to pass options to the package install routine

Sample session:
```
$ concrete/bin/concrete5 c5:package-install handyman
Looking for package 'handyman'... found (Handyman).
Checking preconditions... good.
Installing package... done.
```

### Uninstall a package
`c5:package-uninstall [--trash] <packageHandle>`

Where:
- `--trash` moves the package directory to the trash
- `packageHandle` is the handle of the package to uninstall

Sample session:
```
$ concrete/bin/concrete5 c5:package-uninstall handyman
Looking for package 'handyman'... found (Handyman).
Checking preconditions... good.
Uninstalling package... done.
```
