### PR TITLE
Fix #3098

### DIFF
--- a/tests/tests/Core/Package/DbXmlTest.php
+++ b/tests/tests/Core/Package/DbXmlTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Concrete\Tests\Core\Package;
+
+use Database;
+use Package;
+
+class DbXmlTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Tests that the table is properly updated according to the updated
+     * database schema XML file when the database table already exists.
+     */
+    public function testTableUpdates()
+    {
+        // The easiest way to test that the DB is updated properly is to make
+        // two consecutive calls to Package::installDB(). This is actually what
+        // the package also internally does during the install() and upgrade()
+        // calls and also what the block types do when the refresh() method is
+        // called on them. So, this should cover the actual scenarios we want
+        // to cover here.
+        $db = Database::get();
+
+        // Create the table initially.
+        Package::installDB(__DIR__ . '/fixtures/db-1.xml');
+
+        // Make sure the table was properly created and it does NOT contain the
+        // column we are about to add. We are not interested here whether the
+        // table otherwise follows the defined schema, so no need to test
+        // anything else here.
+        $schema = $db->getSchemaManager()->createSchema();
+        $this->assertTrue($schema->hasTable('TestPackageTable'));
+
+        $tbl = $schema->getTable('TestPackageTable');
+        $this->assertFalse($tbl->hasColumn('newColumn'));
+
+        // db-2.xml modifies the already existing table.
+        Package::installDB(__DIR__ . '/fixtures/db-2.xml');
+
+        // Make sure the column exists in the updated database that is added in
+        // db-2.xml. This is what we actually want to test here.
+        $schema = $db->getSchemaManager()->createSchema();
+
+        $tbl = $schema->getTable('TestPackageTable');
+        $this->assertTrue($tbl->hasColumn('newColumn'));
+    }
+
+}

--- a/tests/tests/Core/Package/DbXmlTest.php
+++ b/tests/tests/Core/Package/DbXmlTest.php
@@ -21,18 +21,22 @@ class DbXmlTest extends \PHPUnit_Framework_TestCase
         // to cover here.
         $db = Database::get();
 
+        // Make sure the DB is in the initial state
+        $schema = $db->getSchemaManager()->createSchema();
+        $this->assertFalse($schema->hasTable('TestPackageTable'));
+
         // Create the table initially.
         Package::installDB(__DIR__ . '/fixtures/db-1.xml');
 
-        // Make sure the table was properly created and it does NOT contain the
-        // column we are about to add. We are not interested here whether the
-        // table otherwise follows the defined schema, so no need to test
-        // anything else here.
+        // Make sure the table was properly created and it contains the column
+        // we are about to remove does NOT contain the column we are about to
+        // add.
         $schema = $db->getSchemaManager()->createSchema();
         $this->assertTrue($schema->hasTable('TestPackageTable'));
 
         $tbl = $schema->getTable('TestPackageTable');
         $this->assertFalse($tbl->hasColumn('newColumn'));
+        $this->assertTrue($tbl->hasColumn('testColumn'));
 
         // db-2.xml modifies the already existing table.
         Package::installDB(__DIR__ . '/fixtures/db-2.xml');

--- a/tests/tests/Core/Package/DbXmlTest.php
+++ b/tests/tests/Core/Package/DbXmlTest.php
@@ -38,11 +38,14 @@ class DbXmlTest extends \PHPUnit_Framework_TestCase
         Package::installDB(__DIR__ . '/fixtures/db-2.xml');
 
         // Make sure the column exists in the updated database that is added in
-        // db-2.xml. This is what we actually want to test here.
+        // db-2.xml. Also make sure that the column we drop in db-2.xml no
+        // longer exists in the table. This is what we actually want to test
+        // here.
         $schema = $db->getSchemaManager()->createSchema();
 
         $tbl = $schema->getTable('TestPackageTable');
         $this->assertTrue($tbl->hasColumn('newColumn'));
+        $this->assertFalse($tbl->hasColumn('testColumn'));
     }
 
 }

--- a/tests/tests/Core/Package/fixtures/db-1.xml
+++ b/tests/tests/Core/Package/fixtures/db-1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="TestPackageTable">
+    <field name="tID" type="integer" size="10">
+      <unsigned />
+      <autoincrement />
+      <key />
+    </field>
+    <field name="testColumn" type="string" size="255" />
+  </table>
+</schema>

--- a/tests/tests/Core/Package/fixtures/db-2.xml
+++ b/tests/tests/Core/Package/fixtures/db-2.xml
@@ -10,7 +10,6 @@
       <autoincrement />
       <key />
     </field>
-    <field name="testColumn" type="string" size="255" />
     <field name="newColumn" type="string" size="255" />
   </table>
 </schema>

--- a/tests/tests/Core/Package/fixtures/db-2.xml
+++ b/tests/tests/Core/Package/fixtures/db-2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+
+  <table name="TestPackageTable">
+    <field name="tID" type="integer" size="10">
+      <unsigned />
+      <autoincrement />
+      <key />
+    </field>
+    <field name="testColumn" type="string" size="255" />
+    <field name="newColumn" type="string" size="255" />
+  </table>
+</schema>


### PR DESCRIPTION
Fix #3098 by refactoring the Package class. Now all changes to the db.xml files (the package's own or its blocks') are respected if a package is re-installed (i.e. installed for a second time).

This also refactors the duplicate code in the Package class regarding installing the database through the db.xml.