### PR TITLE
Allow saving options to the generated_overrides folder

### DIFF
--- a/web/concrete/src/Config/DirectFileSaver.php
+++ b/web/concrete/src/Config/DirectFileSaver.php
@@ -2,11 +2,9 @@
 namespace Concrete\Core\Config;
 
 use Illuminate\Filesystem\Filesystem;
-use Concrete\Core\Cache\OpCache;
 
 class DirectFileSaver extends FileSaver
 {
-
     /**
      * @var string|null
      */
@@ -32,5 +30,4 @@ class DirectFileSaver extends FileSaver
             return "{$path}/{$file}";
         }
     }
-
 }

--- a/web/concrete/src/Config/FileSaver.php
+++ b/web/concrete/src/Config/FileSaver.php
@@ -6,7 +6,6 @@ use Concrete\Core\Cache\OpCache;
 
 class FileSaver implements SaverInterface
 {
-
     /**
      * The filesystem instance.
      *
@@ -92,9 +91,8 @@ class FileSaver implements SaverInterface
             " * @namespace {$ns_string}",
             " * -----------------------------------------------------------------------------",
             " */",
-            "return "
+            "return ",
         );
-
 
         $rendered = $renderer->render(PHP_EOL, '    ', implode(PHP_EOL, $header));
         $result = $this->files->put($file, $rendered) !== false;
@@ -104,5 +102,4 @@ class FileSaver implements SaverInterface
 
         return $result;
     }
-
 }

--- a/web/concrete/src/Console/Command/ConfigCommand.php
+++ b/web/concrete/src/Console/Command/ConfigCommand.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Config\DirectFileSaver;
+use Concrete\Core\Config\FileSaver;
 use Concrete\Core\Config\FileLoader;
 use Concrete\Core\Config\Repository\Repository;
 use Illuminate\Filesystem\Filesystem;
@@ -33,6 +33,7 @@ class ConfigCommand extends Command
             ->addArgument('item', InputArgument::REQUIRED, 'The configuration item (eg: concrete.debug.display_errors)')
             ->addArgument('value', InputArgument::OPTIONAL, 'The new value of the configuration item')
             ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
+            ->addOption('generated-overrides', 'g', InputOption::VALUE_NONE, 'Set this option to save configurations to the generated_overrides folder')
         ;
         $this->setHelp(<<<EOT
 When setting values that may be evaluated as boolean (true/false), null or numbers, but you want to store them as strings, you can enclose those values in single or double quotes.
@@ -54,7 +55,11 @@ EOT
 
         $file_system = new Filesystem();
         $file_loader = new FileLoader($file_system);
-        $file_saver = new DirectFileSaver($file_system, $environment == $default_environment ? null : $environment);
+        if ($input->getOption('generated-override')) {
+            $file_saver = new FileSaver($file_system, $environment == $default_environment ? null : $environment);
+        } else {
+            $file_saver = new DirectFileSaver($file_system, $environment == $default_environment ? null : $environment);
+        }
         $this->repository = new Repository($file_loader, $file_saver, $environment);
 
         try {


### PR DESCRIPTION
Add an option to the c5:config command to control if saving to the `generated_overrides` folder:

Current (and default) behavior of
`concrete5 c5:config set concrete.external.news_overlay false`
is to save to `application/config/concrete.php`

Let's add a new option (`--generated-overrides` or simply `-g`):
`concrete5 c5:config -g set concrete.external.news_overlay false`
will to save to `application/config/generated_overrides/concrete.php`