### PR TITLE
Fix detecting generated-overrides option in CLI config command

### DIFF
--- a/web/concrete/src/Console/Command/ConfigCommand.php
+++ b/web/concrete/src/Console/Command/ConfigCommand.php
@@ -55,7 +55,7 @@ EOT
 
         $file_system = new Filesystem();
         $file_loader = new FileLoader($file_system);
-        if ($input->hasOption('generated-override')) {
+        if ($input->getOption('generated-overrides')) {
             $file_saver = new FileSaver($file_system, $environment == $default_environment ? null : $environment);
         } else {
             $file_saver = new DirectFileSaver($file_system, $environment == $default_environment ? null : $environment);


### PR DESCRIPTION
The correct name for the newly introduced option is `generated-overrides` and not `generated-override`
So, `$input->hasOption('generated-override')` always returns false.
It should be `$input->getOption('generated-overrides')`

My fault