### PR TITLE
Add a configuration option that allows reporting all warnings

### DIFF
--- a/web/concrete/bootstrap/start.php
+++ b/web/concrete/bootstrap/start.php
@@ -100,6 +100,10 @@ if (!$cms->bound('config')) {
 
 $config = $cms->make('config');
 
+if ($config->get('concrete.debug.picky')) {
+    error_reporting(-1);
+}
+
 /*
  * ----------------------------------------------------------------------------
  * Finalize paths.


### PR DESCRIPTION
I've been looking forward to this for years, and I think it's time to have this possibility now that concrete5 raise a lot less warnings (zero during install and browsing the public contents):
what about introducing a configuration option that aborts the execution when a warning is encountered?

This mode (that should not be used in production but only during development) could greatly help developers to avoid bugs.
Think for instance at this:
```php
$variableName = true;
if ($variabeName) {
    ...
}
```
Here `$variabeName` is mispelled, and this new mode could highlight this.