### PR TITLE
Client side image resize on upload, dashboard page for configuration

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -203,8 +203,18 @@ module.exports = function(grunt) {
         jquery_fileupload: {
             dest: '<%= DIR_BASE %>/concrete/js/jquery-fileupload.js',
             src: [
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image-ios.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image-orientation.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image-meta.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image-exif.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/load-image-exif-map.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/javascript-canvas-to-blob.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/javascript-canvas-to-blob.js',
                 '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/jquery-iframe-transport.js',
-                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload.js'
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-process.js',
+                '<%= DIR_BASE %>/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-image.js'
             ]
         },
 

--- a/web/concrete/config/install/base/dashboard.xml
+++ b/web/concrete/config/install/base/dashboard.xml
@@ -621,6 +621,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Image Uploading" path="/dashboard/system/files/image_uploading"
+              filename="/dashboard/system/files/image_uploading.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>uploading, upload, images, image, resizing, manager</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="File Storage Locations" path="/dashboard/system/files/storage"
               filename="/dashboard/system/files/storage.php" pagetype="" description="" package="">
             <attributes>

--- a/web/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
+++ b/web/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
@@ -11,9 +11,10 @@ class ImageUploading extends DashboardPageController {
 	var $helpers = array('form','concrete/ui','validation/token', 'concrete/file');
 
 	public function view() {
-		$restrict = Config::get('concrete.file_manager.restrict_uploaded_image_sizes');
-		$this->set('restrict_uploaded_image_sizes', $restrict);
-
+		$this->set('restrict_uploaded_image_sizes', Config::get('concrete.file_manager.restrict_uploaded_image_sizes'));
+		$this->set('restrict_max_width', Config::get('concrete.file_manager.restrict_max_width'));
+		$this->set('restrict_max_height', Config::get('concrete.file_manager.restrict_max_height'));
+		$this->set('restrict_resize_quality', Config::get('concrete.file_manager.restrict_resize_quality'));
 	}
 
 	public function saved() {
@@ -22,7 +23,28 @@ class ImageUploading extends DashboardPageController {
 	}
 
 	public function save(){
+		$quality =(int)$this->post('restrict_resize_quality');
+
+		if ($quality < 1 or $quality > 100) {
+			$quality = 85;
+		}
+
+		$maxwidth =(int)$this->post('restrict_max_width');
+
+		if (!$maxwidth || $maxwidth < 1) {
+			$maxwidth = 1920;
+		}
+
+		$maxheight =(int)$this->post('restrict_max_height');
+
+		if (!$maxheight || $maxheight < 1) {
+			$maxheight = 1080;
+		}
+
 		Config::save('concrete.file_manager.restrict_uploaded_image_sizes', (bool)$this->post('restrict_uploaded_image_sizes'));
+		Config::save('concrete.file_manager.restrict_max_width', $maxwidth);
+		Config::save('concrete.file_manager.restrict_max_height', $maxheight);
+		Config::save('concrete.file_manager.restrict_resize_quality', $quality);
 		$this->redirect('/dashboard/system/files/image_uploading','saved');
 	}
 }

--- a/web/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
+++ b/web/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
@@ -1,0 +1,28 @@
+<?
+namespace Concrete\Controller\SinglePage\Dashboard\System\Files;
+use \Concrete\Core\Page\Controller\DashboardPageController;
+use Config;
+use Loader;
+use PermissionKey;
+use TaskPermission;
+use PermissionAccess;
+class ImageUploading extends DashboardPageController {
+
+	var $helpers = array('form','concrete/ui','validation/token', 'concrete/file');
+
+	public function view() {
+		$restrict = Config::get('concrete.file_manager.restrict_uploaded_image_sizes');
+		$this->set('restrict_uploaded_image_sizes', $restrict);
+
+	}
+
+	public function saved() {
+		$this->set('message', t('Image uploading settings saved.'));
+		$this->view();
+	}
+
+	public function save(){
+		Config::save('concrete.file_manager.restrict_uploaded_image_sizes', (bool)$this->post('restrict_uploaded_image_sizes'));
+		$this->redirect('/dashboard/system/files/image_uploading','saved');
+	}
+}

--- a/web/concrete/elements/files/search.php
+++ b/web/concrete/elements/files/search.php
@@ -38,8 +38,14 @@ $req = $flr->getSearchRequest();
             <li><a href="#" data-search-toggle="customize" data-search-column-customize-url="<?php echo URL::to('/ccm/system/dialogs/file/search/customize')?>"><?php echo t('Customize Results')?></a>
             <?php
             $fp = FilePermissions::getGlobal();
-            if ($fp->canAddFile()) { ?>
-                <li class="ccm-file-manager-show-dialog ccm-file-manager-upload"><a href="javascript:void"><?php echo t('Upload Files')?><input type="file" name="files[]" multiple="multiple" /></a></li>
+            if ($fp->canAddFile()) {
+            $imageresize = Config::get('concrete.file_manager.restrict_uploaded_image_sizes');
+            if ($imageresize) {
+                $datastring = ' data-image-max-width="'. (int)Config::get('concrete.file_manager.restrict_max_width') . '" ';
+                $datastring .=' data-image-max-height="'. (int) Config::get('concrete.file_manager.restrict_max_height'). '" ';
+                $datastring .= ' data-image-quality="'. (int)Config::get('concrete.file_manager.restrict_resize_quality'). '" ';
+            }  ?>
+                <li class="ccm-file-manager-show-dialog ccm-file-manager-upload" <?=$datastring?>><a href="javascript:void"><?php echo t('Upload Files')?><input type="file" name="files[]" multiple="multiple" /></a></li>
                 <li class="ccm-file-manager-show-dialog">        <a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/import"
                                class="dialog-launch"
                                dialog-width="500"

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -50,6 +50,7 @@
         var my = this,
             $fileUploaders = $('.ccm-file-manager-upload'),
             $fileUploader = $fileUploaders.filter('#ccm-file-manager-upload-prompt'),
+            $imageResize = $fileUploader.data('image-resize') == '1',
             errors = [],
             files = [],
             error_template = _.template(
@@ -60,6 +61,8 @@
                 url: CCM_DISPATCHER_FILENAME + '/ccm/system/file/upload',
                 dataType: 'json',
                 formData: {'ccm_token': CCM_SECURITY_TOKEN},
+                disableImageResize: !$imageResize,
+                imageQuality: 85,
                 error: function(r) {
                     var message = r.responseText;
                     try {

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -50,7 +50,10 @@
         var my = this,
             $fileUploaders = $('.ccm-file-manager-upload'),
             $fileUploader = $fileUploaders.filter('#ccm-file-manager-upload-prompt'),
-            $imageResize = $fileUploader.data('image-resize') == '1',
+            $maxWidth = $fileUploaders.data('image-max-width'),
+            $maxHeight = $fileUploaders.data('image-max-height'),
+            $imageResize = ($maxWidth > 0 && $maxHeight>0),
+            $quality = $fileUploaders.data('image-quality'),
             errors = [],
             files = [],
             error_template = _.template(
@@ -62,7 +65,9 @@
                 dataType: 'json',
                 formData: {'ccm_token': CCM_SECURITY_TOKEN},
                 disableImageResize: !$imageResize,
-                imageQuality: 85,
+                imageQuality: ($quality > 0 ? $quality : 85),
+                imageMaxWidth:($maxWidth > 0 ? $maxWidth : 1920),
+                imageMaxHeight:($maxHeight > 0 ? $maxHeight : 1080),
                 error: function(r) {
                     var message = r.responseText;
                     try {

--- a/web/concrete/js/build/vendor/jquery-fileupload/javascript-canvas-to-blob.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/javascript-canvas-to-blob.js
@@ -1,0 +1,95 @@
+/*
+ * JavaScript Canvas to Blob 2.0.5
+ * https://github.com/blueimp/JavaScript-Canvas-to-Blob
+ *
+ * Copyright 2012, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ *
+ * Based on stackoverflow user Stoive's code snippet:
+ * http://stackoverflow.com/q/4998908
+ */
+
+/*jslint nomen: true, regexp: true */
+/*global window, atob, Blob, ArrayBuffer, Uint8Array, define */
+
+(function (window) {
+    'use strict';
+    var CanvasPrototype = window.HTMLCanvasElement &&
+            window.HTMLCanvasElement.prototype,
+        hasBlobConstructor = window.Blob && (function () {
+                try {
+                    return Boolean(new Blob());
+                } catch (e) {
+                    return false;
+                }
+            }()),
+        hasArrayBufferViewSupport = hasBlobConstructor && window.Uint8Array &&
+            (function () {
+                try {
+                    return new Blob([new Uint8Array(100)]).size === 100;
+                } catch (e) {
+                    return false;
+                }
+            }()),
+        BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder ||
+            window.MozBlobBuilder || window.MSBlobBuilder,
+        dataURLtoBlob = (hasBlobConstructor || BlobBuilder) && window.atob &&
+            window.ArrayBuffer && window.Uint8Array && function (dataURI) {
+                var byteString,
+                    arrayBuffer,
+                    intArray,
+                    i,
+                    mimeString,
+                    bb;
+                if (dataURI.split(',')[0].indexOf('base64') >= 0) {
+                    // Convert base64 to raw binary data held in a string:
+                    byteString = atob(dataURI.split(',')[1]);
+                } else {
+                    // Convert base64/URLEncoded data component to raw binary data:
+                    byteString = decodeURIComponent(dataURI.split(',')[1]);
+                }
+                // Write the bytes of the string to an ArrayBuffer:
+                arrayBuffer = new ArrayBuffer(byteString.length);
+                intArray = new Uint8Array(arrayBuffer);
+                for (i = 0; i < byteString.length; i += 1) {
+                    intArray[i] = byteString.charCodeAt(i);
+                }
+                // Separate out the mime component:
+                mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+                // Write the ArrayBuffer (or ArrayBufferView) to a blob:
+                if (hasBlobConstructor) {
+                    return new Blob(
+                        [hasArrayBufferViewSupport ? intArray : arrayBuffer],
+                        {type: mimeString}
+                    );
+                }
+                bb = new BlobBuilder();
+                bb.append(arrayBuffer);
+                return bb.getBlob(mimeString);
+            };
+    if (window.HTMLCanvasElement && !CanvasPrototype.toBlob) {
+        if (CanvasPrototype.mozGetAsFile) {
+            CanvasPrototype.toBlob = function (callback, type, quality) {
+                if (quality && CanvasPrototype.toDataURL && dataURLtoBlob) {
+                    callback(dataURLtoBlob(this.toDataURL(type, quality)));
+                } else {
+                    callback(this.mozGetAsFile('blob', type));
+                }
+            };
+        } else if (CanvasPrototype.toDataURL && dataURLtoBlob) {
+            CanvasPrototype.toBlob = function (callback, type, quality) {
+                callback(dataURLtoBlob(this.toDataURL(type, quality)));
+            };
+        }
+    }
+    if (typeof define === 'function' && define.amd) {
+        define(function () {
+            return dataURLtoBlob;
+        });
+    } else {
+        window.dataURLtoBlob = dataURLtoBlob;
+    }
+}(window));

--- a/web/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-image.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-image.js
@@ -1,0 +1,321 @@
+/*
+ * jQuery File Upload Image Preview & Resize Plugin
+ * https://github.com/blueimp/jQuery-File-Upload
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/* jshint nomen:false */
+/* global define, require, window, Blob */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define([
+            'jquery',
+            'load-image',
+            'load-image-meta',
+            'load-image-exif',
+            'load-image-ios',
+            'canvas-to-blob',
+            './jquery.fileupload-process'
+        ], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS:
+        factory(
+            require('jquery'),
+            require('load-image')
+        );
+    } else {
+        // Browser globals:
+        factory(
+            window.jQuery,
+            window.loadImage
+        );
+    }
+}(function ($, loadImage) {
+    'use strict';
+
+    // Prepend to the default processQueue:
+    $.blueimp.fileupload.prototype.options.processQueue.unshift(
+        {
+            action: 'loadImageMetaData',
+            disableImageHead: '@',
+            disableExif: '@',
+            disableExifThumbnail: '@',
+            disableExifSub: '@',
+            disableExifGps: '@',
+            disabled: '@disableImageMetaDataLoad'
+        },
+        {
+            action: 'loadImage',
+            // Use the action as prefix for the "@" options:
+            prefix: true,
+            fileTypes: '@',
+            maxFileSize: '@',
+            noRevoke: '@',
+            disabled: '@disableImageLoad'
+        },
+        {
+            action: 'resizeImage',
+            // Use "image" as prefix for the "@" options:
+            prefix: 'image',
+            maxWidth: '@',
+            maxHeight: '@',
+            minWidth: '@',
+            minHeight: '@',
+            crop: '@',
+            orientation: '@',
+            forceResize: '@',
+            disabled: '@disableImageResize'
+        },
+        {
+            action: 'saveImage',
+            quality: '@imageQuality',
+            type: '@imageType',
+            disabled: '@disableImageResize'
+        },
+        {
+            action: 'saveImageMetaData',
+            disabled: '@disableImageMetaDataSave'
+        },
+        {
+            action: 'resizeImage',
+            // Use "preview" as prefix for the "@" options:
+            prefix: 'preview',
+            maxWidth: '@',
+            maxHeight: '@',
+            minWidth: '@',
+            minHeight: '@',
+            crop: '@',
+            orientation: '@',
+            thumbnail: '@',
+            canvas: '@',
+            disabled: '@disableImagePreview'
+        },
+        {
+            action: 'setImage',
+            name: '@imagePreviewName',
+            disabled: '@disableImagePreview'
+        },
+        {
+            action: 'deleteImageReferences',
+            disabled: '@disableImageReferencesDeletion'
+        }
+    );
+
+    // The File Upload Resize plugin extends the fileupload widget
+    // with image resize functionality:
+    $.widget('blueimp.fileupload', $.blueimp.fileupload, {
+
+        options: {
+            // The regular expression for the types of images to load:
+            // matched against the file type:
+            loadImageFileTypes: /^image\/(gif|jpeg|png|svg\+xml)$/,
+            // The maximum file size of images to load:
+            loadImageMaxFileSize: 10000000, // 10MB
+            // The maximum width of resized images:
+            imageMaxWidth: 1920,
+            // The maximum height of resized images:
+            imageMaxHeight: 1080,
+            // Defines the image orientation (1-8) or takes the orientation
+            // value from Exif data if set to true:
+            imageOrientation: false,
+            // Define if resized images should be cropped or only scaled:
+            imageCrop: false,
+            // Disable the resize image functionality by default:
+            disableImageResize: true,
+            // The maximum width of the preview images:
+            previewMaxWidth: 80,
+            // The maximum height of the preview images:
+            previewMaxHeight: 80,
+            // Defines the preview orientation (1-8) or takes the orientation
+            // value from Exif data if set to true:
+            previewOrientation: true,
+            // Create the preview using the Exif data thumbnail:
+            previewThumbnail: true,
+            // Define if preview images should be cropped or only scaled:
+            previewCrop: false,
+            // Define if preview images should be resized as canvas elements:
+            previewCanvas: true
+        },
+
+        processActions: {
+
+            // Loads the image given via data.files and data.index
+            // as img element, if the browser supports the File API.
+            // Accepts the options fileTypes (regular expression)
+            // and maxFileSize (integer) to limit the files to load:
+            loadImage: function (data, options) {
+                if (options.disabled) {
+                    return data;
+                }
+                var that = this,
+                    file = data.files[data.index],
+                    dfd = $.Deferred();
+                if (($.type(options.maxFileSize) === 'number' &&
+                    file.size > options.maxFileSize) ||
+                    (options.fileTypes &&
+                    !options.fileTypes.test(file.type)) ||
+                    !loadImage(
+                        file,
+                        function (img) {
+                            if (img.src) {
+                                data.img = img;
+                            }
+                            dfd.resolveWith(that, [data]);
+                        },
+                        options
+                    )) {
+                    return data;
+                }
+                return dfd.promise();
+            },
+
+            // Resizes the image given as data.canvas or data.img
+            // and updates data.canvas or data.img with the resized image.
+            // Also stores the resized image as preview property.
+            // Accepts the options maxWidth, maxHeight, minWidth,
+            // minHeight, canvas and crop:
+            resizeImage: function (data, options) {
+                if (options.disabled || !(data.canvas || data.img)) {
+                    return data;
+                }
+                options = $.extend({canvas: true}, options);
+                var that = this,
+                    dfd = $.Deferred(),
+                    img = (options.canvas && data.canvas) || data.img,
+                    resolve = function (newImg) {
+                        if (newImg && (newImg.width !== img.width ||
+                            newImg.height !== img.height ||
+                            options.forceResize)) {
+                            data[newImg.getContext ? 'canvas' : 'img'] = newImg;
+                        }
+                        data.preview = newImg;
+                        dfd.resolveWith(that, [data]);
+                    },
+                    thumbnail;
+                if (data.exif) {
+                    if (options.orientation === true) {
+                        options.orientation = data.exif.get('Orientation');
+                    }
+                    if (options.thumbnail) {
+                        thumbnail = data.exif.get('Thumbnail');
+                        if (thumbnail) {
+                            loadImage(thumbnail, resolve, options);
+                            return dfd.promise();
+                        }
+                    }
+                    // Prevent orienting the same image twice:
+                    if (data.orientation) {
+                        delete options.orientation;
+                    } else {
+                        data.orientation = options.orientation;
+                    }
+                }
+                if (img) {
+                    resolve(loadImage.scale(img, options));
+                    return dfd.promise();
+                }
+                return data;
+            },
+
+            // Saves the processed image given as data.canvas
+            // inplace at data.index of data.files:
+            saveImage: function (data, options) {
+                if (!data.canvas || options.disabled) {
+                    return data;
+                }
+                var that = this,
+                    file = data.files[data.index],
+                    dfd = $.Deferred();
+                if (data.canvas.toBlob) {
+                    data.canvas.toBlob(
+                        function (blob) {
+                            if (!blob.name) {
+                                if (file.type === blob.type) {
+                                    blob.name = file.name;
+                                } else if (file.name) {
+                                    blob.name = file.name.replace(
+                                        /\.\w+$/,
+                                        '.' + blob.type.substr(6)
+                                    );
+                                }
+                            }
+                            // Don't restore invalid meta data:
+                            if (file.type !== blob.type) {
+                                delete data.imageHead;
+                            }
+                            // Store the created blob at the position
+                            // of the original file in the files list:
+                            data.files[data.index] = blob;
+                            dfd.resolveWith(that, [data]);
+                        },
+                        options.type || file.type,
+                        options.quality
+                    );
+                } else {
+                    return data;
+                }
+                return dfd.promise();
+            },
+
+            loadImageMetaData: function (data, options) {
+                if (options.disabled) {
+                    return data;
+                }
+                var that = this,
+                    dfd = $.Deferred();
+                loadImage.parseMetaData(data.files[data.index], function (result) {
+                    $.extend(data, result);
+                    dfd.resolveWith(that, [data]);
+                }, options);
+                return dfd.promise();
+            },
+
+            saveImageMetaData: function (data, options) {
+                if (!(data.imageHead && data.canvas &&
+                    data.canvas.toBlob && !options.disabled)) {
+                    return data;
+                }
+                var file = data.files[data.index],
+                    blob = new Blob([
+                        data.imageHead,
+                        // Resized images always have a head size of 20 bytes,
+                        // including the JPEG marker and a minimal JFIF header:
+                        this._blobSlice.call(file, 20)
+                    ], {type: file.type});
+                blob.name = file.name;
+                data.files[data.index] = blob;
+                return data;
+            },
+
+            // Sets the resized version of the image as a property of the
+            // file object, must be called after "saveImage":
+            setImage: function (data, options) {
+                if (data.preview && !options.disabled) {
+                    data.files[data.index][options.name || 'preview'] = data.preview;
+                }
+                return data;
+            },
+
+            deleteImageReferences: function (data, options) {
+                if (!options.disabled) {
+                    delete data.img;
+                    delete data.canvas;
+                    delete data.preview;
+                    delete data.imageHead;
+                }
+                return data;
+            }
+
+        }
+
+    });
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-process.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/jquery-fileupload-process.js
@@ -1,0 +1,175 @@
+/*
+ * jQuery File Upload Processing Plugin
+ * https://github.com/blueimp/jQuery-File-Upload
+ *
+ * Copyright 2012, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/* jshint nomen:false */
+/* global define, require, window */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define([
+            'jquery',
+            './jquery.fileupload'
+        ], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS:
+        factory(require('jquery'));
+    } else {
+        // Browser globals:
+        factory(
+            window.jQuery
+        );
+    }
+}(function ($) {
+    'use strict';
+
+    var originalAdd = $.blueimp.fileupload.prototype.options.add;
+
+    // The File Upload Processing plugin extends the fileupload widget
+    // with file processing functionality:
+    $.widget('blueimp.fileupload', $.blueimp.fileupload, {
+
+        options: {
+            // The list of processing actions:
+            processQueue: [
+                /*
+                 {
+                 action: 'log',
+                 type: 'debug'
+                 }
+                 */
+            ],
+            add: function (e, data) {
+                var $this = $(this);
+                data.process(function () {
+                    return $this.fileupload('process', data);
+                });
+                originalAdd.call(this, e, data);
+            }
+        },
+
+        processActions: {
+            /*
+             log: function (data, options) {
+             console[options.type](
+             'Processing "' + data.files[data.index].name + '"'
+             );
+             }
+             */
+        },
+
+        _processFile: function (data, originalData) {
+            var that = this,
+                dfd = $.Deferred().resolveWith(that, [data]),
+                chain = dfd.promise();
+            this._trigger('process', null, data);
+            $.each(data.processQueue, function (i, settings) {
+                var func = function (data) {
+                    if (originalData.errorThrown) {
+                        return $.Deferred()
+                            .rejectWith(that, [originalData]).promise();
+                    }
+                    return that.processActions[settings.action].call(
+                        that,
+                        data,
+                        settings
+                    );
+                };
+                chain = chain.pipe(func, settings.always && func);
+            });
+            chain
+                .done(function () {
+                    that._trigger('processdone', null, data);
+                    that._trigger('processalways', null, data);
+                })
+                .fail(function () {
+                    that._trigger('processfail', null, data);
+                    that._trigger('processalways', null, data);
+                });
+            return chain;
+        },
+
+        // Replaces the settings of each processQueue item that
+        // are strings starting with an "@", using the remaining
+        // substring as key for the option map,
+        // e.g. "@autoUpload" is replaced with options.autoUpload:
+        _transformProcessQueue: function (options) {
+            var processQueue = [];
+            $.each(options.processQueue, function () {
+                var settings = {},
+                    action = this.action,
+                    prefix = this.prefix === true ? action : this.prefix;
+                $.each(this, function (key, value) {
+                    if ($.type(value) === 'string' &&
+                        value.charAt(0) === '@') {
+                        settings[key] = options[
+                        value.slice(1) || (prefix ? prefix +
+                        key.charAt(0).toUpperCase() + key.slice(1) : key)
+                            ];
+                    } else {
+                        settings[key] = value;
+                    }
+
+                });
+                processQueue.push(settings);
+            });
+            options.processQueue = processQueue;
+        },
+
+        // Returns the number of files currently in the processsing queue:
+        processing: function () {
+            return this._processing;
+        },
+
+        // Processes the files given as files property of the data parameter,
+        // returns a Promise object that allows to bind callbacks:
+        process: function (data) {
+            var that = this,
+                options = $.extend({}, this.options, data);
+            if (options.processQueue && options.processQueue.length) {
+                this._transformProcessQueue(options);
+                if (this._processing === 0) {
+                    this._trigger('processstart');
+                }
+                $.each(data.files, function (index) {
+                    var opts = index ? $.extend({}, options) : options,
+                        func = function () {
+                            if (data.errorThrown) {
+                                return $.Deferred()
+                                    .rejectWith(that, [data]).promise();
+                            }
+                            return that._processFile(opts, data);
+                        };
+                    opts.index = index;
+                    that._processing += 1;
+                    that._processingQueue = that._processingQueue.pipe(func, func)
+                        .always(function () {
+                            that._processing -= 1;
+                            if (that._processing === 0) {
+                                that._trigger('processstop');
+                            }
+                        });
+                });
+            }
+            return this._processingQueue;
+        },
+
+        _create: function () {
+            this._super();
+            this._processing = 0;
+            this._processingQueue = $.Deferred().resolveWith(this)
+                .promise();
+        }
+
+    });
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image-exif-map.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image-exif-map.js
@@ -1,0 +1,384 @@
+/*
+ * JavaScript Load Image Exif Map 1.0.2
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Exif tags mapping based on
+ * https://github.com/jseidelin/exif-js
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*global define, window */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define(['load-image', 'load-image-exif'], factory);
+    } else {
+        // Browser globals:
+        factory(window.loadImage);
+    }
+}(function (loadImage) {
+    'use strict';
+
+    loadImage.ExifMap.prototype.tags = {
+        // =================
+        // TIFF tags (IFD0):
+        // =================
+        0x0100: 'ImageWidth',
+        0x0101: 'ImageHeight',
+        0x8769: 'ExifIFDPointer',
+        0x8825: 'GPSInfoIFDPointer',
+        0xA005: 'InteroperabilityIFDPointer',
+        0x0102: 'BitsPerSample',
+        0x0103: 'Compression',
+        0x0106: 'PhotometricInterpretation',
+        0x0112: 'Orientation',
+        0x0115: 'SamplesPerPixel',
+        0x011C: 'PlanarConfiguration',
+        0x0212: 'YCbCrSubSampling',
+        0x0213: 'YCbCrPositioning',
+        0x011A: 'XResolution',
+        0x011B: 'YResolution',
+        0x0128: 'ResolutionUnit',
+        0x0111: 'StripOffsets',
+        0x0116: 'RowsPerStrip',
+        0x0117: 'StripByteCounts',
+        0x0201: 'JPEGInterchangeFormat',
+        0x0202: 'JPEGInterchangeFormatLength',
+        0x012D: 'TransferFunction',
+        0x013E: 'WhitePoint',
+        0x013F: 'PrimaryChromaticities',
+        0x0211: 'YCbCrCoefficients',
+        0x0214: 'ReferenceBlackWhite',
+        0x0132: 'DateTime',
+        0x010E: 'ImageDescription',
+        0x010F: 'Make',
+        0x0110: 'Model',
+        0x0131: 'Software',
+        0x013B: 'Artist',
+        0x8298: 'Copyright',
+        // ==================
+        // Exif Sub IFD tags:
+        // ==================
+        0x9000: 'ExifVersion',                  // EXIF version
+        0xA000: 'FlashpixVersion',              // Flashpix format version
+        0xA001: 'ColorSpace',                   // Color space information tag
+        0xA002: 'PixelXDimension',              // Valid width of meaningful image
+        0xA003: 'PixelYDimension',              // Valid height of meaningful image
+        0xA500: 'Gamma',
+        0x9101: 'ComponentsConfiguration',      // Information about channels
+        0x9102: 'CompressedBitsPerPixel',       // Compressed bits per pixel
+        0x927C: 'MakerNote',                    // Any desired information written by the manufacturer
+        0x9286: 'UserComment',                  // Comments by user
+        0xA004: 'RelatedSoundFile',             // Name of related sound file
+        0x9003: 'DateTimeOriginal',             // Date and time when the original image was generated
+        0x9004: 'DateTimeDigitized',            // Date and time when the image was stored digitally
+        0x9290: 'SubSecTime',                   // Fractions of seconds for DateTime
+        0x9291: 'SubSecTimeOriginal',           // Fractions of seconds for DateTimeOriginal
+        0x9292: 'SubSecTimeDigitized',          // Fractions of seconds for DateTimeDigitized
+        0x829A: 'ExposureTime',                 // Exposure time (in seconds)
+        0x829D: 'FNumber',
+        0x8822: 'ExposureProgram',              // Exposure program
+        0x8824: 'SpectralSensitivity',          // Spectral sensitivity
+        0x8827: 'PhotographicSensitivity',      // EXIF 2.3, ISOSpeedRatings in EXIF 2.2
+        0x8828: 'OECF',                         // Optoelectric conversion factor
+        0x8830: 'SensitivityType',
+        0x8831: 'StandardOutputSensitivity',
+        0x8832: 'RecommendedExposureIndex',
+        0x8833: 'ISOSpeed',
+        0x8834: 'ISOSpeedLatitudeyyy',
+        0x8835: 'ISOSpeedLatitudezzz',
+        0x9201: 'ShutterSpeedValue',            // Shutter speed
+        0x9202: 'ApertureValue',                // Lens aperture
+        0x9203: 'BrightnessValue',              // Value of brightness
+        0x9204: 'ExposureBias',                 // Exposure bias
+        0x9205: 'MaxApertureValue',             // Smallest F number of lens
+        0x9206: 'SubjectDistance',              // Distance to subject in meters
+        0x9207: 'MeteringMode',                 // Metering mode
+        0x9208: 'LightSource',                  // Kind of light source
+        0x9209: 'Flash',                        // Flash status
+        0x9214: 'SubjectArea',                  // Location and area of main subject
+        0x920A: 'FocalLength',                  // Focal length of the lens in mm
+        0xA20B: 'FlashEnergy',                  // Strobe energy in BCPS
+        0xA20C: 'SpatialFrequencyResponse',
+        0xA20E: 'FocalPlaneXResolution',        // Number of pixels in width direction per FPRUnit
+        0xA20F: 'FocalPlaneYResolution',        // Number of pixels in height direction per FPRUnit
+        0xA210: 'FocalPlaneResolutionUnit',     // Unit for measuring the focal plane resolution
+        0xA214: 'SubjectLocation',              // Location of subject in image
+        0xA215: 'ExposureIndex',                // Exposure index selected on camera
+        0xA217: 'SensingMethod',                // Image sensor type
+        0xA300: 'FileSource',                   // Image source (3 == DSC)
+        0xA301: 'SceneType',                    // Scene type (1 == directly photographed)
+        0xA302: 'CFAPattern',                   // Color filter array geometric pattern
+        0xA401: 'CustomRendered',               // Special processing
+        0xA402: 'ExposureMode',                 // Exposure mode
+        0xA403: 'WhiteBalance',                 // 1 = auto white balance, 2 = manual
+        0xA404: 'DigitalZoomRatio',             // Digital zoom ratio
+        0xA405: 'FocalLengthIn35mmFilm',
+        0xA406: 'SceneCaptureType',             // Type of scene
+        0xA407: 'GainControl',                  // Degree of overall image gain adjustment
+        0xA408: 'Contrast',                     // Direction of contrast processing applied by camera
+        0xA409: 'Saturation',                   // Direction of saturation processing applied by camera
+        0xA40A: 'Sharpness',                    // Direction of sharpness processing applied by camera
+        0xA40B: 'DeviceSettingDescription',
+        0xA40C: 'SubjectDistanceRange',         // Distance to subject
+        0xA420: 'ImageUniqueID',                // Identifier assigned uniquely to each image
+        0xA430: 'CameraOwnerName',
+        0xA431: 'BodySerialNumber',
+        0xA432: 'LensSpecification',
+        0xA433: 'LensMake',
+        0xA434: 'LensModel',
+        0xA435: 'LensSerialNumber',
+        // ==============
+        // GPS Info tags:
+        // ==============
+        0x0000: 'GPSVersionID',
+        0x0001: 'GPSLatitudeRef',
+        0x0002: 'GPSLatitude',
+        0x0003: 'GPSLongitudeRef',
+        0x0004: 'GPSLongitude',
+        0x0005: 'GPSAltitudeRef',
+        0x0006: 'GPSAltitude',
+        0x0007: 'GPSTimeStamp',
+        0x0008: 'GPSSatellites',
+        0x0009: 'GPSStatus',
+        0x000A: 'GPSMeasureMode',
+        0x000B: 'GPSDOP',
+        0x000C: 'GPSSpeedRef',
+        0x000D: 'GPSSpeed',
+        0x000E: 'GPSTrackRef',
+        0x000F: 'GPSTrack',
+        0x0010: 'GPSImgDirectionRef',
+        0x0011: 'GPSImgDirection',
+        0x0012: 'GPSMapDatum',
+        0x0013: 'GPSDestLatitudeRef',
+        0x0014: 'GPSDestLatitude',
+        0x0015: 'GPSDestLongitudeRef',
+        0x0016: 'GPSDestLongitude',
+        0x0017: 'GPSDestBearingRef',
+        0x0018: 'GPSDestBearing',
+        0x0019: 'GPSDestDistanceRef',
+        0x001A: 'GPSDestDistance',
+        0x001B: 'GPSProcessingMethod',
+        0x001C: 'GPSAreaInformation',
+        0x001D: 'GPSDateStamp',
+        0x001E: 'GPSDifferential',
+        0x001F: 'GPSHPositioningError'
+    };
+
+    loadImage.ExifMap.prototype.stringValues = {
+        ExposureProgram: {
+            0: 'Undefined',
+            1: 'Manual',
+            2: 'Normal program',
+            3: 'Aperture priority',
+            4: 'Shutter priority',
+            5: 'Creative program',
+            6: 'Action program',
+            7: 'Portrait mode',
+            8: 'Landscape mode'
+        },
+        MeteringMode: {
+            0: 'Unknown',
+            1: 'Average',
+            2: 'CenterWeightedAverage',
+            3: 'Spot',
+            4: 'MultiSpot',
+            5: 'Pattern',
+            6: 'Partial',
+            255: 'Other'
+        },
+        LightSource: {
+            0: 'Unknown',
+            1: 'Daylight',
+            2: 'Fluorescent',
+            3: 'Tungsten (incandescent light)',
+            4: 'Flash',
+            9: 'Fine weather',
+            10: 'Cloudy weather',
+            11: 'Shade',
+            12: 'Daylight fluorescent (D 5700 - 7100K)',
+            13: 'Day white fluorescent (N 4600 - 5400K)',
+            14: 'Cool white fluorescent (W 3900 - 4500K)',
+            15: 'White fluorescent (WW 3200 - 3700K)',
+            17: 'Standard light A',
+            18: 'Standard light B',
+            19: 'Standard light C',
+            20: 'D55',
+            21: 'D65',
+            22: 'D75',
+            23: 'D50',
+            24: 'ISO studio tungsten',
+            255: 'Other'
+        },
+        Flash: {
+            0x0000: 'Flash did not fire',
+            0x0001: 'Flash fired',
+            0x0005: 'Strobe return light not detected',
+            0x0007: 'Strobe return light detected',
+            0x0009: 'Flash fired, compulsory flash mode',
+            0x000D: 'Flash fired, compulsory flash mode, return light not detected',
+            0x000F: 'Flash fired, compulsory flash mode, return light detected',
+            0x0010: 'Flash did not fire, compulsory flash mode',
+            0x0018: 'Flash did not fire, auto mode',
+            0x0019: 'Flash fired, auto mode',
+            0x001D: 'Flash fired, auto mode, return light not detected',
+            0x001F: 'Flash fired, auto mode, return light detected',
+            0x0020: 'No flash function',
+            0x0041: 'Flash fired, red-eye reduction mode',
+            0x0045: 'Flash fired, red-eye reduction mode, return light not detected',
+            0x0047: 'Flash fired, red-eye reduction mode, return light detected',
+            0x0049: 'Flash fired, compulsory flash mode, red-eye reduction mode',
+            0x004D: 'Flash fired, compulsory flash mode, red-eye reduction mode, return light not detected',
+            0x004F: 'Flash fired, compulsory flash mode, red-eye reduction mode, return light detected',
+            0x0059: 'Flash fired, auto mode, red-eye reduction mode',
+            0x005D: 'Flash fired, auto mode, return light not detected, red-eye reduction mode',
+            0x005F: 'Flash fired, auto mode, return light detected, red-eye reduction mode'
+        },
+        SensingMethod: {
+            1: 'Undefined',
+            2: 'One-chip color area sensor',
+            3: 'Two-chip color area sensor',
+            4: 'Three-chip color area sensor',
+            5: 'Color sequential area sensor',
+            7: 'Trilinear sensor',
+            8: 'Color sequential linear sensor'
+        },
+        SceneCaptureType: {
+            0: 'Standard',
+            1: 'Landscape',
+            2: 'Portrait',
+            3: 'Night scene'
+        },
+        SceneType: {
+            1: 'Directly photographed'
+        },
+        CustomRendered: {
+            0: 'Normal process',
+            1: 'Custom process'
+        },
+        WhiteBalance: {
+            0: 'Auto white balance',
+            1: 'Manual white balance'
+        },
+        GainControl: {
+            0: 'None',
+            1: 'Low gain up',
+            2: 'High gain up',
+            3: 'Low gain down',
+            4: 'High gain down'
+        },
+        Contrast: {
+            0: 'Normal',
+            1: 'Soft',
+            2: 'Hard'
+        },
+        Saturation: {
+            0: 'Normal',
+            1: 'Low saturation',
+            2: 'High saturation'
+        },
+        Sharpness: {
+            0: 'Normal',
+            1: 'Soft',
+            2: 'Hard'
+        },
+        SubjectDistanceRange: {
+            0: 'Unknown',
+            1: 'Macro',
+            2: 'Close view',
+            3: 'Distant view'
+        },
+        FileSource: {
+            3: 'DSC'
+        },
+        ComponentsConfiguration: {
+            0: '',
+            1: 'Y',
+            2: 'Cb',
+            3: 'Cr',
+            4: 'R',
+            5: 'G',
+            6: 'B'
+        },
+        Orientation: {
+            1: 'top-left',
+            2: 'top-right',
+            3: 'bottom-right',
+            4: 'bottom-left',
+            5: 'left-top',
+            6: 'right-top',
+            7: 'right-bottom',
+            8: 'left-bottom'
+        }
+    };
+
+    loadImage.ExifMap.prototype.getText = function (id) {
+        var value = this.get(id);
+        switch (id) {
+        case 'LightSource':
+        case 'Flash':
+        case 'MeteringMode':
+        case 'ExposureProgram':
+        case 'SensingMethod':
+        case 'SceneCaptureType':
+        case 'SceneType':
+        case 'CustomRendered':
+        case 'WhiteBalance':
+        case 'GainControl':
+        case 'Contrast':
+        case 'Saturation':
+        case 'Sharpness':
+        case 'SubjectDistanceRange':
+        case 'FileSource':
+        case 'Orientation':
+            return this.stringValues[id][value];
+        case 'ExifVersion':
+        case 'FlashpixVersion':
+            return String.fromCharCode(value[0], value[1], value[2], value[3]);
+        case 'ComponentsConfiguration':
+            return this.stringValues[id][value[0]] +
+                this.stringValues[id][value[1]] +
+                this.stringValues[id][value[2]] +
+                this.stringValues[id][value[3]];
+        case 'GPSVersionID':
+            return value[0] + '.' + value[1]  + '.' + value[2]  + '.' + value[3];
+        }
+        return String(value);
+    };
+
+    (function (exifMapPrototype) {
+        var tags = exifMapPrototype.tags,
+            map = exifMapPrototype.map,
+            prop;
+
+        // Map the tag names to tags:
+        for (prop in tags) {
+            if (tags.hasOwnProperty(prop)) {
+                map[tags[prop]] = prop;
+            }
+        }
+    }(loadImage.ExifMap.prototype));
+
+    loadImage.ExifMap.prototype.getAll = function () {
+        var map = {},
+            prop,
+            id;
+        for (prop in this) {
+            if (this.hasOwnProperty(prop)) {
+                id = this.tags[prop];
+                if (id) {
+                    map[id] = this.getText(id);
+                }
+            }
+        }
+        return map;
+    };
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image-exif.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image-exif.js
@@ -1,0 +1,299 @@
+/*
+ * JavaScript Load Image Exif Parser 1.0.0
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*jslint unparam: true */
+/*global define, window, console */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define(['load-image', 'load-image-meta'], factory);
+    } else {
+        // Browser globals:
+        factory(window.loadImage);
+    }
+}(function (loadImage) {
+    'use strict';
+
+    loadImage.ExifMap = function () {
+        return this;
+    };
+
+    loadImage.ExifMap.prototype.map = {
+        'Orientation': 0x0112
+    };
+
+    loadImage.ExifMap.prototype.get = function (id) {
+        return this[id] || this[this.map[id]];
+    };
+
+    loadImage.getExifThumbnail = function (dataView, offset, length) {
+        var hexData,
+            i,
+            b;
+        if (!length || offset + length > dataView.byteLength) {
+            console.log('Invalid Exif data: Invalid thumbnail data.');
+            return;
+        }
+        hexData = [];
+        for (i = 0; i < length; i += 1) {
+            b = dataView.getUint8(offset + i);
+            hexData.push((b < 16 ? '0' : '') + b.toString(16));
+        }
+        return 'data:image/jpeg,%' + hexData.join('%');
+    };
+
+    loadImage.exifTagTypes = {
+        // byte, 8-bit unsigned int:
+        1: {
+            getValue: function (dataView, dataOffset) {
+                return dataView.getUint8(dataOffset);
+            },
+            size: 1
+        },
+        // ascii, 8-bit byte:
+        2: {
+            getValue: function (dataView, dataOffset) {
+                return String.fromCharCode(dataView.getUint8(dataOffset));
+            },
+            size: 1,
+            ascii: true
+        },
+        // short, 16 bit int:
+        3: {
+            getValue: function (dataView, dataOffset, littleEndian) {
+                return dataView.getUint16(dataOffset, littleEndian);
+            },
+            size: 2
+        },
+        // long, 32 bit int:
+        4: {
+            getValue: function (dataView, dataOffset, littleEndian) {
+                return dataView.getUint32(dataOffset, littleEndian);
+            },
+            size: 4
+        },
+        // rational = two long values, first is numerator, second is denominator:
+        5: {
+            getValue: function (dataView, dataOffset, littleEndian) {
+                return dataView.getUint32(dataOffset, littleEndian) /
+                    dataView.getUint32(dataOffset + 4, littleEndian);
+            },
+            size: 8
+        },
+        // slong, 32 bit signed int:
+        9: {
+            getValue: function (dataView, dataOffset, littleEndian) {
+                return dataView.getInt32(dataOffset, littleEndian);
+            },
+            size: 4
+        },
+        // srational, two slongs, first is numerator, second is denominator:
+        10: {
+            getValue: function (dataView, dataOffset, littleEndian) {
+                return dataView.getInt32(dataOffset, littleEndian) /
+                    dataView.getInt32(dataOffset + 4, littleEndian);
+            },
+            size: 8
+        }
+    };
+    // undefined, 8-bit byte, value depending on field:
+    loadImage.exifTagTypes[7] = loadImage.exifTagTypes[1];
+
+    loadImage.getExifValue = function (dataView, tiffOffset, offset, type, length, littleEndian) {
+        var tagType = loadImage.exifTagTypes[type],
+            tagSize,
+            dataOffset,
+            values,
+            i,
+            str,
+            c;
+        if (!tagType) {
+            console.log('Invalid Exif data: Invalid tag type.');
+            return;
+        }
+        tagSize = tagType.size * length;
+        // Determine if the value is contained in the dataOffset bytes,
+        // or if the value at the dataOffset is a pointer to the actual data:
+        dataOffset = tagSize > 4 ?
+                tiffOffset + dataView.getUint32(offset + 8, littleEndian) : (offset + 8);
+        if (dataOffset + tagSize > dataView.byteLength) {
+            console.log('Invalid Exif data: Invalid data offset.');
+            return;
+        }
+        if (length === 1) {
+            return tagType.getValue(dataView, dataOffset, littleEndian);
+        }
+        values = [];
+        for (i = 0; i < length; i += 1) {
+            values[i] = tagType.getValue(dataView, dataOffset + i * tagType.size, littleEndian);
+        }
+        if (tagType.ascii) {
+            str = '';
+            // Concatenate the chars:
+            for (i = 0; i < values.length; i += 1) {
+                c = values[i];
+                // Ignore the terminating NULL byte(s):
+                if (c === '\u0000') {
+                    break;
+                }
+                str += c;
+            }
+            return str;
+        }
+        return values;
+    };
+
+    loadImage.parseExifTag = function (dataView, tiffOffset, offset, littleEndian, data) {
+        var tag = dataView.getUint16(offset, littleEndian);
+        data.exif[tag] = loadImage.getExifValue(
+            dataView,
+            tiffOffset,
+            offset,
+            dataView.getUint16(offset + 2, littleEndian), // tag type
+            dataView.getUint32(offset + 4, littleEndian), // tag length
+            littleEndian
+        );
+    };
+
+    loadImage.parseExifTags = function (dataView, tiffOffset, dirOffset, littleEndian, data) {
+        var tagsNumber,
+            dirEndOffset,
+            i;
+        if (dirOffset + 6 > dataView.byteLength) {
+            console.log('Invalid Exif data: Invalid directory offset.');
+            return;
+        }
+        tagsNumber = dataView.getUint16(dirOffset, littleEndian);
+        dirEndOffset = dirOffset + 2 + 12 * tagsNumber;
+        if (dirEndOffset + 4 > dataView.byteLength) {
+            console.log('Invalid Exif data: Invalid directory size.');
+            return;
+        }
+        for (i = 0; i < tagsNumber; i += 1) {
+            this.parseExifTag(
+                dataView,
+                tiffOffset,
+                dirOffset + 2 + 12 * i, // tag offset
+                littleEndian,
+                data
+            );
+        }
+        // Return the offset to the next directory:
+        return dataView.getUint32(dirEndOffset, littleEndian);
+    };
+
+    loadImage.parseExifData = function (dataView, offset, length, data, options) {
+        if (options.disableExif) {
+            return;
+        }
+        var tiffOffset = offset + 10,
+            littleEndian,
+            dirOffset,
+            thumbnailData;
+        // Check for the ASCII code for "Exif" (0x45786966):
+        if (dataView.getUint32(offset + 4) !== 0x45786966) {
+            // No Exif data, might be XMP data instead
+            return;
+        }
+        if (tiffOffset + 8 > dataView.byteLength) {
+            console.log('Invalid Exif data: Invalid segment size.');
+            return;
+        }
+        // Check for the two null bytes:
+        if (dataView.getUint16(offset + 8) !== 0x0000) {
+            console.log('Invalid Exif data: Missing byte alignment offset.');
+            return;
+        }
+        // Check the byte alignment:
+        switch (dataView.getUint16(tiffOffset)) {
+        case 0x4949:
+            littleEndian = true;
+            break;
+        case 0x4D4D:
+            littleEndian = false;
+            break;
+        default:
+            console.log('Invalid Exif data: Invalid byte alignment marker.');
+            return;
+        }
+        // Check for the TIFF tag marker (0x002A):
+        if (dataView.getUint16(tiffOffset + 2, littleEndian) !== 0x002A) {
+            console.log('Invalid Exif data: Missing TIFF marker.');
+            return;
+        }
+        // Retrieve the directory offset bytes, usually 0x00000008 or 8 decimal:
+        dirOffset = dataView.getUint32(tiffOffset + 4, littleEndian);
+        // Create the exif object to store the tags:
+        data.exif = new loadImage.ExifMap();
+        // Parse the tags of the main image directory and retrieve the
+        // offset to the next directory, usually the thumbnail directory:
+        dirOffset = loadImage.parseExifTags(
+            dataView,
+            tiffOffset,
+            tiffOffset + dirOffset,
+            littleEndian,
+            data
+        );
+        if (dirOffset && !options.disableExifThumbnail) {
+            thumbnailData = {exif: {}};
+            dirOffset = loadImage.parseExifTags(
+                dataView,
+                tiffOffset,
+                tiffOffset + dirOffset,
+                littleEndian,
+                thumbnailData
+            );
+            // Check for JPEG Thumbnail offset:
+            if (thumbnailData.exif[0x0201]) {
+                data.exif.Thumbnail = loadImage.getExifThumbnail(
+                    dataView,
+                    tiffOffset + thumbnailData.exif[0x0201],
+                    thumbnailData.exif[0x0202] // Thumbnail data length
+                );
+            }
+        }
+        // Check for Exif Sub IFD Pointer:
+        if (data.exif[0x8769] && !options.disableExifSub) {
+            loadImage.parseExifTags(
+                dataView,
+                tiffOffset,
+                tiffOffset + data.exif[0x8769], // directory offset
+                littleEndian,
+                data
+            );
+        }
+        // Check for GPS Info IFD Pointer:
+        if (data.exif[0x8825] && !options.disableExifGps) {
+            loadImage.parseExifTags(
+                dataView,
+                tiffOffset,
+                tiffOffset + data.exif[0x8825], // directory offset
+                littleEndian,
+                data
+            );
+        }
+    };
+
+    // Registers the Exif parser for the APP1 JPEG meta data segment:
+    loadImage.metaDataParsers.jpeg[0xffe1].push(loadImage.parseExifData);
+
+    // Adds the following properties to the parseMetaData callback data:
+    // * exif: The exif tags, parsed by the parseExifData method
+
+    // Adds the following options to the parseMetaData method:
+    // * disableExif: Disables Exif parsing.
+    // * disableExifThumbnail: Disables parsing of the Exif Thumbnail.
+    // * disableExifSub: Disables parsing of the Exif Sub IFD.
+    // * disableExifGps: Disables parsing of the Exif GPS Info IFD.
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image-ios.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image-ios.js
@@ -1,0 +1,181 @@
+/*
+ * JavaScript Load Image iOS scaling fixes 1.0.3
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * iOS image scaling fixes based on
+ * https://github.com/stomita/ios-imagefile-megapixel
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*jslint nomen: true, bitwise: true */
+/*global define, window, document */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define(['load-image'], factory);
+    } else {
+        // Browser globals:
+        factory(window.loadImage);
+    }
+}(function (loadImage) {
+    'use strict';
+
+    // Only apply fixes on the iOS platform:
+    if (!window.navigator || !window.navigator.platform ||
+             !(/iP(hone|od|ad)/).test(window.navigator.platform)) {
+        return;
+    }
+
+    var originalRenderMethod = loadImage.renderImageToCanvas;
+
+    // Detects subsampling in JPEG images:
+    loadImage.detectSubsampling = function (img) {
+        var canvas,
+            context;
+        if (img.width * img.height > 1024 * 1024) { // only consider mexapixel images
+            canvas = document.createElement('canvas');
+            canvas.width = canvas.height = 1;
+            context = canvas.getContext('2d');
+            context.drawImage(img, -img.width + 1, 0);
+            // subsampled image becomes half smaller in rendering size.
+            // check alpha channel value to confirm image is covering edge pixel or not.
+            // if alpha value is 0 image is not covering, hence subsampled.
+            return context.getImageData(0, 0, 1, 1).data[3] === 0;
+        }
+        return false;
+    };
+
+    // Detects vertical squash in JPEG images:
+    loadImage.detectVerticalSquash = function (img, subsampled) {
+        var naturalHeight = img.naturalHeight || img.height,
+            canvas = document.createElement('canvas'),
+            context = canvas.getContext('2d'),
+            data,
+            sy,
+            ey,
+            py,
+            alpha;
+        if (subsampled) {
+            naturalHeight /= 2;
+        }
+        canvas.width = 1;
+        canvas.height = naturalHeight;
+        context.drawImage(img, 0, 0);
+        data = context.getImageData(0, 0, 1, naturalHeight).data;
+        // search image edge pixel position in case it is squashed vertically:
+        sy = 0;
+        ey = naturalHeight;
+        py = naturalHeight;
+        while (py > sy) {
+            alpha = data[(py - 1) * 4 + 3];
+            if (alpha === 0) {
+                ey = py;
+            } else {
+                sy = py;
+            }
+            py = (ey + sy) >> 1;
+        }
+        return (py / naturalHeight) || 1;
+    };
+
+    // Renders image to canvas while working around iOS image scaling bugs:
+    // https://github.com/blueimp/JavaScript-Load-Image/issues/13
+    loadImage.renderImageToCanvas = function (
+        canvas,
+        img,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        destX,
+        destY,
+        destWidth,
+        destHeight
+    ) {
+        if (img._type === 'image/jpeg') {
+            var context = canvas.getContext('2d'),
+                tmpCanvas = document.createElement('canvas'),
+                tileSize = 1024,
+                tmpContext = tmpCanvas.getContext('2d'),
+                subsampled,
+                vertSquashRatio,
+                tileX,
+                tileY;
+            tmpCanvas.width = tileSize;
+            tmpCanvas.height = tileSize;
+            context.save();
+            subsampled = loadImage.detectSubsampling(img);
+            if (subsampled) {
+                sourceX /= 2;
+                sourceY /= 2;
+                sourceWidth /= 2;
+                sourceHeight /= 2;
+            }
+            vertSquashRatio = loadImage.detectVerticalSquash(img, subsampled);
+            if (subsampled || vertSquashRatio !== 1) {
+                sourceY *= vertSquashRatio;
+                destWidth = Math.ceil(tileSize * destWidth / sourceWidth);
+                destHeight = Math.ceil(
+                    tileSize * destHeight / sourceHeight / vertSquashRatio
+                );
+                destY = 0;
+                tileY = 0;
+                while (tileY < sourceHeight) {
+                    destX = 0;
+                    tileX = 0;
+                    while (tileX < sourceWidth) {
+                        tmpContext.clearRect(0, 0, tileSize, tileSize);
+                        tmpContext.drawImage(
+                            img,
+                            sourceX,
+                            sourceY,
+                            sourceWidth,
+                            sourceHeight,
+                            -tileX,
+                            -tileY,
+                            sourceWidth,
+                            sourceHeight
+                        );
+                        context.drawImage(
+                            tmpCanvas,
+                            0,
+                            0,
+                            tileSize,
+                            tileSize,
+                            destX,
+                            destY,
+                            destWidth,
+                            destHeight
+                        );
+                        tileX += tileSize;
+                        destX += destWidth;
+                    }
+                    tileY += tileSize;
+                    destY += destHeight;
+                }
+                context.restore();
+                return canvas;
+            }
+        }
+        return originalRenderMethod(
+            canvas,
+            img,
+            sourceX,
+            sourceY,
+            sourceWidth,
+            sourceHeight,
+            destX,
+            destY,
+            destWidth,
+            destHeight
+        );
+    };
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image-meta.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image-meta.js
@@ -1,0 +1,143 @@
+/*
+ * JavaScript Load Image Meta 1.0.2
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Image meta data handling implementation
+ * based on the help and contribution of
+ * Achim Stöhr.
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*jslint continue:true */
+/*global define, window, DataView, Blob, Uint8Array, console */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define(['load-image'], factory);
+    } else {
+        // Browser globals:
+        factory(window.loadImage);
+    }
+}(function (loadImage) {
+    'use strict';
+
+    var hasblobSlice = window.Blob && (Blob.prototype.slice ||
+            Blob.prototype.webkitSlice || Blob.prototype.mozSlice);
+
+    loadImage.blobSlice = hasblobSlice && function () {
+        var slice = this.slice || this.webkitSlice || this.mozSlice;
+        return slice.apply(this, arguments);
+    };
+
+    loadImage.metaDataParsers = {
+        jpeg: {
+            0xffe1: [] // APP1 marker
+        }
+    };
+
+    // Parses image meta data and calls the callback with an object argument
+    // with the following properties:
+    // * imageHead: The complete image head as ArrayBuffer (Uint8Array for IE10)
+    // The options arguments accepts an object and supports the following properties:
+    // * maxMetaDataSize: Defines the maximum number of bytes to parse.
+    // * disableImageHead: Disables creating the imageHead property.
+    loadImage.parseMetaData = function (file, callback, options) {
+        options = options || {};
+        var that = this,
+            // 256 KiB should contain all EXIF/ICC/IPTC segments:
+            maxMetaDataSize = options.maxMetaDataSize || 262144,
+            data = {},
+            noMetaData = !(window.DataView  && file && file.size >= 12 &&
+                file.type === 'image/jpeg' && loadImage.blobSlice);
+        if (noMetaData || !loadImage.readFile(
+                loadImage.blobSlice.call(file, 0, maxMetaDataSize),
+                function (e) {
+                    if (e.target.error) {
+                        // FileReader error
+                        console.log(e.target.error);
+                        callback(data);
+                        return;
+                    }
+                    // Note on endianness:
+                    // Since the marker and length bytes in JPEG files are always
+                    // stored in big endian order, we can leave the endian parameter
+                    // of the DataView methods undefined, defaulting to big endian.
+                    var buffer = e.target.result,
+                        dataView = new DataView(buffer),
+                        offset = 2,
+                        maxOffset = dataView.byteLength - 4,
+                        headLength = offset,
+                        markerBytes,
+                        markerLength,
+                        parsers,
+                        i;
+                    // Check for the JPEG marker (0xffd8):
+                    if (dataView.getUint16(0) === 0xffd8) {
+                        while (offset < maxOffset) {
+                            markerBytes = dataView.getUint16(offset);
+                            // Search for APPn (0xffeN) and COM (0xfffe) markers,
+                            // which contain application-specific meta-data like
+                            // Exif, ICC and IPTC data and text comments:
+                            if ((markerBytes >= 0xffe0 && markerBytes <= 0xffef) ||
+                                    markerBytes === 0xfffe) {
+                                // The marker bytes (2) are always followed by
+                                // the length bytes (2), indicating the length of the
+                                // marker segment, which includes the length bytes,
+                                // but not the marker bytes, so we add 2:
+                                markerLength = dataView.getUint16(offset + 2) + 2;
+                                if (offset + markerLength > dataView.byteLength) {
+                                    console.log('Invalid meta data: Invalid segment size.');
+                                    break;
+                                }
+                                parsers = loadImage.metaDataParsers.jpeg[markerBytes];
+                                if (parsers) {
+                                    for (i = 0; i < parsers.length; i += 1) {
+                                        parsers[i].call(
+                                            that,
+                                            dataView,
+                                            offset,
+                                            markerLength,
+                                            data,
+                                            options
+                                        );
+                                    }
+                                }
+                                offset += markerLength;
+                                headLength = offset;
+                            } else {
+                                // Not an APPn or COM marker, probably safe to
+                                // assume that this is the end of the meta data
+                                break;
+                            }
+                        }
+                        // Meta length must be longer than JPEG marker (2)
+                        // plus APPn marker (2), followed by length bytes (2):
+                        if (!options.disableImageHead && headLength > 6) {
+                            if (buffer.slice) {
+                                data.imageHead = buffer.slice(0, headLength);
+                            } else {
+                                // Workaround for IE10, which does not yet
+                                // support ArrayBuffer.slice:
+                                data.imageHead = new Uint8Array(buffer)
+                                    .subarray(0, headLength);
+                            }
+                        }
+                    } else {
+                        console.log('Invalid JPEG file: Missing JPEG marker.');
+                    }
+                    callback(data);
+                },
+                'readAsArrayBuffer'
+            )) {
+            callback(data);
+        }
+    };
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image-orientation.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image-orientation.js
@@ -1,0 +1,166 @@
+/*
+ * JavaScript Load Image Orientation 1.1.0
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*global define, window */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define(['load-image'], factory);
+    } else {
+        // Browser globals:
+        factory(window.loadImage);
+    }
+}(function (loadImage) {
+    'use strict';
+
+    var originalHasCanvasOption = loadImage.hasCanvasOption,
+        originalTransformCoordinates = loadImage.transformCoordinates,
+        originalGetTransformedOptions = loadImage.getTransformedOptions;
+
+    // This method is used to determine if the target image
+    // should be a canvas element:
+    loadImage.hasCanvasOption = function (options) {
+        return originalHasCanvasOption.call(loadImage, options) ||
+            options.orientation;
+    };
+
+    // Transform image orientation based on
+    // the given EXIF orientation option:
+    loadImage.transformCoordinates = function (canvas, options) {
+        originalTransformCoordinates.call(loadImage, canvas, options);
+        var ctx = canvas.getContext('2d'),
+            width = canvas.width,
+            height = canvas.height,
+            orientation = options.orientation;
+        if (!orientation || orientation > 8) {
+            return;
+        }
+        if (orientation > 4) {
+            canvas.width = height;
+            canvas.height = width;
+        }
+        switch (orientation) {
+        case 2:
+            // horizontal flip
+            ctx.translate(width, 0);
+            ctx.scale(-1, 1);
+            break;
+        case 3:
+            // 180° rotate left
+            ctx.translate(width, height);
+            ctx.rotate(Math.PI);
+            break;
+        case 4:
+            // vertical flip
+            ctx.translate(0, height);
+            ctx.scale(1, -1);
+            break;
+        case 5:
+            // vertical flip + 90 rotate right
+            ctx.rotate(0.5 * Math.PI);
+            ctx.scale(1, -1);
+            break;
+        case 6:
+            // 90° rotate right
+            ctx.rotate(0.5 * Math.PI);
+            ctx.translate(0, -height);
+            break;
+        case 7:
+            // horizontal flip + 90 rotate right
+            ctx.rotate(0.5 * Math.PI);
+            ctx.translate(width, -height);
+            ctx.scale(-1, 1);
+            break;
+        case 8:
+            // 90° rotate left
+            ctx.rotate(-0.5 * Math.PI);
+            ctx.translate(-width, 0);
+            break;
+        }
+    };
+
+    // Transforms coordinate and dimension options
+    // based on the given orientation option:
+    loadImage.getTransformedOptions = function (img, opts) {
+        var options = originalGetTransformedOptions.call(loadImage, img, opts),
+            orientation = options.orientation,
+            newOptions,
+            i;
+        if (!orientation || orientation > 8 || orientation === 1) {
+            return options;
+        }
+        newOptions = {};
+        for (i in options) {
+            if (options.hasOwnProperty(i)) {
+                newOptions[i] = options[i];
+            }
+        }
+        switch (options.orientation) {
+        case 2:
+            // horizontal flip
+            newOptions.left = options.right;
+            newOptions.right = options.left;
+            break;
+        case 3:
+            // 180° rotate left
+            newOptions.left = options.right;
+            newOptions.top = options.bottom;
+            newOptions.right = options.left;
+            newOptions.bottom = options.top;
+            break;
+        case 4:
+            // vertical flip
+            newOptions.top = options.bottom;
+            newOptions.bottom = options.top;
+            break;
+        case 5:
+            // vertical flip + 90 rotate right
+            newOptions.left = options.top;
+            newOptions.top = options.left;
+            newOptions.right = options.bottom;
+            newOptions.bottom = options.right;
+            break;
+        case 6:
+            // 90° rotate right
+            newOptions.left = options.top;
+            newOptions.top = options.right;
+            newOptions.right = options.bottom;
+            newOptions.bottom = options.left;
+            break;
+        case 7:
+            // horizontal flip + 90 rotate right
+            newOptions.left = options.bottom;
+            newOptions.top = options.right;
+            newOptions.right = options.top;
+            newOptions.bottom = options.left;
+            break;
+        case 8:
+            // 90° rotate left
+            newOptions.left = options.bottom;
+            newOptions.top = options.left;
+            newOptions.right = options.top;
+            newOptions.bottom = options.right;
+            break;
+        }
+        if (options.orientation > 4) {
+            newOptions.maxWidth = options.maxHeight;
+            newOptions.maxHeight = options.maxWidth;
+            newOptions.minWidth = options.minHeight;
+            newOptions.minHeight = options.minWidth;
+            newOptions.sourceWidth = options.sourceHeight;
+            newOptions.sourceHeight = options.sourceWidth;
+        }
+        return newOptions;
+    };
+
+}));

--- a/web/concrete/js/build/vendor/jquery-fileupload/load-image.js
+++ b/web/concrete/js/build/vendor/jquery-fileupload/load-image.js
@@ -1,0 +1,301 @@
+/*
+ * JavaScript Load Image 1.10.0
+ * https://github.com/blueimp/JavaScript-Load-Image
+ *
+ * Copyright 2011, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/*jslint nomen: true */
+/*global define, window, document, URL, webkitURL, Blob, File, FileReader */
+
+(function ($) {
+    'use strict';
+
+    // Loads an image for a given File object.
+    // Invokes the callback with an img or optional canvas
+    // element (if supported by the browser) as parameter:
+    var loadImage = function (file, callback, options) {
+            var img = document.createElement('img'),
+                url,
+                oUrl;
+            img.onerror = callback;
+            img.onload = function () {
+                if (oUrl && !(options && options.noRevoke)) {
+                    loadImage.revokeObjectURL(oUrl);
+                }
+                if (callback) {
+                    callback(loadImage.scale(img, options));
+                }
+            };
+            if (loadImage.isInstanceOf('Blob', file) ||
+                    // Files are also Blob instances, but some browsers
+                    // (Firefox 3.6) support the File API but not Blobs:
+                    loadImage.isInstanceOf('File', file)) {
+                url = oUrl = loadImage.createObjectURL(file);
+                // Store the file type for resize processing:
+                img._type = file.type;
+            } else if (typeof file === 'string') {
+                url = file;
+                if (options && options.crossOrigin) {
+                    img.crossOrigin = options.crossOrigin;
+                }
+            } else {
+                return false;
+            }
+            if (url) {
+                img.src = url;
+                return img;
+            }
+            return loadImage.readFile(file, function (e) {
+                var target = e.target;
+                if (target && target.result) {
+                    img.src = target.result;
+                } else {
+                    if (callback) {
+                        callback(e);
+                    }
+                }
+            });
+        },
+        // The check for URL.revokeObjectURL fixes an issue with Opera 12,
+        // which provides URL.createObjectURL but doesn't properly implement it:
+        urlAPI = (window.createObjectURL && window) ||
+            (window.URL && URL.revokeObjectURL && URL) ||
+            (window.webkitURL && webkitURL);
+
+    loadImage.isInstanceOf = function (type, obj) {
+        // Cross-frame instanceof check
+        return Object.prototype.toString.call(obj) === '[object ' + type + ']';
+    };
+
+    // Transform image coordinates, allows to override e.g.
+    // the canvas orientation based on the orientation option,
+    // gets canvas, options passed as arguments:
+    loadImage.transformCoordinates = function () {
+        return;
+    };
+
+    // Returns transformed options, allows to override e.g.
+    // maxWidth, maxHeight and crop options based on the aspectRatio.
+    // gets img, options passed as arguments:
+    loadImage.getTransformedOptions = function (img, options) {
+        var aspectRatio = options.aspectRatio,
+            newOptions,
+            i,
+            width,
+            height;
+        if (!aspectRatio) {
+            return options;
+        }
+        newOptions = {};
+        for (i in options) {
+            if (options.hasOwnProperty(i)) {
+                newOptions[i] = options[i];
+            }
+        }
+        newOptions.crop = true;
+        width = img.naturalWidth || img.width;
+        height = img.naturalHeight || img.height;
+        if (width / height > aspectRatio) {
+            newOptions.maxWidth = height * aspectRatio;
+            newOptions.maxHeight = height;
+        } else {
+            newOptions.maxWidth = width;
+            newOptions.maxHeight = width / aspectRatio;
+        }
+        return newOptions;
+    };
+
+    // Canvas render method, allows to override the
+    // rendering e.g. to work around issues on iOS:
+    loadImage.renderImageToCanvas = function (
+        canvas,
+        img,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        destX,
+        destY,
+        destWidth,
+        destHeight
+    ) {
+        canvas.getContext('2d').drawImage(
+            img,
+            sourceX,
+            sourceY,
+            sourceWidth,
+            sourceHeight,
+            destX,
+            destY,
+            destWidth,
+            destHeight
+        );
+        return canvas;
+    };
+
+    // This method is used to determine if the target image
+    // should be a canvas element:
+    loadImage.hasCanvasOption = function (options) {
+        return options.canvas || options.crop || options.aspectRatio;
+    };
+
+    // Scales and/or crops the given image (img or canvas HTML element)
+    // using the given options.
+    // Returns a canvas object if the browser supports canvas
+    // and the hasCanvasOption method returns true or a canvas
+    // object is passed as image, else the scaled image:
+    loadImage.scale = function (img, options) {
+        options = options || {};
+        var canvas = document.createElement('canvas'),
+            useCanvas = img.getContext ||
+                (loadImage.hasCanvasOption(options) && canvas.getContext),
+            width = img.naturalWidth || img.width,
+            height = img.naturalHeight || img.height,
+            destWidth = width,
+            destHeight = height,
+            maxWidth,
+            maxHeight,
+            minWidth,
+            minHeight,
+            sourceWidth,
+            sourceHeight,
+            sourceX,
+            sourceY,
+            tmp,
+            scaleUp = function () {
+                var scale = Math.max(
+                    (minWidth || destWidth) / destWidth,
+                    (minHeight || destHeight) / destHeight
+                );
+                if (scale > 1) {
+                    destWidth = destWidth * scale;
+                    destHeight = destHeight * scale;
+                }
+            },
+            scaleDown = function () {
+                var scale = Math.min(
+                    (maxWidth || destWidth) / destWidth,
+                    (maxHeight || destHeight) / destHeight
+                );
+                if (scale < 1) {
+                    destWidth = destWidth * scale;
+                    destHeight = destHeight * scale;
+                }
+            };
+        if (useCanvas) {
+            options = loadImage.getTransformedOptions(img, options);
+            sourceX = options.left || 0;
+            sourceY = options.top || 0;
+            if (options.sourceWidth) {
+                sourceWidth = options.sourceWidth;
+                if (options.right !== undefined && options.left === undefined) {
+                    sourceX = width - sourceWidth - options.right;
+                }
+            } else {
+                sourceWidth = width - sourceX - (options.right || 0);
+            }
+            if (options.sourceHeight) {
+                sourceHeight = options.sourceHeight;
+                if (options.bottom !== undefined && options.top === undefined) {
+                    sourceY = height - sourceHeight - options.bottom;
+                }
+            } else {
+                sourceHeight = height - sourceY - (options.bottom || 0);
+            }
+            destWidth = sourceWidth;
+            destHeight = sourceHeight;
+        }
+        maxWidth = options.maxWidth;
+        maxHeight = options.maxHeight;
+        minWidth = options.minWidth;
+        minHeight = options.minHeight;
+        if (useCanvas && maxWidth && maxHeight && options.crop) {
+            destWidth = maxWidth;
+            destHeight = maxHeight;
+            tmp = sourceWidth / sourceHeight - maxWidth / maxHeight;
+            if (tmp < 0) {
+                sourceHeight = maxHeight * sourceWidth / maxWidth;
+                if (options.top === undefined && options.bottom === undefined) {
+                    sourceY = (height - sourceHeight) / 2;
+                }
+            } else if (tmp > 0) {
+                sourceWidth = maxWidth * sourceHeight / maxHeight;
+                if (options.left === undefined && options.right === undefined) {
+                    sourceX = (width - sourceWidth) / 2;
+                }
+            }
+        } else {
+            if (options.contain || options.cover) {
+                minWidth = maxWidth = maxWidth || minWidth;
+                minHeight = maxHeight = maxHeight || minHeight;
+            }
+            if (options.cover) {
+                scaleDown();
+                scaleUp();
+            } else {
+                scaleUp();
+                scaleDown();
+            }
+        }
+        if (useCanvas) {
+            canvas.width = destWidth;
+            canvas.height = destHeight;
+            loadImage.transformCoordinates(
+                canvas,
+                options
+            );
+            return loadImage.renderImageToCanvas(
+                canvas,
+                img,
+                sourceX,
+                sourceY,
+                sourceWidth,
+                sourceHeight,
+                0,
+                0,
+                destWidth,
+                destHeight
+            );
+        }
+        img.width = destWidth;
+        img.height = destHeight;
+        return img;
+    };
+
+    loadImage.createObjectURL = function (file) {
+        return urlAPI ? urlAPI.createObjectURL(file) : false;
+    };
+
+    loadImage.revokeObjectURL = function (url) {
+        return urlAPI ? urlAPI.revokeObjectURL(url) : false;
+    };
+
+    // Loads a given File object via FileReader interface,
+    // invokes the callback with the event object (load or error).
+    // The result can be read via event.target.result:
+    loadImage.readFile = function (file, callback, method) {
+        if (window.FileReader) {
+            var fileReader = new FileReader();
+            fileReader.onload = fileReader.onerror = callback;
+            method = method || 'readAsDataURL';
+            if (fileReader[method]) {
+                fileReader[method](file);
+                return fileReader;
+            }
+        }
+        return false;
+    };
+
+    if (typeof define === 'function' && define.amd) {
+        define(function () {
+            return loadImage;
+        });
+    } else {
+        $.loadImage = loadImage;
+    }
+}(window));

--- a/web/concrete/single_pages/dashboard/files/search.php
+++ b/web/concrete/single_pages/dashboard/files/search.php
@@ -4,6 +4,7 @@
 $c = Page::getCurrentPage();
 $ocID = $c->getCollectionID();
 $fp = FilePermissions::getGlobal();
+$imageresize = Config::get('concrete.file_manager.restrict_uploaded_image_sizes');
 if ($fp->canAddFile() || $fp->canSearchFiles()) { ?>
 
 <div class="ccm-dashboard-content-full" data-search="files">
@@ -11,7 +12,7 @@ if ($fp->canAddFile() || $fp->canSearchFiles()) { ?>
 </div>
 
     <? if ($fp->canAddFile()) { ?>
-	<div id="ccm-file-manager-upload-prompt" class="ccm-file-manager-upload">
+	<div id="ccm-file-manager-upload-prompt" class="ccm-file-manager-upload" data-image-resize="<?=($imageresize ? '1' : '0')?>">
         <?=t("<strong>Upload Files</strong> / Click to Choose or Drag &amp; Drop. / ")?>
         <a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/import"
            class="dialog-launch"

--- a/web/concrete/single_pages/dashboard/files/search.php
+++ b/web/concrete/single_pages/dashboard/files/search.php
@@ -5,6 +5,13 @@ $c = Page::getCurrentPage();
 $ocID = $c->getCollectionID();
 $fp = FilePermissions::getGlobal();
 $imageresize = Config::get('concrete.file_manager.restrict_uploaded_image_sizes');
+
+if ($imageresize) {
+    $datastring = ' data-image-max-width="'. (int)Config::get('concrete.file_manager.restrict_max_width') . '" ';
+    $datastring .=' data-image-max-height="'. (int) Config::get('concrete.file_manager.restrict_max_height'). '" ';
+    $datastring .= ' data-image-quality="'. (int)Config::get('concrete.file_manager.restrict_resize_quality'). '" ';
+}
+
 if ($fp->canAddFile() || $fp->canSearchFiles()) { ?>
 
 <div class="ccm-dashboard-content-full" data-search="files">
@@ -12,7 +19,7 @@ if ($fp->canAddFile() || $fp->canSearchFiles()) { ?>
 </div>
 
     <? if ($fp->canAddFile()) { ?>
-	<div id="ccm-file-manager-upload-prompt" class="ccm-file-manager-upload" data-image-resize="<?=($imageresize ? '1' : '0')?>">
+	<div id="ccm-file-manager-upload-prompt" class="ccm-file-manager-upload" <?=$datastring?>>
         <?=t("<strong>Upload Files</strong> / Click to Choose or Drag &amp; Drop. / ")?>
         <a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/import"
            class="dialog-launch"

--- a/web/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/web/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -25,7 +25,7 @@
 
                             <div class="input-group">
                                 <input class="form-control" type="number" name="restrict_max_width" placeholder="1920" value="<?=$restrict_max_width?>">
-                                <div class="input-group-addon">px</div>
+                                <div class="input-group-addon"><?= t(/* i18n: short for pixels */ 'px') ?></div>
                             </div>
                         </div>
 
@@ -34,7 +34,7 @@
 
                             <div class="input-group">
                                 <input class="form-control" type="number" name="restrict_max_height" placeholder="1080" value="<?=$restrict_max_height?>">
-                                <div class="input-group-addon">px</div>
+                                <div class="input-group-addon"><?= t(/* i18n: short for pixels */ 'px') ?></div>
                             </div>
                         </div>
 

--- a/web/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/web/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -1,0 +1,22 @@
+<? defined('C5_EXECUTE') or die("Access Denied."); ?>
+
+    <?=Core::make('helper/concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Image Uploading'), false, 'span8 offset2', false)?>
+
+    <form method="post" id="file-access-extensions" action="<?=$view->action('save')?>" role="form">
+        <?=$validation_token->output('image_uploading');?>
+
+         <div class="checkbox">
+            <label>
+                <?=$form->checkbox('restrict_uploaded_image_sizes', '1', $restrict_uploaded_image_sizes)?>
+                <span><?=t('Automatically resize uploaded images')?></span>
+            </label>
+        </div>
+
+        <div class="ccm-dashboard-form-actions-wrapper">
+            <div class="ccm-dashboard-form-actions">
+                <button class="pull-right btn btn-primary" type="submit" value="file-access-extensions"><?=t('Save')?></button>
+            </div>
+        </div>	        
+    </form>
+
+    <?=Core::make('helper/concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>

--- a/web/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/web/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -5,18 +5,69 @@
     <form method="post" id="file-access-extensions" action="<?=$view->action('save')?>" role="form">
         <?=$validation_token->output('image_uploading');?>
 
-         <div class="checkbox">
-            <label>
-                <?=$form->checkbox('restrict_uploaded_image_sizes', '1', $restrict_uploaded_image_sizes)?>
-                <span><?=t('Automatically resize uploaded images')?></span>
-            </label>
-        </div>
+        <fieldset>
+            <div class="row">
+                <div class="col-md-12">
+                    <legend>Image Resizing</legend>
+                 </div>
+
+                <div class="col-md-5">
+                    <div class="checkbox">
+                        <label>
+                            <?=$form->checkbox('restrict_uploaded_image_sizes', '1', $restrict_uploaded_image_sizes)?>
+                            <span><?=t('Automatically resize uploaded images')?></span>
+                        </label>
+                    </div>
+
+                    <div id="resizing-values" <?=($restrict_uploaded_image_sizes ?  '' : 'style="display: none"');?>>
+                        <div class="form-group">
+                            <label for="restrict_max_width" class="control-label"><?= t('Maximum Width') ?></label>
+
+                            <div class="input-group">
+                                <input class="form-control" type="number" name="restrict_max_width" placeholder="1920" value="<?=$restrict_max_width?>">
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="restrict_max_height" class="control-label"><?= t('Maximum Height') ?></label>
+
+                            <div class="input-group">
+                                <input class="form-control" type="number" name="restrict_max_height" placeholder="1080" value="<?=$restrict_max_height?>">
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="restrict_resize_quality" class="control-label"><?= t('Image Compression Quality') ?></label>
+
+                            <div class="input-group">
+                                <input class="form-control" type="number" name="restrict_resize_quality" placeholder="85" value="<?=$restrict_resize_quality?>">
+                                <div class="input-group-addon">%</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </fieldset>
 
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
                 <button class="pull-right btn btn-primary" type="submit" value="file-access-extensions"><?=t('Save')?></button>
             </div>
-        </div>	        
+        </div>
     </form>
 
     <?=Core::make('helper/concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>
+
+<script type="text/javascript">
+$("input[name=restrict_uploaded_image_sizes]").click(function() {
+   if ($(this).is(":checked")) {
+       $("#resizing-values").show();
+   } else {
+       $("#resizing-values").hide();
+   }
+});
+</script>
+

--- a/web/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/web/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -8,7 +8,7 @@
         <fieldset>
             <div class="row">
                 <div class="col-md-12">
-                    <legend>Image Resizing</legend>
+                    <legend><?=t('Image Resizing')?></legend>
                  </div>
 
                 <div class="col-md-5">


### PR DESCRIPTION
Works on modern browsers, IE10+.
In older browsers (such as IE9), the file upload still completes but simply doesn't do the client size resize.