### PR TITLE
Should not cache block when the page is in draft

### DIFF
--- a/web/concrete/src/Block/View/BlockView.php
+++ b/web/concrete/src/Block/View/BlockView.php
@@ -370,8 +370,9 @@ class BlockView extends AbstractView
     protected function useBlockCache()
     {
         $u = new User();
+        $c = Page::getCurrentPage();
         if ($this->viewToRender == 'view' && Config::get('concrete.cache.blocks') && $this->block instanceof Block
-            && $this->block->cacheBlockOutput()
+            && $this->block->cacheBlockOutput() && $c->isPageDraft() === false
         ) {
             if ((!$u->isRegistered() || ($this->block->cacheBlockOutputForRegisteredUsers())) &&
                 (($_SERVER['REQUEST_METHOD'] != 'POST' || ($this->block->cacheBlockOutputOnPost() == true)))


### PR DESCRIPTION
I found an instance of "Share this page" block which link is draft url. concrete5 should not create block output cache when that block is in draft page.