### PR TITLE
Correctly escape string from PHP to Javascript

### DIFF
--- a/web/concrete/tools/pages/delete.php
+++ b/web/concrete/tools/pages/delete.php
@@ -129,7 +129,7 @@ foreach($pages as $c) {
                 function() {
                     jQuery.fn.dialog.closeAll();
                     ConcreteEvent.publish('SitemapDeleteRequestComplete');
-                    ConcreteAlert.notify({message: '<?=t('Pages deleted successfully.')?>'});
+                    ConcreteAlert.notify({message: <?=json_encode(t('Pages deleted successfully.'))?>});
                 }
             );
         }


### PR DESCRIPTION
Bugtracker: https://www.concrete5.org/developers/bugs/5-7-5-3/properly-escape-javascript-strings/