### PR TITLE
Add thumbnail option to file manager menu

### DIFF
--- a/web/concrete/controllers/frontend/assets_localization.php
+++ b/web/concrete/controllers/frontend/assets_localization.php
@@ -198,6 +198,7 @@ var ccmi18n_filemanager = {
   duplicateFile: <?=json_encode(t('Copy File'))?>,
   clear: <?=json_encode(t('Clear'))?>,
   edit: <?=json_encode(t('Edit'))?>,
+  thumbnailImages: <?=json_encode(t('Thumbnail Images'))?>,
   replace: <?=json_encode(t('Replace'))?>,
   duplicate: <?=json_encode(t('Copy'))?>,
   chooseNew: <?=json_encode(t('Choose New File'))?>,

--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -304,6 +304,7 @@
                 '<% } %>' +
                 '<% if (item.canEditFile && item.canEditFileContents) { %>' +
                     '<li><a class="dialog-launch" dialog-modal="true" dialog-width="90%" dialog-height="70%" dialog-title="' + ccmi18n_filemanager.edit + '" href="' + CCM_TOOLS_PATH + '/files/edit?fID=<%=item.fID%>">' + ccmi18n_filemanager.edit + '</a></li>' +
+                    '<li><a class="dialog-launch" dialog-modal="true" dialog-width="90%" dialog-height="70%" dialog-title="' + ccmi18n_filemanager.thumbnailImages + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/file/thumbnails?fID=<%=item.fID%>">' + ccmi18n_filemanager.thumbnailImages + '</a></li>' +
                 '<% } %>' +
                 '<li><a class="dialog-launch" dialog-modal="true" dialog-width="850" dialog-height="450" dialog-title="' + ccmi18n_filemanager.properties + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/file/properties?fID=<%=item.fID%>">' + ccmi18n_filemanager.properties + '</a></li>' +
                 '<% if (item.canReplaceFile) { %>' +


### PR DESCRIPTION
Thumbnail editing is hidden away within the properties dialog. This simply adds the option to the file menu in the file manager, so you can directly edit thumbnails.

Thumbnail defining is such an underrated and under-discussed feature of 5.7!