### PR TITLE
Config option to hide introduction

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -448,7 +448,8 @@ return array(
         'page_search_index_lifetime'    => 259200,
         'enable_trash_can'              => true,
         'app_version_display_in_header' => true,
-        'default_jpeg_image_compression'     => 80
+        'default_jpeg_image_compression'     => 80,
+        'help_overlay'                  => true,
     ),
 
     'theme' => array(

--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -1,11 +1,11 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
-$html = Loader::helper('html');
-$dh = Loader::helper('concrete/dashboard');
-$ihm = Loader::helper('concrete/ui/menu');
-$valt = Loader::helper('validation/token');
+$html = Core::make('helper/html');
+$dh = Core::make('helper/concrete/dashboard');
+$ihm = Core::make('helper/concrete/ui/menu');
+$valt = Core::make('helper/validation/token');
 $token = '&' . $valt->getParameter();
-$logouttoken = Loader::helper('validation/token')->generate('logout');
+$logouttoken = $valt->generate('logout');
 $cID = $c->getCollectionID();
 $permissions = new Permissions($c);
 
@@ -31,12 +31,12 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
     }
 
     if (!$c->isEditMode()) {
-       print Loader::helper('concrete/ui/help')->displayHelpDialogLauncher();
+       print Core::make('helper/concrete/ui/help')->displayHelpDialogLauncher();
     }
 
     $cih = Core::make("helper/concrete/ui");
     if ($cih->showHelpOverlay()) {
-        Loader::element('help/dialog/introduction');
+        View::element('help/dialog/introduction');
         $v = View::getInstance();
         $v->addFooterItem('<script type="text/javascript">$(function() { new ConcreteHelpDialog().open(); });</script>');
         $cih->trackHelpOverlayDisplayed();
@@ -60,9 +60,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                                     ?>href="<?= URL::to(
                                         '/ccm/system/page/check_in',
                                         $c->getCollectionID(),
-                                        Loader::helper(
-                                            'validation/token')
-                                              ->generate()) ?>" data-panel-url="<?= URL::to(
+                                        $valt->generate()) ?>" data-panel-url="<?= URL::to(
                                         '/ccm/system/panels/page/check_in') ?>"><?php echo t(
                                         'Save Changes') ?><?
                                 } ?></a></li>
@@ -181,13 +179,13 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                 </li>
                 <? } ?>
                 <li>
-                    <i class="fa fa-sign-out mobile-leading-icon"></i><a href="<?= URL::to('/login', 'logout', Loader::helper('validation/token')->generate('logout')); ?>"><?= t('Sign Out'); ?></a>
+                    <i class="fa fa-sign-out mobile-leading-icon"></i><a href="<?= URL::to('/login', 'logout', $valt->generate('logout')); ?>"><?= t('Sign Out'); ?></a>
                 </li>
             </ul>
         </div>
     </div>
     <ul class="ccm-toolbar-item-list">
-        <li class="ccm-logo pull-left"><span><?= Loader::helper('concrete/ui')->getToolbarLogoSRC() ?></span></li>
+        <li class="ccm-logo pull-left"><span><?= Core::make('helper/concrete/ui')->getToolbarLogoSRC() ?></span></li>
         <? if ($c->isMasterCollection()) { ?>
         <li class="pull-left"><a href="<?= URL::to('/dashboard/pages/types') ?>"><i class="fa fa-arrow-left"></i></a>
             <? } ?>
@@ -199,7 +197,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                data-launch-panel="check-in" <? } else { ?>href="<?= URL::to(
                 '/ccm/system/page/check_in',
                 $c->getCollectionID(),
-                Loader::helper('validation/token')->generate()) ?>"<? } ?>
+                $valt->generate()) ?>"<? } ?>
                data-panel-url="<?= URL::to('/ccm/system/panels/page/check_in') ?>"
                title="<?= t('Exit Edit Mode') ?>">
                 <i class="fa fa-pencil"></i>
@@ -277,7 +275,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
         }
     }
 
-    if (Loader::helper('concrete/ui')->showWhiteLabelMessage()) {
+    if (Core::make('helper/concrete/ui')->showWhiteLabelMessage()) {
         ?>
         <li class="pull-left visible-xs visible-lg" id="ccm-white-label-message"><?= t(
                 'Powered by <a href="%s">concrete5</a>.',
@@ -300,7 +298,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
         </li>
         <? } else { ?>
             <li class="pull-right hidden-xs ">
-                <a href="<?=URL::to('/login', 'logout', Loader::helper('validation/token')->generate('logout'))?>" title="<?=t('Sign Out')?>"><i class="fa fa-sign-out"></i>
+                <a href="<?=URL::to('/login', 'logout', $valt->generate('logout'))?>" title="<?=t('Sign Out')?>"><i class="fa fa-sign-out"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings">
                     <?= tc('toolbar', 'Sign Out') ?>
                 </span>
@@ -359,7 +357,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
     ?>
 
     <? if ($pageInUseBySomeoneElse) { ?>
-        <?= Loader::helper('concrete/ui')->notify(
+        <?= Core::make('helper/concrete/ui')->notify(
             array(
                 'title'   => t('Editing Unavailable.'),
                 'message' => t("%s is currently editing this page.", $c->getCollectionCheckedOutUserName()),
@@ -380,7 +378,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                         'Remove Alias') . '</a>';
             }
 
-            print Loader::helper('concrete/ui')->notify(
+            print Core::make('helper/concrete/ui')->notify(
                 array(
                     'title'   => t('Page Alias.'),
                     'message' => t("This page is an alias of one that actually appears elsewhere."),
@@ -455,7 +453,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                 if (!$vo->isApproved() && !$c->isEditMode()) {
 
                     if ($c->isPageDraft()) {
-                    print Loader::helper('concrete/ui')->notify(
+                    print Core::make('helper/concrete/ui')->notify(
                         array(
                             'title'   => t('Page Draft.'),
                             'message' => t("This is an un-published draft."),
@@ -492,7 +490,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
 
                         }
 
-                        print Loader::helper('concrete/ui')->notify(
+                        print Core::make('helper/concrete/ui')->notify(
                             array(
                                 'title'   => t('Page is Pending Approval.'),
                                 'message' => t("This page is newer than what appears to visitors on your live site."),

--- a/web/concrete/src/Application/Service/UserInterface.php
+++ b/web/concrete/src/Application/Service/UserInterface.php
@@ -7,30 +7,32 @@ use Loader;
 use Page;
 use Config;
 use Session;
-use \Concrete\Core\View\ErrorView;
+use Concrete\Core\View\ErrorView;
 use stdClass;
 
 /**
- * Useful functions for generating elements on the Concrete interface
+ * Useful functions for generating elements on the Concrete interface.
+ *
  * @subpackage Concrete
  * @package Helpers
+ *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
-
 class UserInterface
 {
-
     public static $menuItems = array();
 
     /**
-     * Generates a submit button in the Concrete style
+     * Generates a submit button in the Concrete style.
+     *
      * @param string $text The text of the button
      * @param bool|string $formID The form this button will submit
      * @param string $buttonAlign
      * @param string $innerClass
      * @param array $args Extra args passed to the link
+     *
      * @return string
      */
     public function submit($text, $formID = false, $buttonAlign = 'right', $innerClass = null, $args = array())
@@ -45,19 +47,22 @@ class UserInterface
             $formID = 'button';
         }
         $argsstr = '';
-        foreach($args as $k => $v) {
+        foreach ($args as $k => $v) {
             $argsstr .= $k . '="' . $v . '" ';
         }
+
         return '<input type="submit" class="btn ' . $innerClass . '" value="' . $text . '" id="ccm-submit-' . $formID . '" name="ccm-submit-' . $formID . '" ' . $argsstr . ' />';
     }
 
     /**
-     * Generates a simple link button in the Concrete style
+     * Generates a simple link button in the Concrete style.
+     *
      * @param string $text The text of the button
      * @param string $href
      * @param string $buttonAlign
      * @param string $innerClass
      * @param array $args Extra args passed to the link
+     *
      * @return string
      */
     public function button($text, $href, $buttonAlign = 'right', $innerClass = null, $args = array())
@@ -71,16 +76,19 @@ class UserInterface
         foreach ($args as $k => $v) {
             $argsstr .= $k . '="' . $v . '" ';
         }
+
         return '<a href="'.$href.'" class="btn btn-default '.$innerClass.'" '.$argsstr.'>'.$text.'</a>';
     }
 
     /**
-     * Generates a JavaScript function button in the Concrete style
+     * Generates a JavaScript function button in the Concrete style.
+     *
      * @param string $text The text of the button
      * @param string $onclick
      * @param string $buttonAlign
      * @param string $innerClass - no longer used
      * @param array $args Extra args passed to the link
+     *
      * @return string
      */
     public function buttonJs($text, $onclick, $buttonAlign = 'right', $innerClass = null, $args = array())
@@ -94,6 +102,7 @@ class UserInterface
         foreach ($args as $k => $v) {
             $argsstr .= $k . '="' . $v . '" ';
         }
+
         return '<input type="button" class="btn btn-default ' . $innerClass . '" value="' . $text . '" onclick="' . $onclick . '" ' . $buttonAlign . ' ' . $argsstr . ' />';
     }
 
@@ -110,7 +119,9 @@ class UserInterface
      * <code>
      *    $bh->buttons($myButton1, $myButton2, $myButton3);
      * </code>
+     *
      * @param string $buttons
+     *
      * @return string
      */
     public function buttons($buttons = null)
@@ -123,11 +134,13 @@ class UserInterface
             $html .= $_html . ' ';
         }
         $html .= '</div>';
+
         return $html;
     }
 
     /**
      * @param \Concrete\Core\Page\Page $c
+     *
      * @return string
      */
     public function getQuickNavigationLinkHTML($c)
@@ -176,6 +189,7 @@ class UserInterface
                 $dimensions = 'width="23" height="23"';
             }
         }
+
         return '<img id="ccm-logo" src="' . $src . '" ' . $dimensions . ' alt="' . $alt . '" title="' . $alt . '" />';
     }
 
@@ -187,7 +201,7 @@ class UserInterface
         $tp = new \TaskPermission();
         $c = Page::getCurrentPage();
         if (Config::get('concrete.external.news_overlay') && $tp->canViewNewsflow() && $c->getCollectionPath() != '/dashboard/news') {
-            $u = new ConcreteUser;
+            $u = new ConcreteUser();
             $nf = $u->config('NEWSFLOW_LAST_VIEWED');
             if ($nf == 'FIRSTRUN') {
                 return false;
@@ -210,7 +224,7 @@ class UserInterface
 
     public function showHelpOverlay()
     {
-        $u = new ConcreteUser;
+        $u = new ConcreteUser();
         $timestamp = $u->config('MAIN_HELP_LAST_VIEWED');
         if (!$timestamp) {
             return true;
@@ -219,12 +233,12 @@ class UserInterface
 
     public function trackHelpOverlayDisplayed()
     {
-        $u = new ConcreteUser;
+        $u = new ConcreteUser();
         $u->saveConfig('MAIN_HELP_LAST_VIEWED', time());
     }
 
     /**
-     * Clears the Interface Items Cache (clears the session)
+     * Clears the Interface Items Cache (clears the session).
      */
     public function clearInterfaceItemsCache()
     {
@@ -235,7 +249,7 @@ class UserInterface
     }
 
     /**
-     * Cache the interface items
+     * Cache the interface items.
      */
     public function cacheInterfaceItems()
     {
@@ -247,6 +261,7 @@ class UserInterface
 
     /**
      * @param \Concrete\Core\Page\Page[] $tabs
+     *
      * @return string
      */
     public function pagetabs($tabs)
@@ -272,6 +287,7 @@ class UserInterface
             $html .= '<li class="' . (($active) ? 'active' : ''). '"><a href="' . $href . '">' . $name . '</a></li>';
         }
         $html .= '</ul>';
+
         return $html;
     }
 
@@ -279,6 +295,7 @@ class UserInterface
      * @param \Concrete\Core\Page\Page[] $tabs
      * @param bool $jstabs
      * @param string $callback
+     *
      * @return string
      */
     public function tabs($tabs, $jstabs = true, $callback = 'ccm_activateTabBar')
@@ -299,6 +316,7 @@ class UserInterface
         if ($jstabs) {
             $html .= '<script type="text/javascript">$(function() { ' . $callback . '($(\'#ccm-tabs-' . $tcn . '\'));});</script>';
         }
+
         return $html;
     }
 
@@ -309,7 +327,7 @@ class UserInterface
      */
     public function renderError($title, $error, $exception = false)
     {
-        $o = new stdClass;
+        $o = new stdClass();
         $o->title = $title;
         $o->content = $error;
         if ($exception) {
@@ -323,6 +341,7 @@ class UserInterface
 
     /**
      * @param array $arguments
+     *
      * @return string
      */
     public function notify($arguments)
@@ -332,7 +351,7 @@ class UserInterface
             'icon' => 'ok',
             'title' => false,
             'message' => false,
-            'buttons' => array()
+            'buttons' => array(),
         );
 
         // overwrite all the defaults with the arguments
@@ -355,8 +374,7 @@ class UserInterface
         $content = '<div id="ccm-notification-page-alert" class="ccm-ui ccm-notification ccm-notification-' . $arguments['type'] . '">';
         $content .= '<i class="ccm-notification-icon fa fa-' . $arguments['icon'] . '"></i><div class="ccm-notification-inner">' . $messageText . '</div>';
         $content .= '<div class="ccm-notification-actions"><a href="#" data-dismiss-alert="page-alert">' . t('Hide') . '</a></div></div>';
+
         return $content;
-
     }
-
 }

--- a/web/concrete/src/Application/Service/UserInterface.php
+++ b/web/concrete/src/Application/Service/UserInterface.php
@@ -223,13 +223,23 @@ class UserInterface
         return false;
     }
 
+    /**
+     * Shall we show the introductive help overlay?
+     *
+     * @return bool
+     */
     public function showHelpOverlay()
     {
-        $u = new ConcreteUser();
-        $timestamp = $u->config('MAIN_HELP_LAST_VIEWED');
-        if (!$timestamp) {
-            return true;
+        $result = false;
+        if (Config::get('concrete.misc.help_overlay')) {
+            $u = new ConcreteUser();
+            $timestamp = $u->config('MAIN_HELP_LAST_VIEWED');
+            if (!$timestamp) {
+                $result = true;
+            }
         }
+
+        return $result;
     }
 
     public function trackHelpOverlayDisplayed()

--- a/web/concrete/src/Application/Service/UserInterface.php
+++ b/web/concrete/src/Application/Service/UserInterface.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Application\Service;
 use PermissionKey;
 use User as ConcreteUser;
 use Loader;
+use Core;
 use Page;
 use Config;
 use Session;
@@ -149,7 +150,7 @@ class UserInterface
         if (method_exists($cnt, 'getQuickNavigationLinkHTML')) {
             return $cnt->getQuickNavigationLinkHTML();
         } else {
-            return '<a href="' . Loader::helper('navigation')->getLinkToCollection($c) . '">' . $c->getCollectionName() . '</a>';
+            return '<a href="' . Core::make('helper/navigation')->getLinkToCollection($c) . '">' . $c->getCollectionName() . '</a>';
         }
     }
 
@@ -255,7 +256,7 @@ class UserInterface
     {
         $u = new ConcreteUser();
         if ($u->isRegistered()) {
-            Loader::helper('concrete/dashboard')->getIntelligentSearchMenu();
+            Core::make('helper/concrete/dashboard')->getIntelligentSearchMenu();
         }
     }
 
@@ -279,7 +280,7 @@ class UserInterface
                 $name = $t->getCollectionName();
             }
 
-            $href = Loader::helper('navigation')->getLinkToCollection($_c);
+            $href = Core::make('helper/navigation')->getLinkToCollection($_c);
             $active = false;
             if (is_object($c) && $c->getCollectionID() == $_c->getCollectionID()) {
                 $active = true;

--- a/web/concrete/src/Console/Command/InstallCommand.php
+++ b/web/concrete/src/Console/Command/InstallCommand.php
@@ -158,7 +158,6 @@ class InstallCommand extends Command
             );
             $output->writeln('done.');
         }
-        Config::save('concrete.misc.seen_introduction', true);
         $output->writeln('Installation Complete!');
     }
 }


### PR DESCRIPTION
There's no way to globally hide the introductive help overlay.
Maybe once there was the `concrete.misc.seen_introduction` option, but now it does not affect anything.
What about adding a new `concrete.misc.help_overlay` option?