### PR TITLE
add date added to page drafts in Pages panel

### DIFF
--- a/web/concrete/views/panels/sitemap.php
+++ b/web/concrete/views/panels/sitemap.php
@@ -27,7 +27,7 @@
 <? } ?>
 
 <?
-if ($canViewSitemap) { ?>	
+if ($canViewSitemap) { ?>
 	<h5><?=t('Sitemap')?></h5>
 	<div id="ccm-sitemap-panel-sitemap"></div>
 	<script type="text/javascript">
@@ -44,13 +44,13 @@ if ($canViewSitemap) { ?>
 <? if (count($drafts)) {?>
 	<h5><?=t('Page Drafts')?></h5>
 	<ul class="ccm-panel-sitemap-list">
-	<? foreach($drafts as $dc) { 
-		?> 
+	<? foreach($drafts as $dc) {
+		?>
 		<li><a href="<?=Loader::helper('navigation')->getLinkToCollection($dc)?>"><?
 			if ($dc->getCollectionName()) {
-				print $dc->getCollectionName();
+                echo $dc->getCollectionName() . ' ' . Core::make('date')->formatDateTime($dc->getCollectionDateAdded(), false);
 			} else {
-				print t('(Untitled)');
+                echo t('(Untitled)') . ' ' . Core::make('date')->formatDateTime($dc->getCollectionDateAdded(), false);
 			}
 		?></a></li>
 	<? } ?>


### PR DESCRIPTION
When making a page draft, the name of the page draft (or "(Untitled)" if there is no name) is displayed in the Pages panel. You could potentially have page drafts with the same name in different locations, but not know which one was which. This pull request adds the date added to the draft name.

**Current**
![current](https://cloud.githubusercontent.com/assets/10898145/11806082/a366d7f6-a2de-11e5-80f0-9851482182e6.png)

**Pull Request**
![draft_date](https://cloud.githubusercontent.com/assets/10898145/11806088/a716ad18-a2de-11e5-83e1-3b310664d268.png)
