### PR TITLE
Allow manually setting radio id

### DIFF
--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -233,7 +233,13 @@ class Form
                 $checked = true;
             }
         }
-        $str = '<input type="radio" id="' . $key . $this->radioIndex . '" name="' . $key . '" value="' . $value . '"';
+        $id = null;
+        if (isset($miscFields['id'])) {
+            $id = $miscFields['id'];
+            unset($miscFields['id']);
+        }
+        $id = $id ?: $key.$this->radioIndex;
+        $str = '<input type="radio" id="' . $id . '" name="' . $key . '" value="' . $value . '"';
         $str .= $this->parseMiscFields('ccm-input-radio', $miscFields);
         if ($checked) {
             $str .= ' checked="checked"';


### PR DESCRIPTION
The `id` attribute of `<input type="radio">` elements is build starting from `radioIndex`, btw the value of `radioIndex` may not be known.

What about adding the ability to manually specify it via
```php
$form->radio('name', 'value, '', array('id' => 'id'));
```
?