### PR TITLE
Better support for <picture> elements in content blocks

### DIFF
--- a/web/concrete/src/Editor/LinkAbstractor.php
+++ b/web/concrete/src/Editor/LinkAbstractor.php
@@ -120,6 +120,18 @@ class LinkAbstractor extends Object
 				$fID = $picture->fid;
 				$fo = \File::getByID($fID);
 				if (is_object($fo)) {
+					// move width px to width attribute and height px to height attribute
+					$widthPattern = "/width:\\s([0-9]+)px;?/i";
+					if (preg_match($widthPattern, $picture->style, $matches)) {
+						$picture->style = preg_replace($widthPattern, '', $picture->style);
+						$picture->width = $matches[1];
+					}
+					$heightPattern = "/height:\\s([0-9]+)px;?/i";
+					if (preg_match($heightPattern, $picture->style, $matches)) {
+						$picture->style = preg_replace($heightPattern, '', $picture->style);
+						$picture->height = $matches[1];
+					}
+					$picture->style = preg_replace('/\s+/', '', $picture->style);
 					if ($picture->style) {
 						$image = new \Concrete\Core\Html\Image($fo, false);
 						$image->getTag()->width(false)->height(false);

--- a/web/concrete/src/Editor/LinkAbstractor.php
+++ b/web/concrete/src/Editor/LinkAbstractor.php
@@ -121,23 +121,18 @@ class LinkAbstractor extends Object
 				$fo = \File::getByID($fID);
 				if (is_object($fo)) {
 					// move width px to width attribute and height px to height attribute
-					$widthPattern = "/width:\\s([0-9]+)px;?/i";
+					$widthPattern = "/(?:^width|[^-]width):\\s([0-9]+)px;?/i";
 					if (preg_match($widthPattern, $picture->style, $matches)) {
 						$picture->style = preg_replace($widthPattern, '', $picture->style);
 						$picture->width = $matches[1];
 					}
-					$heightPattern = "/height:\\s([0-9]+)px;?/i";
+					$heightPattern = "/(?:^height|[^-]height):\\s([0-9]+)px;?/i";
 					if (preg_match($heightPattern, $picture->style, $matches)) {
 						$picture->style = preg_replace($heightPattern, '', $picture->style);
 						$picture->height = $matches[1];
 					}
 					$picture->style = preg_replace('/\s+/', '', $picture->style);
-					if ($picture->style) {
-						$image = new \Concrete\Core\Html\Image($fo, false);
-						$image->getTag()->width(false)->height(false);
-					} else {
-						$image = new \Concrete\Core\Html\Image($fo);
-					}
+					$image = new \Concrete\Core\Html\Image($fo);
 					$tag = $image->getTag();
 
 					foreach ($picture->attr as $attr => $val) {


### PR DESCRIPTION
Allows images that might have something like <img style="width: 200px; height: 200px;"...> to leverage the responsive picture elements. Previously these would have been detected as having a style attribute and thus would not be placed within the <picture> element