### PR TITLE
Fixes feature paragraph edit

### DIFF
--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -50,6 +50,11 @@ class Controller extends BlockController
         }
     }
 
+    public function getParagraph()
+    {
+        return LinkAbstractor::translateFrom($this->paragraph);
+    }
+
     public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('css', 'font-awesome');

--- a/web/concrete/blocks/feature/form.php
+++ b/web/concrete/blocks/feature/form.php
@@ -20,7 +20,7 @@
         <?php echo $form->label('paragraph', t('Paragraph:'));?>
         <?php
             $editor = Core::make('editor');
-            echo $editor->outputBlockEditModeEditor('paragraph', $paragraph);
+            echo $editor->outputBlockEditModeEditor('paragraph', $controller->getParagraph());
         ?>
     </div>
 


### PR DESCRIPTION
Currently if you add a picture to a feature paragraph area (or other abstracted string) and go to edit it it doesn't get translated back