### PR TITLE
Fix newsflow url to Dashboard's update page

### DIFF
--- a/web/concrete/blocks/dashboard_app_status/view.php
+++ b/web/concrete/blocks/dashboard_app_status/view.php
@@ -4,7 +4,7 @@
 <br/>
 
 <? if (version_compare($latest_version, APP_VERSION, '>')) { ?>
-<p><span class="label notice"><?=t('concrete5 Update')?></span> <?=t('The latest version of concrete5 is <strong>%s</strong>. You are currently running concrete5 version <strong>%s</strong>.', $latest_version, APP_VERSION)?> <a class="" href="<?=$view->url('/dashboard/system/backup_restore/update')?>"><?=t('Learn more and update.')?></a></p>
+<p><span class="label notice"><?=t('concrete5 Update')?></span> <?=t('The latest version of concrete5 is <strong>%s</strong>. You are currently running concrete5 version <strong>%s</strong>.', $latest_version, APP_VERSION)?> <a class="" href="<?=$view->url('/dashboard/system/backup/update')?>"><?=t('Learn more and update.')?></a></p>
 
 <? } else if (version_compare(APP_VERSION, Config::get('concrete.version'), '>')) { ?>
 <p><span class="label warning"><?=t('concrete5')?></span>


### PR DESCRIPTION
The URL was old 5.6 link to Update page resulted on 404.

Bug report from Endo from concrete5 Japan.
http://concrete5-japan.org/community/forums/bug/post-12302/