### PR TITLE
Fix install apostrophes

### DIFF
--- a/web/concrete/controllers/install.php
+++ b/web/concrete/controllers/install.php
@@ -370,12 +370,12 @@ class Install extends Controller
                 if ($this->fpu) {
                     $hasher = new PasswordHash(Config::get('concrete.user.password.hash_cost_log2'), Config::get('concrete.user.password.hash_portable'));
                     $configuration = "<?php\n";
-                    $configuration .= "define('INSTALL_USER_EMAIL', '" . $_POST['uEmail'] . "');\n";
-                    $configuration .= "define('INSTALL_USER_PASSWORD_HASH', '" . $hasher->HashPassword($_POST['uPassword']) . "');\n";
-                    $configuration .= "define('INSTALL_STARTING_POINT', '" . $this->post('SAMPLE_CONTENT') . "');\n";
-                    $configuration .= "define('SITE', '" . addslashes($_POST['SITE']) . "');\n";
+                    $configuration .= "define('INSTALL_USER_EMAIL', " . var_export((string) $_POST['uEmail'], true) . ");\n";
+                    $configuration .= "define('INSTALL_USER_PASSWORD_HASH', " . var_export((string) $hasher->HashPassword($_POST['uPassword']), true) . ");\n";
+                    $configuration .= "define('INSTALL_STARTING_POINT', " . var_export((string) $this->post('SAMPLE_CONTENT'), true) . ");\n";
+                    $configuration .= "define('SITE', " . var_export((string) $_POST['SITE'], true) . ");\n";
                     if (Localization::activeLocale() != '' && Localization::activeLocale() != 'en_US') {
-                        $configuration .= "define('SITE_INSTALL_LOCALE', '" . Localization::activeLocale() . "');\n";
+                        $configuration .= "define('SITE_INSTALL_LOCALE', " . var_export((string) Localization::activeLocale(), true) . ");\n";
                     }
                     $res = fwrite($this->fpu, $configuration);
                     fclose($this->fpu);

--- a/web/concrete/controllers/install.php
+++ b/web/concrete/controllers/install.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Controller;
 
 use Concrete\Core\Cache\Cache;
@@ -78,7 +77,9 @@ class Install extends Controller
                     'successMessage',
                     t(
                         'Congratulations. concrete5 has been installed. You have been logged in as <b>%s</b> with the password you chose. If you wish to change this password, you may do so from the users area of the dashboard.',
-                        USER_SUPER));
+                        USER_SUPER
+                    )
+                );
             }
         }
     }
@@ -108,7 +109,9 @@ class Install extends Controller
                         $e->add(
                             t(
                                 'There are already %s tables in this database. concrete5 must be installed in an empty database.',
-                                count($num)));
+                                count($num)
+                            )
+                        );
                     }
 
                     try {
@@ -368,8 +371,7 @@ class Install extends Controller
                     $hasher = new PasswordHash(Config::get('concrete.user.password.hash_cost_log2'), Config::get('concrete.user.password.hash_portable'));
                     $configuration = "<?php\n";
                     $configuration .= "define('INSTALL_USER_EMAIL', '" . $_POST['uEmail'] . "');\n";
-                    $configuration .= "define('INSTALL_USER_PASSWORD_HASH', '" . $hasher->HashPassword(
-                            $_POST['uPassword']) . "');\n";
+                    $configuration .= "define('INSTALL_USER_PASSWORD_HASH', '" . $hasher->HashPassword($_POST['uPassword']) . "');\n";
                     $configuration .= "define('INSTALL_STARTING_POINT', '" . $this->post('SAMPLE_CONTENT') . "');\n";
                     $configuration .= "define('SITE', '" . addslashes($_POST['SITE']) . "');\n";
                     if (Localization::activeLocale() != '' && Localization::activeLocale() != 'en_US') {

--- a/web/concrete/views/frontend/install.php
+++ b/web/concrete/views/frontend/install.php
@@ -18,7 +18,7 @@ $(function() {
 });
 </script>
 
-<?
+<?php
 
 $introMsg = t('To install concrete5, please fill out the form below.');
 
@@ -27,13 +27,14 @@ if (isset($successMessage)) { ?>
 <script type="text/javascript">
 $(function() {
 
-<? for ($i = 1; $i <= count($installRoutines); $i++) {
-	$routine = $installRoutines[$i-1]; ?>
+<?php for ($i = 1; $i <= count($installRoutines); ++$i) {
+	$routine = $installRoutines[$i - 1];
+	?>
 
 	ccm_installRoutine<?=$i?> = function() {
-		<? if ($routine->getText() != '') { ?>
+		<?php if ($routine->getText() != '') { ?>
 			$("#install-progress-summary").html('<?=addslashes($routine->getText())?>');
-		<? } ?>
+		<?php } ?>
 		$.ajax('<?=$view->url("/install", "run_routine", $installPackage, $routine->getMethod())?>', {
 			dataType: 'json',
 			error: function(r) {
@@ -48,19 +49,19 @@ $(function() {
 					$("#install-progress-error-wrapper").fadeIn(300);
 				} else {
 					$('#install-progress-bar div.progress-bar').css('width', '<?=$routine->getProgress()?>%');
-					<? if ($i < count($installRoutines)) { ?>
-						ccm_installRoutine<?=$i+1?>();
-					<? } else { ?>
+					<?php if ($i < count($installRoutines)) { ?>
+						ccm_installRoutine<?=$i + 1?>();
+					<?php } else { ?>
 						$("#install-progress-wrapper").fadeOut(300, function() {
 							$("#success-message").fadeIn(300);
 						});
-					<? } ?>
+					<?php } ?>
 				}
 			}
 		});
 	}
 
-<? } ?>
+<?php } ?>
 
 	ccm_installRoutine1();
 
@@ -113,7 +114,7 @@ $(function() {
 </div>
 </div>
 
-<? } else if ($this->controller->getTask() == 'setup' || $this->controller->getTask() == 'configure') { ?>
+<?php } elseif ($this->controller->getTask() == 'setup' || $this->controller->getTask() == 'configure') { ?>
 
 <script type="text/javascript">
 $(function() {
@@ -165,13 +166,13 @@ $(function() {
 		<div class="form-group">
 		<label for="uPassword" class="control-label col-md-4"><?=t('Password')?>:</label>
 		<div class="col-md-8">
-		<?=$form->password('uPassword', array('class' => '', 'autocomplete'=>'off'))?>
+		<?=$form->password('uPassword', array('class' => '', 'autocomplete' => 'off'))?>
 		</div>
 		</div>
 		<div class="form-group">
 		<label for="uPasswordConfirm" class="control-label col-md-4"><?=t('Confirm Password')?>:</label>
 		<div class="col-md-8">
-			<?=$form->password('uPasswordConfirm', array('class' => '', 'autocomplete'=>'off'))?>
+			<?=$form->password('uPasswordConfirm', array('class' => '', 'autocomplete' => 'off'))?>
 		</div>
 		</div>
 
@@ -200,7 +201,7 @@ $(function() {
 	<div class="form-group">
 	<label class="control-label col-md-4" for="DB_PASSWORD"><?=t('MySQL Password')?>:</label>
 	<div class="col-md-8">
-		<?=$form->password('DB_PASSWORD', array('class' => '', 'autocomplete'=>'off'))?>
+		<?=$form->password('DB_PASSWORD', array('class' => '', 'autocomplete' => 'off'))?>
 	</div>
 	</div>
 
@@ -220,32 +221,32 @@ $(function() {
 <h3><?=t('Sample Content')?></h3>
 
 
-		<?
+		<?php
 		$uh = Loader::helper('concrete/urls');
 		?>
 
 		<table class="table table-striped" id="sample-content-selector">
 		<tbody>
-		<?
+		<?php
 		$availableSampleContent = StartingPointPackage::getAvailableList();
-		foreach($availableSampleContent as $spl) {
+		foreach ($availableSampleContent as $spl) {
 			$pkgHandle = $spl->getPackageHandle();
 		?>
 
-		<tr class="<? if ($this->post('SAMPLE_CONTENT') == $pkgHandle || (!$this->post('SAMPLE_CONTENT') && $pkgHandle == 'elemental_full') || count($availableSampleContent) == 1) { ?>package-selected<? } ?>">
+		<tr class="<?php if ($this->post('SAMPLE_CONTENT') == $pkgHandle || (!$this->post('SAMPLE_CONTENT') && $pkgHandle == 'elemental_full') || count($availableSampleContent) == 1) { ?>package-selected<?php } ?>">
 			<td><?=$form->radio('SAMPLE_CONTENT', $pkgHandle, ($pkgHandle == 'elemental_full' || count($availableSampleContent) == 1))?></td>
 			<td class="sample-content-thumbnail"><img src="<?=$uh->getPackageIconURL($spl)?>" width="97" height="97" alt="<?=$spl->getPackageName()?>" /></td>
 			<td class="sample-content-description"><h4><?=$spl->getPackageName()?></h4><p><?=$spl->getPackageDescription()?></td>
 		</tr>
 
-		<? } ?>
+		<?php } ?>
 
 		</tbody>
 		</table>
 		<br/>
-		<? if (!StartingPointPackage::hasCustomList()) { ?>
+		<?php if (!StartingPointPackage::hasCustomList()) { ?>
 			<div class="alert alert-info"><?=t('concrete5 veterans can choose "Empty Site," but otherwise we recommend starting with some sample content.')?></div>
-		<? } ?>
+		<?php } ?>
 
 
 </div>
@@ -264,7 +265,7 @@ $(function() {
 </form>
 
 
-<? } else if (isset($locale) || count($locales) == 0) { ?>
+<?php } elseif (isset($locale) || count($locales) == 0) { ?>
 
 <script type="text/javascript">
 
@@ -272,11 +273,11 @@ $(function() {
 	$("#install-errors").hide();
 });
 
-<? if ($this->controller->passedRequiredItems()) { ?>
+<?php if ($this->controller->passedRequiredItems()) { ?>
 	var showFormOnTestCompletion = true;
-<? } else { ?>
+<?php } else { ?>
 	var showFormOnTestCompletion = false;
-<? } ?>
+<?php } ?>
 
 
 $(function() {
@@ -335,9 +336,9 @@ $(function() {
 <table class="table table-striped requirements-table">
 <tbody>
 <tr>
-	<td class="ccm-test-phpversion"><? if ($phpVtest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td class="ccm-test-phpversion"><?php if ($phpVtest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t(/*i18n: %s is the php version*/'PHP %s', $phpVmin)?></td>
-	<td><? if (!$phpVtest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires at least PHP %s', $phpVmin)?>"></i><? } ?></td>
+	<td><?php if (!$phpVtest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires at least PHP %s', $phpVmin)?>"></i><?php } ?></td>
 </tr>
 <tr>
 	<td class="ccm-test-js"><i id="ccm-test-js-success" class="fa fa-check" style="display: none"></i>
@@ -346,10 +347,10 @@ $(function() {
 	<td class="ccm-test-js"><i class="fa fa-question-circle launch-tooltip" title="<?=t('Please enable JavaScript in your browser.')?>"></i></td>
 </tr>
 <tr>
-	<td><? if ($mysqlTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td><?php if ($mysqlTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t('MySQL PDO Extension Enabled')?>
 	</td>
-	<td><? if (!$mysqlTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=$this->controller->getDBErrorMsg()?>"></i><? } ?></td>
+	<td><?php if (!$mysqlTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=$this->controller->getDBErrorMsg()?>"></i><?php } ?></td>
 </tr>
 <tr>
 	<td><i id="ccm-test-request-loading"  class="fa fa-spinner fa-spin"></i></td>
@@ -358,15 +359,15 @@ $(function() {
 	<td><i id="ccm-test-request-tooltip" class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 cannot parse the PATH_INFO or ORIG_PATH_INFO information provided by your server.')?>"></i></td>
 </tr>
 <tr>
-	<td><? if ($jsonTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td><?php if ($jsonTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t('JSON Extension Enabled')?>
 	</td>
-	<td><? if (!$jsonTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable PHP\'s JSON support. This should be enabled by default in PHP 5.2 and above.')?>"></i><? } ?></td>
+	<td><?php if (!$jsonTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable PHP\'s JSON support. This should be enabled by default in PHP 5.2 and above.')?>"></i><?php } ?></td>
 </tr>
 <tr>
-    <td><? if ($aspTagsTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+    <td><?php if ($aspTagsTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
     <td width="100%"><?=t('ASP Style Tags Disabled')?></td>
-    <td><? if (!$aspTagsTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must disable PHP\'s ASP Style Tags.')?>"></i><? } ?></td>
+    <td><?php if (!$aspTagsTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must disable PHP\'s ASP Style Tags.')?>"></i><?php } ?></td>
 </tr>
 
 </table>
@@ -376,22 +377,22 @@ $(function() {
 
 <table class="table table-striped requirements-table">
 <tr>
-	<td><? if ($imageTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td><?php if ($imageTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t('Image Manipulation Available')?>
 	</td>
-	<td><? if (!$imageTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires GD library 2.0.1 with JPEG, PNG and GIF support. Doublecheck that your installation has support for all these image types.')?>"></i><? } ?></td>
+	<td><?php if (!$imageTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires GD library 2.0.1 with JPEG, PNG and GIF support. Doublecheck that your installation has support for all these image types.')?>"></i><?php } ?></td>
 </tr>
 <tr>
-	<td><? if ($xmlTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td><?php if ($xmlTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t('XML Support')?>
 	</td>
-	<td><? if (!$xmlTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires PHP XML Parser and SimpleXML extensions')?>"></i><? } ?></td>
+	<td><?php if (!$xmlTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 requires PHP XML Parser and SimpleXML extensions')?>"></i><?php } ?></td>
 </tr>
 <tr>
-	<td><? if ($fileWriteTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+	<td><?php if ($fileWriteTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
 	<td width="100%"><?=t('Writable Files and Configuration Directories')?>
 	</td>
-	<td><? if (!$fileWriteTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('The packages/, application/config/ and application/files/ directories must be writable by your web server.')?>"></i><? } ?></td>
+	<td><?php if (!$fileWriteTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('The packages/, application/config/ and application/files/ directories must be writable by your web server.')?>"></i><?php } ?></td>
 </tr>
 <tr>
 	<td><i id="ccm-test-cookies-enabled-loading" class="fa fa-spinner fa-spin"></i></td>
@@ -400,15 +401,15 @@ $(function() {
 	<td><i id="ccm-test-cookies-enabled-tooltip" class="fa fa-question-circle launch-tooltip" title="<?=t('Cookies must be enabled in your browser to install concrete5.')?>"></i></td>
 </tr>
 <tr>
-    <td><? if ($i18nTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+    <td><?php if ($i18nTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
     <td width="100%"><?=t('Internationalization Support')?>
     </td>
-    <td><? if (!$i18nTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable ctype and multibyte string (mbstring) support in PHP.')?>"></i><? } ?></td>
+    <td><?php if (!$i18nTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable ctype and multibyte string (mbstring) support in PHP.')?>"></i><?php } ?></td>
 </tr>
 <tr>
-    <td><? if ($docCommentTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-exclamation-circle"></i><? } ?></td>
+    <td><?php if ($docCommentTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
     <td width="100%"><?=t('PHP Comments Preserved')?>
-    <td><? if (!$docCommentTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 is not compatible with opcode caches that strip PHP comments. Certain configurations of eAccelerator and Zend opcode caching may use this behavior, and it must be disabled.')?>"></td><? } ?></td>
+    <td><?php if (!$docCommentTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 is not compatible with opcode caches that strip PHP comments. Certain configurations of eAccelerator and Zend opcode caching may use this behavior, and it must be disabled.')?>"></td><?php } ?></td>
 </tr>
 </table>
 
@@ -430,10 +431,10 @@ $(function() {
 <table class="table table-striped requirements-table">
 <tbody>
 <tr>
-	<td><? if ($remoteFileUploadTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-warning"></i><? } ?></td>
+	<td><?php if ($remoteFileUploadTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-warning"></i><?php } ?></td>
 	<td width="100%"><?=t('Remote File Importing Available')?>
 	</td>
-	<td><? if (!$remoteFileUploadTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('Remote file importing through the file manager requires the iconv PHP extension.')?>"></i><? } ?></td>
+	<td><?php if (!$remoteFileUploadTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('Remote file importing through the file manager requires the iconv PHP extension.')?>"></i><?php } ?></td>
 </tr>
 </table>
 
@@ -444,10 +445,10 @@ $(function() {
     <table class="table table-striped requirements-table">
         <tbody>
         <tr>
-            <td><? if ($fileZipTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-warning"></i><? } ?></td>
+            <td><?php if ($fileZipTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-warning"></i><?php } ?></td>
             <td width="100%"><?=t('Zip Support')?>
             </td>
-            <td><? if (!$fileZipTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('Downloading zipped files from the file manager, remote updating and marketplace integration requires the Zip extension.')?>"></i><? } ?></td>
+            <td><?php if (!$fileZipTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('Downloading zipped files from the file manager, remote updating and marketplace integration requires the Zip extension.')?>"></i><?php } ?></td>
         </tr>
     </table>
 
@@ -470,27 +471,27 @@ $(function() {
                 <tbody>
                 <tr>
                     <td>
-                        <? if ($memoryTest === -1) { ?>
+                        <?php if ($memoryTest === -1) { ?>
                             <i class="fa fa-exclamation-circle"></i>
-                        <? } else if ($memoryTest === 1) { ?>
+                        <?php } elseif ($memoryTest === 1) { ?>
                             <i class="fa fa-check"></i>
-                        <? } else { ?>
+                        <?php } else { ?>
                             <i class="fa fa-warning"></i>
-                        <? } ?>
+                        <?php } ?>
                     </td>
                     <td width="100%">
-                        <? if ($memoryTest === -1) { ?>
+                        <?php if ($memoryTest === -1) { ?>
                             <span class="text-danger"><?=t('concrete5 will not install with less than 24MB of RAM.
                             Your memory limit is currently %sMB. Please increase your memory_limit using ini_set.', round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2))?>
                             </span>
-                        <? } ?>
-                        <? if ($memoryTest === 0) { ?>
+                        <?php } ?>
+                        <?php if ($memoryTest === 0) { ?>
                             <span class="text-warning"><?=t('concrete5 runs best with at least 64MB of RAM.
                             Your memory limit is currently %sMB. You may experience problems uploading and resizing large images, and may have to install concrete5 without sample content.', round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2))?></span>
-                        <? } ?>
-                        <? if ($memoryTest === 1) { ?>
+                        <?php } ?>
+								<?php if ($memoryTest === 1) { ?>
                             <span class="text-success"><?=t('Memory limit %sMB.', round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2))?></span>
-                        <? } ?>
+                        <?php } ?>
 
                     </td>
                 </tr>
@@ -503,7 +504,7 @@ $(function() {
 <div class="row">
 <div class="col-sm-10 col-sm-offset-1">
 <div class="well" id="install-success">
-	<form method="post" action="<?=$view->url('/install','setup')?>">
+	<form method="post" action="<?=$view->url('/install', 'setup')?>">
 	<input type="hidden" name="locale" value="<?=h($locale)?>" />
 	<a class="btn btn-large btn-primary" href="javascript:void(0)" onclick="$(this).parent().submit()"><?=t('Continue to Installation')?> <i class="fa fa-arrow-right fa-white"></i></a>
 	</form>
@@ -519,13 +520,13 @@ $(function() {
 </div>
 
 <div class="alert alert-info">
-<? $install_forum_url = tc('InstallationHelpForums', 'http://www.concrete5.org/community/forums/installation')?>
+<?php $install_forum_url = tc('InstallationHelpForums', 'http://www.concrete5.org/community/forums/installation')?>
 <?=t('Having trouble? Check the <a href="%s">installation help forums</a>, or <a href="%s">have us host a copy</a> for you.', $install_forum_url, 'http://www.concrete5.org/services/hosting')?>
 </div>
 </div>
 </div>
 
-<? } else { ?>
+<?php } else { ?>
 
 <div class="row">
 <div class="col-sm-8 col-sm-offset-2">
@@ -560,4 +561,4 @@ $(function() {
 </div>
 </div>
 
-<? } ?>
+<?php } ?>


### PR DESCRIPTION
Let's use `var_export` when saving the variables to `site_install_user.php` to avoid problems.

For instance, emails may contain apostrophes: in this case the concrete5 installation breaks.