### PR TITLE
Add configuration to disable download statistics tracking

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -870,7 +870,7 @@ return array(
      * ------------------------------------------------------------------------
      */
     'statistics'        => array(
-//        'track_page_views' => true
+        'track_downloads' => true
     ),
     'limits'            => array(
         'sitemap_pages'           => 100,

--- a/web/concrete/src/File/File.php
+++ b/web/concrete/src/File/File.php
@@ -629,11 +629,14 @@ class File implements \Concrete\Core\Permission\ObjectInterface
         $fve = new \Concrete\Core\File\Event\FileAccess($fv);
         Events::dispatch('on_file_download', $fve);
 
-        $db = Loader::db();
-        $db->Execute(
-            'insert into DownloadStatistics (fID, fvID, uID, rcID) values (?, ?, ?, ?)',
-            array($this->fID, intval($fvID), $uID, $rcID)
-        );
+        $config = Core::make('config');
+        if ($config->get('concrete.statistics.track_downloads')) {
+            $db = Loader::db();
+            $db->Execute(
+                'insert into DownloadStatistics (fID, fvID, uID, rcID) values (?, ?, ?, ?)',
+                array($this->fID, intval($fvID), $uID, $rcID)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This table can bloat, for people who don't need it it would be good to have an option to disable it.