### PR TITLE
Making Members Page Configurable to be system or not

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -450,6 +450,7 @@ return array(
         'app_version_display_in_header' => true,
         'default_jpeg_image_compression'     => 80,
         'help_overlay'                  => true,
+        'member_is_systempage'          => true,
     ),
 
     'theme' => array(

--- a/web/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/web/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -25,16 +25,22 @@ class Profiles extends DashboardPageController {
 			Config::save('concrete.user.gravatar.max_level', Loader::helper('security')->sanitizeString($this->post('gravatar_max_level')));
 			Config::save('concrete.user.gravatar.image_set', Loader::helper('security')->sanitizeString($this->post('gravatar_image_set')));
 			// $message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));
+            $db = Database::connection();
+            $cPath = '/members%';			
             if($this->post('public_profiles')) {
                 if (Config::get('concrete.misc.member_is_systempage') == false) {
-                    $db = Database::connection();
-                    $cPath = array('/member', '/member/*');
-                    $cID = $db->fetchColumn('select cID from PagePaths where cPath = ? and ppIsCanonical = 1', $cPath);
-                    $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', array($cID));
+                    $cIDs = $db->fetchAll('select cID from PagePaths where cPath like ? and ppIsCanonical = 1', array($cPath));
+                    foreach ($cIDs as $cID) {
+                        $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', array($cID['cID']));
+                    }
                 }
                 
 			    $this->redirect('/dashboard/system/registration/profiles/profiles_enabled');
             } else {
+                $cIDs = $db->fetchAll('select cID from PagePaths where cPath like ? and ppIsCanonical = 1', array($cPath));
+                foreach ($cIDs as $cID) {
+                    $db->executeQuery('update Pages set cIsSystemPage = 1 where cID = ?', array($cID['cID']));
+                }
                 $this->redirect('/dashboard/system/registration/profiles/profiles_disabled');
             }
 		}

--- a/web/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/web/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\SinglePage\Dashboard\System\Registration;
 use \Concrete\Core\Page\Controller\DashboardPageController;
 use Config;
 use Loader;
+use Database;
 
 class Profiles extends DashboardPageController {
 
@@ -25,6 +26,13 @@ class Profiles extends DashboardPageController {
 			Config::save('concrete.user.gravatar.image_set', Loader::helper('security')->sanitizeString($this->post('gravatar_image_set')));
 			// $message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));
             if($this->post('public_profiles')) {
+                if (Config::get('concrete.misc.member_is_systempage') == false) {
+                    $db = Database::connection();
+                    $cPath = array('/member', '/member/*');
+                    $cID = $db->fetchColumn('select cID from PagePaths where cPath = ? and ppIsCanonical = 1', $cPath);
+                    $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', array($cID));
+                }
+                
 			    $this->redirect('/dashboard/system/registration/profiles/profiles_enabled');
             } else {
                 $this->redirect('/dashboard/system/registration/profiles/profiles_disabled');

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2651,7 +2651,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $db = Database::connection();
         $newPath = $db->fetchColumn('select cPath from PagePaths where cID = ? and ppIsCanonical = 1', array($cID));
         // now we mark the page as a system page based on this path:
-        $systemPages = array('/login', '/register', Config::get('concrete.paths.trash'), STACKS_PAGE_PATH, Config::get('concrete.paths.drafts'), '/members', '/members/*', '/account', '/account/*', Config::get('concrete.paths.trash').'/*', STACKS_PAGE_PATH.'/*', Config::get('concrete.paths.drafts').'/*', '/download_file', '/dashboard', '/dashboard/*','/page_forbidden','/page_not_found');
+        $systemPages = array('/login', '/register', Config::get('concrete.paths.trash'), STACKS_PAGE_PATH, Config::get('concrete.paths.drafts'), '/account', '/account/*', Config::get('concrete.paths.trash').'/*', STACKS_PAGE_PATH.'/*', Config::get('concrete.paths.drafts').'/*', '/download_file', '/dashboard', '/dashboard/*','/page_forbidden','/page_not_found');
+        if (Config::get('concrete.misc.member_is_systempage')) {
+            array_push($systemPages, '/members', '/members/*');
+        }
         $th = Core::make('helper/text');
         $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', array($cID));
         if ($this->cParentID == 0) {


### PR DESCRIPTION
Recently, I've been making a lot of Single Pages for projects.

Then, I had an opportunity to make multiple member directory pages. Each member directory page is filtered by group. So that each member can find people easier.

Then, the client wants to include the member directory pages in Auto Nav blocks.
But since Single Page is always registered as system pages, it won't show up in autonav.

Also although I don't know if it's a good idea since we are not really able to use cache much, they want to include Single Page in sitemap.xml.

In the future, there could be a single page which is not the part of SystemPage.

Thoughts?