### PR TITLE
Update illuminate/container dependency and deprecate bindShared method

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -11,7 +11,7 @@
     "optimize-autoloader": true
   },
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.5.9",
     "doctrine/dbal": "2.5.*",
     "symfony/class-loader": "2.5.*",
     "symfony/http-foundation": "2.5.*",
@@ -22,7 +22,7 @@
     "league/flysystem": "1.0.*",
     "symfony/event-dispatcher": "2.5.*",
     "symfony/serializer": "2.5.*",
-    "illuminate/container": "4.1.*",
+    "illuminate/container": "5.*",
     "illuminate/config": "4.1.*",
     "patchwork/utf8": "1.1.x-dev",
     "oyejorge/less.php": "v1.7.0.1",

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "02a4eaebea88ca788089a7f79be6096a",
-    "content-hash": "82cd9a94d10409e673a30051b669bae2",
+    "hash": "4d682429d742ec4d9be152b9cb0fe302",
+    "content-hash": "96a3867cb84ba77a3124f9cd1a86f242",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -199,33 +199,33 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.5.4",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136"
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/47cdc76ceb95cc591d9c79a36dc3794975b5d136",
-                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "predis/predis": "~1.0",
                 "satooshi/php-coveralls": "~0.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -265,7 +265,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-19 05:03:47"
+            "time": "2015-12-31 16:37:02"
         },
         {
             "name": "doctrine/collections",
@@ -1090,34 +1090,31 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v4.1.30",
-            "target-dir": "Illuminate/Container",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
-                "reference": "5b76abf9138fe1ad99788944e0561ebc655a254f"
+                "reference": "64c728a58f35c71cbcafe3ef17eb8057965d3dbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/container/zipball/5b76abf9138fe1ad99788944e0561ebc655a254f",
-                "reference": "5b76abf9138fe1ad99788944e0561ebc655a254f",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/64c728a58f35c71cbcafe3ef17eb8057965d3dbc",
+                "reference": "64c728a58f35c71cbcafe3ef17eb8057965d3dbc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.0.*"
+                "illuminate/contracts": "5.2.*",
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Illuminate\\Container": ""
+                "psr-4": {
+                    "Illuminate\\Container\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1127,12 +1124,54 @@
             "authors": [
                 {
                     "name": "Taylor Otwell",
-                    "email": "taylorotwell@gmail.com",
-                    "homepage": "https://github.com/taylorotwell",
-                    "role": "Creator of Laravel"
+                    "email": "taylorotwell@gmail.com"
                 }
             ],
-            "time": "2014-05-22 21:07:57"
+            "description": "The Illuminate Container package.",
+            "homepage": "http://laravel.com",
+            "time": "2015-12-17 20:45:15"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "51b3acf96a12f5a10d767d5f2a534fed6f304235"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/51b3acf96a12f5a10d767d5f2a534fed6f304235",
+                "reference": "51b3acf96a12f5a10d767d5f2a534fed6f304235",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "http://laravel.com",
+            "time": "2015-12-19 14:25:38"
         },
         {
             "name": "illuminate/filesystem",
@@ -4078,7 +4117,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0"
+        "php": ">=5.5.9"
     },
     "platform-dev": []
 }

--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -24,6 +24,7 @@ use Environment;
 use Illuminate\Container\Container;
 use Job;
 use JobSet;
+use Log;
 use Package;
 use Page;
 use Redirect;
@@ -520,7 +521,7 @@ class Application extends Container
      *
      * @throws BindingResolutionException
      */
-    public function build($concrete, $parameters = array())
+    public function build($concrete, array $parameters = array())
     {
         $object = parent::build($concrete, $parameters);
         if (is_object($object) && $object instanceof ApplicationAwareInterface) {
@@ -550,6 +551,16 @@ class Application extends Container
         }
 
         return $runtime;
+    }
+
+    /**
+     * @deprecated Use the singleton method
+     * @param $abstract
+     * @param $concrete
+     */
+    public function bindShared($abstract, $concrete)
+    {
+        return $this->singleton($abstract, $concrete);
     }
 
 }


### PR DESCRIPTION
This allows us to make full use of the new DI features in laravel 5.2. Check out https://laravel.com/docs/5.2/container for more info (We support all of that!)