### PR TITLE
Fix typo in password_changed.php

### DIFF
--- a/web/concrete/authentication/concrete/password_changed.php
+++ b/web/concrete/authentication/concrete/password_changed.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access denied.'); ?>
 
-<div class="alert alert-sucess">
+<div class="alert alert-success">
 	<?= t('Successfully changed password'); ?>
 </div>
 <div>


### PR DESCRIPTION
The class `.alert-sucess` should be `.alert-success`