### PR TITLE
add ResponsiveSlides.js options to Image Slider block form

### DIFF
--- a/web/concrete/blocks/image_slider/add.php
+++ b/web/concrete/blocks/image_slider/add.php
@@ -1,4 +1,3 @@
-<?
+<?php
 defined('C5_EXECUTE') or die("Access Denied.");
-
 $this->inc('form_setup_html.php');

--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -1,11 +1,11 @@
 <?php
-
 namespace Concrete\Block\ImageSlider;
 
 use Concrete\Core\Block\BlockController;
 use Database;
 use Page;
 use Concrete\Core\Editor\LinkAbstractor;
+use Core;
 
 class Controller extends BlockController
 {
@@ -136,8 +136,33 @@ class Controller extends BlockController
         parent::delete();
     }
 
+    public function validate($args)
+    {
+        $error = Core::make('helper/validation/error');
+        $timeout = intval($args['timeout']);
+        $speed = intval($args['speed']);
+
+        if (!$timeout) {
+            $error->add(t('Slide Duration must be greater than 0.'));
+        }
+        if (!$speed) {
+            $error->add(t('Slide Transition Speed must be greater than 0.'));
+        }
+        // https://github.com/viljamis/ResponsiveSlides.js/issues/132#issuecomment-12543345
+        // "The 'timeout' (amount of time spent on one slide) has to be at least 100 bigger than 'speed', otherwise the function simply returns."
+        if(($timeout - $speed) < 100) {
+            $error->add(t('Slide Duration must be at least 100 ms greater than the Slide Transition Speed.'));
+        }
+        return $error;
+    }
+
     public function save($args)
     {
+        $args['timeout'] = intval($args['timeout']);
+        $args['speed'] = intval($args['speed']);
+        $args['noAnimate'] = isset($args['noAnimate']) ? 1 : 0;
+        $args['pause'] = isset($args['pause']) ? 1 : 0;
+
         $db = Database::get();
         $db->execute('DELETE from btImageSliderEntries WHERE bID = ?', array($this->bID));
         parent::save($args);

--- a/web/concrete/blocks/image_slider/db.xml
+++ b/web/concrete/blocks/image_slider/db.xml
@@ -12,6 +12,18 @@
       <unsigned/>
       <default value="0"/>
     </field>
+    <field name="timeout" type="integer">
+      <unsigned/>
+    </field>
+    <field name="speed" type="integer">
+      <unsigned/>
+    </field>
+    <field name="noAnimate" type="integer">
+      <unsigned/>
+    </field>
+    <field name="pause" type="integer">
+      <unsigned/>
+    </field>
   </table>
 
   <table name="btImageSliderEntries">

--- a/web/concrete/blocks/image_slider/form_setup_html.php
+++ b/web/concrete/blocks/image_slider/form_setup_html.php
@@ -2,6 +2,11 @@
 
 $fp = FilePermissions::getGlobal();
 $tp = new TaskPermission();
+
+echo Core::make('helper/concrete/ui')->tabs(array(
+    array('slides', t('Slides'), true),
+    array('options', t('Options'))
+));
 ?>
 <script>
     var CCM_EDITOR_SECURITY_TOKEN = "<?=Loader::helper('validation/token')->generate('editor')?>";
@@ -95,7 +100,7 @@ $tp = new TaskPermission();
                 sort_order: '<?php echo $row['sortOrder'] ?>'
             }));
             sliderEntriesContainer.find('.ccm-image-slider-entry:last-child div[data-field=entry-link-page-selector]').concretePageSelector({
-                'inputName': 'internalLinkCID[]', 'cID': <? if ($linkType == 1) { ?><?=intval($row['internalLinkCID'])?><? } else { ?>false<? } ?>
+                'inputName': 'internalLinkCID[]', 'cID': <?php if ($linkType == 1) { ?><?=intval($row['internalLinkCID'])?><?php } else { ?>false<?php } ?>
             });
         <?php }
         }?>
@@ -205,24 +210,50 @@ $tp = new TaskPermission();
         right: 10px;
     }
 </style>
-<div class="ccm-image-slider-block-container">
-    <label class="control-label"><?php echo t('Navigation') ?></label>
-    <div class="form-group">
-        <div class="radio">
-            <label><input type="radio" name="<?=$view->field('navigationType')?>" value="0" <?php echo $navigationType > 0 ? '' : 'checked' ?> /><?php echo t('Arrows') ?></label>
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="radio">
-            <label><input type="radio" name="<?=$view->field('navigationType')?>" value="1" <?php echo $navigationType > 0 ? 'checked' : '' ?> /><?php echo t('Bullets') ?></label>
-        </div>
-    </div>
 
-    <span class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Entry') ?></span>
-    <div class="ccm-image-slider-entries">
+<div id="ccm-tab-content-slides" class="ccm-tab-content">
+    <div class="ccm-image-slider-block-container">
+        <span class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Entry'); ?></span>
+        <div class="ccm-image-slider-entries">
 
+        </div>
     </div>
 </div>
+
+<div id="ccm-tab-content-options" class="ccm-tab-content">
+    <label class="control-label"><?php echo t('Navigation'); ?></label>
+    <div class="form-group">
+        <div class="radio">
+            <label><input type="radio" name="<?php echo $view->field('navigationType'); ?>" value="0" <?php echo $navigationType > 0 ? '' : 'checked'; ?> /><?php echo t('Arrows'); ?></label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="radio">
+            <label><input type="radio" name="<?php echo $view->field('navigationType'); ?>" value="1" <?php echo $navigationType > 0 ? 'checked' : ''; ?> /><?php echo t('Bullets'); ?></label>
+        </div>
+    </div>
+    <div class="form-group">
+        <?php echo $form->label('timeout', t('Slide Duration')); ?>
+        <div class="input-group" style="width: 150px">
+        <?php echo $form->text('timeout', $timeout ? $timeout : 4000, array('maxlength' => '5'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <?php echo $form->label('speed', t('Slide Transition Speed')); ?>
+        <div class="input-group" style="width: 150px">
+        <?php echo $form->text('speed', $speed ? $speed : 500, array('maxlength' => '5'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <?php echo $form->label('noAnimate', t('Disable Automatic Slideshow')); ?>
+        <?php echo $form->checkbox('noAnimate', $noAnimate, $noAnimate ? 'checked' : ''); ?>
+    </div>
+    <div class="form-group">
+        <?php echo $form->label('pause', t('Pause Slideshow on Hover')); ?>
+        <?php echo $form->checkbox('pause', $pause, $pause ? 'checked' : ''); ?>
+    </div>
+</div>
+
 <script type="text/template" id="imageTemplate">
     <div class="ccm-image-slider-entry well">
         <i class="fa fa-sort-desc"></i>

--- a/web/concrete/blocks/image_slider/view.php
+++ b/web/concrete/blocks/image_slider/view.php
@@ -1,11 +1,11 @@
-<? defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 $navigationTypeText = ($navigationType == 0) ? 'arrows' : 'pages';
 $c = Page::getCurrentPage();
 if ($c->isEditMode()) { ?>
-    <div class="ccm-edit-mode-disabled-item" style="<? echo isset($width) ? "width: $width;" : '' ?><? echo isset($height) ? "height: $height;" : '' ?>">
-        <div style="padding: 40px 0px 40px 0px"><? echo t('Image Slider disabled in edit mode.')?></div>
+    <div class="ccm-edit-mode-disabled-item" style="<?php echo isset($width) ? "width: $width;" : '' ?><?php echo isset($height) ? "height: $height;" : '' ?>">
+        <div style="padding: 40px 0px 40px 0px"><?php echo t('Image Slider disabled in edit mode.')?></div>
     </div>
-<?  } else { ?>
+<?php  } else { ?>
 <script>
 $(document).ready(function(){
     $(function () {
@@ -13,10 +13,14 @@ $(document).ready(function(){
             prevText: "",   // String: Text for the "previous" button
             nextText: "",
             <?php if($navigationType == 0) { ?>
-            nav:true
+            nav:true,
             <?php } else { ?>
-            pager: true
+            pager: true,
             <?php } ?>
+            <?php if ($timeout) { echo "timeout: $timeout,"; } ?>
+            <?php if ($speed) { echo "speed: $speed,"; } ?>
+            <?php if ($pause) { echo "pause: true,"; } ?>
+            <?php if ($noAnimate) { echo "auto: false,"; } ?>
         });
     });
 });
@@ -41,7 +45,7 @@ $(document).ready(function(){
                     if($row['title']) {
                     	$tag->alt($row['title']);
                     }else{
-                    	$tag->alt("slide"); 
+                    	$tag->alt("slide");
                     }
                     print $tag; ?>
                 <?php } ?>


### PR DESCRIPTION
This pull request adds the following ResponsiveSlides.js features to the Image Slider block form.

auto: true,             // Boolean: Animate automatically, true or false
speed: 500,            // Integer: Speed of the transition, in milliseconds
timeout: 4000,          // Integer: Time between slide transitions, in milliseconds
pause: false,           // Boolean: Pause on hover, true or false

The navigation and options have been placed together in a new tab. By default the slider will use the speed and timeout defaults included in ResponsiveSlides.js.

An extra validation check is required due to a bug in ResponsiveSlides.js. 

"The 'timeout' (amount of time spent on one slide) has to be at least 100 bigger than 'speed', otherwise the function simply returns."
https://github.com/viljamis/ResponsiveSlides.js/issues/132#issuecomment-12543345

http://www.concrete5.org/community/forums/5-7-discussion/i-need-to-slow-the-slider-down/

**Current**

![current](https://cloud.githubusercontent.com/assets/10898145/12069844/38b23df8-b01f-11e5-8221-1b280ce38e8b.png)

**Changes**

![1 change-slides_tab](https://cloud.githubusercontent.com/assets/10898145/12069818/3ed22de4-b01d-11e5-883a-5a84b80cf837.png)

![2 change-options_tab](https://cloud.githubusercontent.com/assets/10898145/12069819/430727ac-b01d-11e5-9cf6-725001025cb3.png)

**Validation**

![error1](https://cloud.githubusercontent.com/assets/10898145/12069903/b95ba844-b020-11e5-80ba-9548dfe6565d.png)

![error2](https://cloud.githubusercontent.com/assets/10898145/12069904/bc04b5ea-b020-11e5-9f61-86ec5a07d4e6.png)

![error3](https://cloud.githubusercontent.com/assets/10898145/12069905/be8d9232-b020-11e5-9681-85752881e77c.png)

