### PR TITLE
Put Javascript Inline Asset directly into edit block dialog

### DIFF
--- a/web/concrete/src/View/DialogView.php
+++ b/web/concrete/src/View/DialogView.php
@@ -4,6 +4,7 @@ use Concrete\Core\Asset\Asset;
 use View as ConcreteView;
 use \Concrete\Core\Asset\CssAsset;
 use \Concrete\Core\Asset\JavascriptAsset;
+use \Concrete\Core\Asset\JavascriptInlineAsset;
 use User;
 
 class DialogView extends ConcreteView {
@@ -17,6 +18,10 @@ class DialogView extends ConcreteView {
 		if ($item instanceof CssAsset) {
 			$str .= '<script type="text/javascript">';
 			$str .= 'ccm_addHeaderItem("' . $item->getAssetURL() . '", "CSS")';
+			$str .= '</script>';
+		} else if ($item instanceof JavascriptInlineAsset) {
+			$str .= '<script type="text/javascript">';
+			$str .= $item->getAssetURL();
 			$str .= '</script>';
 		} else if ($item instanceof JavascriptAsset) {
 			$str .= '<script type="text/javascript">';


### PR DESCRIPTION
Put Inline Javascript with `ccm_addHeaderItem()` causes 404 error.