### PR TITLE
add Fit Image button to Image Editor

### DIFF
--- a/web/concrete/js/image-editor/controls/position.js
+++ b/web/concrete/js/image-editor/controls/position.js
@@ -12,6 +12,42 @@ im.bind('changeActiveElement', function () {
     resetScale();
 });
 
+function FitImage(im, me) {
+
+    function resetThumbnail() {
+        if (im.settings.saveWidth && !im.settings.saveHeight) {
+            $(width_input).val(im.settings.saveWidth).keyup();
+        } else if (im.settings.saveWidth && im.settings.saveHeight) {
+            if (ratio > 1 || ratio === 1) {
+                if (im.settings.saveWidth > im.settings.saveHeight) {
+                    $(width_input).val(im.settings.saveWidth).keyup();
+                } else {
+                    $(height_input).val(im.settings.saveHeight).keyup();
+                }
+            } else if (ratio < 1) {
+                if (im.settings.saveWidth < im.settings.saveHeight) {
+                    $(height_input).val(im.settings.saveHeight).keyup();
+                } else {
+                    $(width_input).val(im.settings.saveWidth).keyup();
+                }
+            }
+        }
+    }
+
+    function centerImage() {
+        im.activeElement.setPosition(0, 0);
+        im.activeElement.parent.draw();
+    }
+
+    $('button.reset', me).on('click', function() {
+        resetThumbnail();
+        centerImage();
+    });
+
+}
+
+new FitImage(im, me);
+
 function Rotation(im, me) {
     var my = this,
         RotationFlipModeVertical = 0,

--- a/web/concrete/js/image-editor/controls/position.js
+++ b/web/concrete/js/image-editor/controls/position.js
@@ -39,10 +39,14 @@ function FitImage(im, me) {
         im.activeElement.parent.draw();
     }
 
-    $('button.reset', me).on('click', function() {
-        resetThumbnail();
-        centerImage();
-    });
+    if (im.settings.saveWidth || im.settings.saveHeight) {
+        $('button.reset', me).on('click', function() {
+            resetThumbnail();
+            centerImage();
+        });
+    } else {
+        $('button.reset', me).hide();
+    }
 
 }
 

--- a/web/concrete/views/image-editor/controls/position.php
+++ b/web/concrete/views/image-editor/controls/position.php
@@ -51,6 +51,7 @@
             <i class="fa fa-arrows-h"></i>
         </button>
     </div>
+    <button class="reset btn btn-default"><?php echo t('Fit Image'); ?></button>
 </div>
 
 <div class="form-group crop">


### PR DESCRIPTION
When editing a thumbnail, it can be challenging to use the scale slider and mouse to restore the thumbnail's original position and size. 

The Fit Image button resets the thumbnail to its original size and position.

**Reset Thumbnail Size**

![reset_size1](https://cloud.githubusercontent.com/assets/10898145/12088860/ee735d40-b2ac-11e5-8e04-3f3f67547b5f.jpg)

![reset_size2](https://cloud.githubusercontent.com/assets/10898145/12088863/f098ec70-b2ac-11e5-8892-91b91864d724.jpg)

**Reset Thumbnail Position**

![reset_position1](https://cloud.githubusercontent.com/assets/10898145/12088784/626e2e56-b2ac-11e5-9a56-0265cc0c45de.jpg)

![reset_position2](https://cloud.githubusercontent.com/assets/10898145/12088785/64d14624-b2ac-11e5-9901-349711fe2277.jpg)

