### PR TITLE
ControllerResolver already in namespace

### DIFF
--- a/web/concrete/src/Controller/ApplicationAwareControllerResolver.php
+++ b/web/concrete/src/Controller/ApplicationAwareControllerResolver.php
@@ -6,7 +6,6 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 
 class ApplicationAwareControllerResolver extends ControllerResolver implements ApplicationAwareInterface
 {


### PR DESCRIPTION
This was extended, having this definition and the ControllerResolver in the same namespace prevents installation. I assume we want to use the one provided in the core?