### PR TITLE
Update PageList::filterByPath()

### DIFF
--- a/web/concrete/src/Page/PageList.php
+++ b/web/concrete/src/Page/PageList.php
@@ -390,7 +390,9 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
             $this->query->andWhere(
                 $this->query->expr()->like('pp.cPath', ':cPath')
             );
+            $this->query->orWhere('pp.cPath = :parentPath'); //add parent page to list
             $this->query->setParameter('cPath', $path . '/%');
+            $this->query->setParameter('parentPath', $path);
         }
         $this->query->andWhere('pp.ppIsCanonical = 1');
     }


### PR DESCRIPTION
filterByPath() with param $includeAllChildren return only childrens, without parent.
"INCLUDE all children" does not mean that we should throw out the parent