### PR TITLE
fix: new ControllerResolver namespace collision

### DIFF
--- a/tests/tests/Core/Controller/ControllerResolverTest.php
+++ b/tests/tests/Core/Controller/ControllerResolverTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Concrete\Tests\Core\Controller;
+
+
+class ControllerResolverTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testNamespaceCollision()
+    {
+        class_exists('Concrete\Core\Controller\ControllerResolver');
+        class_exists('Concrete\Core\Controller\ApplicationAwareControllerResolver');
+
+        $this->assertTrue(true);
+    }
+
+}

--- a/web/concrete/src/Controller/ApplicationAwareControllerResolver.php
+++ b/web/concrete/src/Controller/ApplicationAwareControllerResolver.php
@@ -6,9 +6,9 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver as SymfonyControllerResolver;
 
-class ApplicationAwareControllerResolver extends ControllerResolver implements ApplicationAwareInterface
+class ApplicationAwareControllerResolver extends SymfonyControllerResolver implements ApplicationAwareInterface
 {
 
     /** @var Application */


### PR DESCRIPTION
When the old controller resolver was loaded before the new one, a namespace collision would occur. resolves #3279