### PR TITLE
Feature: Attach mode for CLI installer

### DIFF
--- a/web/concrete/controllers/install.php
+++ b/web/concrete/controllers/install.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller;
 
 use Concrete\Core\Cache\Cache;
 use Concrete\Core\Config\Renderer;
+use Concrete\Core\Error\Error;
 use Concrete\Core\Localization\Localization as Localization;
 use Controller;
 use Config;
@@ -27,6 +28,13 @@ class Install extends Controller
      * @var int
      */
     protected $docCommentCanary = 1;
+
+    /**
+     * If the database already exists and is valid, lets just attach to it rather than installing over it.
+     *
+     * @var bool
+     */
+    protected $auto_attach = false;
 
     protected $fp;
     protected $fpu;
@@ -84,7 +92,7 @@ class Install extends Controller
         }
     }
 
-    protected function validateDatabase($e)
+    protected function validateDatabase(Error $e)
     {
         if (!extension_loaded('pdo')) {
             $e->add($this->getDBErrorMsg());
@@ -103,7 +111,7 @@ class Install extends Controller
             if ($DB_SERVER && $DB_DATABASE) {
                 if (!$db) {
                     $e->add(t('Unable to connect to database.'));
-                } else {
+                } elseif (!$this->isAutoAttachEnabled()) {
                     $num = $db->GetCol("show tables");
                     if (count($num) > 0) {
                         $e->add(
@@ -418,4 +426,22 @@ class Install extends Controller
     {
         return '5.3.3';
     }
+
+    /**
+     * @return boolean
+     */
+    public function isAutoAttachEnabled()
+    {
+        return $this->auto_attach;
+    }
+
+    /**
+     * @param boolean $auto_attach
+     */
+    public function setAutoAttach($auto_attach)
+    {
+        $this->auto_attach = $auto_attach;
+    }
+
+
 }

--- a/web/concrete/src/Package/Routine/AttachModeCompatibleRoutineInterface.php
+++ b/web/concrete/src/Package/Routine/AttachModeCompatibleRoutineInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Concrete\Core\Package\Routine;
+
+/**
+ * Interface AttachModeCompatibleRoutineInterface
+ *
+ * `StartingPointInstallRoutine`s that implement this interface will not be skipped when the install command runs in
+ * attach mode. Attach mode is used and a new concrete5 instance is attached to an already installed database.
+ *
+ * @package Concrete\Core\Package
+ */
+interface AttachModeCompatibleRoutineInterface
+{
+
+}

--- a/web/concrete/src/Package/Routine/AttachModeInstallRoutine.php
+++ b/web/concrete/src/Package/Routine/AttachModeInstallRoutine.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Package\Routine;
+
+use Concrete\Core\Package\StartingPointInstallRoutine;
+
+class AttachModeInstallRoutine extends StartingPointInstallRoutine implements AttachModeCompatibleRoutineInterface
+{
+
+}

--- a/web/concrete/src/Package/StartingPointPackage.php
+++ b/web/concrete/src/Package/StartingPointPackage.php
@@ -7,6 +7,7 @@ use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Config\Renderer;
 use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\Mail\Importer\MailImporter;
+use Concrete\Core\Package\Routine\AttachModeInstallRoutine;
 use Concrete\Core\Permission\Access\Entity\ConversationMessageAuthorEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\PageOwnerEntity as PageOwnerPermissionAccessEntity;
@@ -62,7 +63,7 @@ class StartingPointPackage extends BasePackage
             new StartingPointInstallRoutine('import_files', 65, t('Importing files.')),
             new StartingPointInstallRoutine('install_content', 70, t('Adding pages and content.')),
             new StartingPointInstallRoutine('set_site_permissions', 90, t('Setting up site permissions.')),
-            new StartingPointInstallRoutine('finish', 95, t('Finishing.')),
+            new AttachModeInstallRoutine('finish', 95, t('Finishing.')),
         );
     }
 
@@ -100,6 +101,10 @@ class StartingPointPackage extends BasePackage
         return $availableList;
     }
 
+    /**
+     * @param string $pkgHandle
+     * @return static
+     */
     public static function getClass($pkgHandle)
     {
         if (is_dir(DIR_STARTING_POINT_PACKAGES . '/' . $pkgHandle)) {
@@ -112,6 +117,9 @@ class StartingPointPackage extends BasePackage
         return $cl;
     }
 
+    /**
+     * @return StartingPointInstallRoutine[]
+     */
     public function getInstallRoutines()
     {
         return $this->routines;
@@ -251,6 +259,7 @@ class StartingPointPackage extends BasePackage
     {
         $db = Database::get();
         $num = $db->GetCol("show tables");
+
         if (count($num) > 0) {
             throw new \Exception(
                 t(


### PR DESCRIPTION
When the `--attach` flag is supplied with a `concrete5 c5:install` call, if the supplied database already has rows we will attach to it rather than failing.

This change adds an interface that lets you mark your own `StartingPointInstallRoutine` steps as required to run in attach mode, just implement the `\Concrete\Core\Package\Routine\AttachModeCompatibleRoutineInterface` interface.

This should resolve #3298