### PR TITLE
Refactor: Clean up session management

### DIFF
--- a/tests/tests/Core/Session/SessionFactoryTest.php
+++ b/tests/tests/Core/Session/SessionFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Concrete\Tests\Core\Session;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Session\SessionFactory;
+use Concrete\Core\Session\SessionFactoryInterface;
+
+class SessionFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var Application */
+    protected $app;
+
+    /** @var Request */
+    protected $request;
+
+    /** @var SessionFactoryInterface */
+    protected $factory;
+
+    public function setUp()
+    {
+        $this->app = clone \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+        $this->app['config'] = clone $this->app['config'];
+
+        $this->request = Request::create('http://url.com/');
+        $this->factory = new SessionFactory($this->app, $this->request);
+    }
+
+    public function tearDown()
+    {
+        $this->app = $this->request = null;
+    }
+
+    public function testCreatesSession()
+    {
+        $session = $this->factory->createSession();
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\SessionInterface', $session);
+    }
+
+    /**
+     * This should be removed and moved into a request middleware layer, lets just make sure it happens here for now
+     */
+    public function testAddedToRequest()
+    {
+        $session = $this->factory->createSession();
+
+        $this->assertEquals($session, $this->request->getSession());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\SessionInterface', $this->request->getSession());
+    }
+
+    public function testHandlerConfiguration()
+    {
+        $config = $this->app['config'];
+        $config['concrete.session'] = array('handler' => 'database', 'save_path' => '/tmp');
+
+        // Make the private `getSessionHandler` method accessible
+        $reflection = new \ReflectionClass(get_class($this->factory));
+        $method = $reflection->getMethod('getSessionHandler');
+        $method->setAccessible(true);
+
+        // Make sure database session gives us something other than native file session
+        $pdo_handler = $method->invokeArgs($this->factory, array($config));
+        $this->assertNotInstanceOf(
+            'Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler', $pdo_handler);
+
+        $config['concrete.session.handler'] = 'file';
+        // Make sure file session does give us native file session
+        /** @var \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler $native_handler */
+        $native_handler = $method->invokeArgs($this->factory, array($config));
+        $this->assertInstanceOf('Concrete\Core\Session\Storage\Handler\NativeFileSessionHandler', $native_handler);
+    }
+
+}

--- a/tests/tests/Core/Session/SessionValidatorTest.php
+++ b/tests/tests/Core/Session/SessionValidatorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Concrete\Tests\Core\Session;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Session\SessionValidator;
+use Concrete\Core\Support\Facade\Application;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class SessionValidatorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var \Concrete\Core\Application\Application */
+    protected $app;
+
+    /** @var Request */
+    protected $request;
+
+    /** @var SessionValidator */
+    protected $validator;
+
+    /** @var Session */
+    protected $session;
+
+    public function setUp()
+    {
+        $this->app = clone Application::getFacadeApplication();
+        $this->app['config'] = clone $this->app['config'];
+
+        $this->request = Request::create('http://url.com/');
+        $this->validator = new SessionValidator($this->app, $this->app['config'], $this->request);
+
+        $store = array();
+        $mock = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')
+            ->setMethods(array('has', 'get', 'set', 'invalidate', 'all'))
+            ->getMock();
+
+        $mock->expects($this->any())
+            ->method('has')->willReturnCallback(function($key) use (&$store) {
+                return array_get($store, $key) !== null;
+            });
+
+        $mock->expects($this->any())
+            ->method('get')->willReturnCallback(function($key, $default=null) use (&$store) {
+                return array_get($store, $key, $default);
+            });
+
+        $mock->expects($this->any())
+            ->method('set')->willReturnCallback(function($key, $value) use (&$store) {
+                return $store[$key] = $value;
+            });
+
+        $mock->expects($this->any())
+            ->method('all')->willReturnCallback(function() use (&$store) {
+                return $store;
+            });
+
+        $this->session = $mock;
+    }
+
+    public function tearDown()
+    {
+        $this->session = $this->app = $this->validator = $this->request = null;
+    }
+
+    public function testSetsOnFirstCheck()
+    {
+        // Change client ip
+        $this->request->server->set('REMOTE_ADDR', '111.112.113.114');
+        $this->request->server->set('HTTP_USER_AGENT', 'TESTING');
+
+        // Don't invalidate
+        $this->session->expects($this->never())->method('invalidate');
+        $this->validator->handleSessionValidation($this->session);
+
+        $this->assertEquals($this->session->all(), array(
+            'CLIENT_REMOTE_ADDR' => '111.112.113.114',
+            'CLIENT_HTTP_USER_AGENT' => 'TESTING'));
+    }
+
+    public function testInvalidatesOnInvalidIP()
+    {
+        $logger = $this->getMockBuilder('Monolog\Logger')->setConstructorArgs(array(''))->enableArgumentCloning()->getMock();
+
+        // Change client ip
+        $this->request->server->set('REMOTE_ADDR', '111.112.113.114');
+
+        // Set session ip to something different
+        $this->session->set('CLIENT_REMOTE_ADDR', '123.123.123.123');
+
+        $this->validator->setLogger($logger);
+
+        // Don't invalidate
+        $logger->expects($this->once())->method('debug');
+        $this->session->expects($this->once())->method('invalidate');
+        $this->validator->handleSessionValidation($this->session);
+    }
+
+    public function testInvalidatesOnInvalidUserAgent()
+    {
+        $logger = $this->getMockBuilder('Monolog\Logger')->setConstructorArgs(array(''))->enableArgumentCloning()->getMock();
+
+        // Change client agent
+        $this->request->server->set('HTTP_USER_AGENT', 'TESTING');
+
+        // Set session agent to something different
+        $this->session->set('CLIENT_HTTP_USER_AGENT', 'SOME OTHER USER AGENT');
+
+        $this->validator->setLogger($logger);
+
+        // Invalidate
+        $logger->expects($this->once())->method('debug');
+        $this->session->expects($this->once())->method('invalidate');
+        $this->validator->handleSessionValidation($this->session);
+    }
+
+}

--- a/web/concrete/src/Session/Session.php
+++ b/web/concrete/src/Session/Session.php
@@ -1,77 +1,36 @@
 <?php
 namespace Concrete\Core\Session;
 
-use Concrete\Core\Session\Storage\Handler\NativeFileSessionHandler;
-use Concrete\Core\Utility\IPAddress;
-use Config;
+use Concrete\Core\Support\Facade\Application;
 use \Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
-use \Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
-use \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
-use Core;
 
+/**
+ * Class Session
+ * @package Concrete\Core\Session
+ * @deprecated
+ */
 class Session
 {
 
+    /**
+     * Class Session
+     * @package Concrete\Core\Session
+     * @deprecated Create the session using \Concrete\Core\Session\SessionFactory
+     */
     public static function start()
     {
-        $app = Core::make('app');
-        if ($app->isRunThroughCommandLineInterface()) {
-            $storage = new MockArraySessionStorage();
-        } else {
-            if (Config::get('concrete.session.handler') == 'database') {
-                $db = \Database::get();
-                $storage = new NativeSessionStorage(array(),
-                    new PdoSessionHandler($db->getWrappedConnection(), array(
-                            'db_table' => 'Sessions',
-                            'db_id_col' => 'sessionID',
-                            'db_data_col' => 'sessionValue',
-                            'db_time_col' => 'sessionTime'
-                        )
-                    )
-                );
-            } else {
-                $savePath = Config::get('concrete.session.save_path') ?: null;
-                $storage = new NativeSessionStorage(array(), new NativeFileSessionHandler($savePath));
-            }
-            $options = Config::get('concrete.session.cookie');
-            if ($options['cookie_path'] === false) {
-                $options['cookie_path'] = $app['app_relative_path'] . '/';
-            }
-            $options['gc_max_lifetime'] = Config::get('concrete.session.max_lifetime');
-            $storage->setOptions($options);
-        }
-
-        $session = new SymfonySession($storage);
-        $session->setName(Config::get('concrete.session.name'));
-        return $session;
+        /** @var FactoryInterface $factory */
+        $factory = Application::make('Concrete\Core\Session\SessionFactoryInterface');
+        return $factory->createSession();
     }
 
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     * @deprecated Use \Concrete\Core\Session\SessionValidator
+     */
     public static function testSessionFixation(SymfonySession $session)
     {
-        $iph = Core::make('helper/validation/ip');
-        $currentIp = $iph->getRequestIP();
-        $ip = $session->get('CLIENT_REMOTE_ADDR');
-        $agent = $session->get('CLIENT_HTTP_USER_AGENT');
-        $currentUserAgent = $_SERVER['HTTP_USER_AGENT'];
-
-        if (\Config::get('concrete.security.session.invalidate_on_ip_mismatch') && $ip && $ip != $currentIp->getIp(IPAddress::FORMAT_IP_STRING)) {
-            \Log::warning(t('Session Invalidated. Session IP %s did not match provided IP %s.', $ip, $currentIp->getIp(IPAddress::FORMAT_IP_STRING)));
-            $session->invalidate();
-            return;
-        }
-
-        if (\Config::get('concrete.security.session.invalidate_on_user_agent_mismatch') && $agent && $agent != $currentUserAgent) {
-            \Log::warning(t('Session Invalidated. Session user agent %s did not match provided agent %s', $agent, $currentUserAgent));
-            $session->invalidate();
-            return;
-        }
-
-        if (!$ip && $currentIp !== false) {
-            $session->set('CLIENT_REMOTE_ADDR', $currentIp->getIp(IPAddress::FORMAT_IP_STRING));
-        }
-        if (!$agent && isset($_SERVER['HTTP_USER_AGENT'])) {
-            $session->set('CLIENT_HTTP_USER_AGENT', $_SERVER['HTTP_USER_AGENT']);
-        }
+        $validator = Application::make('Concrete\Core\Session\SessionValidatorInterface');
+        $validator->handleSessionValidation($session);
     }
 }

--- a/web/concrete/src/Session/SessionFactory.php
+++ b/web/concrete/src/Session/SessionFactory.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Concrete\Core\Session;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Http\Request;
+use Illuminate\Config\Repository;
+use Concrete\Core\Session\Storage\Handler\NativeFileSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+
+/**
+ * Class SessionFactory
+ * Base concrete5 session factory
+ * @package Concrete\Core\Session
+ */
+class SessionFactory implements SessionFactoryInterface
+{
+
+    /** @var \Concrete\Core\Application\Application */
+    private $app;
+
+    /** @var \Concrete\Core\Http\Request */
+    private $request;
+
+    public function __construct(Application $app, Request $request)
+    {
+        $this->app = $app;
+        $this->request = $request;
+    }
+
+    /**
+     * Create a new symfony session object
+     * This method MUST NOT start the session
+     *
+     * @return \Symfony\Component\HttpFoundation\Session\Session
+     */
+    public function createSession()
+    {
+        $config = $this->app['config'];
+        $storage = $this->getSessionStorage($config);
+
+        $session = new SymfonySession($storage);
+        $session->setName($config->get('concrete.session.name'));
+
+        /**
+         * @todo Move this to somewhere else
+         */
+        $this->request->setSession($session);
+
+        return $session;
+    }
+
+    /**
+     * @param \Illuminate\Config\Repository $config
+     * @return \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface
+     */
+    private function getSessionStorage(Repository $config)
+    {
+        $app = $this->app;
+
+        if ($app->isRunThroughCommandLineInterface()) {
+            $storage = new MockArraySessionStorage();
+        } else {
+            $handler = $this->getSessionHandler($config);
+            $storage = new NativeSessionStorage(array(), $handler);
+
+            // Initialize the storage with some options
+            $options = $config->get('concrete.session.cookie');
+            if ($options['cookie_path'] === false) {
+                $options['cookie_path'] = $app['app_relative_path'] . '/';
+            }
+            $options['gc_max_lifetime'] = $config->get('concrete.session.max_lifetime');
+            $storage->setOptions($options);
+        }
+
+        return $storage;
+    }
+
+    /**
+     * @param \Illuminate\Config\Repository $config
+     * @return \SessionHandlerInterface
+     */
+    private function getSessionHandler(Repository $config)
+    {
+        if ($config->get('concrete.session.handler') == 'database') {
+            $db = $this->app['database']->connection();
+            $handler = new PdoSessionHandler($db->getWrappedConnection(), array(
+                'db_table' => 'Sessions',
+                'db_id_col' => 'sessionID',
+                'db_data_col' => 'sessionValue',
+                'db_time_col' => 'sessionTime'
+            ));
+        } else {
+            $savePath = $config->get('concrete.session.save_path') ?: null;
+            $handler = new NativeFileSessionHandler($savePath);
+        }
+
+        return $handler;
+    }
+
+}

--- a/web/concrete/src/Session/SessionFactoryInterface.php
+++ b/web/concrete/src/Session/SessionFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+namespace Concrete\Core\Session;
+
+use Symfony\Component\HttpFoundation\Session\Session;
+
+/**
+ * Interface FactoryInterface
+ * An object that can create symfony sessions
+ *
+ * @package Concrete\Core\Session
+ */
+interface SessionFactoryInterface
+{
+
+    /**
+     * Create a new symfony session object
+     * This method MUST NOT start the session
+     *
+     * @return Session
+     */
+    public function createSession();
+
+}

--- a/web/concrete/src/Session/SessionServiceProvider.php
+++ b/web/concrete/src/Session/SessionServiceProvider.php
@@ -5,16 +5,15 @@ use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
 class SessionServiceProvider extends ServiceProvider
 {
-
     public function register()
     {
+        $this->app->bind('Concrete\Core\Session\SessionValidatorInterface', 'Concrete\Core\Session\SessionValidator');
+        $this->app->bind('Concrete\Core\Session\SessionFactoryInterface', 'Concrete\Core\Session\SessionFactory');
 
-        $this->app->singleton(
-            'session',
-            function () {
-                return Session::start();
-            });
-
+        $this->app->singleton('session', function ($app) {
+            return $app->make('Concrete\Core\Session\SessionFactoryInterface')->createSession();
+        });
+        $this->app->bind('Symfony\Component\HttpFoundation\Session\Session', 'session');
     }
 
 }

--- a/web/concrete/src/Session/SessionValidator.php
+++ b/web/concrete/src/Session/SessionValidator.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Concrete\Core\Session;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Utility\IPAddress;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+
+/**
+ * Class SessionValidator
+ * Base concrete5 session validator, validates the IP and the agent across requests
+ * @package Concrete\Core\Session
+ */
+class SessionValidator implements SessionValidatorInterface, LoggerAwareInterface
+{
+
+    /** @var \Concrete\Core\Application\Application */
+    private $app;
+
+    /** @var \Concrete\Core\Config\Repository\Repository */
+    private $config;
+
+    /** @var \Concrete\Core\Http\Request */
+    private $request;
+
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    public function __construct(Application $app, Repository $config, Request $request, LoggerInterface $logger = null)
+    {
+        $this->app = $app;
+        $this->config = $config;
+        $this->request = $request;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     */
+    public function handleSessionValidation(SymfonySession $session)
+    {
+        $ip_address = new IPAddress($this->request->getClientIp());
+        $request_ip = $ip_address->getIp(IPAddress::FORMAT_IP_STRING);
+
+        $invalidate = false;
+
+        $ip = $session->get('CLIENT_REMOTE_ADDR');
+        $agent = $session->get('CLIENT_HTTP_USER_AGENT');
+        $request_agent = $this->request->server->get('HTTP_USER_AGENT');
+
+        // Validate the request IP
+        if ($this->shouldCompareIP() && $ip && $ip != $request_ip) {
+            if ($this->logger) {
+                $this->logger->debug('Session Invalidated. Session IP "{session}" did not match provided IP "{client}".',
+                    array(
+                        'session' => $ip,
+                        'client' => $request_ip));
+            }
+
+            $invalidate = true;
+        }
+
+        // Validate the request user agent
+        if ($this->shouldCompareAgent() && $agent && $agent != $request_agent) {
+            if ($this->logger) {
+                $this->logger->debug('Session Invalidated. Session user agent "{session}" did not match provided agent "{client}"',
+                    array(
+                        'session' => $agent,
+                        'client' => $request_agent));
+            }
+
+            $invalidate = true;
+        }
+
+        if ($invalidate) {
+            $session->invalidate();
+        } else {
+            if (!$ip && $request_ip) {
+                $session->set('CLIENT_REMOTE_ADDR', $request_ip);
+            }
+
+            if (!$agent && $request_agent) {
+                $session->set('CLIENT_HTTP_USER_AGENT', $request_agent);
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldCompareIP()
+    {
+        return $this->config->get('concrete.security.session.invalidate_on_ip_mismatch', true);
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldCompareAgent()
+    {
+        return $this->config->get('concrete.security.session.invalidate_on_user_agent_mismatch', true);
+    }
+
+    /**
+     * Sets a logger instance on the object
+     *
+     * @param LoggerInterface $logger
+     * @return null
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+}

--- a/web/concrete/src/Session/SessionValidatorInterface.php
+++ b/web/concrete/src/Session/SessionValidatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Session;
+
+use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+
+interface SessionValidatorInterface
+{
+
+    /**
+     * Handle invalidating a session
+     * This method MUST manage invalidating the session
+     *
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     * @return void
+     */
+    public function handleSessionValidation(SymfonySession $session);
+}

--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\User;
 
 use Concrete\Core\Foundation\Object;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Session\SessionValidatorInterface;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\Authentication\AuthenticationType;
@@ -85,7 +86,7 @@ class User extends Object
             self::refreshUserGroups();
         }
 
-        \Concrete\Core\Session\Session::testSessionFixation($session);
+        $app->make('Concrete\Core\Session\SessionValidatorInterface')->handleSessionValidation($session);
 
         if ($session->get('uID') > 0) {
             $db = $app['database']->connection();


### PR DESCRIPTION
This allows us to use session with the DI container, and makes it a bit easier to work with session generation in a middleware request initialization flow.