### PR TITLE
Edit Defaults - open in the same window, add label, and change back arrow link

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -187,7 +187,13 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
     <ul class="ccm-toolbar-item-list">
         <li class="ccm-logo pull-left"><span><?= Core::make('helper/concrete/ui')->getToolbarLogoSRC() ?></span></li>
         <? if ($c->isMasterCollection()) { ?>
-        <li class="pull-left"><a href="<?= URL::to('/dashboard/pages/types') ?>"><i class="fa fa-arrow-left"></i></a>
+        <li class="pull-left">
+            <a href="<?php echo URL::to('/dashboard/pages/types/output', $c->getPageTypeID()); ?>">
+                <i class="fa fa-arrow-left"></i>
+                <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-edit-mode">
+                    <?php echo tc('toolbar', 'Exit Edit Defaults'); ?>
+                </span>
+            </a>
             <? } ?>
             <? if (!$pageInUseBySomeoneElse && $c->getCollectionPointerID() == 0) { ?>
 

--- a/web/concrete/single_pages/dashboard/pages/types/output.php
+++ b/web/concrete/single_pages/dashboard/pages/types/output.php
@@ -1,22 +1,22 @@
-<? defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 <p class="lead"><?php echo $pagetype->getPageTypeDisplayName(); ?></p>
 
     <table class="table table-striped">
 
-<? foreach($pagetype->getPageTypePageTemplateObjects() as $pt) { ?>
-	
+<?php foreach($pagetype->getPageTypePageTemplateObjects() as $pt) { ?>
+
 
     <tr>
-        <td><a href="<?=$view->action('edit_defaults', $pagetype->getPageTypeID(), $pt->getPageTemplateID())?>" target="_blank"><?=$pt->getPageTemplateIconImage()?></a></td>
-        <td style="width: 100%; vertical-align: middle"><p class="lead" style="margin-bottom: 0px"><?=$pt->getPageTemplateDisplayName()?></p></td>
-        <td style="vertical-align: middle"><a href="<?=$view->action('edit_defaults', $pagetype->getPageTypeID(), $pt->getPageTemplateID())?>" target="_blank" class="btn btn-default"><?=t('Edit Defaults')?></a></td>
+        <td><a href="<?php echo $view->action('edit_defaults', $pagetype->getPageTypeID(), $pt->getPageTemplateID()); ?>" target="_blank"><?php echo $pt->getPageTemplateIconImage(); ?></a></td>
+        <td style="width: 100%; vertical-align: middle"><p class="lead" style="margin-bottom: 0px"><?php echo $pt->getPageTemplateDisplayName(); ?></p></td>
+        <td style="vertical-align: middle"><a href="<?php echo $view->action('edit_defaults', $pagetype->getPageTypeID(), $pt->getPageTemplateID()); ?>" class="btn btn-default"><?php echo t('Edit Defaults'); ?></a></td>
     </tr>
 
-<? } ?>
+<?php } ?>
 
 </table>
 
 <div class="ccm-dashboard-header-buttons">
-    <a href="<?=URL::to('/dashboard/pages/types')?>" class="btn btn-default"><?=t('Back to List')?></a>
+    <a href="<?php echo URL::to('/dashboard/pages/types'); ?>" class="btn btn-default"><?php echo t('Back to List'); ?></a>
 </div>


### PR DESCRIPTION
**Current**
- when on the Defaults and Output page, clicking on an Edit Defaults link opens a new tab
- the new Edit Defaults tab looks very similar to editing a regular page, with the only difference being the arrow/back button in the toolbar

![current_button](https://cloud.githubusercontent.com/assets/10898145/12197266/9e9612b6-b5d3-11e5-8d35-c455efab606d.png)

- the arrow/back button in the toolbar is a link back to the Page Types page

**Changes**
- Edit Defaults links open in the same window
- the arrow/back button in the toolbar has a text label "Exit Edit Defaults" to help differentiate it from editing a regular page

![change_label_button](https://cloud.githubusercontent.com/assets/10898145/12197272/a956ef9a-b5d3-11e5-91e0-fcc8bf6259ed.png)

- the arrow/back button links to the Defaults and Output page for that page type for faster editing of multiple page template defaults

http://www.concrete5.org/community/forums/documentation_efforts/really-hard-user-expirence-for-editing-master-page-pagetype/