### PR TITLE
enhc: add ability to enable fulltextsearch in search block

### DIFF
--- a/web/concrete/blocks/search/controller.php
+++ b/web/concrete/blocks/search/controller.php
@@ -22,6 +22,7 @@ class Controller extends BlockController
     public $title = "";
     public $buttonText = ">";
     public $baseSearchPath = "";
+    public $isFulltextSearch = 0; 
     public $resultsURL = "";
     public $postTo_cID = "";
 
@@ -126,6 +127,7 @@ class Controller extends BlockController
         $this->set('buttonText', $this->buttonText);
         $this->set('baseSearchPath', $this->baseSearchPath);
         $this->set('postTo_cID', $this->postTo_cID);
+        $this->set('isFulltextSearch', $this->isFulltextSearch);
 
         $resultsURL = $c->getCollectionPath();
 
@@ -154,6 +156,7 @@ class Controller extends BlockController
             'title' => '',
             'buttonText' => '',
             'baseSearchPath' => '',
+            'isFulltextSearch' => 0,
             'searchUnderCID' => 0,
             'postTo_cID' => 0,
             'externalTarget' => 0,
@@ -163,6 +166,8 @@ class Controller extends BlockController
         $args['title'] = $data['title'];
         $args['buttonText'] = $data['buttonText'];
         $args['baseSearchPath'] = $data['baseSearchPath'];
+        $args['isFulltextSearch'] = $data['isFulltextSearch'];
+
         if ($args['baseSearchPath'] == 'OTHER' && intval($data['searchUnderCID']) > 0) {
             $customPathC = Page::getByID(intval($data['searchUnderCID']));
             if (!$customPathC) {
@@ -233,7 +238,11 @@ class Controller extends BlockController
         }
 
         if (isset($_REQUEST['query'])) {
+          if($this->isFulltextSearch == 1) {
+            $ipl->filterByFulltextKeywords($_q);
+          } else {
             $ipl->filterByKeywords($_q);
+          }
         }
 
         if (is_array($_REQUEST['search_paths'])) {

--- a/web/concrete/blocks/search/db.xml
+++ b/web/concrete/blocks/search/db.xml
@@ -11,6 +11,7 @@
     <field name="title" type="string" size="255"/>
     <field name="buttonText" type="string" size="128"/>
     <field name="baseSearchPath" type="string" size="255"/>
+    <field name="isFulltextSearch" type="integer"/>
     <field name="postTo_cID" type="string" size="255"/>
     <field name="resultsURL" type="string" size="255"/>
   </table>

--- a/web/concrete/blocks/search/form_setup_html.php
+++ b/web/concrete/blocks/search/form_setup_html.php
@@ -91,5 +91,10 @@ if (is_object($basePostPage) && $basePostPage->isError()) {
             <?=$form->text('resultsURL',$searchObj->resultsURL);?>
         </div>
     </div>
+    <div class='form-group'>
+        <label for='buttonText'><?=t('Fulltext Search')?>:</label>
+        <br>
+        <?=$form->checkbox('isFulltextSearch', 1, $searchObj->isFulltextSearch);?> Enable
+    </div>
 
 </fieldset>


### PR DESCRIPTION
This allows the user to enable Fulltext Search for the Search block.

Testing.

### 1 Installed project from repo

### 2 Created a search block at the bottom of the site

![screen shot 2016-01-08 at 12 26 41 pm](https://cloud.githubusercontent.com/assets/176908/12208756/94a601b4-b603-11e5-970a-d1eff63aedcd.png)

### 3 Left full text disabled

![screen shot 2016-01-08 at 12 26 29 pm](https://cloud.githubusercontent.com/assets/176908/12208760/9a9ea45e-b603-11e5-9c0c-ea343e2deea5.png)

### 4 Searched for the word `Sed` which returned the following

![screen shot 2016-01-08 at 12 27 02 pm](https://cloud.githubusercontent.com/assets/176908/12208776/b7258f66-b603-11e5-9aed-67ef7d927042.png)

### 5 Searched for the words `Sed dignissim` which returned the following

![screen shot 2016-01-08 at 12 27 10 pm](https://cloud.githubusercontent.com/assets/176908/12208816/fc51b308-b603-11e5-806c-588fb3be1234.png)

### 6 Enabled Fulltext Search

![screen shot 2016-01-08 at 12 27 38 pm](https://cloud.githubusercontent.com/assets/176908/12208817/04682a2c-b604-11e5-870f-4d4c6c96e7f4.png)

### 7 Searched for the words `Sed dignissim` which returned the following

![screen shot 2016-01-08 at 12 28 00 pm](https://cloud.githubusercontent.com/assets/176908/12208822/0e9977e4-b604-11e5-9ec2-3523623ee15c.png)
