### PR TITLE
Fix position of blue spinner on toolbar when titles turned on

### DIFF
--- a/web/concrete/css/build/core/app/toolbar.less
+++ b/web/concrete/css/build/core/app/toolbar.less
@@ -33,6 +33,9 @@ div#ccm-toolbar {
     li > a i, li > a img {
       position: static;
     }
+    .spinner {
+      left: 11px;
+    }
   }
 
   &.large-font {


### PR DESCRIPTION
When toolbar titles are turned on the little blue pulsing spinner doesn't sit on top of the icon correctly.
![screen shot 2016-01-11 at 10 38 55 am](https://cloud.githubusercontent.com/assets/1079600/12225011/a9b5fb6a-b84f-11e5-93de-69b9a51ce836.png)

This is a fix for that. After:
![screen shot 2016-01-11 at 10 39 23 am](https://cloud.githubusercontent.com/assets/1079600/12225013/afbbddfe-b84f-11e5-9bd8-9953725d1419.png)
