### PR TITLE
cache permission keys

### DIFF
--- a/web/concrete/src/Permission/Key/Key.php
+++ b/web/concrete/src/Permission/Key/Key.php
@@ -318,6 +318,8 @@ abstract class Key extends Object
         $pkn = self::add($pkCategoryHandle, $pk['handle'], $pk['name'], $pk['description'], $pkCanTriggerWorkflow,
             $pkHasCustomClass, $pkg);
 
+        static::clearCache();
+
         return $pkn;
     }
 
@@ -368,6 +370,8 @@ abstract class Key extends Object
         $a = array($pkHandle, $pkName, $pkDescription, $pkCategoryID, $pkCanTriggerWorkflow, $pkHasCustomClass, $pkgID);
         $r = $db->query("insert into PermissionKeys (pkHandle, pkName, pkDescription, pkCategoryID, pkCanTriggerWorkflow, pkHasCustomClass, pkgID) values (?, ?, ?, ?, ?, ?, ?)",
             $a);
+
+        static::clearCache();
 
         if ($r) {
             $pkID = $db->Insert_ID();
@@ -431,7 +435,7 @@ abstract class Key extends Object
     {
         $db = Database::connection();
         $db->Execute('delete from PermissionKeys where pkID = ?', array($this->getPermissionKeyID()));
-        self::loadAll();
+        static::clearCache();
     }
 
     /**
@@ -497,5 +501,11 @@ abstract class Key extends Object
         }
 
         return $translations;
+    }
+
+    public static function clearCache()
+    {
+        $cache = Core::make('cache/expensive');
+        $cache->getItem('permission_keys')->clear();
     }
 }


### PR DESCRIPTION
I guess there's a reason why `ExpensiveCache` isn't used that much in the core, but when profiling the `loadAll` method was consuming 7.06% of the time to render a page. When measuring I was able to improve performance by slightly less than 3%

part of #3287