### PR TITLE
make slide entries collapsible and draggable

### DIFF
--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -13,7 +13,7 @@ class Controller extends BlockController
     protected $btExportTables = array('btImageSlider', 'btImageSliderEntries');
     protected $btInterfaceWidth = "600";
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "465";
+    protected $btInterfaceHeight = "550";
     protected $btCacheBlockRecord = true;
     protected $btExportFileColumns = array('fID');
     protected $btCacheBlockOutput = true;

--- a/web/concrete/blocks/image_slider/form_setup_html.php
+++ b/web/concrete/blocks/image_slider/form_setup_html.php
@@ -1,4 +1,4 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
 $fp = FilePermissions::getGlobal();
 $tp = new TaskPermission();
@@ -8,53 +8,39 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     array('options', t('Options'))
 ));
 ?>
+
 <script>
-    var CCM_EDITOR_SECURITY_TOKEN = "<?=Loader::helper('validation/token')->generate('editor')?>";
-    $(document).ready(function(){
+    var CCM_EDITOR_SECURITY_TOKEN = "<?php echo Core::make('helper/validation/token')->generate('editor'); ?>";
+    $(document).ready(function() {
         var ccmReceivingEntry = '';
         var sliderEntriesContainer = $('.ccm-image-slider-entries');
         var _templateSlide = _.template($('#imageTemplate').html());
+
         var attachDelete = function($obj) {
-            $obj.click(function(){
-                var deleteIt = confirm('<?php echo t('Are you sure?') ?>');
-                if(deleteIt == true) {
+            $obj.click(function() {
+                var deleteIt = confirm('<?php echo t('Are you sure?'); ?>');
+                if (deleteIt === true) {
                     $(this).closest('.ccm-image-slider-entry').remove();
                     doSortCount();
                 }
             });
-        }
-
-        var attachSortDesc = function($obj) {
-            $obj.click(function(){
-               var myContainer = $(this).closest($('.ccm-image-slider-entry'));
-               myContainer.insertAfter(myContainer.next('.ccm-image-slider-entry'));
-               doSortCount();
-            });
-        }
-
-        var attachSortAsc = function($obj) {
-            $obj.click(function(){
-                var myContainer = $(this).closest($('.ccm-image-slider-entry'));
-                myContainer.insertBefore(myContainer.prev('.ccm-image-slider-entry'));
-                doSortCount();
-            });
-        }
+        };
 
         var attachFileManagerLaunch = function($obj) {
-            $obj.click(function(){
+            $obj.click(function() {
                 var oldLauncher = $(this);
-                ConcreteFileManager.launchDialog(function (data) {
+                ConcreteFileManager.launchDialog(function(data) {
                     ConcreteFileManager.getFileDetails(data.fID, function(r) {
                         jQuery.fn.dialog.hideLoader();
                         var file = r.files[0];
                         oldLauncher.html(file.resultsThumbnailImg);
-                        oldLauncher.next('.image-fID').val(file.fID)
+                        oldLauncher.next('.image-fID').val(file.fID);
                     });
                 });
             });
-        }
+        };
 
-        var doSortCount = function(){
+        var doSortCount = function() {
             $('.ccm-image-slider-entry').each(function(index) {
                 $(this).find('.ccm-image-slider-entry-sort').val(index);
             });
@@ -62,54 +48,54 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
         sliderEntriesContainer.on('change', 'select[data-field=entry-link-select]', function() {
             var container = $(this).closest('.ccm-image-slider-entry');
-            switch(parseInt($(this).val())) {
+            switch (parseInt($(this).val())) {
                 case 2:
-                    container.find('div[data-field=entry-link-page-selector]').hide();
-                    container.find('div[data-field=entry-link-url]').show();
+                    container.find('div[data-field=entry-link-page-selector]').addClass('hide-slide-link').removeClass('show-slide-link');
+                    container.find('div[data-field=entry-link-url]').addClass('show-slide-link').removeClass('hide-slide-link');
                     break;
                 case 1:
-                    container.find('div[data-field=entry-link-url]').hide();
-                    container.find('div[data-field=entry-link-page-selector]').show();
+                    container.find('div[data-field=entry-link-url]').addClass('hide-slide-link').removeClass('show-slide-link');
+                    container.find('div[data-field=entry-link-page-selector]').addClass('show-slide-link').removeClass('hide-slide-link');
                     break;
                 default:
-                    container.find('div[data-field=entry-link-page-selector]').hide();
-                    container.find('div[data-field=entry-link-url]').hide();
+                    container.find('div[data-field=entry-link-page-selector]').addClass('hide-slide-link').removeClass('show-slide-link');
+                    container.find('div[data-field=entry-link-url]').addClass('hide-slide-link').removeClass('show-slide-link');
                     break;
             }
         });
 
-       <?php if($rows) {
-           foreach ($rows as $row) {
-            $linkType = 0;
-            if ($row['linkURL']) {
-                $linkType = 2;
-            } else if ($row['internalLinkCID']) {
-                $linkType = 1;
-           } ?>
-           sliderEntriesContainer.append(_templateSlide({
-                fID: '<?php echo $row['fID'] ?>',
-                <?php if(File::getByID($row['fID'])) { ?>
-                image_url: '<?php echo File::getByID($row['fID'])->getThumbnailURL('file_manager_listing');?>',
-                <?php } else { ?>
-                image_url: '',
-               <?php } ?>
-                link_url: '<?php echo $row['linkURL'] ?>',
-                link_type: '<?php echo $linkType?>',
-                title: '<?php echo addslashes(h($row['title'])) ?>',
-                description: '<?php echo str_replace(array("\t", "\r", "\n"), "", addslashes(h($row['description'])))?>',
-                sort_order: '<?php echo $row['sortOrder'] ?>'
-            }));
-            sliderEntriesContainer.find('.ccm-image-slider-entry:last-child div[data-field=entry-link-page-selector]').concretePageSelector({
-                'inputName': 'internalLinkCID[]', 'cID': <?php if ($linkType == 1) { ?><?=intval($row['internalLinkCID'])?><?php } else { ?>false<?php } ?>
-            });
-        <?php }
-        }?>
+        <?php if ($rows) {
+            foreach ($rows as $row) {
+                $linkType = 0;
+                if ($row['linkURL']) {
+                    $linkType = 2;
+                } else if ($row['internalLinkCID']) {
+                    $linkType = 1;
+               } ?>
+               sliderEntriesContainer.append(_templateSlide({
+                    fID: '<?php echo $row['fID']; ?>',
+                    <?php if (File::getByID($row['fID'])) { ?>
+                    image_url: '<?php echo File::getByID($row['fID'])->getThumbnailURL('file_manager_listing'); ?>',
+                    <?php } else { ?>
+                    image_url: '',
+                   <?php } ?>
+                    link_url: '<?php echo $row['linkURL']; ?>',
+                    link_type: '<?php echo $linkType; ?>',
+                    title: '<?php echo addslashes(h($row['title'])); ?>',
+                    description: '<?php echo str_replace(array("\t", "\r", "\n"), "", addslashes(h($row['description']))); ?>',
+                    sort_order: '<?php echo $row['sortOrder']; ?>'
+                }));
+                sliderEntriesContainer.find('.ccm-image-slider-entry:last-child div[data-field=entry-link-page-selector]').concretePageSelector({
+                    'inputName': 'internalLinkCID[]', 'cID': <?php if ($linkType == 1) { ?><?php echo intval($row['internalLinkCID']); ?><?php } else { ?>false<?php } ?>
+                });
+            <?php }
+        } ?>
 
         doSortCount();
         sliderEntriesContainer.find('select[data-field=entry-link-select]').trigger('change');
 
-        $('.ccm-add-image-slider-entry').click(function(){
-           var thisModal = $(this).closest('.ui-dialog-content');
+        $('.ccm-add-image-slider-entry').click(function() {
+            var thisModal = $(this).closest('.ui-dialog-content');
             sliderEntriesContainer.append(_templateSlide({
                 fID: '',
                 title: '',
@@ -120,13 +106,22 @@ echo Core::make('helper/concrete/ui')->tabs(array(
                 sort_order: '',
                 image_url: ''
             }));
+
+            $('.ccm-image-slider-entry').not('.slide-closed').each(function() {
+                $(this).addClass('slide-closed');
+                var thisEditButton = $(this).closest('.ccm-image-slider-entry').find('.btn.ccm-edit-slide');
+                thisEditButton.text(thisEditButton.data('slideEditText'));
+            });
             var newSlide = $('.ccm-image-slider-entry').last();
+            var closeText = newSlide.find('.btn.ccm-edit-slide').data('slideCloseText');
+            newSlide.removeClass('slide-closed').find('.btn.ccm-edit-slide').text(closeText);
+
             thisModal.scrollTop(newSlide.offset().top);
             newSlide.find('.redactor-content').redactor({
                 minHeight: 200,
                 'concrete5': {
-                    filemanager: <?=$fp->canAccessFileManager()?>,
-                    sitemap: <?=$tp->canAccessSitemap()?>,
+                    filemanager: <?php echo $fp->canAccessFileManager(); ?>,
+                    sitemap: <?php echo $tp->canAccessSitemap(); ?>,
                     lightbox: true
                 }
             });
@@ -135,20 +130,37 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             newSlide.find('div[data-field=entry-link-page-selector-select]').concretePageSelector({
                 'inputName': 'internalLinkCID[]'
             });
-            attachSortDesc(newSlide.find('i.fa-sort-desc'));
-            attachSortAsc(newSlide.find('i.fa-sort-asc'));
             doSortCount();
         });
+
+        $('.ccm-image-slider-entries').on('click','.ccm-edit-slide', function() {
+            $(this).closest('.ccm-image-slider-entry').toggleClass('slide-closed');
+            var thisEditButton = $(this).closest('.ccm-image-slider-entry').find('.btn.ccm-edit-slide');
+            if (thisEditButton.data('slideEditText') === thisEditButton.text()) {
+                thisEditButton.text(thisEditButton.data('slideCloseText'));
+            } else if (thisEditButton.data('slideCloseText') === thisEditButton.text()) {
+                thisEditButton.text(thisEditButton.data('slideEditText'));
+            }
+        });
+
+        $('.ccm-image-slider-entries').sortable({
+            placeholder: "ui-state-highlight",
+            axis: "y",
+            handle: "i.fa-arrows",
+            cursor: "move",
+            update: function() {
+                doSortCount();
+            }
+        });
+
         attachDelete($('.ccm-delete-image-slider-entry'));
-        attachSortAsc($('i.fa-sort-asc'));
-        attachSortDesc($('i.fa-sort-desc'));
         attachFileManagerLaunch($('.ccm-pick-slide-image'));
         $(function() {  // activate redactors
             $('.redactor-content').redactor({
                 minHeight: 200,
                 'concrete5': {
-                    filemanager: <?=$fp->canAccessFileManager()?>,
-                    sitemap: <?=$tp->canAccessSitemap()?>,
+                    filemanager: <?php echo $fp->canAccessFileManager(); ?>,
+                    sitemap: <?php echo $tp->canAccessSitemap(); ?>,
                     lightbox: true
                 }
             });
@@ -156,7 +168,6 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     });
 </script>
 <style>
-
     .ccm-image-slider-block-container .redactor_editor {
         padding: 20px;
     }
@@ -168,52 +179,83 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     .ccm-image-slider-block-container .btn-success {
         margin-bottom: 20px;
     }
-
     .ccm-image-slider-entries {
         padding-bottom: 30px;
     }
-
+    .ccm-image-slider-block-container .slide-well {
+        min-height: 20px;
+        padding: 10px;
+        margin-bottom: 10px;
+        background-color: #f5f5f5;
+        border: 1px solid #e3e3e3;
+        border-radius: 4px;
+        -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+        -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+        box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+    }
     .ccm-pick-slide-image {
-        padding: 15px;
+        padding: 5px;
         cursor: pointer;
         background: #dedede;
         border: 1px solid #cdcdcd;
         text-align: center;
         vertical-align: middle;
+        width: 72px;
+        height: 72px;
+        display: table-cell;
     }
-
     .ccm-pick-slide-image img {
         max-width: 100%;
     }
-
     .ccm-image-slider-entry {
         position: relative;
     }
-
-
-
-    .ccm-image-slider-block-container i.fa-sort-asc {
+    .ccm-image-slider-entry.slide-closed .form-group {
+        display: none;
+    }
+    .ccm-image-slider-entry.slide-closed .form-group:first-of-type {
+        display: block;
+        margin-bottom: 0px;
+    }
+    .ccm-image-slider-entry.slide-closed .form-group:first-of-type label {
+        display: none;
+    }
+    .btn.ccm-edit-slide {
         position: absolute;
         top: 10px;
-        right: 10px;
-        cursor: pointer;
+        right: 127px;
     }
-
-    .ccm-image-slider-block-container i:hover {
-        color: #5cb85c;
-    }
-
-    .ccm-image-slider-block-container i.fa-sort-desc {
+    .btn.ccm-delete-image-slider-entry {
         position: absolute;
-        top: 15px;
-        cursor: pointer;
-        right: 10px;
+        top: 10px;
+        right: 41px;
+    }
+    .ccm-image-slider-block-container i:hover {
+        color: #428bca;
+    }
+    .ccm-image-slider-block-container i.fa-arrows {
+        position: absolute;
+        top: 6px;
+        right: 5px;
+        cursor: move;
+        font-size: 20px;
+        padding: 5px;
+    }
+    .ccm-image-slider-block-container .ui-state-highlight {
+        height: 94px;
+        margin-bottom: 15px;
+    }
+    .ccm-image-slider-block-container .show-slide-link {
+        display: block;
+    }
+    .ccm-image-slider-block-container .hide-slide-link {
+        display: none;
     }
 </style>
 
 <div id="ccm-tab-content-slides" class="ccm-tab-content">
     <div class="ccm-image-slider-block-container">
-        <span class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Entry'); ?></span>
+        <button type="button" class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Slide'); ?></button>
         <div class="ccm-image-slider-entries">
 
         </div>
@@ -235,13 +277,13 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     <div class="form-group">
         <?php echo $form->label('timeout', t('Slide Duration')); ?>
         <div class="input-group" style="width: 150px">
-        <?php echo $form->text('timeout', $timeout ? $timeout : 4000, array('maxlength' => '5'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
+        <?php echo $form->number('timeout', $timeout ? $timeout : 4000, array('min' => '1', 'max' => '99999'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
         </div>
     </div>
     <div class="form-group">
         <?php echo $form->label('speed', t('Slide Transition Speed')); ?>
         <div class="input-group" style="width: 150px">
-        <?php echo $form->text('speed', $speed ? $speed : 500, array('maxlength' => '5'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
+        <?php echo $form->number('speed', $speed ? $speed : 500, array('min' => '1', 'max' => '99999'))?><span class="input-group-addon"><?php echo t('ms'); ?></span>
         </div>
     </div>
     <div class="form-group">
@@ -255,11 +297,12 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 </div>
 
 <script type="text/template" id="imageTemplate">
-    <div class="ccm-image-slider-entry well">
-        <i class="fa fa-sort-desc"></i>
-        <i class="fa fa-sort-asc"></i>
+    <div class="ccm-image-slider-entry slide-well slide-closed">
+        <button type="button" class="btn btn-default ccm-edit-slide" data-slide-close-text="<?php echo t('Collapse Slide'); ?>" data-slide-edit-text="<?php echo t('Edit Slide'); ?>"><?php echo t('Edit Slide'); ?></button>
+        <button type="button" class="btn btn-danger ccm-delete-image-slider-entry"><?php echo t('Remove'); ?></button>
+        <i class="fa fa-arrows"></i>
         <div class="form-group">
-            <label><?php echo t('Image') ?></label>
+            <label><?php echo t('Image'); ?></label>
             <div class="ccm-pick-slide-image">
                 <% if (image_url.length > 0) { %>
                     <img src="<%= image_url %>" />
@@ -267,39 +310,33 @@ echo Core::make('helper/concrete/ui')->tabs(array(
                     <i class="fa fa-picture-o"></i>
                 <% } %>
             </div>
-            <input type="hidden" name="<?=$view->field('fID')?>[]" class="image-fID" value="<%=fID%>" />
+            <input type="hidden" name="<?php echo $view->field('fID'); ?>[]" class="image-fID" value="<%=fID%>" />
         </div>
-        <div class="form-group">
-            <label><?php echo t('Title') ?></label>
-            <input type="text" name="<?=$view->field('title')?>[]" value="<%=title%>" />
+        <div class="form-group" >
+            <label><?php echo t('Title'); ?></label>
+            <input type="text" name="<?php echo $view->field('title'); ?>[]" value="<%=title%>" />
         </div>
-        <div class="form-group">
-            <label><?php echo t('Description') ?></label>
+        <div class="form-group" >
+            <label><?php echo t('Description'); ?></label>
             <div class="redactor-edit-content"></div>
-            <textarea style="display: none" class="redactor-content" name="<?=$view->field('description')?>[]"><%=description%></textarea>
+            <textarea style="display: none" class="redactor-content" name="<?php echo $view->field('description'); ?>[]"><%=description%></textarea>
         </div>
-        <div class="form-group">
-           <label><?php echo t('Link') ?></label>
+        <div class="form-group" >
+           <label><?php echo t('Link'); ?></label>
             <select data-field="entry-link-select" name="linkType[]" class="form-control" style="width: 60%;">
-                <option value="0" <% if (!link_type) { %>selected<% } %>><?=t('None')?></option>
-                <option value="1" <% if (link_type == 1) { %>selected<% } %>><?=t('Another Page')?></option>
-                <option value="2" <% if (link_type == 2) { %>selected<% } %>><?=t('External URL')?></option>
+                <option value="0" <% if (!link_type) { %>selected<% } %>><?php echo t('None'); ?></option>
+                <option value="1" <% if (link_type == 1) { %>selected<% } %>><?php echo t('Another Page'); ?></option>
+                <option value="2" <% if (link_type == 2) { %>selected<% } %>><?php echo t('External URL'); ?></option>
             </select>
         </div>
-
-        <div style="display: none;" data-field="entry-link-url" class="form-group">
-           <label><?php echo t('URL:') ?></label>
+        <div data-field="entry-link-url" class="form-group hide-slide-link">
+           <label><?php echo t('URL:'); ?></label>
             <textarea name="linkURL[]"><%=link_url%></textarea>
         </div>
-
-        <div style="display: none;" data-field="entry-link-page-selector" class="form-group">
-           <label><?php echo t('Choose Page:') ?></label>
+        <div data-field="entry-link-page-selector" class="form-group hide-slide-link">
+           <label><?php echo t('Choose Page:'); ?></label>
             <div data-field="entry-link-page-selector-select"></div>
         </div>
-
-        <input class="ccm-image-slider-entry-sort" type="hidden" name="<?=$view->field('sortOrder')?>[]" value="<%=sort_order%>"/>
-        <div class="form-group">
-            <span class="btn btn-danger ccm-delete-image-slider-entry"><?php echo t('Delete Entry'); ?></span>
-        </div>
+        <input class="ccm-image-slider-entry-sort" type="hidden" name="<?php echo $view->field('sortOrder'); ?>[]" value="<%=sort_order%>"/>
     </div>
 </script>


### PR DESCRIPTION
This pull request makes the individual slide entries collapsible and draggable. When adding a new slide, all other slides collapse, significantly reducing the amount of scrolling to reach the Add Slide button to create another slide. When dragging, there is a blue placeholder showing where the slide will be dropped

The Slide Duration and Slide Transition Speed inputs were changed from text to number.

**Closed Slides**

![closed_slides](https://cloud.githubusercontent.com/assets/10898145/12261030/963dc67e-b8ec-11e5-9bc4-31f28c85b916.png)

**Open Slide**

![open_slide](https://cloud.githubusercontent.com/assets/10898145/12261037/a8389372-b8ec-11e5-81ec-d58fc4332c61.png)

**Drag Placeholder**

![drag1](https://cloud.githubusercontent.com/assets/10898145/12261503/82585e14-b8ef-11e5-8b24-059e73c77853.png)

![drag2](https://cloud.githubusercontent.com/assets/10898145/12261504/8588b7f0-b8ef-11e5-9d79-b8fe1ca49196.png)

I believe there is an existing upgrade script for the Image Slider block:
https://github.com/concrete5/concrete5/blob/develop/web/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php#L27-L30

