### PR TITLE
Use ASSETS_URL_IMAGES instead of DIR_REL

### DIFF
--- a/web/concrete/themes/concrete/background_image.php
+++ b/web/concrete/themes/concrete/background_image.php
@@ -51,7 +51,7 @@ $(function() {
             .append(
             $('<img/>')
                 .css({ width: '100%', height: '100%' })
-                .attr('src', '<?= DIR_REL ?>/concrete/images/login_fade.png'))
+                .attr('src', '<?= ASSETS_URL_IMAGES ?>/login_fade.png'))
             .fadeIn();
     }, 0);
 


### PR DESCRIPTION
If concrete5 has been updated and is running from `updates/`, `DIR_REL` always points to the original concrete5 core, `ASSETS_URL_IMAGES` points to the right update.