### PR TITLE
Fix oauth_extractor bind parameters

### DIFF
--- a/web/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
+++ b/web/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
@@ -29,11 +29,17 @@ class ServiceProvider extends Provider
 
         $this->app->bind(
             'oauth_extractor',
-            function ($app, $service=null) {
-                if (!$service) {
+            function ($app, $params = array()) {
+
+                if (!is_array($params)) {
+                    $params = array($params);
+                }
+
+                if (!isset($params[0])) {
                     return null;
                 }
 
+                $service = $params[0];
                 $extractor_factory = $app->make('oauth/factory/extractor');
                 return $extractor_factory->get($service);
             });


### PR DESCRIPTION
The following change broke the generic OAuth login in 5.7.5.4: https://github.com/concrete5/concrete5/commit/8eaac83641686eb43f81f72027c412d264e02ca1#diff-ced5220248e4a9d14defe88b7d4e7836

Error message: `Argument 1 passed to OAuth\UserData\ExtractorFactory::get() must implement interface OAuth\Common\Service\ServiceInterface, array given, called in […]/concrete/src/Authentication/Type/OAuth/ServiceProvider.php on line 38 and defined`

I'm not too familiar with Laravel IoC and [the documentation](https://laravel.com/docs/4.2/ioc) about it rather sparse, but from what I gathered by looking at the source and usage on GitHub it seems the second parameter of the bind closure should be `$params = array()`.

This proposed fix keeps the type `oauth_extractor` backward compatible.

@KorvinSzanto Can you check?