### PR TITLE
An implementation of the tracker service and a stack tracker

### DIFF
--- a/tests/tests/Core/Express/ObjectAssociationBuilderTest.php
+++ b/tests/tests/Core/Express/ObjectAssociationBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-require __DIR__ . '/ExpressEntityManagerTestCaseTrait.php';
+require_once __DIR__ . '/ExpressEntityManagerTestCaseTrait.php';
 
 class ObjectAssociationBuilderTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Concrete\tests\Core\Statistics\UsageTracker;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+use Concrete\Core\Statistics\UsageTracker\TrackerInterface;
+use InvalidArgumentException;
+use ReflectionClass;
+use stdClass;
+
+class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var Application */
+    private $app;
+
+    /** @var AggregateTracker */
+    private $tracker;
+
+    public function setUp()
+    {
+        $this->app = new Application();
+        $this->tracker = $this->app->build(AggregateTracker::class);
+    }
+
+    public function tearDown()
+    {
+        $this->app = $this->tracker = null;
+    }
+
+    public function testCallsTrack()
+    {
+        // Create the trackers
+        $tracker1 = $this->getMock(TrackerInterface::class);
+        $tracker2 = $this->getMock(TrackerInterface::class);
+        $tracker3 = $this->getMock(TrackerInterface::class);
+
+        // Change the properties
+        $this->changeProperty($this->tracker, 'trackers', [$tracker1, $tracker2, $tracker3]);
+        $this->changeProperty($this->tracker, 'map', [0, 1, 2]);
+
+        // Set the expectations
+        $tracker1->expects($this->once())->method('track');
+        $tracker2->expects($this->once())->method('track');
+        $tracker3->expects($this->once())->method('track');
+
+        // Run the track;
+        $this->tracker->track($this->getMock(TrackableInterface::class));
+    }
+
+    public function testCallsForget()
+    {
+        // Create the trackers
+        $tracker1 = $this->getMock(TrackerInterface::class);
+        $tracker2 = $this->getMock(TrackerInterface::class);
+        $tracker3 = $this->getMock(TrackerInterface::class);
+
+        // Change the properties
+        $this->changeProperty($this->tracker, 'trackers', [$tracker1, $tracker2, $tracker3]);
+        $this->changeProperty($this->tracker, 'map', [0, 1, 2]);
+
+        // Set the expectations
+        $tracker1->expects($this->once())->method('forget');
+        $tracker2->expects($this->once())->method('forget');
+        $tracker3->expects($this->once())->method('forget');
+
+        // Run the track;
+        $this->tracker->forget($this->getMock(TrackableInterface::class));
+    }
+
+    public function testCallsCreator()
+    {
+        $return_tracker = $this->getMock(TrackerInterface::class);
+        $this->tracker->addTracker('test', function() use ($return_tracker) {
+            return $return_tracker;
+        });
+
+        // Expect that the `track` method gets called
+        $return_tracker->expects($this->once())->method('track');
+
+        // Run the track method
+        $this->tracker->track($this->getMock(TrackableInterface::class));
+    }
+
+    public function testUsesDIContainer()
+    {
+        $this->app->bind(stdClass::class, function() {
+            return (object)['test' => 'tested'];
+        });
+
+        $passed = null;
+        $return_tracker = $this->getMock(TrackerInterface::class);
+        $this->tracker->addTracker('test', function(stdClass $obj) use (&$passed, $return_tracker) {
+            $passed = $obj;
+            return $return_tracker;
+        });
+
+        // Run the track method
+        $this->tracker->track($this->getMock(TrackableInterface::class));
+
+        // Make sure it gave us the right stdclass
+        $this->assertInstanceOf(stdClass::class, $passed);
+        $this->assertEquals('tested', $passed->test);
+    }
+
+    public function testSomeCreated()
+    {
+        // Create the trackers
+        $tracker1 = $this->getMock(TrackerInterface::class);
+        $tracker2 = $this->getMock(TrackerInterface::class);
+        $tracker3 = $this->getMock(TrackerInterface::class);
+        $tracker4 = $this->getMock(TrackerInterface::class);
+
+        $calls = 0;
+        // Bind the trackers
+        $this->tracker
+            ->addTracker('test1', function() use ($tracker1, &$calls) { $calls++; return $tracker1; })
+            ->addTracker('test2', function() use ($tracker2, &$calls) { $calls++; return $tracker2; })
+            ->addTracker('test3', function() use ($tracker3, &$calls) { $calls++; return $tracker3; })
+            ->addTracker('test4', function() use ($tracker4, &$calls) { $calls++; return $tracker4; });
+
+        // Set the expectations
+        $tracker1->expects($this->exactly(2))->method('track');
+        $tracker2->expects($this->exactly(2))->method('track');
+        $tracker3->expects($this->exactly(2))->method('track');
+        $tracker4->expects($this->exactly(2))->method('track');
+
+        // Create a couple of them
+        $this->tracker->tracker('test1');
+        $this->tracker->tracker('test3');
+
+        // Make sure we only have 2 calls so far
+        $this->assertEquals(2, $calls);
+
+        // Now track something
+        $this->tracker->track($this->getMock(TrackableInterface::class));
+
+        // Make sure there were only 4 calls
+        $this->assertEquals(4, $calls);
+
+        // Now track one more thing
+        $this->tracker->track($this->getMock(TrackableInterface::class));
+
+        // Make sure there were only 4 calls
+        $this->assertEquals(4, $calls);
+    }
+
+    public function testReturnsInstance()
+    {
+        $result = $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->assertSame($this->tracker, $result);
+    }
+
+    public function testOverwrite()
+    {
+        $tracker1 = $this->getMock(TrackerInterface::class);
+        $tracker2 = $this->getMock(TrackerInterface::class);
+
+        // Bind 'test' to the first tracker
+        $this->tracker->addTracker('test', function () use ($tracker1) { return $tracker1; });
+
+        // Lets make sure it's really the right tracker twice to test retrieving from cache
+        $this->assertEquals($tracker1, $this->tracker->tracker('test'));
+        $this->assertEquals($tracker1, $this->tracker->tracker('test'));
+
+        // Rebind 'test' to the other tracker
+        $this->tracker->addTracker('test', function () use ($tracker2) { return $tracker2; });
+
+        // Make sure it's the right tracker again
+        $this->assertEquals($tracker2, $this->tracker->tracker('test'));
+        $this->assertEquals($tracker2, $this->tracker->tracker('test'));
+    }
+
+    public function testErrorOnMiss()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+        $this->tracker->tracker('test');
+    }
+
+    private function changeProperty($object, $property, $value)
+    {
+        $reflection = new ReflectionClass($object);
+        $property = $reflection->getProperty($property);
+        $property->setAccessible(true);
+
+        $property->setValue($object, $value);
+    }
+
+}

--- a/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Concrete\tests\Core\Statistics\UsageTracker;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Statistics\UsageTracker\ServiceProvider;
+use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
+
+class ServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRegister()
+    {
+        $app = new Application();
+
+        $provider = new ServiceProvider($app);
+        $provider->register();
+
+        // Make sure the service provider provides everything we need
+        $this->assertTrue($app->isShared(AggregateTracker::class));
+        $this->assertTrue($app->bound(TrackerManagerInterface::class));
+        $this->assertInstanceOf(TrackerManagerInterface::class, $app->make(AggregateTracker::class));
+    }
+}

--- a/web/concrete/blocks/core_stack_display/controller.php
+++ b/web/concrete/blocks/core_stack_display/controller.php
@@ -23,6 +23,9 @@ class Controller extends BlockController
     protected $btIsInternal = true;
     protected $btCacheSettingsInitialized = false;
 
+    /** @var int The stack ID */
+    public $stID;
+
     public function getBlockTypeDescription()
     {
         return t("Proxy block for stacks added through the UI.");
@@ -191,4 +194,10 @@ class Controller extends BlockController
 
         return $this->btCacheBlockOutputLifetime;
     }
+
+    public function getStackID()
+    {
+        return $this->stID;
+    }
+
 }

--- a/web/concrete/blocks/core_stack_display/controller.php
+++ b/web/concrete/blocks/core_stack_display/controller.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Block\CoreStackDisplay;
 
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+use Concrete\Core\Support\Facade\Application;
 use Stack;
 use Permissions;
 use Page;
@@ -16,7 +18,7 @@ use Concrete\Core\Block\BlockController;
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
-class Controller extends BlockController
+class Controller extends BlockController implements TrackableInterface
 {
     protected $btCacheBlockRecord = true;
     protected $btTable = 'btCoreStackDisplay';
@@ -198,6 +200,19 @@ class Controller extends BlockController
     public function getStackID()
     {
         return $this->stID;
+    }
+
+    public function save($args)
+    {
+        parent::save($args);
+        $this->stID = $args['stID'];
+        Application::getFacadeApplication()->make('statistics/tracker')->track($this);
+    }
+
+    public function delete()
+    {
+        Application::getFacadeApplication()->make('statistics/tracker')->forget($this);
+        parent::delete();
     }
 
 }

--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -138,6 +138,9 @@ return array(
         // Express
         'core_attribute' => '\Concrete\Core\Attribute\AttributeServiceProvider',
         'core_express' => '\Concrete\Core\Express\ExpressServiceProvider',
+
+        // Tracker
+        'core_usagetracker' => '\Concrete\Core\Statistics\UsageTracker\ServiceProvider'
     ),
 
     /*

--- a/web/concrete/config/statistics.php
+++ b/web/concrete/config/statistics.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'trackers' => [
+        'core_stack' => \Concrete\Core\Page\Stack\UsageTracker::class
+    ]
+];

--- a/web/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/web/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -54,11 +54,11 @@ if ($controller->getTask() == 'view_details') {
         <?php if ($isGlobalArea) {
     ?>
         <a href="<?=URL::to('/dashboard/blocks/stacks/view_global_areas')?>" data-dialog="add-stack" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?=t("Back to Global Areas")?></a>
-        <?php 
+        <?php
 } else {
     ?>
         <a href="<?=URL::to('/dashboard/blocks/stacks')?>" data-dialog="add-stack" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?=t("Back to Stacks")?></a>
-        <?php 
+        <?php
 }
     ?>
     </div>
@@ -80,35 +80,43 @@ if ($controller->getTask() == 'view_details') {
         <?php if ($cpc->canEditPageProperties() && $stack->getStackType() != \Concrete\Core\Page\Stack\Stack::ST_TYPE_GLOBAL_AREA) {
     ?>
             <li><a href="<?=$view->action('rename', $stack->getCollectionID())?>"><?=t('Rename')?></a></li>
-        <?php 
+        <?php
 }
     ?>
         <?php if ($cpc->canEditPagePermissions() && Config::get('concrete.permissions.model') == 'advanced') {
     ?>
             <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/edit_area_popup?cID=<?=$stack->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>&atask=groups"><?=t('Permissions')?></a></li>
-        <?php 
+        <?php
 }
     ?>
 
         <?php if ($cpc->canMoveOrCopyPage() && $stack->getStackType() != \Concrete\Core\Page\Stack\Stack::ST_TYPE_GLOBAL_AREA) {
     ?>
             <li><a href="<?=$view->action('duplicate', $stack->getCollectionID())?>" style="margin-right: 4px;"><?=t('Duplicate Stack')?></a></li>
-        <?php 
+        <?php
 }
     ?>
+
+
+        <li>
+            <a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackUsage" dialog-title="<?=t('Stack Usage')?>" href="<?= $view->action('usage', $stack->getCollectionID()) ?>">
+                <?=t('Stack Usage')?>
+            </a>
+        </li>
+
         <?php if ($cpc->canDeletePage()) {
     ?>
             <?php if ($stack->getStackType() == \Concrete\Core\Page\Stack\Stack::ST_TYPE_GLOBAL_AREA) {
     ?>
                 <li><a href="javascript:void(0)" data-dialog="delete-stack"><span class="text-danger"><?=t('Clear Global Area')?></span></a></li>
-            <?php 
+            <?php
 } else {
     ?>
                 <li><a href="javascript:void(0)" data-dialog="delete-stack"><span class="text-danger"><?=t('Delete Stack')?></span></a></li>
-            <?php 
+            <?php
 }
     ?>
-        <?php 
+        <?php
 }
     ?>
     </ul>
@@ -116,13 +124,13 @@ if ($controller->getTask() == 'view_details') {
     ?>
     <ul class="nav navbar-nav navbar-right">
         <li id="ccm-stack-list-approve-button" class="navbar-form" <?php if ($vo->isApproved()) {
-    ?> style="display: none;" <?php 
+    ?> style="display: none;" <?php
 }
     ?>>
             <button class="btn btn-success" onclick="window.location.href='<?=URL::to('/dashboard/blocks/stacks', 'approve_stack', $stack->getCollectionID(), $token->generate('approve_stack'))?>'"><?=$publishTitle?></button>
         </li>
     </ul>
-    <?php 
+    <?php
 }
     ?>
     </div>
@@ -225,7 +233,7 @@ if ($controller->getTask() == 'view_details') {
         });
     </script>
 
-<?php 
+<?php
 } elseif ($this->controller->getTask() == 'duplicate') {
     $sv = CollectionVersion::get($stack, 'ACTIVE');
     ?>
@@ -245,7 +253,7 @@ if ($controller->getTask() == 'view_details') {
         </div>
     </form>
 
-<?php 
+<?php
 } elseif ($this->controller->getTask() == 'rename') {
     $sv = CollectionVersion::get($stack, 'ACTIVE');
     ?>
@@ -265,7 +273,7 @@ if ($controller->getTask() == 'view_details') {
         </div>
     </form>
 
-<?php 
+<?php
 } else {
     ?>
 
@@ -278,14 +286,14 @@ if ($controller->getTask() == 'view_details') {
 
             <li id="stID_<?=$st->getCollectionID()?>">
                 <?php if ($canMoveStacks) {
-    ?><i class="ccm-item-select-list-sort"></i><?php 
+    ?><i class="ccm-item-select-list-sort"></i><?php
 }
     ?>
                 <a href="<?=$view->url('/dashboard/blocks/stacks', 'view_details', $st->getCollectionID())?>">
                     <i class="fa fa-bars"></i> <?=$sv->getVersionName()?>
                 </a>
             </li>
-        <?php 
+        <?php
 }
     ?>
         </ul>
@@ -318,11 +326,11 @@ if ($controller->getTask() == 'view_details') {
     ?>
                 <li><a href="<?=$view->action('set_default_language', $section->getCollectionID(), $controller->getTask())?>"><?=$ch->getSectionFlagIcon($section)?> <?php echo $section->getLanguageText()?> <span class="text-muted"><?php echo $section->getLocale();
     ?></span></a></li>
-            <?php 
+            <?php
 }
     ?>
         </ul>
-        <?php 
+        <?php
 }
     ?>
         </span>
@@ -331,11 +339,11 @@ if ($controller->getTask() == 'view_details') {
             <?php if ($controller->getTask() == 'view_global_areas') {
     ?>
                 <?=t('View Global Areas')?>
-            <?php 
+            <?php
 } else {
     ?>
                 <?=t('View Stacks')?>
-            <?php 
+            <?php
 }
     ?>
             <span class="caret"></span>
@@ -348,7 +356,7 @@ if ($controller->getTask() == 'view_details') {
         <?php if ($controller->getTask() != 'view_global_areas') {
     ?>
             <a href="javascript:void(0)" data-dialog="add-stack" class="btn btn-primary"><?=t("Add Stack")?></a>
-        <?php 
+        <?php
 }
     ?>
     </div>
@@ -401,12 +409,12 @@ if ($controller->getTask() == 'view_details') {
                 });
             }
         });
-        <?php 
+        <?php
 }
     ?>
 
     });
     </script>
 
-<?php 
+<?php
 } ?>

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -433,6 +433,7 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
         }
         $this->instance->setBlockObject($this);
 
+
         return $this->instance;
     }
 

--- a/web/concrete/src/Block/BlockType/BlockType.php
+++ b/web/concrete/src/Block/BlockType/BlockType.php
@@ -3,10 +3,12 @@ namespace Concrete\Core\Block\BlockType;
 
 use Block;
 use BlockTypeSet;
+use Concrete\Block\CoreStackDisplay\Controller;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Filesystem\TemplateFile;
 use Concrete\Core\Package\PackageList;
+use Concrete\Core\Support\Facade\Application;
 use Core;
 use Database as DB;
 use Environment;
@@ -739,6 +741,11 @@ class BlockType
     protected function loadController()
     {
         $class = static::getBlockTypeMappedClass($this->getBlockTypeHandle(), $this->getPackageHandle());
+
+        /** @var Controller controller */
         $this->controller = new $class($this);
+
+        /** @todo Move controller construction out of BlockType */
+        $this->controller->setApplication(Application::getFacadeApplication());
     }
 }

--- a/web/concrete/src/Entity/Statistics/UsageTracker/StackUsageRecord.php
+++ b/web/concrete/src/Entity/Statistics/UsageTracker/StackUsageRecord.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Concrete\Core\Entity\Statistics\UsageTracker;
+
+/**
+ * Class StackUsageRecord
+ * @package Concrete\Core\Entity\Statistics\UsageTracker
+ * @Entity
+ * @Table(name="StackUsageRecord")
+ */
+class StackUsageRecord
+{
+
+    /**
+     * @Id @Column(type="integer")
+     * @var int
+     */
+    protected $stack_id;
+
+    /**
+     * @Id @Column(type="integer")
+     * @var int
+     */
+    protected $block_id;
+
+    /**
+     * @Id @Column(type="integer")
+     * @var int
+     */
+    protected $collection_id;
+
+    /**
+     * @Id @Column(type="integer")
+     * @var int
+     */
+    protected $collection_version_id;
+
+    /**
+     * @return int
+     */
+    public function getStackId()
+    {
+        return $this->stack_id;
+    }
+
+    /**
+     * @param int $stack_id
+     */
+    public function setStackId($stack_id)
+    {
+        $this->stack_id = $stack_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBlockId()
+    {
+        return $this->block_id;
+    }
+
+    /**
+     * @param int $block_id
+     */
+    public function setBlockId($block_id)
+    {
+        $this->block_id = $block_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCollectionId()
+    {
+        return $this->collection_id;
+    }
+
+    /**
+     * @param int $collection_id
+     */
+    public function setCollectionId($collection_id)
+    {
+        $this->collection_id = $collection_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCollectionVersionId()
+    {
+        return $this->collection_version_id;
+    }
+
+    /**
+     * @param int $collection_version_id
+     */
+    public function setCollectionVersionId($collection_version_id)
+    {
+        $this->collection_version_id = $collection_version_id;
+    }
+
+}

--- a/web/concrete/src/Page/Stack/UsageTracker.php
+++ b/web/concrete/src/Page/Stack/UsageTracker.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Concrete\Core\Page\Stack;
+
+use Concrete\Block\CoreStackDisplay\Controller;
+use Concrete\Core\Block\Block;
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Entity\Statistics\UsageTracker\StackUsageRecord;
+use Concrete\Core\Page\Collection\Collection;
+use Concrete\Core\Page\Controller\PageController;
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+use Concrete\Core\Statistics\UsageTracker\TrackerInterface;
+use Doctrine\ORM\EntityManager;
+
+class UsageTracker implements TrackerInterface
+{
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $manager;
+
+    /**
+     * @var \Doctrine\ORM\EntityRepository
+     */
+    private $repository;
+
+    public function __construct(EntityManager $manager)
+    {
+
+        $this->manager = $manager;
+        $this->repository = $manager->getRepository(StackUsageRecord::class);
+    }
+
+    /**
+     * Track a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function track(TrackableInterface $trackable)
+    {
+        if ($trackable instanceof Collection) {
+            $this->trackCollection($trackable);
+        }
+
+        if ($trackable instanceof PageController) {
+            $this->trackCollection($trackable->getPageObject());
+        }
+
+        if ($trackable instanceof Controller) {
+            $this->trackBlocks($trackable->getCollectionObject(), [$trackable]);
+        }
+    }
+
+    /**
+     * Forget a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function forget(TrackableInterface $trackable)
+    {
+        if ($trackable instanceof Collection) {
+            $this->forgetCollection($trackable);
+        }
+
+        if ($trackable instanceof PageController) {
+            $this->forgetCollection($trackable->getPageObject());
+        }
+
+        if ($trackable instanceof Controller) {
+            // Delete all blocks with this id
+            $this->manager->createQueryBuilder()
+                ->delete(StackUsageRecord::class, 'r')
+                ->where('r.block_id = :block_id')
+                ->setParameter('block_id', $trackable->getBlockObject()->getBlockID())
+                ->getQuery()->execute();
+        }
+    }
+
+    /**
+     * Track a collection object
+     * @param \Concrete\Core\Page\Collection\Collection $collection
+     */
+    private function trackCollection(Collection $collection)
+    {
+        $blocks = $collection->getBlocks();
+        $this->trackBlocks($collection, $blocks);
+    }
+
+    /**
+     * Forget about a collection object
+     * @param \Concrete\Core\Page\Collection\Collection $collection
+     */
+    private function forgetCollection(Collection $collection)
+    {
+        $query_builder = $this->manager->createQueryBuilder();
+        $query_builder
+            ->delete(StackUsageRecord::class, 'r')
+            ->where('r.collection_id = :collection_id')
+            ->setParameter('collection_id', $collection->getCollectionID())
+            ->getQuery()->execute();
+    }
+
+    /**
+     * Track a list of blocks for a collection
+     * @param \Concrete\Core\Page\Collection\Collection $collection
+     * @param Block[]|BlockController[] $blocks
+     */
+    private function trackBlocks(Collection $collection, array $blocks)
+    {
+        $version = $collection->getVersionID();
+        $buffer = 0;
+
+        foreach ($blocks as $block) {
+
+            if ($block instanceof Controller) {
+                $controller = $block;
+                $block = $controller->getBlockObject();
+            }
+
+            if ($block->getBlockTypeHandle() == BLOCK_HANDLE_STACK_PROXY) {
+                if (!$controller) {
+                    $controller = $block->getController();
+                }
+
+                $this->persist(
+                    $controller->getStackID(),
+                    $collection->getCollectionID(),
+                    $version,
+                    $block->getBlockID());
+                $buffer++;
+            }
+
+            if ($buffer > 2) {
+                $this->manager->flush();
+                $buffer = 0;
+            }
+        }
+
+        if ($buffer) {
+            // Sometimes you just need an extra flush...
+            $this->manager->flush();
+        }
+    }
+
+    /**
+     * @param $stack_id
+     * @param $collection_id
+     * @param $collection_version_id
+     * @param $block_id
+     */
+    private function persist($stack_id, $collection_id, $collection_version_id, $block_id)
+    {
+        $search = [
+            'block_id' => $block_id
+        ];
+
+        if (!$record = $this->repository->findOneBy($search)) {
+            $record = new StackUsageRecord();
+        }
+
+        $record->setCollectionId($collection_id);
+        $record->setCollectionVersionId($collection_version_id);
+        $record->setBlockId($block_id);
+        $record->setStackId($stack_id);
+        $this->manager->merge($record);
+    }
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/AggregateTracker.php
+++ b/web/concrete/src/Statistics/UsageTracker/AggregateTracker.php
@@ -1,0 +1,125 @@
+<?php
+namespace Concrete\Core\Statistics\UsageTracker;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Application\ApplicationAwareInterface;
+use InvalidArgumentException;
+
+/**
+ * Class PolyTracker
+ * A tracker that employes `\Illuminate\Support\Manager` to keep track of a list of Trackers.
+ * When `::track` is called, `PolyTracker` forwards the call to each of its drivers.
+ *
+ * @package Concrete\Core\Statistics\UsageTracker
+ */
+final class AggregateTracker implements TrackerManagerInterface, ApplicationAwareInterface
+{
+
+    /** @var TrackerInterface[] */
+    protected $trackers = [];
+
+    /** @var callable[] */
+    protected $creators = [];
+
+    /** @var string[] */
+    protected $map = [];
+
+    /** @var Application */
+    protected $app;
+
+    /**
+     * Set the application object.
+     *
+     * @param \Concrete\Core\Application\Application $application
+     */
+    public function setApplication(Application $application)
+    {
+        $this->app = $application;
+    }
+
+    /**
+     * Track a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function track(TrackableInterface $trackable)
+    {
+        foreach ($this->getTrackerGenerator() as $tracker) {
+            $tracker->track($trackable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Forget a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function forget(TrackableInterface $trackable)
+    {
+        foreach ($this->getTrackerGenerator() as $tracker) {
+            $tracker->forget($trackable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register a custom tracker creator Closure.
+     *
+     * @param  string $tracker The handle of the tracker
+     * @param  callable $creator The closure responsible for returning the new tracker instance
+     * @return static
+     */
+    public function addTracker($tracker, callable $creator)
+    {
+        $this->creators[$tracker] = $creator;
+        $this->map[] = $tracker;
+
+        if (isset($this->trackers[$tracker])) {
+            unset($this->trackers[$tracker]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get a tracker by handle
+     * @param $tracker
+     * @return TrackerInterface
+     */
+    public function tracker($tracker)
+    {
+        // We've already made this tracker, so just return it.
+        if ($cached = array_get($this->trackers, $tracker)) {
+            return $cached;
+        }
+
+        // We've got a creator, lets create the tracker
+        if ($creator = array_get($this->creators, $tracker)) {
+            // Create through Container
+            $created = $this->app->call($creator);
+
+            $this->trackers[$tracker] = $created;
+            unset($this->creators[$tracker]);
+
+            return $created;
+        }
+
+        throw new InvalidArgumentException("Tracker [$tracker] not supported.");
+    }
+
+    /**
+     * @return \Generator|TrackerInterface[]
+     */
+    private function getTrackerGenerator()
+    {
+        foreach ($this->map as $tracker) {
+            yield $this->tracker($tracker);
+        }
+    }
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/ServiceProvider.php
+++ b/web/concrete/src/Statistics/UsageTracker/ServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Concrete\Core\Statistics\UsageTracker;
+
+use Concrete\Core\Foundation\Service\Provider;
+
+class ServiceProvider extends Provider
+{
+
+    /**
+     * Registers the services provided by this provider.
+     */
+    public function register()
+    {
+        // Make the main tracker manager a singleton
+        $this->app->singleton(AggregateTracker::class, function($app) {
+            $tracker = $app->build(AggregateTracker::class);
+
+            return $tracker;
+        });
+
+        // Bind the manager interface to the tracker singleton
+        $this->app->bind(TrackerManagerInterface::class, PolyTracker::class);
+    }
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/TrackableInterface.php
+++ b/web/concrete/src/Statistics/UsageTracker/TrackableInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Concrete\Core\Statistics\UsageTracker;
+
+/**
+ * Interface TrackableInterface
+ * Implement this interface to declare compatibility with the statistic tracker.
+ * @package Concrete\Core\Statistics\UsageTracker
+ */
+interface TrackableInterface
+{
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/TrackerInterface.php
+++ b/web/concrete/src/Statistics/UsageTracker/TrackerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Concrete\Core\Statistics\UsageTracker;
+
+interface TrackerInterface
+{
+
+    /**
+     * Track a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function track(TrackableInterface $trackable);
+
+    /**
+     * Forget a trackable object
+     * Any object could be passed to this method so long as it implements TrackableInterface
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackableInterface $trackable
+     * @return static|TrackerInterface
+     */
+    public function forget(TrackableInterface $trackable);
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/TrackerManagerInterface.php
+++ b/web/concrete/src/Statistics/UsageTracker/TrackerManagerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Concrete\Core\Statistics\UsageTracker;
+
+interface TrackerManagerInterface extends TrackerInterface
+{
+
+    /**
+     * Register a custom tracker creator callabl.
+     *
+     * @param  string $tracker The handle of the tracker
+     * @param  callable $creator The callable responsible for returning the new tracker instance
+     * @return static
+     */
+    public function addTracker($tracker, callable $creator);
+
+}

--- a/web/concrete/src/Statistics/UsageTracker/TrackerManagerInterface.php
+++ b/web/concrete/src/Statistics/UsageTracker/TrackerManagerInterface.php
@@ -6,7 +6,7 @@ interface TrackerManagerInterface extends TrackerInterface
 {
 
     /**
-     * Register a custom tracker creator callabl.
+     * Register a custom tracker creator callable.
      *
      * @param  string $tracker The handle of the tracker
      * @param  callable $creator The callable responsible for returning the new tracker instance

--- a/web/concrete/views/dialogs/stack/usage.php
+++ b/web/concrete/views/dialogs/stack/usage.php
@@ -1,0 +1,27 @@
+<div class="ccm-ui">
+
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <td><?= t('Page ID') ?></td>
+            <td><?= t('Version') ?></td>
+            <td><?= t('Handle') ?></td>
+            <td><?= t('Location') ?></td>
+        </tr>
+        </thead>
+        <?php
+        /** @var \Concrete\Core\Page\Collection\Collection $page */
+        foreach ($records as $page) {
+            ?>
+            <tr>
+                <td><?= $page->getCollectionID() ?></td>
+                <td><?= $page->getVersionID() ?></td>
+                <td><?= $page->getCollectionHandle() ?></td>
+                <td><a target="_blank" href="<?= \URL::to($page) ?>"><?= h($page->getCollectionPath() ?: '/') ?></a></td>
+            </tr>
+            <?php
+        }
+        ?>
+    </table>
+
+</div>


### PR DESCRIPTION
This is an complete example of the Statistics/UsageTracker as discussed in #3240. 

5ffae98 is the core `\Concrete\Statistics\UsageTracker` package
84ee3a8 is a convenience method I added so that I wouldn't have to access `$controller->stID`
8d94dbe is a Tracker that tracks stacks given a trackable core stack view block controller or a page or a page controller
