### PR TITLE
Prevent default behaviour when showing all available page types

### DIFF
--- a/web/concrete/views/panels/sitemap.php
+++ b/web/concrete/views/panels/sitemap.php
@@ -18,7 +18,8 @@
 
     <script type="text/javascript">
     $(function() {
-        $('a[data-sitemap=show-more]').on('click', function() {
+        $('a[data-sitemap=show-more]').on('click', function(e) {
+            e.preventDefault();
             $('li[data-page-type=other]').show();
             $(this).parent().remove();
         });


### PR DESCRIPTION
Prevent default behaviour (#) when clicking a link to show more page types

![more-page-types](https://cloud.githubusercontent.com/assets/4508405/12373877/880ccd8a-bc92-11e5-9de3-b7ff543a6fe9.jpg)
