### PR TITLE
Add PSR4 namespacing to tests

### DIFF
--- a/web/concrete/composer.json
+++ b/web/concrete/composer.json
@@ -59,5 +59,10 @@
   },
   "require-dev": {
     "concrete5/documentation_generator": "1.0-beta3"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Concrete\\Tests\\": "../../tests/tests"
+    }
   }
 }

--- a/web/concrete/composer.lock
+++ b/web/concrete/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a18fffbab1f93a649b0c8afe5e70775f",
+    "hash": "78d1f451b72662fe82a524d061bb5ab6",
+    "content-hash": "c4034bd9686cf6952f744874ebcca138",
     "packages": [
         {
             "name": "anahkiasen/html-object",


### PR DESCRIPTION
All this does is add PSR-4 namespacing to the tests when composer is installed in development mode. 

#3356 