### PR TITLE
Fix user update in strict mysql

### DIFF
--- a/web/concrete/src/User/UserInfo.php
+++ b/web/concrete/src/User/UserInfo.php
@@ -306,7 +306,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
                 if ($data['uPassword'] == $data['uPasswordConfirm']) {
                     $dh = Core::make('helper/date');
                     $dateTime = $dh->getOverridableNow();
-                    $v = array($uName, $uEmail, $this->getUserObject()->getUserPasswordHasher()->HashPassword($data['uPassword']), $uHasAvatar, $uTimezone, $uDefaultLanguage, $dateTime, $this->uID);
+                    $v = array($uName, $uEmail, $this->getUserObject()->getUserPasswordHasher()->HashPassword($data['uPassword']), $uHasAvatar ? 1 : 0, $uTimezone, $uDefaultLanguage, $dateTime, $this->uID);
                     $r = $db->prepare("update Users set uName = ?, uEmail = ?, uPassword = ?, uHasAvatar = ?, uTimezone = ?, uDefaultLanguage = ?, uLastPasswordChange = ? where uID = ?");
                     $res = $db->execute($r, $v);
 
@@ -319,7 +319,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
                     }
                 }
             } else {
-                $v = array($uName, $uEmail, $uHasAvatar, $uTimezone, $uDefaultLanguage, $this->uID);
+                $v = array($uName, $uEmail, $uHasAvatar ? 1 : 0, $uTimezone, $uDefaultLanguage, $this->uID);
                 $r = $db->prepare("update Users set uName = ?, uEmail = ?, uHasAvatar = ?, uTimezone = ?, uDefaultLanguage = ? where uID = ?");
                 $res = $db->execute($r, $v);
             }


### PR DESCRIPTION
An error was thrown e.g. when trying to change user's password in dashboard while MYSQL is used in STRICT_TRANS_TABLES mode

```
'update Users set uName = ?, uEmail = ?, uPassword = ?, uHasAvatar = ?, uTimezone = ?, uDefaultLanguage = ?, uLastPasswordChange = ? where uID = ?' with params ["username", "test@example.com", "hash", false, null, "fi_FI", "2016-01-19 09:20:00", "1"]
SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'uHasAvatar' at row 1
```