### PR TITLE
Avoid accessing undefined $translate property in Localization

### DIFF
--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -98,12 +98,14 @@ class Localization
 
     public function getLocale()
     {
-        return isset($this->translate) ? $this->translate->getLocale() : 'en_US';
+        $translate = $this->getActiveTranslateObject();
+
+        return $translate ? $translate->getLocale() : 'en_US';
     }
 
     public function getActiveTranslateObject()
     {
-        return $this->translate;
+        return isset($this->translate) ? $this->translate : null;
     }
 
     public static function getTranslate()

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -27,21 +27,23 @@ class Localization
 
     public static function changeLocale($locale)
     {
-        $loc = Localization::getInstance();
+        $loc = self::getInstance();
         $loc->setLocale($locale);
     }
     /** Returns the currently active locale
      * @return string
+     *
      * @example 'en_US'
      */
     public static function activeLocale()
     {
-        $loc = Localization::getInstance();
+        $loc = self::getInstance();
 
         return $loc->getLocale();
     }
     /** Returns the language for the currently active locale
      * @return string
+     *
      * @example 'en'
      */
     public static function activeLanguage()
@@ -110,7 +112,7 @@ class Localization
 
     public static function getTranslate()
     {
-        $loc = Localization::getInstance();
+        $loc = self::getInstance();
 
         return $loc->getActiveTranslateObject();
     }
@@ -146,12 +148,14 @@ class Localization
      *   "en_US" => "English (United States)",
      *   "fr_FR" => "Francais (France)"]
      * The result will be sorted by the key.
-     * If the $displayLocale is set, the language- and region-names will be returned in that language
+     * If the $displayLocale is set, the language- and region-names will be returned in that language.
+     *
      * @param string|null $displayLocale Language of the description.
      *                    Set to null to get each locale name in its own language,
      *                    set to '' to use the current locale,
      *                    set to a specific locale to get the names in that language
-     * @return Array An associative Array with locale as the key and description as content
+     *
+     * @return array An associative Array with locale as the key and description as content
      */
     public static function getAvailableInterfaceLanguageDescriptions($displayLocale = '')
     {
@@ -170,12 +174,14 @@ class Localization
 
     /**
      * Get the description of a locale consisting of language and region description
-     * e.g. "French (France)"
+     * e.g. "French (France)".
+     *
      * @param string $locale Locale that should be described
      * @param string|null $displayLocale Language of the description.
      *                    Set to null to get each locale name in its own language,
      *                    set to '' to use the current locale,
      *                    set to a specific locale to get the names in that language
+     *
      * @return string Description of a language
      */
     public static function getLanguageDescription($locale, $displayLocale = '')
@@ -196,7 +202,7 @@ class Localization
     }
 
     /**
-     * Clear the translations cache
+     * Clear the translations cache.
      */
     public static function clearCache()
     {

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -51,14 +51,12 @@ class Localization
         return current(explode('_', self::activeLocale()));
     }
 
-    protected $translate;
+    protected $translate = null;
 
     public function setLocale($locale)
     {
         if (($locale == 'en_US') && (!Config::get('concrete.misc.enable_translate_locale_en_us'))) {
-            if (isset($this->translate)) {
-                unset($this->translate);
-            }
+            $this->translate = null;
         } else {
             $this->translate = new Translator();
             $this->translate->setLocale($locale);


### PR DESCRIPTION
We call `unset($this->translate)`: this leads to warnings when we try to access `$this->translate`
