### PR TITLE
Fix wrong index field type for textarea attribute

### DIFF
--- a/web/concrete/attributes/text/controller.php
+++ b/web/concrete/attributes/text/controller.php
@@ -5,7 +5,7 @@ use \Concrete\Core\Foundation\Object;
 use \Concrete\Core\Attribute\DefaultController;
 class Controller extends DefaultController  {
 
-	protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('length' => 4294967295, 'default' => null, 'notnull' => false));
+	protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('length' => 2147483647, 'default' => null, 'notnull' => false));
 
 	public function form() {
 		if (is_object($this->attributeValue)) {


### PR DESCRIPTION
The length value is lost when it's bigger than php int max
https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Column.php#L149