### PR TITLE
Fix wrong index field type for textarea attribute (the previous was f…

### DIFF
--- a/web/concrete/attributes/textarea/controller.php
+++ b/web/concrete/attributes/textarea/controller.php
@@ -8,7 +8,7 @@ use Database;
 
 class Controller extends DefaultController
 {
-    protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('length' => 4294967295, 'default' => null, 'notnull' => false));
+    protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('length' => 2147483647, 'default' => null, 'notnull' => false));
 
     public $helpers = array('form');
 


### PR DESCRIPTION
…or Text attribute)

The length value is lost when it's bigger than php int max
https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Column.php#L149