### PR TITLE
Fix wrong index field type for topics attribute

### DIFF
--- a/web/concrete/attributes/topics/controller.php
+++ b/web/concrete/attributes/topics/controller.php
@@ -15,7 +15,7 @@ class Controller extends AttributeTypeController
 {
     protected $searchIndexFieldDefinition = array(
         'type' => 'text',
-        'options' => array('length' => 4294967295, 'default' => null, 'notnull' => false),
+        'options' => array('length' => 2147483647, 'default' => null, 'notnull' => false),
     );
 
     public $helpers = array('form');


### PR DESCRIPTION
The length value is lost when it's bigger than php int max
https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Column.php#L149