### PR TITLE
Fix questions' order in form block

### DIFF
--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -184,6 +184,9 @@ $addSelected = true;
 		</div>
 		
 	</fieldset> 
+
+	<input type="hidden" id="position" name="position" value="1000" />
+
 </div> 
 		
 <div class="ccm-tab-content" id="ccm-tab-content-form-edit">


### PR DESCRIPTION
Form block's questions are ordered incorrectly after ordering some of them and creating a new question.

#### Steps to reproduce:
- Add form block to a page
- Write `Q1` to Question and click `Add Question`
- Write `Q2` to Question and click `Add Question`
- Click `Edit` tab
- Change order of the question, move `Q2` to first position
- Click `Add` to save the block
- Questions are now in correct order
```
Q2
Q1
```
- Edit the block you just created
- Write `Q3` to Question and click `Add Question`
- Click `Save` to save your changes
- Questions are now in wrong order
```
Q2
Q3
Q1
```

The reason is that the position value was always passed on as undefined to save method while adding a new question. Easiest way to prevent this is to add a similar position field to add template that edit template has.