### PR TITLE
Add Package::hasUninstallNotes()

### DIFF
--- a/web/concrete/single_pages/dashboard/extend/install.php
+++ b/web/concrete/single_pages/dashboard/extend/install.php
@@ -71,7 +71,11 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
                 </tr>
             </table>
 
-            <?php @Loader::packageElement('dashboard/uninstall', $pkg->getPackageHandle()); ?>
+            <?php
+            if ($pkg->hasUninstallNotes()) {
+                View::element('dashboard/uninstall', null, $pkg->getPackageHandle());
+            }
+            ?>
 
             <div class="alert alert-danger">
                 <?=t('This will remove all elements associated with the %s package. While you can reinstall the package, this may result in data loss.', $pkg->getPackageName())?>

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -636,6 +636,11 @@ class Package extends Object
         return file_exists($this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/install.php');
     }
 
+    public function hasUninstallNotes()
+    {
+        return file_exists($this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/uninstall.php');
+    }
+
     public function allowsFullContentSwap()
     {
         return $this->pkgAllowsFullContentSwap;


### PR DESCRIPTION
Currently when a package is uninstalled, we always try to load an uninstall element, even if it does not exist.
Let's add a `hasUninstallNotes` method that checks if this element exists or not (like we already have for the pre-install and post-install phases - see `hasInstallNotes` and `hasInstallPostScreen` respectively).