### PR TITLE
Ignore Eclipse folder: .externalToolBuilders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ error_log
 .project
 
 # ignore Eclipse-specific files
+/.externalToolBuilders/
 /.settings/
 /.buildpath
 


### PR DESCRIPTION
Eclipse just created a `.externalToolBuilders` folder in my local concrete5 directory. I don't know neither why nor what's it. Let's just ignore it...