### PR TITLE
Fix: Make copy/pasted blocks retain full width setting

### DIFF
--- a/web/concrete/blocks/core_scrapbook_display/controller.php
+++ b/web/concrete/blocks/core_scrapbook_display/controller.php
@@ -28,7 +28,7 @@ class Controller extends BlockController
     {
         $bc = $this->getScrapbookBlockController();
         if (is_object($bc)) {
-            return $bc->$this->ignorePageThemeGridFrameworkContainer();
+            return $bc->ignorePageThemeGridFrameworkContainer();
         }
 
         return false;

--- a/web/concrete/elements/block_footer_view.php
+++ b/web/concrete/elements/block_footer_view.php
@@ -10,6 +10,8 @@ if ($a->isGlobalArea()) {
     $c = $b->getBlockCollectionObject();
 }
 
+$bi = $b->getInstance();
+
 $blockStyle = $b->getCustomStyle();
 ?>
 
@@ -17,7 +19,7 @@ $blockStyle = $b->getCustomStyle();
 if (
     $pt->supportsGridFramework()
     && $b->getBlockAreaObject()->isGridContainerEnabled()
-    && !$b->ignorePageThemeGridFrameworkContainer()
+    && !$bi->ignorePageThemeGridFrameworkContainer()
 ) {
     $gf = $pt->getThemeGridFrameworkObject();
     print '</div>';

--- a/web/concrete/elements/block_header_view.php
+++ b/web/concrete/elements/block_header_view.php
@@ -9,6 +9,8 @@ if ($a->isGlobalArea()) {
     $c = $b->getBlockCollectionObject();
 }
 
+$bi = $b->getInstance();
+
 $p = new Permissions($b);
 $showMenu = false;
 if ($a->showControls() && $p->canViewEditInterface() && $view->showControls()) {
@@ -31,7 +33,7 @@ if ($showMenu) { ?>
 if (
     $pt->supportsGridFramework()
     && $a->isGridContainerEnabled()
-    && !$b->ignorePageThemeGridFrameworkContainer()
+    && !$bi->ignorePageThemeGridFrameworkContainer()
 ) {
     $gf = $pt->getThemeGridFrameworkObject();
     print $gf->getPageThemeGridFrameworkContainerStartHTML();
@@ -75,6 +77,12 @@ if ($showMenu) {
             $editInline = true;
         }
     }
+
+    if (is_object($_bo)) {
+        $bi = $_bo->getInstance();
+    } else {
+        $bi = $b->getInstance();
+    }
     $canDesign = ($p->canEditBlockDesign() && Config::get('concrete.design.enable_custom') == true);
     $canModifyGroups = ($p->canEditBlockPermissions() && Config::get('concrete.permissions.model') != 'simple' && (!$a->isGlobalArea()));
     $canEditName = $p->canEditBlockName();
@@ -104,6 +112,7 @@ if ($showMenu) {
         data-area-id="<?=$a->getAreaID()?>"
         data-block-id="<?=$b->getBlockID()?>"
         data-block-type-wraps="<?= intval(!$b->ignorePageThemeGridFrameworkContainer(), 10) ?>"
+        data-block-wraps="<?= intval(!$bi->ignorePageThemeGridFrameworkContainer(), 10) ?>"
         class="<?=$class?>"
         data-block-type-handle="<?=$btHandle?>"
         data-launch-block-menu="block-menu-b<?=$b->getBlockID()?>-<?=$a->getAreaID()?>"
@@ -129,11 +138,6 @@ if ($showMenu) {
                     <ul class="dropdown-menu">
 
                         <? if ($btOriginal->getBlockTypeHandle() == BLOCK_HANDLE_STACK_PROXY) {
-                            if (is_object($_bo)) {
-                                $bi = $_bo->getInstance();
-                            } else {
-                                $bi = $b->getInstance();
-                            }
                             $stack = Stack::getByID($bi->stID);
                             if (is_object($stack)) {
                                 $sp = new Permissions($stack);

--- a/web/concrete/js/build/core/app/edit-mode/block.js
+++ b/web/concrete/js/build/core/app/edit-mode/block.js
@@ -26,7 +26,7 @@
                 handle: elem.data('block-type-handle'),
                 areaId: elem.data('area-id'),
                 cID: elem.data('cid'),
-                wraps: !!elem.data('block-type-wraps'),
+                wraps: !!elem.data('block-wraps'),
                 area: null,
                 elem: elem,
                 dragger: null,


### PR DESCRIPTION
Test:
* Install full elemental
* Copy HR block on the homepage
* Paste HR block on the homepage

Before this commit, the pasted HR does not span full width. After, it does.