### PR TITLE
Fix: Make copy/pasted blocks retain full width setting

### DIFF
--- a/web/concrete/blocks/core_scrapbook_display/controller.php
+++ b/web/concrete/blocks/core_scrapbook_display/controller.php
@@ -28,7 +28,7 @@ class Controller extends BlockController
     {
         $bc = $this->getScrapbookBlockController();
         if (is_object($bc)) {
-            return $bc->$this->ignorePageThemeGridFrameworkContainer();
+            return $bc->ignorePageThemeGridFrameworkContainer();
         }
 
         return false;

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -669,9 +669,10 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
         if ($this->overrideBlockTypeContainerSettings()) {
             return !$this->enableBlockContainer();
         }
-        $bt = $this->getBlockTypeObject();
+        /** @var \Concrete\Core\Block\BlockController $controller */
+        $controller = $this->getInstance();
 
-        return $bt->ignorePageThemeGridFrameworkContainer();
+        return $controller->ignorePageThemeGridFrameworkContainer();
     }
 
     public function overrideBlockTypeContainerSettings()


### PR DESCRIPTION
Test:

Install full elemental
Copy HR block on the homepage
Paste HR block on the homepage
Before this commit, the pasted HR does not span full width. After, it does.

Supersedes #3397