### PR TITLE
forward page description to  header_required

### DIFF
--- a/web/concrete/themes/elemental/elements/header_top.php
+++ b/web/concrete/themes/elemental/elements/header_top.php
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/css/bootstrap-modified.css">
     <?=$html->css($view->getStylesheet('main.less'))?>
-    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : ''));?>
+    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : '', 'pageDescription' => isset($pageDescription) ? $pageDescription : ''));?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         if (navigator.userAgent.match(/IEMobile\/10\.0/)) {


### PR DESCRIPTION
this line https://github.com/concrete5/concrete5/blob/develop/web/concrete/elements/header_required.php#L39 is currently useless as we can't set `pageDescription` from a controller.