### PR TITLE
Add RTL support to the Redactor toolBar

### DIFF
--- a/web/concrete/blocks/core_scrapbook_display/controller.php
+++ b/web/concrete/blocks/core_scrapbook_display/controller.php
@@ -28,7 +28,7 @@ class Controller extends BlockController
     {
         $bc = $this->getScrapbookBlockController();
         if (is_object($bc)) {
-            return $bc->$this->ignorePageThemeGridFrameworkContainer();
+            return $bc->ignorePageThemeGridFrameworkContainer();
         }
 
         return false;

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -669,9 +669,10 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
         if ($this->overrideBlockTypeContainerSettings()) {
             return !$this->enableBlockContainer();
         }
-        $bt = $this->getBlockTypeObject();
+        /** @var \Concrete\Core\Block\BlockController $controller */
+        $controller = $this->getInstance();
 
-        return $bt->ignorePageThemeGridFrameworkContainer();
+        return $controller->ignorePageThemeGridFrameworkContainer();
     }
 
     public function overrideBlockTypeContainerSettings()


### PR DESCRIPTION
Please add this feature (buttons for rtl and ltr - for the Redactor toolbar - like in word or adobe CC programs - see the screenshot)

https://imperavi.com/redactor/docs/settings/lang/

https://imperavi.com/redactor/examples/text-direction/

It will be Under:
1) dashboard/system/basics/editor (The user will have new checkbox option "Direction".
2) And option to set deafult direction (beacuse we dont want to add a markup for all the blocks).

The RTL support its really really important for a lot of users (foundation6 for example 100% rtl support. framework7 Etc..) - and important for the grow of C5 

I dont want to get inside the core files and change redactor setting (what happen when the client update the site in the future for example?) 
![ids_jfd_hbrw5](https://cloud.githubusercontent.com/assets/16711871/12493728/11cdeffe-c08f-11e5-88cb-9b29d6306db0.jpg)
----
