### PR TITLE
remove max height from filemanager thumbnail

### DIFF
--- a/web/concrete/css/build/core/file-manager.less
+++ b/web/concrete/css/build/core/file-manager.less
@@ -35,7 +35,6 @@ table.ccm-search-results-table {
                 img {
                     .border-radius(2px);
                     border: 1px solid #999;
-                    max-height: 60px;
                 }
             }
 

--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -182,7 +182,6 @@ $dh = Core::make('helper/date');
 	    .ccm-file-set-file-list:hover {cursor: move}
         .ccm-file-set-file-placeholder { background-color: #ffd !important;  }
         .ccm-file-set-file-placeholder td { background:transparent !important; }
-        .ccm-file-set-file-list td.ccm-file-manager-search-results-thumbnail img {max-height: 60px}
 	</style>
 
 <?php } else { ?>


### PR DESCRIPTION
We can change the thumbnail size for the filemanager list, but what's the point of that if there's a max height? A customer of mine wants bigger thumbnails (actually a bigger thumbnail on hover), but that didn't work without thix change.