### PR TITLE
PHP7 Fix incompatible declaration of UpdateArchive::install

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/backup/update.php
+++ b/web/concrete/controllers/single_page/dashboard/system/backup/update.php
@@ -19,9 +19,9 @@ class UpdateArchive extends Archive
         $this->targetDirectory = DIR_CORE_UPDATES;
     }
 
-    public function install($file)
+    public function install($file, $inplace = true)
     {
-        parent::install($file, true);
+        parent::install($file, $inplace);
     }
 
 }


### PR DESCRIPTION
WIth PHP 7.0.2 visiting /index.php/dashboard/system/backup/update results in an exception:

Declaration of Concrete\Controller\SinglePage\Dashboard\System\Backup\UpdateArchive::install($file)
should be compatible with Concrete\Core\Updater\Archive::install($file, $inplace = false) 

http://www.concrete5.org/developers/bugs/5-7-5-5/php7-concrete5-dashboard-update-throws-exception/
