### PR TITLE
Prevent default behaviour when clearing user's attribute or avatar

### DIFF
--- a/web/concrete/js/build/core/editable-field/container.js
+++ b/web/concrete/js/build/core/editable-field/container.js
@@ -177,13 +177,13 @@
 
 				ajaxData.push({'name': 'akID', 'value': akID});
 
-				return new ConcreteAjaxRequest({
+				new ConcreteAjaxRequest({
 					url: url,
 					data: ajaxData,
 					success: function(r) {
      					$('[data-key-id=' + akID + '][data-editable-field-type=xeditableAttribute]').editable('setValue', '');
 					}
-				})
+				});
 				return false;
 			});
 		}

--- a/web/concrete/js/build/core/editable-field/container.js
+++ b/web/concrete/js/build/core/editable-field/container.js
@@ -151,14 +151,14 @@
 				data.task = 'clear';
 
 				var url = my.getAjaxURL($field);
-				return new ConcreteAjaxRequest({
+				new ConcreteAjaxRequest({
 					url: url,
 					data: data,
 					success: function(r) {
 						my[method](r, $field);
 
 					}
-				})
+				});
 				return false;
 			});
 			my.$element.on('click', '[data-editable-field-command=clear_attribute]', function() {


### PR DESCRIPTION
These links' default behaviour (#) should be prevented, but their click functions were returning an object instead of false.

These functions are called when clearing user's attribute or avatar in 
Dashboard -> Members -> Search Users -> Edit User