### PR TITLE
Force user avatar to reload after a change

### DIFF
--- a/web/concrete/js/build/core/editable-field/container.js
+++ b/web/concrete/js/build/core/editable-field/container.js
@@ -123,7 +123,10 @@
 		updateImageField: function(r, $field) {
 			var my = this;
         	if (ConcreteAjaxRequest.validateResponse(r)) {
-	        	$field.find('.editable-image-display').html(r.imageHTML);
+	        	$field.find('.editable-image-display').html(r.imageHTML)
+	        		.find('img').attr('src', function(index, attr) {
+	        			return attr + '?' + new Date().getTime();
+	        		});
 	        	my.setupImageField($field);
 				ConcreteAlert.notify({
 				'message': r.message


### PR DESCRIPTION
Dashboard -> Members -> Search Users -> Edit User -> Change Profile Picture

User's avatar's url doesn't change when you change the image. Because of that the image doesn't reload after a change until you reload the page. That can cause users to think that it is not working. 

Let's force the image to reload by adding unique parameter to it's url after a change.