### PR TITLE
Adjust clear log button to indicate dangerousness of the action

### DIFF
--- a/web/concrete/single_pages/dashboard/reports/logs.php
+++ b/web/concrete/single_pages/dashboard/reports/logs.php
@@ -38,9 +38,9 @@ $th = Loader::helper('text');
                 <div class="ccm-search-field-content">
                     <?=$form->select('channel', $channels)?>
                     <? if ($selectedChannel) { ?>
-                        <a href="<?=$controller->action('clear', $valt->generate(), $selectedChannel)?>" class="btn btn-default btn-sm"><?=tc('%s is a channel', 'Clear all in %s', Log::getChannelDisplayName($selectedChannel))?></a>
+                        <a href="<?=$controller->action('clear', $valt->generate(), $selectedChannel)?>" class="btn btn-default btn-danger"><?=tc('%s is a channel', 'Clear all in %s', Log::getChannelDisplayName($selectedChannel))?></a>
                     <? } else { ?>
-                        <a href="<?=$controller->action('clear', $valt->generate())?>" class="btn btn-default btn-sm"><?=t('Clear all')?></a>
+                        <a href="<?=$controller->action('clear', $valt->generate())?>" class="btn btn-default btn-danger"><?=t('Clear all')?></a>
                      <? } ?>
                 </div>
             </div>


### PR DESCRIPTION
Dashboard -> Reports -> Logs

Change the clear button to red to indicate that it actually deletes something

**before**
![clear-log-before](https://cloud.githubusercontent.com/assets/4508405/12531719/8a7ff920-c20a-11e5-91a7-73477cec4551.jpg)

**after**
![clear-log-after](https://cloud.githubusercontent.com/assets/4508405/12531723/ad44bebe-c20a-11e5-98c8-c70c7f50e5e0.jpg)
