### PR TITLE
Fix displayed base path in single pages

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/single.php
+++ b/web/concrete/single_pages/dashboard/pages/single.php
@@ -8,7 +8,7 @@ echo Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Sing
 		<?php if(Config::get('concrete.seo.url_rewriting')) {
 			$base = Core::getApplicationURL();
 		} else {
-			$base = Core::getApplicationURL() . DISPATCHER_FILENAME;
+			$base = Core::getApplicationURL() . '/' . DISPATCHER_FILENAME;
 		}?>
 		<form class="form-inline" method="post" id="add_static_page_form" action="<?php echo $view->url('/dashboard/pages/single')?>">
 			<?php echo $this->controller->token->output('add_single_page')?>


### PR DESCRIPTION
Base path is displayed incorrectly if url rewriting is disabled

![base-path](https://cloud.githubusercontent.com/assets/4508405/12531852/11785028-c20e-11e5-8565-dac82871f9e6.jpg)