### PR TITLE
Prevent error while adding a new feed without a page type filter

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/pages/feeds.php
+++ b/web/concrete/controllers/single_page/dashboard/pages/feeds.php
@@ -133,7 +133,7 @@ class Feeds extends DashboardPageController
 
     public function add()
     {
-        $pageTypes = array('' => t('** No Filtering'));
+        $pageTypes = array('0' => t('** No Filtering'));
         $types = Type::getList();
         foreach($types as $type) {
             $pageTypes[$type->getPageTypeID()] = $type->getPageTypeDisplayName();


### PR DESCRIPTION
Add default value for page type filter.

An error was thrown while adding a new feed without page type filtration when using mysql in strict mode.

```
An exception occurred while executing 'INSERT INTO PageFeeds (customTopicAttributeKeyHandle, customTopicTreeNodeID, iconFID, pfDescription, pfHandle, pfTitle, cParentID, ptID, pfIncludeAllDescendents, pfDisplayAliases, pfContentToDisplay, pfAreaHandleToDisplay, pfDisplayFeaturedOnly) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params ["", 0, "0", "Description", "lorem", "Lorem", 154, "", "1", "0", "S", null, "0"]: 
SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'ptID' at row 1
```