### PR TITLE
Fix incorrect action after renaming a stack

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/web/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -266,7 +266,7 @@ class Stacks extends DashboardPageController {
 	public function stack_renamed($cID) {
 		$this->set('message', t('Stack renamed successfully'));
 		$this->view_details($cID);
-		$this->task = 'view_details';
+		$this->action = 'view_details';
 	}
 
 	public function duplicate($cID) {


### PR DESCRIPTION
Steps to reproduce:
- Go to: Dashboard -> Stacks & Blocks
- Add a new stack `A`
- Click rename
- Change name to `B`

You will now get a message "No stacks have been added." as a result of an incorrect action.