### PR TITLE
Remove New Page link from stacks version history

### DIFF
--- a/web/concrete/src/Page/Collection/Version/EditResponse.php
+++ b/web/concrete/src/Page/Collection/Version/EditResponse.php
@@ -48,6 +48,7 @@ class EditResponse extends PageEditResponse
             $obj->cvAuthorUserName = $v->getVersionAuthorUserName();
             $obj->cvApproverUserName = $v->getVersionApproverUserName();
             $obj->cvComments = $v->getVersionComments();
+            $obj->cIsStack = ($c->getCollectionTypeHandle() === STACKS_PAGE_TYPE);
             $versions[] = $obj;
         }
         $o->versions = $versions;

--- a/web/concrete/views/panels/page/versions.php
+++ b/web/concrete/views/panels/page/versions.php
@@ -35,7 +35,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 					<li><% if (cvIsApproved == 1) { %><span><?=t('Approve')?></span><% } else { %><a href="#" data-version-menu-task="approve" data-version-id="<%-cvID%>"><?=t('Approve')?></a><% } %></li>
 					<li><a href="#" data-version-menu-task="duplicate" data-version-id="<%-cvID%>"><?=t('Duplicate')?></a></li>
 					<li class="divider"></li>
+					<% if ( ! cIsStack) { %>
 					<li><a href="#" data-version-menu-task="new-page" data-version-id="<%-cvID%>"><?=t('New Page')?></a></li>
+					<% } %>
 					<% if (cpCanDeletePageVersions) { %>
 						<li><% if (cvIsApproved == 1) { %><span><?=t('Delete')?></span><% } else { %><a href="#" data-version-menu-task="delete" data-version-id="<%-cvID%>"><?=t('Delete')?></a><% } %></li>
 					<% } %>


### PR DESCRIPTION
Dashboard -> Stacks & Blocks -> View stacks details -> Version history -> Hover over a version and click the arrow link next to it

Remove redundant `New Page` link from stacks version history item's menu

![stack-history-menu](https://cloud.githubusercontent.com/assets/4508405/12532697/b4704f1a-c222-11e5-9474-e2e07de3208e.jpg)
