### PR TITLE
Fix: Show area tab in parallaxic layout view

### DIFF
--- a/web/concrete/blocks/core_area_layout/templates/parallax/view.css
+++ b/web/concrete/blocks/core_area_layout/templates/parallax/view.css
@@ -7,7 +7,6 @@ div.ccm-block-custom-template-parallax {
 div.ccm-block-custom-template-parallax.parallaxic-container,  /* template is also the container */
 div.ccm-block-custom-template-parallax div.parallaxic-container {
 	position: relative;
-	overflow: hidden;
 	z-index: 5;
 }
 
@@ -26,3 +25,11 @@ div.ccm-block-custom-template-parallax .parallax-stripe-inner {
 	position: relative;
 }
 
+div.ccm-block-custom-template-parallax .parallax-image-container {
+    position: absolute;
+    overflow: hidden;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}

--- a/web/concrete/blocks/core_area_layout/templates/parallax/view.js
+++ b/web/concrete/blocks/core_area_layout/templates/parallax/view.js
@@ -10,7 +10,6 @@ $(function () {
             $wrapper = $self.closest('div.ccm-block-custom-template-parallax'),
             $children = $wrapper.children(),
             $inner = $children.first();
-            console.log($wrapper);
 
         $wrapper.attr('data-stripe', 'parallax').attr('data-background-image', $self.attr('data-background-image'));
         $inner.addClass('parallax-stripe-inner');

--- a/web/concrete/js/build/core/frontend/parallax-image.js
+++ b/web/concrete/js/build/core/frontend/parallax-image.js
@@ -38,10 +38,11 @@ $.fn.parallaxize = (function (global, $) {
 
         initializeDOM: function () {
             var elem = this.config('element'),
+                image_container = $('<div/>'),
                 image = new Image(),
-                image_elem = $(image),
+                image_elem = $(image).appendTo(image_container),
                 me = this;
-            elem.prepend(image_elem);
+            elem.prepend(image_container);
             image_elem.hide();
 
             var synchronous = true;
@@ -64,6 +65,7 @@ $.fn.parallaxize = (function (global, $) {
 
             elem.addClass('parallaxic-container');
             image_elem.addClass('parallaxic-image');
+            image_container.addClass('parallax-image-container');
 
         },
 


### PR DESCRIPTION
Resolves issue #3413. The issue was that the container had `overflow:hidden` on it. Instead I give the parallaxic image it's own full width full height `overflow:hidden` container.