### PR TITLE
Fix flag image layout

### DIFF
--- a/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
+++ b/web/concrete/src/Multilingual/Service/UserInterface/Flag.php
@@ -40,7 +40,7 @@ class Flag
                 if ($filePathOnly) {
                     return $icon;
                 } else {
-                    return '<img class="ccm-region-flag img-responsive" id="ccm-region-flag-' . $region . '" src="' . $icon . '" alt="' . $region . '" />';
+                    return '<img class="ccm-region-flag" id="ccm-region-flag-' . $region . '" src="' . $icon . '" alt="' . $region . '" />';
                 }
             }
         }


### PR DESCRIPTION
A small bug was introduced in #3362 (#3309). It fixed a typo in a class name. When the correct class is applied to a flag image it gets displayed as a block, which causes layout to break if toolbar titles are enabled.

That class seems to be redundant, so let's just remove it.

![flag-before](https://cloud.githubusercontent.com/assets/4508405/12546294/91d6e2fe-c351-11e5-938a-877035a6ef70.jpg)

![flag-after](https://cloud.githubusercontent.com/assets/4508405/12546300/973a2e0e-c351-11e5-9cc3-9948ede86bbc.jpg)


