### PR TITLE
restrict maximum row height in file manager to match thumbnail height

### DIFF
--- a/web/concrete/elements/files/search.php
+++ b/web/concrete/elements/files/search.php
@@ -8,6 +8,9 @@ $flr = new \Concrete\Core\Search\StickyRequest('files');
 $req = $flr->getSearchRequest();
 
 ?>
+<style type="text/css">
+    .ccm-file-manager-search-results-thumbnail img { max-height: <?=Concrete\Core\File\Image\Thumbnail\Type\Version::getByHandle('file_manager_listing')->getHeight();?>px; }
+</style>
 
 <script type="text/template" data-template="search-form">
 <form role="form" data-search-form="files" action="<?php echo URL::to('/ccm/system/search/files/submit')?>" class="ccm-search-fields">

--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -182,6 +182,7 @@ $dh = Core::make('helper/date');
 	    .ccm-file-set-file-list:hover {cursor: move}
         .ccm-file-set-file-placeholder { background-color: #ffd !important;  }
         .ccm-file-set-file-placeholder td { background:transparent !important; }
+        .ccm-file-set-file-list td.ccm-file-manager-search-results-thumbnail img {max-height: <?=Concrete\Core\File\Image\Thumbnail\Type\Version::getByHandle('file_manager_listing')->getHeight();?>px}
 	</style>
 
 <?php } else { ?>


### PR DESCRIPTION
I had a quick look at how we could restrict the row height in the file manager.
* I tried to set the height attribute of the img tag, but that's a bit tricky since we create the markup in JavaScript `file.resultsThumbnailImg` in https://github.com/ortic/concrete5-5.7.0/blob/b0f9f083e814e74080a116a4bd9efc0f3a4034a6/web/concrete/elements/files/search.php#L118
* I was also a bit confused that `Config::get('concrete.icons.file_manager_listing.height')` would return 60 despite that I've set the thumbnail height to 100 and also cleared the cache.
* I ended up with this tad bit ugly long line of inline CSS

Might replace https://github.com/concrete5/concrete5/pull/3438