### PR TITLE
allow for faster browsing of thumbnails

### DIFF
--- a/web/concrete/css/build/core/file-manager.less
+++ b/web/concrete/css/build/core/file-manager.less
@@ -179,16 +179,39 @@ div.ccm-file-selector {
 /**
  *Thumbnail listing
  */
-div.ccm-file-manager-image-thumbnail {
-  margin-bottom: 50px;
-  padding: 20px;
-  text-align: center;
-  background-color: #efefef;
-  font-size: 18px;
-  font-weight: 300;
-  color: #999;
+.ccm-ui {
+  .ccm-image-thumbnail-card {
+    padding: 12px;
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+  }
+  .ccm-file-manager-image-thumbnail {
+    margin-bottom: 0px;
+    padding: 20px;
+    text-align: center;
+    background-color: #efefef;
+    font-size: 18px;
+    font-weight: 300;
+    color: #999;
+  }
+  .ccm-image-thumbnail-display-name {
+    min-height: 40px;
+  }
+  .ccm-image-thumbnail-display-name h4 {
+    margin-top: 0px;
+  }
+  .ccm-image-thumbnail-dimensions {
+    display: block;
+    margin-bottom: 10px;
+    color: #999;
+    font-size: 13.5px;
+  }
+  .ccm-image-thumbnail-divider {
+    margin-top: 15px;
+    margin-bottom: 15px;
+  }
 }
-
 
 @media (max-width: @screen-xs-max) {
   div#ccm-file-manager-upload-prompt {

--- a/web/concrete/src/File/Image/Thumbnail/Type/Version.php
+++ b/web/concrete/src/File/Image/Thumbnail/Type/Version.php
@@ -79,7 +79,7 @@ class Version
     {
         $value = tc('ThumbnailTypeName', $this->getName());
         if ($this->isDoubledVersion) {
-            $value = t('%s (Retina Version)', $value);
+            $value = t('%s (Retina)', $value);
         }
         switch ($format) {
             case 'html':

--- a/web/concrete/views/dialogs/file/thumbnails.php
+++ b/web/concrete/views/dialogs/file/thumbnails.php
@@ -1,12 +1,13 @@
-<?php
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
-use Concrete\Core\File\Image\Thumbnail\Type\Version;
-
-defined('C5_EXECUTE') or die("Access Denied.");
 /* @var FileVersion $version */
+use Concrete\Core\File\Image\Thumbnail\Type\Version;
 ?>
+
 <div class="ccm-ui">
     <?php
+    $i = 1;
+
     /* @var Version $type */
     foreach ($types as $type) {
         $width = $type->getWidth();
@@ -23,39 +24,51 @@ defined('C5_EXECUTE') or die("Access Denied.");
             'fvID' => $version->getFileVersionID(),
             'thumbnail' => $type->getHandle(),
         ));
+    ?>
+
+        <?php if ($i % 3 === 1) { ?>
+            <div class="row">
+        <?php } ?>
+                <div class="col-md-4">
+                    <div class="ccm-image-thumbnail-card">
+                        <div class="ccm-image-thumbnail-display-name">
+                            <h4><?php echo $type->getDisplayName(); ?></h4>
+                        </div>
+                        <small class="ccm-image-thumbnail-dimensions"><?php echo t('%s x %s dimensions', $width, $height); ?></small>
+                        <?php if ($fp->canEditFileContents() && $hasFile) { ?>
+                            <a href="<?php echo $url . '?' . $query; ?>"
+                                dialog-width="90%"
+                                dialog-height="70%"
+                                class="btn btn-sm btn-default dialog-launch"
+                                dialog-title="<?php echo t('Edit Thumbnail Images'); ?>">
+                                <?php echo t('Edit Thumbnail'); ?>
+                            </a>
+                        <?php } ?>
+                        <hr class="ccm-image-thumbnail-divider">
+                        <div class="ccm-file-manager-image-thumbnail">
+                            <?php if ($hasFile) { ?>
+                                <img class="ccm-file-manager-image-thumbnail-image"
+                                    data-handle='<?php echo $type->getHandle(); ?>'
+                                    data-fid="<?php echo $version->getFileID(); ?>"
+                                    data-fvid="<?php echo $version->getFileVersionID(); ?>"
+                                    style="max-width: 100%"
+                                    src="<?php echo $configuration->getPublicURLToFile($thumbnailPath); ?>"/>
+                            <?php
+                            } else {
+                                echo t(
+                                    'No thumbnail found. Usually this is because the ' .
+                                    'source file is smaller than this thumbnail configuration.');
+                            }
+                            ?>
+                        </div>
+                    </div>
+                </div>
+        <?php if ($i % 3 === 0 || $i === count($types)) { ?>
+            </div>
+        <?php }
+
+        ++$i;
         ?>
-        <h4>
-            <?= $type->getDisplayName() ?>
-            <small><?= t('%s x %s dimensions', $width, $height) ?></small>
-            <?php if ($fp->canEditFileContents() && $hasFile) { ?>
-                <a href="<?= $url . '?' . $query ?>"
-                   dialog-width="90%"
-                   dialog-height="70%"
-                   class="pull-right btn btn-sm btn-default dialog-launch"
-                   dialog-title="<?= t('Edit Thumbnail Images') ?>">
-                    <?= t('Edit Thumbnail') ?>
-                </a>
-            <?php } ?>
-        </h4>
-        <hr/>
-        <div class="ccm-file-manager-image-thumbnail">
-            <?php
-            if ($hasFile) {
-                ?>
-                <img class="ccm-file-manager-image-thumbnail-image"
-                     data-handle='<?= $type->getHandle() ?>'
-                     data-fid="<?= $version->getFileID() ?>"
-                     data-fvid="<?= $version->getFileVersionID() ?>"
-                     style="max-width: 100%"
-                     src="<?= $configuration->getPublicURLToFile($thumbnailPath) ?>"/>
-                <?php
-            } else {
-                echo t(
-                    'No thumbnail found. Usually this is because the ' .
-                    'source file is smaller than this thumbnail configuration.');
-            }
-            ?>
-        </div>
 
     <?php } ?>
 


### PR DESCRIPTION
Bootstrap style cards for faster browsing of large numbers of thumbnails.

I tested this by creating a mix of very wide and very tall thumbnails and also long thumbnail names.

**Current**

![current](https://cloud.githubusercontent.com/assets/10898145/12637763/d2efddb6-c565-11e5-8bc2-3b5af143a0f3.jpg)

**Changes**

_standard and wide thumbnail sizes_

![change_regular](https://cloud.githubusercontent.com/assets/10898145/12637777/e3456622-c565-11e5-9f55-924768f189a7.jpg)

_standard and tall thumbnail sizes_

![change_irregular](https://cloud.githubusercontent.com/assets/10898145/12637784/e7afda80-c565-11e5-9d7b-63c2dae191ad.jpg)

_responsive_

![change_responsive](https://cloud.githubusercontent.com/assets/10898145/12637789/eaf9c55c-c565-11e5-8473-b4883aac889d.jpg)

_long thumbnail names_

![image 1](https://cloud.githubusercontent.com/assets/10898145/12638099/682c9fac-c568-11e5-8293-7486b1bf93bf.jpg)







