### PR TITLE
Changed setDescription to setContent in RSS feed writer.

### DIFF
--- a/web/concrete/src/Page/Feed.php
+++ b/web/concrete/src/Page/Feed.php
@@ -492,7 +492,7 @@ class Feed
                 if (!$content) {
                     $content = t('No Content.');
                 }
-                $entry->setDescription($content);
+                $entry->setContent($content);
                 $entry->setLink((string) $p->getCollectionLink(true));
                 $writer->addEntry($entry);
             }


### PR DESCRIPTION
Some RSS readers, eg Feedly, wants the content in the "content" node and not the "description"