### PR TITLE
Fix: Page Type Default Block Styles

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/BlockControl.php
+++ b/web/concrete/src/Page/Type/Composer/Control/BlockControl.php
@@ -313,6 +313,7 @@ class BlockControl extends Control
         $arHandle = $b->getAreaHandle();
         $blockDisplayOrder = $b->getBlockDisplayOrder();
         $bFilename = $b->getBlockFilename();
+        $defaultStyles = $b->getCustomStyle();
         $b->deleteBlock();
         $ax = Area::getOrCreate($c, $arHandle);
         $b = $c->addBlock($bt, $ax, $data);
@@ -320,6 +321,10 @@ class BlockControl extends Control
         $b->setAbsoluteBlockDisplayOrder($blockDisplayOrder);
         if ($bFilename) {
             $b->setCustomTemplate($bFilename);
+        }
+
+        if ($defaultStyles) {
+            $b->setCustomStyleSet($defaultStyles->getStyleSet());
         }
 
         // make a reference to the new block


### PR DESCRIPTION
#2787 Composer Page Template Block Default Styles

To reproduce issue on a current build, find any page type that has a composer form defined. Edit it's default output and set a custom style on any block that is generated via a composer control. If you then go and create a page of this type via composer, the custom styles are not applied to that block.