### PR TITLE
Add display names to display Path

### DIFF
--- a/web/concrete/src/Tree/Node/Node.php
+++ b/web/concrete/src/Tree/Node/Node.php
@@ -213,10 +213,10 @@ abstract class Node extends Object implements \Concrete\Core\Permission\ObjectIn
                 continue;
             }
             $n = $nodes[$i];
-            $path .= $n->getTreeNodeName() . '/';
+            $path .= $n->getTreeNodeDisplayName() . '/';
         }
         if (count($nodes) > 0) {
-            $path .= $this->getTreeNodeName();
+            $path .= $this->getTreeNodeDisplayName();
         }
 
         return $path;


### PR DESCRIPTION
When trees are used on sites with translations, the TreeNodePath does not get properly translated. Updating the calls from getTreeNodeName to getTreeNodeDisplayName resolves this.