### PR TITLE
Adding Meta Keyword Override

### DIFF
--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -72,13 +72,15 @@ if (is_object($c)) {
 
 <meta http-equiv="content-type" content="text/html; charset=<?php echo APP_CHARSET?>" />
 <?php
-$akk = $c->getCollectionAttributeValue('meta_keywords');
+if (!isset($pageMetaKeywords) || !$pageMetaKeywords) {
+    $pageMetaKeywords = $c->getCollectionAttributeValue('meta_keywords');
+}
 ?>
 <title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET)?></title>
 <meta name="description" content="<?=htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET)?>" />
 
-<? if ($akk) { ?>
-<meta name="keywords" content="<?=htmlspecialchars($akk, ENT_COMPAT, APP_CHARSET)?>" />
+<? if ($pageMetaKeywords) { ?>
+<meta name="keywords" content="<?=htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET)?>" />
 <?php }
 if($c->getCollectionAttributeValue('exclude_search_index')) { ?>
     <meta name="robots" content="noindex" />

--- a/web/concrete/themes/elemental/elements/header_top.php
+++ b/web/concrete/themes/elemental/elements/header_top.php
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/css/bootstrap-modified.css">
     <?=$html->css($view->getStylesheet('main.less'))?>
-    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : '', 'pageDescription' => isset($pageDescription) ? $pageDescription : ''));?>
+    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : '', 'pageDescription' => isset($pageDescription) ? $pageDescription : '', 'pageMetaKeyword' => isset($pageMetaKeyword) ? $pageMetaKeyword : ''));?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         if (navigator.userAgent.match(/IEMobile\/10\.0/)) {

--- a/web/concrete/themes/elemental/elements/header_top.php
+++ b/web/concrete/themes/elemental/elements/header_top.php
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/css/bootstrap-modified.css">
     <?=$html->css($view->getStylesheet('main.less'))?>
-    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : '', 'pageDescription' => isset($pageDescription) ? $pageDescription : '', 'pageMetaKeyword' => isset($pageMetaKeyword) ? $pageMetaKeyword : ''));?>
+    <?php Loader::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : '', 'pageDescription' => isset($pageDescription) ? $pageDescription : '', 'pageMetaKeywords' => isset($pageMetaKeywords) ? $pageMetaKeywords : ''));?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         if (navigator.userAgent.match(/IEMobile\/10\.0/)) {


### PR DESCRIPTION
I know that I feel I'm wasting my time.

But, one of my clients asked me if they can override meta keyword.

I've told them that Google no longer uses Meta Keyword. They knew, but they still want to set the Meta Keyword pattern.

So, I had to implement the meta keyword override.
But header_required.php doesn't allow override. So I would like to suggest to include the override.