### PR TITLE
Addition of Composer label to Page Settings button (if applicable)

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -230,14 +230,19 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                 $permissions->canEditPageTheme() ||
                 $permissions->canEditPageTemplate() ||
                 $permissions->canDeletePage() ||
-                $permissions->canEditPagePermissions())) { ?>
+                $permissions->canEditPagePermissions())) {
+                $hasComposer = is_object($pagetype) && $cp->canEditPageContents(); ?>
         <li data-guide-toolbar-action="page-settings" class="pull-left hidden-xs">
             <a href="#" data-launch-panel="page"
                data-panel-url="<?= URL::to('/ccm/system/panels/page') ?>"
+               <? if ($hasComposer) { ?>}
+               title="<?= t('Composer, Page Design, Location, Attributes and Settings') ?>">
+               <? } else { ?>
                title="<?= t('Page Design, Location, Attributes and Settings') ?>">
+               <? } ?>
                 <i class="fa fa-cog"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-settings">
-                    <? if (is_object($pagetype) && $cp->canEditPageContents()) { ?>
+                    <? if ($hasComposer) { ?>
                     <?= tc('toolbar', 'Composer') ?> /
                     <? } ?>
                     <?= tc('toolbar', 'Page Settings') ?>

--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -237,6 +237,9 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                title="<?= t('Page Design, Location, Attributes and Settings') ?>">
                 <i class="fa fa-cog"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-settings">
+                    <? if (is_object($pagetype) && $cp->canEditPageContents()) { ?>
+                    <?= tc('toolbar', 'Composer') ?> /
+                    <? } ?>
                     <?= tc('toolbar', 'Page Settings') ?>
                 </span>
             </a>


### PR DESCRIPTION
This appends the label 'Composer' to the Page Settings button, if the current page is configured for the composer.

![screen shot 2016-02-03 at 9 07 09 pm](https://cloud.githubusercontent.com/assets/1079600/12780111/df8e6870-cabb-11e5-9d19-dc081ce5f84e.png)

A current concern is that the composer is sort of hidden away in the Page Settings panel, and it's not really obvious that you can click the Page Settings button to get to it. So this is a small suggestion as to how the feature can be made a bit clearer (at least when the labels are turned on).

For 5.6, Hissy and myself both released 'Edit In Composer' toolbar buttons - I had _many_ requests to add this button to sites, and I know personally it made a huge difference. 5.7 fortunately has the _feature_ of being able to directly edit a page in Composer, but it's just not clear that it's there.