### PR TITLE
Removal of unnecessary margins on dashboard result message

### DIFF
--- a/web/concrete/css/build/themes/dashboard/main.less
+++ b/web/concrete/css/build/themes/dashboard/main.less
@@ -135,8 +135,6 @@ div.ccm-attribute-list-wrapper {
  */
 div#ccm-dashboard-content {
   div#ccm-dashboard-result-message {
-    margin-right: 20px;
-    margin-left: 0px;
   }
 }
 


### PR DESCRIPTION
The alerts that get shown in the dashboard don't align on the right hand side with the rest of the page content \*twitch\*, due to an unnecessary right margin. This PR simply removes this. I couldn't find a reason for this margin to be there.

before
<img width="1020" alt="screen shot 2016-02-03 at 10 16 27 pm" src="https://cloud.githubusercontent.com/assets/1079600/12781443/514dd420-cac4-11e5-84ba-1a1fd81eea26.png">
after
<img width="1021" alt="screen shot 2016-02-03 at 10 15 52 pm" src="https://cloud.githubusercontent.com/assets/1079600/12781446/5676c1dc-cac4-11e5-8882-afe7f413a929.png">
