### PR TITLE
Add default parameter values to   method

### DIFF
--- a/web/concrete/controllers/feed.php
+++ b/web/concrete/controllers/feed.php
@@ -3,7 +3,7 @@ namespace Concrete\Controller;
 
 class Feed extends \Concrete\Core\Controller\Controller
 {
-    public function get($identifier)
+    public function get($identifier=null, $defaultValue=null)
     {
         $feed = \Concrete\Core\Page\Feed::getByHandle($identifier);
         if (is_object($feed)) {


### PR DESCRIPTION
The \Concrete\Core\Controller\Controller::get method has a signature of get($identifier=null, $defaultValue=null). This signature was causing issues on PHP7.