### PR TITLE
Fix translated placeholders on storage location paths

### DIFF
--- a/web/concrete/elements/storage_location_types/local.php
+++ b/web/concrete/elements/storage_location_types/local.php
@@ -9,11 +9,11 @@ if (is_object($configuration)) {
 <div class="form-group">
     <label for="path"><?=t('Root Path')?></label>
     <div class="input-group">
-        <?=$form->text('fslType[path]', $path, array('placeholder' => t('Example: %ssome/path', $_SERVER['DOCUMENT_ROOT'])))?>
+        <?=$form->text('fslType[path]', $path, array('placeholder' => t('Example: %ssome/path', $_SERVER['DOCUMENT_ROOT'] . '/')))?>
         <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
     </div>
 </div>
 <div class="form-group">
     <label for="path"><?=t('Relative Path')?></label>
-    <?=$form->text('fslType[relativePath]', $relativePath, array('placeholder' => t('Example: %s', '/some/path')))?>
+    <?=$form->text('fslType[relativePath]', $relativePath, array('placeholder' => t('Example: %ssome/path', '/')))?>
 </div>


### PR DESCRIPTION
before:
![placeholder-before](https://cloud.githubusercontent.com/assets/4508405/12825577/b9e5b6e0-cb7f-11e5-9642-6a0dff12c7cc.jpg)

after:
![placeholder-after](https://cloud.githubusercontent.com/assets/4508405/12825583/bf1b9972-cb7f-11e5-8e92-d9ea5ef4f908.jpg)
