### PR TITLE
Fix error when attribute value not found

### DIFF
--- a/web/concrete/src/Attribute/Value/Value.php
+++ b/web/concrete/src/Attribute/Value/Value.php
@@ -25,11 +25,11 @@ class Value extends Object
         $row = $db->GetRow('select avID, akID, uID, avDateAdded, atID from AttributeValues where avID = ?', array($avID));
         if (is_array($row) && $row['avID'] == $avID) {
             $this->setPropertiesFromArray($row);
-        }
 
-        $this->attributeType = $this->getAttributeTypeObject();
-        $this->attributeType->controller->setAttributeKey($this->getAttributeKey());
-        $this->attributeType->controller->setAttributeValue($this);
+            $this->attributeType = $this->getAttributeTypeObject();
+            $this->attributeType->controller->setAttributeKey($this->getAttributeKey());
+            $this->attributeType->controller->setAttributeValue($this);
+        }
     }
 
     public function __destruct()


### PR DESCRIPTION
The `getAttributeTypeObject()` method relies on the instance variable `atID` which might not have been set up if the attribute value doesn't exist.