### PR TITLE
Use correct target in page list links

### DIFF
--- a/web/concrete/blocks/page_list/view.php
+++ b/web/concrete/blocks/page_list/view.php
@@ -130,7 +130,7 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
 
                 <? if (isset($useButtonForLink) && $useButtonForLink): ?>
                 <div class="ccm-block-page-list-page-entry-read-more">
-                    <a href="<?=$url?>" class="<?=$buttonClasses?>"><?=$buttonLinkText?></a>
+                    <a href="<?=$url?>" target="<?=$target?>" class="<?=$buttonClasses?>"><?=$buttonLinkText?></a>
                 </div>
                 <? endif; ?>
 


### PR DESCRIPTION
Use correct target when `Use Different Link than Page Name` option is enabled in page list