### PR TITLE
Enable username change from the dashboard

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/search.php
+++ b/web/concrete/controllers/single_page/dashboard/users/search.php
@@ -236,65 +236,63 @@ class Search extends DashboardPageController
         $this->setupUser($uID);
         if ($this->canEditUserName) {
             $username = $this->post('value');
-            if (!Config::get('concrete.user.registration.email_registration')) {
-                if (!Loader::helper('validation/token')->validate()) {
-                    $this->error->add(Loader::helper('validation/token')->getErrorMessage());
-                }
-                if (strlen($username) < Config::get('concrete.user.username.minimum')) {
-                    $this->error->add(
-                        t(
-                            'A username must be at least %s characters long.',
-                            Config::get('concrete.user.username.minimum')
-                        )
-                    );
-                }
-
-                if (strlen($username) > Config::get('concrete.user.username.maximum')) {
-                    $this->error->add(
-                        t(
-                            'A username cannot be more than %s characters long.',
-                            Config::get('concrete.user.username.maximum')
-                        )
-                    );
-                }
-
-                if (strlen($username) >= Config::get('concrete.user.username.minimum') && !Loader::helper(
-                        'concrete/validation'
-                    )->username($username)
-                ) {
-                    if (Config::get('concrete.user.username.allow_spaces')) {
-                        $this->error->add(
-                            t(
-                                'A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'
-                            )
-                        );
-                    } else {
-                        $this->error->add(
-                            t(
-                                'A username may only contain letters numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'
-                            )
-                        );
-                    }
-                }
-                $uo = $this->user->getUserObject();
-                if (strcasecmp($uo->getUserName(), $username) && !Loader::Helper(
-                        'concrete/validation'
-                    )->isUniqueUsername($username)
-                ) {
-                    $this->error->add(t("The username '%s' already exists. Please choose another", $username));
-                }
-
-                $sr = new UserEditResponse();
-                $sr->setUser($this->user);
-                if (!$this->error->has()) {
-                    $data = array('uName' => $username);
-                    $this->user->update($data);
-                    $sr->setMessage(t('Username saved successfully.'));
-                } else {
-                    $sr->setError($this->error);
-                }
-                $sr->outputJSON();
+            if (!Loader::helper('validation/token')->validate()) {
+                $this->error->add(Loader::helper('validation/token')->getErrorMessage());
             }
+            if (strlen($username) < Config::get('concrete.user.username.minimum')) {
+                $this->error->add(
+                    t(
+                        'A username must be at least %s characters long.',
+                        Config::get('concrete.user.username.minimum')
+                    )
+                );
+            }
+
+            if (strlen($username) > Config::get('concrete.user.username.maximum')) {
+                $this->error->add(
+                    t(
+                        'A username cannot be more than %s characters long.',
+                        Config::get('concrete.user.username.maximum')
+                    )
+                );
+            }
+
+            if (strlen($username) >= Config::get('concrete.user.username.minimum') && !Loader::helper(
+                    'concrete/validation'
+                )->username($username)
+            ) {
+                if (Config::get('concrete.user.username.allow_spaces')) {
+                    $this->error->add(
+                        t(
+                            'A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'
+                        )
+                    );
+                } else {
+                    $this->error->add(
+                        t(
+                            'A username may only contain letters numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'
+                        )
+                    );
+                }
+            }
+            $uo = $this->user->getUserObject();
+            if (strcasecmp($uo->getUserName(), $username) && !Loader::Helper(
+                    'concrete/validation'
+                )->isUniqueUsername($username)
+            ) {
+                $this->error->add(t("The username '%s' already exists. Please choose another", $username));
+            }
+
+            $sr = new UserEditResponse();
+            $sr->setUser($this->user);
+            if (!$this->error->has()) {
+                $data = array('uName' => $username);
+                $this->user->update($data);
+                $sr->setMessage(t('Username saved successfully.'));
+            } else {
+                $sr->setError($this->error);
+            }
+            $sr->outputJSON();
         }
     }
 


### PR DESCRIPTION
Any reason why we disabled username change from the dashboard when the email address was used to log in? The username validation is there so in case someone decides to switch back to usernames they don't have duplicates.