### PR TITLE
Allow filter select attribute using NOT LIKE through comparison

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -599,7 +599,9 @@ class Controller extends AttributeTypeController
             $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
             $qb = $list->getQueryObject();
             $qb->andWhere(
-	            $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
+                $comparison === '!=' || $comparison === '<>'
+                    ? $qb->expr()->notLike($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
+                    : $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
             );
 	        $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $option->getSelectAttributeOptionValue(false) . "\n%");
         }


### PR DESCRIPTION
Currently select attributes ignore the comparison operator. Some operators often won't make sense, but != or <> can be translated into NOT LIKE and will work every time. This commit checks for the two operators mentioned, using NOT LIKE, otherwise defaulting to LIKE.