### PR TITLE
User late static binding

### DIFF
--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -44,7 +44,7 @@ class User extends Object
         $row = $r ? $r->FetchRow() : null;
         $nu = null;
         if ($row) {
-            $nu = new self();
+            $nu = new static();
             $nu->setPropertiesFromArray($row);
             $nu->uGroups = $nu->_getUserGroups(true);
             $nu->superUser = ($nu->getUserID() == USER_SUPER_ID);


### PR DESCRIPTION
This would allow us to still use getByUserID if the User class has been extended.

![static](https://cloud.githubusercontent.com/assets/1431100/12865616/38e59730-ccb1-11e5-951c-8fe9257ad944.png)