### PR TITLE
Fix: we are not able to create a "0" page

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -34,7 +34,10 @@ class DescriptionCorePageProperty extends CorePageProperty
         } else {
             $description = $this->getPageTypeComposerControlDraftValue();
         }
-        if (Core::make('helper/validation/strings')->notempty($description)) {
+        
+        /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
+        $stringValidator = Core::make('helper/validation/strings');
+        if (!$stringValidator->notempty($description)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
 

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -34,7 +34,7 @@ class DescriptionCorePageProperty extends CorePageProperty
         } else {
             $description = $this->getPageTypeComposerControlDraftValue();
         }
-        if (!$description) {
+        if (Core::make('helper/validation/strings')->notempty($description)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
 

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -46,7 +46,10 @@ class NameCorePageProperty extends CorePageProperty
         } else {
             $name = $this->getPageTypeComposerControlDraftValue();
         }
-        if (Core::make('helper/validation/strings')->notempty($name)) {
+        
+        /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
+        $stringValidator = Core::make('helper/validation/strings');
+        if (!$stringValidator->notempty($name)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
 

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -46,7 +46,7 @@ class NameCorePageProperty extends CorePageProperty
         } else {
             $name = $this->getPageTypeComposerControlDraftValue();
         }
-        if (!$name) {
+        if (Core::make('helper/validation/strings')->notempty($name)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
 

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -27,7 +27,7 @@ class UrlSlugCorePageProperty extends CorePageProperty
     {
         $e = Loader::helper('validation/error');
         $handle = $this->getPageTypeComposerControlDraftValue();
-        if (!$handle) {
+        if (Core::make('helper/validation/strings')->notempty($handle)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
             return $e;

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -28,7 +28,10 @@ class UrlSlugCorePageProperty extends CorePageProperty
     {
         $e = Loader::helper('validation/error');
         $handle = $this->getPageTypeComposerControlDraftValue();
-        if (Core::make('helper/validation/strings')->notempty($handle)) {
+        
+        /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
+        $stringValidator = Core::make('helper/validation/strings');
+        if (!$stringValidator->notempty($handle)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlLabel()));
             return $e;

--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Loader;
 use Page;
+use Core;
 
 class UrlSlugCorePageProperty extends CorePageProperty
 {


### PR DESCRIPTION
Our page property validator checks the value is true or false. Let's validate it is empty string or not.