### PR TITLE
Add Delimiter characters for multiple items in btPageAttribute Display

### DIFF
--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -85,6 +85,36 @@ class Controller extends BlockController
         if (!strlen(trim(strip_tags($content))) && ($c->isMasterCollection() || $is_stack)) {
             $content = $this->getPlaceHolderText($this->attributeHandle);
         }
+        
+        if(!empty($this->delimiter)) {
+            $parts = explode("\n", $content);
+            if(count($parts)>1){
+                switch ($this->delimiter) {
+                    case 'comma':
+                        $delimiter = ',';
+                        break;
+                    case 'commaSpace':
+                        $delimiter = ', ';
+                        break;
+                    case 'pipe':
+                        $delimiter = '|';
+                        break;
+                    case 'dash':
+                        $delimiter = '-';
+                        break;
+                    case 'semicolon':
+                        $delimiter = ';';
+                        break;
+                    case 'break':
+                        $delimiter = '<br />';
+                        break;
+                    default:
+                        $delimiter = ' ';
+                        break;
+                }
+                $content = implode($delimiter, $parts);
+            }
+        }
 
         return $content;
     }

--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -105,6 +105,9 @@ class Controller extends BlockController
                     case 'semicolon':
                         $delimiter = ';';
                         break;
+                    case 'semicolonSpace':
+                        $delimiter = '; ';
+                        break;
                     case 'break':
                         $delimiter = '<br />';
                         break;

--- a/web/concrete/blocks/page_attribute_display/db.xml
+++ b/web/concrete/blocks/page_attribute_display/db.xml
@@ -20,6 +20,7 @@
     <field name="thumbnailWidth" type="integer">
       <unsigned/>
     </field>
+	<field name="delimiter" type="string" size="255"/>
   </table>
 
 </schema>

--- a/web/concrete/blocks/page_attribute_display/form.php
+++ b/web/concrete/blocks/page_attribute_display/form.php
@@ -28,6 +28,19 @@ print Core::make('helper/concrete/ui')->tabs(array(
         <input type="text" class="form-control" name="dateFormat" value="<?php  echo $this->controller->dateFormat ?>"/>
         <div class="text-muted"><?php echo sprintf(t('See the formatting options at %s.'), '<a href="http://www.php.net/date" target="_blank">php.net/date</a>'); ?></div>
     </div>
+    <div class="form-group">
+        <label class="control-label"><?php  echo t('Delimiter for multiple items')?></label>
+        <select name="delimiter" class="form-control">
+            <option value="">- none -</option>
+            <option value="comma" <?php echo($this->controller->delimiter == "comma" ? "selected" : "")?>>Comma (",")</option>
+            <option value="commaSpace" <?php echo($this->controller->delimiter == "commaSpace" ? "selected" : "")?>>Comma With Space After (", ")</option>
+            <option value="pipe" <?php echo($this->controller->delimiter == "pipe" ? "selected" : "")?>>Pipe ("|")</option>
+            <option value="dash" <?php echo($this->controller->delimiter == "dash" ? "selected" : "")?>>Dash ("-")</option>
+            <option value="semicolon" <?php echo($this->controller->delimiter == "semicolon" ? "selected" : "")?>>Semicolon (";")</option>
+            <option value="semicolonSpace" <?php echo($this->controller->delimiter == "semicolonSpace" ? "selected" : "")?>>Semicolon With Space After ("; ")</option>
+            <option value="break" <?php echo($this->controller->delimiter == "break" ? "selected" : "")?>>Newline</option>
+        </select>
+    </div> 
     <fieldset>
         <legend><?=t('Thumbnail')?></legend>
         <div class="form-group">

--- a/web/concrete/blocks/page_attribute_display/form.php
+++ b/web/concrete/blocks/page_attribute_display/form.php
@@ -11,16 +11,16 @@ print Core::make('helper/concrete/ui')->tabs(array(
     <div class="form-group">
         <label class="control-label"><?php  echo t('Display property with formatting')?></label>
         <select name="displayTag" class="form-control">
-            <option value="">- none -</option>
-            <option value="h1" <?php echo($this->controller->displayTag == "h1" ? "selected" : "")?>>H1 (Heading 1)</option>
-            <option value="h2" <?php echo($this->controller->displayTag == "h2" ? "selected" : "")?>>H2 (Heading 2)</option>
-            <option value="h3" <?php echo($this->controller->displayTag == "h3" ? "selected" : "")?>>H3 (Heading 3)</option>
-            <option value="p" <?php echo($this->controller->displayTag == "p" ? "selected" : "")?>>p (paragraph)</option>
-            <option value="b" <?php echo($this->controller->displayTag == "b" ? "selected" : "")?>>b (bold)</option>
-            <option value="address" <?php echo($this->controller->displayTag == "address" ? "selected" : "")?>>address</option>
-            <option value="pre" <?php echo($this->controller->displayTag == "pre" ? "selected" : "")?>>pre (preformatted)</option>
-            <option value="blockquote" <?php echo($this->controller->displayTag == "blockquote" ? "selected" : "")?>>blockquote</option>
-            <option value="div" <?php echo($this->controller->displayTag == "div" ? "selected" : "")?>>div</option>
+            <option value=""><?=t('- none -')?></option>
+            <option value="h1" <?php echo($this->controller->displayTag == "h1" ? "selected" : "")?>><?=t('H1 (Heading 1)')?></option>
+            <option value="h2" <?php echo($this->controller->displayTag == "h2" ? "selected" : "")?>><?=t('H2 (Heading 2)')?></option>
+            <option value="h3" <?php echo($this->controller->displayTag == "h3" ? "selected" : "")?>><?=t('H3 (Heading 3)')?></option>
+            <option value="p" <?php echo($this->controller->displayTag == "p" ? "selected" : "")?>><?=t('p (paragraph)')?></option>
+            <option value="b" <?php echo($this->controller->displayTag == "b" ? "selected" : "")?>><?=t('b (bold)')?></option>
+            <option value="address" <?php echo($this->controller->displayTag == "address" ? "selected" : "")?>><?=t('address')?></option>
+            <option value="pre" <?php echo($this->controller->displayTag == "pre" ? "selected" : "")?>><?=t('pre (preformatted)')?></option>
+            <option value="blockquote" <?php echo($this->controller->displayTag == "blockquote" ? "selected" : "")?>><?=t('blockquote')?></option>
+            <option value="div" <?php echo($this->controller->displayTag == "div" ? "selected" : "")?>><?=t('div')?></option>
         </select>
     </div>
     <div class="form-group">
@@ -31,14 +31,14 @@ print Core::make('helper/concrete/ui')->tabs(array(
     <div class="form-group">
         <label class="control-label"><?php  echo t('Delimiter for multiple items')?></label>
         <select name="delimiter" class="form-control">
-            <option value="">- none -</option>
-            <option value="comma" <?php echo($this->controller->delimiter == "comma" ? "selected" : "")?>>Comma (",")</option>
-            <option value="commaSpace" <?php echo($this->controller->delimiter == "commaSpace" ? "selected" : "")?>>Comma With Space After (", ")</option>
-            <option value="pipe" <?php echo($this->controller->delimiter == "pipe" ? "selected" : "")?>>Pipe ("|")</option>
-            <option value="dash" <?php echo($this->controller->delimiter == "dash" ? "selected" : "")?>>Dash ("-")</option>
-            <option value="semicolon" <?php echo($this->controller->delimiter == "semicolon" ? "selected" : "")?>>Semicolon (";")</option>
-            <option value="semicolonSpace" <?php echo($this->controller->delimiter == "semicolonSpace" ? "selected" : "")?>>Semicolon With Space After ("; ")</option>
-            <option value="break" <?php echo($this->controller->delimiter == "break" ? "selected" : "")?>>Newline</option>
+            <option value=""><?=t('- none -')?></option>
+            <option value="comma" <?php echo($this->controller->delimiter == "comma" ? "selected" : "")?>><?=t('Comma (",")')?></option>
+            <option value="commaSpace" <?php echo($this->controller->delimiter == "commaSpace" ? "selected" : "")?>><?=t('Comma With Space After (", ")')?></option>
+            <option value="pipe" <?php echo($this->controller->delimiter == "pipe" ? "selected" : "")?>><?=t('Pipe ("|")')?></option>
+            <option value="dash" <?php echo($this->controller->delimiter == "dash" ? "selected" : "")?>><?=t('Dash ("-")')?></option>
+            <option value="semicolon" <?php echo($this->controller->delimiter == "semicolon" ? "selected" : "")?>><?=t('Semicolon (";")')?></option>
+            <option value="semicolonSpace" <?php echo($this->controller->delimiter == "semicolonSpace" ? "selected" : "")?>><?=t('Semicolon With Space After ("; ")')?></option>
+            <option value="break" <?php echo($this->controller->delimiter == "break" ? "selected" : "")?>><?=t('Newline')?></option>
         </select>
     </div> 
     <fieldset>


### PR DESCRIPTION
One of my big pet peeves with the way the demo install looks is how the project page attributes don't have any delimiting characters, so if multiple word items just run together and can get very confusing, for example web development database could be read as web development, database, or web, development database (which is a horrible example, but the best I can come up with in the moment).
It's easy to add new delimiters as well, and I tried to include the most common ones.