### PR TITLE
Detect CLI environment from current working directory

### DIFF
--- a/web/concrete/bin/concrete5.php
+++ b/web/concrete/bin/concrete5.php
@@ -1,36 +1,63 @@
 <?php
-$DIR_BASE_CORE = dirname(__DIR__);
 
-foreach (array('PHP_SELF', 'SCRIPT_NAME', 'SCRIPT_FILENAME', 'PATH_TRANSLATED') as $key) {
-    // Check if the key is valid
-    if (!isset($_SERVER[$key])) {
-        continue;
-    }
-    $value = $_SERVER[$key];
-    if (!is_file($value)) {
-        continue;
-    }
-    if (stripos(PHP_OS, 'WIN') === 0) {
-        // Just to simplify the regular expressions
-        $value = str_replace('\\', '/', $value);
-        // Check if the key is an absolute path
-        if (preg_match('%^([A-Z]:/|//\w)%i', $value) !== 1) {
-            continue;
+if (!isset($DIR_BASE_CORE)) {
+    // Try to detect the concrete directory starting from the current working directory
+    // (useful with CLI scripts started from a common launcher)
+    $dir = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', getcwd()), '/');
+    while (@is_dir($dir)) {
+        if (is_file($dir.'/index.php') && is_file($dir.'/concrete/bootstrap/configure.php')) {
+            $DIR_BASE_CORE = $dir.'/concrete';
+            break;
         }
-    } else {
-        if (preg_match('%^/%i', $value) !== 1) {
-            continue;
+        $newDir = @dirname($dir);
+        if ($newDir === $dir) {
+            break;
         }
+        $dir = $newDir;
     }
-    if (preg_match('%/\.{1,2}/%', $value) !== 0) {
-        continue;
-    }
-    // Ok!
-    $DIR_BASE_CORE = dirname(dirname($value));
-    break;
+    unset($dir);
+    unset($newDir);
 }
-unset($key);
-unset($value);
+
+if (!isset($DIR_BASE_CORE)) {
+    // Try to detect the concrete directory starting from the filename of the currently executing script
+    // (useful with symlinked concrete directories)
+    foreach (array('PHP_SELF', 'SCRIPT_NAME', 'SCRIPT_FILENAME', 'PATH_TRANSLATED') as $key) {
+        // Check if the key is valid
+        if (!isset($_SERVER[$key])) {
+            continue;
+        }
+        $value = $_SERVER[$key];
+        if (!is_file($value)) {
+            continue;
+        }
+        if (stripos(PHP_OS, 'WIN') === 0) {
+            // Just to simplify the regular expressions
+            $value = str_replace('\\', '/', $value);
+            // Check if the key is an absolute path
+            if (preg_match('%^([A-Z]:/|//\w)%i', $value) !== 1) {
+                continue;
+            }
+        } else {
+            if (preg_match('%^/%i', $value) !== 1) {
+                continue;
+            }
+        }
+        if (preg_match('%/\.{1,2}/%', $value) !== 0) {
+            continue;
+        }
+        // Ok!
+        $DIR_BASE_CORE = dirname(dirname($value));
+        break;
+    }
+    unset($key);
+    unset($value);
+}
+
+if (!isset($DIR_BASE_CORE)) {
+    // Fall back to the real directory containing this script
+    $DIR_BASE_CORE = dirname(__DIR__);
+}
 
 define('DIR_BASE', dirname($DIR_BASE_CORE));
 

--- a/web/concrete/bin/concrete5.php
+++ b/web/concrete/bin/concrete5.php
@@ -4,6 +4,9 @@ if (!isset($DIR_BASE_CORE)) {
     // Try to detect the concrete directory starting from the current working directory
     // (useful with CLI scripts started from a common launcher)
     $dir = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', getcwd()), '/');
+    if (is_dir($dir.'/web')) {
+        $dir .= '/web';
+    }
     while (@is_dir($dir)) {
         if (is_file($dir.'/index.php') && is_file($dir.'/concrete/bootstrap/configure.php')) {
             $DIR_BASE_CORE = $dir.'/concrete';


### PR DESCRIPTION
- Let's assume you symlinked the CLI entrypoint (eg with `ln -s /path/to/website1/concrete/bin/concrete5 /usr/local/bin/c5`) for website 1
- Let's assume you want to run the CLI commands for website 2 using the symlinked `c5` entrypoint

Currently this is not possible.

Let's allow this simply by `cd /path/to/website2`, so that `c5` will use it.