### PR TITLE
fix html block entity

### DIFF
--- a/web/concrete/blocks/html/form_setup_html.php
+++ b/web/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,6 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>  
 
-<div id="ccm-block-html-value"><?=h($content)?></div>
+<div id="ccm-block-html-value"><?=htmlspecialchars($content,ENT_QUOTES,APP_CHARSET)?></div>
 <textarea style="display: none" id="ccm-block-html-value-textarea" name="content"></textarea>
 
 <style type="text/css">


### PR DESCRIPTION
Entity of html block become invalid

Steps to Reproduce
1.add html block input entitized "&lt;h1&gt;aaaa&lt;/h1&gt;"
2.save
3.edit html block. show "&lt;h1&gt;aaaa&lt;/h1&gt;"
4.Save without doing anything.
5.entity of html block become invalid. 