### PR TITLE
Fix file url in form results

### DIFF
--- a/web/concrete/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/single_pages/dashboard/reports/forms.php
@@ -263,7 +263,7 @@ else {
                                 $file = File::getByID($fID);
                                 if ($fID && $file) {
                                     $fileVersion = $file->getApprovedVersion();
-                                    echo '<td><a href="' . $fileVersion->getRelativePath() . '">' .
+                                    echo '<td><a href="' . $fileVersion->getUrl() . '">' .
                                         $text->entities($fileVersion->getFileName()) . '</a></td>';
                                 } else {
                                     echo '<td>' . t('File not found') . '</td>';


### PR DESCRIPTION
File URL was not working when using a private file location.