### PR TITLE
Detect updated core in CLI commands

### DIFF
--- a/web/concrete/bin/concrete5.php
+++ b/web/concrete/bin/concrete5.php
@@ -1,68 +1,86 @@
 <?php
 
-if (!isset($DIR_BASE_CORE)) {
-    // Try to detect the concrete directory starting from the current working directory
-    // (useful with CLI scripts started from a common launcher)
-    $dir = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', getcwd()), '/');
-    if (is_dir($dir.'/web')) {
-        $dir .= '/web';
+if (!defined('DIR_BASE')) {
+    if (!isset($DIR_BASE)) {
+        // Try to detect the webroot directory starting from the current working directory
+        // (useful with CLI scripts started from a common launcher)
+        $dir = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', getcwd()), '/');
+        if (is_dir($dir.'/web')) {
+            $dir .= '/web';
+        }
+        while (@is_dir($dir)) {
+            if (is_file($dir.'/index.php') && is_file($dir.'/concrete/bootstrap/configure.php')) {
+                $DIR_BASE = $dir;
+                break;
+            }
+            $newDir = @dirname($dir);
+            if ($newDir === $dir) {
+                break;
+            }
+            $dir = $newDir;
+        }
+        unset($dir);
+        unset($newDir);
     }
-    while (@is_dir($dir)) {
-        if (is_file($dir.'/index.php') && is_file($dir.'/concrete/bootstrap/configure.php')) {
-            $DIR_BASE_CORE = $dir.'/concrete';
-            break;
-        }
-        $newDir = @dirname($dir);
-        if ($newDir === $dir) {
-            break;
-        }
-        $dir = $newDir;
-    }
-    unset($dir);
-    unset($newDir);
-}
-
-if (!isset($DIR_BASE_CORE)) {
-    // Try to detect the concrete directory starting from the filename of the currently executing script
-    // (useful with symlinked concrete directories)
-    foreach (array('PHP_SELF', 'SCRIPT_NAME', 'SCRIPT_FILENAME', 'PATH_TRANSLATED') as $key) {
-        // Check if the key is valid
-        if (!isset($_SERVER[$key])) {
-            continue;
-        }
-        $value = $_SERVER[$key];
-        if (!is_file($value)) {
-            continue;
-        }
-        if (stripos(PHP_OS, 'WIN') === 0) {
-            // Just to simplify the regular expressions
-            $value = str_replace('\\', '/', $value);
-            // Check if the key is an absolute path
-            if (preg_match('%^([A-Z]:/|//\w)%i', $value) !== 1) {
+    if (!isset($DIR_BASE)) {
+        // Try to detect the webroot directory starting from the filename of the currently executing script
+        // (useful with symlinked concrete directories)
+        foreach (array('PHP_SELF', 'SCRIPT_NAME', 'SCRIPT_FILENAME', 'PATH_TRANSLATED') as $key) {
+            // Check if the key is valid
+            if (!isset($_SERVER[$key])) {
                 continue;
             }
-        } else {
-            if (preg_match('%^/%i', $value) !== 1) {
+            $value = $_SERVER[$key];
+            if (!is_file($value)) {
                 continue;
             }
+            if (stripos(PHP_OS, 'WIN') === 0) {
+                // Just to simplify the regular expressions
+                $value = str_replace('\\', '/', $value);
+                // Check if the key is an absolute path
+                if (preg_match('%^([A-Z]:/|//\w)%i', $value) !== 1) {
+                    continue;
+                }
+            } else {
+                if (preg_match('%^/%i', $value) !== 1) {
+                    continue;
+                }
+            }
+            if (preg_match('%/\.{1,2}/%', $value) !== 0) {
+                continue;
+            }
+            // Ok!
+            $DIR_BASE = dirname(dirname(dirname($value)));
+            break;
         }
-        if (preg_match('%/\.{1,2}/%', $value) !== 0) {
-            continue;
-        }
-        // Ok!
-        $DIR_BASE_CORE = dirname(dirname($value));
-        break;
+        unset($key);
+        unset($value);
     }
-    unset($key);
-    unset($value);
+    if (!isset($DIR_BASE)) {
+        // Fall back to the real directory containing this script
+        $DIR_BASE = dirname(dirname(__DIR__));
+    }
+    define('DIR_BASE', $DIR_BASE);
+    unset($DIR_BASE);
 }
 
 if (!isset($DIR_BASE_CORE)) {
-    // Fall back to the real directory containing this script
-    $DIR_BASE_CORE = dirname(__DIR__);
-}
+    // Check for an updated core available
+    $update = DIR_BASE.'/application/config/update.php';
+    if (is_file($update)) {
+        $update = (array) include $update;
+        if (isset($update['core']) && is_dir(DIR_BASE.'/updates/'.$update['core'].'/concrete')) {
+            $DIR_BASE_CORE = DIR_BASE.'/updates/'.$update['core'].'/concrete';
+            require $DIR_BASE_CORE.'/bin/concrete5.php';
 
-define('DIR_BASE', dirname($DIR_BASE_CORE));
+            return;
+        }
+    }
+    $DIR_BASE_CORE = DIR_BASE.'/concrete';
+}
+unset($update);
+
+define('APP_UPDATED_PASSTHRU', true);
 
 require $DIR_BASE_CORE . '/bootstrap/configure.php';
 require $DIR_BASE_CORE . '/bootstrap/autoload.php';


### PR DESCRIPTION
Currently the CLI entrypoint that gets executed is the one in the /concrete/bin directory.

Let's detect if there's an updated core, and if so let's run the new CLI entrypoint.