### PR TITLE
fix content block entity

### DIFF
--- a/web/concrete/src/Editor/RedactorEditor.php
+++ b/web/concrete/src/Editor/RedactorEditor.php
@@ -74,7 +74,7 @@ class RedactorEditor implements EditorInterface
         }
         $options = json_encode($options);
         $identifier = id(new Identifier())->getString(32);
-        $html = sprintf('<textarea data-redactor-editor="%s" name="%s">%s</textarea>', $identifier, $key, $content);
+        $html = sprintf('<textarea data-redactor-editor="%s" name="%s">%s</textarea>', $identifier, $key, htmlspecialchars($content, ENT_QUOTES, APP_CHARSET));
         $html .= <<<EOL
         <script type="text/javascript">
         var CCM_EDITOR_SECURITY_TOKEN = "{$this->token}";


### PR DESCRIPTION
Entity of content block become invalid.
Steps to Reproduce
1.add content block "html mode " input entitized "&lt;h1&gt;aaaa&lt;/h1&gt;"
2.save
3.edit content block. show "&lt;h1&gt;aaaa&lt;/h1&gt;"
4.Save without doing anything.
5.entity of content block become invalid. 
