### PR TITLE
Trigger refresh on save of attributes and SEO

### DIFF
--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -329,14 +329,16 @@ function ConcretePanel(options) {
                 obj.closePanelDetail();
             });
 
-            $content.find('[data-panel-detail-form]').not('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm();
-
-            $content.find('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm({complete: function(){
-                location.reload();
-            }});
+            $content.find('[data-panel-detail-form]').concreteAjaxForm();
 
             $('button[data-panel-detail-action=submit]').on('click', function () {
                 $('[data-panel-detail-form]').submit();
+            });
+
+            ConcreteEvent.subscribe('AjaxFormSubmitSuccess', function(e, data) {
+                if ($('[data-panel-detail-form="'+ data.form + '"]').data('action-after-save')=='reload') {
+                    location.reload();
+                }
             });
         }
     };

--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -332,8 +332,7 @@ function ConcretePanel(options) {
             $content.find('[data-panel-detail-form]').not('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm();
 
             $content.find('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm({complete: function(){
-                var panel = ConcretePanelManager.getByIdentifier('check-in');
-                panel.toggle();
+                location.reload();
             }});
 
             $('button[data-panel-detail-action=submit]').on('click', function () {

--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -329,7 +329,7 @@ function ConcretePanel(options) {
                 obj.closePanelDetail();
             });
 
-            $content.find('[data-panel-detail-form]').concreteAjaxForm();
+            $content.find('[data-panel-detail-form]').not('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm();
 
             $content.find('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm({complete: function(){
                 var panel = ConcretePanelManager.getByIdentifier('check-in');

--- a/web/concrete/js/build/core/app/panels.js
+++ b/web/concrete/js/build/core/app/panels.js
@@ -328,7 +328,14 @@ function ConcretePanel(options) {
             $('button[data-panel-detail-action=cancel]').on('click', function () {
                 obj.closePanelDetail();
             });
+
             $content.find('[data-panel-detail-form]').concreteAjaxForm();
+
+            $content.find('[data-panel-detail-form="seo"],[data-panel-detail-form="attributes"]').concreteAjaxForm({complete: function(){
+                var panel = ConcretePanelManager.getByIdentifier('check-in');
+                panel.toggle();
+            }});
+
             $('button[data-panel-detail-action=submit]').on('click', function () {
                 $('[data-panel-detail-form]').submit();
             });

--- a/web/concrete/views/panels/details/page/attributes.php
+++ b/web/concrete/views/panels/details/page/attributes.php
@@ -16,7 +16,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 <div id="ccm-detail-page-attributes">
 
 <section class="ccm-ui">
-	<form method="post" action="<?=$controller->action('submit')?>" data-dialog-form="attributes" data-panel-detail-form="attributes">
+	<form method="post" action="<?=$controller->action('submit')?>" data-dialog-form="attributes" data-panel-detail-form="attributes"  data-action-after-save="reload">
 
         <? if (isset($sitemap) && $sitemap) { ?>
             <input type="hidden" name="sitemap" value="1" />

--- a/web/concrete/views/panels/details/page/seo.php
+++ b/web/concrete/views/panels/details/page/seo.php
@@ -4,7 +4,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <section class="ccm-ui">
 	<header><?=t('SEO')?></header>
-	<form method="post" action="<?=$controller->action('submit')?>" class="ccm-panel-detail-content-form" data-dialog-form="seo" data-panel-detail-form="seo">
+	<form method="post" action="<?=$controller->action('submit')?>" class="ccm-panel-detail-content-form" data-dialog-form="seo" data-panel-detail-form="seo" data-action-after-save="reload">
 
 	<?php if ($allowEditName) { ?>
 	<div class="form-group">


### PR DESCRIPTION
This is a suggested change to improve the user experience when updating page attributes (or attributes via the SEO panel). 

At the moment when you go into these panels and do a save, there's no prompt to suggest you need to actually publish the page.

<del>This tweak triggers the page publishing panel on the save of these two panels. </del>
Updated to a refresh instead

Overly descriptive video demo here!  - https://www.youtube.com/watch?v=PfHyYQ3d8Js