### PR TITLE
export translation info

### DIFF
--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -88,6 +88,7 @@ class Controller extends BlockController
         $data->addAttribute('table', $this->btTable);
         $record = $data->addChild('record');
         $cnode = $record->addChild('content');
+        $cnode->addAttribute('translatable', true);
         $node = dom_import_simplexml($cnode);
         $no = $node->ownerDocument;
         $content = LinkAbstractor::export($this->content);

--- a/web/concrete/blocks/date_navigation/controller.php
+++ b/web/concrete/blocks/date_navigation/controller.php
@@ -18,6 +18,7 @@ class Controller extends BlockController
     protected $btExportPageColumns = array('cParentID', 'cTargetID');
     protected $btExportPageTypeColumns = array('ptID');
     protected $btTable = 'btDateNavigation';
+    protected $btTranslatableColumns = array('title');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/faq/controller.php
+++ b/web/concrete/blocks/faq/controller.php
@@ -16,6 +16,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btTranslatableColumns = array('blockTitle', 'linkTitle', 'title', 'description');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -22,6 +22,7 @@ class Controller extends BlockController
     protected $btExportPageColumns = array('internalLinkCID');
     protected $btInterfaceHeight = 520;
     protected $btTable = 'btFeature';
+    protected $btTranslatableColumns = array('title', 'paragraph', 'externalLink');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/file/controller.php
+++ b/web/concrete/blocks/file/controller.php
@@ -14,8 +14,8 @@ class Controller extends BlockController
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btInterfaceHeight = 320;
     protected $btTable = 'btContentFile';
-
     protected $btExportFileColumns = array('fID');
+    protected $btTranslatableColumns = array('fileLinkText');
 
     /** 
      * Used for localization. If we want to localize the name/description we have to include this.

--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -30,6 +30,7 @@ class Controller extends BlockController
     protected $btExportTables = array('btForm', 'btFormQuestions');
     protected $btExportPageColumns = array('redirectCID');
     protected $lastAnswerSetId = 0;
+    protected $btTranslatableColumns = array('surveyName', 'submitText', 'thankyouMsg', 'question');
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this.

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -15,6 +15,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
+    protected $btTranslatableColumns = array('title', 'location');
 
     public $title = "";
     public $location = "";

--- a/web/concrete/blocks/html/controller.php
+++ b/web/concrete/blocks/html/controller.php
@@ -15,6 +15,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btIgnorePageThemeGridFrameworkContainer = true;
+    protected $btTranslatableColumns = array('content');
 
     public $content = "";
 

--- a/web/concrete/blocks/image/controller.php
+++ b/web/concrete/blocks/image/controller.php
@@ -23,6 +23,7 @@ class Controller extends BlockController
     protected $btFeatures = array(
         'image',
     );
+    protected $btTranslatableColumns = array('altText', 'title');
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this.

--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -20,6 +20,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btIgnorePageThemeGridFrameworkContainer = true;
+    protected $btTranslatableColumns = array('title', 'description');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/next_previous/controller.php
+++ b/web/concrete/blocks/next_previous/controller.php
@@ -14,6 +14,7 @@ class Controller extends BlockController
     protected $btInterfaceHeight = "400";
     protected $btCacheBlockRecord = true;
     protected $btWrapperClass = 'ccm-ui';
+    protected $btTranslatableColumns = array('nextLabel', 'previousLabel', 'parentLabel');
     /**
      * Used for localization. If we want to localize the name/description we have to include this.
      */

--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -19,6 +19,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
+    protected $btTranslatableColumns = array('attributeTitleText');
 
     /**
      * @var int thumbnail height

--- a/web/concrete/blocks/page_list/controller.php
+++ b/web/concrete/blocks/page_list/controller.php
@@ -26,6 +26,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputLifetime = 300;
     protected $list;
+    protected $btTranslatableColumns = array('buttonLinkText', 'pageListTitle');
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this.

--- a/web/concrete/blocks/page_title/controller.php
+++ b/web/concrete/blocks/page_title/controller.php
@@ -19,6 +19,7 @@ class Controller extends BlockController
     protected $btInterfaceHeight = 400;
     protected $btTable = 'btPageTitle';
     protected $btWrapperClass = 'ccm-ui';
+    protected $btTranslatableColumns = array('titleText');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/rss_displayer/controller.php
+++ b/web/concrete/blocks/rss_displayer/controller.php
@@ -21,6 +21,7 @@ class Controller extends BlockController
     protected $btWrapperClass = 'ccm-ui';
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btCacheBlockOutputLifetime = 3600;
+    protected $btTranslatableColumns = array('title');
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this

--- a/web/concrete/blocks/search/controller.php
+++ b/web/concrete/blocks/search/controller.php
@@ -18,6 +18,7 @@ class Controller extends BlockController
     protected $btExportPageColumns = array('postTo_cID');
     protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = null;
+    protected $btTranslatableColumns = array('title', 'buttonText');
 
     public $title = "";
     public $buttonText = ">";

--- a/web/concrete/blocks/survey/controller.php
+++ b/web/concrete/blocks/survey/controller.php
@@ -15,6 +15,7 @@ class Controller extends BlockController
     protected $btInterfaceWidth = "420";
     protected $btInterfaceHeight = "400";
     protected $btExportTables = array('btSurvey', 'btSurveyOptions', 'btSurveyResults');
+    protected $btTranslatableColumns = array('question', 'optionName');
 
     public function on_start()
     {

--- a/web/concrete/blocks/switch_language/controller.php
+++ b/web/concrete/blocks/switch_language/controller.php
@@ -14,6 +14,7 @@ class Controller extends BlockController
     protected $btInterfaceWidth = "500";
     protected $btInterfaceHeight = "150";
     protected $btTable = 'btSwitchLanguage';
+    protected $btTranslatableColumns = array('label');
 
     public $helpers = array('form');
 

--- a/web/concrete/blocks/tags/controller.php
+++ b/web/concrete/blocks/tags/controller.php
@@ -21,6 +21,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = false;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btWrapperClass = 'ccm-ui';
+    protected $btTranslatableColumns = array('title');
 
     public $attributeHandle = 'tags';
     public $displayMode = 'page';

--- a/web/concrete/blocks/testimonial/controller.php
+++ b/web/concrete/blocks/testimonial/controller.php
@@ -17,6 +17,7 @@ class Controller extends BlockController
     protected $btInterfaceHeight = 560;
     protected $btExportFileColumns = array('fID');
     protected $btTable = 'btTestimonial';
+    protected $btTranslatableColumns = array('name', 'position', 'company', 'companyURL', 'paragraph');
 
     public function getBlockTypeDescription()
     {

--- a/web/concrete/blocks/topic_list/controller.php
+++ b/web/concrete/blocks/topic_list/controller.php
@@ -110,7 +110,8 @@ class Controller extends BlockController
         $tree = Tree::getByID($this->topicTreeID);
         $data = $blockNode->addChild('data');
         $data->addChild('mode', $this->mode);
-        $data->addChild("title", $this->title);
+        $title = $data->addChild("title", $this->title);
+        $title->setAttribute('translatable', true);
         $data->addChild('topicAttributeKeyHandle', $this->topicAttributeKeyHandle);
         if (is_object($tree)) {
             $data->addChild('tree', $tree->getTreeName());

--- a/web/concrete/blocks/youtube/controller.php
+++ b/web/concrete/blocks/youtube/controller.php
@@ -13,7 +13,8 @@ class Controller extends BlockController
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
-    
+    protected $btTranslatableColumns = array('title');
+
     /**
      * Used for localization. If we want to localize the name/description we have to include this.
      */

--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -55,6 +55,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $btFeatureObjects;
     protected $identifier;
     protected $btTable = null;
+    protected $btTranslatableColumns = array();
 
     public function getBlockTypeExportPageColumns()
     {
@@ -323,18 +324,22 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 foreach ($record as $key => $value) {
                     if (isset($columns[strtolower($key)])) {
                         if (in_array($key, $this->btExportPageColumns)) {
-                            $tableRecord->addChild($key, ContentExporter::replacePageWithPlaceHolder($value));
+                            $newChild = $tableRecord->addChild($key, ContentExporter::replacePageWithPlaceHolder($value));
                         } elseif (in_array($key, $this->btExportFileColumns)) {
-                            $tableRecord->addChild($key, ContentExporter::replaceFileWithPlaceHolder($value));
+                            $newChild = $tableRecord->addChild($key, ContentExporter::replaceFileWithPlaceHolder($value));
                         } elseif (in_array($key, $this->btExportPageTypeColumns)) {
-                            $tableRecord->addChild($key, ContentExporter::replacePageTypeWithPlaceHolder($value));
+                            $newChild = $tableRecord->addChild($key, ContentExporter::replacePageTypeWithPlaceHolder($value));
                         } elseif (in_array($key, $this->btExportPageFeedColumns)) {
-                            $tableRecord->addChild($key, ContentExporter::replacePageFeedWithPlaceHolder($value));
+                            $newChild = $tableRecord->addChild($key, ContentExporter::replacePageFeedWithPlaceHolder($value));
                         } else {
-                            $cnode = $tableRecord->addChild($key);
-                            $node = dom_import_simplexml($cnode);
+                            $newChild = $tableRecord->addChild($key);
+                            $node = dom_import_simplexml($newChild);
                             $no = $node->ownerDocument;
                             $node->appendChild($no->createCDataSection($value));
+                        }
+
+                        if (in_array($key, $this->btTranslatableColumns)) {
+                            $newChild->addAttribute('translatable', true);
                         }
                     }
                 }


### PR DESCRIPTION
@mlocati do you think that part would be okay? 

* [x] extract those translatable strings
* [x]  add them to the strings that should be parsed on transifex
* [ ] update the scripts that download the translated resources and build different setup xml for different languages
* [ ] enjoy fully localized concrete5 installations out of the box :wink: