### PR TITLE
use getRequestValue instead of $_REQUEST 

### DIFF
--- a/tests/tests/Core/Form/Service/FormTest.php
+++ b/tests/tests/Core/Form/Service/FormTest.php
@@ -463,7 +463,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
             array(
                 'radio',
                 array('Key[subkey1][subkey2]', 'Value'),
-                '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2]" value="Value" class="ccm-input-radio" />',
+                '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2]" value="Value" class="ccm-input-radio" checked="checked" />',
                 array('Key' => array('subkey1' => array('subkey2' => 'Value'))),
             ),
             // inputType (text, number, email, telephone, url, search, password)

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -227,7 +227,7 @@ class Form
 
         $requestValue = $this->getRequestValue($key);
 
-        if ($requestValue) {
+        if ($requestValue !== false) {
             if ($requestValue == $value) {
                 $checked = true;
             }

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -224,8 +224,11 @@ class Form
             $checkedValue = $checkedValueOrMiscFields;
         }
         $checked = false;
-        if (isset($_REQUEST[$key])) {
-            if ($_REQUEST[$key] == $value) {
+
+        $requestValue = $this->getRequestValue($key);
+
+        if (isset($requestValue)) {
+            if ($requestValue == $value) {
                 $checked = true;
             }
         } else {

--- a/web/concrete/src/Form/Service/Form.php
+++ b/web/concrete/src/Form/Service/Form.php
@@ -227,7 +227,7 @@ class Form
 
         $requestValue = $this->getRequestValue($key);
 
-        if (isset($requestValue)) {
+        if ($requestValue) {
             if ($requestValue == $value) {
                 $checked = true;
             }

--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -214,9 +214,13 @@ EOS;
     public function date($field, $value = null, $calendarAutoStart = true)
     {
         $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
+        $fh = Core::make("helper/form");
         $id = preg_replace("/[^0-9A-Za-z-]/", "_", $field);
-        if (isset($_REQUEST[$field])) {
-            $timestamp = empty($_REQUEST[$field]) ? false : @strtotime($_REQUEST[$field]);
+
+        $requestValue = $fh->getRequestValue($field);
+
+        if (isset($requestValue)) {
+            $timestamp = empty($requestValue) ? false : @strtotime($requestValue);
         } elseif ($value) {
             $timestamp = @strtotime($value);
         } elseif ($value === '') {

--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -219,7 +219,7 @@ EOS;
 
         $requestValue = $fh->getRequestValue($field);
 
-        if (isset($requestValue)) {
+        if ($requestValue !== false) {
             $timestamp = empty($requestValue) ? false : @strtotime($requestValue);
         } elseif ($value) {
             $timestamp = @strtotime($value);

--- a/web/concrete/src/Form/Service/Widget/DateTime.php
+++ b/web/concrete/src/Form/Service/Widget/DateTime.php
@@ -235,7 +235,7 @@ EOS;
             $defaultDateJs = '""';
         }
         $html = '';
-        $html .= '<div><span class="ccm-input-date-wrapper" id="' . $id . '_dw"><input id="' . $id . '_pub" class="form-control ccm-input-date"  /><input id="' . $id . '" name="' . $field . '" type="hidden"  /></span></div>';
+        $html .= '<div><span class="ccm-input-date-wrapper" id="' . $id . '_dw"><input id="' . $id . '_pub" type="text" class="form-control ccm-input-date"  /><input id="' . $id . '" name="' . $field . '" type="hidden"  /></span></div>';
         $jh = Core::make('helper/json'); /* @var $jh \Concrete\Core\Http\Service\Json */
         if ($calendarAutoStart) {
             $html .= '<script type="text/javascript">$(function () {


### PR DESCRIPTION
This seems like the last function in the Form.php file that was using $_REQUEST. 
Did the same thing in the DateTime widget.
The fix allow to use id with brackets. Eg.:  myRadio[1][foo] 
