### PR TITLE
Bugfix: gc_max_lifetime should be gc_maxlifetime

### DIFF
--- a/web/concrete/src/Session/SessionFactory.php
+++ b/web/concrete/src/Session/SessionFactory.php
@@ -72,7 +72,7 @@ class SessionFactory implements SessionFactoryInterface
             if ($options['cookie_path'] === false) {
                 $options['cookie_path'] = $app['app_relative_path'] . '/';
             }
-            $options['gc_max_lifetime'] = $config->get('concrete.session.max_lifetime');
+            $options['gc_maxlifetime'] = $config->get('concrete.session.max_lifetime');
             $storage->setOptions($options);
         }
 


### PR DESCRIPTION
The PHP setting `gc_maxlifetime` is named incorrectly and as such, settings in `/application/config/concrete.php` are not applied to the session correctly.

See also http://php.net/manual/en/session.configuration.php#ini.session.gc-maxlifetime