### PR TITLE
Make User::loginByUserID static

### DIFF
--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -62,7 +62,7 @@ class User extends Object
      *
      * @return User
      */
-    public function loginByUserID($uID)
+    public static function loginByUserID($uID)
     {
         return self::getByUserID($uID, true);
     }


### PR DESCRIPTION
I tested the community authentication, and I had a strange error in `getByUserID`: `$nu` didn't have the `setPropertiesFromArray` method.

This PR fixes this problem.