### PR TITLE
Re-enable tests on translatable strings

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -12,6 +12,7 @@
             <directory>tests/Asset/</directory>
             <directory>tests/Block/</directory>
             <directory>tests/Attribute/</directory>
+            <directory>tests/Localization/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/tests/Localization/LocalizationTest.php
+++ b/tests/tests/Localization/LocalizationTest.php
@@ -61,7 +61,7 @@ class LocalizationTest extends \PHPUnit_Framework_TestCase
         $cmd .= ' --verbose'; // increase verbosity level
         $cmd .= ' --output-file='.escapeshellarg($moFile);
         $cmd .= ' '.escapeshellarg($poFile);
-        $cmd .= '2>&1';
+        $cmd .= ' 2>&1';
         $output = array();
         @exec($cmd, $output, $rc);
         $this->assertSame(0, $rc, "msgfmt output:\n" . implode("\n", $output));

--- a/tests/tests/Localization/LocalizationTest.php
+++ b/tests/tests/Localization/LocalizationTest.php
@@ -4,64 +4,67 @@ class LocalizationTest extends \PHPUnit_Framework_TestCase
 {
     public function testGeneratedPO()
     {
-        // Create the .pot file with the strings taken from the source code
-        $potFile = DIR_APPLICATION . '/' . DIRNAME_LANGUAGES . '/messages.pot';
-        $cmd = array();
-        $cmd[] = 'php ' . escapeshellarg(DIR_BUILDTOOLS . '/i18n.php');
-        $cmd[] = '--webroot=' . escapeshellarg(DIR_BASE);
-        $cmd[] = '--createpot=yes';
-        $cmd[] = '--createpo=no';
-        $cmd[] = '--compile=no';
-        $cmd[] = '2>&1';
-        $output = array();
-        exec(implode(' ', $cmd), $output, $rc);
-        $this->assertSame(0, $rc, "i18n.php output:\n" . implode("\n", $output));
+        $translationsFolder = DIR_APPLICATION.'/'.DIRNAME_LANGUAGES;
+        if (!is_dir($translationsFolder)) {
+            mkdir($translationsFolder);
+        }
+
+        // Extract the translatable strings and create the template .pot file
+        $potFile = $translationsFolder.'/messages.pot';
+        $translations = new \Gettext\Translations();
+        $cifParser = new \C5TL\Parser\Cif();
+        $phpParser = new \C5TL\Parser\Php();
+        $blockTemplatesParser = new \C5TL\Parser\BlockTemplates();
+        $themesPresetsParser = new \C5TL\Parser\ThemePresets();
+        $parsersForDir = array(
+            '' => array($phpParser),
+            DIRNAME_BLOCKS => array($blockTemplatesParser),
+            DIRNAME_THEMES => array($phpParser, $themesPresetsParser, $blockTemplatesParser),
+            'config/install' => array($cifParser),
+        );
+        foreach ($parsersForDir as $parsersDir => $parsers) {
+            $dir = DIR_BASE_CORE;
+            $relDir = DIRNAME_CORE;
+            if ($parsersDir !== '') {
+                $dir .= '/'.$parsersDir;
+                $relDir  .= '/'.$parsersDir;
+            }
+            foreach ($parsers as $parser) {
+                $parser->parseDirectory($dir, $relDir, $translations);
+            }
+        }
+        $translatableStrings = count($translations);
+        $this->assertGreaterThan(2000, $translatableStrings);
+        $translations->toPoFile($potFile);
         $this->assertFileExists($potFile);
 
-        // Create a fake English .po file (translated string same as source strings)
-        $poFile = DIR_APPLICATION . '/' . DIRNAME_LANGUAGES . '/messages.po';
-        $cmd = array();
-        $cmd[] = 'msgen';
-        $cmd[] = '--lang=en-US';
-        $cmd[] = '--output-file=' . escapeshellarg($poFile);
-        $cmd[] = escapeshellarg($potFile);
-        $cmd[] = '2>&1';
+        // Create a .po file with translations set to source strings
+        $poFile = $translationsFolder.'/messages.po';
+        $cmd = 'msgen --lang=en-US --output-file='.escapeshellarg($poFile).' '.escapeshellarg($potFile).' 2>&1';
         $output = array();
-        exec(implode(' ', $cmd), $output, $rc);
+        @exec($cmd, $output, $rc);
         $this->assertSame(0, $rc, "msgen output:\n" . implode("\n", $output));
         $this->assertFileExists($poFile);
 
-        // Add missing header entries
-        $poData = @file_get_contents($poFile);
-        $this->assertSame('string', gettype($poData), 'Read .po file');
-        $positionInHeader = strpos($poData, '"Language:');
-        $this->assertSame('integer', gettype($positionInHeader), 'Find Language in po header');
-        $poData =
-            substr($poData, 0, $positionInHeader)
-            . '"Plural-Forms: nplurals=2; plural=(n != 1)\n"' . "\n"
-            . '"PO-Revision-Date: 2014-06-19 14:55+0000\n"' . "\n"
-            . '"Last-Translator: \n"' . "\n"
-            . '"Language-Team: \n"' . "\n"
-            . substr($poData, $positionInHeader)
-        ;
-        $wroteBytes = @file_put_contents($poFile, $poData);
-        $this->assertSame('integer', gettype($wroteBytes), 'Write patched .po file ');
+        // Set the plural rules
+        $translations = \Gettext\Translations::fromPoFile($poFile);
+        $translations->setLanguage('en_US');
+        $translations->toPoFile($poFile);
+        $this->assertSame($translatableStrings, count($translations));
 
-        // Compile the fake .po file to a compiled .mo file
-        $moFile = DIR_APPLICATION . '/' . DIRNAME_LANGUAGES . '/messages.mo';
-        $cmd = array();
-        $cmd[] = 'msgfmt';
-        $cmd[] = '--check-format'; // check language dependent format strings
-        $cmd[] = '--check-header'; // verify presence and contents of the header entry
-        $cmd[] = '--check-domain'; // check for conflicts between domain directives and the --output-file option
-        $cmd[] = '--verbose'; // increase verbosity level
-        $cmd[] = '--output-file=' . escapeshellarg($moFile);
-        $cmd[] = escapeshellarg($poFile);
-        $cmd[] = '2>&1';
+        // Compile the .po file checking the strings
+        $moFile = $translationsFolder.'/messages.mo';
+        $cmd = 'msgfmt';
+        $cmd .= ' --check-format'; // check language dependent format strings
+        $cmd .= ' --check-header'; // verify presence and contents of the header entry
+        $cmd .= ' --check-domain'; // check for conflicts between domain directives and the --output-file option
+        $cmd .= ' --verbose'; // increase verbosity level
+        $cmd .= ' --output-file='.escapeshellarg($moFile);
+        $cmd .= ' '.escapeshellarg($poFile);
+        $cmd .= '2>&1';
         $output = array();
-        exec(implode(' ', $cmd), $output, $rc);
+        @exec($cmd, $output, $rc);
         $this->assertSame(0, $rc, "msgfmt output:\n" . implode("\n", $output));
         $this->assertFileExists($moFile);
     }
-
 }

--- a/tests/tests/bootstrap.php
+++ b/tests/tests/bootstrap.php
@@ -7,13 +7,6 @@
 
 use Concrete\Core\Config\Repository\Repository;
 
-define('DIR_BUILDTOOLS', dirname(dirname(__FILE__)) . '/build-tools');
-if (!is_dir(DIR_BUILDTOOLS)) {
-    exec(
-        'git clone --depth 1 --single-branch --branch master https://github.com/mlocati/concrete5-build ' . escapeshellarg(
-            DIR_BUILDTOOLS));
-}
-
 // error reporting
 PHPUnit_Framework_Error_Notice::$enabled = false;
 


### PR DESCRIPTION
This would detect wrong translatable strings.

For instance, if the PHP code contains something like this:
```php
echo t2('One %s', 'Two %d', $n);
```

The tests would fail with this message:
```
/application/languages/messages.po:19: format specifications in 'msgid_plural' and 'msgstr[0]'
    for argument 1 are not the same
msgfmt: found 1 fatal error
4284 translated messages.
```

(we've had this problem in an old version of 5.6)