### PR TITLE
Preserve original URL when login is needed

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -246,6 +246,13 @@ class Login extends PageController
             }
             do {
                 // redirect to original destination
+                if ($session->has('rUri')) {
+                    $rUrl = $session->get('rUri');
+                    $session->remove('rUri');
+                    if ($rUrl) {
+                        break;
+                    }
+                }
                 if ($session->has('rcID')) {
                     $rcID = $session->get('rcID');
                     if ($nh->integer($rcID)) {

--- a/web/concrete/src/Routing/DispatcherRouteCallback.php
+++ b/web/concrete/src/Routing/DispatcherRouteCallback.php
@@ -52,6 +52,7 @@ class DispatcherRouteCallback extends RouteCallback
     {
         // set page for redirection after successful login
         Session::set('rcID', $currentPage->getCollectionID());
+        Session::set('rUri', $request->getRequestUri());
 
         // load page forbidden
         $item = '/page_forbidden';


### PR DESCRIPTION
Let's preserve the requested URI when we access a page that requires user access but no user is logged in, so that we can forward to a page specific action after users log in.