### PR TITLE
Avoid sitemap.xml error on Search Console

### DIFF
--- a/web/concrete/jobs/generate_sitemap.php
+++ b/web/concrete/jobs/generate_sitemap.php
@@ -144,7 +144,7 @@ class GenerateSitemap extends AbstractJob
         $xmlNode->addChild('lastmod', $lastmod->format(DateTime::ATOM));
         $xmlNode->addChild(
             'changefreq',
-            empty($changefreq) ? Config::get('concrete.sitemap_xml.frequency') : $changefreq
+            Core::make('helper/validation/strings')->notempty($changefreq) ? $changefreq : Config::get('concrete.sitemap_xml.frequency')
         );
         $xmlNode->addChild(
             'priority',


### PR DESCRIPTION
Issue detail:

1. Empty self-closing changefreq element is not allowed on Search Console
2. There is a possibility that $changefreq is a object if the attribute type is select