### PR TITLE
remove unsupported attributes from source and replace img src with srcset

### DIFF
--- a/web/concrete/src/Html/Object/Picture.php
+++ b/web/concrete/src/Html/Object/Picture.php
@@ -4,25 +4,24 @@ namespace Concrete\Core\Html\Object;
 use HtmlObject\Element;
 use HtmlObject\Image;
 
-
 class Picture extends Element
 {
     /**
-     * Default element
+     * Default element.
      *
      * @var string
      */
     protected $element = 'picture';
 
     /**
-     * Whether the element is self closing
+     * Whether the element is self closing.
      *
-     * @var boolean
+     * @var bool
      */
     protected $isSelfClosing = false;
 
     /**
-     * Default element for nested children
+     * Default element for nested children.
      *
      * @var string
      */
@@ -39,12 +38,13 @@ class Picture extends Element
     }
 
     /**
-     * Static alias for constructor
+     * Static alias for constructor.
      *
-     * @param string $element
+     * @param string          $element
      * @param string|null|Tag $value
-     * @param array $attributes
-     * @return                Table
+     * @param array           $attributes
+     *
+     * @return Table
      */
     public static function create($sources = array(), $fallbackSrc = false, $attributes = array())
     {
@@ -59,7 +59,7 @@ class Picture extends Element
     {
         $this->nest("<!--[if IE 9]><video style='display: none;'><![endif]-->");
 
-        foreach($sources as $source) {
+        foreach ($sources as $source) {
             $path = $source['src'];
             $width = $source['width'];
             $source = Source::create();
@@ -75,17 +75,18 @@ class Picture extends Element
         return $this;
     }
 
-    public function fallback($src)
+    public function fallback($srcset)
     {
         $img = Image::create();
-        $img->src($src);
+        $img->srcset($srcset);
+        $img->removeAttribute('src');
         $this->setChild($img);
     }
 
     public function alt($alt)
     {
-        foreach($this->getChildren() as $child) {
-            if ($child instanceof Image || $child instanceof Source) {
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
                 $child->alt($alt);
             }
         }
@@ -93,8 +94,8 @@ class Picture extends Element
 
     public function title($title)
     {
-        foreach($this->getChildren() as $child) {
-            if ($child instanceof Image || $child instanceof Source) {
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
                 $child->title($title);
             }
         }
@@ -102,10 +103,10 @@ class Picture extends Element
 
     public function addClass($classes)
     {
-        $sources = $this->getChildren();
-        foreach($sources as $source) {
-            $source->addClass($classes);
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
+                $child->addClass($classes);
+            }
         }
     }
-
 }


### PR DESCRIPTION
### Remove unsupported attributes from source

The source element when used with the picture element does not support class, title, and alt attributes.
https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element

Example: browser that doesn't support picture and using Picturefill 3.0.2

**Current**
```
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 900px)" class="ccm-image-block img-responsive bID-13225" alt="strawberry red velvet cupcakes with butter cream frosting" title="mmmm cupcakes">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/medium/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 768px)" class="ccm-image-block img-responsive bID-13225" alt="strawberry red velvet cupcakes with butter cream frosting" title="mmmm cupcakes">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" class="ccm-image-block img-responsive bID-13225" alt="strawberry red velvet cupcakes with butter cream frosting" title="mmmm cupcakes">
    <!--[if IE 9]></video><![endif]-->
    <img src="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" alt="strawberry red velvet cupcakes with butter cream frosting" class="ccm-image-block img-responsive bID-13225" title="mmmm cupcakes" data-pfsrc="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
</picture>
```

**Change**
````
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 900px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/medium/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 768px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
    <!--[if IE 9]></video><![endif]-->
    <img src="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" alt="strawberry red velvet cupcakes with butter cream frosting" class="ccm-image-block img-responsive bID-13225" title="mmmm cupcakes" data-pfsrc="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
</picture>
````

### Replace the img src attribute with srcset

"Trying to use the src attribute in a browser that doesn't support picture natively can result in a double download. To avoid this, don't use the src attribute on the img tag"
https://github.com/scottjehl/picturefill#the-gotchas

Example: browser that doesn't support picture and not using Picturefill

**Change**
````
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 900px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/medium/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 768px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
    <!--[if IE 9]></video><![endif]-->
    <img alt="strawberry red velvet cupcakes with butter cream frosting" srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" class="ccm-image-block img-responsive bID-13225" title="mmmm cupcakes">
</picture>
````
Example: browser that doesn't support picture and using Picturefill 3.0.2

**Change**
````
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 900px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/medium/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" media="(min-width: 768px)">
    <source srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
    <!--[if IE 9]></video><![endif]-->
    <img alt="strawberry red velvet cupcakes with butter cream frosting" srcset="http://localhost/concrete5/application/files/thumbnails/small/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg" class="ccm-image-block img-responsive bID-13225" title="mmmm cupcakes" src="http://localhost/concrete5/application/files/thumbnails/large/5414/5102/4445/Strawberry-Red-Velvet-Cupcakes1.jpg">
</picture>
````
Picturefill will add the src attribute and value to prevent the double download.