### PR TITLE
Add c5:exec CLI command

### DIFF
--- a/web/concrete/src/Console/Application.php
+++ b/web/concrete/src/Console/Application.php
@@ -2,7 +2,6 @@
 namespace Concrete\Core\Console;
 
 use Core;
-use Database;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use Concrete\Core\Updater\Migrations\Configuration as MigrationsConfiguration;
 
@@ -20,6 +19,7 @@ class Application extends \Symfony\Component\Console\Application
         $this->add(new Command\GenerateIDESymbolsCommand());
         $this->add(new Command\ConfigCommand());
         $this->add(new Command\PackPackageCommand());
+        $this->add(new Command\ExecCommand());
         if (Core::make('app')->isInstalled()) {
             $this->add(new Command\ClearCacheCommand());
             $this->add(new Command\InstallPackageCommand());

--- a/web/concrete/src/Console/Command/ExecCommand.php
+++ b/web/concrete/src/Console/Command/ExecCommand.php
@@ -1,0 +1,52 @@
+<?php
+namespace Concrete\Core\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Exception;
+
+class ExecCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('c5:exec')
+            ->setDescription('Execute a PHP script within the concrete5 environment')
+            ->addArgument('script', InputArgument::REQUIRED, 'The path of the script to be executed')
+            ->addArgument('arguments', InputArgument::IS_ARRAY, 'The arguments to pass to the script')
+        ->setHelp(<<<EOT
+In the included script you'll have these variables:
+- \$input: an instance of \Symfony\Component\Console\Input\InputInterface
+- \$output: an instance of \Symfony\Component\Console\Input\OutputInterface
+- \$args: an array of strings containing the arguments specified after the script to be executed 
+
+To specify the command return code, define an int variable named '\$rc'.
+
+Returns codes:
+  0 operation completed successfully
+  1 errors occurred
+EOT
+            )
+            ;
+    }
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            if (!is_file($input->getArgument('script'))) {
+                throw new Exception(sprintf('Unable to find the file %s', $input->getArgument('script')));
+            }
+            $args = $input->getArgument('arguments');
+            require $input->getArgument('script');
+            if (!isset($rc)) {
+                $rc = 0;
+            }
+        } catch (Exception $x) {
+            $output->writeln('<error>'.$x->getMessage().'</error>');
+            $rc = 1;
+        }
+
+        return $rc;
+    }
+}


### PR DESCRIPTION
I often have to run one-time scripts from the console.

Every time I need this, I have to initialize the concrete5 environment, then write the script itself.

What about adding a wrapper command?

Here's an example:

1) create a `test.php` file like this:
```php
<?php
$dh = Core::make('helper/date');
echo $dh->formatDateTime('now', true);
```
2) execute `test.php` simply with `concrete/bin/concrete5 c5:exec test.php`
