### PR TITLE
Backwards compatibility

### DIFF
--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -568,6 +568,10 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function getPackageEntityPaths()
     {
+        // Support for the legacy method for backwards compatibility
+        if (method_exists($this, 'getPackageEntityPath')) {
+            return array($this->getPackageEntityPath());
+        }
         return array($this->getPackagePath() . '/' . DIRNAME_CLASSES);
     }
 


### PR DESCRIPTION
Fixes backwards comaptibility for the modified package methods, as discussed here:
https://github.com/concrete5/concrete5/commit/8a5b34dde8d81f98517f18ece8cd7da104689732#diff-b2c917c0f9a391f0bd443dd9ae1af539L590