### PR TITLE
Add Set Page Type Control Label Setting/Getting during Creation

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -20,6 +20,7 @@ abstract class Control extends Object
     protected $ptComposerControlRequiredByDefault = false;
     protected $ptComposerControlRequiredOnThisRequest = false;
     protected $ptComposerControlCustomLabel;
+    protected $ptComposerControlDescription;
 
     abstract public function getPageTypeComposerControlCustomTemplates();
     abstract public function render($label, $customTemplate, $description);
@@ -56,6 +57,16 @@ abstract class Control extends Object
     {
         return $this->ptComposerControlCustomLabel;
     }
+    
+    public function setPageTypeComposerControlDescription($description)
+    {
+        $this->ptComposerControlDescription = $description;
+    }
+    
+    public function getPageTypeComposerControlDescription()
+    {
+        return $this->ptComposerControlDescription;
+    }
 
     public function setPageObject($page)
     {
@@ -86,6 +97,7 @@ abstract class Control extends Object
     {
         return $this->ptComposerControlName;
     }
+    
     public function getPageTypeComposerControlDisplayName($format = 'html')
     {
         $value = $this->getPageTypeComposerControlName();
@@ -170,8 +182,9 @@ abstract class Control extends Object
         }
         $controlType = $this->getPageTypeComposerControlTypeObject();
         $customLabel = $this->getPageTypeComposerControlCustomLabel();
-        $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlCustomLabel, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?, ?)', array(
-            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $customLabel, $ptComposerFormLayoutSetControlRequired,
+        $description = $this->getPageTypeComposerControlDescription();
+        $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlCustomLabel, ptComposerFormLayoutSetControlDescription, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?, ?, ?)', array(
+            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $customLabel, $description, $ptComposerFormLayoutSetControlRequired,
         ));
 
         return PageTypeComposerFormLayoutSetControl::getByID($db->Insert_ID());

--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -47,7 +47,6 @@ abstract class Control extends Object
         $this->ptComposerControlRequiredOnThisRequest = $req;
     }
 
-    
     public function setPageTypeComposerControlCustomLabel($label)
     {
         $this->ptComposerControlCustomLabel = $label;

--- a/web/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/web/concrete/src/Page/Type/Composer/Control/Control.php
@@ -19,6 +19,7 @@ abstract class Control extends Object
     protected $ptComposerControl;
     protected $ptComposerControlRequiredByDefault = false;
     protected $ptComposerControlRequiredOnThisRequest = false;
+    protected $ptComposerControlCustomLabel;
 
     abstract public function getPageTypeComposerControlCustomTemplates();
     abstract public function render($label, $customTemplate, $description);
@@ -46,11 +47,22 @@ abstract class Control extends Object
         $this->ptComposerControlRequiredOnThisRequest = $req;
     }
 
+    
+    public function setPageTypeComposerControlCustomLabel($label)
+    {
+        $this->ptComposerControlCustomLabel = $label;
+    }
+    
+    public function getPageTypeComposerControlCustomLabel()
+    {
+        return $this->ptComposerControlCustomLabel;
+    }
+
     public function setPageObject($page)
     {
         $this->page = $page;
     }
-
+    
     public function getPageObject()
     {
         return $this->page;
@@ -158,8 +170,9 @@ abstract class Control extends Object
             $ptComposerFormLayoutSetControlRequired = 1;
         }
         $controlType = $this->getPageTypeComposerControlTypeObject();
-        $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?)', array(
-            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $ptComposerFormLayoutSetControlRequired,
+        $customLabel = $this->getPageTypeComposerControlCustomLabel();
+        $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlCustomLabel, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?, ?)', array(
+            $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $customLabel, $ptComposerFormLayoutSetControlRequired,
         ));
 
         return PageTypeComposerFormLayoutSetControl::getByID($db->Insert_ID());


### PR DESCRIPTION
As I was creating documentation for adding Page Type's Composer forms programmatically, I noticed that you can only set the custom label after the fact. While this makes sense with the web ui, it doesn't make sense for people programmatically creating these items with packages.
This adds setting, getting, and adding the custom label to the initial creation of the object.
UPDATE: the 3rd commit also adds support for presetting the description, since there is no reason that shouldn't be allowed as well.