### PR TITLE
Move ADD button for image slider to below the slides

### DIFF
--- a/web/concrete/blocks/image_slider/form_setup_html.php
+++ b/web/concrete/blocks/image_slider/form_setup_html.php
@@ -255,10 +255,10 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
 <div id="ccm-tab-content-slides" class="ccm-tab-content">
     <div class="ccm-image-slider-block-container">
-        <button type="button" class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Slide'); ?></button>
         <div class="ccm-image-slider-entries">
 
         </div>
+        <button type="button" class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Slide'); ?></button>
     </div>
 </div>
 

--- a/web/concrete/blocks/image_slider/form_setup_html.php
+++ b/web/concrete/blocks/image_slider/form_setup_html.php
@@ -258,7 +258,9 @@ echo Core::make('helper/concrete/ui')->tabs(array(
         <div class="ccm-image-slider-entries">
 
         </div>
-        <button type="button" class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Slide'); ?></button>
+        <div>
+            <button type="button" class="btn btn-success ccm-add-image-slider-entry"><?php echo t('Add Slide'); ?></button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Makes for far less scrolling and annoyance when adding multiple slides.
I was just trying to add 15 slides to a slideshow, and kept having to scroll back up to add. It makes more sense for the ADD button to be below the entries. 
(pre-emptive comment: Yes, if there are already entries, they will have to scroll down. But it can be assumed that people editing slideshows will have added images before, and the scroll bar in general makes it pretty obvious. The decrease in annoyance for all users vs a very low chance of confusion for one or two users weighs towards the former for me).