### PR TITLE
Add Max Width to Image Slider

### DIFF
--- a/web/concrete/blocks/image_slider/controller.php
+++ b/web/concrete/blocks/image_slider/controller.php
@@ -166,6 +166,7 @@ class Controller extends BlockController
         $args['speed'] = intval($args['speed']);
         $args['noAnimate'] = isset($args['noAnimate']) ? 1 : 0;
         $args['pause'] = isset($args['pause']) ? 1 : 0;
+        $args['maxWidth'] = isset($args['maxWidth']) ? intval($args['maxWidth']) : 0;
 
         $db = Database::get();
         $db->execute('DELETE from btImageSliderEntries WHERE bID = ?', array($this->bID));

--- a/web/concrete/blocks/image_slider/db.xml
+++ b/web/concrete/blocks/image_slider/db.xml
@@ -24,7 +24,7 @@
     <field name="pause" type="integer">
       <unsigned/>
     </field>
-	<field name=maxWidth" type="integer">
+    <field name=maxWidth" type="integer">
       <unsigned/>
     </field>
   </table>

--- a/web/concrete/blocks/image_slider/db.xml
+++ b/web/concrete/blocks/image_slider/db.xml
@@ -24,6 +24,9 @@
     <field name="pause" type="integer">
       <unsigned/>
     </field>
+	<field name=maxWidth" type="integer">
+      <unsigned/>
+    </field>
   </table>
 
   <table name="btImageSliderEntries">

--- a/web/concrete/blocks/image_slider/form_setup_html.php
+++ b/web/concrete/blocks/image_slider/form_setup_html.php
@@ -294,6 +294,10 @@ echo Core::make('helper/concrete/ui')->tabs(array(
         <?php echo $form->label('pause', t('Pause Slideshow on Hover')); ?>
         <?php echo $form->checkbox('pause', $pause, $pause ? 'checked' : ''); ?>
     </div>
+    <div class="form-group">
+        <?php echo $form->label('maxWidth', t('Maximum Slide Width (0 means no limit)')); ?>
+        <?php echo $form->number('speed', $speed ? $speed : 0, array('min' => '1', 'max' => '4000'))?><span class="input-group-addon"><?php echo t('px'); ?></span>
+    </div>
 </div>
 
 <script type="text/template" id="imageTemplate">

--- a/web/concrete/blocks/image_slider/view.php
+++ b/web/concrete/blocks/image_slider/view.php
@@ -21,6 +21,7 @@ $(document).ready(function(){
             <?php if ($speed) { echo "speed: $speed,"; } ?>
             <?php if ($pause) { echo "pause: true,"; } ?>
             <?php if ($noAnimate) { echo "auto: false,"; } ?>
+            <?php if ($maxWidth) { echo "maxWidth: $maxWidth,"; } ?>
         });
     });
 });


### PR DESCRIPTION
This will allow the image slider to be narrower if needed in wide situations
As I was adding in some 4:3 images to the slider, the lower responsive breakpoints were fine, but the 1170 one was making the images crop in an insanely ugly way. This option will allow more control in those types of situations