### PR TITLE
add height auto to div.ccm-page img

### DIFF
--- a/web/concrete/themes/elemental/css/build/content.less
+++ b/web/concrete/themes/elemental/css/build/content.less
@@ -23,6 +23,7 @@ div.ccm-page {
 
   img {
     max-width: 100%;
+    height: auto;
   }
 
   hr {


### PR DESCRIPTION
Images added using the Content block will not resize correctly if they are wider than their parent container. Adding height auto corrects this.

Example:
The top image was added to the page using the Image block. By default this image will get the img-responsive class. The bottom image was added using the Content block. 

**Current**
![current](https://cloud.githubusercontent.com/assets/10898145/13543713/df5f0c28-e23b-11e5-88fb-c37b33327fb8.jpg)

**Changes**
![add_height_auto](https://cloud.githubusercontent.com/assets/10898145/13543717/e1d01c68-e23b-11e5-931f-e823bf0b6985.jpg)

https://www.concrete5.org/community/forums/usage/squashed-images-mobile-view/