### PR TITLE
Allow extending translator.js functions

### DIFF
--- a/web/concrete/controllers/frontend/assets_localization.php
+++ b/web/concrete/controllers/frontend/assets_localization.php
@@ -512,6 +512,7 @@ var ccmi18n_imageeditor = {
         ?>
 ccmTranslator.setI18NDictionart({
   AskDiscardDirtyTranslation: <?=json_encode(t("The current item has changed.\nIf you proceed you will lose your changes.\n\nDo you want to proceed anyway?"))?>,
+  Approved: <?=json_encode(tc('Translation', 'Approved')); ?>,
   Comments: <?=json_encode(t('Comments'))?>,
   Context: <?=json_encode(t('Context'))?>,
   ExamplePH: <?=json_encode(t('Example: %s'))?>,
@@ -535,6 +536,8 @@ ccmTranslator.setI18NDictionart({
   TAB_SHIFT: <?=json_encode(t('[SHIFT]+[TAB] Backward'))?>,
   Translate: <?=json_encode(t('Translate'))?>,
   Translation: <?=json_encode(t('Translation'))?>,
+  TranslationIsApproved_WillNeedApproval: <?=json_encode(t('This translation is approved: your changes will need approval.')); ?>,
+  TranslationIsNotApproved: <?=json_encode(t('This translation is not approved.')); ?>,
   PluralNames: {
     zero: <?=json_encode(tc('PluralCase', 'Zero'))?>,
     one: <?=json_encode(tc('PluralCase', 'One'))?>,

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -853,7 +853,8 @@ window.ccmTranslator = {
     var translator = new Translator(data);
     Startup.setTranslatorReady(translator);
     return translator;
-  }
+  },
+  views: TranslationView
 };
   
 $(document).ready(function() {

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -34,7 +34,7 @@ var i18n = {
   TAB_SHIFT: '[SHIFT]+[TAB] Backward',
   Translate: 'Translate',
   Translation: 'Translation',
-  TranslationIsApproved_ReadOnly: 'This translation is approved: you can NOT change it.',
+  TranslationIsApproved_WillNeedApproval: 'This translation is approved: your changes will need approval.',
   TranslationIsNotApproved: 'This translation is not approved.',
   PluralNames: {
     zero: 'Zero',
@@ -149,10 +149,6 @@ var TranslationView = (function() {
     this.translation = translation;
     this.multiline = multiline;
     this.element = this.multiline ? 'textarea rows="8"' : 'input type="text"';
-    this.readOnly = false;
-    if (this.translation.translator.approvalSupport && this.translation.isApproved && (!this.translation.translator.canModifyApproved)) {
-      this.readOnly = true;
-    }
     this.UI.$container = this.translation.translator.UI.$translation;
     this.UI.$container.empty();
     this.UI.$container.closest('.panel').css('visibility', 'visible');
@@ -167,7 +163,7 @@ var TranslationView = (function() {
             )
         ;
       } else {
-        this.UI.$container.append($('<p />').text(this.translation.isApproved ? i18n.TranslationIsApproved_ReadOnly : i18n.TranslationIsNotApproved));
+        this.UI.$container.append($('<p />').text(this.translation.isApproved ? i18n.TranslationIsApproved_WillNeedApproval : i18n.TranslationIsNotApproved));
       }
     }
     if (('comments' in this.translation) || ('context' in this.translation) || ('references' in this.translation)) {
@@ -295,7 +291,7 @@ var TranslationView = (function() {
       this.UI.$container
         .append($('<div class="form-group" />')
           .append($('<label class="control-label" />').text(i18n.Translation))
-          .append(this.UI.$translated = $('<' + this.element + (this.readOnly ? ' readonly="readonly"' : '') + ' class="form-control" />').val(this.translation.isTranslated ? this.translation.translations[0] : ''))
+          .append(this.UI.$translated = $('<' + this.element + ' class="form-control" />').val(this.translation.isTranslated ? this.translation.translations[0] : ''))
         )
       ;
       this.UI.$translated.focus();
@@ -359,7 +355,7 @@ var TranslationView = (function() {
         );
         my.UI.$tabBodies.append($('<div class="tab-pane' + ((index === 0) ? ' active' : '') + '"  data-key="' + key + '" />')
           .append($('<p />').text(i18n.ExamplePH.replace(/%s/, examples)))
-          .append(my.UI.$translated[key] = $('<' + my.element + (my.readOnly ? ' readonly="readonly"' : '') + ' class="form-control" />').val(my.translation.isTranslated ? my.translation.translations[index] : ''))
+          .append(my.UI.$translated[key] = $('<' + my.element + ' class="form-control" />').val(my.translation.isTranslated ? my.translation.translations[index] : ''))
         );
         index++;
       });

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -296,6 +296,9 @@ var TranslationView = (function() {
       ;
       this.UI.$translated.focus();
     },
+    getCurrentTextInput: function() {
+      return this.UI.$translated;
+    },
     /**
      * @return null if no string is translated
      * @return false if forSave === true and some string is not translated
@@ -364,6 +367,9 @@ var TranslationView = (function() {
         my.showTranslationTab($(this).closest('li').attr('data-key'));
       });
       this.UI.$translated[firstKey].focus();
+    },
+    getCurrentTextInput: function() {
+      return this.UI.$tabBodies.find('.tab-pane.active').find('textarea,input');
     },
     /**
      * @return null if no string is translated

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -157,7 +157,7 @@ var TranslationView = (function() {
     if (this.translation.translator.approvalSupport) {
       if (this.translation.translator.canModifyApproved) {
         this.UI.$container
-            .append($('<label class="control-label checkbox inline" />')
+            .append($('<label class="control-label inline" />')
               .text(i18n.Approved)
               .prepend(this.UI.$approved = $('<input type="checkbox" ' + (this.translation.isApproved ? ' checked="checked"' : '') + ' />'))
             )

--- a/web/concrete/js/build/core/translator.js
+++ b/web/concrete/js/build/core/translator.js
@@ -848,7 +848,9 @@ window.ccmTranslator = {
     }
   },
   initialize: function(data) {
-    Startup.setTranslatorReady(new Translator(data));
+    var translator = new Translator(data);
+    Startup.setTranslatorReady(translator);
+    return translator;
   }
 };
   


### PR DESCRIPTION
The [Community Translation](https://github.com/concrete5/addon_community_translation) add-on requires to intercept some functions/events of the Translator javascript object.

I'll add to this pull request the required changes, so that people that want to try the add-on can have a functional concrete5 installation.

Please wait before accepting/refusing this pull request until I'm sure that every required edit is done.