### PR TITLE
remove extra div from forgot password

### DIFF
--- a/web/concrete/authentication/concrete/forgot_password.php
+++ b/web/concrete/authentication/concrete/forgot_password.php
@@ -4,9 +4,8 @@
 	<form method="post" action="<?= URL::to('/login', 'callback', $authType->getAuthenticationTypeHandle(), 'forgot_password') ?>">
 		<h4><?= t('Forgot Your Password?') ?></h4>
 		<div class="ccm-message"><?= isset($intro_msg) ? $intro_msg : '' ?></div>
-			<div class='help-block'>
-				<?= t('Enter your email address below. We will send you instructions to reset your password.') ?>
-			</div>
+		<div class='help-block'>
+			<?= t('Enter your email address below. We will send you instructions to reset your password.') ?>
 		</div>
 		<div class="form-group">
 			<input name="uEmail" type="email" placeholder="<?= t('Email Address') ?>" class="form-control" />


### PR DESCRIPTION
there was an extra closing div in the forgot password action of the default concrete5 authentication. This pr removes it.

This may have an impact on people who have styled their pages based off the previous HTML