### PR TITLE
Keep binary/executable files in releases

### DIFF
--- a/build/tasks/build-release/clean.js
+++ b/build/tasks/build-release/clean.js
@@ -49,7 +49,6 @@ module.exports = function(grunt, config, parameters, done) {
 				/^\/concrete\/vendor\/.*\/UPGRADE_TO_\w+$/,
 				/^\/concrete\/vendor\/.*\/UPGRADE$/i,
 				/^\/concrete\/vendor\/htmlawed\/htmlawed\/htmLawed_[README|TESTCASE]/,
-				/^\/concrete\/vendor\/.*\.(sh|bash|bat|exe|cmd|dll)$/i,
 			]
 		},
 		dir: {


### PR DESCRIPTION
Now that we have a CLI interface, some package could require them (for instance https://github.com/concrete5/addon_community_translation/issues/7)