### PR TITLE
Suggestion to support line break to Page Attribute Display

### DIFF
--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -81,13 +81,6 @@ class Controller extends BlockController
                 } else {
                     if (!is_scalar($content) && (!is_object($content) || !method_exists($content, '__toString'))) {
                         $content = $c->getAttribute($this->attributeHandle, 'displaySanitized');
-                        $attributeKey = CollectionAttributeKey::getByHandle($this->attributeHandle);
-                        if (is_object($attributeKey)) {
-                            $attributeType = $attributeKey->getAttributeType();
-                            if ($attributeType->atHandle == 'textarea') {
-                                $content = nl2br($content);
-                            }
-                        }
                     }
                 }
                 break;

--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -52,7 +52,7 @@ class Controller extends BlockController
                 $content = h($c->getCollectionName());
                 break;
             case "rpv_pageDescription":
-                $content = h($c->getCollectionDescription());
+                $content = nl2br(h($c->getCollectionDescription()));
                 break;
             case "rpv_pageDateCreated":
                 $content = $c->getCollectionDateAdded();
@@ -81,6 +81,13 @@ class Controller extends BlockController
                 } else {
                     if (!is_scalar($content) && (!is_object($content) || !method_exists($content, '__toString'))) {
                         $content = $c->getAttribute($this->attributeHandle, 'displaySanitized');
+                        $attributeKey = CollectionAttributeKey::getByHandle($this->attributeHandle);
+                        if (is_object($attributeKey)) {
+                            $attributeType = $attributeKey->getAttributeType();
+                            if ($attributeType->atHandle == 'textarea') {
+                                $content = nl2br($content);
+                            }
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
I just wanted to throw a small idea.

This is very minor suggestion to add nl2br to Page Displayer Block when displaying the collection description.

I kinda wanted to support nl2br to text area attribute. But if it's Rich Text, it should not add the line break to it. So I hold on to it.

At first, I would like to open a discussion if anyone is interested in embracing my idea.

Thanks.