### PR TITLE
Avoid to use url helper on pagination view renderer

### DIFF
--- a/web/concrete/src/Search/Pagination/View/ViewRenderer.php
+++ b/web/concrete/src/Search/Pagination/View/ViewRenderer.php
@@ -1,14 +1,13 @@
 <?php
-
 namespace Concrete\Core\Search\Pagination\View;
+
 use Concrete\Core\Search\Pagination\Pagination;
 use Concrete\Core\Search\Pagination\View\ViewInterface;
-use \Core;
 use Request;
 use URL;
+
 class ViewRenderer
 {
-
     protected $view;
     protected $pagination;
     protected $routeCollectionFunction;
@@ -24,6 +23,7 @@ class ViewRenderer
             $query = $url->getQuery();
             $query->modify(array($list->getQueryPaginationPageParameter() => $page));
             $url = $url->setQuery($query);
+
             return (string) $url;
         };
     }

--- a/web/concrete/src/Search/Pagination/View/ViewRenderer.php
+++ b/web/concrete/src/Search/Pagination/View/ViewRenderer.php
@@ -4,6 +4,8 @@ namespace Concrete\Core\Search\Pagination\View;
 use Concrete\Core\Search\Pagination\Pagination;
 use Concrete\Core\Search\Pagination\View\ViewInterface;
 use \Core;
+use Request;
+use URL;
 class ViewRenderer
 {
 
@@ -17,9 +19,12 @@ class ViewRenderer
         $this->pagination = $pagination;
         $list = $pagination->getItemListObject();
         $this->routeCollectionFunction = function ($page) use ($list) {
-            $qs = Core::make('helper/url');
-            $url = $qs->setVariable($list->getQueryPaginationPageParameter(), $page);
-            return $url;
+            $request = Request::getInstance();
+            $url = URL::to($request->getRequestUri());
+            $query = $url->getQuery();
+            $query->modify(array($list->getQueryPaginationPageParameter() => $page));
+            $url = $url->setQuery($query);
+            return (string) $url;
         };
     }
 


### PR DESCRIPTION
Legacy URL helper uses raw `$_SERVER` global variables. It is not best for url manipulation.
Let's replace it with league URL component.