### PR TITLE
set package id in upgradeable packages

### DIFF
--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -407,6 +407,7 @@ class Package extends Object
             );
             if ($row) {
                 if (version_compare($p->getPackageVersion(), $row['pkgVersion'], '>')) {
+                    $p->setPackageID($row['pkgID']);
                     $p->pkgCurrentVersion = $row['pkgVersion'];
                     $upgradeables[] = $p;
                 }


### PR DESCRIPTION
Without the id we'll run into an issue when running `c5:package-update --all`. This method calls this line at some point https://github.com/concrete5/concrete5/blob/develop/web/concrete/src/Package/Package.php#L805
If that happens we'll need the package id to get the list of block types in that package..