### PR TITLE
Change to onkeypress - fixes bug with webkit browsers

### DIFF
--- a/web/concrete/attributes/select/type_form.php
+++ b/web/concrete/attributes/select/type_form.php
@@ -28,7 +28,7 @@ function getAttributeOptionHTML($v){
 				<? } else { ?>
 					<input id="akSelectValueNewOption_<?=$akSelectValueID?>" name="akSelectValueNewOption_<?=$akSelectValueID?>" type="hidden" value="<?=$akSelectValueID?>" />
 				<? } ?>
-				<input id="akSelectValueField_<?php echo $akSelectValueID?>" onkeypress="ccmAttributesHelper.keydownHandler(event);" class="akSelectValueField form-control" data-select-value-id="<?php echo $akSelectValueID; ?>" name="akSelectValue_<?php echo $akSelectValueID?>" type="text" value="<?php echo $akSelectValue?>" size="40" />
+				<input id="akSelectValueField_<?php echo $akSelectValueID?>" onkeydown="ccmAttributesHelper.keydownHandler(event);" class="akSelectValueField form-control" data-select-value-id="<?php echo $akSelectValueID; ?>" name="akSelectValue_<?php echo $akSelectValueID?>" type="text" value="<?php echo $akSelectValue?>" size="40" />
 			</span>		
 			<div class="rightCol">
 				<input class="btn btn-default" type="button" onClick="ccmAttributesHelper.editValue('<?=addslashes($akSelectValueID)?>')" value="<?=t('Cancel')?>" />


### PR DESCRIPTION
This fixes a bug in webkit browsers when editing the options of a select attribute.
There currently is a handler in place to respond to an enter keypress to save, as well as up and down keypresses to quickly navigate between editing the options.  

The problem is that if you type Shift+9  (for a left parenthesis), in webkit browsers onkeypress returns the wrong keycode, it returns the keycode for a down keypress for some reason. So you can't type in a ( character, it jumps to the next field. Pressing up and down on the keywork also doesn't work.

By changing it to onkeydown, the correct keycodes are returned again and it works as designed.