### PR TITLE
Add default.php to dashboard theme

### DIFF
--- a/web/concrete/themes/dashboard/default.php
+++ b/web/concrete/themes/dashboard/default.php
@@ -1,0 +1,2 @@
+<?php
+$this->inc('view.php');


### PR DESCRIPTION
I was doing some testing, and realized that it was impossible to add regular pages (as opposed to single pages) under the dashboard node in the site map. Almost every project I've done in 5.6 in the last three years has used page types in the dashboard instead of single pages. But it would be just a blank white page in 5.7 because the system couldn't find /web/concrete/themes/dashboard/default.php

Hopefully this can be merged in, so I can port my page management tools from 5.6 to 5.7. It doesn't really change anything major... 