### PR TITLE
Disable scrolling also on mobile

### DIFF
--- a/web/concrete/blocks/google_map/view.php
+++ b/web/concrete/blocks/google_map/view.php
@@ -29,6 +29,7 @@ if ($c->isEditMode()) { ?>
                 mapTypeId: google.maps.MapTypeId.ROADMAP,
                 streetViewControl: false,
                 scrollwheel: <?=!!$scrollwheel ? "true" : "false"?>,
+                draggable: <?=!!$scrollwheel ? "true" : "false"?>,
                 mapTypeControl: false
             };
             var map = new google.maps.Map(document.getElementById('googleMapCanvas<?=$unique_identifier?>'), mapOptions);


### PR DESCRIPTION
I believe "Enable Scroll Wheel" option is useful when we'd like to use the full width Google Map, because it hijacks user's scrolling. However, with a mobile browser, this problem is still remaining. We should also stop dragging.