### PR TITLE
line break added between the content of a search result and the link …

### DIFF
--- a/web/concrete/blocks/search/view.php
+++ b/web/concrete/blocks/search/view.php
@@ -41,7 +41,7 @@ if (!isset($query) || !is_string($query)) {
 
                             }
                             echo $currentPageBody;
-                            ?> <a href="<?=$r->getCollectionLink()?>" class="pageLink"><?=$this->controller->highlightedMarkup($r->getCollectionLink(), $query)?></a>
+                            ?> <br/><a href="<?=$r->getCollectionLink()?>" class="pageLink"><?=$this->controller->highlightedMarkup($r->getCollectionLink(), $query)?></a>
                         </p>
                     </div><?php
                 }


### PR DESCRIPTION
On line 44, there was no line break between the content of a search result and the link to the page, so I've added it.