### PR TITLE
Login page not redirect to destination page if user logged in the sys…

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -320,6 +320,12 @@ class Login extends PageController
 
     public function view($type = null, $element = 'form')
     {
+        //Check if user login or not, If user login redirect to destination page
+        $u = new User();
+        if($u->isLoggedIn()){
+            $this->chooseRedirect();
+        }
+        
         $this->requireAsset('javascript', 'backstretch');
         $this->set('authTypeParams', $this->getSets());
         if (strlen($type)) {


### PR DESCRIPTION
I have just login as admin to my concrete5 store, And able to see "index.php/dashboard" . Now without logout , when i go to login page "index.php/login" it still allow me to login which should not allow.