### PR TITLE
Add ZIP helper

### DIFF
--- a/tests/tests/Core/File/Service/ZipTest.php
+++ b/tests/tests/Core/File/Service/ZipTest.php
@@ -42,14 +42,30 @@ class ZipTest extends \PHPUnit_Framework_TestCase
                 throw new Exception('Failed to create a temporary file');
             }
             $this->delFiles[] = $this->sourceDir.'/root.txt';
+            if (@file_put_contents($this->sourceDir.'/.root.txt', 'Root hidden') === false) {
+                throw new Exception('Failed to create a temporary file');
+            }
+            $this->delFiles[] = $this->sourceDir.'/root.txt';
             if (@mkdir($this->sourceDir.'/inner') === false) {
                 throw new Exception('Failed to create a temporary directory');
             }
             $this->delDirs[] = $this->sourceDir.'/inner';
+            if (@mkdir($this->sourceDir.'/inner/empty') === false) {
+                throw new Exception('Failed to create a temporary directory');
+            }
+            $this->delDirs[] = $this->sourceDir.'/inner/empty';
             if (@file_put_contents($this->sourceDir.'/inner/file with space.txt', 'Inner file with space') === false) {
                 throw new Exception('Failed to create a temporary file');
             }
             $this->delFiles[] = $this->sourceDir.'/inner/file with space.txt';
+            if (@mkdir($this->sourceDir.'/.innerHidden') === false) {
+                throw new Exception('Failed to create a temporary directory');
+            }
+            $this->delDirs[] = $this->sourceDir.'/.innerHidden';
+            if (@file_put_contents($this->sourceDir.'/.innerHidden/underHidden.txt', 'File under hidden directory') === false) {
+                throw new Exception('Failed to create a temporary file');
+            }
+            $this->delFiles[] = $this->sourceDir.'/.innerHidden/underHidden.txt';
             $this->destDir = @tempnam($tempDir, 'c5');
             @unlink($this->destDir);
             if (@mkdir($this->destDir) === false) {
@@ -85,15 +101,17 @@ class ZipTest extends \PHPUnit_Framework_TestCase
     public function useNativeProvider()
     {
         return array(
-            array(false),
-            array(true),
+            array(false, false),
+            array(true, false),
+            array(false, true),
+            array(true, true),
         );
     }
 
     /**
      * @dataProvider useNativeProvider
      */
-    public function testZip($useNativeCommands)
+    public function testZip($useNativeCommands, $includeDotFiles)
     {
         if ($this->fileSystemProblem !== null) {
             $this->markTestIncomplete('Error setting up files and directories');
@@ -111,9 +129,22 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         } else {
             $zh->disableNativeCommands();
         }
-        $zh->zip($this->sourceDir, $this->zipFile);
+        $zh->zip($this->sourceDir, $this->zipFile, compact('includeDotFiles'));
         $zh->unzip($this->zipFile, $this->destDir);
         $this->assertFileExists($this->destDir.'/root.txt');
+        $this->assertSame('Root', file_get_contents($this->destDir.'/root.txt'));
         $this->assertFileExists($this->destDir.'/inner/file with space.txt');
+        $this->assertSame('Inner file with space', file_get_contents($this->destDir.'/inner/file with space.txt'));
+        $this->assertTrue(is_dir($this->destDir.'/inner/empty'), 'Checking empty dir re-created');
+        if ($includeDotFiles) {
+            $this->assertFileExists($this->destDir.'/.root.txt');
+            $this->assertSame('Root hidden', file_get_contents($this->destDir.'/.root.txt'));
+            $this->assertFileExists($this->destDir.'/.innerHidden/underHidden.txt');
+            $this->assertSame('File under hidden directory', file_get_contents($this->destDir.'/.innerHidden/underHidden.txt'));
+        } else {
+            $this->assertFileNotExists($this->destDir.'/.root.txt');
+            $this->assertFileNotExists($this->destDir.'/.innerHidden');
+            $this->assertFileNotExists($this->destDir.'/.innerHidden/underHidden.txt');
+        }
     }
 }

--- a/tests/tests/Core/File/Service/ZipTest.php
+++ b/tests/tests/Core/File/Service/ZipTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Concrete\Tests\Core\File\Service;
+
+use Core;
+use Exception;
+use Concrete\Core\File\Service\Zip;
+
+class ZipTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Concrete\Core\File\Service\Zip
+     */
+    protected $zipHelper;
+
+    protected $sourceDir;
+    protected $destDir;
+    protected $zipFile;
+
+    protected $fileSystemProblem;
+    protected $delDirs;
+    protected $delFiles;
+
+    protected function setUp()
+    {
+        $this->zipHelper = Core::make('helper/zip');
+        $this->delDirs = array();
+        $this->delFiles = array();
+        try {
+            $tempDir = @sys_get_temp_dir();
+            if (!is_dir($tempDir) || !is_writable($tempDir)) {
+                throw new Exception('Temporary directory not found or not writable');
+            }
+            // Create source directory and data.
+            $this->sourceDir = @tempnam($tempDir, 'c:5');
+            @unlink($this->sourceDir);
+            if (@mkdir($this->sourceDir) === false) {
+                throw new Exception('Failed to create a temporary directory');
+            }
+            $this->delDirs[] = $this->sourceDir;
+            if (@file_put_contents($this->sourceDir.'/root.txt', 'Root') === false) {
+                throw new Exception('Failed to create a temporary file');
+            }
+            $this->delFiles[] = $this->sourceDir.'/root.txt';
+            if (@mkdir($this->sourceDir.'/inner') === false) {
+                throw new Exception('Failed to create a temporary directory');
+            }
+            $this->delDirs[] = $this->sourceDir.'/inner';
+            if (@file_put_contents($this->sourceDir.'/inner/file with space.txt', 'Inner file with space') === false) {
+                throw new Exception('Failed to create a temporary file');
+            }
+            $this->delFiles[] = $this->sourceDir.'/inner/file with space.txt';
+            $this->destDir = @tempnam($tempDir, 'c5');
+            @unlink($this->destDir);
+            if (@mkdir($this->destDir) === false) {
+                throw new Exception('Failed to create a temporary directory');
+            }
+            $this->delDirs[] = $this->destDir;
+            $this->zipFile = @tempnam($tempDir, 'c5');
+            if ($this->zipFile === false) {
+                throw new Exception('Failed to create a temporary file');
+            }
+            $this->delFiles[] = $this->zipFile;
+            $this->delFiles[] = $this->destDir.'/root.txt';
+            $this->delDirs[] = $this->destDir.'/inner';
+            $this->delFiles[] = $this->destDir.'/inner/file with space.txt';
+            $this->fileSystemProblem = null;
+        } catch (Exception $x) {
+            $this->fileSystemProblem = $x->getMessage();
+        }
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->delFiles as $delFile) {
+            @unlink($delFile);
+        }
+        $this->delFiles = array();
+        foreach (array_reverse($this->delDirs) as $delDir) {
+            @rmdir($delDir);
+        }
+        $this->delDirs = array();
+    }
+
+    public function useNativeProvider()
+    {
+        return array(
+            array(false),
+            array(true),
+        );
+    }
+
+    /**
+     * @dataProvider useNativeProvider
+     */
+    public function testZip($useNativeCommands)
+    {
+        if ($this->fileSystemProblem !== null) {
+            $this->markTestIncomplete('Error setting up files and directories');
+
+            return;
+        }
+        $zh = $this->zipHelper;
+        if ($useNativeCommands) {
+            if (!$zh->isNativeCommandAvailable('zip') || !$zh->isNativeCommandAvailable('unzip')) {
+                $this->markTestIncomplete('Native zip/unzip commands are not available');
+
+                return;
+            }
+            $zh->enableNativeCommands();
+        } else {
+            $zh->disableNativeCommands();
+        }
+        $zh->zip($this->sourceDir, $this->zipFile);
+        $zh->unzip($this->zipFile, $this->destDir);
+        $this->assertFileExists($this->destDir.'/root.txt');
+        $this->assertFileExists($this->destDir.'/inner/file with space.txt');
+    }
+}

--- a/web/concrete/src/File/FileServiceProvider.php
+++ b/web/concrete/src/File/FileServiceProvider.php
@@ -1,26 +1,26 @@
-<?php 
+<?php
 namespace Concrete\Core\File;
-use \Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
-class FileServiceProvider extends ServiceProvider {
+use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
-	public function register() {
-		$singletons = array(
-			'helper/file' => '\Concrete\Core\File\Service\File',
-			'helper/concrete/file' => '\Concrete\Core\File\Service\Application',
-			'helper/image' => '\Concrete\Core\File\Image\BasicThumbnailer',
-			'helper/mime' => '\Concrete\Core\File\Service\Mime',
-		    'helper/zip' => '\Concrete\Core\File\Service\Zip',
-		);
+class FileServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $singletons = array(
+            'helper/file' => '\Concrete\Core\File\Service\File',
+            'helper/concrete/file' => '\Concrete\Core\File\Service\Application',
+            'helper/image' => '\Concrete\Core\File\Image\BasicThumbnailer',
+            'helper/mime' => '\Concrete\Core\File\Service\Mime',
+            'helper/zip' => '\Concrete\Core\File\Service\Zip',
+        );
 
-		foreach($singletons as $key => $value) {
-			$this->app->singleton($key, $value);
-		}
+        foreach ($singletons as $key => $value) {
+            $this->app->singleton($key, $value);
+        }
 
         $this->app->bind('image/imagick', '\Imagine\Imagick\Imagine');
         $this->app->bind('image/gd', '\Imagine\Gd\Imagine');
-		$this->app->bind('image/thumbnailer', '\Concrete\Core\File\Image\BasicThumbnailer');
-	}
-
-
+        $this->app->bind('image/thumbnailer', '\Concrete\Core\File\Image\BasicThumbnailer');
+    }
 }

--- a/web/concrete/src/File/FileServiceProvider.php
+++ b/web/concrete/src/File/FileServiceProvider.php
@@ -9,7 +9,8 @@ class FileServiceProvider extends ServiceProvider {
 			'helper/file' => '\Concrete\Core\File\Service\File',
 			'helper/concrete/file' => '\Concrete\Core\File\Service\Application',
 			'helper/image' => '\Concrete\Core\File\Image\BasicThumbnailer',
-			'helper/mime' => '\Concrete\Core\File\Service\Mime'
+			'helper/mime' => '\Concrete\Core\File\Service\Mime',
+		    'helper/zip' => '\Concrete\Core\File\Service\Zip',
 		);
 
 		foreach($singletons as $key => $value) {

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -1,8 +1,6 @@
 <?php
-
 namespace Concrete\Core\File\Service;
 
-use Concrete\Core\Application\Application;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Illuminate\Filesystem\Filesystem;
 use Exception;
@@ -14,7 +12,7 @@ use ZipArchive;
 class Zip implements ApplicationAwareInterface
 {
     /**
-     * @var Application
+     * @var \Concrete\Core\Application\Application
      */
     protected $app;
 
@@ -23,7 +21,7 @@ class Zip implements ApplicationAwareInterface
      *
      * @see ApplicationAwareInterface::setApplication()
      */
-    public function setApplication(Application $app)
+    public function setApplication(\Concrete\Core\Application\Application $app)
     {
         $this->app = $app;
     }

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -140,7 +140,7 @@ class Zip implements ApplicationAwareInterface
     }
 
     /**
-     * Check if a native command is available.
+     * Check if a native command is available and if we may use it.
      *
      * @param string $command
      *
@@ -403,7 +403,7 @@ class Zip implements ApplicationAwareInterface
      *
      * @throws Exception
      */
-    public function zipNative($sourceDirectory, $zipFile, array $options)
+    protected function zipNative($sourceDirectory, $zipFile, array $options)
     {
         $cmd = 'zip';
         $cmd .= ' -r'; // recurse into directories
@@ -440,7 +440,7 @@ class Zip implements ApplicationAwareInterface
      *
      * @throws Exception
      */
-    public function zipPHP($sourceDirectory, $zipFile, array $options)
+    protected function zipPHP($sourceDirectory, $zipFile, array $options)
     {
         if (!class_exists('ZipArchive')) {
             throw new Exception('Unable to zip files using ZipArchive. Please ensure the Zip extension is installed.');

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\File\Service;
 
-use Concrete\Core\Application\ApplicationAwareInterface;
 use Illuminate\Filesystem\Filesystem;
 use Exception;
 use ZipArchive;
@@ -10,23 +9,8 @@ use ZipArchive;
 /**
  * Wrapper for ZIP functions.
  */
-class Zip implements ApplicationAwareInterface
+class Zip
 {
-    /**
-     * @var \Concrete\Core\Application\Application
-     */
-    protected $app;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @see ApplicationAwareInterface::setApplication()
-     */
-    public function setApplication(\Concrete\Core\Application\Application $app)
-    {
-        $this->app = $app;
-    }
-
     /**
      * The Filesystem instance to use.
      *

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -410,9 +410,10 @@ class Zip
         $cmd .= ' -q'; // quiet mode, to avoid overflow of stdout
         $cmd .= ' '.escapeshellarg($zipFile); // destination ZIP archive
         if ($options['includeDotFiles']) {
-            $cmd .= ' .*'; // source files
+            $cmd .= ' .'; // source files: everything in current directory
+        } else {
+            $cmd .= ' *'; // source files: everything, excluding dot-files
         }
-        $cmd .= ' *'; // source files
         $rc = 1;
         $output = array();
         $prevDir = @getcwd();

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace Concrete\Core\File\Service;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Illuminate\Filesystem\Filesystem;
+use Exception;
+use ZipArchive;
+
+/**
+ * Wrapper for ZIP functions.
+ */
+class Zip implements ApplicationAwareInterface
+{
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ApplicationAwareInterface::setApplication()
+     */
+    public function setApplication(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * The Filesystem instance to use.
+     *
+     * @var Filesystem
+     */
+    protected $filesystem = null;
+
+    /**
+     * Set the Filesystem instance to use.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function setFilesystem(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Get the Filesystem instance to use.
+     *
+     * @return Filesystem
+     */
+    public function getFilesystem()
+    {
+        if ($this->filesystem === null) {
+            $this->filesystem = new Filesystem();
+        }
+
+        return $this->filesystem;
+    }
+
+    /**
+     * Can we try to use native commands?
+     *
+     * @var bool
+     */
+    protected $enableNativeCommands = true;
+
+    /**
+     * State that we can try to use native commands.
+     */
+    public function enableNativeCommands()
+    {
+        $this->enableNativeCommands = true;
+    }
+
+    /**
+     * State that we can NOT try to use native commands.
+     */
+    public function disableNativeCommands()
+    {
+        $this->enableNativeCommands = false;
+    }
+
+    /**
+     * Can we try to use native commands?
+     *
+     * @return bool
+     */
+    public function nativeCommandsEnabled()
+    {
+        return $this->enableNativeCommands;
+    }
+
+    /**
+     * Cache for the available native commands.
+     *
+     * @var array
+     */
+    protected $availableNativeCommands = array();
+
+    /**
+     * Check if a native command is available.
+     *
+     * @param string $command
+     *
+     * @return bool
+     */
+    public function isNativeCommandAvailable($command)
+    {
+        switch ($command) {
+            case 'zip':
+            case 'unzip':
+                break;
+            default:
+                return false;
+        }
+        if (!isset($this->availableNativeCommands[$command])) {
+            $this->availableNativeCommands[$command] = false;
+            $safeMode = @ini_get('safe_mode');
+            if (empty($safeMode)) {
+                if (function_exists('exec')) {
+                    $disabledCommands = array_map('trim', explode(',', strtolower((string) @ini_get('disable_functions'))));
+                    if (!in_array('exec', $disabledCommands, true)) {
+                        $rc = 1;
+                        $output = array();
+                        @exec($command.' -v 2>&1', $output, $rc);
+                        if ($rc === 0) {
+                            $stdOut = implode("\n", $output);
+                            if (stripos($stdOut, 'info-zip') !== false || stripos($stdOut, 'infozip') !== false) {
+                                $this->availableNativeCommands[$command] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $this->availableNativeCommands[$command];
+    }
+
+    /**
+     * Check if a native command is available.
+     *
+     * @param string $command
+     *
+     * @return bool
+     */
+    protected function mayUseNativeCommand($command)
+    {
+        return $this->enableNativeCommands ? $this->isNativeCommandAvailable($command) : false;
+    }
+
+    /**
+     * Decompress a ZIP archive to a directory.
+     *
+     * @param string $zipFile The source ZIP archive.
+     * @param string $destinationDirectory The destination folder.
+     * @param array $options {
+     *
+     *   @var bool $skipCheck Skip test compressed archive data
+     * }
+     *
+     * @throws Exception
+     */
+    public function unzip($zipFile, $destinationDirectory, array $options = array())
+    {
+        $fs = $this->getFilesystem();
+        $normalized = @realpath($zipFile);
+        if ($normalized === false || !$fs->isFile($normalized)) {
+            throw new Exception(t('Unable to find the ZIP file %s', $zipFile));
+        }
+        $zipFile = $normalized;
+        $normalized = @realpath($destinationDirectory);
+        if ($normalized === false || !$fs->isDirectory($normalized)) {
+            throw new Exception(t('Unable to find the directory %s', $destinationDirectory));
+        }
+        if (!$fs->isWritable($normalized)) {
+            throw new Exception(t('The directory "%s" is not writable', $destinationDirectory));
+        }
+        $destinationDirectory = $normalized;
+        $options += array(
+            'skipCheck' => false,
+        );
+        if ($this->mayUseNativeCommand('unzip')) {
+            $this->unzipNative($zipFile, $destinationDirectory, $options);
+        } else {
+            $this->unzipPHP($zipFile, $destinationDirectory, $options);
+        }
+    }
+
+    /**
+     * Compress the contents of a directory to a ZIP archive.
+     *
+     * @param string $sourceDirectory The directory to compress.
+     * @param string $zipFile The ZIP file to create (it will be deleted if already exists).
+     * @param array $options {
+     *
+     *   @var bool $skipCheck Skip test compressed archive data
+     *   @var int $level Compression level (0 to 9)
+     * }
+     *
+     * @throws Exception
+     */
+    public function zip($sourceDirectory, $zipFile, array $options = array())
+    {
+        $fs = $this->getFilesystem();
+        $normalized = @realpath($sourceDirectory);
+        if ($normalized === false || !$fs->isDirectory($normalized)) {
+            throw new Exception(t('Unable to find the directory %s', $destinationDirectory));
+        }
+        $sourceDirectory = $normalized;
+        $zipFile = str_replace('/', DIRECTORY_SEPARATOR, $zipFile);
+        if ($fs->exists($zipFile)) {
+            if (@$fs->delete(array($zipFile)) === false) {
+                throw new Exception(t('Failed to delete file %s', $zipFile));
+            }
+        }
+        $options += array(
+            'skipCheck' => false,
+            'level' => 9,
+        );
+        if ($this->mayUseNativeCommand('zip')) {
+            $this->zipNative($sourceDirectory, $zipFile, $options);
+        } else {
+            $this->zipPHP($sourceDirectory, $zipFile, $options);
+        }
+    }
+
+    /**
+     * Describe a ZipArchive related problem.
+     *
+     * @param ZipArchive $zip
+     * @param int $errorCode
+     */
+    protected function describeZipArchiveError(ZipArchive $zip, $errorCode)
+    {
+        $result = '';
+        switch ($errorCode) {
+            case ZipArchive::ER_OK:
+                break;
+            case ZipArchive::ER_MULTIDISK:
+                $result = t('Multi-disk ZIP archives are not supported.');
+                break;
+            case ZipArchive::ER_RENAME:
+                $result = t('Renaming a temporary file failed working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_CLOSE:
+                $result = t('Closing ZIP archive failed.');
+                break;
+            case ZipArchive::ER_SEEK:
+                $result = t('Seek error working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_READ:
+                $result = t('Error reading a file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_WRITE:
+                $result = t('Error writing a file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_CRC:
+                $result = t('CRC error working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_ZIPCLOSED:
+                $result = t('ZIP archive was closed.');
+                break;
+            case ZipArchive::ER_NOENT:
+                $result = t('File not found working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_EXISTS:
+                $result = t('File already exists working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_OPEN:
+                $result = t('Failed to open a file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_TMPOPEN:
+                $result = t('Failed to open a temporary file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_ZLIB:
+                $result = t('ZLIB error working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_MEMORY:
+                $result = t('Out of memory problems working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_CHANGED:
+                $result = t('Entry has been changed working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_COMPNOTSUPP:
+                $result = t('Compression method not supported working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_EOF:
+                $result = t('Premature end of file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_INVAL:
+                $result = t('Invalid argument working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_NOZIP:
+                $result = t('Not a ZIP archive.');
+                break;
+            case ZipArchive::ER_INTERNAL:
+                $result = t('Internal error working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_INCONS:
+                $result = t('ZIP archive is inconsistent.');
+                break;
+            case ZipArchive::ER_REMOVE:
+                $result = t('Can\'t remove file working with a ZIP archive.');
+                break;
+            case ZipArchive::ER_DELETED:
+                $result = t('Entry has been deleted working with a ZIP archive.');
+                break;
+            default:
+                $result = t('Unknown ZIP-related problem (code: %s).', $errorCode);
+                break;
+        }
+        $status = @$zip->getStatusString();
+        if (is_string($status) && $status !== '') {
+            if ($result === '') {
+                $result = $status;
+            } else {
+                $result .= "\n".$status;
+            }
+        }
+
+        if ($result === '') {
+            $result = t('Unknown ZIP-related problem');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Decompress a ZIP archive to a directory using the native 'unzip' command.
+     *
+     * @param string $zipFile
+     * @param string $destinationDirectory
+     * @param array $options
+     *
+     * @throws Exception
+     */
+    protected function unzipNative($zipFile, $destinationDirectory, array $options)
+    {
+        $cmd = 'unzip';
+        $cmd .= ' -o'; // overwrite files WITHOUT prompting
+        $cmd .= ' -q'; // quiet mode, to avoid overflow of stdout
+        $cmd .= ' '.escapeshellarg($zipFile); // file to extract
+        $cmd .= ' -d '.escapeshellarg($destinationDirectory); // destination directory
+        $rc = 1;
+        $output = array();
+        @exec($cmd.' 2>&1', $output, $rc);
+        if ($rc !== 0) {
+            $error = trim(implode("\n", $output)) ?: t('Unknown error decompressing a ZIP archive');
+            throw new Exception($error);
+        }
+    }
+
+    /**
+     * Decompress a ZIP archive to a directory using the PHP functions.
+     *
+     * @param string $zipFile
+     * @param string $destinationDirectory
+     * @param array $options
+     *
+     * @throws Exception
+     */
+    protected function unzipPHP($zipFile, $destinationDirectory, array $options)
+    {
+        if (!class_exists('ZipArchive')) {
+            throw new Exception('Unable to unzip files using ZipArchive. Please ensure the Zip extension is installed.');
+        }
+        $zip = new ZipArchive();
+        try {
+            $flags = 0;
+            if (!$options['skipCheck']) {
+                $flags |= ZipArchive::CHECKCONS;
+            }
+            $zipErr = @$zip->open($zipFile, $flags);
+            if ($zipErr !== true) {
+                throw new Exception($this->describeZipArchiveError($zip, $zipErr));
+            }
+            if (@$zip->extractTo($destinationDirectory) !== true) {
+                throw new Exception($this->describeZipArchiveError($zip, ZipArchive::ER_OK));
+            }
+            @$zip->close();
+            $zip = null;
+        } catch (Exception $x) {
+            if ($zip !== null) {
+                try {
+                    @$zip->close();
+                } catch (\Exception $foo) {
+                }
+                $zip = null;
+            }
+            throw $x;
+        }
+    }
+
+    /**
+     * Compress the contents of a directory to a ZIP archive using the native 'zip' command.
+     *
+     * @param string $sourceDirectory
+     * @param string $zipFile
+     * @param array $options
+     *
+     * @throws Exception
+     */
+    public function zipNative($sourceDirectory, $zipFile, array $options)
+    {
+        $cmd = 'zip';
+        $cmd .= ' -r'; // recurse into directories
+        $level = (isset($options['level']) && is_numeric($options['level'])) ? @intval($options['level']) : null;
+        if ($level !== null && $level >= 0 && $level <= 9) {
+            $cmd .= ' -'.$level;
+        }
+        $cmd .= ' -q'; // quiet mode, to avoid overflow of stdout
+        $cmd .= ' '.escapeshellarg($zipFile); // destination ZIP archive
+        $cmd .= ' *'; // source files
+        $rc = 1;
+        $output = array();
+        $prevDir = @getcwd();
+        if ($prevDir === false) {
+            throw new Exception(t('Failed to determine current directory'));
+        }
+        if (@chdir($sourceDirectory) === false) {
+            throw new Exception(t('Failed to enter directory '.$sourceDirectory));
+        }
+        @exec($cmd.' 2>&1', $output, $rc);
+        @chdir($prevDir);
+        if ($rc !== 0) {
+            $error = trim(implode("\n", $output)) ?: t('Unknown error compressing a directory');
+            throw new Exception($error);
+        }
+    }
+
+    /**
+     * Compress the contents of a directory to a ZIP archive using the PHP functions.
+     *
+     * @param string $sourceDirectory
+     * @param string $zipFile
+     * @param array $options
+     *
+     * @throws Exception
+     */
+    public function zipPHP($sourceDirectory, $zipFile, array $options)
+    {
+        if (!class_exists('ZipArchive')) {
+            throw new Exception('Unable to zip files using ZipArchive. Please ensure the Zip extension is installed.');
+        }
+        $zip = new ZipArchive();
+        try {
+            $flags = ZipArchive::CREATE;
+            if (!$options['skipCheck']) {
+                $flags |= ZipArchive::CHECKCONS;
+            }
+            $zipErr = @$zip->open($zipFile, $flags);
+            if ($zipErr !== true) {
+                throw new Exception($this->describeZipArchiveError($zip, $zipErr));
+            }
+            $skipPathLength = strlen(rtrim($sourceDirectory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR);
+            $contents = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($sourceDirectory),
+                \RecursiveIteratorIterator::SELF_FIRST
+            );
+            foreach ($contents as $item) {
+                switch ($item->getFilename()) {
+                    case '.':
+                    case '..':
+                        break;
+                    default:
+                        $itemFullPath = $item->getRealPath();
+                        $itemRelPath = substr($itemFullPath, $skipPathLength);
+                        if ($item->isDir()) {
+                            $added = @$zip->addEmptyDir($itemRelPath);
+                        } else {
+                            $added = @$zip->addFile($itemFullPath, $itemRelPath);
+                        }
+                        if ($added !== true) {
+                            throw new Exception($this->describeZipArchiveError($zip, ZipArchive::ER_OK));
+                        }
+                        break;
+                }
+            }
+            if (@$zip->close() !== true) {
+                throw new Exception($this->describeZipArchiveError($zip, ZipArchive::ER_OK));
+            }
+            $zip = null;
+        } catch (Exception $x) {
+            if ($zip !== null) {
+                try {
+                    @$zip->close();
+                } catch (\Exception $foo) {
+                }
+                $zip = null;
+            }
+            @$this->getFilesystem()->delete(array($zipFile));
+            throw $x;
+        }
+    }
+}

--- a/web/concrete/src/File/Service/Zip.php
+++ b/web/concrete/src/File/Service/Zip.php
@@ -474,13 +474,17 @@ class Zip
                     case '..':
                         break;
                     default:
+                        $itemFullPath = $item->getRealPath();
+                        $itemRelPath = substr($itemFullPath, $skipPathLength);
                         if (
                             $options['includeDotFiles']
                             ||
-                            strpos($item, '.') !== 0
+                            (
+                                strpos($itemRelPath, '.') !== 0
+                                &&
+                                strpos($itemRelPath, DIRECTORY_SEPARATOR.'.') === false
+                            )
                         ) {
-                            $itemFullPath = $item->getRealPath();
-                            $itemRelPath = substr($itemFullPath, $skipPathLength);
                             if ($item->isDir()) {
                                 $added = @$zip->addEmptyDir($itemRelPath);
                             } else {


### PR DESCRIPTION
I'm quite tired of writing the same code over and over again :wink:, so, what about adding a new helper to handle zip files?

## Sample usage:

```php
$zh = \Core::make('helper/zip');

// Compress a directory
$zh->zip('/directory/to/compress', 'file.zip');

// Decompress a zip file to a directory
$zh->unzip('file.zip', '/destination/directory');
```

## Features

For faster execution, this helper uses the native `zip`/`unzip` commands (if they are available), otherwise it uses the `ZipArchive` native PHP class.
This behavior can be controlled with two methods:
```php
// Never use native zip/unzip commands
$zh->disableNativeCommands();

// Re-enable native commands:
$zh->enableNativeCommands();
```
