### PR TITLE
Bugfix: RSS feeds get cached indefinitely

### DIFF
--- a/web/concrete/blocks/rss_displayer/controller.php
+++ b/web/concrete/blocks/rss_displayer/controller.php
@@ -20,7 +20,32 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btWrapperClass = 'ccm-ui';
     protected $btCacheBlockOutputForRegisteredUsers = true;
+    
+    /**
+     * Default number of seconds that the output of this block should be cached
+     * (Can be overridden by the user within C5 UI)
+     * 
+     * @var integer
+     */
     protected $btCacheBlockOutputLifetime = 3600;
+    
+    /**
+     * Number of seconds that the RSS feed itself should be cached before fetching
+     * a fresh copy 
+     * 
+     * (Perhaps this could eventually become a user-setting?)
+     * 
+     * Caching is important as fetching a remote URL can significantly delay
+     * the rendering of a PHP page.
+     * 
+     * Setting to "null" should cache it indefinitely until cache is manually cleared.
+     * 
+     * Should probably be less than $btCacheBlockOutputLifetime above, otherwise the
+     * block will be re-rendered using the same stale RSS data.
+     * 
+     * @var integer
+     */
+    protected $rssFeedCacheLifetime = 1800;   
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this
@@ -122,7 +147,7 @@ class Controller extends BlockController
         $posts = array();
 
         try {
-            $channel = $fp->load($this->url);
+            $channel = $fp->load($this->url, $this->rssFeedCacheLifetime);
             $i = 0;
             foreach ($channel as $post) {
                 $posts[] = $post;
@@ -164,7 +189,9 @@ class Controller extends BlockController
         $posts = array();
 
         try {
-            $channel = $fp->load($this->url);
+            // We manually set cache time to 2hrs here as getSearchableContent()
+            // can probably cope with slightly older data
+            $channel = $fp->load($this->url, 7200);
             $i = 0;
             foreach ($channel as $post) {
                 $posts[] = $post;

--- a/web/concrete/src/Cache/Adapter/ZendCacheDriver.php
+++ b/web/concrete/src/Cache/Adapter/ZendCacheDriver.php
@@ -12,6 +12,16 @@ use Zend\Cache\Storage\FlushableInterface;
 /**
  * Class ZendCacheDriver
  * Adapter class to hook Zend's cache into Concrete5's cache.
+ * 
+ * By passing this class into various Zend classes, it tells Zend use it for storing and retrieving
+ * cache values. Values are passed through here and onto Concrete5's caching layer which uses the
+ * Stash library. Allows us to use many of the helpful Zend classes without having to maintain
+ * a separate cache configuration.
+ * 
+ * Currently used by:
+ * 
+ *     - Concrete\Core\Feed\FeedService
+ *     - Concrete\Core\Localization\Localization
  *
  * @package Concrete\Core\Cache\Adapter
  */
@@ -23,9 +33,15 @@ class ZendCacheDriver extends AbstractAdapter implements StorageInterface, Flush
     private $cacheName;
 
     /**
-     * @param string $cacheName Name of the cache being used. Defaults to cache.
+     * @var int Number of seconds to consider the cache fresh before it expires
      */
-    public function __construct($cacheName = 'cache')
+    protected $cacheLifetime;
+
+    /**
+     * @param string $cacheName Name of the cache being used. Defaults to cache.
+     * @param int $cacheLifetime Number of seconds to consider the cache fresh before it expires.
+     */
+    public function __construct($cacheName = 'cache', $cacheLifetime = null)
     {
         parent::__construct();
 
@@ -71,7 +87,7 @@ class ZendCacheDriver extends AbstractAdapter implements StorageInterface, Flush
         $cache = Core::make($this->cacheName);
         $item = $cache->getItem('zend/'.$normalizedKey);
 
-        return $item->set($value);
+        return $item->set($value, $this->cacheLifetime);
     }
 
     /**

--- a/web/concrete/src/Cache/Cache.php
+++ b/web/concrete/src/Cache/Cache.php
@@ -7,6 +7,17 @@ use Stash\Driver\BlackHole;
 use Stash\Driver\Composite;
 use Stash\Pool;
 
+/**
+ * Base class for the three caching layers present in Concrete5:
+ *   - ExpensiveCache
+ *   - ObjectCache
+ *   - RequestCache
+ *   
+ * Cache storage is performed using the Stash Library, see http://www.stashphp.com/
+ * 
+ * This class imports the various caching settings from Config class, sets
+ * up the Stash pools and provides a basic caching API for all of Concrete5.
+ */
 abstract class Cache
 {
     /** @var Pool */

--- a/web/concrete/src/Feed/FeedService.php
+++ b/web/concrete/src/Feed/FeedService.php
@@ -11,15 +11,19 @@ class FeedService
      * Loads a newsfeed object.
      *
      * @param string $feedurl
-     * @param bool   $cache
+     * @param int    $cache - number of seconds to cache the RSS feed data for
      * @return Reader
      */
-    public function load($url, $cache = true)
+    public function load($url, $cache = 3600)
     {
-        if ($cache) {
-            Reader::setCache(new ZendCacheDriver('cache/expensive'));
+        if ($cache !== false) {
+            Reader::setCache(new ZendCacheDriver('cache/expensive', $cache));
         }
+        
+        // Load the RSS feed, either from remote URL or from cache
+        // (if specified above and still fresh)
         $feed = Reader::import($url);
+        
         return $feed;
     }
 


### PR DESCRIPTION
I've noticed that when using the RSS Feed block that the feed gets cached almost indefinitely, regardless of what your page/block caching settings are, this appears to be because the `FeedService` class enables an additional caching layer and there seems to be no expiry time set on the cache.

Here is my quick initial attempt at fixing it, but not fully tested as yet. Would like someone with a better core knowledge to review and provide any feedback.

Simon.