### PR TITLE
Proposal: Make the block edit menu customizable for developers

### DIFF
--- a/web/concrete/elements/block_header_view.php
+++ b/web/concrete/elements/block_header_view.php
@@ -194,6 +194,13 @@ if ($showMenu) {
                             <? } ?>
                         <? } ?>
 
+                        <?php
+                        $event = new \Symfony\Component\EventDispatcher\GenericEvent();
+                        $event->setArgument('bID', $b->getBlockID());
+                        $event->setArgument('arHandle', $a->getAreaHandle());
+                        \Events::dispatch('on_block_edit_menu', $event);
+                        ?>
+
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Sometimes developers would like to add custom menu item to block edit menu, but we have to override the element to do it, and can't do it with a package.

This pull request adds availability to do it for package developer.

Sample code:

```php
\Events::addListener('on_block_edit_menu', function($event) {
    $b = \Block::getByID($event->getArgument('bID'));
    $p = new \Permissions($b);
    if ($p->canEditBlockDesign()) {
        ?>
        <li><a 
            data-menu-action="block_dialog" 
            data-menu-href="<?=URL::to('/ccm/system/custom/block/menu')?>" 
            dialog-title="<?=t('Custom Action')?>" 
            dialog-modal="false" 
            dialog-width="450" 
            dialog-height="300"><?=t("Custom Action")?></a></li>
        <?php
    }
});
```

![concrete5_demo____home](https://cloud.githubusercontent.com/assets/514294/13944100/8edbf9c4-f045-11e5-86bb-6689feebe57f.png)
