### PR TITLE
Update docblock on Mail service addParameter method to reflect that i…

### DIFF
--- a/web/concrete/src/Mail/Service.php
+++ b/web/concrete/src/Mail/Service.php
@@ -99,7 +99,7 @@ class Service
      * Adds a parameter to a mail template.
      *
      * @param string $key
-     * @param string $val
+     * @param mixed $val
      */
     public function addParameter($key, $val)
     {


### PR DESCRIPTION
The [documentation](http://documentation.concrete5.org/developers/sending-mail/working-mail-service) states:

> The first parameter of addParameter() 'mailContent' will be the variable named $mailContent inside the template. Naturally we may add multiple parameters by invoking addParameter() several times. Don't forget to set all parameter variables set here inside the template too. Also we can send any type of data (arrays, objects, etc) and work with it inside the template as the template file is a normal PHP-file.

The docblock for the method has the `$val` parameter marked as accepting a string:
```
    /**
     * Adds a parameter to a mail template.
     *
     * @param string $key
     * @param string $val
     */
    public function addParameter($key, $val)
    {
        $this->data[$key] = $val;
    }
```

This should be updated to `mixed` to reflect that any type can be used.