### PR TITLE
Shouldn't use page cache when the config is false

### DIFF
--- a/web/concrete/src/Cache/Page/PageCache.php
+++ b/web/concrete/src/Cache/Page/PageCache.php
@@ -49,6 +49,9 @@ abstract class PageCache
         $config = $app['config'];
         $cookie = $app['cookie'];
         $loginCookie = sprintf('%s_LOGIN', $config->get('concrete.session.name'));
+        if (Config::get('concrete.cache.pages') === false) {
+            return false;
+        }
         if ($cookie->has($loginCookie) && $cookie->get($loginCookie)) {
             return false;
         }


### PR DESCRIPTION
Use case:

When you use CDN like amazon CloudFront to improve performance of concrete5 site.
You'd like to detect host name and use separate cache config value.

You have to prevent full page cache when a user (admin) access to the origin server.
Why? Because, they are two different FQDN both for origin and CDN.

You should force full page cache when a user (guest) access to website through CDN.
Why? Because, when the origin server adds `Cache-Control: no-cache, no-store` header, CDN will cache contents with minimum TTL.
http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html

OK, let's separate config file by http host name.

```php
// application/bootstrap/start.php
$app->detectEnvironment(function(){
    $request = \Concrete\Core\Http\Request::getInstance();
    if ($request->server->get('HTTP_HOST') == 'origin.concrete5.example.com') {
        return 'origin';
    }
});
```

Then, let's disable full page cache on origin server.

```php
// applciation/config/origin.concrete.php
return array(
    'cache' => array(
        'blocks' => false,
        'pages' => false
    )
);
```

It looks nice, but you will get a cached page even you are accessed on origin host.

This pull request fill fix the situation.