### PR TITLE
Don't add a blank line after PHP opening tag

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,7 @@ return Symfony\CS\Config\Config::create()
         // Don't force an empty line before namespace declaration
         '-single_blank_line_before_namespace',
         'no_blank_lines_before_namespace',
+		  '-blankline_after_open_tag',
     ))
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()


### PR DESCRIPTION
If we run php-cs-fixer against this code:
```php
<?php
namespace X;
```

The result currently is:
```php
<?php

namespace X;
```

But it should remain untouched:
```php
<?php
namespace X;
```
