### PR TITLE
Update footer to include `rel="nofollow"` for c5.org link

### DIFF
--- a/web/concrete/themes/elemental/elements/footer.php
+++ b/web/concrete/themes/elemental/elements/footer.php
@@ -59,7 +59,7 @@ $displayFirstSection = $footerSiteTitleBlocks > 0 || $footerSocialBlocks > 0 || 
     <div class="container">
         <div class="row">
             <div class="col-sm-12">
-                <span><?=t('Built with <a href="http://www.concrete5.org" class="concrete5">concrete5</a> CMS.')?></span>
+                <span><?=t('Built with <a href="http://www.concrete5.org" class="concrete5" rel="nofollow">concrete5</a> CMS.')?></span>
                 <span class="pull-right">
                     <?=Core::make('helper/navigation')->getLogInOutLink()?>
                 </span>


### PR DESCRIPTION
I've been told that these links are negatively effecting concrete5.org's SEP :-1: 