### PR TITLE
Bug fix: multiple workflow on same page causes errors

### DIFF
--- a/web/concrete/src/Workflow/Workflow.php
+++ b/web/concrete/src/Workflow/Workflow.php
@@ -205,6 +205,12 @@ abstract class Workflow extends Object implements \Concrete\Core\Permission\Obje
 
     public function validateTrigger(WorkflowRequest $req)
     {
-        return true;
+        // Check if the current workflow request is not already deleted
+        $wr = $req::getByID($req->getWorkflowRequestID());
+        if (is_object($wr)) {
+            return true;
+        }
+        
+        return false;
     }
 }


### PR DESCRIPTION
> PHP Fatal error:  Call to a member function getRequesterUserID() on null in /path/to/concrete5/web/concrete/src/Workflow/BasicWorkflow.php on line 70

## Steps to reproduce

1. Turn advanced permissions on.
2. Add 2 or more workflows. You have to attach "Approve or Deny" permission to you.
3. Apply these workflows to "Approve Changes" permission on a same page.
4. Edit the page and publish.