### PR TITLE
Fix ImageFileType constructor

### DIFF
--- a/web/concrete/src/Entity/Attribute/Key/Type/ImageFileType.php
+++ b/web/concrete/src/Entity/Attribute/Key/Type/ImageFileType.php
@@ -25,7 +25,7 @@ class ImageFileType extends Type
 
     public function __construct()
     {
-        $this->mode = self::TYPE_FILE_MANAGER;
+        $this->akFileManagerMode = self::TYPE_FILE_MANAGER;
     }
 
     public function getMode()


### PR DESCRIPTION
Fix the following install error:
```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'akFileManagerMode' cannot be null
```