### PR TITLE
Fixing the wrong link in dashboard/blocks/types to marketetplace listing page

### DIFF
--- a/web/concrete/single_pages/dashboard/blocks/types/view.php
+++ b/web/concrete/single_pages/dashboard/blocks/types/view.php
@@ -66,7 +66,7 @@
 
     <? if (Config::get('concrete.marketplace.enabled') == true) { ?>
     <div class="alert alert-info">
-        <a class="btn btn-success btn-xs pull-right" href="<?=$view->url('/dashboard/extend/add-ons')?>"><?=t("More Add-ons")?></a>
+        <a class="btn btn-success btn-xs pull-right" href="<?=$view->url('/dashboard/extend/addons')?>"><?=t("More Add-ons")?></a>
         <p><?=t('Browse our marketplace of add-ons to extend your site!')?></p>
     </div>
     <? } ?>


### PR DESCRIPTION
Fixing the wrong URL link where is says "More Add-ons" from Dashboard/Block/Types/index.html which is supposed to link to
/index.php/dashboard/blocks/types