### PR TITLE
DOM extension is required

### DIFF
--- a/web/concrete/controllers/install.php
+++ b/web/concrete/controllers/install.php
@@ -192,8 +192,8 @@ class Install extends Controller
             && function_exists('imagegif')
             && function_exists('imagejpeg'));
         $this->set('mysqlTest', extension_loaded('pdo_mysql'));
-        $this->set('i18nTest', function_exists('ctype_lower')
-           );
+        $this->set('i18nTest', function_exists('ctype_lower'));
+        $this->set('domTest', extension_loaded('dom'));
         $this->set('jsonTest', extension_loaded('json'));
         $this->set('xmlTest', function_exists('xml_parse') && function_exists('simplexml_load_file'));
         $this->set('fileWriteTest', $this->testFileWritePermissions());
@@ -263,7 +263,8 @@ class Install extends Controller
     {
         if ($this->get('imageTest') && $this->get('mysqlTest') && $this->get('fileWriteTest') &&
             $this->get('xmlTest') && $this->get('phpVtest') && $this->get('i18nTest') &&
-            $this->get('memoryTest') !== -1 && $this->get('docCommentTest') && $this->get('aspTagsTest')
+            $this->get('memoryTest') !== -1 && $this->get('docCommentTest') && $this->get('aspTagsTest') &&
+            $this->get('domTest')
         ) {
             return true;
         }

--- a/web/concrete/views/frontend/install.php
+++ b/web/concrete/views/frontend/install.php
@@ -365,6 +365,12 @@ $(function() {
 	<td><?php if (!$jsonTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable PHP\'s JSON support. This should be enabled by default in PHP 5.2 and above.')?>"></i><?php } ?></td>
 </tr>
 <tr>
+	<td><?php if ($domTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
+	<td width="100%"><?php echo t('DOM Extension Enabled')?>
+	</td>
+	<td><?php if (!$domTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?php echo t('You must enable PHP\'s DOM support.')?>"></i><?php } ?></td>
+</tr>
+<tr>
     <td><?php if ($aspTagsTest) { ?><i class="fa fa-check"></i><?php } else { ?><i class="fa fa-exclamation-circle"></i><?php } ?></td>
     <td width="100%"><?=t('ASP Style Tags Disabled')?></td>
     <td><?php if (!$aspTagsTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must disable PHP\'s ASP Style Tags.')?>"></i><?php } ?></td>


### PR DESCRIPTION
Install fails if the DOM extension is not loaded.

{"error":{"message":"Class 'DOMDocument' not found"},"errors":["Class 'DOMDocument' not found"]}