### PR TITLE
Fix: unable to redirect to home on submit form block

### DIFF
--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -578,7 +578,9 @@ class Controller extends BlockController
             }
 
             if (!$this->noSubmitFormRedirect) {
-                if ($this->redirectCID > 0) {
+                if ($this->redirectCID == HOME_CID) {
+                    $this->redirect(Core::make('url/canonical'));
+                } elseif ($this->redirectCID > 0) {
                     $pg = Page::getByID($this->redirectCID);
                     if (is_object($pg) && $pg->cID) {
                         $this->redirect($pg->getCollectionPath());


### PR DESCRIPTION
You're not able to set Home page as redirect page of form submission.

Error message:
```
InvalidArgumentException: Cannot redirect to an empty URL.
```