### PR TITLE
Added a check to see if the method (attribute) is callable in the tag…

### DIFF
--- a/web/concrete/src/Editor/LinkAbstractor.php
+++ b/web/concrete/src/Editor/LinkAbstractor.php
@@ -145,7 +145,7 @@ class LinkAbstractor extends Object
 										$child->$attr($val);
 									}
 								}
-							} else {
+							} elseif (is_callable($tag, true, $attr)) {
 								$tag->$attr($val);
 							}
 						}


### PR DESCRIPTION
This prevents a 'Method name must be a string' error in the case someone tried to use attribute names starting with an integer.