### PR TITLE
[8.0] Save to session the locale of the page being visited

### DIFF
--- a/web/concrete/src/Multilingual/Service/Detector.php
+++ b/web/concrete/src/Multilingual/Service/Detector.php
@@ -96,6 +96,7 @@ class Detector
 
         $locale = $ms->getLocale();
         if ($locale) {
+            $app->make('session')->set('multilingual_default_locale', $locale);
             $loc = Localization::getInstance();
             $loc->setContextLocale('site', $locale);
         }


### PR DESCRIPTION
This will be used when accessing pages not under multilingual sections, like /login