### PR TITLE
Fix #3125

### DIFF
--- a/web/concrete/src/Page/Collection/Version/Version.php
+++ b/web/concrete/src/Page/Collection/Version/Version.php
@@ -399,8 +399,7 @@ class Version extends Object implements \Concrete\Core\Permission\ObjectInterfac
         if ($c->getCollectionInheritance() == 'TEMPLATE') {
             // we make sure to update the cInheritPermissionsFromCID value
             $pType = PageType::getByID($c->getPageTypeID());
-            $pTemplate = PageTemplate::getByID($c->getPageTemplateID());
-            $masterC = $pType->getPageTypePageTemplateDefaultPageObject($pTemplate);
+            $masterC = $pType->getPageTypePageTemplateDefaultPageObject();
             $db->Execute('update Pages set cInheritPermissionsFromCID = ? where cID = ?', array(
                 $masterC->getCollectionID(),
                 $c->getCollectioniD()


### PR DESCRIPTION
Fixes #3125
When the page template is different to the page type default template the cInheritPermissionsFromCID is set to an incorrect master collection ID which leads to none/different permissions applied to the page.