### PR TITLE
Fix package localization

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -281,6 +281,8 @@ class Application extends Container
                 }
             }
             $pkg->setupPackageLocalization();
+        }
+        foreach($this->packages as $pkg) {
             if (method_exists($pkg, 'on_start')) {
                 $pkg->on_start();
             }


### PR DESCRIPTION
If a package, in its `on_start method`, calls `t()`, the localization files are loaded and cached.

Once these localization files are loaded, translations of subsequent packages are not loaded anymore since the translation cache is already built.

So, let's first initialize the localization of all the packages, and only after let's call the packages `on_start` methods.