### PR TITLE
fix: feature block wasn't pulling paragraph correctly in editmode

### DIFF
--- a/web/concrete/blocks/feature/controller.php
+++ b/web/concrete/blocks/feature/controller.php
@@ -55,6 +55,11 @@ class Controller extends BlockController
         return LinkAbstractor::translateFrom($this->paragraph);
     }
 
+    public function getParagraphEditMode()
+    {
+        return LinkAbstractor::translateFromEditMode($this->paragraph);
+    }
+
     public function registerViewAssets($outputContent = '')
     {
         $this->requireAsset('css', 'font-awesome');

--- a/web/concrete/blocks/feature/form.php
+++ b/web/concrete/blocks/feature/form.php
@@ -20,7 +20,7 @@
         <?php echo $form->label('paragraph', t('Paragraph:'));?>
         <?php
             $editor = Core::make('editor');
-            echo $editor->outputBlockEditModeEditor('paragraph', $controller->getParagraph());
+            echo $editor->outputBlockEditModeEditor('paragraph', $controller->getParagraphEditMode());
         ?>
     </div>
 


### PR DESCRIPTION
I was noticing that when a Feature block linked to a document using the file manager, it would continually append the cID on every block save.

Edit the block.

![screen shot 2016-04-12 at 3 13 02 pm](https://cloud.githubusercontent.com/assets/176908/14477232/53540270-00c1-11e6-9d7a-493dd34cb30d.png)

Then click save, click edit the block again, click save, do this several times and the URL grows.

![screen shot 2016-04-12 at 3 12 35 pm](https://cloud.githubusercontent.com/assets/176908/14477242/6216fb5a-00c1-11e6-995a-f4b85eaadfb9.png)

I looked through the Content block controller because that block wasn't suffering the same bug and realized that it contained a method called getContentEditMode() so I duplicated this functionality for the Feature block.

I tested this on both Linux and OSX using apache 2.2, php 5.5, and php 5.6. 

Thanks,
Jared
