### PR TITLE
Cache file thumbnail paths

### DIFF
--- a/tests/tests/Core/File/ImporterTest.php
+++ b/tests/tests/Core/File/ImporterTest.php
@@ -21,6 +21,7 @@ class ImporterTest extends \FileStorageTestCase {
             'PermissionAccessEntityTypes',
             'FileAttributeValues',
             'FileImageThumbnailTypes',
+            'FileImageThumbnailPaths',
             'FilePermissionAssignments',
             'AttributeKeyCategories',
             'AttributeTypes',

--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -7,9 +7,9 @@ return array(
      *
      * @var string
      */
-    'version'           => '5.7.5.7a1',
-    'version_installed' => '5.7.5.7a1',
-    'version_db' => '20160314000000', // the key of the latest database migration
+    'version'           => '5.7.5.7a2',
+    'version_installed' => '5.7.5.7a2',
+    'version_db' => '20160412000000', // the key of the latest database migration
 
     /**
      * Installation status

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -5437,4 +5437,33 @@
     </field>
   </table>
 
+  <table name="FileImageThumbnailPaths">
+    <field name="fileID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <field name="fileVersionID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <field name="thumbnailTypeHandle" type="string" size="255">
+      <notnull/>
+    </field>
+    <field name="storageLocationID" type="integer">
+      <unsigned/>
+      <notnull/>
+    </field>
+    <field name="path" type="text">
+      <notnull/>
+    </field>
+
+    <index name="thumbnailPathID">
+      <unique/>
+      <col>fileID</col>
+      <col>fileVersionID</col>
+      <col>thumbnailTypeHandle</col>
+      <col>storageLocationID</col>
+    </index>
+  </table>
+
 </schema>

--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -6,6 +6,7 @@ use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Cache\Page\PageCache;
 use Concrete\Core\Cache\Page\PageCacheRecord;
 use Concrete\Core\Cache\OpCache;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Foundation\ClassLoader;
 use Concrete\Core\Foundation\EnvironmentDetector;
 use Concrete\Core\Localization\Localization;
@@ -115,6 +116,11 @@ class Application extends Container
         if (is_object($pageCache)) {
             $pageCache->flush();
         }
+
+        // Clear the file thumbnail path cache
+        $connection = $this['database'];
+        $sql = $connection->getDatabasePlatform()->getTruncateTableSQL('FileImageThumbnailPaths');
+        $connection->executeUpdate($sql);
 
         // clear the environment overrides cache
         $env = \Environment::get();

--- a/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -67,6 +67,14 @@ class Resolver
         }
     }
 
+    /**
+     * Get the stored path for a file
+     * @param int $file_id
+     * @param int $version_id
+     * @param int $storage_location_id
+     * @param string $thumbnail_handle
+     * @return null|string
+     */
     protected function getStoredPath($file_id, $version_id, $storage_location_id, $thumbnail_handle)
     {
         $builder = $this->connection->createQueryBuilder();
@@ -88,6 +96,15 @@ class Resolver
         }
     }
 
+    /**
+     * Store a path in the database against a storage location for a file version and a thumbnail handle
+     *
+     * @param $path
+     * @param $file_id
+     * @param $version_id
+     * @param $storage_location_id
+     * @param $thumbnail_handle
+     */
     protected function storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle)
     {
         $this->connection->insert('FileImageThumbnailPaths', array(
@@ -99,6 +116,13 @@ class Resolver
         ));
     }
 
+    /**
+     * Determine the path for a file version thumbnail based on the configured storage location
+     *
+     * @param \Concrete\Core\File\Version $file_version
+     * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $thumbnail
+     * @return string
+     */
     protected function determinePath(Version $file_version, ThumbnailVersion $thumbnail)
     {
         $file = $file_version->getFile();
@@ -117,6 +141,13 @@ class Resolver
         return $this->getDefaultPath($file_version, $thumbnail);
     }
 
+    /**
+     * Fallback to getting the
+     *
+     * @param \Concrete\Core\File\Version $file_version
+     * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $thumbnail
+     * @return string
+     */
     protected function getDefaultPath(Version $file_version, ThumbnailVersion $thumbnail)
     {
         $cf = $this->app->make('helper/concrete/file');
@@ -129,8 +160,6 @@ class Resolver
             if ($configuration->hasPublicURL()) {
                 $file = $cf->prefix($file_version->getPrefix(), $file_version->getFileName());
                 return $configuration->getPublicURLToFile($file);
-            } else {
-                return $this->getDownloadURL();
             }
         }
     }

--- a/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -4,14 +4,11 @@ namespace Concrete\Core\File\Image\Thumbnail\Path;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\File\File;
-use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailVersion;
 use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
 use Concrete\Core\File\StorageLocation\Configuration\DeferredConfigurationInterface;
 use Concrete\Core\File\StorageLocation\StorageLocation;
 use Concrete\Core\File\Version;
-use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\EntityManagerInterface;
 
 class Resolver
 {
@@ -133,8 +130,12 @@ class Resolver
      * @param \Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface $configuration
      * @return string
      */
-    protected function determinePath(Version $file_version, ThumbnailVersion $thumbnail, StorageLocation $storage, ConfigurationInterface $configuration)
-    {
+    protected function determinePath(
+        Version $file_version,
+        ThumbnailVersion $thumbnail,
+        StorageLocation $storage,
+        ConfigurationInterface $configuration
+    ) {
         $fss = $storage->getFileSystemObject();
         $path = $thumbnail->getFilePath($file_version);
 
@@ -156,8 +157,12 @@ class Resolver
      * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $thumbnail
      * @return string
      */
-    protected function getDefaultPath(Version $file_version, ThumbnailVersion $thumbnail, StorageLocation $storage, ConfigurationInterface $configuration)
-    {
+    protected function getDefaultPath(
+        Version $file_version,
+        ThumbnailVersion $thumbnail,
+        StorageLocation $storage,
+        ConfigurationInterface $configuration
+    ) {
         $cf = $this->app->make('helper/concrete/file');
 
         if ($configuration->hasPublicURL()) {

--- a/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -142,7 +142,7 @@ class Resolver
     }
 
     /**
-     * Fallback to getting the
+     * Get the main image path ignoring the thumbnail requirements
      *
      * @param \Concrete\Core\File\Version $file_version
      * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $thumbnail

--- a/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -1,0 +1,138 @@
+<?php
+namespace Concrete\Core\File\Image\Thumbnail\Path;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\File\File;
+use Concrete\Core\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailVersion;
+use Concrete\Core\File\Version;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+
+class Resolver
+{
+
+    protected $app;
+
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $connection;
+
+    /**
+     * Resolver constructor.
+     * @param \Concrete\Core\Application\Application $app
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     */
+    public function __construct(Application $app, Connection $connection)
+    {
+        $this->app = $app;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Get the path for a file version
+     *
+     * @param Version $file_version
+     * @param ThumbnailVersion $thumbnail
+     * @return null|string
+     */
+    public function getPath(Version $file_version, ThumbnailVersion $thumbnail)
+    {
+        /** @var File $file */
+        $file = $file_version->getFile();
+        $file_id = $file->getFileID();
+        $version_id = $file_version->getFileVersionID();
+        $storage_location_id = $file->getStorageLocationID();
+        $thumbnail_handle = $thumbnail->getHandle();
+
+        $path = $this->getStoredPath(
+            $file_id,
+            $version_id,
+            $storage_location_id,
+            $thumbnail_handle);
+
+        if ($path) {
+            return $path;
+        } elseif ($path = $this->determinePath($file_version, $thumbnail)) {
+            $this->storePath(
+                $path,
+                $file->getFileID(),
+                $file_version->getFileVersionID(),
+                $storage_location_id,
+                $thumbnail_handle);
+
+            return $path;
+        }
+    }
+
+    protected function getStoredPath($file_id, $version_id, $storage_location_id, $thumbnail_handle)
+    {
+        $builder = $this->connection->createQueryBuilder();
+        $query = $builder
+            ->select('path')->from('FileImageThumbnailPaths', 'p')
+            ->where('p.fileID = :file')
+            ->andWhere('p.fileVersionID = :version')
+            ->andWhere('p.storageLocationID = :storage')
+            ->andWhere('p.thumbnailTypeHandle = :thumbnail')
+            ->setParameters(array(
+                'file' => $file_id,
+                'version' => $version_id,
+                'storage' => $storage_location_id,
+                'thumbnail' => $thumbnail_handle
+            ))->execute();
+
+        if ($query->rowCount()) {
+            return $query->fetchColumn();
+        }
+    }
+
+    protected function storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle)
+    {
+        $this->connection->insert('FileImageThumbnailPaths', array(
+            'path' => $path,
+            'fileID' => $file_id,
+            'fileVersionID' => $version_id,
+            'storageLocationID' => $storage_location_id,
+            'thumbnailTypeHandle' => $thumbnail_handle
+        ));
+    }
+
+    protected function determinePath(Version $file_version, ThumbnailVersion $thumbnail)
+    {
+        $file = $file_version->getFile();
+        $storage_location = $file->getFileStorageLocationObject();
+
+        if ($storage_location) {
+            $configuration = $storage_location->getConfigurationObject();
+            $fss = $storage_location->getFileSystemObject();
+            $path = $thumbnail->getFilePath($file_version);
+
+            if ($fss->has($path)) {
+                return $configuration->getPublicURLToFile($path);
+            }
+        }
+
+        return $this->getDefaultPath($file_version, $thumbnail);
+    }
+
+    protected function getDefaultPath(Version $file_version, ThumbnailVersion $thumbnail)
+    {
+        $cf = $this->app->make('helper/concrete/file');
+
+        $fsl = $file_version->getFile()->getFileStorageLocationObject();
+
+        if (is_object($fsl)) {
+            $configuration = $fsl->getConfigurationObject();
+
+            if ($configuration->hasPublicURL()) {
+                $file = $cf->prefix($file_version->getPrefix(), $file_version->getFileName());
+                return $configuration->getPublicURLToFile($file);
+            } else {
+                return $this->getDownloadURL();
+            }
+        }
+    }
+
+}

--- a/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/web/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -164,7 +164,6 @@ class Resolver
             $file = $cf->prefix($file_version->getPrefix(), $file_version->getFileName());
 
             if ($configuration instanceof DeferredConfigurationInterface) {
-                dd('test');
                 return $file;
             }
 

--- a/web/concrete/src/File/Image/Thumbnail/Type/Version.php
+++ b/web/concrete/src/File/Image/Thumbnail/Type/Version.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\File\Image\Thumbnail\Type;
 
+use Concrete\Core\File\Image\Thumbnail\Path\Resolver;
 use Concrete\Core\File\Version as FileVersion;
 use Core;
 

--- a/web/concrete/src/File/StorageLocation/Configuration/DeferredConfigurationInterface.php
+++ b/web/concrete/src/File/StorageLocation/Configuration/DeferredConfigurationInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Concrete\Core\File\StorageLocation\Configuration;
+
+interface DeferredConfigurationInterface
+{
+
+}

--- a/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\File\StorageLocation\Configuration;
 use Concrete\Core\Error\Error;
 use \Concrete\Flysystem\Adapter\Local;
 
-class LocalConfiguration extends Configuration implements ConfigurationInterface
+class LocalConfiguration extends Configuration implements ConfigurationInterface, DeferredConfigurationInterface
 {
 
     protected $path;

--- a/web/concrete/src/File/Version.php
+++ b/web/concrete/src/File/Version.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\File;
 use Carbon\Carbon;
 use Concrete\Core\Attribute\Value\FileValue as FileAttributeValue;
 use Concrete\Core\File\Exception\InvalidDimensionException;
+use Concrete\Core\File\Image\Thumbnail\Path\Resolver;
 use Concrete\Core\File\Image\Thumbnail\Thumbnail;
 use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailTypeVersion;
@@ -851,20 +852,26 @@ class Version
         }
     }
 
+    /**
+     * Resolve a path using the default core path resolver.
+     * Avoid using this method when you have access to your a resolver instance.
+     *
+     * @param $type
+     * @return null|string
+     */
     public function getThumbnailURL($type)
     {
         if (!($type instanceof ThumbnailTypeVersion)) {
             $type = ThumbnailTypeVersion::getByHandle($type);
         }
-        $fsl = $this->getFile()->getFileStorageLocationObject();
-        if ($fsl && $type) {
-            $configuration = $fsl->getConfigurationObject();
-            $fss = $fsl->getFileSystemObject();
-            $path = $type->getFilePath($this);
-            if ($fss->has($path)) {
-                return $configuration->getPublicURLToFile($path);
-            }
+
+        /** @var Resolver $path_resolver */
+        $path_resolver = Core::make('Concrete\Core\File\Image\Thumbnail\Path\Resolver');
+
+        if ($path = $path_resolver->getPath($this, $type)) {
+            return $path;
         }
+
         return $this->getURL();
     }
 

--- a/web/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
+++ b/web/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Page\Page;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use ORM;
+
+class Version20160412000000 extends AbstractMigration
+{
+
+    public function up(Schema $schema)
+    {
+        // background size/position
+        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema(array(
+            'FileImageThumbnailPaths'
+        ));
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+
+
+}


### PR DESCRIPTION
Resolves #3590

Some interesting tidbits:

* To avoid caching the base url of the site, we added an interface that is used as a flag. Any storage location that wants to cache the "file path" instead of the public url should implement this interface.
* To clear this table, you must clear site cache. There is talk of moving this to storage locations interface.

To get the path for a file version:
```php
<?php
$path_resolver = $app->make('Concrete\Core\File\Image\Thumbnail\Path\Resolver');
$path = $path_resolver->getPath($file_version, $thumbnail_type_version);
```