### PR TITLE
Fix Brazilian state name Tocatins -> Tocantins

### DIFF
--- a/web/concrete/src/Localization/Service/StatesProvincesList.php
+++ b/web/concrete/src/Localization/Service/StatesProvincesList.php
@@ -393,7 +393,7 @@ class StatesProvincesList
                     'SC' => tc('Brazilian State', 'Santa Catarina'),
                     'SE' => tc('Brazilian State', 'Sergipe'),
                     'SP' => tc('Brazilian State', 'São Paulo'),
-                    'TO' => tc('Brazilian State', 'Tocatins'),
+                    'TO' => tc('Brazilian State', 'Tocantins'),
                 ),
 
                 'IT' => array(


### PR DESCRIPTION
Quite unbelievably: this typo has been there since [2009-09-08](https://github.com/concrete5/concrete5-legacy/commit/ec45c6bbcfa3ae6ea8062fb54cd2ef7bc89e6fa4#diff-4e657b13dc28140874bf76211deff574R231) :wink: