### PR TITLE
Remove protocol and domain from localized asset URLs

### DIFF
--- a/web/concrete/src/Asset/CssLocalizedAsset.php
+++ b/web/concrete/src/Asset/CssLocalizedAsset.php
@@ -27,7 +27,7 @@ class CssLocalizedAsset extends CssAsset
 
     public function getAssetURL()
     {
-        return (string) URL::to($this->assetURL);
+        return URL::to($this->assetURL)->getRelativeUrl();
     }
 
     /**

--- a/web/concrete/src/Asset/JavascriptLocalizedAsset.php
+++ b/web/concrete/src/Asset/JavascriptLocalizedAsset.php
@@ -27,7 +27,7 @@ class JavascriptLocalizedAsset extends JavascriptAsset
 
     public function getAssetURL()
     {
-        return (string) URL::to($this->assetURL);
+        return URL::to($this->assetURL)->getRelativeUrl();
     }
 
     /**


### PR DESCRIPTION
Bug tracker: https://www.concrete5.org/developers/bugs/5-7-5-6/javascriptlocalizedasset-loads-asset-with-base_url-resulting-in-/