### PR TITLE
Don't print closing video tag when there is no video selected

### DIFF
--- a/web/concrete/blocks/video/view.php
+++ b/web/concrete/blocks/video/view.php
@@ -41,6 +41,6 @@ if ($c->isEditMode()) { ?>
 			<embed src="<?=$mp4URL?>" width="<?=$controller->width?>" height="<?=$controller->height?>" autoplay="true" loop="false" controller="true" pluginspage="http://www.apple.com/quicktime/"></embed>
 		</object>
         <?php } ?>
-<? } ?>
    </video>
+<? } ?>
 </div>


### PR DESCRIPTION
Video closing tag was placed outside if.