### PR TITLE
Add configuration option to require version comments

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -450,6 +450,7 @@ return array(
         'app_version_display_in_header' => true,
         'default_jpeg_image_compression'     => 80,
         'help_overlay'                  => true,
+        'require_version_comments'      => true,
     ),
 
     'theme' => array(

--- a/web/concrete/controllers/panel/page/check_in.php
+++ b/web/concrete/controllers/panel/page/check_in.php
@@ -73,6 +73,11 @@ class CheckIn extends BackendInterfacePageController
     public function submit()
     {
         if ($this->validateAction()) {
+            $comments = $this->request->request('comments');
+            $comments = is_string($comments) ? trim($comments) : '';
+            if ($comments === '' && $this->app->make('config')->get('concrete.misc.require_version_comments')) {
+                return Response::create(t('Please specify the version comments'), 400);
+            }
             $c = $this->page;
             $u = new User();
             $v = CollectionVersion::get($c, "RECENT");

--- a/web/concrete/views/panels/page/check_in.php
+++ b/web/concrete/views/panels/page/check_in.php
@@ -1,6 +1,7 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
 $v = $c->getVersionObject();
+$require_version_comments = (bool) Config::get('concrete.misc.require_version_comments');
 ?>
 
 <div class="ccm-panel-content-inner">
@@ -9,7 +10,7 @@ $v = $c->getVersionObject();
 
 <h5><?=t('Version Comments')?></h5>
 
-<div class="ccm-panel-check-in-comments"><textarea name="comments" id="ccm-check-in-comments" /></textarea></div>
+<div class="ccm-panel-check-in-comments"><textarea name="comments" id="ccm-check-in-comments"<?php echo $require_version_comments ? ' required="required"' : ''; ?>></textarea></div>
 
 <? if ($cp->canApprovePageVersions()) {
 	if ($c->isPageDraft()) {


### PR DESCRIPTION
If the new configuration option `concrete.misc.require_version_comments` is set to true, version comments are required