### PR TITLE
Add topic, tag, and date filtering to the Page Title block

### DIFF
--- a/web/concrete/blocks/page_title/db.xml
+++ b/web/concrete/blocks/page_title/db.xml
@@ -2,18 +2,36 @@
 <schema
   xmlns="http://www.concrete5.org/doctrine-xml/0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
-
-  <table name="btPageTitle">
-    <field name="bID" type="integer">
-      <unsigned/>
-      <key/>
-    </field>
-    <field name="useCustomTitle" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="titleText" type="string" size="255"/>
-    <field name="formatting" type="string" size="3"/>
-  </table>
-
+    <table name="btPageTitle">
+        <field name="bID" type="integer">
+            <unsigned/>
+            <key/>
+        </field>
+        <field name="useCustomTitle" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="useFilterTitle" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="useFilterTopic" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="useFilterTag" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="useFilterDate" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="topicTextFormat" type="string" size="255"/>
+        <field name="tagTextFormat" type="string" size="255"/>
+        <field name="dateTextFormat" type="string" size="255"/>
+        <field name="filterDateFormat" type="string" size="255"/>
+        <field name="titleText" type="string" size="255"/>
+        <field name="formatting" type="string" size="3"/>
+    </table>
 </schema>

--- a/web/concrete/blocks/page_title/form_add_edit.php
+++ b/web/concrete/blocks/page_title/form_add_edit.php
@@ -1,29 +1,140 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-if(!strlen($titleText)) { $titleText = $controller->getTitleText();}
-?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
-<div class="form-group" class="ccm-ui">
-    <label><?=t("Custom Title")?></label>
-    <div class="checkbox"><label>
-        <?php echo $form->checkbox('useCustomTitle', 1, $useCustomTitle);?>
-        <?=t('Override page name with custom title?')?>
-    </label></div>
+<div class="form-group">
+    <label><?php echo t("Custom Title"); ?></label>
+    <div class="checkbox">
+        <label>
+        <?php echo $form->checkbox('useCustomTitle', 1, $useCustomTitle); ?>
+        <?php echo t('Override page name with custom title'); ?>
+        </label>
+    </div>
 </div>
 
 <div class="form-group">
-    <?=$form->label('titleText', t('Custom Title Text'))?>
-    <?php echo $form->text('titleText', $titleText); ?>
+    <?php echo $form->label('titleText', t('Custom Title Text')); ?>
+    <?php echo $form->text('titleText', $titleText ? $titleText : $controller->getTitleText()); ?>
 </div>
 
 <div class="form-group">
-    <?php echo $form->label('formatting', t('Formatting Style'))?>
+    <?php echo $form->label('formatting', t('Formatting Style')); ?>
     <select class="form-control" name="formatting" id="formatting">
-        <option value="h1" <?php echo ($this->controller->formatting=="h1"?"selected":"")?>><?php echo t('H1')?></option>
-        <option value="h2" <?php echo ($this->controller->formatting=="h2"?"selected":"")?>><?php echo t('H2')?></option>
-        <option value="h3" <?php echo ($this->controller->formatting=="h3"?"selected":"")?>><?php echo t('H3')?></option>
-        <option value="h4" <?php echo ($this->controller->formatting=="h4"?"selected":"")?>><?php echo t('H4')?></option>
-        <option value="h5" <?php echo ($this->controller->formatting=="h5"?"selected":"")?>><?php echo t('H5')?></option>
-        <option value="h6" <?php echo ($this->controller->formatting=="h6"?"selected":"")?>><?php echo t('H6')?></option>
+        <option value="h1" <?php echo $this->controller->formatting == 'h1' ? 'selected' : ''; ?>><?php echo t('H1'); ?></option>
+        <option value="h2" <?php echo $this->controller->formatting == 'h2' ? 'selected' : ''; ?>><?php echo t('H2'); ?></option>
+        <option value="h3" <?php echo $this->controller->formatting == 'h3' ? 'selected' : ''; ?>><?php echo t('H3'); ?></option>
+        <option value="h4" <?php echo $this->controller->formatting == 'h4' ? 'selected' : ''; ?>><?php echo t('H4'); ?></option>
+        <option value="h5" <?php echo $this->controller->formatting == 'h5' ? 'selected' : ''; ?>><?php echo t('H5'); ?></option>
+        <option value="h6" <?php echo $this->controller->formatting == 'h6' ? 'selected' : ''; ?>><?php echo t('H6'); ?></option>
     </select>
 </div>
 
+<div class="form-group">
+    <label><?php echo t("Page Title Filtering"); ?></label>
+    <div class="checkbox">
+        <label>
+        <?php echo $form->checkbox('useFilterTitle', 1, $useFilterTitle); ?>
+        <?php echo t('Enable other blocks to filter this page title'); ?>
+        </label>
+    </div>
+
+    <div class="well filterTitleOptions">
+        <div class="checkbox">
+            <label>
+            <?php echo $form->checkbox('useFilterTopic', 1, $useFilterTopic); ?>
+            <?php echo t('Topic'); ?>
+            </label>
+        </div>
+        <div class="checkbox">
+            <label>
+            <?php echo $form->checkbox('useFilterTag', 1, $useFilterTag); ?>
+            <?php echo t('Tag'); ?>
+            </label>
+        </div>
+        <div class="checkbox">
+            <label>
+            <?php echo $form->checkbox('useFilterDate', 1, $useFilterDate); ?>
+            <?php echo t('Date'); ?>
+            </label>
+        </div>
+
+        <div class="filterTopicOptions">
+            <div class="form-group">
+                <?php echo $form->label('topicTextFormat', t('Topic Text Formatting')); ?>
+                <?php echo $form->select('topicTextFormat',
+                    array(
+                        0 => t('Default'),
+                        'upperFirst' => t('Capitalize the first letter of each word'),
+                        'lowercase' => t('Lowercase'),
+                        'uppercase' => t('Uppercase')
+                    ), $topicTextFormat); ?>
+            </div>
+        </div>
+        <div class="filterTagOptions">
+            <div class="form-group">
+                <?php echo $form->label('tagTextFormat', t('Tag Text Formatting')); ?>
+                <?php echo $form->select('tagTextFormat',
+                    array(
+                        'upperFirst' => t('Capitalize the first letter of each word'),
+                        'lowercase' => t('Lowercase'),
+                        'uppercase' => t('Uppercase')
+                    ), $tagTextFormat); ?>
+            </div>
+        </div>
+        <div class="filterDateOptions">
+            <div class="form-group">
+                <?php echo $form->label('dateTextFormat', t('Date Text Formatting')); ?>
+                <?php echo $form->select('dateTextFormat',
+                    array(
+                        0 => t('Default'),
+                        'upperFirst' => t('Capitalize the first letter of each word'),
+                        'lowercase' => t('Lowercase'),
+                        'uppercase' => t('Uppercase')
+                    ), $dateTextFormat); ?>
+            </div>
+            <div class="form-group">
+                <?php echo $form->label('filterDateFormat', t('Date Year and Month Format')); ?>
+                <?php echo $form->text('filterDateFormat', $filterDateFormat ? $filterDateFormat : t('F Y')); ?>
+            </div>
+            <div class="text-muted"><?php echo sprintf(t('See the formatting options for year and month at %s.'), '<a href="http://www.php.net/date" target="_blank">php.net/date</a>'); ?></div>
+        </div>
+    </div>
+</div>
+
+<script>
+$(document).ready(function() {
+    if ($('#useFilterTitle').prop('checked')) {
+        $('.filterTitleOptions').show();
+    } else {
+        $('.filterTitleOptions').hide();
+    }
+    $('#useFilterTitle').on('change', function() {
+        $('.filterTitleOptions').toggle();
+    });
+
+    if ($('#useFilterTopic').prop('checked')) {
+        $('.filterTopicOptions').show();
+    } else {
+        $('.filterTopicOptions').hide();
+    }
+    $('#useFilterTopic').on('change', function() {
+        $('.filterTopicOptions').toggle();
+    });
+
+    if ($('#useFilterTag').prop('checked')) {
+        $('.filterTagOptions').show();
+    } else {
+        $('.filterTagOptions').hide();
+    }
+    $('#useFilterTag').on('change', function() {
+        $('.filterTagOptions').toggle();
+    });
+
+    if ($('#useFilterDate').prop('checked')) {
+        $('.filterDateOptions').show();
+    } else {
+        $('.filterDateOptions').hide();
+    }
+    $('#useFilterDate').on('change', function() {
+        $('.filterDateOptions').toggle();
+    });
+});
+</script>

--- a/web/concrete/blocks/page_title/view.php
+++ b/web/concrete/blocks/page_title/view.php
@@ -1,2 +1,21 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied."); ?>
-<<?=$formatting;?> class="page-title"><?php echo h($title)?></<?=$formatting;?>>
+<?php  defined('C5_EXECUTE') or die('Access Denied.');
+
+if ($useFilterTitle) {
+    if (is_object($currentTopic) && $useFilterTopic) {
+        $title = $controller->formatPageTitle($currentTopic->getTreeNodeDisplayName(), $topicTextFormat);
+    }
+    if ($tag && $useFilterTag) {
+        $title = $controller->formatPageTitle($tag, $tagTextFormat);
+    }
+    if ($year && $month && $useFilterDate) {
+        $srv = Core::make('helper/date');
+        $date = strtotime("$year-$month-01");
+        $title = $srv->date($filterDateFormat ? $filterDateFormat : 'F Y', $date);
+
+        $title = $controller->formatPageTitle($title, $dateTextFormat);
+    }
+}
+
+if ($title) {
+    echo "<$formatting  class=\"page-title\">" . h($title) . "<$formatting>";
+}

--- a/web/concrete/blocks/tags/controller.php
+++ b/web/concrete/blocks/tags/controller.php
@@ -136,7 +136,7 @@ class Controller extends BlockController
             $target = \Page::getCurrentPage();
         }
         if ($option) {
-            return \URL::page($target, 'tag', strtolower($option->getSelectAttributeOptionDisplayValue()));
+            return \URL::page($target, 'tag', mb_strtolower($option->getSelectAttributeOptionDisplayValue()));
         } else {
             return \URL::page($target);
         }


### PR DESCRIPTION
This pull request adds topic, tag, and date "filtering" to the Page Title block. Allowing the text of the Page Title block to be updated to reflect the current topic, tag, or date. It includes basic text case formatting of default (no formatting change), capitalize the first letter of each word, lowercase, and uppercase.

**Topic text formatting:**
- Default (no formatting change)
- Capitalize the first letter of each word
- Lowercase
- Uppercase

**Tag text formatting:**
- Capitalize the first letter of each word
- Lowercase
- Uppercase   

_Tag text has no default formatting_

**Date text formatting:**
- Default (no formatting change)
- Capitalize the first letter of each word
- Lowercase
- Uppercase

![1](https://cloud.githubusercontent.com/assets/10898145/14939079/569605d4-0f06-11e6-969a-895ede4240ec.png)

![2](https://cloud.githubusercontent.com/assets/10898145/14939080/5c1094a2-0f06-11e6-91eb-1eea5334b14d.png)

![3](https://cloud.githubusercontent.com/assets/10898145/14939081/5e3225de-0f06-11e6-883c-b9ce92750c10.png)

![4](https://cloud.githubusercontent.com/assets/10898145/14939083/60783ae0-0f06-11e6-849d-f34707e59389.png)

![5](https://cloud.githubusercontent.com/assets/10898145/14939085/62edf36e-0f06-11e6-847f-cb5605675dde.png)

**Examples of text used to test:**
サンドイッチポテト
Сэндвич Картофеля
תפוח אדמה כריך
土豆三明治
schräger Vogel £

I tested the title filtering using German, Hebrew, Russian, Chinese, and Japanese. Making sure to include accented characters, like the German umlaut. I found that the standard strtolower(), strtoupper(), and ucwords() functions to convert text case did not work with certain languages. Causing them to fail to display or display incorrectly. Using mb_strtolower(), mb_strtoupper(), and mb_convert_case(), I was able to display all languages correctly. The URLs created by the Tags block are made using strtolower(), which caused issues displaying certain languages, so I replaced it with mb_strtolower().

Page title filtering does not work with block caching. Some users may only use the Page Title block to display a basic page title and will never use the title filtering. I did not want to disable block caching for everyone, so I added a check in the controller on_start() method - conditionally enabling or disabling caching based on whether it was checked in the block form. This appears to work, but I am not sure if it correct or used correctly.
```
public function on_start()
{
    if ($this->useFilterTitle) {
        $this->btCacheBlockOutput = false;
        $this->btCacheBlockOutputOnPost = false;
    }
}
```

I do not have experience with localization and handling multiple languages. Because of this I would kindly ask that others with this experience, like @mlocati, please review the changes I have made. I have attempted to test it thoroughly, but know it is likely that I have made mistakes.

An example:
When using mb_strtolower(), mb_strtoupper(), and mb_convert_case() is the encoding parameter required to be defined or is the default internal character encoding value acceptable?

This pull request makes changes to the block db.xml, but I am not familiar with how to create the migration update script.

https://github.com/concrete5/concrete5/issues/3626