### PR TITLE
Suggestion to add "crop" option to thumbnail

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -3271,6 +3271,10 @@
       <default value="0"/>
       <notnull/>
     </field>
+    <field name="ftTypeIsConstrained" type="boolean">
+      <default value="0"/>
+      <notnull/>
+    </field>
   </table>
 
   <table name="FileStorageLocations">

--- a/web/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/web/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -58,6 +58,11 @@ class Thumbnails extends DashboardPageController {
             $this->error->add(t('Width must be greater than zero.'));
         }
 
+        $IsConstrained = (bool) $request->request->get('ftTypeIsConstrained');
+        if (!is_bool($IsConstrained)) {
+            $this->error->add(t('Something wrong with crop option.'));
+        }
+
         if ($valStrings->notempty($request->request->get('ftTypeHeight'))) {
             if (!$valNumbers->integer($request->request->get('ftTypeHeight'))) {
                 $this->error->add(t('If used, height can only be an integer, with no units.'));
@@ -119,6 +124,7 @@ class Thumbnails extends DashboardPageController {
             } else {
                 $type->setHeight(null);
             }
+            $type->setConstrained((bool) $request->request->get('ftTypeIsConstrained'));
             $type->setName($request->request->get('ftTypeName'));
             $type->setHandle($request->request->get('ftTypeHandle'));
             $type->save();
@@ -141,6 +147,7 @@ class Thumbnails extends DashboardPageController {
                 $type->setHeight($request->request->get('ftTypeHeight'));
             }
             $type->setWidth($request->request->get('ftTypeWidth'));
+            $type->setConstrained((bool) $request->request->get('ftTypeIsConstrained'));
             $type->setName($request->request->get('ftTypeName'));
             $type->setHandle($request->request->get('ftTypeHandle'));
             $type->save();

--- a/web/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/web/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -13,6 +13,7 @@
         $ftTypeWidth = $type->getWidth();
         $ftTypeHeight = $type->getHeight();
         $ftTypeIsRequired = $type->isRequired();
+        if ($type->isConstrained()) $ftTypeIsConstrained = 1;
         $method = 'update';
 
         if (!$ftTypeIsRequired) { ?>
@@ -64,7 +65,11 @@
                 <?=$form->label('ftTypeHeight', t('Height'))?>
                 <?=$form->text('ftTypeHeight', $ftTypeHeight)?>
             </div>
-            <div class="alert alert-info"><i class="fa fa-exclamation-circle"></i> <?=t('Only place a value in here if you want this thumbnail to force its dimensions to the width and height.')?></div>
+            <div class="form-group">
+                <div><?=$form->label('ftTypeIsConstrained', t('Crop?'))?></div>
+                <?=$form->checkbox('ftTypeIsConstrained', 1, $ftTypeIsConstrained)?> <?=t('No, keep images\' contrained ratio')?>
+            </div>
+            <div class="alert alert-info"><i class="fa fa-exclamation-circle"></i> <?=t('If you leave the height field empty, the value of width becomes the max width and/or height and constrain the image ratio. If you set both width and height, concrete5 will try to crop the thumbnail to indicated size unless you check "No" to the crop option.')?></div>
         </fieldset>
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
@@ -103,6 +108,7 @@
         <th><?=t('Width')?></th>
         <th><?=t('Height')?></th>
         <th><?=t('Required')?></th>
+        <th><?=t('Contrain')?></th>
     </tr>
     </thead>
     <tbody>
@@ -113,6 +119,7 @@
         <td><?=$type->getWidth()?></td>
         <td><?=($type->getHeight()) ? $type->getHeight() : '<span class="text-muted">' . t('Automatic') . '</span>' ?></td>
         <td><?=($type->isRequired()) ? t('Yes') : t('No')?></td>
+        <td><?=($type->isConstrained()) ? t('Yes') : t('No')?></td>
     </tr>
     <? } ?>
     </tbody>

--- a/web/concrete/src/File/Image/Thumbnail/Type/Type.php
+++ b/web/concrete/src/File/Image/Thumbnail/Type/Type.php
@@ -36,6 +36,11 @@ class Type
     protected $ftTypeIsRequired = false;
 
     /**
+     * @Column(type="boolean")
+     */
+    protected $ftTypeIsConstrained = false;
+
+    /**
      * @Id @Column(type="integer")
      * @GeneratedValue
      */
@@ -79,6 +84,14 @@ class Type
     public function isRequired()
     {
         return $this->ftTypeIsRequired;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function isConstrained()
+    {
+        return $this->ftTypeIsConstrained;
     }
 
     /**
@@ -130,6 +143,14 @@ class Type
     public function setHeight($ftTypeHeight)
     {
         $this->ftTypeHeight = is_numeric($ftTypeHeight) ? $ftTypeHeight : null;
+    }
+
+    /**
+     * @param mixed $ftTypeIsConstrained
+     */
+    public function setConstrained($ftTypeIsConstrained)
+    {
+        $this->ftTypeIsConstrained = is_bool($ftTypeIsConstrained) ? $ftTypeIsConstrained : false;
     }
 
     /**
@@ -195,6 +216,9 @@ class Type
             if ($link->isRequired()) {
                 $linkNode->addAttribute('required', $link->isRequired());
             }
+            if ($link->isConstrained()) {
+                $linkNode->addAttribute('constrained', $link->isConstrained());
+            }
         }
     }
 
@@ -237,7 +261,7 @@ class Type
 
     public function getBaseVersion()
     {
-        return new Version($this->getHandle(), $this->getHandle(), $this->getName(), $this->getWidth(), $this->getHeight());
+        return new Version($this->getHandle(), $this->getHandle(), $this->getName(), $this->getWidth(), $this->getHeight(), false, $this->isConstrained());
     }
 
     public function getDoubledVersion()
@@ -247,6 +271,6 @@ class Type
             $height = $this->getHeight() * 2;
         }
 
-        return new Version($this->getHandle() . '_2x', $this->getHandle() . '_2x', $this->getName(), $this->getWidth() * 2, $height, true);
+        return new Version($this->getHandle() . '_2x', $this->getHandle() . '_2x', $this->getName(), $this->getWidth() * 2, $height, true, $this->isConstrained());
     }
 }

--- a/web/concrete/src/File/Image/Thumbnail/Type/Version.php
+++ b/web/concrete/src/File/Image/Thumbnail/Type/Version.php
@@ -17,9 +17,10 @@ class Version
     protected $name;
     protected $width;
     protected $height;
+    protected $isConstraied;
     protected $isDoubledVersion;
 
-    public function __construct($directoryName, $handle, $name, $width, $height, $isDoubledVersion = false)
+    public function __construct($directoryName, $handle, $name, $width, $height, $isDoubledVersion = false, $isConstrained = false)
     {
         $this->handle = $handle;
         $this->name = $name;
@@ -27,6 +28,7 @@ class Version
         $this->height = $height;
         $this->directoryName = $directoryName;
         $this->isDoubledVersion = (bool) $isDoubledVersion;
+        $this->isConstrained = (bool) $isConstrained;
     }
 
     /**
@@ -113,6 +115,22 @@ class Version
     public function getHeight()
     {
         return $this->height;
+    }
+
+    /**
+     * @param mixed $isConstrained
+     */
+    public function setConstrained($isConstrained)
+    {
+        $this->isConstrained = $isConstrained;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function isConstrained()
+    {
+        return $this->isConstrained;
     }
 
     /**

--- a/web/concrete/src/File/Version.php
+++ b/web/concrete/src/File/Version.php
@@ -768,10 +768,15 @@ class Version
 
                 $height = $type->getHeight();
                 $thumbnailMode = ImageInterface::THUMBNAIL_OUTBOUND;
-                if (!$height) {
-                    $height = $type->getWidth();
+                if ($type->isConstrained()) {
+                    $thumbnailMode = ImageInterface::THUMBNAIL_INSET;
+                } elseif (!$height) {
                     $thumbnailMode = ImageInterface::THUMBNAIL_INSET;
                 }
+                if (!height) {
+                    $height = $type->getWidth();
+                }
+
                 $thumbnail = $image->thumbnail(new \Imagine\Image\Box($type->getWidth(), $height), $thumbnailMode);
                 $thumbnailPath = $type->getFilePath($this);
                 $thumbnailOptions = array();


### PR DESCRIPTION
I would like to suggest to add "crop" option to thumbnail.

I had a client who wants to set both width and height and make the $thumbnailMode to ImageInterface::THUMBNAIL_INSET.

It's like old 5.6 era of

```
$ih = Loader::helper('image');
$f = File::getByID(1);
$image = $ih->getThumbnail($thumbnail, 640, 640, false);
```

They wanted to set both max width and max height, and set the crop mode to false.

This was used in the news article page showing thumbnail image of the article.
So they sometime want to add portrait image in addition to landscape image.

In the future, I can see more of the cases like this would happen.

It would be like this
![thumbnail](https://cloud.githubusercontent.com/assets/485751/11924662/4a119d3a-a7f7-11e5-8d56-059b1f1eb0ac.png)

What do you think?
