### PR TITLE
Fix: Resolve BIZARRE issue with using ::loginByUserID() from within a class method

### DIFF
--- a/web/concrete/src/User/User.php
+++ b/web/concrete/src/User/User.php
@@ -61,9 +61,9 @@ class User extends Object
      *
      * @return User
      */
-    public function loginByUserID($uID)
+    public static function loginByUserID($uID)
     {
-        return self::getByUserID($uID, true);
+        return static::getByUserID($uID, true);
     }
 
     public static function isLoggedIn()


### PR DESCRIPTION
Due to LSB and some extremely bizarre PHP behavior, `\User::loginByUserID()` previously did not work from within a class method.

To replicate open up /application/bootstrap/app.php and replace the contents with:

```php
<?php

class Foo {

    public function bar() {
        \Concrete\Core\User\User::loginByUserID(1);
    }

}

$f = new Foo;
$f->bar();
```

The error you see will make you very confused. This pull requests resolves that issue and makes this behave in a sane way.
