### PR TITLE
Fix: Move community oauth service bootstrapping to a factory class.

### DIFF
--- a/web/concrete/authentication/community/controller.php
+++ b/web/concrete/authentication/community/controller.php
@@ -1,12 +1,17 @@
 <?php
 namespace Concrete\Authentication\Community;
 
+use Concrete\Core\Authentication\Type\Community\Factory\CommunityServiceFactory;
 use Concrete\Core\Authentication\Type\Community\Service\Community;
+use Concrete\Core\Authentication\Type\Community\Service\Community as CommunityService;
 use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
+use Concrete\Core\Support\Facade\Application;
 use Core;
+use OAuth\ServiceFactory;
 
 class Controller extends GenericOauth2TypeController
 {
+
     public function registrationGroupID()
     {
         return \Config::get('auth.community.registration.group');
@@ -35,7 +40,16 @@ class Controller extends GenericOauth2TypeController
     public function getService()
     {
         if (!$this->service) {
-            $this->service = \Core::make('authentication/community');
+            /** @var \Concrete\Core\Application\Application $app */
+            $app = Application::getFacadeApplication();
+
+            /** @var ServiceFactory $serviceFactory */
+            $serviceFactory = $app->make('oauth/factory/service');
+            $serviceFactory->registerService('community', CommunityService::class);
+
+            /** @var CommunityServiceFactory $communityFactory */
+            $communityFactory = $app->make(CommunityServiceFactory::class);
+            $this->service = $communityFactory->createService($serviceFactory);
         }
 
         return $this->service;
@@ -76,4 +90,5 @@ class Controller extends GenericOauth2TypeController
             dd($e);
         }
     }
+
 }

--- a/web/concrete/authentication/community/controller.php
+++ b/web/concrete/authentication/community/controller.php
@@ -40,15 +40,12 @@ class Controller extends GenericOauth2TypeController
     public function getService()
     {
         if (!$this->service) {
-            /** @var \Concrete\Core\Application\Application $app */
-            $app = Application::getFacadeApplication();
-
             /** @var ServiceFactory $serviceFactory */
-            $serviceFactory = $app->make('oauth/factory/service');
+            $serviceFactory = $this->app->make('oauth/factory/service');
             $serviceFactory->registerService('community', CommunityService::class);
 
             /** @var CommunityServiceFactory $communityFactory */
-            $communityFactory = $app->make(CommunityServiceFactory::class);
+            $communityFactory = $this->app->make(CommunityServiceFactory::class);
             $this->service = $communityFactory->createService($serviceFactory);
         }
 

--- a/web/concrete/src/Authentication/Type/Community/Factory/CommunityServiceFactory.php
+++ b/web/concrete/src/Authentication/Type/Community/Factory/CommunityServiceFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Concrete\Core\Authentication\Type\Community\Factory;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use League\Url\UrlInterface;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Storage\SymfonySession;
+use OAuth\ServiceFactory;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+/**
+ * Class CommunityServiceFactory
+ * A simple factory class for creating community authentication services
+ *
+ * @package Concrete\Core\Authentication\Type\Community\Factory
+ */
+class CommunityServiceFactory
+{
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Session
+     */
+    protected $session;
+
+    /**
+     * @var \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface
+     */
+    protected $urlResolver;
+
+    /**
+     * CommunityServiceFactory constructor.
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     * @param \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $url
+     */
+    public function __construct(Repository $config, Session $session, ResolverManagerInterface $url)
+    {
+        $this->config = $config;
+        $this->session = $session;
+        $this->urlResolver = $url;
+    }
+
+    /**
+     * Create a service object given a ServiceFactory object
+     *
+     * @param \OAuth\ServiceFactory $factory
+     * @return \OAuth\Common\Service\ServiceInterface
+     */
+    public function createService(ServiceFactory $factory)
+    {
+        $appId = $this->config->get('auth.community.appid');
+        $appSecret = $this->config->get('auth.community.secret');
+
+        // Get the callback url
+        $callbackUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/community/callback/']);
+
+        // Create a credential object with our ID, Secret, and callback url
+        $credentials = new Credentials($appId, $appSecret, (string) $callbackUrl);
+
+        // Create a new session storage object and pass it the active session
+        $storage = new SymfonySession($this->session, false);
+
+        // Create the service using the oauth service factory
+        return $factory->createService('community', $credentials, $storage);
+    }
+
+}
+

--- a/web/concrete/src/Authentication/Type/Community/ServiceProvider.php
+++ b/web/concrete/src/Authentication/Type/Community/ServiceProvider.php
@@ -1,9 +1,8 @@
 <?php
 namespace Concrete\Core\Authentication\Type\Community;
 
-use OAuth\Common\Consumer\Credentials;
-use OAuth\Common\Storage\SymfonySession;
-use OAuth\ServiceFactory;
+use Concrete\Core\Authentication\Type\Community\Extractor\Community as CommunityExtractor;
+use Concrete\Core\Authentication\Type\Community\Service\Community;
 use OAuth\UserData\ExtractorFactory;
 
 class ServiceProvider extends \Concrete\Core\Foundation\Service\Provider
@@ -15,26 +14,6 @@ class ServiceProvider extends \Concrete\Core\Foundation\Service\Provider
     {
         /** @var ExtractorFactory $extractor */
         $extractor = $this->app->make('oauth/factory/extractor');
-        $extractor->addExtractorMapping(
-            'Concrete\\Core\\Authentication\\Type\\Community\\Service\\Community',
-            'Concrete\\Core\\Authentication\\Type\\Community\\Extractor\\Community');
-
-        /** @var ServiceFactory $factory */
-        $factory = $this->app->make('oauth/factory/service');
-        $factory->registerService('community', '\\Concrete\\Core\\Authentication\\Type\\Community\\Service\\Community');
-
-        $this->app->bindShared(
-            'authentication/community',
-            function ($app, $callback = '/ccm/system/authentication/oauth2/community/callback/') use ($factory) {
-                return $factory->createService(
-                    'community',
-                    new Credentials(
-                        \Config::get('auth.community.appid'),
-                        \Config::get('auth.community.secret'),
-                        (string) \URL::to($callback)
-                    ),
-                    new SymfonySession(\Session::getFacadeRoot(), false));
-            }
-        );
+        $extractor->addExtractorMapping(Community::class, CommunityExtractor::class);
     }
 }


### PR DESCRIPTION
This allows the community oauth auth type to work. The reason it didn't work previously is because callables bound to core accept two parameters, `$app` and `$args` while the bound callable was expecting a string. This caused the callback url to always be an empty string which would break oauth.

I took this opportunity to move this logic into a factory class. Note that all of the dependencies of the factory class are provided by the IoC container.