### PR TITLE
Fix Tree\Node\Type\SearchPreset::add should be compatible with Tree\Node\Node::add

### DIFF
--- a/web/concrete/controllers/dialog/file/advanced_search.php
+++ b/web/concrete/controllers/dialog/file/advanced_search.php
@@ -84,7 +84,7 @@ class AdvancedSearch extends BackendInterfaceController
 
             $filesystem = new Filesystem();
             $folder = $filesystem->getRootFolder();
-            $node = \Concrete\Core\Tree\Node\Type\SearchPreset::add($search, $folder);
+            $node = \Concrete\Core\Tree\Node\Type\SearchPreset::addSearchPreset($search, $folder);
 
             $provider = $this->app->make('Concrete\Core\File\Search\SearchProvider');
             $result = $provider->getSearchResultFromQuery($query);

--- a/web/concrete/src/Tree/Node/Type/SearchPreset.php
+++ b/web/concrete/src/Tree/Node/Type/SearchPreset.php
@@ -110,7 +110,7 @@ class SearchPreset extends Node
         return new SavedSearchListFormatter();
     }
 
-    public static function add(SavedFileSearch $search, $parent = false)
+    public static function addSearchPreset(SavedFileSearch $search, $parent = false)
     {
         $node = parent::add($parent);
         if (is_object($search)) {


### PR DESCRIPTION
This PR fixes this problem (that prevents installing on PHP 7):
```
Declaration of
Concrete\Core\Tree\Node\Type\SearchPreset::add()
should be compatible with
Concrete\Core\Tree\Node\Node::add($parent = false)
```
