### PR TITLE
Correctly initialize the block type controllers

### DIFF
--- a/web/concrete/src/Block/BlockType/BlockType.php
+++ b/web/concrete/src/Block/BlockType/BlockType.php
@@ -8,7 +8,7 @@ use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Filesystem\TemplateFile;
 use Concrete\Core\Package\PackageList;
-use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Support\Facade\Facade;
 use Core;
 use Database as DB;
 use Environment;
@@ -757,13 +757,8 @@ class BlockType
     protected function loadController()
     {
         $class = static::getBlockTypeMappedClass($this->getBlockTypeHandle(), $this->getPackageHandle());
-
-        /** @var Controller controller */
         if ($class) {
-            $this->controller = new $class($this);
-
-            /** @todo Move controller construction out of BlockType */
-            $this->controller->setApplication(Application::getFacadeApplication());
+            $this->controller = Facade::getFacadeApplication()->build($class, [$this]);
         }
     }
 }


### PR DESCRIPTION
Block type controllers implements `ApplicationAwareInterface`, so they should be instantiated correctly with the ioc (otherwise their `$app` property is not set).