### PR TITLE
Switch to the new Transifex resource

### DIFF
--- a/build/tasks/build-release/translations.js
+++ b/build/tasks/build-release/translations.js
@@ -10,7 +10,7 @@ module.exports = function(grunt, config, parameters, done) {
         buildParameters = parameters;
         buildParameters.destination = workFolder;
         if(!parameters.txResource) {
-        	parameters.txResource = 'core-dev-57';
+        	parameters.txResource = 'core-dev-8';
         }
         require('../translations.js')(grunt, config, buildParameters, done);
 	}


### PR DESCRIPTION
Since concrete5 v8 and v5.7 have a quite different set of translatable strings, I created a new Transifex resource (otherwise we'd have lost 110 translations for every language).

I'm really looking forward for [CommunityTranslation](https://github.com/concrete5/addon_community_translation)... :wink: