### PR TITLE
Bugfix : error on form submission (events class not found)

### DIFF
--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -578,7 +578,7 @@ class Controller extends BlockController
                 @$mh->sendMail();
             }
             
-            //launch form submission event
+            //launch form submission event with dispatch method
             $formEventData = array();
             $formEventData['bID'] = intval($this->bID);
             $formEventData['questionSetID'] = $this->questionSetId;

--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -14,6 +14,7 @@ use FileSet;
 use File;
 use Config;
 use Concrete\Core\File\Version;
+use Events;
 
 class Controller extends BlockController
 {
@@ -586,7 +587,7 @@ class Controller extends BlockController
             $formEventData['questionAnswerPairs'] = $questionAnswerPairs;
             $event = new \Symfony\Component\EventDispatcher\GenericEvent();
             $event->setArgument('formData', $formEventData);
-            Events::fire('on_form_submission', $event);
+            Events::dispatch('on_form_submission', $event);
 
             if (!$this->noSubmitFormRedirect) {
                 $targetPage = null;


### PR DESCRIPTION
(concerning jozzeh-patch-2)
When a form is submitted an error would occur (Events class not found).
This patch fixes that error and it also uses the new Events dispatch method instead of the old fire method. **Fully tested**

Added Events class at top of the file
+
Changed deprecated event fire method to current dispatch method

This is a bugfix and should be merged asap. 