### PR TITLE
Make Stack::getMultilingualSectionFromType static

### DIFF
--- a/web/concrete/src/Page/Stack/Stack.php
+++ b/web/concrete/src/Page/Stack/Stack.php
@@ -165,7 +165,7 @@ class Stack extends Page implements ExportableInterface
         return $stack;
     }
 
-    protected function getMultilingualSectionFromType($type)
+    protected static function getMultilingualSectionFromType($type)
     {
         $detector = Core::make('multilingual/detector');
         if ($type == self::MULTILINGUAL_CONTENT_SOURCE_DEFAULT) {


### PR DESCRIPTION
It's called statically and it does not contain any reference to `$this`