### PR TITLE
Add translation context to 'On' used for dates

### DIFF
--- a/web/concrete/elements/permission/duration.php
+++ b/web/concrete/elements/permission/duration.php
@@ -375,7 +375,7 @@ for ($i = 0; $i < count($values); $i++) {
         <div id="ccm-permissions-access-entity-dates-repeat-weekly-dow" style="display: none">
 
             <div class="form-group">
-                <label class="control-label"><?= t('On') ?></label>
+                <label class="control-label"><?= tc('Date', 'On') ?></label>
                 <div class="">
                     <?php
                     foreach (\Punic\Calendar::getSortedWeekdays('wide') as $weekDay) {


### PR DESCRIPTION
The text `On` is translatable in two places:
- [here](https://github.com/concrete5/concrete5/blob/426b1f409e4dad3ce6e53e898d1713ec7f3e3f4b/web/concrete/elements/permission/duration.php#L378) it's used as a prefix for dates
- [here](https://github.com/concrete5/concrete5/blob/426b1f409e4dad3ce6e53e898d1713ec7f3e3f4b/web/concrete/single_pages/dashboard/system/registration/open.php#L35) it's used to set a value of an option (as in `On`/`Off`)

Since they have a totally different meaning, we need to distinguish them with a translation context, so that they can have different translations.