### PR TITLE
Fix UserInfo trigger methods

### DIFF
--- a/web/concrete/src/User/UserInfo.php
+++ b/web/concrete/src/User/UserInfo.php
@@ -99,7 +99,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
 
     public function triggerDelete()
     {
-        global $u;
+        $u = new \User();
 
         $db = $this->connection;
         $v = array($this->uID);
@@ -501,7 +501,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
     function triggerActivate($action=null, $requesterUID=null)
     {
         if ($requesterUID === null) {
-            global $u;
+            $u = new \User();
             $requesterUID = $u->getUserID();
         }
 
@@ -534,7 +534,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
 
     function triggerDeactivate()
     {
-        global $u;
+        $u = new \User();
 
         $db = $this->connection;
         $v = array($this->uID);


### PR DESCRIPTION
Activating/deactivating users results in a `Call to a member function getUserID() on a non-object` error.

I noticed that the UserInfo::trigger...() methods make use of `global $u`, but that `$u` seems to be not defined...