### PR TITLE
fix for ignore excluded nav items still being excluded.

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -31,6 +31,7 @@ class Controller extends BlockController
     public $haveRetrievedSelfPlus1 = false;
     public $displaySystemPages = false;
     public $displayUnapproved = false;
+    public $ingnoreExludeNav = false;
     protected $btTable = 'btNavigation';
     protected $btInterfaceWidth = "800";
     protected $btInterfaceHeight = "350";
@@ -176,6 +177,8 @@ class Controller extends BlockController
             }
         }
 
+        $this->ingnoreExludeNav = $ignore_exclude_nav;
+
         //Retrieve the raw "pre-processed" list of all nav items (before any custom attributes are considered)
         $allNavItems = $this->generateNav();
 
@@ -201,7 +204,7 @@ class Controller extends BlockController
                 }
             }
 
-            if (!$exclude_page || $ignore_exclude_nav) {
+            if (!$exclude_page || $this->ingnoreExludeNav) {
                 $includedNavItems[] = $ni;
             }
         }
@@ -513,7 +516,7 @@ class Controller extends BlockController
     {
         // Check if the parent page is excluded or if it has been set to exclude child pages
         foreach ($this->navArray as $ni) {
-            if ($ni->getCollectionID() == $cParentID) {
+            if ($ni->getCollectionID() == $cParentID && $this->ingnoreExludeNav === false) {
                 if ($ni->getCollectionObject()->getAttribute('exclude_nav') == 1 || $ni->getCollectionObject()->getAttribute('exclude_subpages_from_nav') == 1) {
                     return;
                 }

--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -31,7 +31,7 @@ class Controller extends BlockController
     public $haveRetrievedSelfPlus1 = false;
     public $displaySystemPages = false;
     public $displayUnapproved = false;
-    public $ingnoreExludeNav = false;
+    public $ignoreExcludeNav = false;
     protected $btTable = 'btNavigation';
     protected $btInterfaceWidth = "800";
     protected $btInterfaceHeight = "350";
@@ -177,7 +177,7 @@ class Controller extends BlockController
             }
         }
 
-        $this->ingnoreExludeNav = $ignore_exclude_nav;
+        $this->ignoreExcludeNav = $ignore_exclude_nav;
 
         //Retrieve the raw "pre-processed" list of all nav items (before any custom attributes are considered)
         $allNavItems = $this->generateNav();
@@ -204,7 +204,7 @@ class Controller extends BlockController
                 }
             }
 
-            if (!$exclude_page || $this->ingnoreExludeNav) {
+            if (!$exclude_page || $this->ignoreExcludeNav) {
                 $includedNavItems[] = $ni;
             }
         }
@@ -516,7 +516,7 @@ class Controller extends BlockController
     {
         // Check if the parent page is excluded or if it has been set to exclude child pages
         foreach ($this->navArray as $ni) {
-            if ($ni->getCollectionID() == $cParentID && $this->ingnoreExludeNav === false) {
+            if ($ni->getCollectionID() == $cParentID && $this->ignoreExcludeNav === false) {
                 if ($ni->getCollectionObject()->getAttribute('exclude_nav') == 1 || $ni->getCollectionObject()->getAttribute('exclude_subpages_from_nav') == 1) {
                     return;
                 }


### PR DESCRIPTION
Children where still excluded when using `$ignore_exclude_nav`.  
In a page template we now also can set the option to ingnore exluded nav items. There is no need to adjust the autonav template.  

```
$nav = BlockType::getByHandle('autonav');  
$nav->controller->ingnoreExludeNav = true;
```