### PR TITLE
Construct block controllers using the application object

### DIFF
--- a/web/concrete/src/Block/BlockType/BlockType.php
+++ b/web/concrete/src/Block/BlockType/BlockType.php
@@ -753,10 +753,8 @@ class BlockType
 
         /** @var Controller controller */
         if ($class) {
-            $this->controller = new $class($this);
-
-            /** @todo Move controller construction out of BlockType */
-            $this->controller->setApplication(Application::getFacadeApplication());
+            $app = Application::getFacadeApplication();
+            $this->controller = $app->build($class, [$this]);
         }
     }
 }


### PR DESCRIPTION
Construct the block controller objects using the application object. This allows block developers to use their constructor to request dependencies.

IE:

```php
class CustomBlock extends BlockController
{

    protected $config;

    public function __construct($blockType, Repository $config)
    {
        parent::__construct($blockType);
        $this->config = $config;
    }

}
```