### PR TITLE
Fix: Provide config mock for usage tracker test

### DIFF
--- a/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Concrete\tests\Core\Statistics\UsageTracker;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
 use Concrete\Core\Statistics\UsageTracker\ServiceProvider;
 use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
@@ -13,6 +14,14 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testRegister()
     {
         $app = new Application();
+
+        // This service provider requires a config repository be registered
+        $mockBuilder = $this->getMockBuilder(Repository::class);
+        $repository = $mockBuilder->disableOriginalConstructor()->getMock();
+
+        $app->bind('config', function() use ($repository) {
+            return $repository;
+        });
 
         $provider = new ServiceProvider($app);
         $provider->register();

--- a/web/concrete/src/Statistics/UsageTracker/ServiceProvider.php
+++ b/web/concrete/src/Statistics/UsageTracker/ServiceProvider.php
@@ -18,11 +18,12 @@ class ServiceProvider extends Provider
             /** @var AggregateTracker $tracker */
             $tracker = $app->build(AggregateTracker::class);
 
-            $config = $app['config']['statistics.trackers'];
-            foreach ($config as $key => $tracker_string) {
-                $tracker->addTracker($key, function(Application $app) use ($tracker_string) {
-                    return $app->make($tracker_string);
-                });
+            if ($trackers = $app['config']['statistics.trackers']) {
+                foreach ($trackers as $key => $tracker_string) {
+                    $tracker->addTracker($key, function (Application $app) use ($tracker_string) {
+                        return $app->make($tracker_string);
+                    });
+                }
             }
 
             return $tracker;


### PR DESCRIPTION
This provides a mock repository object in order to allow the tests to complete.