### PR TITLE
Remove useless CollectionVersion::canWrite

### DIFF
--- a/web/concrete/src/Page/Collection/Version/Version.php
+++ b/web/concrete/src/Page/Collection/Version/Version.php
@@ -261,11 +261,6 @@ class Version extends Object implements \Concrete\Core\Permission\ObjectInterfac
         return $this->cvDateCreated;
     }
 
-    public function canWrite()
-    {
-        return $this->cvCanWrite;
-    }
-
     public function setComment($comment)
     {
         $thisCVID = $this->getVersionID();


### PR DESCRIPTION
I really don't know what this method is meant to do... I can't find any call to this method in the core, and the cvCanWrite field is never set...