### PR TITLE
Update ErrorHandler.php

### DIFF
--- a/web/concrete/src/Error/Handler/ErrorHandler.php
+++ b/web/concrete/src/Error/Handler/ErrorHandler.php
@@ -32,9 +32,16 @@ class ErrorHandler extends PrettyPageHandler
                 $result = parent::handle();
             } else {
                 $e = $this->getInspector()->getException();
+                $estr = sprintf("File: %s<br />
+                                 Line: %d<br />
+                                 Error Text: %s"
+                                ,h($e->getFile())
+                                ,$e->getLine()
+                                ,h($e->getMessage())
+                               );
                 Core::make('helper/concrete/ui')->renderError(
-                    t('An unexpected error occurred.'),
-                    h($e->getMessage())
+                    t(sprintf('An unexpected PHP error (%d) occurred.',$e->getCode()))
+                   ,$estr
                 );
             }
         } else {


### PR DESCRIPTION
This should allow for more verbose output of the PHP error text, as per 
https://www.concrete5.org/community/forums/customizing_c5/error-text-alteration/

(did not run php-code-fixer)
