### PR TITLE
v8: Fix - Add additional package namespaces to the driver chain.

### DIFF
--- a/web/concrete/src/Database/EntityManagerConfigFactory.php
+++ b/web/concrete/src/Database/EntityManagerConfigFactory.php
@@ -174,20 +174,24 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
 
         // add Annotation drivers with "legacy" Annotation reader
         if (count($driverSettingsLegacy) > 0) {
-            foreach ($driverSettingsLegacy as $setting) {
-                $simpleAnnotationDriver = new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($this->getCachedSimpleAnnotationReader(),
-                    $setting['paths']);
-                $driverChain->addDriver($simpleAnnotationDriver,
-                    $setting['namespace']);
+            foreach ($driverSettingsLegacy as $settings) {
+                foreach($settings as $setting){
+                    $simpleAnnotationDriver = new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($this->getCachedSimpleAnnotationReader(),
+                        $setting['paths']);
+                    $driverChain->addDriver($simpleAnnotationDriver,
+                        $setting['namespace']);
+                }
             }
         }
 
         // add Annotation drivers with normal Annotation reader -> Annotation prefixed with \ORM
         if (count($driverSettingsDefault) > 0) {
-            foreach ($driverSettingsDefault as $setting) {
-                $annotationDriver = new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($this->getCachedAnnotationReader(),
-                    $setting['paths']);
-                $driverChain->addDriver($annotationDriver, $setting['namespace']);
+            foreach ($driverSettingsDefault as $settings) {
+                foreach($settings as $setting){
+                    $annotationDriver = new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($this->getCachedAnnotationReader(),
+                        $setting['paths']);
+                    $driverChain->addDriver($annotationDriver, $setting['namespace']);
+                }
             }
         }
     }
@@ -202,9 +206,11 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
     {
         $driverSettings = $this->app->make('config')->get(CONFIG_ORM_METADATA_XML);
         if (count($driverSettings) > 0) {
-            foreach ($driverSettings as $setting) {
-                $xmlDriver = new \Doctrine\ORM\Mapping\Driver\XmlDriver($setting['paths']);
-                $driverChain->addDriver($xmlDriver, $setting['namespace']);
+            foreach ($driverSettings as $settings) {
+                foreach($settings as $setting){
+                    $xmlDriver = new \Doctrine\ORM\Mapping\Driver\XmlDriver($setting['paths']);
+                    $driverChain->addDriver($xmlDriver, $setting['namespace']);
+                }
             }
         }
     }
@@ -219,9 +225,11 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
     {
         $driverSettings = $this->app->make('config')->get(CONFIG_ORM_METADATA_YAML);
         if (count($driverSettings) > 0) {
-            foreach ($driverSettings as $setting) {
-                $yamlDriver = new \Doctrine\ORM\Mapping\Driver\YamlDriver($setting['paths']);
-                $driverChain->addDriver($yamlDriver, $setting['namespace']);
+            foreach ($driverSettings as $settings) {
+                foreach($settings as $setting){
+                    $yamlDriver = new \Doctrine\ORM\Mapping\Driver\YamlDriver($setting['paths']);
+                    $driverChain->addDriver($yamlDriver, $setting['namespace']);
+                }
             }
         }
     }

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -748,13 +748,16 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function getPackageMetadataPaths()
     {
+        // check if the name space should be treated as core extension
+        $corePath = $this->pkgAutoloaderMapCoreExtensions ? DIRECTORY_SEPARATOR . 'Concrete' : '';
+        
         // annotations entity path
         if ($this->metadataDriver === self::PACKAGE_METADATADRIVER_ANNOTATION){
             // Support for the legacy method for backwards compatibility
             if (method_exists($this, 'getPackageEntityPath')) {
                 $paths = array($this->getPackageEntityPath());
             }else{
-                $paths = array($this->getPackagePath() . '/' . DIRNAME_CLASSES);
+                $paths = array($this->getPackagePath() . DIRECTORY_SEPARATOR . DIRNAME_CLASSES . $corePath);
             }
         } else if ($this->metadataDriver === self::PACKAGE_METADATADRIVER_XML){
             // return xml metadata dir
@@ -785,7 +788,29 @@ abstract class Package implements LocalizablePackageInterface
         return $leadingBkslsh . 'Concrete\\Package\\' . camelcase($this->getPackageHandle());
     }
     
+    /**
+     * Get additional namespaces from the pkgAutoloaderRegistries
+     * if it contains any
+     */
+    public function getAdditionalNamespaces(){
         
+        $namespaces = array();
+        
+        if(count($this->pkgAutoloaderRegistries) > 0){
+            foreach($this->pkgAutoloaderRegistries as $src => $rawNamespace){
+                
+                $path = $this->getPackagePath() . DIRECTORY_SEPARATOR . $src;
+                
+                $namespace = ltrim($rawNamespace, '\\');
+                $namespaces[] = array(
+                        'namespace' => $namespace,
+                        'paths' => array($path)
+                    );
+            }
+        }
+        return $namespaces;
+    }
+    
     /**
      * Create a entity manager used for the package installation, 
      * update and unistall process.

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -747,17 +747,14 @@ abstract class Package implements LocalizablePackageInterface
      * @return array 
      */
     public function getPackageMetadataPaths()
-    {
-        // check if the name space should be treated as core extension
-        $corePath = $this->pkgAutoloaderMapCoreExtensions ? DIRECTORY_SEPARATOR . 'Concrete' : '';
-        
+    {       
         // annotations entity path
         if ($this->metadataDriver === self::PACKAGE_METADATADRIVER_ANNOTATION){
             // Support for the legacy method for backwards compatibility
             if (method_exists($this, 'getPackageEntityPath')) {
                 $paths = array($this->getPackageEntityPath());
             }else{
-                $paths = array($this->getPackagePath() . DIRECTORY_SEPARATOR . DIRNAME_CLASSES . $corePath);
+                $paths = array($this->getPackagePath() . DIRECTORY_SEPARATOR . DIRNAME_CLASSES);
             }
         } else if ($this->metadataDriver === self::PACKAGE_METADATADRIVER_XML){
             // return xml metadata dir


### PR DESCRIPTION
Additional package namespaces are now registered automatically into the driver chain. Now the c5 migration tool works.

There are still two open questions. 

1. `$pkgAutoloaderMapCoreExtensions` is set in the migration tool to `true`. If I handle the mapping information the same as the ClassLoader does, say `Concrete\\Package\\MigrationTool` maps to `/packages/migration_tool/src/Concrete` the package isn't installed properly. Are there other packages out there, which use `$pkgAutoloaderMapCoreExtensions=true`?
2. The mapping paths are stored as absolute paths in `config/database.php`. This can generate problem if the web page is moved. Shall I change the absolute paths to relative paths? (If so, every mapping path has to be prepended during bootstrap.) Any preferences?