### PR TITLE
can't set uicolor without messing up editor theme

### DIFF
--- a/web/concrete/src/Editor/CkeditorEditor.php
+++ b/web/concrete/src/Editor/CkeditorEditor.php
@@ -60,7 +60,6 @@ class CkeditorEditor implements EditorInterface
                 'uploadUrl' => (string)URL::to('/ccm/system/file/upload'),
                 'language' => $this->getLanguageOption(),
                 'customConfig' => '',
-                'uiColor' => '#FAFAFA',
                 'allowedContent' => true,
                 'image2_captionedClass' => 'content-editor-image-captioned',
                 'image2_alignClasses' => array(


### PR DESCRIPTION
I think originally this was put in to get rid of the grey colors from the ckeditor theme because they didn't mesh well with concrete5. However, it seems to have had a very bad side effect of completely removing the styling from icons when they are "on".

Before Change:
![image](https://cloud.githubusercontent.com/assets/1292766/15275907/31356e50-1aa6-11e6-9aba-296ab44e99d3.png)


After Change:
![image](https://cloud.githubusercontent.com/assets/1292766/15275911/4d27eef8-1aa6-11e6-97e1-ebab277bb45f.png)

