### PR TITLE
Allow the ability to change the redirect_home_status_code by users fo…

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
@@ -42,6 +42,7 @@ class Setup extends DashboardPageController
         $this->set('defaultSourceCountry', $defaultSourceCountry);
         $this->set('redirectHomeToDefaultLocale', Config::get('concrete.multilingual.redirect_home_to_default_locale'));
         $this->set('useBrowserDetectedLocale', Config::get('concrete.multilingual.use_browser_detected_locale'));
+        $this->set('redirectHomeStatusCode', Config::get('concrete.multilingual.redirect_home_status_code'));
     }
 
     protected function populateCopyArray($startingPage)
@@ -129,6 +130,7 @@ class Setup extends DashboardPageController
                 Config::save('concrete.multilingual.default_locale', $this->post('defaultLocale'));
                 Config::save('concrete.multilingual.redirect_home_to_default_locale', $this->post('redirectHomeToDefaultLocale'));
                 Config::save('concrete.multilingual.use_browser_detected_locale', $this->post('useBrowserDetectedLocale'));
+                Config::save('concrete.multilingual.redirect_home_status_code', $this->post('redirectHomeStatusCode'));
                 $defaultSourceLocale = '';
                 $s = $this->post('defaultSourceLanguage');
                 if (is_string($s) && array_key_exists($s, $languages)) {

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -239,6 +239,13 @@ ccm_multilingualPopulateIcons = function(country) {
             </div>
 
             <div class="form-group">
+                <label class="control-label"><?php echo t('Status code to use when redirecting user to the correct language'); ?></label>
+                <div class="form-inline">
+                    <?= $form->text('redirectHomeStatusCode', $redirectHomeStatusCode); ?>
+                </div>
+            </div>
+
+            <div class="form-group">
                 <?php echo Loader::helper('validation/token')->output('set_default')?>
                 <button class="btn btn-default pull-left" type="submit" name="save"><?=t('Save Settings')?></button>
             </div>


### PR DESCRIPTION
Even through this is not an existing issue, being able to change the redirect status code of the Multislangual as a user is preferable. Makes it easier to manage.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer --config-file==<webroot>/.php_cs fix <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!
…r the Multilangual. SEO experts don't like a 302 and would most likely want it to be set to 301, even though it is wrong.