### PR TITLE
Fix and normalize express permission names

### DIFF
--- a/concrete/config/install/base/permissions.xml
+++ b/concrete/config/install/base/permissions.xml
@@ -172,13 +172,13 @@
 
         <!-- express //-->
 
-        <permissionkey handle="view_express_entries" name="View Entries" package="" category="express_tree_node">
+        <permissionkey handle="view_express_entry" name="View Entries" package="" category="express_tree_node">
         </permissionkey>
-        <permissionkey handle="add_express_entries" name="Add Entry" package="" category="express_tree_node">
+        <permissionkey handle="add_express_entry" name="Add Entry" package="" category="express_tree_node">
         </permissionkey>
-        <permissionkey handle="edit_express_entries" name="Edit Entry" package="" category="express_tree_node">
+        <permissionkey handle="edit_express_entry" name="Edit Entry" package="" category="express_tree_node">
         </permissionkey>
-        <permissionkey handle="delete_express_entries" name="Delete Entry" package="" category="express_tree_node">
+        <permissionkey handle="delete_express_entry" name="Delete Entry" package="" category="express_tree_node">
         </permissionkey>
 
         <!-- groups //-->

--- a/concrete/src/Permission/Response/ExpressEntryResponse.php
+++ b/concrete/src/Permission/Response/ExpressEntryResponse.php
@@ -26,7 +26,7 @@ class ExpressEntryResponse extends Response
     {
         $p = $this->getExpressEntryNodePermissions();
         if (is_object($p)) {
-            return $p->validate('view_express_entries');
+            return $p->validate('view_express_entry');
         }
     }
 
@@ -34,7 +34,7 @@ class ExpressEntryResponse extends Response
     {
         $p = $this->getExpressEntryNodePermissions();
         if (is_object($p)) {
-            return $p->validate('edit_express_entries');
+            return $p->validate('edit_express_entry');
         }
     }
 
@@ -42,7 +42,7 @@ class ExpressEntryResponse extends Response
     {
         $p = $this->getExpressEntryNodePermissions();
         if (is_object($p)) {
-            return $p->validate('delete_express_entries');
+            return $p->validate('delete_express_entry');
         }
     }
 

--- a/concrete/src/Tree/Type/ExpressEntryResults.php
+++ b/concrete/src/Tree/Type/ExpressEntryResults.php
@@ -63,7 +63,7 @@ class ExpressEntryResults extends Tree
         $tree = self::getByID($treeID);
 
         $adminGroupEntity = GroupEntity::getOrCreate(ConcreteGroup::getByID(ADMIN_GROUP_ID));
-        $permissions = ['view_express_entries', 'add_express_entry', 'edit_express_entry', 'delete_express_entry'];
+        $permissions = ['view_express_entry', 'add_express_entry', 'edit_express_entry', 'delete_express_entry'];
         foreach($permissions as $handle) {
             $pk = ExpressTreeNodeKey::getByHandle($handle);
             $pk->setPermissionObject($rootNode);


### PR DESCRIPTION
Trying to install the last develop I get this error:
```
Whoops\Exception\ErrorException:
  Call to a member function setPermissionObject() on a non-object
  in file concrete/src/Tree/Type/ExpressEntryResults.php on line 69
```

That's because of wrong names of an express permission (sometimes they are used in singular form and sometimes they are used in plural form): let's normalize the names by always using the singular form.