### PR TITLE
use full namespace

### DIFF
--- a/web/concrete/src/Cache/Page/FilePageCache.php
+++ b/web/concrete/src/Cache/Page/FilePageCache.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Cache\Page;
 
 use Config;
-use Page as ConcretePage;
+use Concrete\Core\Page\Page as ConcretePage;
 use Loader;
 
 class FilePageCache extends PageCache

--- a/web/concrete/src/Cache/Page/PageCache.php
+++ b/web/concrete/src/Cache/Page/PageCache.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Cache\Page;
 use Concrete\Core\Http\Response;
 use Config;
 use Request;
-use \Page as ConcretePage;
+use Concrete\Core\Page\Page as ConcretePage;
 use \Concrete\Core\Page\View\PageView;
 use Permissions;
 use User;


### PR DESCRIPTION
In the core use statements are mixed (full namespace and alias). This can give problems when instance of is checked. We would like to know what the advice approach is. Using the full namespace gives us some advantages in our IDE.
```
use Concrete\Core\Page\Page;
use \Page;
```

### Example 
We use `Concrete\Core\Page\Page` . When making a copy of a page we get the following error. 

```
Argument 1 passed to Concrete\Core\Cache\Page\FilePageCache::purge() must be an instance of Page, instance of Concrete\Core\Page\Page given
```