### PR TITLE
Prefer Composer dist packages instead of source ones

### DIFF
--- a/build/tasks/build-release/build.js
+++ b/build/tasks/build-release/build.js
@@ -34,7 +34,7 @@ module.exports = function(grunt, config, parameters, done) {
 						process.stdout.write('done.\n');
 						process.stdout.write('Installng PHP dependencies with Composer... ');
 						exec(
-							'composer install --prefer-dist --no-dev',
+							'composer install --no-dev',
 							{
 								cwd: path.join(workFolder, 'concrete')
 							},

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
   ],
   "config": {
     "optimize-autoloader": true,
-    "vendor-dir": "./concrete/vendor"
+    "vendor-dir": "./concrete/vendor",
+    "preferred-install": {
+      "*": "dist"
+    }
   },
   "require": {
     "php": ">=5.5.9",


### PR DESCRIPTION
This was already so in core releases, let's do the same in every case