### PR TITLE
Cleanup next_previous edit dialog

### DIFF
--- a/concrete/blocks/next_previous/form_setup_html.php
+++ b/concrete/blocks/next_previous/form_setup_html.php
@@ -4,36 +4,57 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <fieldset id="ccm_edit_pane_nextPreviousWrap">
     <div class="form-group">
-            <label class="control-label"><?php  echo t('Next Label')?></label>
-            <input name="nextLabel" class="form-control" type="text" value="<?php echo htmlentities($controller->nextLabel, ENT_QUOTES, APP_CHARSET) ?>" placeholder="<?php echo t('leave blank to hide'); ?>" />
+        <?php
+        echo $form->label('nextLabel', t('Next Label'));
+        echo $form->text('nextLabel', h($controller->nextLabel), ['placeholder' => t('leave blank to hide')]);
+        ?>
       </div>
       <div class="form-group">
-            <label class="control-label"><?php  echo t('Previous Label')?></label>
-            <input name="previousLabel" class="form-control" type="text" value="<?php echo htmlentities($controller->previousLabel, ENT_QUOTES, APP_CHARSET) ?>" placeholder="<?php echo t('leave blank to hide'); ?>" />
+          <?php
+          echo $form->label('previousLabel', t('Previous Label'));
+          echo $form->text('previousLabel', h($controller->previousLabel), ['placeholder' => t('leave blank to hide')]);
+          ?>
       </div>
       <div class="form-group">
-            <label class="control-label"><?php  echo t('Up Label')?></label>
-            <input name="parentLabel" class="form-control" type="text" value="<?php echo htmlentities($controller->parentLabel, ENT_QUOTES, APP_CHARSET) ?>" placeholder="<?php echo t('leave blank to hide'); ?>" />
+          <?php
+          echo $form->label('parentLabel', t('Up Label'));
+          echo $form->text('parentLabel', h($controller->parentLabel), ['placeholder' => t('leave blank to hide')]);
+          ?>
       </div>
 
   <div class="form-group">
       <div class="checkbox">
-          <label><input name="loopSequence" type="checkbox" value="1" <?php echo intval($controller->loopSequence) ? 'checked="checked"' : '' ?> /> <?php echo t('Loop Navigation') ?></label>
+          <label>
+          <?php
+          echo $form->checkbox('loopSequence', 1, intval($controller->loopSequence));
+          echo t('Loop Navigation');
+          ?>
+          </label>
       </div>
 
       <div class="checkbox">
-        <label><input name="excludeSystemPages" type="checkbox" value="1" <?php echo intval($controller->excludeSystemPages) ? 'checked="checked"' : '' ?> /> <?php echo t('Exclude system pages.') ?></label>
+          <label>
+          <?php
+          echo $form->checkbox('excludeSystemPages', 1, intval($controller->excludeSystemPages));
+          echo t('Exclude system pages.');
+          ?>
+          </label>
       </div>
   </div>
 
     <div class="form-group">
-      <label class="control-label"><?php echo t('Order Pages')?></label>
-      <select name="orderBy" class="form-control">
-          <option value="display_asc" <?php echo ($controller->orderBy == 'display_asc') ? 'selected="selected"' : '' ?>><?=t('Sitemap')?></option>
-          <option value="chrono_desc" <?php echo ($controller->orderBy == 'chrono_desc') ? 'selected="selected"' : '' ?>><?=t('Chronological')?></option>
-          <option value="display_desc" <?php echo ($controller->orderBy == 'display_desc') ? 'selected="selected"' : '' ?>><?=t('Reverse Sitemap')?></option>
-          <option value="chrono_asc" <?php echo ($controller->orderBy == 'chrono_asc') ? 'selected="selected"' : '' ?>><?=t('Reverse Chronological')?></option>
-      </select>
-    </div>
+        <?php
+        echo $form->label('orderBy', t('Order Pages'));
 
+        $options = [
+            'display_asc' => t('Sitemap'),
+            'chrono_desc' => t('Chronological'),
+            'display_desc' => t('Reverse Sitemap'),
+            'chrono_asc' => t('Reverse Chronological')
+        ];
+
+        echo $form->select('orderBy', $options, $controller->orderBy);
+        ?>
+    </div>
+</fieldset>
 

--- a/concrete/blocks/next_previous/form_setup_html.php
+++ b/concrete/blocks/next_previous/form_setup_html.php
@@ -8,53 +8,53 @@ defined('C5_EXECUTE') or die("Access Denied.");
         echo $form->label('nextLabel', t('Next Label'));
         echo $form->text('nextLabel', h($controller->nextLabel), ['placeholder' => t('leave blank to hide')]);
         ?>
-      </div>
-      <div class="form-group">
-          <?php
-          echo $form->label('previousLabel', t('Previous Label'));
-          echo $form->text('previousLabel', h($controller->previousLabel), ['placeholder' => t('leave blank to hide')]);
-          ?>
-      </div>
-      <div class="form-group">
-          <?php
-          echo $form->label('parentLabel', t('Up Label'));
-          echo $form->text('parentLabel', h($controller->parentLabel), ['placeholder' => t('leave blank to hide')]);
-          ?>
-      </div>
+    </div>
 
-  <div class="form-group">
-      <div class="checkbox">
-          <label>
-          <?php
-          echo $form->checkbox('loopSequence', 1, intval($controller->loopSequence));
-          echo t('Loop Navigation');
-          ?>
-          </label>
-      </div>
+    <div class="form-group">
+        <?php
+        echo $form->label('previousLabel', t('Previous Label'));
+        echo $form->text('previousLabel', h($controller->previousLabel), ['placeholder' => t('leave blank to hide')]);
+        ?>
+    </div>
 
-      <div class="checkbox">
-          <label>
-          <?php
-          echo $form->checkbox('excludeSystemPages', 1, intval($controller->excludeSystemPages));
-          echo t('Exclude system pages.');
-          ?>
-          </label>
-      </div>
-  </div>
+    <div class="form-group">
+        <?php
+        echo $form->label('parentLabel', t('Up Label'));
+        echo $form->text('parentLabel', h($controller->parentLabel), ['placeholder' => t('leave blank to hide')]);
+        ?>
+    </div>
+
+    <div class="form-group">
+         <div class="checkbox">
+            <label>
+                <?php
+                echo $form->checkbox('loopSequence', 1, intval($controller->loopSequence));
+                echo t('Loop Navigation');
+                ?>
+            </label>
+         </div>
+        <div class="checkbox">
+            <label>
+                <?php
+                echo $form->checkbox('excludeSystemPages', 1, intval($controller->excludeSystemPages));
+                echo t('Exclude system pages.');
+                ?>
+            </label>
+        </div>
+    </div>
 
     <div class="form-group">
         <?php
         echo $form->label('orderBy', t('Order Pages'));
 
         $options = [
-            'display_asc' => t('Sitemap'),
-            'chrono_desc' => t('Chronological'),
+            'display_asc'  => t('Sitemap'),
+            'chrono_desc'  => t('Chronological'),
             'display_desc' => t('Reverse Sitemap'),
-            'chrono_asc' => t('Reverse Chronological')
+            'chrono_asc'   => t('Reverse Chronological'),
         ];
 
         echo $form->select('orderBy', $options, $controller->orderBy);
         ?>
     </div>
 </fieldset>
-


### PR DESCRIPTION
See commit messages.

If it's OK I'd gladly add to this PR:
- Placeholders should start with capital letter: "Leave blank to hide".
- Remove the dot after "Exclude system pages.". But this would affect translations.