### PR TITLE
Cleanup html block

### DIFF
--- a/concrete/blocks/html/add.php
+++ b/concrete/blocks/html/add.php
@@ -1,6 +1,4 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$controllerObj = $controller;
-?>
 
-<?php $this->inc('form_setup_html.php');
+$this->inc('form_setup_html.php');

--- a/concrete/blocks/html/composer.php
+++ b/concrete/blocks/html/composer.php
@@ -1,19 +1,21 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$form = Loader::helper('form');
 ?>
 
 <div class="control-group">
-	<label class="control-label"><?=$label?></label>
-	<?php if ($description): ?>
-	<i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
+	<?php
+    echo $form->label($view->field('content'), $label);
+
+    if ($description): ?>
+		<i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo $description ?>"></i>
 	<?php endif; ?>
+
 	<div class="controls">
 		<?php
-        echo $form->textarea($view->field('content'), $content, array(
+        echo $form->textarea($view->field('content'), $content, [
             'class' => $class,
             'style' => 'width: 580px; height: 380px',
-        ));
+        ]);
         ?>
 	</div>
 </div>

--- a/concrete/blocks/html/composer.php
+++ b/concrete/blocks/html/composer.php
@@ -3,19 +3,19 @@ defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
 <div class="control-group">
-	<?php
+    <?php
     echo $form->label($view->field('content'), $label);
 
     if ($description): ?>
-		<i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo $description ?>"></i>
-	<?php endif; ?>
+        <i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo $description ?>"></i>
+    <?php endif; ?>
 
-	<div class="controls">
-		<?php
+    <div class="controls">
+        <?php
         echo $form->textarea($view->field('content'), $content, [
             'class' => $class,
             'style' => 'width: 580px; height: 380px',
         ]);
         ?>
-	</div>
+    </div>
 </div>

--- a/concrete/blocks/html/edit.php
+++ b/concrete/blocks/html/edit.php
@@ -1,6 +1,4 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$controllerObj = $controller;
-?>
 
-<?php $this->inc('form_setup_html.php', array('controllerObj' => $controller)); ?> 
+$this->inc('form_setup_html.php');

--- a/concrete/blocks/html/form_setup_html.php
+++ b/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>  
 
-<div id="ccm-block-html-value"><?=htmlspecialchars($content,ENT_QUOTES,APP_CHARSET)?></div>
+<div id="ccm-block-html-value"><?php echo h($content) ?></div>
 <textarea style="display: none" id="ccm-block-html-value-textarea" name="content"></textarea>
 
 <style type="text/css">
@@ -23,6 +23,6 @@
     });
 
     function refreshTextarea(contents) {
-      $('#ccm-block-html-value-textarea').val(contents);
+        $('#ccm-block-html-value-textarea').val(contents);
     }
 </script>

--- a/concrete/blocks/html/form_setup_html.php
+++ b/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>  
 
-<div id="ccm-block-html-value"><?php echo h($content) ?></div>
+<div id="ccm-block-html-value"><?php echo htmlspecialchars($content,ENT_QUOTES,APP_CHARSET) ?></div>
 <textarea style="display: none" id="ccm-block-html-value-textarea" name="content"></textarea>
 
 <style type="text/css">

--- a/concrete/blocks/html/scrapbook.php
+++ b/concrete/blocks/html/scrapbook.php
@@ -1,5 +1,5 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
-<div id="HTMLBlock<?=intval($bID)?>" class="HTMLBlock" style="max-height:300px; overflow:auto">
-<?php echo Concrete\Block\Html\Controller::xml_highlight(($content)); ?>
+<div id="HTMLBlock<?php echo $bID ?>" class="HTMLBlock" style="max-height:300px; overflow:auto">
+<?php echo Concrete\Block\Html\Controller::xml_highlight($content); ?>
 </div>

--- a/concrete/blocks/html/view.php
+++ b/concrete/blocks/html/view.php
@@ -1,5 +1,5 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-<div id="HTMLBlock<?=intval($bID)?>" class="HTMLBlock">
-<?=$content; ?>
+<div id="HTMLBlock<?php echo $bID ?>" class="HTMLBlock">
+<?php echo $content; ?>
 </div>


### PR DESCRIPTION
- Use h helper instead of htmlspecialchars, **please confirm this is ok**
- bID is always an integer, no need for intval
- Use form helper for labels
- Remove unnecessary vars like $controllerObj
- PSR fixer

I've tested the block with composer and the layout remains the same.