### PR TITLE
[grunt-build-release] Fix permissions extracting downloaded ZIP

### DIFF
--- a/build/tasks/build-release/download.js
+++ b/build/tasks/build-release/download.js
@@ -21,7 +21,7 @@ module.exports = function(grunt, config, parameters, done) {
 		}
 		fs.mkdir(workFolder);
 		process.stdout.write('Downloading & unzipping archive... ');
-		var download = new Download({extract: true})
+		var download = new Download({extract: true, mode: '755'})
 			.get(zipUrl)
 			.dest(workFolder);
 		download.run(function(err) {


### PR DESCRIPTION
Running `cd build & grunt build-release-download` results in an extracted folders readable only by root.

Let's fix this