### PR TITLE
Cleanup image block

### DIFF
--- a/concrete/blocks/image/add.php
+++ b/concrete/blocks/image/add.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die("Access Denied.");
+
 $this->inc('form.php');

--- a/concrete/blocks/image/composer.php
+++ b/concrete/blocks/image/composer.php
@@ -1,23 +1,25 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
-$form = Loader::helper('form');
-$html = Loader::helper('html');
-$url = Loader::helper('concrete/urls');
+
+$al = Core::make('helper/concrete/asset_library');
+$bf = null;
 
 if ($controller->getFileID() > 0) {
     $bf = $controller->getFileObject();
 }
 
 $setcontrol = $control->getPageTypeComposerFormLayoutSetControlObject();
-$al = Loader::helper('concrete/asset_library');
-
+$fieldName = 'ccm-b-image-'.$setcontrol->getPageTypeComposerFormLayoutSetControlID();
 ?>
 
-<div class="control-group">
-	<label class="control-label"><?=$label?></label>
-	<?php if ($description): ?>
-	<i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
-	<?php endif; ?>
-	<div class="controls">
-		<?php echo $al->image('ccm-b-image-'.$setcontrol->getPageTypeComposerFormLayoutSetControlID(), $view->field('fID'), t('Choose Image'), $bf); ?>
-	</div>
+<div class="form-group">
+    <?php
+    echo $form->label($fieldName, $label);
+
+    if ($description): ?>
+        <i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo $description ?>"></i>
+    <?php endif; ?>
+
+    <div class="controls">
+        <?php echo $al->image($fieldName, $view->field('fID'), t('Choose Image'), $bf); ?>
+    </div>
 </div>

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Block\Image;
 
-use Core;
-use Database;
-use File;
-use Page;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Error\Error;
+use Concrete\Core\File\File;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Support\Facade\Facade;
 
 class Controller extends BlockController
 {
@@ -17,15 +17,12 @@ class Controller extends BlockController
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btWrapperClass = 'ccm-ui';
-    protected $btExportFileColumns = array('fID', 'fOnstateID');
-    protected $btExportPageColumns = array('internalLinkCID');
-    protected $btFeatures = array(
+    protected $btExportFileColumns = ['fID', 'fOnstateID'];
+    protected $btExportPageColumns = ['internalLinkCID'];
+    protected $btFeatures = [
         'image',
-    );
+    ];
 
-    /**
-     * Used for localization. If we want to localize the name/description we have to include this.
-     */
     public function getBlockTypeDescription()
     {
         return t("Adds images and onstates from the library to pages.");
@@ -36,78 +33,154 @@ class Controller extends BlockController
         return t("Image");
     }
 
+    /**
+     * @param string $outputContent
+     */
     public function registerViewAssets($outputContent = '')
     {
-        // Ensure we have JQuery if we have an onState image
+        // Ensure we have jQuery if we have an onState image
         if (is_object($this->getFileOnstateObject())) {
             $this->requireAsset('javascript', 'jquery');
         }
     }
 
+    /**
+     * @return bool|null
+     */
     public function view()
     {
+        // Check for a valid File in the view
         $f = File::getByID($this->fID);
-        if (!is_object($f) || !$f->getFileID()) {
-            return false;
-        }
-
-        // onState image available
-        $foS = $this->getFileOnstateObject();
-        if (is_object($foS)) {
-            $imgPath = array();
-            $imgPath['hover'] = File::getRelativePathFromID($this->fOnstateID);
-            $imgPath['default'] = File::getRelativePathFromID($this->fID);
-            $this->set('imgPath', $imgPath);
-            $this->set('foS', $foS);
-        }
-
         $this->set('f', $f);
+
+        // On-State image available
+        $foS = $this->getFileOnstateObject();
+        $this->set('foS', $foS);
+
+        $imgPaths = [];
+        $imgPaths['hover']   = File::getRelativePathFromID($this->fOnstateID);
+        $imgPaths['default'] = File::getRelativePathFromID($this->fID);
+        $this->set('imgPaths', $imgPaths);
+
         $this->set('altText', $this->getAltText());
         $this->set('title', $this->getTitle());
         $this->set('linkURL', $this->getLinkURL());
+
+        $this->set('c', Page::getCurrentPage());
     }
 
+    public function add()
+    {
+        $this->set('bf', null);
+        $this->set('bfo', null);
+
+        $this->set('constrainImage', false);
+    }
+
+    public function edit()
+    {
+        // Image file object
+        $bf = null;
+        if ($this->getFileID() > 0) {
+            $bf = $this->getFileObject();
+        }
+        $this->set('bf', $bf);
+
+        // Image On-State file object
+        $bfo = null;
+        if ($this->getFileOnstateID() > 0) {
+            $bfo = $this->getFileOnstateObject();
+        }
+        $this->set('bfo', $bfo);
+
+        // Constrain dimensions
+        $constrainImage = $this->maxWidth > 0 || $this->maxHeight > 0;
+        $this->set('constrainImage', $constrainImage);
+
+        // Max width is saved as an integer
+        if ($this->maxWidth == 0) {
+            $this->set('maxWidth', '');
+        }
+
+        // Max height is saved as an integer
+        if ($this->maxHeight == 0) {
+            $this->set('maxHeight', '');
+        }
+
+        // None, Internal, or External
+        $linkType = 0;
+        if (empty($this->externalLink) && !empty($this->internalLinkCID)) {
+            $linkType = 1;
+        } elseif (!empty($this->externalLink)) {
+            $linkType = 2;
+        }
+        $this->set('linkType', $linkType);
+    }
+
+    /**
+     * @return array
+     */
     public function getJavaScriptStrings()
     {
-        return array(
+        return [
             'image-required' => t('You must select an image.'),
-        );
+        ];
     }
 
+    /**
+     * @return bool
+     */
     public function isComposerControlDraftValueEmpty()
     {
         $f = $this->getFileObject();
-        if (is_object($f) && !$f->isError()) {
+        if (is_object($f) && $f->getFileID()) {
             return false;
         }
 
         return true;
     }
 
+    /**
+     * @return \Concrete\Core\Entity\File\File|null
+     */
     public function getImageFeatureDetailFileObject()
     {
         // i don't know why this->fID isn't sticky in some cases, leading us to query
         // every damn time
-        $db = Database::connection();
-        $fID = $db->fetchColumn('select fID from btContentImage where bID = ?', array($this->bID), 0);
+        $app = Facade::getFacadeApplication();
+        $db = $app->make('database')->connection();
+
+        $file = null;
+        $fID = $db->fetchColumn('select fID from btContentImage where bID = ?', [$this->bID], 0);
         if ($fID) {
             $f = File::getByID($fID);
-            if (is_object($f) && !$f->isError()) {
-                return $f;
+            if (is_object($f) && $f->getFileID()) {
+                $file = $f;
             }
         }
+
+        return $file;
     }
 
+    /**
+     * @return int
+     */
     public function getFileID()
     {
         return $this->fID;
     }
 
+    /**
+     * @return int
+     */
     public function getFileOnstateID()
     {
         return $this->fOnstateID;
     }
 
+    /**
+     * @return \Concrete\Core\Entity\File\File|null
+     */
     public function getFileOnstateObject()
     {
         if ($this->fOnstateID) {
@@ -115,60 +188,89 @@ class Controller extends BlockController
         }
     }
 
+    /**
+     * @return \Concrete\Core\Entity\File\File|null
+     */
     public function getFileObject()
     {
         return File::getByID($this->fID);
     }
 
+    /**
+     * @return string
+     */
     public function getAltText()
     {
         return $this->altText;
     }
 
+    /**
+     * @return string|null
+     */
     public function getTitle()
     {
-        return isset($this->title) ? $this->title : null;
+        return !empty($this->title) ? $this->title : null;
     }
 
+    /**
+     * @return string
+     */
     public function getExternalLink()
     {
         return $this->externalLink;
     }
 
+    /**
+     * @return int
+     */
     public function getInternalLinkCID()
     {
         return $this->internalLinkCID;
     }
 
+    /**
+     * @return string
+     */
     public function getLinkURL()
     {
-        if (!empty($this->externalLink)) {
-            $sec = \Core::make('helper/security');
+        $app = Facade::getFacadeApplication();
+        $linkUrl = '';
 
-            return $sec->sanitizeURL($this->externalLink);
+        if (!empty($this->externalLink)) {
+            $sec = $app->make('helper/security');
+            $linkUrl = $sec->sanitizeURL($this->externalLink);
         } elseif (!empty($this->internalLinkCID)) {
             $linkToC = Page::getByID($this->internalLinkCID);
-
-            return (empty($linkToC) || $linkToC->error) ? '' : Core::make('helper/navigation')->getLinkToCollection($linkToC);
-        } else {
-            return '';
+            if (is_object($linkToC) && !$linkToC->isError()) {
+                $linkUrl = $linkToC->getCollectionLink();
+            }
         }
+
+        return $linkUrl;
     }
 
+    /**
+     * @return Error
+     */
     public function validate_composer()
     {
+        $app = Facade::getFacadeApplication();
+        $e = $app->make('helper/validation/error');
+
         $f = $this->getFileObject();
-        $e = Core::make('helper/validation/error');
-        if (!is_object($f) || $f->isError() || !$f->getFileID()) {
+        if (!is_object($f) || !$f->getFileID()) {
             $e->add(t('You must specify a valid image file.'));
         }
 
         return $e;
     }
 
+    /**
+     * @param array $args
+     */
     public function save($args)
     {
-        $args = $args + array(
+        $args = $args + [
             'fID' => 0,
             'fOnstateID' => 0,
             'maxWidth' => 0,
@@ -177,15 +279,18 @@ class Controller extends BlockController
             'linkType' => 0,
             'externalLink' => '',
             'internalLinkCID' => 0,
-        );
+        ];
+
         $args['fID'] = ($args['fID'] != '') ? $args['fID'] : 0;
         $args['fOnstateID'] = ($args['fOnstateID'] != '') ? $args['fOnstateID'] : 0;
         $args['maxWidth'] = (intval($args['maxWidth']) > 0) ? intval($args['maxWidth']) : 0;
         $args['maxHeight'] = (intval($args['maxHeight']) > 0) ? intval($args['maxHeight']) : 0;
+
         if (!$args['constrainImage']) {
             $args['maxWidth'] = 0;
             $args['maxHeight'] = 0;
         }
+
         switch (intval($args['linkType'])) {
             case 1:
                 $args['externalLink'] = '';
@@ -198,7 +303,10 @@ class Controller extends BlockController
                 $args['internalLinkCID'] = 0;
                 break;
         }
-        unset($args['linkType']); //this doesn't get saved to the database (it's only for UI usage)
+
+        // This doesn't get saved to the database. It's only for UI usage.
+        unset($args['linkType']);
+
         parent::save($args);
     }
 }

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -5,7 +5,6 @@ use Concrete\Core\Block\BlockController;
 use Concrete\Core\Error\Error;
 use Concrete\Core\File\File;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Support\Facade\Facade;
 
 class Controller extends BlockController
 {
@@ -147,8 +146,7 @@ class Controller extends BlockController
     {
         // i don't know why this->fID isn't sticky in some cases, leading us to query
         // every damn time
-        $app = Facade::getFacadeApplication();
-        $db = $app->make('database')->connection();
+        $db = $this->app->make('database')->connection();
 
         $file = null;
         $fID = $db->fetchColumn('select fID from btContentImage where bID = ?', [$this->bID], 0);
@@ -233,11 +231,10 @@ class Controller extends BlockController
      */
     public function getLinkURL()
     {
-        $app = Facade::getFacadeApplication();
         $linkUrl = '';
 
         if (!empty($this->externalLink)) {
-            $sec = $app->make('helper/security');
+            $sec = $this->app->make('helper/security');
             $linkUrl = $sec->sanitizeURL($this->externalLink);
         } elseif (!empty($this->internalLinkCID)) {
             $linkToC = Page::getByID($this->internalLinkCID);
@@ -254,8 +251,7 @@ class Controller extends BlockController
      */
     public function validate_composer()
     {
-        $app = Facade::getFacadeApplication();
-        $e = $app->make('helper/validation/error');
+        $e = $this->app->make('helper/validation/error');
 
         $f = $this->getFileObject();
         if (!is_object($f) || !$f->getFileID()) {

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -58,7 +58,7 @@ class Controller extends BlockController
         $this->set('foS', $foS);
 
         $imgPaths = [];
-        $imgPaths['hover']   = File::getRelativePathFromID($this->fOnstateID);
+        $imgPaths['hover'] = File::getRelativePathFromID($this->fOnstateID);
         $imgPaths['default'] = File::getRelativePathFromID($this->fID);
         $this->set('imgPaths', $imgPaths);
 

--- a/concrete/blocks/image/edit.php
+++ b/concrete/blocks/image/edit.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die("Access Denied.");
+
 $this->inc('form.php');

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -1,120 +1,118 @@
-<?php 
-defined('C5_EXECUTE') or die("Access Denied.");
-$al = Core::make('helper/concrete/asset_library');
-$bf = null;
-$bfo = null;
-
-if ($controller->getFileID() > 0) {
-    $bf = $controller->getFileObject();
-}
-if ($controller->getFileOnstateID() > 0) {
-    $bfo = $controller->getFileOnstateObject();
-}
-?>
-
-<fieldset>
-
-    <legend><?=t('Files')?></legend>
 <?php
-$args = array();
-$constrain = $maxWidth > 0 || $maxHeight > 0;
-if ($maxWidth == 0) {
-    $maxWidth = '';
-}
-if ($maxHeight == 0) {
-    $maxHeight = '';
-}
+defined('C5_EXECUTE') or die("Access Denied.");
 
+$ps = Core::make('helper/form/page_selector');
+$al = Core::make('helper/concrete/asset_library');
 ?>
 
-<div class="form-group">
-	<label class="control-label"><?=t('Image')?></label>
-	<?=$al->image('ccm-b-image', 'fID', t('Choose Image'), $bf, $args);?>
-</div>
-<div class="form-group">
-	<label class="control-label"><?=t('Image Hover')?> <small style="color:#999999; font-weight: 200;"><?php echo t('(Optional)'); ?></small></label>
-	<?=$al->image('ccm-b-image-onstate', 'fOnstateID', t('Choose Image On-State'), $bfo, $args);?>
-</div>
+<fieldset>
+    <legend><?php echo t('Files') ?></legend>
 
+    <div class="form-group">
+        <?php
+        echo $form->label('ccm-b-image', t('Image'));
+        echo $al->image('ccm-b-image', 'fID', t('Choose Image'), $bf);
+        ?>
+    </div>
+
+    <div class="form-group">
+        <label class="control-label"><?php echo t('Image Hover')?> <small style="color: #999999; font-weight: 200;"><?php echo t('(Optional)'); ?></small></label>
+        <?php
+        echo $al->image('ccm-b-image-onstate', 'fOnstateID', t('Choose Image On-State'), $bfo);
+        ?>
+    </div>
 </fieldset>
 
 <fieldset>
-    <legend><?=t('HTML')?></legend>
+    <legend><?php echo t('HTML') ?></legend>
 
-<div class="form-group">
-	<?=$form->label('imageLinkType', t('Image Link'))?>
-	<select name="linkType" id="imageLinkType" class="form-control">
-		<option value="0" <?=(empty($externalLink) && empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('None')?></option>
-		<option value="1" <?=(empty($externalLink) && !empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('Another Page')?></option>
-		<option value="2" <?=(!empty($externalLink) ? 'selected="selected"' : '')?>><?=t('External URL')?></option>
-	</select>
-</div>
+    <div class="form-group">
+        <?php
+        $options = [
+            0 => t('None'),
+            1 => t('Another Page'),
+            2 => t('External URL'),
+        ];
 
-<div id="imageLinkTypePage" style="display: none;" class="form-group">
-	<?=$form->label('internalLinkCID', t('Choose Page:'))?>
-	<?= Core::make('helper/form/page_selector')->selectPage('internalLinkCID', $internalLinkCID); ?>
-</div>
+        echo $form->label('imageLinkType', t('Image Link'));
+        echo $form->select('linkType', $options, $linkType);
+        ?>
+    </div>
 
-<div id="imageLinkTypeExternal" style="display: none;" class="form-group">
-	<?=$form->label('externalLink', t('URL'))?>
-	<?= $form->text('externalLink', $externalLink); ?>
-</div>
+    <div id="imageLinkTypePage" style="display: none;" class="form-group">
+        <?php
+        echo $form->label('internalLinkCID', t('Choose Page:'));
+        echo $ps->selectPage('internalLinkCID', $internalLinkCID);
+        ?>
+    </div>
 
+    <div id="imageLinkTypeExternal" style="display: none;" class="form-group">
+        <?php
+        echo $form->label('externalLink', t('URL'));
+        echo $form->text('externalLink', $externalLink);
+        ?>
+    </div>
 
-<div class="form-group">
-	<?=$form->label('altText', t('Alt. Text'))?>
-	<?= $form->text('altText', $altText); ?>
-</div>
+    <div class="form-group">
+        <?php
+        echo $form->label('altText', t('Alt. Text'));
+        echo $form->text('altText', $altText, ['maxlength' => 255]);
+        ?>
+    </div>
 
-<div class="form-group">
-    <?=$form->label('title', t('Title'))?>
-    <?= $form->text('title', $title); ?>
-</div>
-
+    <div class="form-group">
+        <?php
+        echo $form->label('title', t('Title'));
+        echo $form->text('title', $title, ['maxlength' => 255]);
+        ?>
+    </div>
 </fieldset>
 
 <fieldset>
-    <legend><?=t('Resize Image')?></legend>
+    <legend><?php echo t('Resize Image') ?></legend>
 
     <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">
-            <label><?=$form->checkbox('constrainImage', 1, $constrain)?>
-            <?=t('Constrain Image Size')?></label>
+            <label>
+                <?php
+                echo $form->checkbox('constrainImage', 1, $constrainImage);
+                echo t('Constrain Image Size');
+                ?>
+            </label>
         </div>
     </div>
 
     <div data-fields="constrain-image" style="display: none">
         <div class="form-group">
-        <?=$form->label('maxWidth', t('Max Width'))?>
-        <?= $form->text('maxWidth', $maxWidth); ?>
+            <?php
+            echo $form->label('maxWidth', t('Max Width'));
+            echo $form->number('maxWidth', $maxWidth, ['min' => 0]);
+            ?>
         </div>
 
         <div class="form-group">
-            <?=$form->label('maxHeight', t('Max Height'))?>
-            <?= $form->text('maxHeight', $maxHeight); ?>
+            <?php
+            echo $form->label('maxHeight', t('Max Height'));
+            echo $form->number('maxHeight', $maxHeight, ['min' => 0]);
+            ?>
         </div>
     </div>
-
 </fieldset>
-
 
 <script type="text/javascript">
 refreshImageLinkTypeControls = function() {
-	var linkType = $('#imageLinkType').val();
-	$('#imageLinkTypePage').toggle(linkType == 1);
-	$('#imageLinkTypeExternal').toggle(linkType == 2);
-}
+    var linkType = $('#linkType').val();
+    $('#imageLinkTypePage').toggle(linkType == 1);
+    $('#imageLinkTypeExternal').toggle(linkType == 2);
+};
 
 $(document).ready(function() {
-	$('#imageLinkType').change(refreshImageLinkTypeControls);
+    $('#linkType').change(refreshImageLinkTypeControls);
 
-    $('div[data-checkbox-wrapper=constrain-image] input').on('change', function() {
-        if ($(this).is(':checked')) {
-            $('div[data-fields=constrain-image]').show();
-        } else {
-            $('div[data-fields=constrain-image]').hide();
-        }
+    $('#constrainImage').on('change', function() {
+        $('div[data-fields=constrain-image]').toggle($(this).is(':checked'));
     }).trigger('change');
-	refreshImageLinkTypeControls();
+
+    refreshImageLinkTypeControls();
 });
 </script>

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -1,55 +1,50 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
 
-$c = Page::getCurrentPage();
-if (is_object($f)) {
+if (is_object($f) && $f->getFileID()) {
     if ($maxWidth > 0 || $maxHeight > 0) {
+        $crop = false;
+
         $im = Core::make('helper/image');
-        $thumb = $im->getThumbnail(
-            $f,
-            $maxWidth,
-            $maxHeight
-        ); //<-- set these 2 numbers to max width and height of thumbnails
+        $thumb = $im->getThumbnail($f, $maxWidth, $maxHeight, $crop);
+
         $tag = new \HtmlObject\Image();
         $tag->src($thumb->src)->width($thumb->width)->height($thumb->height);
     } else {
-        $image = Core::make('html/image', array($f));
+        $image = Core::make('html/image', [$f]);
         $tag = $image->getTag();
     }
-    $tag->addClass('ccm-image-block img-responsive bID-'.$bID);
+
+    $tag->addClass(' bID-'.$bID);
     if ($altText) {
         $tag->alt(h($altText));
     }
+
     if ($title) {
         $tag->title(h($title));
     }
-    if ($linkURL):
-        print '<a href="' . $linkURL . '">';
-    endif;
+
+    if ($linkURL) {
+        echo '<a href="'.$linkURL.'">';
+    }
 
     echo $tag;
 
-    if ($linkURL):
-        print '</a>';
-    endif;
+    if ($linkURL) {
+        echo '</a>';
+    }
 } elseif ($c->isEditMode()) {
     ?>
+    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Image Block.') ?></div>
+    <?php
+}
 
-    <div class="ccm-edit-mode-disabled-item"><?=t('Empty Image Block.')?></div>
-
-<?php 
-} ?>
-
-<?php if (isset($foS) && is_object($foS)) {
-    ?>
+if (is_object($foS)): ?>
 <script>
 $(function() {
-    $('.bID-<?php echo $bID;
-    ?>')
-        .mouseover(function(e){$(this).attr("src", '<?php echo $imgPath["hover"];
-    ?>');})
-        .mouseout(function(e){$(this).attr("src", '<?php echo $imgPath["default"];
-    ?>');});
+    $('.bID-<?php echo $bID; ?>')
+        .mouseover(function(){$(this).attr("src", '<?php echo $imgPaths["hover"]; ?>');})
+        .mouseout(function(){$(this).attr("src", '<?php echo $imgPaths["default"]; ?>');});
 });
 </script>
-<?php 
-} ?>
+<?php
+endif;


### PR DESCRIPTION
See commit messages for details.

Two things:
1. The Error class is deprecated, what should be used instead?
2. The hover state doesn't work. This is not because of this PR, but because of PictureFill. I've tested the image hover in the develop branch, it had the same problem.

I've tested all the fields, including setting it up via composer. I may have made a mistake, so please review before merge. Hopefully this PR eventually gets through though, because the image block is often copied and modified. 