### PR TITLE
Fix html block layout in composer

### DIFF
--- a/concrete/blocks/html/composer.php
+++ b/concrete/blocks/html/composer.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
-<div class="control-group">
+<div class="form-group">
     <?php
     echo $form->label($view->field('content'), $label);
 


### PR DESCRIPTION
It's about that blue line underneath and the additional padding add margin.

Before:
![before](https://cloud.githubusercontent.com/assets/1431100/15450197/e008c56e-1f95-11e6-8031-1c2ae6c81846.png)

After: 
![after](https://cloud.githubusercontent.com/assets/1431100/15450200/ea9d851e-1f95-11e6-8203-e9de7d400121.png)
