### PR TITLE
Check if action exists before assigning points

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/points/assign.php
+++ b/concrete/controllers/single_page/dashboard/users/points/assign.php
@@ -73,8 +73,12 @@ class Assign extends DashboardPageController
             $this->error->add(t('Points Required'));
         }
 
+        $action = UserPointAction::getByID($this->post('upaID'));
+        if (!$action) {
+            $this->error->add(t('Invalid Action'));
+        }
+
         if (!$this->error->has()) {
-            $action = UserPointAction::getByID($this->post('upaID'));
             $obj = new UserPointActionDescription();
             $obj->setComments($this->post('upComments'));
             if ($this->post('manual_datetime') > 0) {


### PR DESCRIPTION
Prevents an SQL error if an action doesn't exist (anymore).