### PR TITLE
Cleanup next_previous controller

### DIFF
--- a/concrete/blocks/next_previous/add.php
+++ b/concrete/blocks/next_previous/add.php
@@ -1,12 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$controller->nextLabel = t('Next');
-$controller->previousLabel = t('Previous');
-$controller->parentLabel = t('Up');
-$controller->showArrows = 1;
-$controller->loopSequence = 1;
-$controller->orderBy = 'display_asc';
-
-$this->inc('/form_setup_html.php', array('controller' => $controller));
+$this->inc('form_setup_html.php');

--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -1,10 +1,10 @@
 <?php
 namespace Concrete\Block\NextPrevious;
 
-use Database;
-use Permissions;
-use Page;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker as Permissions;
+use Concrete\Core\Support\Facade\Facade;
 
 class Controller extends BlockController
 {
@@ -13,9 +13,7 @@ class Controller extends BlockController
     protected $btInterfaceHeight = "400";
     protected $btCacheBlockRecord = true;
     protected $btWrapperClass = 'ccm-ui';
-    /**
-     * Used for localization. If we want to localize the name/description we have to include this.
-     */
+
     public function getBlockTypeDescription()
     {
         return t("Navigate through sibling pages.");
@@ -26,71 +24,102 @@ class Controller extends BlockController
         return t("Next & Previous Nav");
     }
 
-    public function getJavaScriptStrings()
+    public function view()
     {
-        return array();
+        // Next
+        $nextLinkURL = '';
+        $nextLinkText = '';
+        $nextCollection = $this->getNextCollection();
+        if (is_object($nextCollection) && !$nextCollection->isError()) {
+            $nextLinkURL = $nextCollection->getCollectionLink();
+            $nextLinkText = $nextCollection->getCollectionName();
+        }
+
+        $this->set('nextLinkURL', $nextLinkURL);
+        $this->set('nextLinkText', $nextLinkText);
+        $this->set('nextLabel', $this->nextLabel);
+
+        // Previous
+        $previousLinkURL = '';
+        $previousLinkText = '';
+        $previousCollection = $this->getPreviousCollection();
+
+        if (is_object($previousCollection) && !$previousCollection->isError()) {
+            $previousLinkURL = $previousCollection->getCollectionLink();
+            $previousLinkText = $previousCollection->getCollectionName();
+        }
+
+        $this->set('previousLinkURL', $previousLinkURL);
+        $this->set('previousLinkText', $previousLinkText);
+        $this->set('previousLabel', $this->previousLabel);
+
+        // Parent / Up
+        $parentLinkURL = '';
+        $parentCollection = Page::getByID(Page::getCurrentPage()->getCollectionParentID());
+        if (is_object($parentCollection) && !$parentCollection->isError()) {
+            $parentLinkURL = $parentCollection->getCollectionLink();
+        }
+
+        $this->set('parentLinkURL', $parentLinkURL);
+        $this->set('parentLabel', $this->parentLabel);
+    }
+
+    public function add()
+    {
+        $this->set('nextLabel', t('Next'));
+        $this->set('previousLabel', t('Previous'));
+        $this->set('parentLabel', t('Up'));
+        $this->set('loopSequence', 1);
+        $this->set('orderBy', 'display_asc');
     }
 
     public function save($args)
     {
-        $args += array(
-            'showArrows' => 0,
+        $args += [
             'loopSequence' => 0,
             'excludeSystemPages' => 0,
-        );
+        ];
 
-        $args['showArrows'] = intval($args['showArrows']);
         $args['loopSequence'] = intval($args['loopSequence']);
         $args['excludeSystemPages'] = intval($args['excludeSystemPages']);
 
         parent::save($args);
     }
 
-    public function view()
-    {
-        $nextPage = $this->getNextCollection();
-        $previousPage = $this->getPreviousCollection();
-        $parentPage = Page::getByID(Page::getCurrentPage()->getCollectionParentID());
-
-        $nextLinkText = $this->nextLabel;
-        $previousLinkText = $this->previousLabel;
-        $parentLinkText = $this->parentLabel;
-
-        $this->set('nextCollection', $nextPage);
-        $this->set('previousCollection', $previousPage);
-        $this->set('parentCollection', $parentPage);
-
-        $this->set('nextLinkText', $nextLinkText);
-        $this->set('previousLinkText', $previousLinkText);
-        $this->set('parentLinkText', $parentLinkText);
-    }
-
+    /**
+     * @return bool|Page
+     */
     public function getNextCollection()
     {
         $page = false;
-        $db = Database::connection();
+
+        $app = Facade::getFacadeApplication();
+        $db = $app->make('database')->connection();
+
         $systemPages = '';
         if ($this->excludeSystemPages) {
             $systemPages = 'and cIsSystemPage = 0';
         }
         $cID = 1;
         $currentPage = Page::getCurrentPage();
+
         while ($cID > 0) {
             switch ($this->orderBy) {
                 case 'chrono_desc':
-                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', [$currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'chrono_asc':
-                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', [$currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_desc':
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_asc':
                 default:
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
             }
+
             if ($cID > 0) {
                 $page = Page::getByID($cID, 'RECENT');
                 $currentPage = $page;
@@ -98,10 +127,11 @@ class Controller extends BlockController
                 if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
                     break;
                 } else {
-                    $page = null; //avoid accidentally returning this $page if we're on last loop iteration
+                    $page = false; //avoid accidentally returning this $page if we're on last loop iteration
                 }
             }
         }
+
         if (!is_object($page) && $this->loopSequence) {
             $c = Page::getCurrentPage();
             $parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');
@@ -125,32 +155,40 @@ class Controller extends BlockController
         return $page;
     }
 
+    /**
+     * @return bool|Page
+     */
     public function getPreviousCollection()
     {
         $page = false;
-        $db = Database::connection();
+
+        $app = Facade::getFacadeApplication();
+        $db = $app->make('database')->connection();
+
         $systemPages = '';
         if ($this->excludeSystemPages) {
             $systemPages = 'and cIsSystemPage = 0';
         }
         $cID = 1;
         $currentPage = Page::getCurrentPage();
+
         while ($cID > 0) {
             switch ($this->orderBy) {
                 case 'chrono_desc':
-                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic < ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic desc', [$currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'chrono_asc':
-                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', array($currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ? ' . $systemPages . ' order by cvDatePublic asc', [$currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_desc':
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder asc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_asc':
                 default:
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', array($currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()));
+                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? ' . $systemPages . ' order by cDisplayOrder desc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
             }
+
             if ($cID > 0) {
                 $page = Page::getByID($cID, 'RECENT');
                 $currentPage = $page;
@@ -158,10 +196,11 @@ class Controller extends BlockController
                 if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
                     break;
                 } else {
-                    $page = null; //avoid accidentally returning this $page if we're on last loop iteration
+                    $page = false; //avoid accidentally returning this $page if we're on last loop iteration
                 }
             }
         }
+
         if (!is_object($page) && $this->loopSequence) {
             $c = Page::getCurrentPage();
             $parent = Page::getByID($c->getCollectionParentID(), 'ACTIVE');

--- a/concrete/blocks/next_previous/edit.php
+++ b/concrete/blocks/next_previous/edit.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die("Access Denied.");
-$this->inc('/form_setup_html.php', array('controller' => $controller));
+
+$this->inc('form_setup_html.php');

--- a/concrete/blocks/next_previous/form_setup_html.php
+++ b/concrete/blocks/next_previous/form_setup_html.php
@@ -6,21 +6,21 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <div class="form-group">
         <?php
         echo $form->label('nextLabel', t('Next Label'));
-        echo $form->text('nextLabel', h($controller->nextLabel), ['placeholder' => t('leave blank to hide')]);
+        echo $form->text('nextLabel', h($nextLabel), ['placeholder' => t('leave blank to hide')]);
         ?>
     </div>
 
     <div class="form-group">
         <?php
         echo $form->label('previousLabel', t('Previous Label'));
-        echo $form->text('previousLabel', h($controller->previousLabel), ['placeholder' => t('leave blank to hide')]);
+        echo $form->text('previousLabel', h($previousLabel), ['placeholder' => t('leave blank to hide')]);
         ?>
     </div>
 
     <div class="form-group">
         <?php
         echo $form->label('parentLabel', t('Up Label'));
-        echo $form->text('parentLabel', h($controller->parentLabel), ['placeholder' => t('leave blank to hide')]);
+        echo $form->text('parentLabel', h($parentLabel), ['placeholder' => t('leave blank to hide')]);
         ?>
     </div>
 
@@ -28,7 +28,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
          <div class="checkbox">
             <label>
                 <?php
-                echo $form->checkbox('loopSequence', 1, intval($controller->loopSequence));
+                echo $form->checkbox('loopSequence', 1, intval($loopSequence));
                 echo t('Loop Navigation');
                 ?>
             </label>
@@ -36,7 +36,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <div class="checkbox">
             <label>
                 <?php
-                echo $form->checkbox('excludeSystemPages', 1, intval($controller->excludeSystemPages));
+                echo $form->checkbox('excludeSystemPages', 1, intval($excludeSystemPages));
                 echo t('Exclude system pages.');
                 ?>
             </label>
@@ -48,13 +48,13 @@ defined('C5_EXECUTE') or die("Access Denied.");
         echo $form->label('orderBy', t('Order Pages'));
 
         $options = [
-            'display_asc'  => t('Sitemap'),
-            'chrono_desc'  => t('Chronological'),
+            'display_asc' => t('Sitemap'),
+            'chrono_desc' => t('Chronological'),
             'display_desc' => t('Reverse Sitemap'),
-            'chrono_asc'   => t('Reverse Chronological'),
+            'chrono_asc' => t('Reverse Chronological'),
         ];
 
-        echo $form->select('orderBy', $options, $controller->orderBy);
+        echo $form->select('orderBy', $options, $orderBy);
         ?>
     </div>
 </fieldset>

--- a/concrete/blocks/next_previous/view.php
+++ b/concrete/blocks/next_previous/view.php
@@ -1,45 +1,51 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-$nh = Loader::helper('navigation');
-$previousLinkURL = is_object($previousCollection) ? $nh->getLinkToCollection($previousCollection) : '';
-$parentLinkURL = is_object($parentCollection) ? $nh->getLinkToCollection($parentCollection) : '';
-$nextLinkURL = is_object($nextCollection) ? $nh->getLinkToCollection($nextCollection) : '';
-$previousLinkText = is_object($previousCollection) ? $previousCollection->getCollectionName() : '';
-$nextLinkText = is_object($nextCollection) ? $nextCollection->getCollectionName() : '';
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+
+if (!$previousLinkURL && !$nextLinkURL && !$parentLabel) {
+    return false;
+}
 ?>
 
-<?php if ($previousLinkURL || $nextLinkURL || $parentLinkText): ?>
-
 <div class="ccm-block-next-previous-wrapper">
-    <?php if ($previousLabel && $previousLinkURL != ''): ?>
-    <div class="ccm-block-next-previous-header">
-        <h5><?=$previousLabel?></h5>
-    </div>
-    <?php endif; ?>
-
-    <?php if ($previousLinkText): ?>
-	<p class="ccm-block-next-previous-previous-link">
-		<?php echo $previousLinkURL ? '<a href="' . $previousLinkURL . '">' . $previousLinkText . '</a>' : '' ?>
- 	</p>
-	<?php endif; ?>
-
-    <?php if ($nextLabel && $nextLinkURL != ''): ?>
+    <?php
+    if ($previousLinkURL && $previousLabel) {
+        ?>
         <div class="ccm-block-next-previous-header">
-            <h5><?=$nextLabel?></h5>
+            <h5><?php echo $previousLabel ?></h5>
         </div>
-    <?php endif; ?>
+        <?php
+    }
 
-    <?php if ($nextLinkText): ?>
+    if ($previousLinkText) {
+        ?>
+        <p class="ccm-block-next-previous-previous-link">
+            <?php echo $previousLinkURL ? '<a href="' . $previousLinkURL . '">' . $previousLinkText . '</a>' : '' ?>
+        </p>
+        <?php
+    }
+
+    if ($nextLinkURL && $nextLabel) {
+        ?>
+        <div class="ccm-block-next-previous-header">
+            <h5><?php echo $nextLabel ?></h5>
+        </div>
+        <?php
+    }
+
+    if ($nextLinkText) {
+        ?>
         <p class="ccm-block-next-previous-next-link">
             <?php echo $nextLinkURL ? '<a href="' . $nextLinkURL . '">' . $nextLinkText . '</a>' : '' ?>
         </p>
-    <?php endif; ?>
+        <?php
+    }
 
-    <?php if ($parentLinkText): ?>
-	<p class="ccm-block-next-previous-parent-link">
-		<?php echo $parentLinkURL ? '<a href="' . $parentLinkURL . '">' . $parentLinkText . '</a>' : '' ?>
- 	</p>
-	<?php endif; ?>
-
+    if ($parentLabel) {
+        ?>
+        <p class="ccm-block-next-previous-parent-link">
+            <?php echo $parentLinkURL ? '<a href="' . $parentLinkURL . '">' . $parentLabel . '</a>' : '' ?>
+        </p>
+        <?php
+    }
+    ?>
 </div>
-
-<?php endif; ?>


### PR DESCRIPTION
Commit:
- Overall cleanup en PSR
- Remove empty getJavaScriptStrings method
- Move default values from add.php to controller add method
- Move logic from view to controller
- Remove showArrows (save) because it's not used
- get[Next|Previous)Collection should only return Page or false

Notes:

1. Controller still uses Facade, because if the block is set up via page types, $this->app currently returns null.
2. It's possible to use HTML in the label fields. Do we want to use h() in the view.php or do we want to keep it as it stands?
3. The methods getNextCollection and getPreviousCollection should probably be merged some day.