### PR TITLE
Add a getter method to ApplicationAwareTrait

### DIFF
--- a/concrete/src/Application/ApplicationAwareTrait.php
+++ b/concrete/src/Application/ApplicationAwareTrait.php
@@ -1,24 +1,40 @@
 <?php
-
 namespace Concrete\Core\Application;
 
 /**
  * Trait ApplicationAwareTrait
- * A trait used with ApplicationAwareInterface
+ * A trait used with ApplicationAwareInterface.
  */
 trait ApplicationAwareTrait
 {
-
-    /** @var \Concrete\Core\Application\Application */
-    protected $app;
+    /**
+     * The Application instance.
+     *
+     * @var Application
+     */
+    protected $app = null;
 
     /**
-     * Setter method for the application
-     * @param \Concrete\Core\Application\Application $app
+     * Setter method for the application.
+     *
+     * @param Application $app
      */
     public function setApplication(Application $app)
     {
         $this->app = $app;
     }
 
+    /**
+     * Getter method for the application.
+     *
+     * @return Application $app
+     */
+    public function getApplication()
+    {
+        if ($this->app === null) {
+            $this->app = \Concrete\Core\Support\Facade\Facade::getFacadeApplication();
+        }
+
+        return $this->app;
+    }
 }


### PR DESCRIPTION
What about improving the ApplicationAwareTrait by adding a getter that always returns an Application instance? That way we can be sure that we can retrieve an Application instance even if the class is not instantiated in the @KorvinSzanto way :wink: