### PR TITLE
Remove duplicate quote in UserEntity HTML render

### DIFF
--- a/concrete/src/Permission/Access/Entity/UserEntity.php
+++ b/concrete/src/Permission/Access/Entity/UserEntity.php
@@ -65,7 +65,7 @@ class UserEntity extends Entity
     {
         $html = '<a href="' . URL::to(
                 '/ccm/system/dialogs/user/search') . '" dialog-modal="false" dialog-width="90%" dialog-title="' . t(
-                'Add User') . '" class="dialog-launch" dialog-height="70%"">' . tc(
+                'Add User') . '" class="dialog-launch" dialog-height="70%">' . tc(
                 'PermissionAccessEntityTypeName',
                 'User') . '</a>';
 


### PR DESCRIPTION
This is a very tiny fix that fixes a typo which produced invalid HTML.