### PR TITLE
Avoid adding duplicated assets to output

### DIFF
--- a/concrete/src/Http/ResponseAssetGroup.php
+++ b/concrete/src/Http/ResponseAssetGroup.php
@@ -39,7 +39,7 @@ class ResponseAssetGroup
      */
     public function addHeaderAsset($item)
     {
-        $this->outputAssets[Asset::ASSET_POSITION_HEADER][] = $item;
+        $this->addOutputAssetAt($item, Asset::ASSET_POSITION_HEADER);
     }
 
     /**
@@ -47,12 +47,21 @@ class ResponseAssetGroup
      */
     public function addFooterAsset($item)
     {
-        $this->outputAssets[Asset::ASSET_POSITION_FOOTER][] = $item;
+        $this->addOutputAssetAt($item, Asset::ASSET_POSITION_FOOTER);
     }
 
     public function addOutputAsset(Asset $asset)
     {
-        $this->outputAssets[$asset->getAssetPosition()][] = $asset;
+        $this->addOutputAssetAt($asset, $asset->getAssetPosition());
+    }
+
+    protected function addOutputAssetAt($item, $position)
+    {
+        if (!isset($this->outputAssets[$position])) {
+            $this->outputAssets[$position] = [$item];
+        } elseif (!in_array($item, $this->outputAssets[$position])) {
+            $this->outputAssets[$position][] = $item;
+        }
     }
 
     /**


### PR DESCRIPTION
This should fix bug https://www.concrete5.org/developers/bugs/5-7-5-8/file-manager-edit-image-doesnt-work-when-jscss-cache-is-on-becau/