### PR TITLE
header_required cleanup

### DIFF
--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -2,189 +2,142 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 $c = Page::getCurrentPage();
-if (is_object($c)) {
-	$cp = new Permissions($c);
-}
-
-/**
- * Handle page title
- */
+$cp = false;
+$isEditMode = false;
+$isArrangeMode = false;
+$scc = false;
 
 if (is_object($c)) {
-	// We can set a title 3 ways:
-	// 1. It comes through programmatically as $pageTitle. If this is the case then we pass it through, no questions asked
-	// 2. It comes from meta title
-	// 3. It comes from getCollectionName()
-	// In the case of 3, we also pass it through page title format.
+    $cp = new Permissions($c);
+    $cID = $c->getCollectionID();
+    $isEditMode = $c->isEditMode();
+    $isArrangeMode = $c->isArrangeMode();
+    $styleObject = false;
+    /*
+     * Handle page title
+     */
 
-	if (!isset($pageTitle) || !$pageTitle) {
-		// we aren't getting it dynamically.
-		$pageTitle = $c->getCollectionAttributeValue('meta_title');
-		if (!$pageTitle) {
-			$pageTitle = $c->getCollectionName();
-			if($c->isSystemPage()) {
-				$pageTitle = t($pageTitle);
-			}
-			$seo = Core::make('helper/seo');
-			if (!$seo->hasCustomTitle()) {
-				$seo->addTitleSegmentBefore($pageTitle);
-			}
-			$seo->setSiteName(tc('SiteName', Config::get('concrete.site')));
-			$seo->setTitleFormat(Config::get('concrete.seo.title_format'));
-			$seo->setTitleSegmentSeparator(Config::get('concrete.seo.title_segment_separator'));
-			$pageTitle = $seo->getTitle();
-		}
-	}
+    // We can set a title 3 ways:
+    // 1. It comes through programmatically as $pageTitle. If this is the case then we pass it through, no questions asked
+    // 2. It comes from meta title
+    // 3. It comes from getCollectionName()
+    // In the case of 3, we also pass it through page title format.
 
-	if (!isset($pageDescription) || !$pageDescription) {
-		// we aren't getting it dynamically.
-		$pageDescription = $c->getCollectionAttributeValue('meta_description');
-		if (!$pageDescription) {
-			$pageDescription = $c->getCollectionDescription();
-		}
-	}
+    if (!isset($pageTitle) || !$pageTitle) {
+        // we aren't getting it dynamically.
+        $pageTitle = $c->getCollectionAttributeValue('meta_title');
+        if (!$pageTitle) {
+            $pageTitle = $c->getCollectionName();
+            if ($c->isSystemPage()) {
+                $pageTitle = t($pageTitle);
+            }
+            $seo = Core::make('helper/seo');
+            if (!$seo->hasCustomTitle()) {
+                $seo->addTitleSegmentBefore($pageTitle);
+            }
+            $seo->setSiteName(tc('SiteName', Config::get('concrete.site')));
+            $seo->setTitleFormat(Config::get('concrete.seo.title_format'));
+            $seo->setTitleSegmentSeparator(Config::get('concrete.seo.title_segment_separator'));
+            $pageTitle = $seo->getTitle();
+        }
+    }
 
-	$cID = $c->getCollectionID();
-	$isEditMode = ($c->isEditMode()) ? "true" : "false";
-	$isArrangeMode = ($c->isArrangeMode()) ? "true" : "false";
-
-
+    if (!isset($pageDescription) || !$pageDescription) {
+        // we aren't getting it dynamically.
+        $pageDescription = $c->getAttribute('meta_description');
+        if (!$pageDescription) {
+            $pageDescription = $c->getCollectionDescription();
+        }
+    }
     if ($c->hasPageThemeCustomizations()) {
         $styleObject = $c->getCustomStyleObject();
-    } else {
-        $pt = $c->getCollectionThemeObject();
-        if (is_object($pt)) {
-            $styleObject = $pt->getThemeCustomStyleObject();
-        }
+    } elseif (($pt = $c->getCollectionThemeObject()) && is_object($pt)) {
+        $styleObject = $pt->getThemeCustomStyleObject();
     }
-
-    if (is_object($styleObject)) {
+    if (isset($styleObject) && is_object($styleObject)) {
         $scc = $styleObject->getCustomCssRecord();
     }
-
 } else {
-	$cID = 1;
-	if (!isset($pageTitle)) {
-	    $pageTitle = null;
-	}
-}
-?>
+    $cID = 1;
+    if (!isset($pageTitle)) {
+        $pageTitle = null;
+    }
+} ?>
 
-<meta http-equiv="content-type" content="text/html; charset=<?php echo APP_CHARSET?>" />
+<title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET); ?></title>
+
 <?php
-if (!isset($pageMetaKeywords) || !$pageMetaKeywords) {
-    $pageMetaKeywords = $c->getCollectionAttributeValue('meta_keywords');
+$metaTags = array();
+$metaTags['charset'] = sprintf('<meta http-equiv="content-type" content="text/html; charset=%s"/>', APP_CHARSET);
+if (trim($pageDescription) != '') {
+    $metaTags['description'] = sprintf('<meta name="description" content="%s"/>', htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET));
 }
-?>
-<title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET)?></title>
-<meta name="description" content="<?=htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET)?>" />
+$pageMetaKeywords = !isset($pageMetaKeywords) || !$pageMetaKeywords ? $c->getCollectionAttributeValue('meta_keywords') : $pageMetaKeywords;
+if(trim($pageMetaKeywords) != ''){
+    $metaTags['keywords'] = sprintf('<meta name="keywords" content="%s"/>', htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET));
+}
+if ($c->getCollectionAttributeValue('exclude_search_index')) {
+    $metaTags['robots'] = sprintf('<meta name="robots" content="%s"/>', 'noindex');
+}
+$metaTags['generator'] = sprintf('<meta name="generator" content="%s"/>', 'concrete5' . (Config::get('concrete.misc.app_version_display_in_header') ? ' - ' . APP_VERSION : null));
+if (($modernIconFID = intval(Config::get('concrete.misc.modern_tile_thumbnail_fid'))) && ($modernIconFile = File::getByID($modernIconFID)) && is_object($modernIconFile)) {
+    $metaTags['msapplication-TileImage'] = sprintf('<meta name="msapplication-TileImage" content="%s"/>', $modernIconFile->getURL());
+    $modernIconBGColor = strval(Config::get('concrete.misc.modern_tile_thumbnail_bgcolor'));
+    if (strlen($modernIconBGColor)) {
+        $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s"/>', $modernIconBGColor);
+    }
+}
+echo implode(PHP_EOL, $metaTags);
 
-<? if ($pageMetaKeywords) { ?>
-<meta name="keywords" content="<?=htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET)?>" />
-<?php }
-if($c->getCollectionAttributeValue('exclude_search_index')) { ?>
-    <meta name="robots" content="noindex" />
-<?php } ?>
-<?php
-if (Config::get('concrete.misc.app_version_display_in_header')) {
-    echo '<meta name="generator" content="concrete5 - ' . APP_VERSION . '" />';
+$linkTags = array();
+if (($favIconFID = intval(Config::get('concrete.misc.favicon_fid'))) && ($favIconFile = File::getByID($favIconFID)) && is_object($favIconFile)) {
+    $favIconFileURL = $favIconFile->getURL();
+    $linkTags[] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
+    $linkTags[] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
 }
-else {
-    echo '<meta name="generator" content="concrete5" />';
+if (($appleIconFID = intval(Config::get('concrete.misc.iphone_home_screen_thumbnail_fid'))) && ($appleIconFile = File::getByID($appleIconFID)) && is_object($appleIconFile)) {
+    $linkTags[] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
 }
-?>
+if(!empty($linkTags)){
+    echo implode(PHP_EOL, $linkTags);
+} ?>
 
-<?php $u = new User(); ?>
 <script type="text/javascript">
-<?php
-	echo("var CCM_DISPATCHER_FILENAME = '" . DIR_REL . '/' . DISPATCHER_FILENAME . "';\r");
-	echo("var CCM_CID = ".($cID?$cID:0).";\r");
-	if (isset($isEditMode)) {
-		echo("var CCM_EDIT_MODE = {$isEditMode};\r");
-	}
-	if (isset($isEditMode)) {
-		echo("var CCM_ARRANGE_MODE = {$isArrangeMode};\r");
-	}
-?>
-var CCM_IMAGE_PATH = "<?php echo ASSETS_URL_IMAGES?>";
-var CCM_TOOLS_PATH = "<?php echo REL_DIR_FILES_TOOLS_REQUIRED?>";
-var CCM_APPLICATION_URL = "<?php echo \Core::getApplicationURL()?>";
-var CCM_REL = "<?php echo \Core::getApplicationRelativePath()?>";
-
+    var CCM_DISPATCHER_FILENAME = "<?php echo DIR_REL . '/' . DISPATCHER_FILENAME; ?>";
+    var CCM_CID = "<?php echo $cID ? $cID : 0; ?>";
+    var CCM_EDIT_MODE = <?php echo $isEditMode ? 'true' : 'false'; ?>;
+    var CCM_ARRANGE_MODE = <?php echo $isArrangeMode ? 'true' : 'false'; ?>;
+    var CCM_IMAGE_PATH = "<?php echo ASSETS_URL_IMAGES; ?>";
+    var CCM_TOOLS_PATH = "<?php echo REL_DIR_FILES_TOOLS_REQUIRED; ?>";
+    var CCM_APPLICATION_URL = "<?php echo \Core::getApplicationURL(); ?>";
+    var CCM_REL = "<?php echo \Core::getApplicationRelativePath(); ?>";
 </script>
 
-<? if (isset($scc) && is_object($scc)) { ?>
-    <style type="text/css">
-        <? print $scc->getValue();?>
-    </style>
-<? } ?>
-
 <?php
-
 $v = View::getInstance();
-
-if (Config::get('concrete.user.profiles_enabled') && $u->isRegistered()) {
-	$v->requireAsset('core/account');
-	$v->addFooterItem('<script type="text/javascript">$(function() { ccm_enableUserProfileMenu(); });</script>');
+$u = new User();
+if ($u->isRegistered()) {
+    $v->requireAsset('core/account');
+    $v->addFooterItem('<script type="text/javascript">$(function() { ccm_enableUserProfileMenu(); });</script>');
 }
-
-$favIconFID=intval(Config::get('concrete.misc.favicon_fid'));
-$appleIconFID =intval(Config::get('concrete.misc.iphone_home_screen_thumbnail_fid'));
-$modernIconFID = intval(Config::get('concrete.misc.modern_tile_thumbnail_fid'));
-$modernIconBGColor = strval(Config::get('concrete.misc.modern_tile_thumbnail_bgcolor'));
-
-if($favIconFID) {
-    $f = File::getByID($favIconFID);
-    if (is_object($f)) {
-        ?>
-        <link rel="shortcut icon" href="<?php echo $f->getURL() ?>" type="image/x-icon"/>
-        <link rel="icon" href="<?php echo $f->getURL() ?>" type="image/x-icon"/>
-    <?php
-    }
-}
-
-if($appleIconFID) {
-    $f = File::getByID($appleIconFID);
-    if (is_object($f)) {
-        ?>
-        <link rel="apple-touch-icon" href="<?php echo $f->getURL() ?>"/>
-    <?php
-    }
-}
-
-if($modernIconFID) {
-	$f = File::getByID($modernIconFID);
-    if(is_object($f)) {
-        ?>
-        <meta name="msapplication-TileImage" content="<?php echo $f->getURL(); ?>" /><?php
-        echo "\n";
-        if (strlen($modernIconBGColor)) {
-            ?>
-            <meta name="msapplication-TileColor" content="<?php echo $modernIconBGColor; ?>" /><?php
-            echo "\n";
-        }
-    }
-}
-
 if (is_object($cp)) {
-
-	Loader::element('page_controls_header', array('cp' => $cp, 'c' => $c));
-
-	$cih = Loader::helper('concrete/ui');
-	if ($cih->showNewsflowOverlay()) {
-		$v->addFooterItem('<script type="text/javascript">$(function() { new ConcreteNewsflowDialog().open(); });</script>');
-	}
-
-	if (array_get($_COOKIE, 'ccmLoadAddBlockWindow') && $c->isEditMode()) {
-		$v->addFooterItem('<script type="text/javascript">$(function() { setTimeout(function() { $("a[data-launch-panel=add-block]").click()}, 100); });</script>', 'CORE');
-		setcookie("ccmLoadAddBlockWindow", false, -1, DIR_REL . '/');
-	}
+    View::element('page_controls_header', array('cp' => $cp, 'c' => $c));
+    $cih = Core::make('helper/concrete/ui');
+    if ($cih->showNewsflowOverlay()) {
+        $v->addFooterItem('<script type="text/javascript">$(function() { new ConcreteNewsflowDialog().open(); });</script>');
+    }
+    if (array_get($_COOKIE, 'ccmLoadAddBlockWindow') && $c->isEditMode()) {
+        $v->addFooterItem('<script type="text/javascript">$(function() { setTimeout(function() { $("a[data-launch-panel=add-block]").click()}, 100); });</script>', 'CORE');
+        setcookie("ccmLoadAddBlockWindow", false, -1, DIR_REL . '/');
+    }
 }
-
-$v = View::getInstance();
 $v->markHeaderAssetPosition();
-$_trackingCodePosition = Config::get('concrete.seo.tracking.code_position');
-if (empty($disableTrackingCode) && $_trackingCodePosition === 'top') {
-	echo Config::get('concrete.seo.tracking.code');
+if (empty($disableTrackingCode) && Config::get('concrete.seo.tracking.code_position') === 'top') {
+    echo Config::get('concrete.seo.tracking.code');
 }
-echo $c->getCollectionAttributeValue('header_extra_content');
+if (isset($scc) && is_object($scc)) {
+    ?>
+    <style type="text/css"><?php echo $scc->getValue(); ?></style>
+    <?php
+}
+echo $c->getAttribute('header_extra_content');

--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -93,7 +93,19 @@ if (($favIconFID = intval(Config::get('concrete.misc.favicon_fid'))) && ($favIco
 }
 if (($appleIconFID = intval(Config::get('concrete.misc.iphone_home_screen_thumbnail_fid'))) && ($appleIconFile = File::getByID($appleIconFID)) && is_object($appleIconFile)) {
     $linkTags['apple-touch-icon'] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
-} ?>
+} 
+
+// Generate and dispatch an event, to let other Add-Ons make use of the available (meta) tags/page title
+$event = new \Symfony\Component\EventDispatcher\GenericEvent();
+$event->setArgument('metaTags', $metaTags);
+$event->setArgument('linkTags', $linkTags);
+$event->setArgument('pageTitle', $pageTitle);
+$event->setArgument('defaultPageTitle', $defaultPageTitle);
+Events::dispatch('on_header_required_ready', $event);
+$metaTags = $event->getArgument('metaTags');
+$linkTags = $event->getArgument('linkTags');
+$pageTitle = $event->getArgument('pageTitle');
+?>
 
 <title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET); ?></title>
 

--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -6,6 +6,7 @@ $cp = false;
 $isEditMode = false;
 $isArrangeMode = false;
 $scc = false;
+$defaultPageTitle = isset($pageTitle) && $pageTitle ? $pageTitle : null;
 
 if (is_object($c)) {
     $cp = new Permissions($c);
@@ -13,6 +14,7 @@ if (is_object($c)) {
     $isEditMode = $c->isEditMode();
     $isArrangeMode = $c->isArrangeMode();
     $styleObject = false;
+
     /*
      * Handle page title
      */
@@ -23,7 +25,7 @@ if (is_object($c)) {
     // 3. It comes from getCollectionName()
     // In the case of 3, we also pass it through page title format.
 
-    if (!isset($pageTitle) || !$pageTitle) {
+    if (!$defaultPageTitle) {
         // we aren't getting it dynamically.
         $pageTitle = $c->getCollectionAttributeValue('meta_title');
         if (!$pageTitle) {
@@ -62,18 +64,14 @@ if (is_object($c)) {
     if (!isset($pageTitle)) {
         $pageTitle = null;
     }
-} ?>
-
-<title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET); ?></title>
-
-<?php
+}
 $metaTags = array();
 $metaTags['charset'] = sprintf('<meta http-equiv="content-type" content="text/html; charset=%s"/>', APP_CHARSET);
 if (trim($pageDescription) != '') {
     $metaTags['description'] = sprintf('<meta name="description" content="%s"/>', htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET));
 }
 $pageMetaKeywords = !isset($pageMetaKeywords) || !$pageMetaKeywords ? $c->getCollectionAttributeValue('meta_keywords') : $pageMetaKeywords;
-if(trim($pageMetaKeywords) != ''){
+if (trim($pageMetaKeywords) != ''){
     $metaTags['keywords'] = sprintf('<meta name="keywords" content="%s"/>', htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET));
 }
 if ($c->getCollectionAttributeValue('exclude_search_index')) {
@@ -87,18 +85,21 @@ if (($modernIconFID = intval(Config::get('concrete.misc.modern_tile_thumbnail_fi
         $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s"/>', $modernIconBGColor);
     }
 }
-echo implode(PHP_EOL, $metaTags);
-
 $linkTags = array();
 if (($favIconFID = intval(Config::get('concrete.misc.favicon_fid'))) && ($favIconFile = File::getByID($favIconFID)) && is_object($favIconFile)) {
     $favIconFileURL = $favIconFile->getURL();
-    $linkTags[] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
-    $linkTags[] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
+    $linkTags['shortcut icon'] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
+    $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
 }
 if (($appleIconFID = intval(Config::get('concrete.misc.iphone_home_screen_thumbnail_fid'))) && ($appleIconFile = File::getByID($appleIconFID)) && is_object($appleIconFile)) {
-    $linkTags[] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
-}
-if(!empty($linkTags)){
+    $linkTags['apple-touch-icon'] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
+} ?>
+
+<title><?php echo htmlspecialchars($pageTitle, ENT_COMPAT, APP_CHARSET); ?></title>
+
+<?php
+echo implode(PHP_EOL, $metaTags);
+if (!empty($linkTags)) {
     echo implode(PHP_EOL, $linkTags);
 } ?>
 


### PR DESCRIPTION
This will cleanup the header_required.php file. Changes:

- Code has been shortened;
- Code will be used consistent, instead of sometimes outputting straight JavaScript and in between echo'ing JavaScript in PHP;
- Variables have been removed, if they hadn't got to be in a variable but could be used straight away;
- Grouped meta tags into an array;
- Grouped shortcut links in an array;
- Description (meta) will only show when not empty (after trimming);
- Removed deprecated code (Loader::helper('concrete/ui'));

After this cleanup, we can think of firing an event or something, for Add-Ons to be able to add/edit some meta tags. For now, this cleanup only has parts it already had, but organized, clean, no deprecated code and will make it easier to add something in for Add-Ons at a later stage (commit/PR).