### PR TITLE
Fix working with updated core versions

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -39,21 +39,23 @@ defined('DIR_CONFIG_SITE') or define('DIR_CONFIG_SITE', DIR_APPLICATION . '/conf
  * ----------------------------------------------------------------------------
  */
 
-$update_file = DIR_CONFIG_SITE . '/update.php';
-$updates = array();
-if (file_exists($update_file)) {
-    $updates = (array) include $update_file;
-}
-if (!defined('APP_UPDATED_PASSTHRU') && isset($updates['core'])) {
-    define('APP_UPDATED_PASSTHRU', true);
-    if (is_dir(DIR_BASE . '/' . DIRNAME_UPDATES . '/' . $updates['core'])) {
-        require DIR_BASE . '/' . DIRNAME_UPDATES . '/' . $updates['core'] . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
-    } elseif (file_exists(DIRNAME_UPDATES . '/' . $updates['core'] . '/' . DIRNAME_CORE . '/' . 'dispatcher.php')) {
-        require DIRNAME_UPDATES . '/' . $updates['core'] . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
-    } else {
-        die(sprintf('Invalid "%s" defined. Please remove it from %s.', 'update.core', $update_file));
+if (!defined('APP_UPDATED_PASSTHRU')) {
+    $update_file = DIR_CONFIG_SITE . '/update.php';
+    if (file_exists($update_file)) {
+        $updates = (array) include $update_file;
+        if (isset($updates['core'])) {
+            define('APP_UPDATED_PASSTHRU', $updates['core']);
+            if (is_dir(DIR_BASE . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU)) {
+                require DIR_BASE . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
+            } elseif (file_exists(DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php')) {
+                require DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
+            } else {
+                die(sprintf('Invalid "%s" defined. Please remove it from %s.', 'update.core', $update_file));
+            }
+            exit;
+        }
     }
-    exit;
+    define('APP_UPDATED_PASSTHRU', false);
 }
 
 /*

--- a/concrete/bootstrap/paths.php
+++ b/concrete/bootstrap/paths.php
@@ -7,10 +7,10 @@ defined('C5_EXECUTE') or define('C5_EXECUTE', md5(uniqid()));
  * Assets (Images, JS, etc....) URLs
  * ----------------------------------------------------------------------------
  */
-if (defined('APP_UPDATED_PASSTHRU') && APP_UPDATED_PASSTHRU) {
-    $ap = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . $updates['core'] . '/' . DIRNAME_CORE;
-} else {
+if (APP_UPDATED_PASSTHRU === false) {
     $ap = $app['app_relative_path'] . '/' . DIRNAME_CORE;
+} else {
+    $ap = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE;
 }
 
 define('ASSETS_URL', $ap);


### PR DESCRIPTION
With version 5.7, [`concrete/bootstrap/paths.php`](https://github.com/concrete5/concrete5/blob/5.7.5.8/web/concrete/bootstrap/paths.php) was directly included by [`concrete/bootstrap/start.php`](https://github.com/concrete5/concrete5/blob/5.7.5.8/web/concrete/bootstrap/start.php#L39), which was directly included by [`concrete/dispatcher.php`](https://github.com/concrete5/concrete5/blob/5.7.5.8/web/concrete/dispatcher.php#L36), which was directly included by [`index.php`](https://github.com/concrete5/concrete5/blob/5.7.5.8/web/index.php#L2).
That means that before `concrete/bootstrap/paths.php` could access the global variables directly (since that file was included directly and not from functions).

concrete5 version 8 introduced the runtime booters and runners, and now `concrete/bootstrap/paths.php` is included by [`DefaultBooter::boot()`](https://github.com/concrete5/concrete5/blob/815a9ebde8f9ee0b55b9886510eaff2afd23a2ea/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php#L55), so this file is not in the scope of global variables.

The problem is that `concrete/bootstrap/paths.php` currently [needs the value of the `$updates` variable](https://github.com/concrete5/concrete5/blob/815a9ebde8f9ee0b55b9886510eaff2afd23a2ea/concrete/bootstrap/paths.php#L11), that's defined [here](https://github.com/concrete5/concrete5/blob/815a9ebde8f9ee0b55b9886510eaff2afd23a2ea/concrete/bootstrap/configure.php#L43).
Furthermore the current process does not work well with CLI commands.

Let's fix these problems by assigning the value of the previous `$update['core']` to the `APP_UPDATED_PASSTHRU` constant (`APP_UPDATED_PASSTHRU` will be `false` if no updated core is installed).