### PR TITLE
Make changes to the application autoload in order to allow including …

### DIFF
--- a/application/bootstrap/autoload.php
+++ b/application/bootstrap/autoload.php
@@ -7,6 +7,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * Load all composer autoload items.
  * ----------------------------------------------------------------------------
  */
-if (!@include(DIR_BASE_CORE . '/' . DIRNAME_VENDOR . '/autoload.php')) {
-    die('Third party libraries not installed. Make sure that composer has required libraries in the concrete/ directory.');
+
+// If the checker class is already provided, likely we have been included in a separate composer project
+if (!class_exists(\DoctrineXml\Checker::class)) {
+    // Otherwise, lets try to load composer ourselves
+    if (!@include(DIR_BASE_CORE . '/' . DIRNAME_VENDOR . '/autoload.php')) {
+        die('Third party libraries not installed. Make sure that composer has required libraries in the concrete/ directory.');
+    }
 }


### PR DESCRIPTION
If the checker class exists, we know that composer has loaded. No need to attempt loading ourselves.