### PR TITLE
Cookie lifetime for session

### DIFF
--- a/web/concrete/src/Session/SessionFactory.php
+++ b/web/concrete/src/Session/SessionFactory.php
@@ -72,7 +72,9 @@ class SessionFactory implements SessionFactoryInterface
             if ($options['cookie_path'] === false) {
                 $options['cookie_path'] = $app['app_relative_path'] . '/';
             }
-            $options['gc_max_lifetime'] = $config->get('concrete.session.max_lifetime');
+
+            $lifetime = $config->get('concrete.session.max_lifetime');
+            $options['gc_max_lifetime'] = $options['cookie_lifetime'] = $lifetime;
             $storage->setOptions($options);
         }
 


### PR DESCRIPTION
Adds cookie_lifetime option to the session storage, this allows us to retrieve the time remaining on the currently active session when a limit is set.