### PR TITLE
Marketplace.php - undefined constant

### DIFF
--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -73,7 +73,7 @@ class Marketplace
         if (empty($pkg)) {
             $error->add(t('An error occurred while downloading the package.'));
         }
-        if ($pkg == Package::E_PACKAGE_INVALID_APP_VERSION) {
+        if ($pkg == \Package::E_PACKAGE_INVALID_APP_VERSION) {
             $error->add(t('This package isn\'t currently available for this version of concrete5 . Please contact the maintainer of this package for assistance.'));
         }
 


### PR DESCRIPTION
When installing ExchangeCore Dev Tools on 8.0.0a5, I got:
Fatal error: Undefined class constant 'E_PACKAGE_INVALID_APP_VERSION'

E_PACKAGE_INVALID_APP_VERSION is a member of \Package, not Concrete\Core\Support\Facade\Package (Concrete\Core\Package\PackageService)