### PR TITLE
Fix smaller than full size slides to center on page

### DIFF
--- a/concrete/blocks/image_slider/view.css
+++ b/concrete/blocks/image_slider/view.css
@@ -22,3 +22,7 @@
     height: 100%;
     left: 0px;
 }
+
+.rslides {
+    margin: 0 auto;
+}


### PR DESCRIPTION
I went to play with the max slides function I coded, then realized I used the wrong dev directory for git to move the code over, so it was incomplete in the released version! I finally got a git issue sorted today, so I went to fix everything, only to find @MrKarlDilkington fixed most of it (thanks!). But I think if you set the max width of the slides to less than 100%, it moves everything over to the left side. Therefore, this fix recenters the slides back to the center of the div.