### PR TITLE
Fix theme customizations caching

### DIFF
--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -145,7 +145,7 @@ class PageView extends View
             return $this->themeObject->getStylesheet($stylesheet);
         }
 
-        if ($this->c->hasPageThemeCustomizations()) {
+        if ($this->cp->canViewPageVersions() && $this->c->hasPageThemeCustomizations()) {
             if ($this->c->getVersionObject()->isApproved()) {
                 return URL::to('/ccm/system/css/page', $this->c->getCollectionID(), $stylesheet);
             } else {


### PR DESCRIPTION
When using theme customizations on a concrete5 site I noticed an increased load time. After some investigation it seems that with theme customizations the CSS cache is actually not used.

The problem was introduced with this commit: https://github.com/concrete5/concrete5/commit/6bd27450c552c642b12ba68e9d3a206ce64527be#diff-7a93e2465b45c5883e9e24fa04035a3f

I'm not entirely sure which bug exactly this is supposed to fix, but it effectively disables all caching for pages with theme customizations. Before it would only use the "handler script" for previewing unapproved changes, after the "handler script" is used as soon as there are theme customizations.

I think the call `$this->cp->canViewPageVersions()` was removed by accident.
