### PR TITLE
Removal of Australian Antarctic Territory from list of Australian States

### DIFF
--- a/concrete/src/Localization/Service/StatesProvincesList.php
+++ b/concrete/src/Localization/Service/StatesProvincesList.php
@@ -89,7 +89,6 @@ class StatesProvincesList
                 ),
 
                 'AU' => array(
-                    'AAT' => tc('Australian State', 'Australian Antarctic Territory'),
                     'ACT' => tc('Australian State', 'Australian Capital Territory'),
                     'NSW' => tc('Australian State', 'New South Wales'),
                     'NT' => tc('Australian State', 'Northern Territory'),


### PR DESCRIPTION
This option would never be used as a billing or shipping address and shouldn't be included in the list of states and territories of Australia. (Antartica is listed as a country option anyway).