### PR TITLE
Fix autonav exclude

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -32,6 +32,7 @@ class Controller extends BlockController
     public $haveRetrievedSelfPlus1 = false;
     public $displaySystemPages = false;
     public $displayUnapproved = false;
+    public $ignoreExcludeNav = false;
     protected $btTable = 'btNavigation';
     protected $btInterfaceWidth = "800";
     protected $btInterfaceHeight = "350";
@@ -177,6 +178,8 @@ class Controller extends BlockController
             }
         }
 
+        $this->ignoreExcludeNav = $ignore_exclude_nav;
+
         //Retrieve the raw "pre-processed" list of all nav items (before any custom attributes are considered)
         $allNavItems = $this->generateNav();
 
@@ -202,7 +205,7 @@ class Controller extends BlockController
                 }
             }
 
-            if (!$exclude_page || $ignore_exclude_nav) {
+            if (!$exclude_page || $this->ignoreExcludeNav) {
                 $includedNavItems[] = $ni;
             }
         }
@@ -514,7 +517,7 @@ class Controller extends BlockController
     {
         // Check if the parent page is excluded or if it has been set to exclude child pages
         foreach ($this->navArray as $ni) {
-            if ($ni->getCollectionID() == $cParentID) {
+            if ($ni->getCollectionID() == $cParentID && $this->ignoreExcludeNav === false) {
                 if ($ni->getCollectionObject()->getAttribute('exclude_nav') == 1 || $ni->getCollectionObject()->getAttribute('exclude_subpages_from_nav') == 1) {
                     return;
                 }


### PR DESCRIPTION
Fix the autonav bug which breaks breadcrumbs in the 5.7 branch.

Backport of #3769.