### PR TITLE
Tiny issue: Add missing  "/" in $title end tag

### DIFF
--- a/concrete/blocks/page_title/view.php
+++ b/concrete/blocks/page_title/view.php
@@ -17,5 +17,5 @@ if ($useFilterTitle) {
 }
 
 if ($title) {
-    echo "<$formatting  class=\"page-title\">" . h($title) . "<$formatting>";
+    echo "<$formatting  class=\"page-title\">" . h($title) . "</$formatting>";
 }


### PR DESCRIPTION
Wrong output before:
`<h1>Title<h1>`

Correct After:
`<h1>Title</h1>`

This **tiny** issue could break the whole design of the site (Convert other element to h1).