### PR TITLE
5.7.x WCAG fix for Share This Page default view

### DIFF
--- a/web/concrete/blocks/share_this_page/view.php
+++ b/web/concrete/blocks/share_this_page/view.php
@@ -1,9 +1,11 @@
- aria-label="<?php echo h($service->getDisplayName()) ?>"<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="ccm-block-share-this-page">
     <ul class="list-inline">
-    <? foreach($selected as $service) { ?>
+    <?php foreach ($selected as $service) {
+    ?>
         <li><a href="<?= h($service->getServiceLink()) ?>" aria-label="<?php echo h($service->getDisplayName()) ?>"><?=$service->getServiceIconHTML()?></a></li>
-    <? } ?>
+    <?php 
+} ?>
     </ul>
 </div>

--- a/web/concrete/blocks/share_this_page/view.php
+++ b/web/concrete/blocks/share_this_page/view.php
@@ -1,9 +1,9 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+ aria-label="<?php echo h($service->getDisplayName()) ?>"<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 <div class="ccm-block-share-this-page">
     <ul class="list-inline">
     <? foreach($selected as $service) { ?>
-        <li><a href="<?= h($service->getServiceLink()) ?>"><?=$service->getServiceIconHTML()?></a></li>
+        <li><a href="<?= h($service->getServiceLink()) ?>" aria-label="<?php echo h($service->getDisplayName()) ?>"><?=$service->getServiceIconHTML()?></a></li>
     <? } ?>
     </ul>
 </div>


### PR DESCRIPTION
The current block output creates empty anchor links to the various social media networks. WCAG AA requires some kind of descriptive content for links. I opted to add in aria-label attributes and populate them with the display name of each network using the getDisplayName() service call.

I ran the view file through the PHP fixer which cleaned up some whitespace stuff as well.