### PR TITLE
Add WCAG label to Share This Page default view

### DIFF
--- a/web/concrete/blocks/share_this_page/view.php
+++ b/web/concrete/blocks/share_this_page/view.php
@@ -1,9 +1,11 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="ccm-block-share-this-page">
     <ul class="list-inline">
-    <? foreach($selected as $service) { ?>
-        <li><a href="<?= h($service->getServiceLink()) ?>"><?=$service->getServiceIconHTML()?></a></li>
-    <? } ?>
+    <?php foreach ($selected as $service) {
+    ?>
+        <li><a href="<?= h($service->getServiceLink()) ?>" aria-label="<?php echo h($service->getDisplayName()) ?>"><?=$service->getServiceIconHTML()?></a></li>
+    <?php 
+} ?>
     </ul>
 </div>


### PR DESCRIPTION
The default view of the Share This Page block creates empty hyperlinks (they contain only the Bootstrap ```<i></i>``` elements that display the service icons). In order to make WCAG AA happy, hyperlinks need to have some kind of text content. I opted to add aria-label attributes to each anchor tag and popular the attribute with the getDisplayName() service call. This results in markup like this:

```
<li>
  <a href="https://www.facebook.com/sharer/sharer.php?u=path/to/page" aria-label="Facebook"><i class="fa fa-facebook"></i></a>
</li>
```