### PR TITLE
Invalidate browser cache when CSS files are edited

### DIFF
--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -345,6 +345,9 @@ class Theme extends Object
         if ($this->isThemePreviewRequest()) {
             $path .= '?ts='.time();
         }
+        else {
+            $path .= '?ts='.filemtime($stylesheet->getOutputPath());
+        }
 
         return $path;
     }


### PR DESCRIPTION
CSS files are currently cached on two sides; both by Concrete5 and by the client's browser. That's very effective, but when something changes in such a file, both caches need to be invalidated.

Concrete5's cache appears to function just fine, but when a CSS file in a theme is edited, the browser still retains its old version for a while. By adding the last-modified date, the browser is informed that the current version is outdated.

This is particularly relevant for CSS files that are the result of compiled LESS files, which greatly benefit from aggressive caching.