### PR TITLE
Update google type form to have correct regex

### DIFF
--- a/concrete/authentication/google/type_form.php
+++ b/concrete/authentication/google/type_form.php
@@ -56,7 +56,7 @@
     <span class="help-block"><?= t(
             'One per line, to whitelist all %s domains: %s',
             '<code>concrete5.org</code>',
-            '<code>~^concrete5\\.org$i~</code>') ?></span>
+            '<code>~^concrete5\\.org$~i</code>') ?></span>
     <textarea type="text" name="whitelist" class="form-control"><?= implode(PHP_EOL, (array) $whitelist) ?></textarea>
 </div>
 


### PR DESCRIPTION
The regex example in this file was off, instead of `~^concrete5\.org$i~` it should be something that works like `~^concrete5\.org$~i`.