### PR TITLE
Fix attribute option list in Tags block

### DIFF
--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Block\Tags;
 
-use Concrete\Attribute\Select\Option;
+use Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption;
 use Concrete\Core\Block\BlockController;
 use CollectionAttributeKey;
 use Page;
@@ -72,11 +72,11 @@ class Controller extends BlockController
             $controller = $type->getController();
             $controller->setAttributeKey($ak);
             $items = $controller->getOptions();
-            $options = new \Concrete\Attribute\Select\OptionList();
-            if ($this->cloudCount > 0 && $items instanceof \Concrete\Attribute\Select\OptionList && $items->count()) {
+            $options = array();
+            if ($this->cloudCount > 0 && count($items) > 0) {
                 $i = 1;
                 foreach ($items as $item) {
-                    $options->add($item);
+                    $options[] = $item;
                     if ($i >= $this->cloudCount) {
                         break;
                     }
@@ -89,7 +89,8 @@ class Controller extends BlockController
             $c = Page::getCurrentPage();
             $av = $c->getAttributeValueObject($ak);
             $controller = $ak->getController();
-            $options = $c->getAttribute($ak->getAttributeKeyHandle());
+            $attributeValue = $c->getAttribute($ak->getAttributeKeyHandle());
+            $options = $attributeValue->getSelectedOptions();
         }
 
         if ($this->targetCID > 0) {
@@ -130,7 +131,7 @@ class Controller extends BlockController
         parent::save($args);
     }
 
-    public function getTagLink(Option $option = null)
+    public function getTagLink(SelectValueOption $option = null)
     {
         $target = $this->get('target');
         if (!is_object($target)) {

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -1,11 +1,10 @@
 <?php
 
 defined('C5_EXECUTE') or die("Access Denied.");
-use Concrete\Attribute\Select\OptionList;
 
 ?>
 
-<?php if ($options instanceof OptionList && $options->count() > 0): ?>
+<?php if (count($options) > 0): ?>
 
 <div class="ccm-block-tags-wrapper">
 


### PR DESCRIPTION
Proposed fix for #3992.

Replaces `OptionList` with an `array`. Also added required `getSelectedOptions()` call for the page attribute.