### PR TITLE
Use sitemap icon in toolbar

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -409,7 +409,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                 ?>
                 <li data-guide-toolbar-action="sitemap" class="pull-right hidden-xs">
                     <a href="#" data-panel-url="<?= URL::to('/ccm/system/panels/sitemap') ?>" title="<?= t('Add Pages and Navigate Your Site') ?>" data-launch-panel="sitemap">
-                        <i class="fa fa-files-o"></i>
+                        <i class="fa fa-sitemap"></i>
                         <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page"><?= tc('toolbar', 'Pages') ?></span>
                     </a>
                 </li>

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -95,7 +95,7 @@ $large_font = (bool) Config::get('concrete.accessibility.toolbar_large_font');
         </li>
         <li class="pull-right hidden-xs hidden-sm">
             <a href="#" data-panel-url="<?=URL::to('/system/panels/sitemap')?>" data-launch-panel="sitemap">
-                <i class="fa fa-files-o"></i>
+                <i class="fa fa-sitemap"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page">
                     <?= tc('toolbar', 'Pages') ?>
                 </span>


### PR DESCRIPTION
In the beginning I often clicked the plus icon in the toolbar by accident when I wanted to add a new page - now that I've used concrete5 enough it happens only rarely. Still I think the current icon for adding new pages is not very intuitive.

This PR replaces the icon in the toolbar with the sitemap icon which seems more logical to me as the button also shows the sitemap and is about the organization of pages. It was also used for inserting links to other pages in the content block in 5.7.

![screen shot 2016-07-12 at 18 21 53](https://cloud.githubusercontent.com/assets/13346/16774943/75df48c4-485e-11e6-8c74-74333ab91f45.png)
