### PR TITLE
Use rtrim for BASE_URL

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -317,7 +317,7 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
         define('APP_VERSION', $config->get('concrete.version'));
         define('APP_CHARSET', $config->get('concrete.charset'));
         try {
-            define('BASE_URL', (string) $this->app->make('url/canonical'));
+            define('BASE_URL', rtrim((string) $this->app->make('url/canonical'), '/'));
         } catch (\Exception $x) {
             echo $x->getMessage();
             die(1);


### PR DESCRIPTION
Fix for #3869.

Same as in the [Application facade]( https://github.com/concrete5/concrete5/blob/develop/concrete/src/Support/Facade/Application.php#L25).

Assuming it's not wise to call `\Core::getApplicationURL()` here as that would use the static facade app instead of `$this->app`.

Shouldn't this actually be `$app->make('url/canonical')` (parameter) instead of `$this->app->make('url/canonical')` (protected field)?