### PR TITLE
Protect against path traversal more thoroughly

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -424,9 +424,8 @@ class Application extends Container
 
         $path = rawurldecode($request->getPathInfo());
 
-        if (substr($path, 0, 3) == '../' || substr($path, -3) == '/..' || strpos($path, '/../') ||
-            substr($path, 0, 3) == '..\\' || substr($path, -3) == '\\..' || strpos($path, '\\..\\')) {
-            throw new \RuntimeException(t('Invalid path traversal. Please make this request with a valid HTTP client.'));
+        if (strpos($path, '..')) {
+            throw new \RuntimeException(t('Illegal path traversal detected. Please make this request with a valid HTTP client.'));
         }
 
         if ($this->installed) {


### PR DESCRIPTION
By denying any requests with two periods we prevent potential path traversal on some systems completely. Is there ever a case where a valid concrete5 URL has a ".." in it's path?

Another option that will have the same effect is replacing ".." with "", but that would duplicate content for example "/blogs" will be accessible from "/..blo..gs.." or "/b..l..o........g..s"