### PR TITLE
Switch Site name and page title on default

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -910,7 +910,7 @@ return array(
         'canonical_url' => null,
         'canonical_ssl_url' => null,
         'trailing_slash' => false,
-        'title_format' => '%1$s :: %2$s',
+        'title_format' => '%2$s :: %1$s',
         'title_segment_separator' => ' :: ',
         'page_path_separator' => '-',
         'group_name_separator' => ' / ',


### PR DESCRIPTION
Japanese users and I was also wondering why the page title order default has been
SITE NAME :: PAGE NAME
I would like to propose to switch to PAGE NAME :: SITE NAME order by default.
By changing the /concrete/config/concrete.php

Request from Japanese users
http://concrete5-japan.org/community/forums/feature-requests/post-13251/

They want to comply the site to meet WCAG standard
https://www.w3.org/TR/WCAG20-TECHS/G88.html
https://www.w3.org/WAI/WCAG20/quickref/#qr-navigation-mechanisms-title

Thanks.