### PR TITLE
Fix Exception on '../'

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -424,7 +424,7 @@ class Application extends Container
 
         $path = rawurldecode($request->getPathInfo());
 
-        if (strpos($path, '..')) {
+        if (strpos($path, '..') !== false) {
             throw new \RuntimeException(t('Illegal path traversal detected. Please make this request with a valid HTTP client.'));
         }
 


### PR DESCRIPTION
Change to check for `false` to raise exception when first two
characters are '..'.