### PR TITLE
Add parameter to only retrieve scheduled job sets

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -168,7 +168,7 @@ class Application extends Container
 
                 // job sets
                 if (!strlen($url)) {
-                    $jSets = JobSet::getList();
+                    $jSets = JobSet::getList(true);
                     if (is_array($jSets) && count($jSets)) {
                         foreach ($jSets as $set) {
                             if ($set->isScheduledForNow()) {

--- a/concrete/src/Job/Set.php
+++ b/concrete/src/Job/Set.php
@@ -18,10 +18,15 @@ class Set extends Object
     /**
      * @return JobSet[]
      */
-    public static function getList()
-    {
+    public static function getList($scheduledOnly = false) {
         $db = Loader::db();
-        $r = $db->Execute('select jsID, pkgID, jsName, jDateLastRun, isScheduled, scheduledInterval, scheduledValue from JobSets order by jsName asc');
+
+        if ($scheduledOnly) {
+            $q = "select jsID, pkgID, jsName, jDateLastRun, isScheduled, scheduledInterval, scheduledValue from JobSets where isScheduled = 1 order by jsName asc";
+        } else {
+            $q = "select jsID, pkgID, jsName, jDateLastRun, isScheduled, scheduledInterval, scheduledValue from JobSets order by jsName asc";
+        }
+        $r = $db->Execute($q);
         $list = array();
         while ($row = $r->FetchRow()) {
             $js = new JobSet();


### PR DESCRIPTION
In the application shutdown we retrieve scheduled jobs.
We also retrieve job sets, but they're not filtered on whether they're scheduled or not.

This PR also gives a slight performance advantage because shutdown is basically called in each request.