### PR TITLE
Use argument unpacking in Facade abstract class

### DIFF
--- a/concrete/src/Support/Facade/Facade.php
+++ b/concrete/src/Support/Facade/Facade.php
@@ -72,7 +72,7 @@ abstract class Facade
      */
     public static function clearResolvedInstances()
     {
-        static::$resolvedInstance = array();
+        static::$resolvedInstance = [];
     }
 
     /**
@@ -100,7 +100,9 @@ abstract class Facade
      *
      * @param  string $method
      * @param  array $args
+     *
      * @return mixed
+     *
      * @throws \Exception
      */
     public static function __callStatic($method, $args)

--- a/concrete/src/Support/Facade/Facade.php
+++ b/concrete/src/Support/Facade/Facade.php
@@ -98,10 +98,10 @@ abstract class Facade
     /**
      * Handle dynamic, static calls to the object.
      *
-     * @param  string  $method
-     * @param  array   $args
-     *
+     * @param  string $method
+     * @param  array $args
      * @return mixed
+     * @throws \Exception
      */
     public static function __callStatic($method, $args)
     {
@@ -110,24 +110,7 @@ abstract class Facade
         if (!method_exists($instance, $method)) {
             throw new \Exception(t('Invalid Method on class %s: %s.', get_class($instance), $method));
         }
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
 
-            case 1:
-                return $instance->$method($args[0]);
-
-            case 2:
-                return $instance->$method($args[0], $args[1]);
-
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
-
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-            default:
-                return call_user_func_array(array($instance, $method), $args);
-        }
+        return $instance->$method(...$args);
     }
 }


### PR DESCRIPTION
Replace switch and call_user_func_array with argument unpacking.
Argument unpacking (...$var) is available since PHP 5.6.