### PR TITLE
Shorttag Left-over on Advanced Permission Page Panels

### DIFF
--- a/concrete/views/panels/details/page/permissions/advanced.php
+++ b/concrete/views/panels/details/page/permissions/advanced.php
@@ -1,18 +1,27 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <section class="ccm-ui">
 	<header><?=t('Page Permissions')?></header>
 
-	<?
-	  $cpc = $c->getPermissionsCollectionObject();
-	if ($c->getCollectionInheritance() == "PARENT") { ?>
-		<?php if ($c->isPageDraft()) { ?>
-			<div class="alert alert-info"><?=t('This page inherits its permissions from the drafts area, as well as its edit page type drafts permission.');?></div>
-		<?php } else {  ?>
-			<div class="alert alert-info"><?=t('This page inherits its permissions from:');?> <a target="_blank" href="<?=URL::to($cpc)?>"><?=$cpc->getCollectionName()?></a></div>
-		<?php } ?>
-	<? } ?>
+	<?php
+      $cpc = $c->getPermissionsCollectionObject();
+    if ($c->getCollectionInheritance() == 'PARENT') {
+        ?>
+		<?php if ($c->isPageDraft()) {
+    ?>
+			<div class="alert alert-info"><?=t('This page inherits its permissions from the drafts area, as well as its edit page type drafts permission.');
+    ?></div>
+		<?php 
+} else {
+    ?>
+			<div class="alert alert-info"><?=t('This page inherits its permissions from:');
+    ?> <a target="_blank" href="<?=URL::to($cpc)?>"><?=$cpc->getCollectionName()?></a></div>
+		<?php 
+}
+        ?>
+	<?php 
+    } ?>
 
 
 	<div>
@@ -20,19 +29,24 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			<label class="control-label" for="ccm-page-permissions-inherit"><?=t('Assign Permissions')?></label>
 			<select id="ccm-page-permissions-inherit" class="form-control">
 			<?php if ($c->getCollectionID() > 1) {
-    ?><option value="PARENT" <?php if ($c->getCollectionInheritance() == "PARENT") {
+    ?><option value="PARENT" <?php if ($c->getCollectionInheritance() == 'PARENT') {
     ?> selected<?php
+
 }
     ?>><?=t('By Area of Site (Hierarchy)')?></option><?php
+
 } ?>
 			<?php if ($c->getMasterCollectionID() > 1) {
-    ?><option value="TEMPLATE"  <?php if ($c->getCollectionInheritance() == "TEMPLATE") {
+    ?><option value="TEMPLATE"  <?php if ($c->getCollectionInheritance() == 'TEMPLATE') {
     ?> selected<?php
+
 }
     ?>><?=t('From Page Type Defaults')?></option><?php
+
 } ?>
-			<option value="OVERRIDE" <?php if ($c->getCollectionInheritance() == "OVERRIDE") {
+			<option value="OVERRIDE" <?php if ($c->getCollectionInheritance() == 'OVERRIDE') {
     ?> selected<?php
+
 } ?>><?=t('Manually')?></option>
 			</select>
 		</div>
@@ -43,15 +57,18 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			<select id="ccm-page-permissions-subpages-override-template-permissions" class="form-control">
 				<option value="0"<?php if (!$c->overrideTemplatePermissions()) {
     ?>selected<?php
+
 }
     ?>><?=t('Inherit page type default permissions.')?></option>
 				<option value="1"<?php if ($c->overrideTemplatePermissions()) {
     ?>selected<?php
+
 }
     ?>><?=t('Inherit the permissions of this page.')?></option>
 			</select>
 		</div>
 	<?php
+
 } ?>
 	</div>
 
@@ -59,7 +76,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 	<p class="lead"><?=t('Current Permission Set')?></p>
 
     <?php $cat = PermissionKeyCategory::getByHandle('page');?>
-	<form method="post" id="ccm-permission-list-form" data-dialog-form="permissions" data-panel-detail-form="permissions" action="<?=$cat->getToolsURL("save_permission_assignments")?>&cID=<?=$c->getCollectionID()?>">
+	<form method="post" id="ccm-permission-list-form" data-dialog-form="permissions" data-panel-detail-form="permissions" action="<?=$cat->getToolsURL('save_permission_assignments')?>&cID=<?=$c->getCollectionID()?>">
         <?php Loader::element('permission/lists/page', array(
             'page' => $c, 'editPermissions' => $editPermissions,
         ))?>
@@ -81,6 +98,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <button class="pull-right btn btn-success" type="button" data-dialog-action="submit" data-panel-detail-action="submit"><?=t('Save Changes')?></button>
     </div>
 <?php
+
 } ?>
 
 
@@ -93,7 +111,7 @@ ccm_pagePermissionsCancelInheritance = function() {
 
 ccm_pagePermissionsConfirmInheritanceChange = function() { 
 	jQuery.fn.dialog.showLoader();
-	$.getJSON('<?=$cat->getToolsURL("change_permission_inheritance")?>&cID=<?=$c->getCollectionID()?>&mode=' + $('#ccm-page-permissions-inherit').val(), function(r) {
+	$.getJSON('<?=$cat->getToolsURL('change_permission_inheritance')?>&cID=<?=$c->getCollectionID()?>&mode=' + $('#ccm-page-permissions-inherit').val(), function(r) {
 		if (r.deferred) {
 			jQuery.fn.dialog.closeAll();
 			jQuery.fn.dialog.hideLoader();
@@ -141,7 +159,7 @@ $(function() {
 		$('#dialog-buttons-start').addClass('dialog-buttons');
 		jQuery.fn.dialog.open({
 			element: '#ccm-page-permissions-confirm-dialog',
-			title: '<?=t("Confirm Change")?>',
+			title: '<?=t('Confirm Change')?>',
 			width: 280,
 			height: 160,
 			onClose: function() {
@@ -152,7 +170,7 @@ $(function() {
 	
 	$('#ccm-page-permissions-subpages-override-template-permissions').change(function() {
 		jQuery.fn.dialog.showLoader();
-		$.getJSON('<?=$cat->getToolsURL("change_subpage_defaults_inheritance")?>&cID=<?=$c->getCollectionID()?>&inherit=' + $(this).val(), function(r) {
+		$.getJSON('<?=$cat->getToolsURL('change_subpage_defaults_inheritance')?>&cID=<?=$c->getCollectionID()?>&inherit=' + $(this).val(), function(r) {
 			if (r.deferred) {
 				ConcretePanelManager.exitPanelMode();
 				jQuery.fn.dialog.hideLoader();
@@ -173,12 +191,12 @@ ccm_refreshPagePermissions = function() {
     if (panel) {
         panel.openPanelDetail({
             'identifier': 'page-permissions',
-            'url': '<?=URL::to("/ccm/system/panels/details/page/permissions")?>',
+            'url': '<?=URL::to('/ccm/system/panels/details/page/permissions')?>',
             target: null
         });
     } else {
 		jQuery.fn.dialog.showLoader();
-		$.get('<?=URL::to('/ccm/system/panels/details/page/permissions?cID=' . $c->getCollectionID())?>', function(r) {
+		$.get('<?=URL::to('/ccm/system/panels/details/page/permissions?cID='.$c->getCollectionID())?>', function(r) {
 			jQuery.fn.dialog.replaceTop(r);
 			jQuery.fn.dialog.hideLoader();
 		});


### PR DESCRIPTION
When I was testing the advanced page permission, I realized that I was getting non-object error, and found out about shorttag leftover on the line 7.

I just ran PHP CS Fixer for the file to fix the entire file.