### PR TITLE
Fix: "package" is not annotated with @Annotation

### DIFF
--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -10,8 +10,8 @@ use Permissions;
 /**
  * The controller for the Auto-Nav block.
  *
- * @package    Blocks
- * @subpackage Auto-Nav
+ * \@package    Blocks
+ * \@subpackage Auto-Nav
  *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @author     Jordan Lev

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -7,8 +7,8 @@ use Concrete\Core\Editor\LinkAbstractor;
 /**
  * The controller for the content block.
  *
- * @package Blocks
- * @subpackage Content
+ * \@package Blocks
+ * \@subpackage Content
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -12,8 +12,8 @@ use Page;
 /**
  * The controller for the conversation block. This block is used to display conversations in a page.
  *
- * @package Blocks
- * @subpackage Conversation
+ * \@package Blocks
+ * \@subpackage Conversation
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2013 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/core_conversation_message/controller.php
+++ b/concrete/blocks/core_conversation_message/controller.php
@@ -7,8 +7,8 @@ use Concrete\Core\Block\BlockController;
 /**
      * The controller for the conversation message block. This block is used to display conversation messages in a page.
      *
-     * @package Blocks
-     * @subpackage Conversation
+     * \@package Blocks
+     * \@subpackage Conversation
      *
      * @author Andrew Embler <andrew@concrete5.org>
      * @copyright  Copyright (c) 2003-2013 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/core_gathering_display/controller.php
+++ b/concrete/blocks/core_gathering_display/controller.php
@@ -7,8 +7,8 @@ use Core;
 /**
  * Displays an gathering stand-alone in a page.
  *
- * @package Blocks
- * @subpackage Core Gathering Display
+ * \@package Blocks
+ * \@subpackage Core Gathering Display
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2013 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -9,8 +9,8 @@ use Concrete\Core\Block\View\BlockViewTemplate;
  * The controller for the core scrapbook display block. This block is automatically used when a block is copied into a
  * page from a clipboard. It is a proxy block.
  *
- * @package    Blocks
- * @subpackage Core Scrapbook/Clipboard Display
+ * \@package    Blocks
+ * \@subpackage Core Scrapbook/Clipboard Display
  *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -12,8 +12,8 @@ use Concrete\Core\Multilingual\Page\Section\Section;
 /**
  * The controller for the stack display block. This is an internal proxy block that is inserted when a stack's contents are displayed in a page.
  *
- * @package Blocks
- * @subpackage Core Stack Display
+ * \@package Blocks
+ * \@subpackage Core Stack Display
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/desktop_featured_addon/controller.php
+++ b/concrete/blocks/desktop_featured_addon/controller.php
@@ -7,8 +7,8 @@ use Concrete\Core\Marketplace\RemoteItemList as MarketplaceRemoteItemList;
 /**
      * The controller for the block that displays featured add-ons in the dashboard news overlay.
      *
-     * @package Blocks
-     * @subpackage Dashboard Featured Add-On
+     * \@package Blocks
+     * \@subpackage Dashboard Featured Add-On
      *
      * @author Andrew Embler <andrew@concrete5.org>
      * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/desktop_featured_theme/controller.php
+++ b/concrete/blocks/desktop_featured_theme/controller.php
@@ -7,8 +7,8 @@ use Concrete\Core\Marketplace\RemoteItemList as MarketplaceRemoteItemList;
 /**
      * The controller for the block that displays featured themes in the dashboard news overlay.
      *
-     * @package Blocks
-     * @subpackage Dashboard Featured Theme
+     * \@package Blocks
+     * \@subpackage Dashboard Featured Theme
      *
      * @author Andrew Embler <andrew@concrete5.org>
      * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)

--- a/concrete/blocks/desktop_newsflow_latest/controller.php
+++ b/concrete/blocks/desktop_newsflow_latest/controller.php
@@ -8,7 +8,7 @@ use Concrete\Core\Activity\Newsflow;
  * @property mixed $slot
  * Class Controller
  *
- * @package Concrete\Block\DashboardNewsflowLatest
+ * \@package Concrete\Block\DashboardNewsflowLatest
  */
 class Controller extends BlockController
 {

--- a/concrete/blocks/survey/option.php
+++ b/concrete/blocks/survey/option.php
@@ -6,8 +6,8 @@ use Loader;
 /**
  * An object that represents an option in a survey. 
  *
- * @package Blocks
- * @subpackage Survey
+ * \@package Blocks
+ * \@subpackage Survey
  *
  * @author Ryan Tyler <ryan@concrete5.org>
  * @author Tony Trupp <tony@concrete5.org>

--- a/concrete/src/Application/Service/UserInterface.php
+++ b/concrete/src/Application/Service/UserInterface.php
@@ -14,7 +14,7 @@ use stdClass;
 /**
  * Useful functions for generating elements on the Concrete interface.
  *
- * @subpackage Concrete
+ * \@subpackage Concrete
  * \@package Helpers
  *
  * @author Andrew Embler <andrew@concrete5.org>

--- a/concrete/src/File/Type/TypeList.php
+++ b/concrete/src/File/Type/TypeList.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\File\Type;
 use Loader;
 /*
  * \@package Core
- * @subpackage Files
+ * \@subpackage Files
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2009 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
@@ -13,7 +13,7 @@ use Loader;
 
 /*
  * \@package Core
- * @subpackage Files
+ * \@subpackage Files
  * @author Andrew Embler <andrew@concrete5.org>
  * @category Concrete
  * @copyright  Copyright (c) 2003-2009 Concrete5. (http://www.concrete5.org)

--- a/concrete/src/File/ValidationService.php
+++ b/concrete/src/File/ValidationService.php
@@ -6,7 +6,7 @@ use Loader;
 
 /**
  * \@package Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
@@ -17,7 +17,7 @@ use Loader;
  * Helper elements for validating uploaded and existing files in Concrete.
  *
  * \@package Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)

--- a/concrete/src/Form/Service/Validation.php
+++ b/concrete/src/Form/Service/Validation.php
@@ -5,7 +5,7 @@ use Loader;
 
 /**
  * \@package    Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
@@ -16,7 +16,7 @@ use Loader;
  * Helper functions to use with validating submitting forms.
  *
  * \@package    Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)

--- a/concrete/src/Package/PackageArchive.php
+++ b/concrete/src/Package/PackageArchive.php
@@ -7,7 +7,7 @@ use Concrete\Core\Updater\Archive;
  * This class is responsible for unpacking themes that have been zipped and uploaded to the system.
  *
  * \@package Pages
- * @subpackage Themes
+ * \@subpackage Themes
  */
 class PackageArchive extends Archive
 {

--- a/concrete/src/Page/Theme/File.php
+++ b/concrete/src/Page/Theme/File.php
@@ -6,7 +6,7 @@ namespace Concrete\Core\Page\Theme;
  * the file can then be used to create a new page type.
  *
  * \@package Pages
- * @subpackage Themes
+ * \@subpackage Themes
  */
 class File
 {

--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -23,7 +23,7 @@ use Localization;
  * Themes inherit down the tree when a page is added, but can also be set at the site-wide level (thereby overriding any previous choices.).
  *
  * \@package Pages and Collections
- * @subpackages Themes
+ * \@subpackages Themes
  */
 class Theme extends Object
 {

--- a/concrete/src/Permission/Key/AddFileFileSetKey.php
+++ b/concrete/src/Permission/Key/AddFileFileSetKey.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Permission\Key;
  * @deprecated
  * Only here to keep errors from happening on upgrade
  * Class FileFolderKey
- * @package Concrete\Core\Permission\Key
+ * \@package Concrete\Core\Permission\Key
  */
 class AddFileFileSetKey extends Key
 {

--- a/concrete/src/Permission/Key/FileSetKey.php
+++ b/concrete/src/Permission/Key/FileSetKey.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Permission\Key;
  * @deprecated
  * Only here to keep errors from happening on upgrade
  * Class FileFolderKey
- * @package Concrete\Core\Permission\Key
+ * \@package Concrete\Core\Permission\Key
  */
 class FileSetKey extends Key
 {

--- a/concrete/src/Utility/Service/Identifier.php
+++ b/concrete/src/Utility/Service/Identifier.php
@@ -5,7 +5,7 @@ use Loader;
 
 /**
  * \@package Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
@@ -16,7 +16,7 @@ use Loader;
  * A helper that allows the creation of unique strings, for use when creating hashes, identifiers.
  *
  * \@package Helpers
- * @subpackage Validation
+ * \@subpackage Validation
  *
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)

--- a/concrete/src/Validation/SanitizeService.php
+++ b/concrete/src/Validation/SanitizeService.php
@@ -7,7 +7,7 @@
  *
  * @category Concrete
  *
- * @subpackage Security
+ * \@subpackage Security
  *
  * @author Chris Rosser <chris@bluefuton.com>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)


### PR DESCRIPTION
Installation of concrete5 fails for me with this error message:
```
Unable to install database: [Semantical Error]
The class "package" is not annotated with @Annotation.
Are you sure this class can be used as annotation?
If so, then you need to add @Annotation to the _class_ doc comment of "package".
If it is indeed no annotation, then you need to add @IgnoreAnnotation("package")
to the _class_ doc comment of class Concrete\Core\Permission\Key\AddFileFileSetKey.
```

This PR fixes this problem.

PS: what are those `@package`/`@subpackage` used for? Why do we need them?