### PR TITLE
Fix typo when setting pretty URLs

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/seo/urls.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/urls.php
@@ -141,7 +141,7 @@ class Urls extends DashboardSitePageController
                 $prettyUrlState = '';
                 $services = $manager->getActiveServices();
                 if (empty($services)) {
-                    $prettyUrlState = 'unsecognized';
+                    $prettyUrlState = 'unrecognized';
                 } else {
                     $service = $services[0];
                     if (!$service->getStorage()->canRead()) {


### PR DESCRIPTION
Fixed typo (unsecognized -> unrecognized) that was causing the .htaccess file contents not to be shown on a server whose type could not be determined.