### PR TITLE
Allow returning to a draft

### DIFF
--- a/concrete/src/Page/View/PageView.php
+++ b/concrete/src/Page/View/PageView.php
@@ -230,7 +230,7 @@ class PageView extends View
             if (!$dh->inDashboard()
                 && $this->c->getCollectionPath() != '/page_not_found'
                 && $this->c->getCollectionPath() != '/download_file'
-                && $this->c->isActive() && !$this->c->isMasterCollection()) {
+                && !$this->c->isMasterCollection()) {
                 $u = new User();
                 $u->markPreviousFrontendPage($this->c);
             }


### PR DESCRIPTION
Fixes #4010.

Removes the `isActive()` check when setting the previous frontend page. 

This doesn't appear to break anything else, but does also seem to fix #4014.