### PR TITLE
Add font-aswome icons to slider in "edit mode"

### DIFF
--- a/concrete/blocks/image_slider/view.php
+++ b/concrete/blocks/image_slider/view.php
@@ -4,7 +4,18 @@ $c = Page::getCurrentPage();
 if ($c->isEditMode()) {
     ?>
     <div class="ccm-edit-mode-disabled-item" style="<?php echo isset($width) ? "width: $width;" : '' ?><?php echo isset($height) ? "height: $height;" : '' ?>">
-        <div style="padding: 40px 0px 40px 0px"><?php echo t('Image Slider disabled in edit mode.')?></div>
+        <i style="font-size:40px; margin-bottom:20px; display:block;" class="fa fa-picture-o" aria-hidden="true"></i>
+        <div style="padding: 40px 0px 40px 0px"><?php echo t('Image Slider disabled in edit mode.')?>
+			<div style="margin-top: 15px; font-size:9px;">
+				<i class="fa fa-circle" aria-hidden="true"></i>
+				<?php if (count($rows) > 0) { ?>
+					<?php foreach (array_slice($rows, 1) as $row) { ?>
+						<i class="fa fa-circle-thin" aria-hidden="true"></i>
+						<?php } 
+					} 
+				?>
+			</div>
+        </div>
     </div>
 <?php
 } else {


### PR DESCRIPTION
Image_slider block Disable in edit mode - so i added more **"Visual"** "edit mode" - "i am a slider" design (Better UI).

- Like "**wireframe**" design of slider (image icon and dots). 

- Also in this code you can know **"how much"** sliders you have also in edit mode (In the image below - 4 sliders = 4 dots - the first is "active"). Mabye this code - array_slice (i want to start from the second item of the array) - cause "travis CI" error - i dont know about "travis" so well. 

![image-slider-wireframe](https://cloud.githubusercontent.com/assets/16711871/17459909/382cb04a-5c57-11e6-9bf6-dc906a2277b3.png)

