### PR TITLE
Fix tests for installed concrete5 instances

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -316,11 +316,13 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
     {
         define('APP_VERSION', $config->get('concrete.version'));
         define('APP_CHARSET', $config->get('concrete.charset'));
-        try {
-            define('BASE_URL', rtrim((string) $this->app->make('url/canonical'), '/'));
-        } catch (\Exception $x) {
-            echo $x->getMessage();
-            die(1);
+        if (!defined('BASE_URL')) {
+            try {
+                define('BASE_URL', rtrim((string) $this->app->make('url/canonical'), '/'));
+            } catch (\Exception $x) {
+                echo $x->getMessage();
+                die(1);
+            }
         }
         define('DIR_REL', $app['app_relative_path']);
     }

--- a/tests/tests/bootstrap.php
+++ b/tests/tests/bootstrap.php
@@ -45,6 +45,7 @@ $r = new \Concrete\Core\Http\Request(
     array(),
     array('HTTP_HOST' => 'www.dummyco.com', 'SCRIPT_NAME' => '/path/to/server/index.php')
 );
+define('BASE_URL', 'http://www.dummyco.com/path/to/server');
 \Concrete\Core\Http\Request::setInstance($r);
 
 /*


### PR DESCRIPTION
When concrete5 is installed, the core determines the value of the legacy constant `BASE_URL`.
Since that happens before the tests bootstrap, the connection is used is the one relative to the installed instance.
That implies that the default connection is already defined before the `/tests/tests/bootstrap.php` file defines the default connection, breaking many tests.

So, let's manually define `BASE_URL` when running tests.