### PR TITLE
Update view.php - 500 when viewing icons

### DIFF
--- a/concrete/tools/files/view.php
+++ b/concrete/tools/files/view.php
@@ -22,10 +22,12 @@ if (!$fp->canViewFileInFileManager()) {
 
 <?php
 $to = $fv->getTypeObject();
-if ($to->getPackageHandle() != '') {
-    Loader::packageElement('files/view/' . $to->getView(), $to->getPackageHandle(), array('fv' => $fv));
-} else {
-    Loader::element('files/view/' . $to->getView(), array('fv' => $fv));
+if ($to->getView() != '') {
+    if ($to->getPackageHandle() != '') {
+        Loader::packageElement('files/view/' . $to->getView(), $to->getPackageHandle(), array('fv' => $fv));
+    } else {
+        Loader::element('files/view/' . $to->getView(), array('fv' => $fv));
+    }
 }
 ?>
 </div>


### PR DESCRIPTION
When uploading an icon (eg. favicon) and then trying to view it from the filemanager, it results in a 
"NetworkError: 500 Internal Server Error - http://8-dev.willict.nl/index.php/tools/required/files/view?fID=26"

In concrete/tools/files/view.php $to->getView() is empty because no editor is set for icon types.

```
    $to = $fv->getTypeObject();

    if ($to->getPackageHandle() != '') {
        Loader::packageElement('files/view/' . $to->getView(), $to->getPackageHandle(), array('fv' => $fv));
    } else {
        Loader::element('files/view/' . $to->getView(), array('fv' => $fv));
    }
```

solution:
a) wrap the above code in a test on $to->getView() != ''
b) add view (and editor and customimporter) values in app.php (not included)

Also the view (and download) options should be disabled for icons in the filemanager context menu. But I didn't check that code yet.
