### PR TITLE
Do not include html on ajax group search

### DIFF
--- a/concrete/src/User/Group/GroupSearchColumnSet.php
+++ b/concrete/src/User/Group/GroupSearchColumnSet.php
@@ -8,7 +8,7 @@ class GroupSearchColumnSet extends \Concrete\Core\Search\Column\Set
 {
     public static function getGroupName($g)
     {
-        return '<a data-group-name="' . $g->getGroupDisplayName() . '" href="' . URL::to('/dashboard/users/groups', 'edit', $g->getGroupID()) . '" data-group-id="' . $g->getGroupID() . '" href="#">' . $g->getGroupDisplayName() . '</a>';
+        return '<a data-group-name="' . $g->getGroupDisplayName(false) . '" href="' . URL::to('/dashboard/users/groups', 'edit', $g->getGroupID()) . '" data-group-id="' . $g->getGroupID() . '" href="#">' . $g->getGroupDisplayName() . '</a>';
     }
 
     public function __construct()


### PR DESCRIPTION
If you use hierarchical Group path, Group#getGroupDisplayName may includes span element, so we should avoid it in `data-group-name` attribute value.