### PR TITLE
Fix Twitter links

### DIFF
--- a/concrete/elements/conversation/message.php
+++ b/concrete/elements/conversation/message.php
@@ -148,7 +148,7 @@ if ((!$message->isConversationMessageDeleted() && $message->isConversationMessag
     ?>
               <li class="ccm-conversation-social-share"><span class="ccm-conversation-message-divider">|</span></li>
               <li class="ccm-conversation-social-share">
-                  <a class="ccm-conversation-message-control-icon share-popup" href="http://twitter.com/intent/tweet?url=<?php echo $cnvMessageURL?>" title="<?=t('Share message URL on Twitter.')?>"><i class="fa fa-twitter"></i></a>
+                  <a class="ccm-conversation-message-control-icon share-popup" href="https://twitter.com/intent/tweet?url=<?php echo $cnvMessageURL?>" title="<?=t('Share message URL on Twitter.')?>"><i class="fa fa-twitter"></i></a>
               </li>
               <li class="ccm-conversation-social-share">
                   <a class="ccm-conversation-message-control-icon share-popup" href="http://www.facebook.com/sharer.php?u=<?php echo $cnvMessageURL?>" title="<?=t('Share message URL on Facebook.')?>"><i class="fa fa-facebook"></i></a>

--- a/concrete/elements/gathering/templates/detail/image_conversation/view.php
+++ b/concrete/elements/gathering/templates/detail/image_conversation/view.php
@@ -64,7 +64,7 @@ if (is_array($image)) {
 		<li class="dropdown">
 		<a class="dropdown-toggle" id="drop4" role="button" data-toggle="dropdown" href="#">Share</a>
 			<ul id="menu1" class="dropdown-menu" role="menu" aria-labelledby="drop4">
-			<li><a class="shareTweet" target="_blank" href="http://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage1">Twitter</a></li>
+			<li><a class="shareTweet" target="_blank" href="https://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage1">Twitter</a></li>
 			<li><a class="shareFacebook" target="_blank" href="http://www.facebook.com/sharer.php?u=http://fivesevenmagic:8888#cnvMessage1">Facebook</a></li>
 			<li><a data-message-id="1" rel="http://fivesevenmagic:8888#cnvMessage1" data-dialog-title="Link" class="share-permalink" href="#">Link</a></li>
 			</ul>
@@ -101,7 +101,7 @@ if (is_array($image)) {
 		<li class="dropdown">
 		<a class="dropdown-toggle" id="drop4" role="button" data-toggle="dropdown" href="#">Share</a>
 			<ul id="menu1" class="dropdown-menu" role="menu" aria-labelledby="drop4">
-			<li><a class="shareTweet" target="_blank" href="http://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage2">Twitter</a></li>
+			<li><a class="shareTweet" target="_blank" href="https://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage2">Twitter</a></li>
 			<li><a class="shareFacebook" target="_blank" href="http://www.facebook.com/sharer.php?u=http://fivesevenmagic:8888#cnvMessage2">Facebook</a></li>
 			<li><a data-message-id="2" rel="http://fivesevenmagic:8888#cnvMessage2" data-dialog-title="Link" class="share-permalink" href="#">Link</a></li>
 			</ul>
@@ -138,7 +138,7 @@ if (is_array($image)) {
 		<li class="dropdown">
 		<a class="dropdown-toggle" id="drop4" role="button" data-toggle="dropdown" href="#">Share</a>
 			<ul id="menu1" class="dropdown-menu" role="menu" aria-labelledby="drop4">
-			<li><a class="shareTweet" target="_blank" href="http://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage3">Twitter</a></li>
+			<li><a class="shareTweet" target="_blank" href="https://twitter.com/intent/tweet?url=http://fivesevenmagic:8888#cnvMessage3">Twitter</a></li>
 			<li><a class="shareFacebook" target="_blank" href="http://www.facebook.com/sharer.php?u=http://fivesevenmagic:8888#cnvMessage3">Facebook</a></li>
 			<li><a data-message-id="3" rel="http://fivesevenmagic:8888#cnvMessage3" data-dialog-title="Link" class="share-permalink" href="#">Link</a></li>
 			</ul>

--- a/concrete/elements/gathering/templates/tile/tweet/view.php
+++ b/concrete/elements/gathering/templates/tile/tweet/view.php
@@ -5,6 +5,6 @@
 	<div class="tweet">
 		<span class="tweet-body"><?=$description?></span>
 		<div style="clear: both;"></div>
-		<p class="tweet-info"><span class="elapsed"><?=date('m/d/y', strtotime($date_time))?></span><span class="who-from"><a href="http://www.twitter.com/<?php echo $author ?>"><?php echo $author ?></a></span></p>
+		<p class="tweet-info"><span class="elapsed"><?=date('m/d/y', strtotime($date_time))?></span><span class="who-from"><a href="https://twitter.com/<?php echo $author ?>"><?php echo $author ?></a></span></p>
 	</div>
 </div>

--- a/concrete/src/Gathering/Item/Twitter.php
+++ b/concrete/src/Gathering/Item/Twitter.php
@@ -47,12 +47,12 @@ class Twitter extends Item
         $userMentions = $tweet->entities->user_mentions;
         if (count($userMentions) > 0) {  // link mentions
             foreach ($tweet->entities->user_mentions as $mention) {
-                $tweet->text = str_replace('@'.$mention->screen_name, '<a target="_blank" href="http://www.twitter.com/'.$mention->screen_name.'">@'.$mention->screen_name.'</a>', $tweet->text);
+                $tweet->text = str_replace('@'.$mention->screen_name, '<a target="_blank" href="https://twitter.com/'.$mention->screen_name.'">@'.$mention->screen_name.'</a>', $tweet->text);
             }
         }
         if (count($tweet->entities->hashtags) > 0) {   //link hashtags
             foreach ($tweet->entities->hashtags as $hash) {
-                $tweet->text = str_replace('#'.$hash->text, '<a target="_blank" href="http://www.twitter.com/search/%23'.$hash->text.'">#'.$hash->text.'</a>', $tweet->text);
+                $tweet->text = str_replace('#'.$hash->text, '<a target="_blank" href="https://twitter.com/search?q=%23'.$hash->text.'">#'.$hash->text.'</a>', $tweet->text);
             }
         }
         if (count($tweet->entities->urls) > 0) {
@@ -70,6 +70,6 @@ class Twitter extends Item
         $this->addFeatureAssignment('description', $tweet->text);
         $this->addFeatureAssignment('date_time', $tweet->created_at);
         $this->addFeatureAssignment('author', $tweet->user->name);
-        $this->addFeatureAssignment('link', 'http://www.twitter.com/' . $tweet->user->name . '/status/' . $tweet->id);
+        $this->addFeatureAssignment('link', 'https://twitter.com/' . $tweet->user->name . '/status/' . $tweet->id);
     }
 }

--- a/concrete/src/Sharing/ShareThisPage/Service.php
+++ b/concrete/src/Sharing/ShareThisPage/Service.php
@@ -28,7 +28,7 @@ class Service extends SocialNetworkService
                 case 'facebook':
                     return "https://www.facebook.com/sharer/sharer.php?u=$url";
                 case 'twitter':
-                    return "https://www.twitter.com/intent/tweet?url=$url";
+                    return "https://twitter.com/intent/tweet?url=$url";
                 case 'linkedin':
                     $title = urlencode($c->getCollectionName());
 

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -239,12 +239,12 @@ class Text
         $target = ($newWindow) ? ' target="_blank" ' : '';
         $output = preg_replace(
             '/([\.|\,|\:|\¡|\¿|\>|\{|\(]?)@{1}(\w*)([\.|\,|\:|\!|\?|\>|\}|\)]?)\s/i',
-            "$1<a href=\"http://twitter.com/$2\" " . $target . " class=\"twitter-username\">@$2</a>$3 ",
+            "$1<a href=\"https://twitter.com/$2\" " . $target . " class=\"twitter-username\">@$2</a>$3 ",
             $input);
         if ($withSearch) {
             $output = preg_replace(
                 '/([\.|\,|\:|\¡|\¿|\>|\{|\(]?)#{1}(\w*)([\.|\,|\:|\!|\?|\>|\}|\)]?)\s/i',
-                "$1<a href=\"http://search.twitter.com/search?q=%23$2\" " . $target . " class=\"twitter-search\">#$2</a>$3 ",
+                "$1<a href=\"https://twitter.com/search?q=%23$2\" " . $target . " class=\"twitter-search\">#$2</a>$3 ",
                 $input);
         }
 


### PR DESCRIPTION
I was installing the `share_this_page` block on a page when I noticed that Twitter links were not formatted correctly. It was using the `www.` version of the domain.

I had a look at the source code of the block but didn't find the link. I did a full-text search on my Concrete5 install and found the link along with other incorrect links in the core code.

I fixed each of them to use the Apex version along with the HTTPS protocol.

I also found a link to `search.twitter.com`. A quick try <https://search.twitter.com/search?q=%23laravel> told me it was no longer active. I migrated it to the new syntax (and HTTPS): <https://dev.twitter.com/rest/public/search>. Another link was using an incorrect syntax of the same search API.

Except for the `search.twitter.com` case, nothing is critical. Twitter redirects all URLs to the correct version. This just looks a lot cleaner with the right URLs =)