### PR TITLE
remove extra form group from the Image Slider form

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -283,8 +283,6 @@ echo Core::make('helper/concrete/ui')->tabs(array(
         <div class="radio">
             <label><input type="radio" name="<?php echo $view->field('navigationType'); ?>" value="0" <?php echo $navigationType > 0 ? '' : 'checked'; ?> /><?php echo t('Arrows'); ?></label>
         </div>
-    </div>
-    <div class="form-group">
         <div class="radio">
             <label><input type="radio" name="<?php echo $view->field('navigationType'); ?>" value="1" <?php echo $navigationType > 0 ? 'checked' : ''; ?> /><?php echo t('Bullets'); ?></label>
         </div>


### PR DESCRIPTION
The extra form group wrapping the radio buttons added an extra fieldless form line.

![extra_form_group](https://cloud.githubusercontent.com/assets/10898145/17501819/72aec01e-5db0-11e6-8e43-5fcf34b8ba8d.png)
