### PR TITLE
add remove button to Selectize selections

### DIFF
--- a/concrete/attributes/select/form.php
+++ b/concrete/attributes/select/form.php
@@ -17,7 +17,7 @@ if ($akSelectAllowMultipleValues && !$akSelectAllowOtherValues) {
 		</div>
 
 
-	<?php 
+	<?php
     }
 }
 
@@ -35,7 +35,7 @@ if (!$akSelectAllowMultipleValues && !$akSelectAllowOtherValues) {
     ?>
 
 
-<?php 
+<?php
 }
 
 /*
@@ -49,6 +49,7 @@ if ($akSelectAllowOtherValues) {
 	<script type="text/javascript">
 		$(function() {
 			$('input[data-select-and-add=<?=$akID?>]').selectize({
+                plugins: ['remove_button'],
 				valueField: 'id',
 				labelField: 'text',
 				options: <?=json_encode($selectedOptions)?>,
@@ -65,11 +66,11 @@ if ($akSelectAllowOtherValues) {
     ?>
 					delimiter: ',',
 					maxItems: 500,
-				<?php 
+				<?php
 } else {
     ?>
 					maxItems: 1,
-				<?php 
+				<?php
 }
     ?>
 				load: function(query, callback) {
@@ -89,5 +90,5 @@ if ($akSelectAllowOtherValues) {
 		});
 	</script>
 
-<?php 
+<?php
 }

--- a/concrete/elements/page_types/form/base.php
+++ b/concrete/elements/page_types/form/base.php
@@ -85,7 +85,7 @@ if (is_object($pagetype)) {
     }
     ?>
             <div class="radio"><label><?=$form->radio('ptPublishTargetTypeID', $t->getPageTypePublishTargetTypeID(), $selected)?><?=$t->getPageTypePublishTargetTypeDisplayName()?></label></div>
-        <?php 
+        <?php
 } ?>
 	</div>
 
@@ -98,13 +98,16 @@ if (is_object($pagetype)) {
         ?>
 		</div>
 
-	<?php 
+	<?php
     }
 } ?>
 
 <script type="text/javascript">
 $(function() {
-	$('#ptPageTemplateID').removeClass('form-control').selectize();
+    $('#ptPageTemplateID').removeClass('form-control').selectize({
+        plugins: ['remove_button']
+    });
+
 	$('input[name=ptPublishTargetTypeID]').on('click', function() {
 		$('div[data-page-type-publish-target-type-id]').hide();
 		var ptPublishTargetTypeID = $('input[name=ptPublishTargetTypeID]:checked').val();

--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -79,7 +79,9 @@
 	ConcreteAjaxSearch.prototype.setupSelectize = function() {
         var selects = this.$element.find('.selectize-select');
         if (selects.length) {
-            selects.selectize();
+        	selects.selectize({
+        		plugins: ['remove_button']
+        	});
         }
     }
 

--- a/concrete/single_pages/dashboard/reports/logs.php
+++ b/concrete/single_pages/dashboard/reports/logs.php
@@ -14,7 +14,9 @@ $th = Loader::helper('text');
 
     <script type="text/javascript">
         $(function() {
-            $('#level').selectize();
+            $('#level').selectize({
+                plugins: ['remove_button']
+            });
         });
     </script>
 


### PR DESCRIPTION
Currently items selected with Selectize cannot be removed with a mouse or by touch. This pull request enables the "remove_button" Selectize plugin, which allows for items to be removed by mouse and touch and provides a visual indicator that a selection can be removed.

The "remove_button" plugin appears to behave like Select2 does in 5.7.

**Example: Select2 in 5.7**

![select2_5 7](https://cloud.githubusercontent.com/assets/10898145/17511368/8de70d74-5df0-11e6-8906-ca5459f8f852.png)

### Select Attribute

**Current**

![selectize_select_attribute-current](https://cloud.githubusercontent.com/assets/10898145/17511046/75a9d0da-5def-11e6-8cab-85509d43b754.png)

**Changes**

![selectize_select_attribute-changes](https://cloud.githubusercontent.com/assets/10898145/17511077/8249942e-5def-11e6-8036-b70864eb4eb5.png)

### Page Type Templates

**Current**

![selectize_page_type-current](https://cloud.githubusercontent.com/assets/10898145/17511101/9252199a-5def-11e6-86a0-0d56dc3a928b.png)

**Changes**

![selectize_page_type-changes](https://cloud.githubusercontent.com/assets/10898145/17511108/960e738a-5def-11e6-91f6-4f344f96278a.png)

### Search

**Current**

![selectize_search-current](https://cloud.githubusercontent.com/assets/10898145/17511134/aa63d4ba-5def-11e6-9dc9-c17ab6dc6352.png)

**Changes**

![selectize_search-changes](https://cloud.githubusercontent.com/assets/10898145/17511144/ad8c5fea-5def-11e6-9636-2dc187dd5007.png)

### Logs

**Current**

![selectize_logs-current](https://cloud.githubusercontent.com/assets/10898145/17511160/b712a38a-5def-11e6-9c6d-2ac8be2efe57.png)

**Changes**

![selectize_logs-changes](https://cloud.githubusercontent.com/assets/10898145/17511161/b9629816-5def-11e6-8749-841829694d7e.png)





