### PR TITLE
Add test to verify short PHP tags

### DIFF
--- a/tests/tests/CodingStyle/NoShortTagsTest.php
+++ b/tests/tests/CodingStyle/NoShortTagsTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Concrete\Tests\CodingStyle;
+
+class NoShortTagsTest extends \Concrete\Tests\CodingStyleTestCase
+{
+    /**
+     *  @dataProvider phpFilesProvider
+     */
+    public function testNoShortTags($phpFile)
+    {
+        $sot = ini_get('short_open_tag');
+        if (empty($sot)) {
+            static::markTestSkipped('short_open_tag must be enabled in order to run the test '.__CLASS__.'::'.__FUNCTION__);
+
+            return;
+        }
+        $contents = @file_get_contents($phpFile);
+        $this->assertNotFalse($contents, 'Failed to read file '.$phpFile);
+        $tokens = @token_get_all($contents);
+        $this->assertTrue(is_array($tokens), 'Failed to retrieve the PHP tokes of the file '.$phpFile);
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                switch ($token[0]) {
+                    case T_OPEN_TAG:
+                        $this->assertSame('<?php', trim($token[1]), "Short tag found in file $phpFile at line {$token[2]}");
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/tests/tests/CodingStyleTestCase.php
+++ b/tests/tests/CodingStyleTestCase.php
@@ -1,0 +1,55 @@
+<?php
+namespace Concrete\Tests;
+
+abstract class CodingStyleTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string[]|null
+     */
+    private static $phpFiles = null;
+
+    /**
+     * @return string[]
+     */
+    protected static function getPhpFiles()
+    {
+        if (self::$phpFiles === null) {
+            $files = [];
+            $baseDir = rtrim(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE), DIRECTORY_SEPARATOR);
+            $directoryIterator = new \RecursiveDirectoryIterator($baseDir);
+            $iterator = new \RecursiveIteratorIterator($directoryIterator, \RecursiveIteratorIterator::LEAVES_ONLY);
+            foreach ($iterator as $f) {
+                /* @var \SplFileInfo $f */
+                if (!$f->isFile()) {
+                    continue;
+                }
+                $filename = $f->getFilename();
+                if ($filename[0] === '.' || strcasecmp(substr($filename, -4), '.php') !== 0) {
+                    continue;
+                }
+                $fullPath = $f->getRealPath();
+                $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', substr($fullPath, strlen($baseDir)));
+                if (strpos($relativePath, '/.') !== false) {
+                    continue;
+                }
+                if (strpos($relativePath, '/concrete/vendor/') === 0) {
+                    continue;
+                }
+                $files[] = $fullPath;
+            }
+            self::$phpFiles = $files;
+        }
+
+        return self::$phpFiles;
+    }
+
+    public function phpFilesProvider()
+    {
+        $result = [];
+        foreach (static::getPhpFiles() as $f) {
+            $result[] = [$f];
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Let's add a test to verify that all the PHP files (except the ones under `/concrete/vendor`) don't have PHP short open tags (`<?`).