### PR TITLE
Fix form control icons

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -9,12 +9,14 @@ use Controller;
 use Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
 use Concrete\Core\Page\Type\Composer\Control\Type\Type as PageTypeComposerControlType;
+use HtmlObject\Element;
 
 abstract class Control extends Object
 {
     protected $ptComposerControlIdentifier;
     protected $ptComposerControlName;
     protected $ptComposerControlIconSRC;
+    protected $ptComposerControlIconFormatter;
     protected $ptComposerControl;
     protected $ptComposerControlRequiredByDefault = false;
     protected $ptComposerControlRequiredOnThisRequest = false;
@@ -113,10 +115,22 @@ abstract class Control extends Object
     {
         $this->ptComposerControlIconSRC = $ptComposerControlIconSRC;
     }
-
-    public function getPageTypeComposerControlIconSRC()
+    
+    public function setPageTypeComposerControlIconFormatter($ptComposerControlIconFormatter)
     {
-        return $this->ptComposerControlIconSRC;
+        $this->ptComposerControlIconFormatter = $ptComposerControlIconFormatter;
+    }
+
+    public function getPageTypeComposerControlIcon()
+    {
+      if (isset($this->ptComposerControlIconSRC)) {
+          $img = new Element('img');
+          $img->src($this->ptComposerControlIconSRC);
+          return $img;
+      }
+      else {
+          return $this->ptComposerControlIconFormatter->getListIconElement();
+      }
     }
 
     public function setPageTypeComposerControlIdentifier($ptComposerControlIdentifier)

--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control;
 
 use Concrete\Core\Page\Type\Type;
@@ -53,17 +54,17 @@ abstract class Control extends Object
     {
         $this->ptComposerControlCustomLabel = $label;
     }
-    
+
     public function getPageTypeComposerControlCustomLabel()
     {
         return $this->ptComposerControlCustomLabel;
     }
-    
+
     public function setPageTypeComposerControlDescription($description)
     {
         $this->ptComposerControlDescription = $description;
     }
-    
+
     public function getPageTypeComposerControlDescription()
     {
         return $this->ptComposerControlDescription;
@@ -73,7 +74,7 @@ abstract class Control extends Object
     {
         $this->page = $page;
     }
-    
+
     public function getPageObject()
     {
         return $this->page;
@@ -98,7 +99,7 @@ abstract class Control extends Object
     {
         return $this->ptComposerControlName;
     }
-    
+
     public function getPageTypeComposerControlDisplayName($format = 'html')
     {
         $value = $this->getPageTypeComposerControlName();
@@ -115,7 +116,7 @@ abstract class Control extends Object
     {
         $this->ptComposerControlIconSRC = $ptComposerControlIconSRC;
     }
-    
+
     public function setPageTypeComposerControlIconFormatter($ptComposerControlIconFormatter)
     {
         $this->ptComposerControlIconFormatter = $ptComposerControlIconFormatter;
@@ -123,14 +124,14 @@ abstract class Control extends Object
 
     public function getPageTypeComposerControlIcon()
     {
-      if (isset($this->ptComposerControlIconSRC)) {
-          $img = new Element('img');
-          $img->src($this->ptComposerControlIconSRC);
-          return $img;
-      }
-      else {
-          return $this->ptComposerControlIconFormatter->getListIconElement();
-      }
+        if (isset($this->ptComposerControlIconSRC)) {
+            $img = new Element('img');
+            $img->src($this->ptComposerControlIconSRC);
+
+            return $img;
+        } else {
+            return $this->ptComposerControlIconFormatter->getListIconElement();
+        }
     }
 
     public function setPageTypeComposerControlIdentifier($ptComposerControlIdentifier)
@@ -165,7 +166,7 @@ abstract class Control extends Object
 
     public function field($key)
     {
-        return 'ptComposer[' . $this->ptComposerFormLayoutSetControlObject->getPageTypeComposerFormLayoutSetControlID(). '][' . $key . ']';
+        return 'ptComposer['.$this->ptComposerFormLayoutSetControlObject->getPageTypeComposerFormLayoutSetControlID().']['.$key.']';
     }
 
     public function getRequestValue($args = false)

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Loader;

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
@@ -3,13 +3,14 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Loader;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class DateTimeCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('date_time');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/date_time/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('calendar'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -3,13 +3,14 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Core;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class DescriptionCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('description');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/textarea/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('font'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Core;
@@ -33,7 +34,7 @@ class DescriptionCorePageProperty extends CorePageProperty
         } else {
             $description = $this->getPageTypeComposerControlDraftValue();
         }
-        
+
         /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
         $stringValidator = Core::make('helper/validation/strings');
         if (!$stringValidator->notempty($description)) {

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Core;
@@ -46,7 +47,7 @@ class NameCorePageProperty extends CorePageProperty
         } else {
             $name = $this->getPageTypeComposerControlDraftValue();
         }
-        
+
         /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
         $stringValidator = Core::make('helper/validation/strings');
         if (!$stringValidator->notempty($name)) {

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Core;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class NameCorePageProperty extends CorePageProperty
 {
@@ -11,7 +12,7 @@ class NameCorePageProperty extends CorePageProperty
     public function __construct()
     {
         $this->setCorePagePropertyHandle('name');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('file-text'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Concrete\Core\Page\Page;

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/PageTemplateCorePageProperty.php
@@ -2,13 +2,14 @@
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class PageTemplateCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('page_template');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/select/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('list-alt'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/PublishTargetCorePageProperty.php
@@ -1,12 +1,14 @@
 <?php
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
+
 class PublishTargetCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('publish_target');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/image_file/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('download'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Loader;
@@ -35,6 +36,7 @@ class UrlSlugCorePageProperty extends CorePageProperty
         if (!$stringValidator->notempty($handle)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlDisplayLabel()));
+
             return $e;
         }
     }

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -4,13 +4,14 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 use Loader;
 use Concrete\Core\Page\Page;
 use Core;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class UrlSlugCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('url_slug');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('file-text'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 
 use Core;

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
@@ -4,13 +4,14 @@ namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 use Core;
 use UserInfo;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 
 class UserCorePageProperty extends CorePageProperty
 {
     public function __construct()
     {
         $this->setCorePagePropertyHandle('user');
-        $this->setPageTypeComposerControlIconSRC(ASSETS_URL . '/attributes/text/icon.png');
+        $this->setPageTypeComposerControlIconFormatter(new FontAwesomeIconFormatter('file-text'));
     }
 
     public function getPageTypeComposerControlName()

--- a/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
+++ b/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Page\Type\Composer\Control\Type;
 
 use CollectionAttributeKey;

--- a/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
+++ b/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
@@ -15,7 +15,7 @@ class CollectionAttributeType extends Type
         foreach ($keys as $ak) {
             $ac = new CollectionAttributeControl();
             $ac->setAttributeKeyID($ak->getAttributeKeyID());
-            //$ac->setPageTypeComposerControlIconSRC($ak->getAttributeKeyIconSRC());
+            $ac->setPageTypeComposerControlIconFormatter($ak->getController()->getIconFormatter());
             $ac->setPageTypeComposerControlName($ak->getAttributeKeyDisplayName());
             $objects[] = $ac;
         }
@@ -28,7 +28,7 @@ class CollectionAttributeType extends Type
         $ak = CollectionAttributeKey::getByID($identifier);
         $ax = new CollectionAttributeControl();
         $ax->setAttributeKeyID($ak->getAttributeKeyID());
-        //$ax->setPageTypeComposerControlIconSRC($ak->getAttributeKeyIconSRC($ak));
+        $ax->setPageTypeComposerControlIconFormatter($ak->getController()->getIconFormatter());
         $ax->setPageTypeComposerControlName($ak->getAttributeKeyDisplayName());
 
         return $ax;

--- a/concrete/tools/page_types/composer/form/add_control.php
+++ b/concrete/tools/page_types/composer/form/add_control.php
@@ -42,7 +42,7 @@ if ($cp->canViewPage()) {
         foreach ($controls as $cnt) {
             ?>
 			<li><a href="#" data-control-type-id="<?=$t->getPageTypeComposerControlTypeID()?>" data-control-identifier="<?=$cnt->getPageTypeComposerControlIdentifier()?>">
-                    <img src="<?=$cnt->getPageTypeComposerControlIconSRC()?>" />
+                    <?=$cnt->getPageTypeComposerControlIcon()?>
                     <?=$cnt->getPageTypeComposerControlDisplayName()?></a></li>
 		<?php 
         }


### PR DESCRIPTION
Fixes #4151.

Adds the ability to specify a FontAwesome icon formatter instead of an image src and selects the right one to render - block types are using image icons so both are still needed.

Gets the correct icon from the type of custom attributes, and replaces the image srcs for core properties with the appropriate icons for the type.