### PR TITLE
Fix missing permission key

### DIFF
--- a/web/concrete/controllers/search/users.php
+++ b/web/concrete/controllers/search/users.php
@@ -17,6 +17,7 @@ use stdClass;
 use User;
 use URL;
 use Group;
+use PermissionKey;
 
 class Users extends Controller
 {
@@ -142,6 +143,7 @@ class Users extends Controller
                                 $groups = $gs->getGroups();
                             }
                             $this->userList->addToQuery('left join UserGroups ugs on u.uID = ugs.uID');
+                            $pk = PermissionKey::getByHandle('search_users_in_group');
                             foreach ($groups as $g) {
                                 if ($pk->validate($g) && (!in_array($g->getGroupID(), $groupsetids))) {
                                     $groupsetids[] = $g->getGroupID();


### PR DESCRIPTION
The permission key object was missing in the users search controller causing filtering by a Group Set to fail.