### PR TITLE
Fix phpunit warnings about mocks

### DIFF
--- a/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Tests\Core\Statistics\UsageTracker;
 
 use Concrete\Core\Application\Application;
@@ -74,7 +73,7 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
     public function testCallsCreator()
     {
         $return_tracker = $this->createMockFromClass(TrackerInterface::class);
-        $this->tracker->addTracker('test', function() use ($return_tracker) {
+        $this->tracker->addTracker('test', function () use ($return_tracker) {
             return $return_tracker;
         });
 
@@ -87,14 +86,15 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
 
     public function testUsesDIContainer()
     {
-        $this->app->bind(stdClass::class, function() {
-            return (object)['test' => 'tested'];
+        $this->app->bind(stdClass::class, function () {
+            return (object) ['test' => 'tested'];
         });
 
         $passed = null;
         $return_tracker = $this->createMockFromClass(TrackerInterface::class);
-        $this->tracker->addTracker('test', function(stdClass $obj) use (&$passed, $return_tracker) {
+        $this->tracker->addTracker('test', function (stdClass $obj) use (&$passed, $return_tracker) {
             $passed = $obj;
+
             return $return_tracker;
         });
 
@@ -117,10 +117,26 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         $calls = 0;
         // Bind the trackers
         $this->tracker
-            ->addTracker('test1', function() use ($tracker1, &$calls) { $calls++; return $tracker1; })
-            ->addTracker('test2', function() use ($tracker2, &$calls) { $calls++; return $tracker2; })
-            ->addTracker('test3', function() use ($tracker3, &$calls) { $calls++; return $tracker3; })
-            ->addTracker('test4', function() use ($tracker4, &$calls) { $calls++; return $tracker4; });
+            ->addTracker('test1', function () use ($tracker1, &$calls) {
+                ++$calls;
+
+                return $tracker1;
+            })
+            ->addTracker('test2', function () use ($tracker2, &$calls) {
+                ++$calls;
+
+                return $tracker2;
+            })
+            ->addTracker('test3', function () use ($tracker3, &$calls) {
+                ++$calls;
+
+                return $tracker3;
+            })
+            ->addTracker('test4', function () use ($tracker4, &$calls) {
+                ++$calls;
+
+                return $tracker4;
+            });
 
         // Set the expectations
         $tracker1->expects($this->exactly(2))->method('track');
@@ -188,5 +204,4 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
 
         $property->setValue($object, $value);
     }
-
 }

--- a/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/AggregateTrackerTest.php
@@ -12,6 +12,7 @@ use stdClass;
 
 class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
 
     /** @var Application */
     private $app;
@@ -33,9 +34,9 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
     public function testCallsTrack()
     {
         // Create the trackers
-        $tracker1 = $this->getMock(TrackerInterface::class);
-        $tracker2 = $this->getMock(TrackerInterface::class);
-        $tracker3 = $this->getMock(TrackerInterface::class);
+        $tracker1 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker2 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker3 = $this->createMockFromClass(TrackerInterface::class);
 
         // Change the properties
         $this->changeProperty($this->tracker, 'trackers', [$tracker1, $tracker2, $tracker3]);
@@ -47,15 +48,15 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         $tracker3->expects($this->once())->method('track');
 
         // Run the track;
-        $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
     }
 
     public function testCallsForget()
     {
         // Create the trackers
-        $tracker1 = $this->getMock(TrackerInterface::class);
-        $tracker2 = $this->getMock(TrackerInterface::class);
-        $tracker3 = $this->getMock(TrackerInterface::class);
+        $tracker1 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker2 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker3 = $this->createMockFromClass(TrackerInterface::class);
 
         // Change the properties
         $this->changeProperty($this->tracker, 'trackers', [$tracker1, $tracker2, $tracker3]);
@@ -67,12 +68,12 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         $tracker3->expects($this->once())->method('forget');
 
         // Run the track;
-        $this->tracker->forget($this->getMock(TrackableInterface::class));
+        $this->tracker->forget($this->createMockFromClass(TrackableInterface::class));
     }
 
     public function testCallsCreator()
     {
-        $return_tracker = $this->getMock(TrackerInterface::class);
+        $return_tracker = $this->createMockFromClass(TrackerInterface::class);
         $this->tracker->addTracker('test', function() use ($return_tracker) {
             return $return_tracker;
         });
@@ -81,7 +82,7 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         $return_tracker->expects($this->once())->method('track');
 
         // Run the track method
-        $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
     }
 
     public function testUsesDIContainer()
@@ -91,14 +92,14 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         });
 
         $passed = null;
-        $return_tracker = $this->getMock(TrackerInterface::class);
+        $return_tracker = $this->createMockFromClass(TrackerInterface::class);
         $this->tracker->addTracker('test', function(stdClass $obj) use (&$passed, $return_tracker) {
             $passed = $obj;
             return $return_tracker;
         });
 
         // Run the track method
-        $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
 
         // Make sure it gave us the right stdclass
         $this->assertInstanceOf(stdClass::class, $passed);
@@ -108,10 +109,10 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
     public function testSomeCreated()
     {
         // Create the trackers
-        $tracker1 = $this->getMock(TrackerInterface::class);
-        $tracker2 = $this->getMock(TrackerInterface::class);
-        $tracker3 = $this->getMock(TrackerInterface::class);
-        $tracker4 = $this->getMock(TrackerInterface::class);
+        $tracker1 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker2 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker3 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker4 = $this->createMockFromClass(TrackerInterface::class);
 
         $calls = 0;
         // Bind the trackers
@@ -135,13 +136,13 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $calls);
 
         // Now track something
-        $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
 
         // Make sure there were only 4 calls
         $this->assertEquals(4, $calls);
 
         // Now track one more thing
-        $this->tracker->track($this->getMock(TrackableInterface::class));
+        $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
 
         // Make sure there were only 4 calls
         $this->assertEquals(4, $calls);
@@ -149,14 +150,14 @@ class AggregateTrackerTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsInstance()
     {
-        $result = $this->tracker->track($this->getMock(TrackableInterface::class));
+        $result = $this->tracker->track($this->createMockFromClass(TrackableInterface::class));
         $this->assertSame($this->tracker, $result);
     }
 
     public function testOverwrite()
     {
-        $tracker1 = $this->getMock(TrackerInterface::class);
-        $tracker2 = $this->getMock(TrackerInterface::class);
+        $tracker1 = $this->createMockFromClass(TrackerInterface::class);
+        $tracker2 = $this->createMockFromClass(TrackerInterface::class);
 
         // Bind 'test' to the first tracker
         $this->tracker->addTracker('test', function () use ($tracker1) { return $tracker1; });

--- a/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
@@ -14,6 +14,7 @@ use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
 
 class ServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
 
     public function testRegister()
     {
@@ -34,15 +35,15 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $repository = $app['config'];
 
         // A tracker that will be called
-        $tracker1 = $this->getMock(TrackerInterface::class);
+        $tracker1 = $this->createMockFromClass(TrackerInterface::class);
         $tracker1->expects($this->once())->method('track');
 
         // A tracker that will not be called
-        $tracker2 = $this->getMock(TrackerInterface::class);
+        $tracker2 = $this->createMockFromClass(TrackerInterface::class);
         $tracker2->expects($this->never())->method('track');
 
         // And another tracker that will be called
-        $tracker3 = $this->getMock(TrackerInterface::class);
+        $tracker3 = $this->createMockFromClass(TrackerInterface::class);
         $tracker3->expects($this->once())->method('track');
 
         // Bind three so that we can register two of them and be sure that the third one doesn't effect the default tracker
@@ -64,7 +65,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $tracker = $app->make(TrackerManagerInterface::class);
 
         // If all is well, this method should call track on tracker1 and tracker3 but not on tracker2
-        $tracker->track($this->getMock(TrackableInterface::class));
+        $tracker->track($this->createMockFromClass(TrackableInterface::class));
     }
 
     /**
@@ -89,8 +90,8 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
 
         // This service provider requires a config repository be registered
-        $loader = $this->getMock(LoaderInterface::class);
-        $saver = $this->getMock(SaverInterface::class);
+        $loader = $this->createMockFromClass(LoaderInterface::class);
+        $saver = $this->createMockFromClass(SaverInterface::class);
         $repository = new Repository($loader, $saver, 'test');
 
         $app->bind('config', $this->returnCallable($repository));

--- a/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/ServiceProviderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Tests\Core\Statistics\UsageTracker;
 
 use Concrete\Core\Application\Application;
@@ -54,7 +53,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         // Lets set the config item
         $repository->set('statistics.trackers', [
             'foo' => 'tracker/1',
-            'bar' => 'tracker/3'
+            'bar' => 'tracker/3',
         ]);
 
         // Register the service provider
@@ -69,9 +68,10 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Method to make it easy to bind an existing object to the IoC
+     * Method to make it easy to bind an existing object to the IoC.
      *
      * @param $tracker
+     *
      * @return \Closure
      */
     private function returnCallable($tracker)
@@ -82,7 +82,8 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Create an application object to test with
+     * Create an application object to test with.
+     *
      * @return \Concrete\Core\Application\Application
      */
     private function createApplication()
@@ -99,5 +100,4 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         return $app;
     }
-
 }

--- a/tests/tests/Core/Url/Resolver/CanonicalUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/CanonicalUrlResolverTest.php
@@ -21,7 +21,7 @@ class CanonicalUrlResolverTest extends ResolverTestCase
 
         $this->assertEquals(
             (string) \Concrete\Core\Url\Url::createFromUrl($canonical)->setPath(\Core::getApplicationRelativePath()),
-            (string) $resolver->resolve(array()));
+            (string) $resolver->resolve([]));
 
         \Config::set('concrete.seo.canonical_url', $old_value);
     }
@@ -41,7 +41,7 @@ class CanonicalUrlResolverTest extends ResolverTestCase
 
         $this->assertEquals(
             (string) \Concrete\Core\Url\Url::createFromUrl("http://somehost")->setPath(\Core::getApplicationRelativePath()),
-            (string) $resolver->resolve(array()));
+            (string) $resolver->resolve([]));
 
         \Config::set('concrete.seo.canonical_url', $old_value);
     }

--- a/tests/tests/Core/Url/Resolver/CanonicalUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/CanonicalUrlResolverTest.php
@@ -4,6 +4,8 @@ require_once __DIR__ . "/ResolverTestCase.php";
 
 class CanonicalUrlResolverTest extends ResolverTestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
+
     public function testConfig()
     {
         $this->markTestIncomplete('This needs to be updated to use the new site-based canonical url');
@@ -28,7 +30,7 @@ class CanonicalUrlResolverTest extends ResolverTestCase
     {
         $this->markTestIncomplete('This needs to be updated to use the new site-based canonical url');
 
-        $mock = $this->getMock('Concrete\Core\Http\Request');
+        $mock = $this->createMockFromClass('Concrete\Core\Http\Request');
         $mock->expects($this->once())->method('getScheme')->willReturn('http');
         $mock->expects($this->once())->method('getHost')->willReturn('somehost');
 

--- a/tests/tests/Core/Url/Resolver/Manager/ResolverManagerTest.php
+++ b/tests/tests/Core/Url/Resolver/Manager/ResolverManagerTest.php
@@ -39,7 +39,7 @@ class ResolverManagerTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultResolve()
     {
-        $this->assertEquals($this->defaultResponse, $this->manager->resolve(array()));
+        $this->assertEquals($this->defaultResponse, $this->manager->resolve([]));
     }
 
     public function testPriority()
@@ -48,7 +48,7 @@ class ResolverManagerTest extends PHPUnit_Framework_TestCase
         $mock->method('resolve')->willReturn('TEST');
 
         $this->manager->addResolver('test_resolver', $mock, 12);
-        $this->assertEquals('TEST', $this->manager->resolve(array()));
+        $this->assertEquals('TEST', $this->manager->resolve([]));
     }
 
     public function testGetters()

--- a/tests/tests/Core/Url/Resolver/Manager/ResolverManagerTest.php
+++ b/tests/tests/Core/Url/Resolver/Manager/ResolverManagerTest.php
@@ -2,6 +2,8 @@
 
 class ResolverManagerTest extends PHPUnit_Framework_TestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
+
     /**
      * @var \Concrete\Core\Url\Resolver\Manager\ResolverManager
      */
@@ -42,7 +44,7 @@ class ResolverManagerTest extends PHPUnit_Framework_TestCase
 
     public function testPriority()
     {
-        $mock = $this->getMock('\Concrete\Core\Url\Resolver\UrlResolverInterface');
+        $mock = $this->createMockFromClass('\Concrete\Core\Url\Resolver\UrlResolverInterface');
         $mock->method('resolve')->willReturn('TEST');
 
         $this->manager->addResolver('test_resolver', $mock, 12);
@@ -51,7 +53,7 @@ class ResolverManagerTest extends PHPUnit_Framework_TestCase
 
     public function testGetters()
     {
-        $mock = $this->getMock('\Concrete\Core\Url\Resolver\UrlResolverInterface');
+        $mock = $this->createMockFromClass('\Concrete\Core\Url\Resolver\UrlResolverInterface');
         $this->manager->addResolver('test_resolver', $mock);
 
         $this->assertEquals($mock, $this->manager->getResolver('test_resolver'));

--- a/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
@@ -4,6 +4,8 @@ require_once __DIR__ . "/ResolverTestCase.php";
 
 class PageUrlResolverTest extends ResolverTestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
+
     protected function setUp()
     {
         $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
@@ -13,7 +15,7 @@ class PageUrlResolverTest extends ResolverTestCase
     public function testWithPage()
     {
         $path = '/some/collection/path';
-        $page = $this->getMock('\Concrete\Core\Page\Page');
+        $page = $this->createMockFromClass('\Concrete\Core\Page\Page');
         $page->expects($this->once())
                 ->method('getCollectionPath')
                 ->willReturn($path);
@@ -25,7 +27,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
     public function testWithHome()
     {
-        $page = $this->getMock('\Concrete\Core\Page\Page');
+        $page = $this->createMockFromClass('\Concrete\Core\Page\Page');
         $page->expects($this->once())
             ->method('getCollectionID')
             ->willReturn(HOME_CID);
@@ -37,7 +39,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
     public function testUnapproved()
     {
-        $page = $this->getMock('\Concrete\Core\Page\Page');
+        $page = $this->createMockFromClass('\Concrete\Core\Page\Page');
         $page->expects($this->exactly(2))
             ->method('getCollectionID')
             ->willReturn(1337);
@@ -50,7 +52,7 @@ class PageUrlResolverTest extends ResolverTestCase
     public function testAlreadyResolved()
     {
         $path = '/some/collection/path';
-        $page = $this->getMock('\Concrete\Core\Page\Page');
+        $page = $this->createMockFromClass('\Concrete\Core\Page\Page');
         $page->expects($this->never())
             ->method('getCollectionPath')
             ->willReturn($path);

--- a/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
@@ -22,7 +22,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
         $this->assertEquals(
             (string) $this->canonicalUrlWithPath($path),
-            (string) $this->urlResolver->resolve(array($page)));
+            (string) $this->urlResolver->resolve([$page]));
     }
 
     public function testWithHome()
@@ -34,7 +34,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
         $this->assertEquals(
             (string) $this->canonicalUrlWithPath('/'),
-            (string) $this->urlResolver->resolve(array($page)));
+            (string) $this->urlResolver->resolve([$page]));
     }
 
     public function testUnapproved()
@@ -46,7 +46,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
         $this->assertEquals(
             (string) $this->canonicalUrlWithPath('/')->setQuery('cID=1337'),
-            (string) $this->urlResolver->resolve(array($page)));
+            (string) $this->urlResolver->resolve([$page]));
     }
 
     public function testAlreadyResolved()
@@ -57,11 +57,11 @@ class PageUrlResolverTest extends ResolverTestCase
             ->method('getCollectionPath')
             ->willReturn($path);
 
-        $this->assertEquals($this, $this->urlResolver->resolve(array($page), $this));
+        $this->assertEquals($this, $this->urlResolver->resolve([$page], $this));
     }
 
     public function testEmptyArguments()
     {
-        $this->assertNull($this->urlResolver->resolve(array()));
+        $this->assertNull($this->urlResolver->resolve([]));
     }
 }

--- a/tests/tests/Core/Validator/ValidatorManagerTest.php
+++ b/tests/tests/Core/Validator/ValidatorManagerTest.php
@@ -31,7 +31,7 @@ class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($manager->getValidators(), 'Manager should not initialize with validators.');
         $manager->setValidator('test', $mock = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface'));
 
-        $this->assertEquals(array('test' => $mock), $manager->getValidators(), 'Unable to set validator to manager');
+        $this->assertEquals(['test' => $mock], $manager->getValidators(), 'Unable to set validator to manager');
     }
 
     public function testHas()
@@ -49,18 +49,18 @@ class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
         $mock_1 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
         $mock_2 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
 
-        $mock_1->method('getRequirementStrings')->willReturn(array(
+        $mock_1->method('getRequirementStrings')->willReturn([
             1 => 'string 1',
-        ));
-        $mock_2->method('getRequirementStrings')->willReturn(array(
+        ]);
+        $mock_2->method('getRequirementStrings')->willReturn([
             1 => 'string 2',
-        ));
+        ]);
 
         $manager = $this->manager;
         $manager->setValidator('mock_1', $mock_1);
         $manager->setValidator('mock_2', $mock_2);
 
-        $this->assertEquals(array('string 1', 'string 2'), $manager->getRequirementStrings());
+        $this->assertEquals(['string 1', 'string 2'], $manager->getRequirementStrings());
     }
 
     public function testValidation()

--- a/tests/tests/Core/Validator/ValidatorManagerTest.php
+++ b/tests/tests/Core/Validator/ValidatorManagerTest.php
@@ -5,6 +5,8 @@ use Concrete\Core\Validator\ValidatorManagerInterface;
 
 class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
 {
+    use \Concrete\Tests\CreateClassMockTrait;
+
     /** @var ValidatorManagerInterface */
     protected $manager;
 
@@ -27,7 +29,7 @@ class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
         $manager = $this->manager;
 
         $this->assertEmpty($manager->getValidators(), 'Manager should not initialize with validators.');
-        $manager->setValidator('test', $mock = $this->getMock('\Concrete\Core\Validator\ValidatorInterface'));
+        $manager->setValidator('test', $mock = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface'));
 
         $this->assertEquals(array('test' => $mock), $manager->getValidators(), 'Unable to set validator to manager');
     }
@@ -37,15 +39,15 @@ class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
         $manager = new \Concrete\Core\Validator\ValidatorManager();
 
         $this->assertFalse($manager->hasValidator('test'), 'Manager should not initialize with validators.');
-        $manager->setValidator('test', $mock = $this->getMock('\Concrete\Core\Validator\ValidatorInterface'));
+        $manager->setValidator('test', $mock = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface'));
 
         $this->assertTrue($manager->hasValidator('test'), 'Manager does not properly report set validator');
     }
 
     public function testGetRequirements()
     {
-        $mock_1 = $this->getMock('\Concrete\Core\Validator\ValidatorInterface');
-        $mock_2 = $this->getMock('\Concrete\Core\Validator\ValidatorInterface');
+        $mock_1 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
+        $mock_2 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
 
         $mock_1->method('getRequirementStrings')->willReturn(array(
             1 => 'string 1',
@@ -63,8 +65,8 @@ class ValidatorManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testValidation()
     {
-        $mock_1 = $this->getMock('\Concrete\Core\Validator\ValidatorInterface');
-        $mock_2 = $this->getMock('\Concrete\Core\Validator\ValidatorInterface');
+        $mock_1 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
+        $mock_2 = $this->createMockFromClass('\Concrete\Core\Validator\ValidatorInterface');
 
         $mock_1->expects($this->once())->method('isValid')->willReturn(false);
         $mock_2->expects($this->once())->method('isValid')->willReturn(true);

--- a/tests/tests/CreateClassMockTrait.php
+++ b/tests/tests/CreateClassMockTrait.php
@@ -1,0 +1,37 @@
+<?php
+namespace Concrete\Tests;
+
+trait CreateClassMockTrait
+{
+    /**
+     * Flag to remember how we should create mocks. 
+     *
+     * @var int|null
+     */
+    private static $mockCreatorVersion;
+
+    /**
+     * Returns a mock object for the specified class.
+     *
+     * @param string $className
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createMockFromClass($className)
+    {
+        if (!isset(self::$mockCreatorVersion)) {
+            $v = \PHPUnit_Runner_Version::id();
+            if (version_compare($v, '5.4') < 0) {
+                self::$mockCreatorVersion = 1;
+            } else {
+                self::$mockCreatorVersion = 2;
+            }
+        }
+        switch (self::$mockCreatorVersion) {
+            case 1:
+                return $this->getMock($className);
+            case 2:
+                return $this->createMock($className);
+        }
+    }
+}


### PR DESCRIPTION
Newer versions of PHPUnit raise these warnings when calling `getMock`:
```
PHPUnit_Framework_TestCase::getMock() is deprecated,
use PHPUnit_Framework_TestCase::createMock()
or PHPUnit_Framework_TestCase::getMockBuilder() instead
```

Since the PHPUnit version that supports PHP 5.5 does not implements the ` PHPUnit_Framework_TestCase::createMock()` method, let's introduce a trait that calls `getMock` for older PHPUnit versions and `createMock` for newer versions.