### PR TITLE
Fix skipping of vendor files analysis

### DIFF
--- a/tests/tests/CodingStyleTestCase.php
+++ b/tests/tests/CodingStyleTestCase.php
@@ -32,7 +32,7 @@ abstract class CodingStyleTestCase extends \PHPUnit_Framework_TestCase
                 if (strpos($relativePath, '/.') !== false) {
                     continue;
                 }
-                if (strpos($relativePath, '/concrete/vendor/') === 0) {
+                if (strpos($relativePath, '/vendor/') === 0) {
                     continue;
                 }
                 $files[] = $fullPath;


### PR DESCRIPTION
This change is needed because of https://github.com/concrete5/concrete5/commit/7dddbc5512218c21e012589f108bca62bbe68a48