### PR TITLE
Fix DateNavigation controller when ONLY_FULL_GROUP_BY enabled in MySQL

### DIFF
--- a/concrete/blocks/date_navigation/controller.php
+++ b/concrete/blocks/date_navigation/controller.php
@@ -99,7 +99,7 @@ class Controller extends BlockController
         $query = $pl->deliverQueryObject();
         $query->select('date_format(cv.cvDatePublic, "%Y") as navYear, date_format(cv.cvDatePublic, "%m") as navMonth');
         $query->groupBy('navYear, navMonth');
-        $query->orderBy('cvDatePublic', 'desc');
+        $query->orderBy('navYear', 'desc')->addOrderBy('navMonth', 'desc');
         $r = $query->execute();
         $dates = array();
         while ($row = $r->fetch()) {

--- a/concrete/blocks/date_navigation/controller.php
+++ b/concrete/blocks/date_navigation/controller.php
@@ -9,12 +9,12 @@ use Loader;
 
 class Controller extends BlockController
 {
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 450;
-    protected $btExportPageColumns = array('cParentID', 'cTargetID');
-    protected $btExportPageTypeColumns = array('ptID');
+    protected $btExportPageColumns = ['cParentID', 'cTargetID'];
+    protected $btExportPageTypeColumns = ['ptID'];
     protected $btTable = 'btDateNavigation';
 
     public function getBlockTypeDescription()
@@ -70,7 +70,7 @@ class Controller extends BlockController
             }
         }
 
-        return array($method, $parameters);
+        return [$method, $parameters];
     }
 
     public function action_filter_by_date($year = false, $month = false)
@@ -101,9 +101,9 @@ class Controller extends BlockController
         $query->groupBy('navYear, navMonth');
         $query->orderBy('navYear', 'desc')->addOrderBy('navMonth', 'desc');
         $r = $query->execute();
-        $dates = array();
+        $dates = [];
         while ($row = $r->fetch()) {
-            $dates[] = array('year' => $row['navYear'], 'month' => $row['navMonth']);
+            $dates[] = ['year' => $row['navYear'], 'month' => $row['navMonth']];
         }
         $this->set('dates', $dates);
     }


### PR DESCRIPTION
Bug report: https://www.concrete5.org/developers/bugs/5-7-5-8/mysql-5.7.5-sql-mode-only_full_group_by-causing-blog-to-fail-c57/