### PR TITLE
loop Setting not working in youtube block

### DIFF
--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -41,7 +41,7 @@ if (isset($iv_load_policy) && $iv_load_policy > 0) {
     $params[] = 'iv_load_policy=' . $iv_load_policy;
 }
 
-if (isset($loop) && $loop) {
+if (isset($loopEnd) && $loopEnd) {
     $params[] = 'loop=1';
 }
 


### PR DESCRIPTION
The variable for the loop setting in the controller is $loopEnd (instead of $loop).