### PR TITLE
Relative urls when canonical url is not set

### DIFF
--- a/concrete/src/Config/Repository/Repository.php
+++ b/concrete/src/Config/Repository/Repository.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Config\Repository;
 
 use Concrete\Core\Config\LoaderInterface;
 use Concrete\Core\Config\SaverInterface;
+use Concrete\Core\Support\Facade\Config;
 
 class Repository extends \Illuminate\Config\Repository
 {

--- a/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -53,7 +53,7 @@ class LocalConfiguration extends Configuration implements ConfigurationInterface
         $url = \Core::getApplicationURL(true);
         $url = $url->setPath($rel);
 
-        return trim((string) $url, '/');
+        return rtrim((string) $url, '/');
     }
 
     public function loadFromRequest(\Concrete\Core\Http\Request $req)

--- a/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -47,44 +47,30 @@ class CanonicalUrlResolver implements UrlResolverInterface
             return $this->cached;
         }
 
-        $config = false;
-        if ($this->app->isInstalled()) {
-            $site = $this->app['site']->getSite();
-            if (is_object($site)) {
-                $config = $site->getConfigRepository();
-            }
-        }
+        $config = $this->app['config'];
 
         // Determine trailing slash setting
-        $trailing_slashes = $config && $config->get('seo.trailing_slash') ? Url::TRAILING_SLASHES_ENABLED : Url::TRAILING_SLASHES_DISABLED;
+        $trailing_slashes = $config->get('concrete.seo.trailing_slash') ? Url::TRAILING_SLASHES_ENABLED : Url::TRAILING_SLASHES_DISABLED;
 
-        $url = Url::createFromUrl('', $trailing_slashes);
+        $url = UrlImmutable::createFromUrl('', $trailing_slashes);
 
-        $url->setHost(null);
-        $url->setScheme(null);
+        $url = $url->setHost(null);
+        $url = $url->setScheme(null);
 
-        if ($config && $config->get('seo.canonical_url')) {
-            $canonical = UrlImmutable::createFromUrl($config->get('seo.canonical_url'), $trailing_slashes);
+        if ($config->get('concrete.seo.canonical_url')) {
+            $canonical = UrlImmutable::createFromUrl($config->get('concrete.seo.canonical_url'), $trailing_slashes);
 
             // If the request is over https and the canonical url is http, lets just say https for the canonical url.
             if (strtolower($canonical->getScheme()) == 'http' && strtolower($this->request->getScheme()) == 'https') {
-                $url->setScheme('https');
+                $url = $url->setScheme('https');
             } else {
-                $url->setScheme($canonical->getScheme());
+                $url = $url->setScheme($canonical->getScheme());
             }
 
-            $url->setHost($canonical->getHost());
+            $url = $url->setHost($canonical->getHost());
 
             if (intval($canonical->getPort()->get()) > 0) {
-                $url->setPort($canonical->getPort());
-            }
-        } else {
-            $host = $this->request->getHost();
-            $scheme = $this->request->getScheme();
-            if ($scheme && $host) {
-                $url->setScheme($scheme)
-                    ->setHost($host)
-                    ->setPort($this->request->getPort());
+                $url = $url->setPort($canonical->getPort());
             }
         }
 
@@ -92,7 +78,7 @@ class CanonicalUrlResolver implements UrlResolverInterface
             $url = $url->setPath($relative_path);
         }
 
-        $this->cached = UrlImmutable::createFromUrl($url, $trailing_slashes);
+        $this->cached = $url;
 
         return $this->cached;
     }

--- a/concrete/src/Url/Url.php
+++ b/concrete/src/Url/Url.php
@@ -92,4 +92,18 @@ class Url extends \League\Url\Url implements UrlInterface
             new    \League\Url\Components\Fragment($components['fragment'])
         );
     }
+
+    /**
+     * Overridden to allow paths be passed in and out
+     * @param $url
+     * @return null|string
+     */
+    protected static function sanitizeUrl($url)
+    {
+        if (strpos($url, '/') === 0) {
+            return $url;
+        }
+        return parent::sanitizeUrl($url);
+    }
+
 }

--- a/concrete/src/Url/UrlImmutable.php
+++ b/concrete/src/Url/UrlImmutable.php
@@ -93,4 +93,18 @@ class UrlImmutable extends \League\Url\UrlImmutable implements UrlInterface
             new    \League\Url\Components\Fragment($components['fragment'])
         );
     }
+
+    /**
+     * Overridden to allow paths be passed in and out
+     * @param $url
+     * @return null|string
+     */
+    protected static function sanitizeUrl($url)
+    {
+        if (strpos($url, '/') === 0) {
+            return $url;
+        }
+        return parent::sanitizeUrl($url);
+    }
+
 }

--- a/tests/config/concrete.php
+++ b/tests/config/concrete.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+    'seo' => array(
+        'canonical_url' => 'http://www.dummyco.com'
+    )
+);

--- a/tests/tests/Core/Routing/URLTest.php
+++ b/tests/tests/Core/Routing/URLTest.php
@@ -33,14 +33,16 @@ class URLTest extends PHPUnit_Framework_TestCase
         $this->service = $service;
         Config::set('concrete.seo.url_rewriting', false);
         Config::set('concrete.seo.url_rewriting_all', false);
-        Config::set('concrete.seo.canonical_url', false);
+        $this->oldUrl = Config::get('concrete.seo.canonical_url');
 
         parent::setUp();
     }
 
     public function tearDown()
     {
+        Config::set('concrete.seo.canonical_url', $this->oldUrl);
         $this->clearCanonicalUrl();
+
         parent::tearDown();
     }
 
@@ -150,8 +152,6 @@ class URLTest extends PHPUnit_Framework_TestCase
         $request = \Concrete\Core\Http\Request::create('http://concrete5.dev/index.php?cID=1');
         $response = $app->handleCanonicalURLRedirection($request, $site);
         $this->assertNull($response);
-
-        Config::set('concrete.seo.canonical_url', null);
     }
 
     public function testCanonicalUrlRedirectionSslUrl()
@@ -340,7 +340,6 @@ class URLTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://www.derpco.com/path/to/server/index.php/dashboard/my/awesome/page', (string) URL::to('/dashboard/my/awesome/page'));
         $this->assertEquals('http://www.derpco.com/path/to/server/index.php/dashboard/my/awesome/page', (string) URL::page($this->dashboard));
-        Config::set('concrete.seo.canonical_url', null);
     }
 
     public function testCanonicalUrlWithPort()
@@ -351,7 +350,6 @@ class URLTest extends PHPUnit_Framework_TestCase
         $this->clearCanonicalUrl();
         $this->assertEquals('http://www.derpco.com:8080/path/to/server/index.php/dashboard/my/awesome/page', (string) URL::to('/dashboard/my/awesome/page'));
         $this->assertEquals('http://www.derpco.com:8080/path/to/server/index.php/dashboard/my/awesome/page', (string) URL::page($this->dashboard));
-        Config::set('concrete.seo.canonical_url', null);
     }
 
     public function testURLFunctionWithCanonicalURL()
@@ -364,7 +362,18 @@ class URLTest extends PHPUnit_Framework_TestCase
 
         $url = URL::to('/dashboard/system/test', 'outstanding');
         $this->assertEquals('http://concrete5/path/to/server/index.php/dashboard/system/test/outstanding', (string) $url);
-        Config::set('concrete.seo.canonical_url', null);
+    }
+
+    public function testURLFunctionWithoutCanonicalURL()
+    {
+        $this->markTestIncomplete('This needs to be updated to use the new site-based canonical url');
+
+        Config::set('concrete.seo.canonical_url', '');
+
+        $this->clearCanonicalUrl();
+
+        $url = URL::to('/dashboard/system/test', 'outstanding');
+        $this->assertEquals('/path/to/server/index.php/dashboard/system/test/outstanding', (string) $url);
     }
 
     private function clearCanonicalUrl()
@@ -373,23 +382,4 @@ class URLTest extends PHPUnit_Framework_TestCase
         $app->make('Concrete\Core\Url\Resolver\CanonicalUrlResolver')->clearCached();
     }
 
-    /*
-    public function testPage()
-    {
-
-        // URL Rewriting
-        Config::set('concrete.seo.url_rewriting', true);
-
-
-        // URL Rewriting All
-        Config::set('concrete.seo.url_rewriting_all', true);
-
-        $this->assertEquals('/path/to/my/page', $c->getCollectionLink());
-        $this->assertEquals('/path/to/my/page',
-            $service->getLinkToCollection($c)
-        );
-        $this->assertEquals('/path/to/my/page', URL::to('/path/to/my/page'));
-        $this->assertEquals('/path/to/my/page', URL::page($c));
-    }
-    */
 }

--- a/tests/tests/Core/Url/Resolver/CallableUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/CallableUrlResolverTest.php
@@ -11,6 +11,7 @@ class CallableUrlResolverTest extends ResolverTestCase
 
     protected function setUp()
     {
+        parent::setUp();
         $this->urlResolver = new \Concrete\Core\Url\Resolver\CallableUrlResolver(function () {});
     }
 

--- a/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
@@ -8,6 +8,7 @@ class PageUrlResolverTest extends ResolverTestCase
 
     protected function setUp()
     {
+        parent::setUp();
         $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
         $this->urlResolver = $app->make('Concrete\Core\Url\Resolver\PageUrlResolver');
     }

--- a/tests/tests/Core/Url/Resolver/PathUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/PathUrlResolverTest.php
@@ -6,6 +6,7 @@ class PathUrlResolverTest extends ResolverTestCase
 {
     protected function setUp()
     {
+        parent::setUp();
         $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
         $this->urlResolver = $app->make('Concrete\Core\Url\Resolver\PathUrlResolver');
     }

--- a/tests/tests/Core/Url/Resolver/ResolverTestCase.php
+++ b/tests/tests/Core/Url/Resolver/ResolverTestCase.php
@@ -12,10 +12,8 @@ abstract class ResolverTestCase extends PHPUnit_Framework_TestCase
      */
     protected $urlResolver;
 
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    protected function setUp()
     {
-        parent::__construct($name, $data, $dataName);
-
         $url = \Concrete\Core\Url\UrlImmutable::createFromUrl(\Core::make('url/canonical'));
         $this->canonicalUrl = $url;
     }

--- a/tests/tests/Core/Url/Resolver/RouteUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/RouteUrlResolverTest.php
@@ -11,6 +11,8 @@ class RouteUrlResolverTest extends ResolverTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
         $path_url_resolver = $app->make('Concrete\Core\Url\Resolver\PathUrlResolver');


### PR DESCRIPTION
If `concrete.seo.canonical_url` is not set, we'll now output the relative url when someone requests the canonical url.
