### PR TITLE
increase Conversation Settings note text size

### DIFF
--- a/concrete/single_pages/dashboard/system/conversations/settings.php
+++ b/concrete/single_pages/dashboard/system/conversations/settings.php
@@ -12,9 +12,7 @@ echo Core::make('helper/concrete/dashboard')->getDashboardPaneHeaderWrapper(t('C
 
     <fieldset>
         <legend><?php echo t('Attachment Settings'); ?></legend>
-        <p style="margin-bottom: 25px; color: #aaa; display: block;"
-           class="small"><?php echo t('Note: These settings can be overridden in the block edit form for individual conversations.') ?></p>
-
+        <p style="margin-bottom: 25px; color: #aaa; display: block;"><?php echo t('Note: These settings can be overridden in the block edit form for individual conversations.'); ?></p>
         <div class="form-group">
             <label class="control-label"><?= t('Enable Attachments') ?></label>
             <?= $form->checkbox('attachmentsEnabled', 1, $attachmentsEnabled) ?>


### PR DESCRIPTION
The note text size was 11px and challenging to read. The "small" class was removed.

**Current**

![conversation_settings_small_text-current](https://cloud.githubusercontent.com/assets/10898145/17688957/d9d984d0-6351-11e6-80eb-5d24b202aa1d.png)

**Changes**

![conversation_settings_small_text-changes](https://cloud.githubusercontent.com/assets/10898145/17688961/df2deb1a-6351-11e6-9688-cef59d3eaf6e.png)
