### PR TITLE
Fix ExpressCategory attribute -> import

### DIFF
--- a/concrete/src/Attribute/Category/ExpressCategory.php
+++ b/concrete/src/Attribute/Category/ExpressCategory.php
@@ -9,7 +9,7 @@ use Concrete\Core\Entity\Attribute\Key\ExpressKey;
 use Concrete\Core\Entity\Attribute\Key\Key;
 use Concrete\Core\Entity\Attribute\Type;
 use Concrete\Core\Entity\Express\Entity;
-use Concrete\Core\Package\Package;
+use Concrete\Core\Entity\Package;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/concrete/src/Attribute/Category/ExpressCategory.php
+++ b/concrete/src/Attribute/Category/ExpressCategory.php
@@ -1,9 +1,7 @@
 <?php
 namespace Concrete\Core\Attribute\Category;
 
-use Concrete\Controller\SinglePage\Dashboard\Express;
 use Concrete\Core\Application\Application;
-use Concrete\Core\Attribute\Category\SearchIndexer\StandardSearchIndexerInterface;
 use Concrete\Core\Attribute\ExpressSetManager;
 use Concrete\Core\Entity\Attribute\Key\ExpressKey;
 use Concrete\Core\Entity\Attribute\Key\Key;
@@ -15,7 +13,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ExpressCategory extends AbstractCategory
 {
-
     protected $expressEntity;
 
     public function getIndexedSearchTable()
@@ -24,14 +21,12 @@ class ExpressCategory extends AbstractCategory
             . 'ExpressSearchIndexAttributes';
     }
 
-
     public function getSearchIndexer()
     {
         $indexer = $this->application->make('Concrete\Core\Attribute\Category\SearchIndexer\ExpressSearchIndexer');
 
         return $indexer;
     }
-
 
     public function getIndexedSearchPrimaryKeyValue($mixed)
     {
@@ -40,16 +35,16 @@ class ExpressCategory extends AbstractCategory
 
     public function getSearchIndexFieldDefinition()
     {
-        return array(
-            'columns' => array(
-                array(
+        return [
+            'columns' => [
+                [
                     'name' => 'exEntryID',
                     'type' => 'integer',
-                    'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true),
-                ),
-            ),
-            'primary' => array('exEntryID'),
-        );
+                    'options' => ['unsigned' => true, 'default' => 0, 'notnull' => true],
+                ],
+            ],
+            'primary' => ['exEntryID'],
+        ];
     }
 
     public function getSetManager()
@@ -57,6 +52,7 @@ class ExpressCategory extends AbstractCategory
         if (!isset($this->setManager)) {
             $this->setManager = new ExpressSetManager($this->expressEntity, $this->entityManager);
         }
+
         return $this->setManager;
     }
 
@@ -83,9 +79,8 @@ class ExpressCategory extends AbstractCategory
 
     public function getList()
     {
-        return $this->getAttributeRepository()->findBy(array('entity' => $this->expressEntity));
+        return $this->getAttributeRepository()->findBy(['entity' => $this->expressEntity]);
     }
-
 
     public function getAttributeTypes()
     {
@@ -98,25 +93,27 @@ class ExpressCategory extends AbstractCategory
     {
         $key = parent::import($type, $element, $package);
         $key->setEntity($this->expressEntity);
+
         return $key;
     }
 
     public function addFromRequest(Type $type, Request $request)
     {
-        /**
-         * @var $key ExpressKey
-         */
         $key = parent::addFromRequest($type, $request);
+        /*
+         * @var ExpressKey
+         */
         $key->setEntity($this->expressEntity);
+
         return $key;
     }
 
     public function getAttributeValues($entry)
     {
         $r = $this->entityManager->getRepository('\Concrete\Core\Entity\Attribute\Value\ExpressValue');
-        $values = $r->findBy(array(
+        $values = $r->findBy([
             'entry' => $entry,
-        ));
+        ]);
 
         return $values;
     }
@@ -124,10 +121,10 @@ class ExpressCategory extends AbstractCategory
     public function getAttributeValue(Key $key, $entry)
     {
         $r = $this->entityManager->getRepository('\Concrete\Core\Entity\Attribute\Value\ExpressValue');
-        $value = $r->findOneBy(array(
+        $value = $r->findOneBy([
             'entry' => $entry,
             'attribute_key' => $key,
-        ));
+        ]);
 
         return $value;
     }


### PR DESCRIPTION
Fix for this error:

```
Declaration of
Concrete\Core\Attribute\Category\ExpressCategory::import(
    Concrete\Core\Entity\Attribute\Type $type,
    SimpleXMLElement $element,
    Concrete\Core\Package\Package $package = NULL
)
should be compatible with
Concrete\Core\Attribute\Category\AbstractCategory::import(
    Concrete\Core\Entity\Attribute\Type $type,
    SimpleXMLElement $element,
    Concrete\Core\Entity\Package $package = NULL
)
```

I start hating this class ambiguity... :unamused: 