### PR TITLE
Fix installation when strict mode is enabled

### DIFF
--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -2463,7 +2463,7 @@
                                                 <thankyouMsg>Thanks!</thankyouMsg>
                                                 <notifyMeOnSubmission>0</notifyMeOnSubmission>
                                                 <recipientEmail></recipientEmail>
-                                                <displayCaptcha></displayCaptcha>
+                                                <displayCaptcha>0</displayCaptcha>
                                                 <redirectCID>0</redirectCID>
                                                 <replyToEmailControlID>02181ae2-634d-11e6-a245-62e65b165d8e</replyToEmailControlID>
                                                 <addFilesToSet>0</addFilesToSet>


### PR DESCRIPTION
If MySQL runs with `STRICT_TRANS_TABLES` mode enabled, installation fails with this error:

```
An exception occurred while executing
'INSERT INTO btExpressForm (
    bID,
	 exFormID,
	 submitLabel,
	 thankyouMsg,
	 notifyMeOnSubmission,
	 recipientEmail,
	 displayCaptcha,
	 redirectCID,
	 replyToEmailControlID,
	 addFilesToSet
) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
with params [
    "120",
	 "881b6bde-220f-4482-b8f9-ace40b5d169b",
	 "Submit",
	 "Thanks!",
	 "0",
	 "",
	 "",
	 "0",
	 "02181ae2-634d-11e6-a245-62e65b165d8e",
	 "0"
]:

SQLSTATE[HY000]: General error: 1366
Incorrect integer value: '' for column 'displayCaptcha' at row 1
```