### PR TITLE
Make CorePageProperty::clearComposerRequestProcessControls static

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/CorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/CorePageProperty.php
@@ -17,7 +17,7 @@ abstract class CorePageProperty extends \Concrete\Core\Page\Type\Composer\Contro
     {
     }
 
-    public function clearComposerRequestProcessControls()
+    public static function clearComposerRequestProcessControls()
     {
         self::$ptComposerRequestControlsProcessed = array();
     }


### PR DESCRIPTION
It's called statically and does not contain any reference to $this