### PR TITLE
Fix avatar creation for not logged-in authors

### DIFF
--- a/concrete/src/User/Avatar/EmptyAvatar.php
+++ b/concrete/src/User/Avatar/EmptyAvatar.php
@@ -9,4 +9,9 @@ class EmptyAvatar extends StandardAvatar
     {
         return $this->application['config']->get('concrete.icons.user_avatar.default');
     }
+
+    protected function getAlt()
+    {
+        return '';
+    }
 }

--- a/concrete/src/User/Avatar/StandardAvatar.php
+++ b/concrete/src/User/Avatar/StandardAvatar.php
@@ -26,10 +26,19 @@ class StandardAvatar implements AvatarInterface
         return $src;
     }
 
+    protected function getAlt()
+    {
+        return $this->userInfo->getUserName();
+    }
+
     public function output()
     {
         $img = new Image();
-        $img->src($this->getPath())->class('u-avatar')->alt($this->userInfo->getUserName());
+        $img->src($this->getPath())->class('u-avatar');
+        $alt = $this->getAlt();
+        if ($alt !== '') {
+            $img->alt($alt);
+        }
 
         return (string) $img;
     }


### PR DESCRIPTION
If conversation message authors are not logged in, we use the EmptyAvatar class and its `userInfo` property does not have any entity associated.
Thus, calling `$this->userInfo->getUserName()` leads to a `Call to a member function getUserName() on null` exception.