### PR TITLE
Remove useless function code in Attribute\View on[Before|After]GetContents

### DIFF
--- a/concrete/src/Attribute/View.php
+++ b/concrete/src/Attribute/View.php
@@ -133,12 +133,10 @@ class View extends AbstractView
 
     protected function onBeforeGetContents()
     {
-        @Loader::element(DIRNAME_ATTRIBUTES . '/' . $view . '_header', array('type' => $this->attributeType));
     }
 
     protected function onAfterGetContents()
     {
-        @Loader::element(DIRNAME_ATTRIBUTES . '/' . $view . '_footer', array('type' => $this->attributeType));
     }
 
     public function field($fieldName)


### PR DESCRIPTION
Those two function bodies are quite useless, since `$view` is not defined.

Should they do something? Since they've been so [for years](https://github.com/concrete5/concrete5/commit/02c446de54fe3c59ad08551f1323cce3e5d21c4f#diff-4d3f5ee2dfcd041eb508179c2564d134R92) I don't think so...

Otherwise, should `$view` be replaced with `$this->viewToRender`?