### PR TITLE
Feature/session renew

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -683,7 +683,7 @@ return array(
         'max_lifetime' => 7200,
         'cookie' => array(
             'cookie_path' => false, // set a specific path here if you know it, otherwise it'll default to relative
-            'cookie_lifetime' => 0,
+            'cookie_lifetime' => 7200,
             'cookie_domain' => false,
             'cookie_secure' => false,
             'cookie_httponly' => true,

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -74,7 +74,8 @@ class SessionFactory implements SessionFactoryInterface
             }
 
             $lifetime = $config->get('concrete.session.max_lifetime');
-            $options['gc_max_lifetime'] = $options['cookie_lifetime'] = $lifetime;
+            $options['gc_max_lifetime'] = $lifetime;
+
             $storage->setOptions($options);
         }
 

--- a/concrete/src/Session/SessionServiceProvider.php
+++ b/concrete/src/Session/SessionServiceProvider.php
@@ -17,5 +17,21 @@ class SessionServiceProvider extends ServiceProvider
             return $app->make('Concrete\Core\Session\SessionFactoryInterface')->createSession();
         });
         $this->app->bind('Symfony\Component\HttpFoundation\Session\Session', 'session');
+
+        $app = $this->app;
+
+        if ($events = $this->app['director']) {
+            // Add an event listener that renews session
+            $this->app['director']->addListener('on_before_render', function () use ($app) {
+                /** @var Session $session */
+                $session = $app['session'];
+
+                if ($session->get('uID', 0) > 0) {
+                    // If the user is logged in, update the session so that we have more time on every page load
+                    $session->migrate();
+                    $session->getMetadataBag()->stampNew();
+                }
+            });
+        }
     }
 }

--- a/concrete/src/Session/SessionServiceProvider.php
+++ b/concrete/src/Session/SessionServiceProvider.php
@@ -20,7 +20,7 @@ class SessionServiceProvider extends ServiceProvider
 
         $app = $this->app;
 
-        if ($events = $this->app['director']) {
+        if ($this->app->bound('director')) {
             // Add an event listener that renews session
             $this->app['director']->addListener('on_before_render', function () use ($app) {
                 /** @var Session $session */


### PR DESCRIPTION
This renews the session on_before_render if a user is logged in. This prevents sessions and session cookies from expiring after the default lifetime.

Resolves #3995 