### PR TITLE
increase Access Entity modal width

### DIFF
--- a/concrete/elements/permission/access/list.php
+++ b/concrete/elements/permission/access/list.php
@@ -3,7 +3,7 @@
 <?php foreach ($accessTypes as $accessType => $title) {
     $list = $permissionAccess->getAccessListItems($accessType);
     ?>
-	<a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?accessType=<?=$accessType?>&pkCategoryHandle=<?=$pkCategoryHandle?>" dialog-width="500" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-xs btn-default"><?=t('Add')?></a>
+	<a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?accessType=<?=$accessType?>&pkCategoryHandle=<?=$pkCategoryHandle?>" dialog-width="510" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-xs btn-default"><?=t('Add')?></a>
 
 	<h4><?=$title?></h4>
 
@@ -22,33 +22,33 @@
 <tr>
     <td>
     <a href="javascript:void(0)" class="icon-link pull-right" style="margin-left: 10px" onclick="ccm_deleteAccessEntityAssignment(<?=$pae->getAccessEntityID()?>)"><i class="fa fa-trash-o"></i></a>
-	<a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?peID=<?=$pae->getAccessEntityID()?>&pdID=<?=$pdID?>&accessType=<?=$accessType?>" dialog-width="500" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="<?php if (!is_object($pa->getPermissionDurationObject())) {
-    ?>icon-link<?php 
+	<a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?peID=<?=$pae->getAccessEntityID()?>&pdID=<?=$pdID?>&accessType=<?=$accessType?>" dialog-width="510" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="<?php if (!is_object($pa->getPermissionDurationObject())) {
+    ?>icon-link<?php
 }
     ?> pull-right dialog-launch"><i class="fa fa-clock-o <?php if (is_object($pa->getPermissionDurationObject())) {
-    ?>text-info<?php 
+    ?>text-info<?php
 }
     ?>"></i></a>
     <?=$pae->getAccessEntityLabel()?>
     </td>
 </tr>
 
-<?php 
+<?php
 }
     ?>
 
-<?php 
+<?php
 } else {
     ?>
 	<tr>
 	<td><?=t('None')?></td>
 	</tr>
-<?php 
+<?php
 }
     ?>
 
 </table>
 
 
-<?php 
+<?php
 } ?>


### PR DESCRIPTION
Increasing the modal width by 10px prevents the date selector from wrapping.

**Current**

![modal_width-current](https://cloud.githubusercontent.com/assets/10898145/17922311/55e199ea-69ac-11e6-9649-21fa23126bc0.png)

**Changes**

![modal_width-changes](https://cloud.githubusercontent.com/assets/10898145/17922383/a9083106-69ac-11e6-82ac-b87e45c0da1d.png)

