### PR TITLE
Remove cookie_lifetime override

### DIFF
--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -74,7 +74,7 @@ class SessionFactory implements SessionFactoryInterface
             }
 
             $lifetime = $config->get('concrete.session.max_lifetime');
-            $options['gc_max_lifetime'] = $options['cookie_lifetime'] = $lifetime;
+            $options['gc_max_lifetime'] = $lifetime;
             $storage->setOptions($options);
         }
 


### PR DESCRIPTION
Pretty self explanatory. When I made this change previously I didn't realize that `cookie_lifetime` was settable through config.

Resolves #3995 (as long as you don't have cookie_lifetime configured)