### PR TITLE
Return proper type from PageUrlResolver

### DIFF
--- a/concrete/src/Url/Resolver/PageUrlResolver.php
+++ b/concrete/src/Url/Resolver/PageUrlResolver.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Core\Url\Resolver;
 
+use Concrete\Core\Url\Url;
+
 class PageUrlResolver implements UrlResolverInterface
 {
     /** @var UrlResolverInterface */
@@ -21,8 +23,8 @@ class PageUrlResolver implements UrlResolverInterface
         $page = array_shift($arguments);
         if ($page && $page instanceof \Concrete\Core\Page\Page) {
 
-            if ($page->getCollectionPointerExternalLink()) {
-                return $page->getCollectionPointerExternalLink();
+            if ($externalUrl = $page->getCollectionPointerExternalLink()) {
+                return Url::createFromUrl($externalUrl);
             }
 
             if ($path = $page->getCollectionPath()) {


### PR DESCRIPTION
fd58e88d145ec0c11222050e5290fbf3a5e13315 introduced the ability for the `PageUrlResolver` to return an external link if the page has one, however the change returns a string instead of what [`UrlResolverInterface` requires](https://github.com/concrete5/concrete5/blob/7b039747ab761de682d06a473441db08911f4988/concrete/src/Url/Resolver/UrlResolverInterface.php#L15-L15) which is an instance of `\League\URL\URLInterface`