### PR TITLE
Better $controller->replace() functionality

### DIFF
--- a/concrete/controllers/single_page/page_not_found.php
+++ b/concrete/controllers/single_page/page_not_found.php
@@ -1,8 +1,27 @@
 <?php
 namespace Concrete\Controller\SinglePage;
 
-use PageController;
+use Concrete\Core\Http\Response;
+use Concrete\Core\Page\Controller\PageController;
 
 class PageNotFound extends PageController
 {
+
+    public function view()
+    {
+        $view = $this->getViewObject();
+        $contents = $view->render();
+
+        return new Response($contents, 404);
+    }
+
+    public function __call($method, $arguments)
+    {
+        if (method_exists($this, $method)) {
+            return call_user_func_array(array($this, $method), $arguments);
+        }
+
+        return $this->view();
+    }
+
 }

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -1,8 +1,8 @@
 <?php
 namespace Concrete\Controller\SinglePage;
 
+use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Validation\ResponseInterface;
-use PageController;
 use Config;
 use Loader;
 use User;
@@ -18,6 +18,7 @@ class Register extends PageController
 	public function on_start() {
 		if(!in_array(Config::get('concrete.user.registration.type'), array('validate_email', 'enabled'))) {
             $this->replace('/page_not_found');
+            return;
         }
         $u = new User();
         $this->set('u', $u);

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -18,6 +18,7 @@ class PageController extends Controller
     protected $action;
     protected $passThruBlocks = array();
     protected $parameters = array();
+    protected $replacement = null;
 
     public function supportsPageCache()
     {
@@ -51,12 +52,17 @@ class PageController extends Controller
         $request = \Request::getInstance();
         $request->setCurrentPage($var);
         $controller = $var->getPageController();
-        $controller->on_start();
-        $controller->runAction('view');
-        $controller->on_before_render();
-        $view = $controller->getViewObject();
-        echo $view->render();
-        exit;
+        $this->replacement = $controller;
+    }
+
+    public function isReplaced()
+    {
+        return !!$this->replacement;
+    }
+
+    public function getReplacement()
+    {
+        return $this->replacement;
     }
 
     public function getSets()

--- a/concrete/src/Routing/DispatcherRouteCallback.php
+++ b/concrete/src/Routing/DispatcherRouteCallback.php
@@ -271,6 +271,14 @@ class DispatcherRouteCallback extends RouteCallback
             return $response;
         }
 
+        if ($controller->isReplaced()) {
+            $controller = $controller->getReplacement();
+            $response = $controller->runAction($requestTask, $requestParameters);
+            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
+                return $response;
+            }
+        }
+
         $c->setController($controller);
         $view = $controller->getViewObject();
 


### PR DESCRIPTION
This change does two things:

1. Makes `$controller->replace` replace in a way that works with the dispatcher instead of just outputting and exiting.
2. Makes the 404 controller a little smarter so that it will apply the 404 response code in all cases.