### PR TITLE
Fix FileUsageTrackerTest::testTrackingCollection test

### DIFF
--- a/tests/tests/Core/Statistics/UsageTracker/FileUsageTrackerTest.php
+++ b/tests/tests/Core/Statistics/UsageTracker/FileUsageTrackerTest.php
@@ -8,6 +8,7 @@ use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\File\Tracker\UsageTracker;
 use Concrete\Core\Page\Collection\Collection;
 use Doctrine\ORM\EntityManagerInterface;
+use Concrete\Core\Block\BlockController;
 
 class FileUsageTrackerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Newer PHPUnit versions show this warning:
```
Trying to configure method "getCollectionObject" which cannot be configured
because it does not exist, has not been specified, is final, or is static
```
Let's fix this warning