### PR TITLE
Avoid accessing undefined var in AddSubpagePageAccess::getAccessListItems

### DIFF
--- a/concrete/src/Permission/Access/AddSubpagePageAccess.php
+++ b/concrete/src/Permission/Access/AddSubpagePageAccess.php
@@ -12,14 +12,14 @@ class AddSubpagePageAccess extends PageAccess
     {
         $newPA = parent::duplicate($newPA);
         $db = Database::connection();
-        $r = $db->executeQuery('select * from PagePermissionPageTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
+        $r = $db->executeQuery('select * from PagePermissionPageTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->FetchRow()) {
-            $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission'], $row['externalLink']);
+            $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['permission'], $row['externalLink']];
             $db->executeQuery('insert into PagePermissionPageTypeAccessList (peID, paID, permission, externalLink) values (?, ?, ?, ?)', $v);
         }
-        $r = $db->executeQuery('select * from PagePermissionPageTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $r = $db->executeQuery('select * from PagePermissionPageTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->FetchRow()) {
-            $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['ptID']);
+            $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['ptID']];
             $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom  (peID, paID, ptID) values (?, ?, ?)', $v);
         }
 
@@ -30,23 +30,23 @@ class AddSubpagePageAccess extends PageAccess
     {
         parent::removeListItem($pe);
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionPageTypeAccessList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $this->getPermissionAccessID()));
-        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', array($pe->getAccessEntityID(), $this->getPermissionAccessID()));
+        $db->executeQuery('delete from PagePermissionPageTypeAccessList where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
+        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
     }
 
-    public function save($args = array())
+    public function save($args = [])
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionPageTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
-        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeQuery('delete from PagePermissionPageTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (is_array($args['pageTypesIncluded'])) {
             foreach ($args['pageTypesIncluded'] as $peID => $permission) {
                 $ext = 0;
                 if (!empty($args['allowExternalLinksIncluded'][$peID])) {
                     $ext = $args['allowExternalLinksIncluded'][$peID];
                 }
-                $v = array($this->getPermissionAccessID(), $peID, $permission, $ext);
+                $v = [$this->getPermissionAccessID(), $peID, $permission, $ext];
                 $db->executeQuery('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
             }
         }
@@ -57,7 +57,7 @@ class AddSubpagePageAccess extends PageAccess
                 if (!empty($args['allowExternalLinksExcluded'][$peID])) {
                     $ext = $args['allowExternalLinksExcluded'][$peID];
                 }
-                $v = array($this->getPermissionAccessID(), $peID, $permission, $ext);
+                $v = [$this->getPermissionAccessID(), $peID, $permission, $ext];
                 $db->executeQuery('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
             }
         }
@@ -65,7 +65,7 @@ class AddSubpagePageAccess extends PageAccess
         if (is_array($args['ptIDInclude'])) {
             foreach ($args['ptIDInclude'] as $peID => $ptIDs) {
                 foreach ($ptIDs as $ptID) {
-                    $v = array($this->getPermissionAccessID(), $peID, $ptID);
+                    $v = [$this->getPermissionAccessID(), $peID, $ptID];
                     $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
                 }
             }
@@ -74,14 +74,14 @@ class AddSubpagePageAccess extends PageAccess
         if (is_array($args['ptIDExclude'])) {
             foreach ($args['ptIDExclude'] as $peID => $ptIDs) {
                 foreach ($ptIDs as $ptID) {
-                    $v = array($this->getPermissionAccessID(), $peID, $ptID);
+                    $v = [$this->getPermissionAccessID(), $peID, $ptID];
                     $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
                 }
             }
         }
     }
 
-    public function getAccessListItems($accessType = PagePermissionKey::ACCESS_TYPE_INCLUDE, $filterEntities = array(), $checkCache = true)
+    public function getAccessListItems($accessType = PagePermissionKey::ACCESS_TYPE_INCLUDE, $filterEntities = [], $checkCache = true)
     {
         $db = Database::connection();
         $list = parent::getAccessListItems($accessType, $filterEntities);
@@ -89,7 +89,7 @@ class AddSubpagePageAccess extends PageAccess
         foreach ($list as $l) {
             $permission = '';
             $pe = $l->getAccessEntityObject();
-            $prow = $db->fetchAssoc('select permission, externalLink from PagePermissionPageTypeAccessList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
+            $prow = $db->fetchAssoc('select permission, externalLink from PagePermissionPageTypeAccessList where peID = ? and paID = ?', [$pe->getAccessEntityID(), $l->getPermissionAccessID()]);
             if (is_array($prow) && $prow['permission']) {
                 $l->setPageTypesAllowedPermission($prow['permission']);
                 $l->setAllowExternalLinks($prow['externalLink']);
@@ -102,7 +102,7 @@ class AddSubpagePageAccess extends PageAccess
                 $l->setAllowExternalLinks(0);
             }
             if ($permission == 'C') {
-                $ptIDs = $db->GetCol('select ptID from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
+                $ptIDs = $db->GetCol('select ptID from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', [$pe->getAccessEntityID(), $l->getPermissionAccessID()]);
                 $l->setPageTypesAllowedArray($ptIDs);
             }
         }

--- a/concrete/src/Permission/Access/AddSubpagePageAccess.php
+++ b/concrete/src/Permission/Access/AddSubpagePageAccess.php
@@ -87,6 +87,7 @@ class AddSubpagePageAccess extends PageAccess
         $list = parent::getAccessListItems($accessType, $filterEntities);
         $list = PermissionDuration::filterByActive($list);
         foreach ($list as $l) {
+            $permission = '';
             $pe = $l->getAccessEntityObject();
             $prow = $db->fetchAssoc('select permission, externalLink from PagePermissionPageTypeAccessList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
             if (is_array($prow) && $prow['permission']) {


### PR DESCRIPTION
**WARNING: behaviour changed**: I *think* there was a bug, since the `$permission` variable could be reused from a previous `foreach` cycle if it's not set in the current cycle.
It wasn't meant to work like this, was it?