### PR TITLE
Make StyleCustomizer\Style\Style::getValuesFromVariables static

### DIFF
--- a/concrete/src/StyleCustomizer/Style/ColorStyle.php
+++ b/concrete/src/StyleCustomizer/Style/ColorStyle.php
@@ -96,7 +96,7 @@ class ColorStyle extends Style
         return $cv;
     }
 
-    public function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = array())
     {
         $values = array();
         foreach ($rules as $rule) {

--- a/concrete/src/StyleCustomizer/Style/ColorStyle.php
+++ b/concrete/src/StyleCustomizer/Style/ColorStyle.php
@@ -96,9 +96,9 @@ class ColorStyle extends Style
         return $cv;
     }
 
-    public static function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = [])
     {
-        $values = array();
+        $values = [];
         foreach ($rules as $rule) {
             if (preg_match('/@(.+)\-color/i',  isset($rule->name) ? $rule->name : '', $matches)) {
                 $value = $rule->value->value[0]->value[0];

--- a/concrete/src/StyleCustomizer/Style/ImageStyle.php
+++ b/concrete/src/StyleCustomizer/Style/ImageStyle.php
@@ -52,9 +52,9 @@ class ImageStyle extends Style
         }
     }
 
-    public static function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = [])
     {
-        $values = array();
+        $values = [];
         foreach ($rules as $rule) {
             if (preg_match('/@(.+)\-image/i', isset($rule->name) ? $rule->name : '', $matches)) {
                 $entryURI = $rule->value->value[0]->value[0]->currentFileInfo['entryUri'];

--- a/concrete/src/StyleCustomizer/Style/ImageStyle.php
+++ b/concrete/src/StyleCustomizer/Style/ImageStyle.php
@@ -52,7 +52,7 @@ class ImageStyle extends Style
         }
     }
 
-    public function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = array())
     {
         $values = array();
         foreach ($rules as $rule) {

--- a/concrete/src/StyleCustomizer/Style/SizeStyle.php
+++ b/concrete/src/StyleCustomizer/Style/SizeStyle.php
@@ -50,7 +50,7 @@ class SizeStyle extends Style
         return $sv;
     }
 
-    public function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = array())
     {
         $values = array();
         foreach ($rules as $rule) {

--- a/concrete/src/StyleCustomizer/Style/SizeStyle.php
+++ b/concrete/src/StyleCustomizer/Style/SizeStyle.php
@@ -50,9 +50,9 @@ class SizeStyle extends Style
         return $sv;
     }
 
-    public static function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = [])
     {
-        $values = array();
+        $values = [];
         foreach ($rules as $rule) {
             if (preg_match('/@(.+)\-size/i',  isset($rule->name) ? $rule->name : '', $matches)) {
                 $value = $rule->value->value[0]->value[0];

--- a/concrete/src/StyleCustomizer/Style/Style.php
+++ b/concrete/src/StyleCustomizer/Style/Style.php
@@ -3,13 +3,20 @@ namespace Concrete\Core\StyleCustomizer\Style;
 
 use Environment;
 
+/**
+ * @method static Value[] getValuesFromVariables($rules = array())
+ */
 abstract class Style
 {
     protected $variable;
     protected $name;
 
     abstract public function render($value = false);
-    abstract public function getValuesFromVariables($rules = array());
+    /*
+     * This is commented out only because PHP raises a "strict standards" warning,
+     * but child classes MUST implement it (see also https://bugs.php.net/bug.php?id=72993 ).
+     * abstract public static function getValuesFromVariables($rules = array());
+     */
     abstract public function getValueFromRequest(\Symfony\Component\HttpFoundation\ParameterBag $request);
 
     public function getValueFromList(\Concrete\Core\StyleCustomizer\Style\ValueList $list)

--- a/concrete/src/StyleCustomizer/Style/Style.php
+++ b/concrete/src/StyleCustomizer/Style/Style.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\StyleCustomizer\Style;
 use Environment;
 
 /**
- * @method static Value[] getValuesFromVariables($rules = array())
+ * @method static Value[] getValuesFromVariables($rules = [])
  */
 abstract class Style
 {
@@ -15,7 +15,7 @@ abstract class Style
     /*
      * This is commented out only because PHP raises a "strict standards" warning,
      * but child classes MUST implement it (see also https://bugs.php.net/bug.php?id=72993 ).
-     * abstract public static function getValuesFromVariables($rules = array());
+     * abstract public static function getValuesFromVariables($rules = []);
      */
     abstract public function getValueFromRequest(\Symfony\Component\HttpFoundation\ParameterBag $request);
 

--- a/concrete/src/StyleCustomizer/Style/TypeStyle.php
+++ b/concrete/src/StyleCustomizer/Style/TypeStyle.php
@@ -11,7 +11,7 @@ class TypeStyle extends Style
     public function render($style = false)
     {
         $fh = Core::make('helper/form/font');
-        $args = array();
+        $args = [];
         if (is_object($style)) {
             $args['fontFamily'] = $style->getFontFamily();
             $color = $style->getColor();
@@ -44,7 +44,7 @@ class TypeStyle extends Style
                 $args['lineHeightUnit'] = $lineHeight->getUnit();
             }
         }
-        echo $fh->output($this->getVariable(), $args, array());
+        echo $fh->output($this->getVariable(), $args, []);
     }
 
     public function getValueFromRequest(\Symfony\Component\HttpFoundation\ParameterBag $request)
@@ -120,9 +120,9 @@ class TypeStyle extends Style
         return $tv;
     }
 
-    public static function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = [])
     {
-        $values = array();
+        $values = [];
 
         foreach ($rules as $rule) {
             $ruleName = isset($rule->name) ? $rule->name : '';

--- a/concrete/src/StyleCustomizer/Style/TypeStyle.php
+++ b/concrete/src/StyleCustomizer/Style/TypeStyle.php
@@ -120,7 +120,7 @@ class TypeStyle extends Style
         return $tv;
     }
 
-    public function getValuesFromVariables($rules = array())
+    public static function getValuesFromVariables($rules = array())
     {
         $values = array();
 


### PR DESCRIPTION
It's called statically and it does not contain any references to `$this`.

BTW, if the base abstract class defines an abstract static methods,
PHP raises a "strict standards" warnings, so let's remove it from the base abstract class (`Style`)

PS: newer PHP versions (>= 7.0) don't throw the "strict standards" warning, and it could be interesting to know why. That's why I submitted https://bugs.php.net/bug.php?id=72993