### PR TITLE
Don't force .?! at the end of phpdoc descriptions

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -20,6 +20,8 @@ return Symfony\CS\Config\Config::create()
         '-blankline_after_open_tag',
         // Use the short array syntax
         'short_array_syntax',
+        // Descriptions don't have to end with [.!?]
+        '-phpdoc_short_description',
     ))
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()


### PR DESCRIPTION
The dot at the end of this line is automatically added with the php cs fixer:

![schermafbeelding 2016-09-02 om 08 31 05](https://cloud.githubusercontent.com/assets/1431100/18194684/b3443984-70e7-11e6-8595-cdb1aa2e568d.png)

Can we get rid of this setting? 