### PR TITLE
Fix 404 page rendering

### DIFF
--- a/concrete/controllers/single_page/page_not_found.php
+++ b/concrete/controllers/single_page/page_not_found.php
@@ -7,6 +7,11 @@ use Concrete\Core\Page\Controller\PageController;
 class PageNotFound extends PageController
 {
 
+    public function validateRequest()
+    {
+        return true;
+    }
+
     public function view()
     {
         $view = $this->getViewObject();

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -11,6 +11,7 @@ use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Collection\Response\ResponseFactoryInterface as CollectionResponseFactoryInterface;
 use Concrete\Core\Page\Collection\Version\Version;
+use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Page\Event;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Checker;
@@ -93,6 +94,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
 
         $item = '/page_not_found';
         $c = Page::getByPath($item);
+
         if (is_object($c) && !$c->isError()) {
             return $this->collection($c, $code, $headers);
         }
@@ -159,9 +161,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function controller(Controller $controller, $code = Response::HTTP_OK, $headers = array())
     {
-        if ($controller->isReplaced()) {
-            return $this->controller($controller->getReplacement());
-        }
+        $request = $this->request;
 
         $view = $controller->getViewObject();
 
@@ -178,8 +178,37 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         }
 
         $controller->on_start();
-        $controller->runAction('view');
+
+        if ($controller instanceof PageController) {
+            $controller->setupRequestActionAndParameters($request);
+
+            $response = $controller->validateRequest();
+            // If validaterequest returned a response
+            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
+                return $response;
+            } else {
+                // If validateRequest did not return true
+                if ($response == false) {
+                    return $this->notFound('', Response::HTTP_NOT_FOUND, $headers);
+                }
+            }
+
+            $requestTask = $controller->getRequestAction();
+            $requestParameters = $controller->getRequestActionParameters();
+            $response = $controller->runAction($requestTask, $requestParameters);
+            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
+                return $response;
+            }
+
+        } else {
+            $controller->runAction('view');
+        }
+
         $view->setController($controller);
+
+        if ($controller->isReplaced()) {
+            return $this->controller($controller->getReplacement());
+        }
 
         return $this->view($view, $code, $headers);
     }
@@ -199,6 +228,10 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             if ($response = $this->collectionNotFound($collection, $request, $headers)) {
                 return $response;
             }
+        }
+
+        if ($collection->getCollectionPath() == '/page_not_found') {
+            return $this->controller($collection->getController());
         }
 
         if (!$collection->cPathFetchIsCanonical) {
@@ -314,30 +347,11 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $this->app['director']->dispatch('on_page_view', $pe);
 
         $controller = $collection->getPageController();
-        $controller->on_start();
-        $controller->setupRequestActionAndParameters($request);
-        $response = $controller->validateRequest();
-        if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
-            return $response;
-        } else {
-            if ($response == false) {
-                return $this->notFound('', Response::HTTP_NOT_FOUND, $headers);
-            }
-        }
-        $requestTask = $controller->getRequestAction();
-        $requestParameters = $controller->getRequestActionParameters();
-        $response = $controller->runAction($requestTask, $requestParameters);
-        if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
-            return $response;
-        }
-
-        $collection->setController($controller);
-        $view = $controller->getViewObject();
 
         // we update the current page with the one bound to this controller.
-        $request->setCurrentPage($collection);
+        $collection->setController($controller);
 
-        return $this->view($view, $code, $headers);
+        return $this->controller($controller);
     }
 
     private function collectionNotFound(Collection $collection, Request $request, array $headers)

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -3,12 +3,13 @@ namespace Concrete\Core\Page\Controller;
 
 use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Controller\Controller;
 use Concrete\Core\Foundation\Environment;
+use Concrete\Core\Html\Service\Html;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Routing\Redirect;
-use Page;
-use Request;
-use Controller;
-use Core;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Page\View\PageView;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,12 +26,12 @@ class PageController extends Controller
         return $this->supportsPageCache;
     }
 
-    public function __construct(\Concrete\Core\Page\Page $c)
+    public function __construct(Page $c)
     {
         parent::__construct();
         $this->c = $c;
         $this->view = new PageView($this->c);
-        $this->set('html', Core::make('\Concrete\Core\Html\Service\Html'));
+        $this->set('html', Application::getFacadeApplication()->make(HTML::class));
     }
 
     /**
@@ -45,11 +46,11 @@ class PageController extends Controller
      */
     public function replace($var)
     {
-        if (!($var instanceof \Concrete\Core\Page\Page)) {
-            $var = \Page::getByPath($var);
+        if (!($var instanceof Page)) {
+            $var = Page::getByPath($var);
         }
 
-        $request = \Request::getInstance();
+        $request = Request::getInstance();
         $request->setCurrentPage($var);
         $controller = $var->getPageController();
         $this->replacement = $controller;
@@ -68,7 +69,7 @@ class PageController extends Controller
     public function getSets()
     {
         $sets = parent::getSets();
-        $session = Core::make('session');
+        $session = Application::getFacadeApplication()->make('session');
         if ($session->getFlashBag()->has('page_message')) {
             $value = $session->getFlashBag()->get('page_message');
             foreach ($value as $message) {
@@ -112,7 +113,7 @@ class PageController extends Controller
 
     public function flash($key, $value)
     {
-        $session = Core::make('session');
+        $session = Application::getFacadeApplication()->make('session');
         $session->getFlashBag()->add('page_message', array($key, $value));
     }
 


### PR DESCRIPTION
The important things in here are:

1. Replacement handling is lower
2. 404 page always validates the request
3. ResponseFactory->controller now handles PageControllers properly

Fixes issue with 404's being redirected to `/page_not_found`