### PR TITLE
Less restrictive User instance in AuthenticationTypeControllerInterface

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -7,7 +7,7 @@ use Config;
 use Exception;
 use Database;
 use Core;
-use User;
+use Concrete\Core\User\User;
 use UserInfo;
 use View;
 use Session;
@@ -319,8 +319,8 @@ class Controller extends AuthenticationTypeController
             throw new \Exception($ip_service->getErrorMessage());
         }
 
-        $user = new User($uName, $uPassword);
-        if (!is_object($user) || !($user instanceof User) || $user->isError()) {
+        $user = new \User($uName, $uPassword);
+        if ($user->isError()) {
             switch ($user->getError()) {
                 case USER_SESSION_EXPIRED:
                     throw new \Exception(t('Your session has expired. Please sign in again.'));

--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -14,7 +14,7 @@ use Session;
 
 class Controller extends AuthenticationTypeController
 {
-    public $apiMethods = array('forgot_password', 'v', 'change_password', 'password_changed', 'email_validated', 'invalid_token', 'required_password_upgrade');
+    public $apiMethods = ['forgot_password', 'v', 'change_password', 'password_changed', 'email_validated', 'invalid_token', 'required_password_upgrade'];
 
     public function getHandle()
     {
@@ -28,7 +28,7 @@ class Controller extends AuthenticationTypeController
             list($uID, $authType, $hash) = explode(':', $cookie);
             if ($authType == 'concrete') {
                 $db = Database::connection();
-                $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', array($uID, $hash));
+                $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', [$uID, $hash]);
             }
         }
     }
@@ -44,14 +44,14 @@ class Controller extends AuthenticationTypeController
         $db = Database::connection();
         $q = $db->fetchColumn(
             'SELECT validThrough FROM authTypeConcreteCookieMap WHERE uID=? AND token=?',
-            array($uID, $hash)
+            [$uID, $hash]
         );
         $bool = time() < $q;
         if (!$bool) {
-            $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', array($uID, $hash));
+            $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', [$uID, $hash]);
         } else {
             $newTime = strtotime('+2 weeks');
-            $db->executeQuery('UPDATE authTypeConcreteCookieMap SET validThrough=?', array($newTime));
+            $db->executeQuery('UPDATE authTypeConcreteCookieMap SET validThrough=?', [$newTime]);
         }
 
         return $bool;
@@ -75,7 +75,7 @@ class Controller extends AuthenticationTypeController
         try {
             $db->executeQuery(
                 'INSERT INTO authTypeConcreteCookieMap (token, uID, validThrough) VALUES (?,?,?)',
-                array($token, $u->getUserID(), $validThrough)
+                [$token, $u->getUserID(), $validThrough]
             );
         } catch (\Exception $e) {
             // HOLY CRAP.. SERIOUSLY?
@@ -242,7 +242,7 @@ class Controller extends AuthenticationTypeController
         $e = Core::make('helper/validation/error');
         $ui = UserInfo::getByValidationHash($uHash);
         if (is_object($ui)) {
-            $hashCreated = $db->fetchColumn('SELECT uDateGenerated FROM UserValidationHashes WHERE uHash=?', array($uHash));
+            $hashCreated = $db->fetchColumn('SELECT uDateGenerated FROM UserValidationHashes WHERE uHash=?', [$uHash]);
             if ($hashCreated < (time() - (USER_CHANGE_PASSWORD_URL_LIFETIME))) {
                 $h->deleteKey('UserValidationHashes', 'uHash', $uHash);
                 throw new \Exception(
@@ -366,7 +366,7 @@ class Controller extends AuthenticationTypeController
         $app = Application::getFacadeApplication();
         $db = $app['database']->connection();
 
-        return $db->GetOne('select uIsPasswordReset from Users where uName = ?', array($this->post('uName')));
+        return $db->GetOne('select uIsPasswordReset from Users where uName = ?', [$this->post('uName')]);
     }
 
     public function v($hash = '')

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -7,7 +7,7 @@ use Concrete\Core\Authentication\LoginException;
 use Concrete\Core\Authentication\Type\Google\Factory\GoogleServiceFactory;
 use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
 use OAuth\OAuth2\Service\Google;
-use User;
+use Concrete\Core\User\User;
 
 class Controller extends GenericOauth2TypeController
 {

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -52,12 +52,12 @@ class Controller extends GenericOauth2TypeController
         \Config::save('auth.google.registration.enabled', (bool) $args['registration_enabled']);
         \Config::save('auth.google.registration.group', intval($args['registration_group'], 10));
 
-        $whitelist = array();
+        $whitelist = [];
         foreach (explode(PHP_EOL, $args['whitelist']) as $entry) {
             $whitelist[] = trim($entry);
         }
 
-        $blacklist = array();
+        $blacklist = [];
         foreach (explode(PHP_EOL, $args['blacklist']) as $entry) {
             $blacklist[] = json_decode(trim($entry), true);
         }
@@ -76,10 +76,10 @@ class Controller extends GenericOauth2TypeController
         $list->includeAllGroups();
         $this->set('groups', $list->getResults());
 
-        $this->set('whitelist', \Config::get('auth.google.email_filters.whitelist', array()));
+        $this->set('whitelist', \Config::get('auth.google.email_filters.whitelist', []));
         $blacklist = array_map(function ($entry) {
             return json_encode($entry);
-        }, \Config::get('auth.google.email_filters.blacklist', array()));
+        }, \Config::get('auth.google.email_filters.blacklist', []));
 
         $this->set('blacklist', $blacklist);
     }
@@ -102,16 +102,16 @@ class Controller extends GenericOauth2TypeController
 
     public function isValid()
     {
-        $filters = (array) \Config::get('auth.google.email_filters', array());
+        $filters = (array) \Config::get('auth.google.email_filters', []);
         $domain = $this->getExtractor()->getExtra('domain');
 
-        foreach (array_get($filters, 'whitelist', array()) as $regex) {
+        foreach (array_get($filters, 'whitelist', []) as $regex) {
             if (preg_match($regex, $domain)) {
                 return true;
             }
         }
 
-        foreach (array_get($filters, 'blacklist', array()) as $arr) {
+        foreach (array_get($filters, 'blacklist', []) as $arr) {
             list($regex, $error) = array_pad((array) $arr, 2, null);
             if (preg_match($regex, $domain)) {
                 if (trim($error)) {

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Authentication;
 
-use User;
+use Concrete\Core\User\User;
 use Page;
 use Controller;
 

--- a/concrete/src/Authentication/AuthenticationTypeControllerInterface.php
+++ b/concrete/src/Authentication/AuthenticationTypeControllerInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Authentication;
 
-use User;
+use Concrete\Core\User\User;
 
 interface AuthenticationTypeControllerInterface
 {

--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -11,7 +11,7 @@ use Concrete\Core\User\User;
 
 abstract class GenericOauthTypeController extends AuthenticationTypeController
 {
-    public $apiMethods = array('handle_error', 'handle_success');
+    public $apiMethods = ['handle_error', 'handle_success'];
 
     /**
      * @var \OAuth\Common\Service\AbstractService
@@ -36,12 +36,12 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         if (!$manager->tablesExist('OauthUserMap')) {
             $schema = new \Doctrine\DBAL\Schema\Schema();
             $table = $schema->createTable('OauthUserMap');
-            $table->addColumn('user_id', 'integer', array('unsigned' => true));
-            $table->addColumn('binding', 'string', array('length' => 255));
-            $table->addColumn('namespace', 'string', array('length' => 255));
+            $table->addColumn('user_id', 'integer', ['unsigned' => true]);
+            $table->addColumn('binding', 'string', ['length' => 255]);
+            $table->addColumn('namespace', 'string', ['length' => 255]);
 
-            $table->setPrimaryKey(array('user_id', 'namespace'));
-            $table->addUniqueIndex(array('binding', 'namespace'), 'oauth_binding');
+            $table->setPrimaryKey(['user_id', 'namespace']);
+            $table->addUniqueIndex(['binding', 'namespace'], 'oauth_binding');
 
             $manager->createTable($table);
         }
@@ -52,7 +52,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
      */
     public function getAdditionalRequestParameters()
     {
-        return array();
+        return [];
     }
 
     public function handle_error($error = false)
@@ -200,7 +200,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     public function getExtractor($new = false)
     {
         if ($new || !$this->extractor) {
-            $this->extractor = \Core::make('oauth_extractor', array($this->getService()));
+            $this->extractor = \Core::make('oauth_extractor', [$this->getService()]);
         }
 
         return $this->extractor;
@@ -227,10 +227,10 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     {
         $result = \Database::connection()->executeQuery(
             'SELECT user_id FROM OauthUserMap WHERE namespace=? AND binding=?',
-            array(
+            [
                 $this->getHandle(),
                 $binding,
-            ));
+            ]);
 
         return $result->fetchColumn();
     }
@@ -269,11 +269,11 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         $first_name = "";
         $last_name = "";
 
-        $name_support = array(
+        $name_support = [
             'full' => $this->supportsFullName(),
             'first' => $this->supportsFirstName(),
             'last' => $this->supportsLastName(),
-        );
+        ];
 
         if ($name_support['first'] && $name_support['last']) {
             $first_name = $this->getFirstName();
@@ -311,7 +311,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
 
         $username = $unique_username;
 
-        $data = array();
+        $data = [];
         $data['uName'] = $username;
         $data['uPassword'] = \Illuminate\Support\Str::random(256);
         $data['uEmail'] = $email;
@@ -452,11 +452,11 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
 
         return \Database::connection()->insert(
             'OauthUserMap',
-            array(
+            [
                 'user_id' => $user_id,
                 'binding' => $binding,
                 'namespace' => $this->getHandle(),
-            ));
+            ]);
     }
 
     public function getUniqueId()

--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -7,6 +7,7 @@ use OAuth\Common\Exception\Exception;
 use OAuth\Common\Service\AbstractService;
 use OAuth\Common\Token\TokenInterface;
 use OAuth\UserData\Extractor\Extractor;
+use Concrete\Core\User\User;
 
 abstract class GenericOauthTypeController extends AuthenticationTypeController
 {
@@ -114,11 +115,11 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     /**
      * Create a cookie hash to identify the user indefinitely.
      *
-     * @param \User $u
+     * @param User $u
      *
      * @return string Unique hash to be used to verify the users identity
      */
-    public function buildHash(\User $u)
+    public function buildHash(User $u)
     {
         return '';
     }
@@ -126,12 +127,12 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     /**
      * Hash authentication disabled for oauth.
      *
-     * @param \User  $u    object requesting verification.
+     * @param User  $u    object requesting verification.
      * @param string $hash
      *
      * @return bool returns true if the hash is valid, false if not
      */
-    public function verifyHash(\User $u, $hash)
+    public function verifyHash(User $u, $hash)
     {
         return false;
     }
@@ -413,12 +414,12 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     }
 
     /**
-     * @param \User $user
+     * @param User $user
      * @param       $binding
      *
      * @return int|null
      */
-    public function bindUser(\User $user, $binding)
+    public function bindUser(User $user, $binding)
     {
         return $this->bindUserID(intval($user->getUserID(), 10), $binding);
     }

--- a/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
@@ -11,7 +11,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
     public function handle_authentication_attempt()
     {
         $token = $this->getService()->requestRequestToken();
-        $url = $this->getService()->getAuthorizationUri(array('oauth_token' => $token->getRequestToken()));
+        $url = $this->getService()->getAuthorizationUri(['oauth_token' => $token->getRequestToken()]);
         id(new RedirectResponse((string) $url))->send();
         exit;
     }
@@ -51,7 +51,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
     public function handle_attach_attempt()
     {
         $token = $this->getService()->requestRequestToken();
-        $url = $this->getService()->getAuthorizationUri(array('oauth_token' => $token->getRequestToken()));
+        $url = $this->getService()->getAuthorizationUri(['oauth_token' => $token->getRequestToken()]);
         id(new RedirectResponse((string) $url))->send();
         exit;
     }

--- a/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Authentication\Type\OAuth\OAuth1a;
 use Concrete\Core\Authentication\Type\OAuth\GenericOauthTypeController;
 use Concrete\Core\Routing\RedirectResponse;
 use OAuth\Common\Exception\Exception;
-use User;
+use Concrete\Core\User\User;
 
 abstract class GenericOauth1aTypeController extends GenericOauthTypeController
 {
@@ -18,8 +18,8 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
 
     public function handle_authentication_callback()
     {
-        $user = new User();
-        if ($user && !$user->isError() && $user->isLoggedIn()) {
+        $user = new \User();
+        if (!$user->isError() && $user->isLoggedIn()) {
             $this->handle_attach_callback();
         }
         $token = \Request::getInstance()->get('oauth_token');
@@ -58,7 +58,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
 
     public function handle_attach_callback()
     {
-        $user = new User();
+        $user = new \User();
         if (!$user->isLoggedIn()) {
             id(new RedirectResponse(\URL::to('')))->send();
             exit;
@@ -88,7 +88,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
      * Method used to clean up.
      * This method must be defined, if it isn't needed, leave it blank.
      *
-     * @param \User $u
+     * @param User $u
      */
     public function deauthenticate(User $u)
     {
@@ -98,7 +98,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
     /**
      * Test user authentication status.
      *
-     * @param \User $u
+     * @param User $u
      *
      * @return bool Returns true if user is authenticated, false if not
      */

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -7,7 +7,7 @@ use Concrete\Core\Routing\RedirectResponse;
 use OAuth\Common\Exception\Exception;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\OAuth2\Service\AbstractService;
-use User;
+use Concrete\Core\User\User;
 
 abstract class GenericOauth2TypeController extends GenericOauthTypeController
 {
@@ -24,8 +24,8 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
 
     public function handle_authentication_callback()
     {
-        $user = new User();
-        if ($user && !$user->isError() && $user->isLoggedIn()) {
+        $user = new \User();
+        if (!$user->isError() && $user->isLoggedIn()) {
             $this->handle_attach_callback();
         }
 
@@ -71,7 +71,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
 
     public function handle_attach_callback()
     {
-        $user = new User();
+        $user = new \User();
         if (!$user->isLoggedIn()) {
             id(new RedirectResponse(\URL::to('')))->send();
             exit;
@@ -111,7 +111,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
      * Method used to clean up.
      * This method must be defined, if it isn't needed, leave it blank.
      *
-     * @param \User $u
+     * @param User $u
      */
     public function deauthenticate(User $u)
     {
@@ -121,7 +121,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
     /**
      * Test user authentication status.
      *
-     * @param \User $u
+     * @param User $u
      *
      * @return bool Returns true if user is authenticated, false if not
      */

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -52,7 +52,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             } catch (Exception $e) {
                 $this->showError($e->getMessage());
             } catch (\Exception $e) {
-                \Log::addError($e->getMessage(), array($e));
+                \Log::addError($e->getMessage(), [$e]);
                 $this->showError(t('An unexpected error occurred.'));
             }
         } else {


### PR DESCRIPTION
I randomly get errors like this one:
```
Argument 1 passed to
Concrete\Authentication\Concrete\Controller::deauthenticate()
must be an instance of User, instance of Concrete\Core\User\User given
```

Let's accept `\Concrete\Core\User\User` instances (`\User` is a subclass of it).