### PR TITLE
Fix GroupList count

### DIFF
--- a/concrete/controllers/search/groups.php
+++ b/concrete/controllers/search/groups.php
@@ -15,6 +15,7 @@ class Groups extends Controller
 
     public function __construct()
     {
+        parent::__construct();
         $this->groupList = new GroupList();
     }
 
@@ -25,14 +26,15 @@ class Groups extends Controller
             return false;
         }
 
-        if ($_REQUEST['filter'] == 'assign') {
+        if ($this->request->request('filter') == 'assign') {
             $this->groupList->filterByAssignable();
         } else {
             $this->groupList->includeAllGroups();
         }
 
-        if (isset($_REQUEST['keywords'])) {
-            $this->groupList->filterByKeywords($_REQUEST['keywords']);
+        $keywords = $this->request->request('keywords');
+        if (isset($keywords)) {
+            $this->groupList->filterByKeywords($keywords);
         }
 
         $this->groupList->sortBy('gID', 'asc');

--- a/concrete/controllers/search/groups.php
+++ b/concrete/controllers/search/groups.php
@@ -11,7 +11,7 @@ use URL;
 
 class Groups extends Controller
 {
-    protected $fields = array();
+    protected $fields = [];
 
     public function __construct()
     {

--- a/concrete/controllers/single_page/dashboard/users/groups.php
+++ b/concrete/controllers/single_page/dashboard/users/groups.php
@@ -19,7 +19,7 @@ class Groups extends DashboardPageController
         $this->set('tree', $tree);
         $this->requireAsset('core/groups');
 
-        $cnt = new SearchGroupsController();
+        $cnt = $this->app->make(SearchGroupsController::class);
         $cnt->search();
         $this->set('searchController', $cnt);
 

--- a/concrete/src/User/Group/GroupList.php
+++ b/concrete/src/User/Group/GroupList.php
@@ -108,7 +108,7 @@ class GroupList extends DatabaseItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(g.gID)')->setMaxResults(1);
+            $query->resetQueryPart('orderBy')->select('count(g.gID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 

--- a/concrete/src/User/Group/GroupList.php
+++ b/concrete/src/User/Group/GroupList.php
@@ -12,7 +12,7 @@ class GroupList extends DatabaseItemList
 {
     protected $includeAllGroups = false;
 
-    protected $autoSortColumns = array('gName', 'gID');
+    protected $autoSortColumns = ['gName', 'gID'];
 
     public function includeAllGroups()
     {
@@ -26,13 +26,13 @@ class GroupList extends DatabaseItemList
      */
     public function filterByKeywords($keywords)
     {
-        $expressions = array(
+        $expressions = [
             $this->query->expr()->like('g.gName', ':keywords'),
             $this->query->expr()->like('g.gDescription', ':keywords'),
-        );
+        ];
 
         $expr = $this->query->expr();
-        $this->query->andWhere(call_user_func_array(array($expr, 'orX'), $expressions));
+        $this->query->andWhere(call_user_func_array([$expr, 'orX'], $expressions));
         $this->query->setParameter('keywords', '%' . $keywords . '%');
     }
 
@@ -49,9 +49,9 @@ class GroupList extends DatabaseItemList
     {
         if (Config::get('concrete.permissions.model') != 'simple') {
             // there's gotta be a more reasonable way than this but right now i'm not sure what that is.
-            $excludeGroupIDs = array(GUEST_GROUP_ID, REGISTERED_GROUP_ID);
+            $excludeGroupIDs = [GUEST_GROUP_ID, REGISTERED_GROUP_ID];
             $db = Loader::db();
-            $r = $db->Execute('select gID from Groups where gID > ?', array(REGISTERED_GROUP_ID));
+            $r = $db->Execute('select gID from Groups where gID > ?', [REGISTERED_GROUP_ID]);
             while ($row = $r->FetchRow()) {
                 $g = Group::getByID($row['gID']);
                 $gp = new Permissions($g);
@@ -60,7 +60,7 @@ class GroupList extends DatabaseItemList
                 }
             }
             $this->query->andWhere(
-                $this->query->expr()->notIn('g.gId', array_map(array($db, 'quote'), $excludeGroupIDs))
+                $this->query->expr()->notIn('g.gId', array_map([$db, 'quote'], $excludeGroupIDs))
             );
         }
     }


### PR DESCRIPTION
If MySQL runs with the `ONLY_FULL_GROUP_BY` flag turned on (default on MySQL 5.7), visiting `dashboard/users/groups` causes this exception:

```
An exception occurred while executing
'SELECT count(g.gID) FROM Groups g ORDER BY gID asc LIMIT 1
SQLSTATE[42000]: Syntax error or access violation:
1140 Mixing of GROUP columns (MIN(),MAX(),COUNT(),...)
with no GROUP columns is illegal if there is no GROUP BY clause
```

Let's fix this.


