### PR TITLE
Avoid using constructor to redirect from dashboard/users

### DIFF
--- a/concrete/controllers/single_page/dashboard/users.php
+++ b/concrete/controllers/single_page/dashboard/users.php
@@ -2,11 +2,12 @@
 namespace Concrete\Controller\SinglePage\Dashboard;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Routing\RedirectResponse;
 
 class Users extends DashboardPageController
 {
-    public function __construct()
+    public function validateRequest()
     {
-        $this->redirect('/dashboard/users/search');
+        return new RedirectResponse($this->app->make('url/manager')->resolve(['/dashboard/users/search']));
     }
 }


### PR DESCRIPTION
Base constructor needs a `Page` parameter: let's use `validateRequest` instead