### PR TITLE
SwitchLanguage block: show language names in their native language

### DIFF
--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -11,8 +11,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController
 {
-    protected $btInterfaceWidth = "500";
-    protected $btInterfaceHeight = "150";
+    protected $btInterfaceWidth = 500;
+    protected $btInterfaceHeight = 150;
     protected $btTable = 'btSwitchLanguage';
 
     public $helpers = array('form');
@@ -89,7 +89,7 @@ class Controller extends BlockController
         if (is_object($al)) {
             $this->set('activeLanguage', $al->getCollectionID());
         }
-        $dl = \Core::make('multilingual/detector');
+        $dl = $this->app->make('multilingual/detector');
         $this->set('defaultLocale', $dl->getPreferredSection());
         $this->set('locale', $locale);
         $this->set('cID', $c->getCollectionID());

--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -82,7 +82,7 @@ class Controller extends BlockController
             $locale = $al->getLanguage();
         }
         foreach ($ml as $m) {
-            $languages[$m->getCollectionID()] = $m->getLanguageText($locale);
+            $languages[$m->getCollectionID()] = $m->getLanguageText($m->getLocale());
         }
         $this->set('languages', $languages);
         $this->set('languageSections', $ml);


### PR DESCRIPTION
For instance, if the current language is Chinese (that sadly I really can't read), I'd really wouldn't understand anything...