### PR TITLE
Add missing parent constructors to controllers

### DIFF
--- a/concrete/controllers/element/dashboard/express/control.php
+++ b/concrete/controllers/element/dashboard/express/control.php
@@ -9,6 +9,7 @@ class Control extends ElementController
 
     public function __construct(\Concrete\Core\Entity\Express\Control\Control $control)
     {
+        parent::__construct();
         $this->control = $control;
     }
 

--- a/concrete/controllers/element/dashboard/express/menu.php
+++ b/concrete/controllers/element/dashboard/express/menu.php
@@ -11,6 +11,7 @@ class Menu extends ElementController
 
     public function __construct(Entity $entity)
     {
+        parent::__construct();
         $this->currentEntity = $entity;
     }
 


### PR DESCRIPTION
I checked all the classes derived from `Concrete\Core\Controller\AbstractController`, and I found two classes that didn't initialize themselves correctly.