### PR TITLE
Update the request with the current page if we get a 404 page

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -100,7 +100,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         }
 
         $cnt = $this->app->make(PageForbidden::class);
-        $this->controller($cnt, $code, $headers);
+        return $this->controller($cnt, $code, $headers);
     }
 
     /**
@@ -229,6 +229,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         }
 
         if ($collection->getCollectionPath() == '/page_not_found') {
+            $request->setCurrentPage($collection);
             return $this->controller($collection->getController());
         }
 


### PR DESCRIPTION
This resolves #4376 

The issue was caused by the fact that we handle the 404 page in a way that prevents an redirect loop. Because [`->collection()` send the page controller over to `->controller()` if it's a page_not_found collection](https://github.com/concrete5/concrete5/blob/50165a9ef5f3b178aec4af9978ad203451007450/concrete/src/Http/ResponseFactory.php#L231-L234) the request was never properly updated with the current page. To resolve this, we just run `$request->setCurrentPage($collection)` before we pass the controller to `->controller()`.

This change also includes a fix for a special case where someone doesn't have access to view the page not found page.