### PR TITLE
Composer save: fallback to use saved parent page ID

### DIFF
--- a/concrete/controllers/panel/detail/page/composer.php
+++ b/concrete/controllers/panel/detail/page/composer.php
@@ -82,7 +82,6 @@ class Composer extends BackendInterfacePageController
             $ptr->setError($e);
 
             if (!$e->has()) {
-
                 $publishDateTime = false;
                 if ($this->request->request->get('action') == 'schedule') {
                     $dateTime = new DateTime();
@@ -136,23 +135,23 @@ class Composer extends BackendInterfacePageController
         }
         $validator = $pagetype->getPageTypeValidatorObject();
         $e = $validator->validateCreateDraftRequest($pt);
-        $outputControls = array();
+        $outputControls = [];
         if (!$e->has()) {
             $c = $c->getVersionToModify();
             $this->page = $c;
 
-			if ($c->isPageDraft()) {
-				/// set the target
-				$configuredTarget = $pagetype->getPageTypePublishTargetObject();
-				$targetPageID = (int) $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
-				if (!$targetPageID === 0) {
-					$targetPageID = (int) $this->request->post('cParentID');
-					if ($targetPageID === 0) {
-					    $targetPageID = $c->getPageDraftTargetParentPageID();
-					}
-				}
+            if ($c->isPageDraft()) {
+                /// set the target
+                $configuredTarget = $pagetype->getPageTypePublishTargetObject();
+                $targetPageID = (int) $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
+                if (!$targetPageID === 0) {
+                    $targetPageID = (int) $this->request->post('cParentID');
+                    if ($targetPageID === 0) {
+                        $targetPageID = $c->getPageDraftTargetParentPageID();
+                    }
+                }
 
-				$c->setPageDraftTargetParentPageID($targetPageID);
+                $c->setPageDraftTargetParentPageID($targetPageID);
             }
 
             $saver = $pagetype->getPageTypeSaverObject();
@@ -160,6 +159,6 @@ class Composer extends BackendInterfacePageController
         }
         $ptr->setError($e);
 
-        return array($ptr, $pagetype, $outputControls);
+        return [$ptr, $pagetype, $outputControls];
     }
 }

--- a/concrete/controllers/panel/detail/page/composer.php
+++ b/concrete/controllers/panel/detail/page/composer.php
@@ -122,14 +122,16 @@ class Composer extends BackendInterfacePageController
     protected function save()
     {
         $c = $this->page;
-        $ptr = new PageEditResponse($e);
+        $ptr = new PageEditResponse();
         $ptr->setPage($c);
 
         $pagetype = $c->getPageTypeObject();
-        if ($_POST['ptComposerPageTemplateID']) {
-            $pt = PageTemplate::getByID($_POST['ptComposerPageTemplateID']);
+        $pt = null;
+        $ptComposerPageTemplateID = (int) $this->request->post('ptComposerPageTemplateID');
+        if ($ptComposerPageTemplateID !== 0) {
+            $pt = PageTemplate::getByID($ptComposerPageTemplateID);
         }
-        if (!is_object($pt)) {
+        if ($pt === null) {
             $pt = $pagetype->getPageTypeDefaultPageTemplateObject();
         }
         $validator = $pagetype->getPageTypeValidatorObject();
@@ -142,9 +144,12 @@ class Composer extends BackendInterfacePageController
 			if ($c->isPageDraft()) {
 				/// set the target
 				$configuredTarget = $pagetype->getPageTypePublishTargetObject();
-				$targetPageID = $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
-				if (!$targetPageID) {
-					$targetPageID = $_POST['cParentID'];
+				$targetPageID = (int) $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
+				if (!$targetPageID === 0) {
+					$targetPageID = (int) $this->request->post('cParentID');
+					if ($targetPageID === 0) {
+					    $targetPageID = $c->getPageDraftTargetParentPageID();
+					}
 				}
 
 				$c->setPageDraftTargetParentPageID($targetPageID);

--- a/concrete/controllers/panel/detail/page/composer.php
+++ b/concrete/controllers/panel/detail/page/composer.php
@@ -144,7 +144,7 @@ class Composer extends BackendInterfacePageController
                 /// set the target
                 $configuredTarget = $pagetype->getPageTypePublishTargetObject();
                 $targetPageID = (int) $configuredTarget->getPageTypePublishTargetConfiguredTargetParentPageID();
-                if (!$targetPageID === 0) {
+                if ($targetPageID === 0) {
                     $targetPageID = (int) $this->request->post('cParentID');
                     if ($targetPageID === 0) {
                         $targetPageID = $c->getPageDraftTargetParentPageID();


### PR DESCRIPTION
Let's assume that:
1. we are creating a page via Composer
2. the page type has `Publish Method` set to `Choose from all pages when publishing`
3. we set the page handle in the `Page Settings` -> `SEO` panel
4. we set the parent page in the `Page Settings` -> `Location` panel

Currently, when we try to publish the page, the parent page ID is only retrieved from the page type or from a `cParentID` post field, but not from the currently saved data. This causes the inability to publish the page since the parent ID set in the `Location` panel is not retrieved: let's retrieve it.