### PR TITLE
Remove old page_not_found fix and fix the original problem more directly

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -228,20 +228,17 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             }
         }
 
-        if ($collection->getCollectionPath() == '/page_not_found') {
-            $request->setCurrentPage($collection);
-            return $this->controller($collection->getController());
-        }
+        if ($collection->getCollectionPath() != '/page_not_found') {
+            if (!isset($collection->cPathFetchIsCanonical) || !$collection->cPathFetchIsCanonical) {
+                // Handle redirect URL (additional page paths)
+                /** @var Url $url */
+                $url = $this->app->make('url/manager')->resolve([$collection]);
+                $query = $url->getQuery();
+                $query->modify($request->getQueryString());
 
-        if (!isset($collection->cPathFetchIsCanonical) || !$collection->cPathFetchIsCanonical) {
-            // Handle redirect URL (additional page paths)
-            /** @var Url $url */
-            $url = $this->app->make('url/manager')->resolve([$collection]);
-            $query = $url->getQuery();
-            $query->modify($request->getQueryString());
-
-            $url = $url->setQuery($query);
-            return $this->redirect($url, Response::HTTP_MOVED_PERMANENTLY, $headers);
+                $url = $url->setQuery($query);
+                return $this->redirect($url, Response::HTTP_MOVED_PERMANENTLY, $headers);
+            }
         }
 
         // maintenance mode


### PR DESCRIPTION
Originally we just deferred to rendering the controller straight if we were given page_not_found in `ResponseFactory::collection()`, this was put there to prevent us being redirected back to "/page_not_found" any time we navigated to a path that didn't exist. That way worked, but it prevented the /bootstrap/process.php from being pulled in so we were unable to edit the page_not_found page through edit mode.

This change simply wraps the canonical url redirect conditional to only redirect if the page is not the page_not_found page.