### PR TITLE
[5.7] Add configuration option to fallback to previous locale

### DIFF
--- a/web/concrete/blocks/switch_language/controller.php
+++ b/web/concrete/blocks/switch_language/controller.php
@@ -80,18 +80,20 @@ class Controller extends BlockController
         $c = \Page::getCurrentPage();
         $al = Section::getBySectionOfSite($c);
         $languages = array();
-        $locale = \Localization::activeLocale();
-        if (is_object($al)) {
+        $locale = null;
+        if ($al) {
             $locale = $al->getLanguage();
+        }
+        if (!$locale) {
+            $locale = \Localization::activeLocale();
+            $al = Section::getByLocale($locale);
         }
         foreach ($ml as $m) {
             $languages[$m->getCollectionID()] = $m->getLanguageText($locale);
         }
         $this->set('languages', $languages);
         $this->set('languageSections', $ml);
-        if (is_object($al)) {
-            $this->set('activeLanguage', $al->getCollectionID());
-        }
+        $this->set('activeLanguage', $al? $al->getCollectionID() : null);
         $dl = \Core::make('multilingual/detector');
         $this->set('defaultLocale', $dl->getPreferredSection());
         $this->set('locale', $locale);


### PR DESCRIPTION
Let's assume this example:
1. a visitor visit a page in Italian
2. then the visitor visit a page not under any locale root

Currently, concrete5 falls back the default site locale.
Let's add a new configuration option (`concrete.multilingual.use_previous_locale`) that, if set to true, set the current locale to the last used one.


