### PR TITLE
Fix declaration error on install

### DIFF
--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -11,6 +11,7 @@ use Database;
 use Core;
 use Concrete\Core\Page\Page;
 use PageType;
+use Concrete\Core\Entity\Site\Site
 
 /**
  * Class Stack.
@@ -238,10 +239,11 @@ class Stack extends Page implements ExportableInterface
     /**
      * @param |\Concrete\Core\Page\Collection $nc
      * @param bool $preserveUserID
+     * @param \Concrete\Core\Entity\Site\Site $site
      *
      * @return Stack
      */
-    public function duplicate($nc = null, $preserveUserID = false)
+    public function duplicate($nc = null, $preserveUserID = false, Site $site = null)
     {
         if (!is_object($nc)) {
             $nc = Page::getByID($this->getCollectionParentID());


### PR DESCRIPTION
I had this error during installation (PHP7): Declaration of Concrete\Core\Page\Stack\Stack::duplicate() must be compatible with Concrete\Core\Page\Page::duplicate()