### PR TITLE
Doctrine annotation registration path fix.

### DIFF
--- a/concrete/src/Database/EntityManagerConfigFactory.php
+++ b/concrete/src/Database/EntityManagerConfigFactory.php
@@ -107,7 +107,7 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
     public function getMetadataDriverImpl()
     {
         // Register the doctrine Annotations
-        \Doctrine\Common\Annotations\AnnotationRegistry::registerFile(DIR_BASE_CORE.'/vendor/doctrine/orm/lib/Doctrine/ORM'.'/Mapping/Driver/DoctrineAnnotations.php');
+        \Doctrine\Common\Annotations\AnnotationRegistry::registerFile('doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
 
         $legacyNamespace = $this->getConfigRepository()->get('app.enable_legacy_src_namespace');
         if ($legacyNamespace) {


### PR DESCRIPTION
Removed hard reference to the vendor directory to allow loading the cms as a composer dependancy, all files in the vendor directory are already within the include path as specified here: https://github.com/concrete5/concrete5/blob/develop/concrete/bootstrap/configure.php#L363