### PR TITLE
Ensure current locale selected in switch_language

### DIFF
--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -15,7 +15,7 @@ class Controller extends BlockController
     protected $btInterfaceHeight = 150;
     protected $btTable = 'btSwitchLanguage';
 
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     public function getBlockTypeDescription()
     {
@@ -76,7 +76,7 @@ class Controller extends BlockController
         $ml = Section::getList();
         $c = \Page::getCurrentPage();
         $al = Section::getBySectionOfSite($c);
-        $languages = array();
+        $languages = [];
         $locale = \Localization::activeLocale();
         if (is_object($al)) {
             $locale = $al->getLanguage();

--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -77,18 +77,20 @@ class Controller extends BlockController
         $c = \Page::getCurrentPage();
         $al = Section::getBySectionOfSite($c);
         $languages = [];
-        $locale = \Localization::activeLocale();
-        if (is_object($al)) {
+        $locale = null;
+        if ($al !== null) {
             $locale = $al->getLanguage();
+        }
+        if (!$locale) {
+            $locale = \Localization::activeLocale();
+            $al = Section::getByLocale($locale);
         }
         foreach ($ml as $m) {
             $languages[$m->getCollectionID()] = $m->getLanguageText($m->getLocale());
         }
         $this->set('languages', $languages);
         $this->set('languageSections', $ml);
-        if (is_object($al)) {
-            $this->set('activeLanguage', $al->getCollectionID());
-        }
+        $this->set('activeLanguage', $al ? $al->getCollectionID() : null);
         $dl = $this->app->make('multilingual/detector');
         $this->set('defaultLocale', $dl->getPreferredSection());
         $this->set('locale', $locale);


### PR DESCRIPTION
This a of https://github.com/concrete5/concrete5/pull/4388, limited to the switch_language block part.

The part related to the page languages seems to be already working fine: @aembler where/when do you see [problems](https://github.com/concrete5/concrete5/pull/4388#issuecomment-248980330)?

