### PR TITLE
Make PackageService::getClass static

### DIFF
--- a/concrete/src/Package/PackageService.php
+++ b/concrete/src/Package/PackageService.php
@@ -237,7 +237,7 @@ class PackageService
      * @param string $pkgHandle Handle of package
      * @return Package
      */
-    public function getClass($pkgHandle)
+    public static function getClass($pkgHandle)
     {
         $app = \Core::make('app');
         $cache = $app->make('cache/request');


### PR DESCRIPTION
It's called statically by Entity\Package::getClass and it does not contain any reference to $this