### PR TITLE
Add type concrete5-update in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "concrete5/concrete5",
   "license": "MIT",
   "description": "concrete5 open source CMS",
+  "type": "concrete5-update",
   "minimum-stability": "beta",
   "prefer-stable": true,
   "config": {
@@ -13,6 +14,7 @@
   },
   "require": {
     "php": ">=5.5.9",
+    "composer/installers": "~1.0",
     "doctrine/dbal": "2.*",
     "symfony/class-loader": "3.*",
     "symfony/http-foundation": "3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3399aaf5b1e66e39a3dbd9be99a5d49d",
-    "content-hash": "cacce29ed142da46dd0713518a6df1b1",
+    "hash": "4d26f49953f139d7f1086e20d657eacd",
+    "content-hash": "826456f7f4f78b24e17e76d88e6515db",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -45,6 +45,113 @@
             ],
             "description": "A set of classes to create and manipulate HTML objects abstractions",
             "time": "2015-03-04 17:12:08"
+        },
+        {
+            "name": "composer/installers",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "d78064c68299743e0161004f2de3a0204e33b804"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d78064c68299743e0161004f2de3a0204e33b804",
+                "reference": "d78064c68299743e0161004f2de3a0204e33b804",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "4.1.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Hurad",
+                "ImageCMS",
+                "MODX Evo",
+                "Mautic",
+                "OXID",
+                "Plentymarkets",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "joomla",
+                "kohana",
+                "laravel",
+                "lithium",
+                "magento",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "moodle",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "time": "2016-08-13 20:53:52"
         },
         {
             "name": "concrete5/doctrine-xml",
@@ -129,7 +236,7 @@
                 "queue",
                 "zf2"
             ],
-            "time": "2016-08-17 19:07:41"
+            "time": "2016-09-01 14:16:11"
         },
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
This continues the discussion from #2087 now that `web/` is gone.

At the moment `composer create-project concrete5/concrete5` has the disadvantage of losing the possibility to update concrete5 via Composer and `composer require concrete5/concrete5` needs the `vendor/` directory to be in the web root to serve the static concrete5 files. 

Using the already existing Composer installer type `concrete5-update` is still not the cleanest solution in my mind, but it has proven to work, we have multiple concrete5 installations running with a [custom Composer repository](https://github.com/worldskills/concrete5-repository/blob/gh-pages/packages.json) which uses `concrete5-update`.

One cleaner solution would be to create a Git subtree split of the core to a new repository `concrete5-core` but that would mean some additional maintenance (ref. [Monorepo](https://speakerdeck.com/fabpot/a-monorepo-vs-manyrepos)) and would require a new Composer installer type `concrete5-core`.

Maybe there are other better solutions?

This is mainly to start the discussion again how to install concrete5 as a dependency with Composer (https://github.com/composer/installers/pull/225 and https://github.com/concrete5/concrete5/issues/3311).