### PR TITLE
Add back special handling for block passthrough

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -368,6 +368,8 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $response = $homeController->validateRequest();
         if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
             return $response;
+        } elseif ($response === true) {
+            return $this->controller($homeController);
         } else {
             return $this->notFound('', Response::HTTP_NOT_FOUND, $headers);
         }


### PR DESCRIPTION
This is a condition that was missed in the dispatcher changes. [Originally we only sent notFound if validaterequest was not true](https://github.com/concrete5/concrete5/blob/5.7.x/web/concrete/src/Routing/DispatcherRouteCallback.php#L205-L207). With the new setup, that means we need to pass the home controller to `$factory->controller()` and return the result of that.

Resolves #4396 