### PR TITLE
Fix forever authentication and make cookie middleware work

### DIFF
--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -97,7 +97,7 @@ class Controller extends GenericOauth2TypeController
             }
         }
 
-        parent::completeAuthentication($u);
+        return parent::completeAuthentication($u);
     }
 
     public function isValid()

--- a/concrete/authentication/twitter/controller.php
+++ b/concrete/authentication/twitter/controller.php
@@ -156,7 +156,7 @@ class Controller extends GenericOauth1aTypeController
 
             $user = $this->createUser();
             if ($user && !$user->isError()) {
-                $this->completeAuthentication($user);
+                return $this->completeAuthentication($user);
             }
         }
 

--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller\SinglePage;
 use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Authentication\AuthenticationTypeFailureException;
 use Concrete\Core\Page\Desktop\DesktopList;
+use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Routing\RedirectResponse;
 use Localization;
 use Page;
@@ -110,7 +111,7 @@ class Login extends PageController
                 $at = AuthenticationType::getByHandle($type);
                 $user = $at->controller->authenticate();
                 if ($user && $user->isLoggedIn()) {
-                    $this->finishAuthentication($at);
+                    return $this->finishAuthentication($at);
                 }
             } catch (\exception $e) {
                 $this->error->add($e->getMessage());
@@ -180,8 +181,7 @@ class Login extends PageController
             $session->set('uRequiredAttributeUserAuthenticationType', $type->getAuthenticationTypeHandle());
 
             $this->view();
-            echo $this->getViewObject()->render();
-            exit;
+            return $this->getViewObject()->render();
         }
 
         $u->setLastAuthType($type);
@@ -189,7 +189,7 @@ class Login extends PageController
         $ue = new \Concrete\Core\User\Event\User($u);
         $this->app->make('director')->dispatch('on_user_login', $ue);
 
-        $this->chooseRedirect();
+        return $this->chooseRedirect();
     }
 
     public function on_start()
@@ -292,11 +292,9 @@ class Login extends PageController
             } while (false);
 
             if ($rUrl) {
-                $r = new RedirectResponse($rUrl);
-                $r->send();
-                exit;
+                return new RedirectResponse($rUrl);
             } else {
-                $this->redirect('/');
+                return Redirect::to('/');
             }
         } else {
             $this->error->add(t('User is not registered. Check your authentication controller.'));
@@ -366,7 +364,7 @@ class Login extends PageController
             if (count($saveAttributes) > 0) {
                 $ui->saveUserAttributesForm($saveAttributes);
             }
-            $this->finishAuthentication($at);
+            return $this->finishAuthentication($at);
         } catch (\Exception $e) {
             $this->error->add($e->getMessage());
         }

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -33,7 +33,7 @@ abstract class AuthenticationTypeController extends Controller implements Authen
     {
         $c = Page::getByPath('/login');
         $controller = $c->getPageController();
-        $controller->finishAuthentication($this->getAuthenticationType());
+        return $controller->finishAuthentication($this->getAuthenticationType());
     }
 
     /**

--- a/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
@@ -32,7 +32,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
             try {
                 $user = $this->attemptAuthentication();
                 if ($user) {
-                    $this->completeAuthentication($user);
+                    return $this->completeAuthentication($user)->send();
                 } else {
                     $this->showError(
                         t('No local user account associated with this user, please log in with a local account and connect your account from your user profile.'));

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -42,7 +42,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             try {
                 $user = $this->attemptAuthentication();
                 if ($user) {
-                    $this->completeAuthentication($user);
+                    return $this->completeAuthentication($user);
                 } else {
                     $this->showError(
                         t('No local user account associated with this user, please log in with a local account and connect your account from your user profile.'));

--- a/concrete/src/Cookie/CookieServiceProvider.php
+++ b/concrete/src/Cookie/CookieServiceProvider.php
@@ -7,9 +7,7 @@ class CookieServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton(
-            'cookie',
-            '\Concrete\Core\Cookie\CookieJar'
-        );
+        $this->app->singleton('\Concrete\Core\Cookie\CookieJar');
+        $this->app->bind('cookie', '\Concrete\Core\Cookie\CookieJar');
     }
 }

--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -60,7 +60,7 @@ class DefaultDispatcher implements DispatcherInterface
     {
         $session = $this->app['session'];
 
-        if ($session->has('uID') && $session->get('uID') > 0) {
+        if (!$session->has('uID')) {
             User::verifyAuthTypeCookie();
         }
 


### PR DESCRIPTION
We weren't returning responses here, instead we were sending em which was causing the cookie middleware we have to not get a chance to deal with cookies. In addition to that, the cookie service provider was setting the singleton on "cookie" instead of on the class name making typehint DI not work properly.
