### PR TITLE
Show all blocktypes by default instead of only the first 100

### DIFF
--- a/concrete/src/Block/BlockType/BlockTypeList.php
+++ b/concrete/src/Block/BlockType/BlockTypeList.php
@@ -23,7 +23,7 @@ class BlockTypeList extends DatabaseItemList
         $this->includeInternalBlockTypes = true;
     }
 
-    public function get($itemsToGet = 100, $offset = 0)
+    public function get($itemsToGet = 0, $offset = 0)
     {
         if (!$this->includeInternalBlockTypes) {
             $this->filter('btIsInternal', false);


### PR DESCRIPTION
When a site has a lot of block types only the first 100 will be shown because this is the default in BlockTypeList->get(). All blocks more then the first 100 cannot be edited, refreshed, removed or assigned permissions. Removing this limit solves that. Code that wants to add pagination can still do so.