### PR TITLE
[8.0.0b6] Delete user fixes (#4395)

### DIFF
--- a/concrete/src/Entity/Attribute/Value/UserValue.php
+++ b/concrete/src/Entity/Attribute/Value/UserValue.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 class UserValue extends Value
 {
     /**
-     * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User"),
+     * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
      */
     protected $user;

--- a/concrete/src/Entity/Notification/NotificationAlert.php
+++ b/concrete/src/Entity/Notification/NotificationAlert.php
@@ -35,7 +35,7 @@ class NotificationAlert
     protected $user;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Notification")
+     * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Notification\Notification", inversedBy="alerts")
      * @ORM\JoinColumn(name="nID", referencedColumnName="nID")
      */
     protected $notification;

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -21,9 +21,16 @@ class User
     protected $uID;
 
     /**
-     * @ORM\ManyToMany(targetEntity="\Concrete\Core\Entity\Notification\Notification", mappedBy="subscribers", cascade={"remove"})
+     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\NotificationAlert", cascade={"remove"}, mappedBy="user")
+     * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
      */
-    protected $notifications;
+    protected $alerts;
+
+    /**
+     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Attribute\Value\UserValue", cascade={"remove"}, mappedBy="user")
+     * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     */
+    protected $attributes;
 
     /**
      * @ORM\Column(type="string", length=64, unique=true)

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -128,7 +128,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
         $db = $this->connection;
         $v = array($this->getUserID());
         $pkr = new DeleteUserWorkflowRequest();
-        $pkr->setRequestedUserID($this->uID);
+        $pkr->setRequestedUserID($this->getUserID());
         $pkr->setRequesterUserID($requester->getUserID());
         $pkr->trigger();
         return $db->GetOne('select count(uID) from Users where uID = ?', $v) == 0;


### PR DESCRIPTION
There was a minor issue with issue with a null target user id being passed to the delete workflow request, I'm guessing that the reference just got missed during the doctrine entity implementation.

Once I'd patched the above, errors were being thrown due to foreign key constraints failing on the UserAttributeValues table. There was no relationship definition from the User entity to the UserValue and thus a users attributes weren't being flushed on deletion.

Also, the User entity was trying to reference the Notification entity directly. I've updated it to reference the intermediate NotificationAlert entity. I've then implemented cascading deletes for User to NotificationAlert and then the NotificationAlert to the various Notification entities which keeps things clean on user deletion.