### PR TITLE
[5.7] Mitigate problems about loading translation files

### DIFF
--- a/web/concrete/src/Application/Application.php
+++ b/web/concrete/src/Application/Application.php
@@ -292,6 +292,8 @@ class Application extends Container
             }
             $pkg->setupPackageLocalization();
         }
+        $config->set('app.bootstrap.packages_loaded', true);
+        \Localization::setupSiteLocalization();
         foreach($this->packages as $pkg) {
             if (method_exists($pkg, 'on_start')) {
                 $pkg->on_start();
@@ -300,8 +302,6 @@ class Application extends Container
                 $checkAfterStart = true;
             }
         }
-        $config->set('app.bootstrap.packages_loaded', true);
-        \Localization::setupSiteLocalization();
 
         if ($checkAfterStart) {
             foreach($this->packages as $pkg) {


### PR DESCRIPTION
There's a quite hard problem to be solved, and here's the cause:

1. concrete5 starts and we initially setup the locale to the default one (user's one or, if no user is logged in, the site default)
2. we setup the packages (including their on-start events)
3. we load the site-level language files
4. localization system is ready

When the first call to t() is done, the Zend-i18n component gets initialized, i.e.:
a. it checks if its cache is ready
b. if not, it loads the configured language files, and stores them in its cache
c. it uses the translations in its cache file

So, if a call to t() is done somewhere between 1. and 4, the Zend-i18n cache is only partially populated, thus leading to some translation file not loaded.

A way to mitigate this problem is by calling package startup functions after all the language files have been communicated to Zend-i18n...