### PR TITLE
Avoid calling PackageService->getClass statically

### DIFF
--- a/concrete/src/Entity/Package.php
+++ b/concrete/src/Entity/Package.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Concrete\Core\Entity;
 
 use Concrete\Core\Package\LocalizablePackageInterface;
-use Concrete\Core\Support\Facade\Package as PackageService;
+use Concrete\Core\Package\PackageService;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use Concrete\Core\Support\Facade\Application;
 
 /**
  * @ORM\Entity
@@ -188,7 +190,9 @@ class Package implements LocalizablePackageInterface
 
     public function getController()
     {
-        return PackageService::getClass($this->getPackageHandle());
+        $app = Application::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getClass($this->getPackageHandle());
     }
 
     public function __call($method, $arguments)

--- a/concrete/src/Entity/Package.php
+++ b/concrete/src/Entity/Package.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Entity;
 
 use Concrete\Core\Package\LocalizablePackageInterface;
-use Concrete\Core\Package\PackageService;
+use Concrete\Core\Support\Facade\Package as PackageService;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 


### PR DESCRIPTION
This should be the only place where PackageService->getClass is called statically