### PR TITLE
Add DisplayName / DisplayType to file types

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -451,14 +451,33 @@ class Version
         }
     }
 
+    /**
+     * Get the file type name.
+     *
+     * @return string
+     */
     public function getType()
     {
         $ftl = $this->getTypeObject();
-        if (is_object($ftl)) {
-            return $ftl->getName();
-        }
+
+        return $ftl->getName();
     }
 
+    /**
+     * Get the file type display name (localized).
+     *
+     * @return string
+     */
+    public function getDisplayType()
+    {
+        $ftl = $this->getTypeObject();
+
+        return $ftl->getDisplayName();
+    }
+
+    /**
+     * @return \Concrete\Core\File\Type\Type
+     */
     public function getTypeObject()
     {
         $fh = Core::make('helper/file');
@@ -1103,7 +1122,7 @@ class Version
     public function canView()
     {
         $to = $this->getTypeObject();
-        if (is_object($to) && $to->getView() != '') {
+        if ($to->getView() != '') {
             return true;
         }
 
@@ -1113,18 +1132,23 @@ class Version
     public function canEdit()
     {
         $to = $this->getTypeObject();
-        if (is_object($to) && $to->getEditor() != '') {
+        if ($to->getEditor() != '') {
             return true;
         }
 
         return false;
     }
 
+    /**
+     * Get the localized name of the generic category type.
+     *
+     * @return string
+     */
     public function getGenericTypeText()
     {
         $to = $this->getTypeObject();
 
-        return $to->getGenericTypeText($to->getGenericType());
+        return $to->getGenericDisplayType();
     }
 
     //takes a string of comma or new line delimited tags, and puts them in the appropriate format

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -540,11 +540,15 @@ class Version
         do {
             $prefix = $importer->generatePrefix();
             $path = $cf->prefix($prefix, $this->getFilename());
-        } while($filesystem->has($path));
-        $filesystem->write($path, $this->getFileResource()->read(), array(
-            'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
-            'mimetype' => Core::make('helper/mime')->mimeFromExtension($fi->getExtension($this->getFilename()))
-        ));
+        } while ($filesystem->has($path));
+        $filesystem->write(
+            $path,
+            $this->getFileResource()->read(),
+            [
+                'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
+                'mimetype' => Core::make('helper/mime')->mimeFromExtension($fi->getExtension($this->getFilename())),
+            ]
+        );
         $this->updateFile($this->getFilename(), $prefix);
     }
 

--- a/concrete/src/File/Search/ColumnSet/FolderSet.php
+++ b/concrete/src/File/Search/ColumnSet/FolderSet.php
@@ -56,13 +56,11 @@ class FolderSet extends Set
 
     public function __construct()
     {
-        $this->addColumn(new Column('folderItemName', t('Name'), array('\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getName')));
-        $this->addColumn(new Column('folderItemType', t('Type'), array('\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getType')));
-        $this->addColumn(new Column('folderItemModified', t('Date Modified'), array('\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getDateModified')));
-        $this->addColumn(new Column('folderItemSize', t('Size'), array('\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getSize')));
+        $this->addColumn(new Column('folderItemName', t('Name'), ['\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getName']));
+        $this->addColumn(new Column('folderItemType', t('Type'), ['\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getType']));
+        $this->addColumn(new Column('folderItemModified', t('Date Modified'), ['\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getDateModified']));
+        $this->addColumn(new Column('folderItemSize', t('Size'), ['\Concrete\Core\File\Search\ColumnSet\FolderSet', 'getSize']));
         $title = $this->getColumnByKey('folderItemName');
         $this->setDefaultSortColumn($title, 'desc');
     }
 }
-
-

--- a/concrete/src/File/Search/ColumnSet/FolderSet.php
+++ b/concrete/src/File/Search/ColumnSet/FolderSet.php
@@ -2,31 +2,33 @@
 namespace Concrete\Core\File\Search\ColumnSet;
 
 use Concrete\Core\File\Type\Type;
-use Core;
 use Concrete\Core\Search\Column\Column;
 use Concrete\Core\Search\Column\Set;
+use Concrete\Core\Support\Facade\Application;
 
 class FolderSet extends Set
 {
     public static function getType($node)
     {
-        if ($node->getTreeNodeTypeHandle() == 'file_folder') {
-            return t('Folder');
-        }
-        if ($node->getTreeNodeTypeHandle() == 'search_preset') {
-            return t('Saved Search');
-        }
-        if ($node->getTreeNodeTypeHandle() == 'file') {
-            $file = $node->getTreeNodeFileObject();
-            if (is_object($file)) {
-                return Type::getGenericTypeText($file->getTypeObject()->getGenericType());
-            }
+        switch ($node->getTreeNodeTypeHandle()) {
+            case 'file_folder':
+                return t('Folder');
+            case 'search_preset':
+                return t('Saved Search');
+            case 'file':
+                $file = $node->getTreeNodeFileObject();
+                if (is_object($file)) {
+                    return $file->getTypeObject()->getGenericDisplayType();
+                }
+                break;
         }
     }
 
     public static function getDateModified($node)
     {
-        return \Core::make('date')->formatDateTime($node->getDateLastModified());
+        $app = Application::getFacadeApplication();
+
+        return $app->make('date')->formatDateTime($node->getDateLastModified());
     }
 
     public static function getName($node)
@@ -50,8 +52,9 @@ class FolderSet extends Set
     public static function getFileDateActivated($f)
     {
         $fv = $f->getVersion();
+        $app = Application::getFacadeApplication();
 
-        return Core::make('helper/date')->formatDateTime($f->getDateAdded()->getTimestamp());
+        return $app->make('date')->formatDateTime($f->getDateAdded()->getTimestamp());
     }
 
     public function __construct()

--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -201,7 +201,7 @@ class Type
      */
     public function setName($value)
     {
-        $this->name = (string) $name;
+        $this->name = (string) $value;
 
         return $this;
     }

--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -1,68 +1,426 @@
 <?php
 namespace Concrete\Core\File\Type;
 
-use Loader;
-use Core;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
 
 class Type
 {
     // File Type Constants
+
+    /**
+     * Image file type.
+     *
+     * @var int
+     */
     const T_IMAGE = 1;          //!< @javascript-exported
+
+    /**
+     * Video file type.
+     *
+     * @var int
+     */
     const T_VIDEO = 2;          //!< @javascript-exported
+
+    /**
+     * Text file type.
+     *
+     * @var int
+     */
     const T_TEXT = 3;           //!< @javascript-exported
+
+    /**
+     * Audio file type.
+     *
+     * @var int
+     */
     const T_AUDIO = 4;          //!< @javascript-exported
+
+    /**
+     * Document file type.
+     *
+     * @var int
+     */
     const T_DOCUMENT = 5;       //!< @javascript-exported
+
+    /**
+     * Application file type.
+     *
+     * @var int
+     */
     const T_APPLICATION = 6;    //!< @javascript-exported
+
+    /**
+     * Other/unknown file type.
+     *
+     * @var int
+     */
     const T_UNKNOWN = 99;       //!< @javascript-exported
 
-    public $pkgHandle = false;
+    // Properties
 
-    public function __construct()
-    {
-        $this->type = static::T_UNKNOWN;
-        $this->name = $this->mapGenericTypeText($this->type);
-    }
+    /**
+     * Handle of the owner package (empty string if not available).
+     *
+     * @deprecated Use the getPackageHandle()/setPackageHandle() methods
+     *
+     * @var string
+     */
+    public $pkgHandle = '';
 
+    /**
+     * Generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants).
+     *
+     * @deprecated Use the getGenericType()/setGenericType()/getGenericDisplayType() methods
+     *
+     * @var int
+     */
+    public $type = null;
+
+    /**
+     * Name (empty string if generic type).
+     *
+     * @deprecated Use the getName()/setName()/getDisplayName() methods
+     *
+     * @var string
+     */
+    public $name = '';
+
+    /**
+     * Single file extension.
+     *
+     * @deprecated Use the getExtension()/setExtension() methods
+     *
+     * @var string
+     */
+    public $extension = '';
+
+    /**
+     * Handle of the custom importer (empty string if not available).
+     *
+     * @deprecated Use the getCustomImporter()/setCustomImporter() methods
+     *
+     * @var string
+     */
+    public $customImporter = '';
+
+    /**
+     * Handle of the editor (empty string if not available).
+     *
+     * @deprecated Use the getEditor()/setEditor() methods
+     *
+     * @var string
+     */
+    public $editor = '';
+
+    /**
+     * Handle of the inline viewer (empty string if not available).
+     *
+     * @deprecated Use the getView()/setView() methods
+     *
+     * @var string
+     */
+    public $view = '';
+
+    // Getters/setters
+
+    /**
+     * Get the handle of the owner package (empty string if not available).
+     *
+     * @return string
+     */
     public function getPackageHandle()
     {
         return $this->pkgHandle;
     }
 
+    /**
+     * Set the handle of the owner package (empty string if not available).
+     *
+     * @param string $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setPackageHandle($value)
+    {
+        $this->pkgHandle = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants).
+     *
+     * @return int
+     */
+    public function getGenericType()
+    {
+        return $this->type ?: static::T_UNKNOWN;
+    }
+
+    /**
+     * Set the generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants).
+     *
+     * @param int $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setGenericType($value)
+    {
+        $this->type = (int) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the name of the generic category type.
+     *
+     * @return string
+     */
+    public function getGenericDisplayType()
+    {
+        return static::getGenericTypeText($this->getGenericType());
+    }
+
+    /**
+     * Get the name (empty string if generic type).
+     *
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * Set the name (empty string if generic type).
+     *
+     * @param string
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setName($value)
+    {
+        $this->name = (string) $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the display name (localized).
+     *
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        $name = $this->getName();
+
+        return ($name === '') ? $this->getGenericDisplayType() : t($name);
+    }
+
+    /**
+     * Get the single file extension.
+     *
+     * @return string
+     */
     public function getExtension()
     {
         return $this->extension;
     }
 
+    /**
+     * Set the single file extension.
+     *
+     * @param string $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setExtension($value)
+    {
+        $this->extension = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the handle of the custom importer (empty string if not available).
+     *
+     * @return string
+     */
     public function getCustomImporter()
     {
         return $this->customImporter;
     }
 
-    public function getGenericType()
+    /**
+     * Set the handle of the custom importer (empty string if not available).
+     *
+     * @param string $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setCustomImporter($value)
     {
-        return $this->type;
+        $this->customImporter = (string) $value;
+
+        return $this;
     }
 
-    public function getView()
-    {
-        return $this->view;
-    }
-
+    /**
+     * Get the handle of the editor (empty string if not available).
+     *
+     * @return string
+     */
     public function getEditor()
     {
         return $this->editor;
     }
 
-    protected function mapGenericTypeText($type)
+    /**
+     * Set the handle of the editor (empty string if not available).
+     *
+     * @param string $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setEditor($value)
     {
-        return static::getGenericTypeText($type);
+        $this->editor = (string) $value;
+
+        return $this;
     }
 
+    /**
+     * Get the handle of the inline viewer (empty string if not available).
+     *
+     * @return string
+     */
+    public function getView()
+    {
+        return $this->view;
+    }
+
+    /**
+     * Set the handle of the inline viewer (empty string if not available).
+     *
+     * @param string $value
+     *
+     * @return static Returns the class instance itself for method chaining
+     */
+    public function setView($value)
+    {
+        $this->view = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the inspector for this file type (if available).
+     *
+     * @return \Concrete\Core\File\Type\Inspector|null
+     */
+    public function getCustomInspector()
+    {
+        $importer = $this->getCustomImporter();
+        if ($importer === '') {
+            $result = null;
+        } else {
+            $name = camelcase($importer) . 'Inspector';
+            $class = overrideable_core_class('Core\\File\\Type\\Inspector\\' . $name, 'File/Type/Inspector/' . $name . '.php', $this->getPackageHandle());
+            $app = Application::getFacadeApplication();
+            $result = $app->make($class);
+        }
+
+        return $result;
+    }
+
+    // Helper functions
+
+    /**
+     * Get the list of all the file extensions used by approved file versions.
+     *
+     * @return string[]
+     */
+    public static function getUsedExtensionList()
+    {
+        $app = Application::getFacadeApplication();
+        $db = $app->make('database')->connection();
+        $stm = $db->executeQuery("select distinct fvExtension from FileVersions where fvIsApproved = 1 and fvExtension is not null and fvExtension <> ''");
+        $extensions = [];
+        while ($row = $stm->fetch()) {
+            $extensions[] = $row['fvExtension'];
+        }
+
+        return $extensions;
+    }
+
+    /**
+     * Get the list of all the file types used by approved file versions.
+     *
+     * @return int[]
+     */
+    public static function getUsedTypeList()
+    {
+        $app = Application::getFacadeApplication();
+        $db = $app->make('database')->connection();
+        $stm = $db->query('select distinct fvType from FileVersions where fvIsApproved = 1 and fvType is not null and fvType <> 0');
+        $types = [];
+        while ($row = $stm->fetch()) {
+            $types[] = (int) $row['fvType'];
+        }
+
+        return $types;
+    }
+
+    /**
+     * Get the list of all the available type IDs.
+     *
+     * @return int[]
+     */
+    public static function getTypeList()
+    {
+        return [
+            static::T_DOCUMENT,
+            static::T_IMAGE,
+            static::T_VIDEO,
+            static::T_AUDIO,
+            static::T_TEXT,
+            static::T_APPLICATION,
+            static::T_UNKNOWN,
+        ];
+    }
+
+    /**
+     * Returns a thumbnail for this type of file.
+     *
+     * @param bool $fullImageTag Set to true to retrieve the full HTML image tag, false to just retrieve the image URL
+     *
+     * @return string
+     */
+    public function getThumbnail($fullImageTag = true)
+    {
+        $app = Application::getFacadeApplication();
+        $config = $app->make('config');
+        $type = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_listing.handle'));
+        if (file_exists(DIR_AL_ICONS . '/' . $this->getExtension() . '.svg')) {
+            $url = REL_DIR_AL_ICONS . '/' . $this->getExtension() . '.svg';
+        } else {
+            $url = AL_ICON_DEFAULT;
+        }
+        if ($fullImageTag == true) {
+            return sprintf('<img src="%s" width="%s" height="%s" class="img-responsive ccm-generic-thumbnail">', $url, $type->getWidth(), $type->getHeight());
+        } else {
+            return $url;
+        }
+    }
+
+    /**
+     * Get the name of a generic file type.
+     *
+     * @param int $type Generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants)
+     *
+     * @return string|null Returns null if the type is not recognized, its translated display name otherwise
+     */
     public static function getGenericTypeText($type)
     {
         switch ($type) {
@@ -88,70 +446,6 @@ class Type
                 return t('File');
                 break;
 
-        }
-    }
-
-    public function getCustomInspector()
-    {
-        $name = camelcase($this->getCustomImporter()) . 'Inspector';
-        $class = overrideable_core_class('Core\\File\\Type\\Inspector\\' . $name, 'File/Type/Inspector/' . $name . '.php', $this->getPackageHandle());
-        $cl = Core::make($class);
-
-        return $cl;
-    }
-
-    public static function getUsedExtensionList()
-    {
-        $db = Loader::db();
-        $stm = $db->query('select distinct fvExtension from FileVersions where fvIsApproved = 1 and fvExtension <> ""');
-        $extensions = [];
-        while ($row = $stm->fetch()) {
-            $extensions[] = $row['fvExtension'];
-        }
-
-        return $extensions;
-    }
-
-    public static function getUsedTypeList()
-    {
-        $db = Loader::db();
-        $stm = $db->query('select distinct fvType from FileVersions where fvIsApproved = 1 and fvType <> 0');
-        $types = [];
-        while ($row = $stm->fetch()) {
-            $types[] = $row['fvType'];
-        }
-
-        return $types;
-    }
-
-    public static function getTypeList()
-    {
-        return [
-            static::T_DOCUMENT,
-            static::T_IMAGE,
-            static::T_VIDEO,
-            static::T_AUDIO,
-            static::T_TEXT,
-            static::T_APPLICATION,
-            static::T_UNKNOWN,
-        ];
-    }
-
-    /**
-     * Returns a thumbnail for this type of file.
-     */
-    public function getThumbnail($fullImageTag = true)
-    {
-        $type = \Concrete\Core\File\Image\Thumbnail\Type\Type::getByHandle(\Config::get('concrete.icons.file_manager_listing.handle'));
-        if (file_exists(DIR_AL_ICONS . '/' . $this->extension . '.svg')) {
-            $url = REL_DIR_AL_ICONS . '/' . $this->extension . '.svg';
-        } else {
-            $url = AL_ICON_DEFAULT;
-        }
-        if ($fullImageTag == true) {
-            return sprintf('<img src="%s" width="%s" height="%s" class="img-responsive ccm-generic-thumbnail">', $url, $type->getWidth(), $type->getHeight());
-        } else {
-            return $url;
         }
     }
 }

--- a/concrete/src/File/Type/TypeList.php
+++ b/concrete/src/File/Type/TypeList.php
@@ -2,23 +2,11 @@
 namespace Concrete\Core\File\Type;
 
 use Loader;
-/*
- * \@package Core
- * @subpackage Files
- * @author Andrew Embler <andrew@concrete5.org>
- * @copyright  Copyright (c) 2003-2009 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
- *
- */
 
 /*
- * \@package Core
- * @subpackage Files
  * @author Andrew Embler <andrew@concrete5.org>
- * @category Concrete
  * @copyright  Copyright (c) 2003-2009 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
- *
  */
 use Concrete\Core\File\Type\Type as FileType;
 
@@ -38,8 +26,8 @@ class TypeList
         return $instance;
     }
 
-    protected $types = array();
-    protected $importerAttributes = array();
+    protected $types = [];
+    protected $importerAttributes = [];
 
     public function define(
         $extension,
@@ -69,7 +57,7 @@ class TypeList
         foreach ($types as $type_name => $type_settings) {
             array_splice($type_settings, 1, 0, $type_name);
 
-            call_user_func_array(array($this, 'define'), $type_settings);
+            call_user_func_array([$this, 'define'], $type_settings);
         }
     }
 
@@ -87,7 +75,7 @@ class TypeList
     {
         foreach ($importer_attributes as $attribute_name => $attribute_settings) {
             array_unshift($attribute_settings, $attribute_name);
-            call_user_func_array(array($this, 'defineImporterAttribute'), $attribute_settings);
+            call_user_func_array([$this, 'defineImporterAttribute'], $attribute_settings);
         }
     }
 


### PR DESCRIPTION
Currently the File\Type class initialized itself with texts that are translated when the class is instantiated.

This causes problems when setting/changing the locale (file types are initialized very early during the boot process).

So, let's introduce the getDisplay* methods.

While we're at this, let's add getters/setters and deprecate the access to the class properties, add some phpdoc and get rid of other deprecated methods