### PR TITLE
BugFix: Load predefined attribute when creating new page by composer

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -367,8 +367,13 @@ class Controller extends AttributeTypeController
                     }
                 }
             } else {
-                if (is_array($value)) {
-                    $value = $value[0];
+                if (is_foreachable($value)) {
+                    if(is_array($value)){
+                        $value = reset($value);
+                    } else {
+                        $value->rewind();
+                        $value = $value->current();
+                    }
                 }
 
                 if ($value instanceof Option) {

--- a/web/concrete/bootstrap/helpers.php
+++ b/web/concrete/bootstrap/helpers.php
@@ -264,3 +264,12 @@ function var_dump_safe($o, $maxDepth = true)
 {
     return Doctrine\Common\Util\Debug::dump($o, $maxDepth);
 }
+
+/**
+ * @param mixed $var
+ * @return boolean
+ */
+function is_foreachable($var)
+{
+    return is_array($var) || $var instanceof Iterator;
+}

--- a/web/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
@@ -128,7 +128,14 @@ class CollectionAttributeControl extends Control
         // the data for this actually doesn't come from $data. Attributes have their own way of gettin data.
         $ak = $this->getAttributeKeyObject();
         if (is_object($ak)) {
-            $ak->saveAttributeForm($c);
+            if(is_object($this->page)){
+                $av = $this->page->getAttributeValueObject($ak);
+            }
+            if (is_object($av)) {
+                $c->setAttribute($ak, $av->getValue());
+            } else {
+                $ak->saveAttributeForm($c);
+            }
         }
     }
 

--- a/web/concrete/src/Page/Type/Type.php
+++ b/web/concrete/src/Page/Type/Type.php
@@ -1135,8 +1135,10 @@ class Type extends Object implements \Concrete\Core\Permission\ObjectInterface
 
         // we have to publish the controls to the page. i'm not sure why
         $controls = PageTypeComposerControl::getList($this);
+        $defaultsPage = $this->getPageTypePageTemplateDefaultPageObject();
         $outputControls = array();
         foreach ($controls as $cn) {
+            $cn->page = $defaultsPage;
             $cn->publishToPage($p, array(), $controls);
         }
 


### PR DESCRIPTION
Predefined attributes in /dashboard/pages/types/attributes/{ptID} are not being loaded when we create a new page.

@Remo 