### PR TITLE
Fix router service provider registration

### DIFF
--- a/concrete/src/Routing/RoutingServiceProvider.php
+++ b/concrete/src/Routing/RoutingServiceProvider.php
@@ -10,7 +10,7 @@ class RoutingServiceProvider extends Provider
      */
     public function register()
     {
-        $this->app->singleton(RouterInterface::class);
+        $this->app->singleton(Router::class);
         $this->app->bind(RouterInterface::class, Router::class);
     }
 }


### PR DESCRIPTION
These registrations are kinda difficult to get right in your head...

So here's what I want to be true:
```php
// Rebinding the interface clears the singleton
$app->bind(RouterInterface::class, NewRouter::class);
$app->make(NewRouter::class) === $app->make(RouterInterface::class); 

// Same type AND same instance
$app->make(Router::class) === $app->make(RouterInterface::class); 

```

The issue currently is that this won't work since NewRouter is not setup as a singleton, so overrides need to take care to set their override object as a singleton for the override to work. The hope with the broken code was that the singleton would be bound to the interface instead of the implementation.

