### PR TITLE
Make File Manager Active Date really shows File Version Date

### DIFF
--- a/web/concrete/src/File/Search/ColumnSet/DefaultSet.php
+++ b/web/concrete/src/File/Search/ColumnSet/DefaultSet.php
@@ -18,7 +18,7 @@ class DefaultSet extends Set
     {
         $fv = $f->getVersion();
 
-        return Core::make('helper/date')->formatDateTime($f->getDateAdded()->getTimestamp());
+        return Core::make('helper/date')->formatDateTime($fv->getDateAdded()->getTimestamp());
     }
 
     public function __construct()


### PR DESCRIPTION
5.7.5.9 File Manager's active date was showing the same "File originally added" date where it should be showing when the latest approved file version added.

It was simple mistake.

Although we're not sure if there is any further fix for 5.7.x but I just needed to fix this for my client. I'll go ahead submit as PR anyway to fix the minor yet major bug for the site which file manager versioning takes the serious role.