### PR TITLE
Fix file usage tracker

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Block\Image;
 
+use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Error\Error;
 use Concrete\Core\File\File;
@@ -176,7 +177,7 @@ class Controller extends BlockController implements FileTrackableInterface
      */
     public function getFileID()
     {
-        return isset($this->fID) ? $this->fID : null;
+        return isset($this->record->fID) ? $this->record->fID : (isset($this->fID) ? $this->fID : null);
     }
 
     /**
@@ -322,8 +323,8 @@ class Controller extends BlockController implements FileTrackableInterface
         // This doesn't get saved to the database. It's only for UI usage.
         unset($args['linkType']);
 
-        $this->tracker->track($this);
         parent::save($args);
+        $this->tracker->track($this);
     }
 
     public function getUsedFiles()

--- a/concrete/src/File/Tracker/UsageTracker.php
+++ b/concrete/src/File/Tracker/UsageTracker.php
@@ -56,7 +56,7 @@ class UsageTracker implements TrackerInterface
 
         if ($trackable instanceof BlockController) {
             if ($collection = $trackable->getCollectionObject()) {
-                $this->trackBlocks($trackable->getCollectionObject(), [$trackable->getBlockObject()]);
+                $this->trackBlocks($trackable->getCollectionObject(), [$trackable]);
                 $tracked = true;
             }
         }
@@ -166,8 +166,12 @@ class UsageTracker implements TrackerInterface
     {
         $this->trackTrackables(
             $collection,
-            $this->getTrackables($blocks, function (Block $block) {
-                return $block->getController();
+            $this->getTrackables($blocks, function ($block) {
+                if ($block instanceof Block) {
+                    return $block->getController();
+                }
+
+                return $block;
             }),
             function (Collection $collection, BlockController $controller, $fileId) {
                 $this->persist(


### PR DESCRIPTION
Previously the file usage tracker would convert block controllers to blocks then back to block controllers. This caused data to be lost, instead we just handle blocks and block controllers in the tracker object filter.