### PR TITLE
Resolve issue with adding replies to conversations

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -313,7 +313,7 @@ return array(
          */
         'enabled' => true,
         'default' => array(
-            'address' => 'concrete5-noreply@' . (isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'localhost'),
+            'address' => 'concrete5-noreply@concrete5',
             'name' => '',
         ),
         'form_block' => array(

--- a/concrete/src/Conversation/Message/Message.php
+++ b/concrete/src/Conversation/Message/Message.php
@@ -18,9 +18,9 @@ use Events;
 
 class Message extends Object implements \Concrete\Core\Permission\ObjectInterface
 {
-    protected $cnvMessageID;
+    public $cnvMessageID;
     protected $cnvMessageDateCreated;
-    protected $cnvMessageFlagTypes;
+    public $cnvMessageFlagTypes;
 
     public function getConversationMessageID()
     {


### PR DESCRIPTION
Some defined properties with a new more restrictive visibility was the cause of this javascript error. 

An additional issue I ran into was the fact that my webserver always has SERVER_NAME set, but it might not always be filled. Because of that it was breaking submission. This could be a security risk because someone could potentially use hosts entry to send legit looking mail from a separate domain.

This resolves #4392 