### PR TITLE
Image slider remove fix

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -25,6 +25,11 @@ echo Core::make('helper/concrete/ui')->tabs($tabs);
             $obj.click(function() {
                 var deleteIt = confirm('<?php echo t('Are you sure?'); ?>');
                 if (deleteIt === true) {
+                    slideID = $(this).closest('.ccm-image-slider-entry').find('.editor-content').attr('id');
+                    if (typeof CKEDITOR === 'object') {
+                        CKEDITOR.instances[slideID].destroy();
+                    }
+
                     $(this).closest('.ccm-image-slider-entry-<?php echo $bID?>').remove();
                     doSortCount();
                 }
@@ -326,7 +331,7 @@ echo Core::make('helper/concrete/ui')->tabs($tabs);
         <div class="form-group" >
             <label><?php echo t('Description'); ?></label>
             <div class="editor-edit-content"></div>
-            <textarea style="display: none" class="editor-content editor-content-<?php echo $bID?>" name="<?php echo $view->field('description'); ?>[]"><%=description%></textarea>
+            <textarea id="ccm-slide-<%= _.uniqueId() %>" style="display: none" class="editor-content editor-content-<?php echo $bID?>" name="<?php echo $view->field('description'); ?>[]"><%=description%></textarea>
         </div>
         <div class="form-group" >
            <label><?php echo t('Link'); ?></label>

--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -331,7 +331,7 @@ echo Core::make('helper/concrete/ui')->tabs($tabs);
         <div class="form-group" >
             <label><?php echo t('Description'); ?></label>
             <div class="editor-edit-content"></div>
-            <textarea id="ccm-slide-<%= _.uniqueId() %>" style="display: none" class="editor-content editor-content-<?php echo $bID?>" name="<?php echo $view->field('description'); ?>[]"><%=description%></textarea>
+            <textarea id="ccm-slide-editor-<%= _.uniqueId() %>" style="display: none" class="editor-content editor-content-<?php echo $bID?>" name="<?php echo $view->field('description'); ?>[]"><%=description%></textarea>
         </div>
         <div class="form-group" >
            <label><?php echo t('Link'); ?></label>


### PR DESCRIPTION
If the last Image Slider slide is removed, the block will error when saved.

Steps to reproduce:
1. remove the last Image Slider slide
2. save
3. console error
VM939:324 Uncaught The editor instance "description[]" is already attached to the provided element.

To remove the slide, the CKEditor instance for that slide needs to be destroyed before the slide is removed from the DOM. This requires each slide to have a unique ID.