### PR TITLE
Fix tests warnings

### DIFF
--- a/tests/tests/Core/Foundation/ClassloaderTest.php
+++ b/tests/tests/Core/Foundation/ClassloaderTest.php
@@ -266,7 +266,7 @@ class ClassloaderTest extends ClassLoaderTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $package->expects($this->any())
-            ->method('enableLegacyNamespace')
+            ->method('shouldEnableLegacyNamespace')
             ->will($this->returnValue(false));
         $package->expects($this->any())
             ->method('getPackageHandle')


### PR DESCRIPTION
This should fix [these tests warnings](https://travis-ci.org/concrete5/concrete5/jobs/166360018#L535-L557) caused by [this change](https://github.com/concrete5/concrete5/pull/4453/files#diff-2fdc1f2cb748756db77f4cbcfe01a3d9L125).