### PR TITLE
Adjustment of block panel block labels

### DIFF
--- a/concrete/css/build/core/app/panels/add-block.less
+++ b/concrete/css/build/core/app/panels/add-block.less
@@ -132,17 +132,16 @@ a.ccm-panel-add-block-draggable-block-type {
 		left: 0px;
 		bottom: 0px;
 		width: 100%;
-		text-overflow: ellipsis;
 		text-align: center;
 		display: block;
 		color: #8f969a;
 		background-color: #000;
 		font-size: 12px;
-		line-height: 12px;
-  		padding-top: 10px;
-		padding-bottom: 10px;
-		overflow: hidden;
-		white-space: nowrap;
+		line-height: 14px;
+		padding-left: 2px;
+		padding-right: 2px;
+		padding-top: 6px;
+		padding-bottom: 6px;
 		.border-bottom-radius(4px);
 	}
 


### PR DESCRIPTION
This is a small adjustment to the way block labels are handled in the add block panel, without changing the overall appearance.

Currently some of the labels for the built in blocks are being truncated when there is room to display them in full. Even two word block names that really wouldn't be considered 'long' are being unnecessarily truncated. This just makes understanding the purpose of each block more difficult.

![screen shot 2016-10-11 at 5 41 16 pm](https://cloud.githubusercontent.com/assets/1079600/19262430/80bf83cc-8fde-11e6-8dbf-e3f451f18dcf.png)
![screen shot 2016-10-11 at 5 41 53 pm](https://cloud.githubusercontent.com/assets/1079600/19262436/863f4d46-8fde-11e6-8a73-e9cec6e496c8.png)
![screen shot 2016-10-11 at 5 42 15 pm](https://cloud.githubusercontent.com/assets/1079600/19262438/897f6806-8fde-11e6-9e4d-2e5978bea63b.png)

This change removes this ellipsis truncation and subtly adjusts the padding to allow more text to fit.
![screen shot 2016-10-11 at 5 42 01 pm](https://cloud.githubusercontent.com/assets/1079600/19262729/1d1c3a5c-8fe0-11e6-9edf-7dbd39a98c56.png)
![screen shot 2016-10-11 at 5 41 31 pm](https://cloud.githubusercontent.com/assets/1079600/19262735/2723948c-8fe0-11e6-8438-e98e22a305cd.png)
In one screen shot above I changed the text of one block to show a much longer block title.
Although this isn't suitable as a block name, it shows that it at least will continue to fit the text.

An option could be to reduce the font size further down by 1px, then it fits even more comfortably, but that hasn't been included in this PR. 

