### PR TITLE
[5.7] Corrected page custom style property / variable name.

### DIFF
--- a/web/concrete/src/Page/CustomStyle.php
+++ b/web/concrete/src/Page/CustomStyle.php
@@ -15,9 +15,9 @@ class CustomStyle
     protected $presetHandle;
     protected $sccRecordID;
 
-    public function setThemeID($ptThemeID)
+    public function setThemeID($pThemeID)
     {
-        $this->ptThemeID = $ptThemeID;
+        $this->pThemeID = $pThemeID;
     }
 
     public function setValueListID($valueListID)


### PR DESCRIPTION
Fixes #4496 for 5.7.x.