### PR TITLE
Fix welcome page when MySQL runs in strict mode

### DIFF
--- a/concrete/src/User/Workflow/Progress/ProgressList.php
+++ b/concrete/src/User/Workflow/Progress/ProgressList.php
@@ -14,7 +14,7 @@ class ProgressList extends UserList
 
     public function __construct()
     {
-        $this->setQuery('SELECT DISTINCT u.uID, u.uName, wp.wpID FROM Users u INNER JOIN UserWorkflowProgress uwp ON uwp.uID = u.uID INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID');
+        $this->setQuery('SELECT DISTINCT u.uID, u.uName, wp.wpID, wp.wpDateLastAction, wp.wpCurrentStatus FROM Users u INNER JOIN UserWorkflowProgress uwp ON uwp.uID = u.uID INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID');
         $this->filter('wpIsCompleted', 0);
     }
 


### PR DESCRIPTION
When MySQL 5.7 runs in strict mode (that's the default), visiting `/dashboard/welcome` leads to this error:

```
Doctrine\DBAL\Exception\DriverException thrown with message
"An exception occurred while executing
'SELECT DISTINCT u.uID, u.uName, wp.wpID
FROM Users u
INNER JOIN UserWorkflowProgress uwp ON uwp.uID = u.uID
INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID 
where
1=1
and wpIsCompleted = '0'
and wpApproved = '0'
order by wpDateLastAction desc
':
SQLSTATE[HY000]: General error: 3065
Expression #1 of ORDER BY clause is not in SELECT list, references column
'wp.wpDateLastAction'
which is not in SELECT list; this is incompatible with DISTINCT"
```

...let's fix this