### PR TITLE
Add support for resolving canonical url based on passed page

### DIFF
--- a/concrete/src/Url/Resolver/PageUrlResolver.php
+++ b/concrete/src/Url/Resolver/PageUrlResolver.php
@@ -20,7 +20,10 @@ class PageUrlResolver implements UrlResolverInterface
             return $resolved;
         }
 
-        $page = array_shift($arguments);
+        if ($arguments) {
+            $page = head($arguments);
+        }
+
         if ($page && $page instanceof \Concrete\Core\Page\Page) {
 
             if ($externalUrl = $page->getCollectionPointerExternalLink()) {


### PR DESCRIPTION
With this change, the PageUrlResolver will pass the Page used to the PathUrlResolver, which will also pass the page used to the CanonicalUrlResolver. If a page is passed to the CanonicalUrlResolver, it will ignore its internal cache and resolve the url based on the page specific site config.