### PR TITLE
Avoid accessing undefined vars in CanonicalUrlResolver::resolve

### DIFF
--- a/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -47,7 +47,8 @@ class CanonicalUrlResolver implements UrlResolverInterface
      */
     public function resolve(array $arguments, $resolved = null)
     {
-
+        $config = null;
+        $page = null;
 
         // Canonical urls for pages can be different than for the entire site
         if (count($arguments) && head($arguments) instanceof Page) {


### PR DESCRIPTION
@KorvinSzanto What about installing [Warnings Log](https://github.com/mlocati/warnings_log) ? :wink: