### PR TITLE
Require canonical URL if generating RSS

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -338,6 +338,12 @@ class Controller extends BlockController
                 $e->add(t('Your RSS feed must have a valid description.'));
             }
         }
+        if ($args['rss']) {
+            $canonicalURL = $this->app->make('site')->getSite()->getSiteCanonicalURL();
+            if (!$canonicalURL) {
+                $e->add(t('In order to enable RSS you must specify the website canonical URL.'));
+            }
+        }
 
         return $e;
     }


### PR DESCRIPTION
After #4499, when generating RSS feeds without a canonical URL set, we have [this exception](https://github.com/zendframework/zend-feed/blob/release-2.7.0/src/Writer/AbstractFeed.php#L360).

Let's mitigate this problem by requiring a canonical URL when we create a RSS with the PageList block
