### PR TITLE
Center welcome picture and don't repeat it

### DIFF
--- a/concrete/elements/dashboard/welcome.php
+++ b/concrete/elements/dashboard/welcome.php
@@ -80,6 +80,8 @@ if (Config::get('concrete.white_label.background_image') !== 'none' && !Config::
     <style type="text/css">
         div.ccm-dashboard-welcome {
             background-image: url(<?=$imagePath?>);
+            background-repeat: no-repeat;
+            background-position: center center;
         }
     </style>
 <?php } ?>


### PR DESCRIPTION
usually the (great) Image Of The Day pictures have their best part in the middle: let's show it in the dashboard welcome page (and avoid repeating it).

===

Turns this:

![before](https://cloud.githubusercontent.com/assets/928116/19444477/e74d5748-9490-11e6-8ac8-9e1c8f360eed.png)

Into this:

![after](https://cloud.githubusercontent.com/assets/928116/19444486/f1ef50ca-9490-11e6-932c-4f6cce25fac7.png)
