### PR TITLE
[v5.7] Added 'ccm-edit-mode' class to HTML tag.

### DIFF
--- a/web/concrete/elements/page_controls_header.php
+++ b/web/concrete/elements/page_controls_header.php
@@ -29,8 +29,11 @@ if (!$dh->inDashboard()) {
 
 	$editMode = $c->isEditMode();
 	$tools = REL_DIR_FILES_TOOLS_REQUIRED;
+	$htmlTagClasses = 'ccm-toolbar-visible';
+
 	if ($c->isEditMode()) {
 		$startEditMode = 'new Concrete.EditMode();';
+		$htmlTagClasses .= ' ccm-edit-mode';
 	} else {
         $startEditMode = '';
     }
@@ -51,7 +54,7 @@ if (!$dh->inDashboard()) {
 
 	$js = <<<EOL
 <script type="text/javascript">$(function() {
-	$('html').addClass('ccm-toolbar-visible');
+	$('html').addClass('$htmlTagClasses');
 	ConcretePanelManager.register({'identifier': 'dashboard', 'position': 'right', url: '{$panelDashboard}'});
 	ConcretePanelManager.register({'identifier': 'page', url: '{$panelPage}'});
 	ConcretePanelManager.register({'identifier': 'sitemap', 'position': 'right', url: '{$panelSitemap}'});


### PR DESCRIPTION
As the title says, added class to HTML tag while pages are in edit mode. Fixes #4381.