### PR TITLE
Let's call the static method to create a collection from a static method

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3190,7 +3190,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         $uID = USER_SUPER_ID;
         $data['uID'] = $uID;
-        $cobj = parent::addCollection($data);
+        $cobj = parent::createCollection($data);
         $cID = $cobj->getCollectionID();
 
         // These get set to parent by default here, but they can be overridden later


### PR DESCRIPTION
The static method `Page::addStatic` should call the static [`Collection::createCollection`](https://github.com/concrete5/concrete5/blob/d44febcd8ff84c93cd7f97761c7b7451d0898d54/concrete/src/Page/Collection/Collection.php#L98) method instead of the not-static [`Collection->addCollection`](https://github.com/concrete5/concrete5/blob/d44febcd8ff84c93cd7f97761c7b7451d0898d54/concrete/src/Page/Collection/Collection.php#L88), otherwise we have this `E_DEPRECATED` warning:

```
Non-static method
Concrete\Core\Page\Collection\Collection::addCollection()
should not be called statically
```
