### PR TITLE
Form styling adjustments

### DIFF
--- a/concrete/css/build/core/app/components.less
+++ b/concrete/css/build/core/app/components.less
@@ -201,7 +201,7 @@ div.ccm-item-selector {
   color: #ffffff;
   background-color: #3f9edc;
   text-align: center;
-  font-size: 18px;
+  font-size: 15px;
   padding: 8px 12px 8px 8px;
   .transition(0.1s linear all);
 

--- a/concrete/css/build/core/app/dialog.less
+++ b/concrete/css/build/core/app/dialog.less
@@ -132,13 +132,9 @@ div.ui-dialog {
     overflow: auto;
     .border-top-radius(4px);
     box-sizing: content-box;
+    padding-top: 22px;
 
     div.form-group {
-
-      padding-left: 26px;
-      padding-right: 26px;
-      margin-left: -26px;
-      margin-right: -26px;
     }
 
     div.well {
@@ -152,10 +148,6 @@ div.ui-dialog {
 
     hr {
       border-color: #dcdcdc;
-      padding-left: 26px;
-      padding-right: 26px;
-      margin-left: -26px;
-      margin-right: -26px;
     }
 
   }

--- a/concrete/css/build/core/app/forms.less
+++ b/concrete/css/build/core/app/forms.less
@@ -1,34 +1,32 @@
 .ccm-ui {
   label.control-label {
-    font-size: 13px;
-    letter-spacing: 1px;
-    /*
-    color: #999;
-    */
+    font-size: 15px;
     color: #4290be;
     font-weight: 600;
     margin-bottom: 5px;
     display: inline-block;
-    text-transform: uppercase;
+    //text-transform: uppercase;
   }
 
   fieldset:first-of-type {
     margin-top: 0px;
   }
   fieldset {
-    margin-top: 40px;
+    margin-top: 0;
+    padding-bottom: 20px;
+    //border-bottom: 1px solid #dcdcdc;
     margin-bottom: 0px;
     position: relative; /* we need this for right aligned tooltips */
     legend {
-      font-weight: bold;
-      border: 0px;
 
+      border: 0px;
+      margin-bottom: 15px;
 
     }
   }
 
-  legend + div.form-group {
-    border-top: 1px solid #dcdcdc;
+  .form-group {
+    margin-bottom: 25px;
   }
 
   .selectize-control.single .selectize-input {
@@ -61,10 +59,6 @@
 
 div.form-group-highlight {
   background-color: #e7e7e7;
-  margin-left: -26px;
-  margin-right: -26px;
-  padding-left: 26px;
-  padding-right: 26px;
   padding-bottom: 8px;
   padding-top: 10px;
   margin-top: 8px;
@@ -89,17 +83,12 @@ div.form-group-highlight {
   }
 }
 
+
 div.form-group {
   position: relative;
-  padding-top: 30px;
-  padding-bottom: 30px;
-  margin-bottom: 0px;
-  font-size: 18px;
-  border-bottom: 1px solid #ededed;
-
-  &:last-of-type {
-    border-bottom: 0px;
-  }
+  padding-bottom: 0;
+  margin-bottom: 0;
+  font-size: 15px;
 
   .help-block {
     display: none;
@@ -181,9 +170,11 @@ div.form-group {
   input.form-control,
   textarea.form-control {
     color: #606060;
-    font-size: 18px;
-    padding: 3px 12px;
+    font-size: 15px;
+    padding: 3px 10px;
     .border-radius(2px);
+    -webkit-box-shadow: none;
+    box-shadow: none;
 
     &:focus {
       + .help-block {
@@ -195,6 +186,7 @@ div.form-group {
   .input-group {
     .input-group-addon {
       padding-right: 10px;
+      border-radius: 2px;
     }
   }
 
@@ -211,9 +203,11 @@ div.form-group {
 
 div.checkbox,
 div.radio {
+  margin-top: 0;
+
   label {
     color: #606060;
-    font-size: 18px;
+    font-size: 15px;
   }
 }
 
@@ -233,10 +227,13 @@ div.ccm-ui {
     margin-left: -26px;
     margin-right: -26px;
     margin-bottom: 0px;
+    margin-top: -16px;
+
     > li {
       margin-bottom: 0px;
       a {
-        font-size: 13px;
+        font-size: 14px;
+        font-weight: bold;
         padding: 10px 15px;
         -webkit-font-smoothing: antialiased;
       }
@@ -249,7 +246,6 @@ div.ccm-ui {
       font-size: 16px;
       position: absolute;
       bottom: -15px;
-
       left: 0px;
       width: 100%;
       color: #48b4fb;
@@ -274,7 +270,6 @@ div.ccm-ui {
       &:hover,
       &:focus {
         color: #48b4fb;
-        font-weight: bold;
         text-decoration: none;
         background-color: transparent;
         outline: none;

--- a/concrete/css/build/core/app/panels.less
+++ b/concrete/css/build/core/app/panels.less
@@ -679,19 +679,11 @@ div#ccm-panel-detail-page-location {
     background-color: #f3fbff;
 
     div.form-group-highlight {
-      margin-left: -40px;
-      margin-right: -40px;
-      padding-left: 40px;
-      padding-right: 40px;
     }
 
     div.form-group {
 
       color: #606060;
-      padding-left: 40px;
-      padding-right: 40px;
-      margin-left: -40px;
-      margin-right: -40px;
       border-bottom-color: #d1e7fc;
 
       /*
@@ -742,10 +734,6 @@ div#ccm-panel-detail-page-location {
   fieldset {
     legend {
       color: #113455;
-
-      & + div.form-group {
-        border-top-color: #b7cfe4;
-      }
     }
   }
 }

--- a/concrete/css/build/core/app/tabs.less
+++ b/concrete/css/build/core/app/tabs.less
@@ -1,1 +1,1 @@
-.ccm-tab-content { padding-top: 20px;display: none;}
+.ccm-tab-content { padding-top: 30px;display: none;}

--- a/concrete/css/build/core/file-manager.less
+++ b/concrete/css/build/core/file-manager.less
@@ -39,7 +39,7 @@ div.ccm-file-selector {
   color: #ffffff;
   background-color: #3f9edc;
   text-align: center;
-  font-size: 18px;
+  font-size: 15px;
   line-height: @line-height-base;
   .transition(0.1s linear all);
   cursor: pointer;


### PR DESCRIPTION
This is a continuation of the recent work on the form styling by MrKarlDilkington in https://github.com/concrete5/concrete5/pull/4512

What I aimed to do with these adjustments is try to balance out some of the form font sizes and margins so they're more comfortable/consistent. I referred to the install screen, common and custom blocks, the composer and a dashboard pages overall.

One small change I included is the removal of the ALL CAPS treatment of the labels. This was done as it was hard to try and work out a visual balance with the caps in place. Feedback along the way has been that the caps are harder to read, and I think things look more balanced without that treatment, but it's a trivial thing to flick back.

(as a sidenote, I recently Snipcart's dashboard itself uses lots of all caps for its form labels and I think it's a strong example of how it makes things harder to read and use)

The other aspect that I simply couldn't get to work were the field divider lines. I did try some different options, but they just don't add anything but clutter and unnecessary large spacings between fields. I think for these to work in the future they'd have to be specifically added via a class (or horizontal rules), not just applied to every field. I just couldn't get things to look balanced and clear with them in place.

My thinking is that these changes are easier to work from from this point onwards, as they're really just less of a jump from 5.7. 

So here's a bunch of before and after screenshots:
![screen shot 2016-10-19 at 8 31 23 pm](https://cloud.githubusercontent.com/assets/1079600/19515362/a0e7eaf2-963e-11e6-84ee-63e8e4a8ebe9.png)
![screen shot 2016-10-19 at 8 30 03 pm](https://cloud.githubusercontent.com/assets/1079600/19515366/a84ee12e-963e-11e6-9ba9-c247020e9edf.png)
-----
![screen shot 2016-10-19 at 8 32 17 pm](https://cloud.githubusercontent.com/assets/1079600/19515380/bae1cee6-963e-11e6-86ab-ec53b4d67243.png)
![screen shot 2016-10-19 at 8 27 56 pm](https://cloud.githubusercontent.com/assets/1079600/19515385/bf868b80-963e-11e6-9b07-55b9a67a0f4a.png)
-----
![screen shot 2016-10-19 at 8 34 09 pm](https://cloud.githubusercontent.com/assets/1079600/19515399/cd97a614-963e-11e6-8a2a-ceb76c3a7b66.png)
![screen shot 2016-10-19 at 8 27 24 pm](https://cloud.githubusercontent.com/assets/1079600/19515406/d1acd9a4-963e-11e6-8441-c9042b65debb.png)
-----
![screen shot 2016-10-19 at 8 33 17 pm](https://cloud.githubusercontent.com/assets/1079600/19515431/ed5c0e72-963e-11e6-937f-cab73f363aa0.png)
![screen shot 2016-10-19 at 8 28 34 pm](https://cloud.githubusercontent.com/assets/1079600/19515434/efae72b4-963e-11e6-8936-83632b3c8d7a.png)
-----
![screen shot 2016-10-19 at 8 33 01 pm](https://cloud.githubusercontent.com/assets/1079600/19515490/4a6f9d54-963f-11e6-8000-bf34ecf04e78.png)
![screen shot 2016-10-19 at 8 29 05 pm](https://cloud.githubusercontent.com/assets/1079600/19515495/5442c1e4-963f-11e6-9a9e-b02ad36264db.png)
-----
![screen shot 2016-10-19 at 8 34 24 pm](https://cloud.githubusercontent.com/assets/1079600/19515511/6876ff86-963f-11e6-8186-7da8104d9554.png)
![screen shot 2016-10-19 at 8 27 03 pm](https://cloud.githubusercontent.com/assets/1079600/19515517/6ca0685e-963f-11e6-9fb2-210ac6326447.png)
-----
![screen shot 2016-10-19 at 8 32 44 pm](https://cloud.githubusercontent.com/assets/1079600/19515537/75b5ba0c-963f-11e6-95b6-27332abb39b6.png)
![screen shot 2016-10-19 at 8 29 31 pm](https://cloud.githubusercontent.com/assets/1079600/19515552/80483a4e-963f-11e6-9c91-a2e1468c01e0.png)








