### PR TITLE
[5.7] don't try to create thumbnails of a directory

### DIFF
--- a/web/concrete/src/File/Image/BasicThumbnailer.php
+++ b/web/concrete/src/File/Image/BasicThumbnailer.php
@@ -107,7 +107,7 @@ class BasicThumbnailer
         $src = REL_DIR_FILES_CACHE . '/' . $filename;
         $abspath = Config::get('concrete.cache.directory') . '/' . $filename;
         $thumb = new \stdClass;
-        if (isset($abspath) && file_exists($abspath) && is_file($abspath)) {
+        if (isset($abspath) && is_file($abspath)) {
             $thumb->src = $src;
             $dimensions = getimagesize($abspath);
             $thumb->width = $dimensions[0];

--- a/web/concrete/src/File/Image/BasicThumbnailer.php
+++ b/web/concrete/src/File/Image/BasicThumbnailer.php
@@ -107,7 +107,7 @@ class BasicThumbnailer
         $src = REL_DIR_FILES_CACHE . '/' . $filename;
         $abspath = Config::get('concrete.cache.directory') . '/' . $filename;
         $thumb = new \stdClass;
-        if (isset($abspath) && file_exists($abspath)) {
+        if (isset($abspath) && file_exists($abspath) && is_file($abspath)) {
             $thumb->src = $src;
             $dimensions = getimagesize($abspath);
             $thumb->width = $dimensions[0];


### PR DESCRIPTION
`file_exists` returns true for a directory too, should probably check for `is_file`, otherwise `getimagesize` will throw an exception if things went wrong on the disk. I'd rather have no picture but still see the page.