### PR TITLE
Fix shown memory sizes

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -260,6 +260,10 @@ class Install extends Controller
         $rp = $rf->getProperty('docCommentCanary');
         $this->set('docCommentTest', (bool) $rp->getDocComment());
 
+        $memoryThresoldMin = 24 * 1024 * 1024;
+        $memoryThresold = 64 * 1024 * 1024;
+        $this->set('memoryThresoldMin', $memoryThresoldMin);
+        $this->set('memoryThresold', $memoryThresold);
         $memoryLimit = ini_get('memory_limit');
         if ($memoryLimit == -1) {
             $this->set('memoryTest', 1);
@@ -267,9 +271,9 @@ class Install extends Controller
         } else {
             $val = $this->app->make('helper/number')->getBytes($memoryLimit);
             $this->set('memoryBytes', $val);
-            if ($val < 25165824) {
+            if ($val < $memoryThresoldMin) {
                 $this->set('memoryTest', -1);
-            } elseif ($val >= 67108864) {
+            } elseif ($val >= $memoryThresold) {
                 $this->set('memoryTest', 1);
             } else {
                 $this->set('memoryTest', 0);

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -838,8 +838,10 @@ if (isset($successMessage)) {
                                 if ($memoryTest === -1) {
                                     ?>
                                     <span class="text-danger">
-                        <?= t('concrete5 will not install with less than 24MB of RAM. Your memory limit is currently %sMB. Please increase your memory_limit using ini_set.',
-                            round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2)) ?>
+                        <?= t('concrete5 will not install with less than %1$s of RAM. Your memory limit is currently %2$s. Please increase your memory_limit using ini_set.',
+                            Core::make('helper/number')->formatSize($memoryThresoldMin),
+                            Core::make('helper/number')->formatSize($memoryBytes)
+                        ) ?>
                     </span>
                                     <?php
                                 }
@@ -848,8 +850,10 @@ if (isset($successMessage)) {
                                 if ($memoryTest === 0) {
                                     ?>
                                     <span class="text-warning">
-                        <?= t('concrete5 runs best with at least 64MB of RAM. Your memory limit is currently %sMB. You may experience problems uploading and resizing large images, and may have to install concrete5 without sample content.',
-                            round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2)) ?>
+                        <?= t('concrete5 runs best with at least %1$s of RAM. Your memory limit is currently %2$s. You may experience problems uploading and resizing large images, and may have to install concrete5 without sample content.',
+                            Core::make('helper/number')->formatSize($memoryThresold),
+                            Core::make('helper/number')->formatSize($memoryBytes)
+                        ) ?>
                     </span>
                                     <?php
                                 }
@@ -858,8 +862,8 @@ if (isset($successMessage)) {
                                 if ($memoryTest === 1) {
                                     ?>
                                     <span class="text-success">
-                        <?= t('Memory limit %sMB.',
-                            round(Core::make('helper/number')->formatSize($memoryBytes, 'MB'), 2)) ?>
+                        <?= t('Memory limit %s.',
+                            Core::make('helper/number')->formatSize($memoryBytes)) ?>
                     </span>
                                     <?php
                                 }


### PR DESCRIPTION
The result of `Core::make('helper/number')->formatSize` already contains the size unit.

Turn this:

![before](https://cloud.githubusercontent.com/assets/928116/19592481/45f35052-977c-11e6-9d2a-b6da78046ea2.png)

Into this:

![after](https://cloud.githubusercontent.com/assets/928116/19592483/4b13954c-977c-11e6-8d49-b14d3450ff48.png)
