### PR TITLE
Allow /ccm/assets/localization/* URLs in install page

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -380,8 +380,11 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
     private function checkInstall(Application $app, Request $request)
     {
         if (!$app->isInstalled()) {
-            if (!$request->matches('/install/*') &&
-                $request->getPath() != '/install') {
+            if (
+                !$request->matches('/install/*')
+                && $request->getPath() != '/install'
+                && !$request->matches('/ccm/assets/localization/*')
+            ) {
                 $manager = $app->make('Concrete\Core\Url\Resolver\Manager\ResolverManager');
                 $response = new RedirectResponse($manager->resolve(array('install')));
 


### PR DESCRIPTION
Assets localization is required because we now include the core/app asset group in the install page