### PR TITLE
Always check if there's some multilingual section

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -10,8 +10,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Detector
 {
-    protected static $enabled;
-
     /**
      * Returns the preferred section based on session, cookie,
      * user object, default browser (if allowed), and finally
@@ -107,18 +105,22 @@ class Detector
         }
     }
 
+    /**
+     * Check if there's some multilingual section.
+     *
+     * @return bool
+     */
     public static function isEnabled()
     {
-        if (!isset(self::$enabled)) {
-            $app = Facade::getFacadeApplication();
-            if (!$app->isInstalled()) {
-                return false;
+        $result = false;
+        $app = Facade::getFacadeApplication();
+        if ($app->isInstalled()) {
+            $db = $app->make('database')->connection();
+            if ($db->executeQuery('select cID from MultilingualSections limit 1')->fetchColumn()) {
+                $result = true;
             }
-            $db = $app->make('database')->getEntityManager();
-            $sections = $db->getRepository('Concrete\Core\Entity\Multilingual\Section')->findAll();
-            self::$enabled = count($sections) > 0;
         }
 
-        return self::$enabled;
+        return $result;
     }
 }


### PR DESCRIPTION
Caching the "is there some multilingua section?" value may lead to problems if in the same request/execution we create a multilingual section and we need its value.

So, let's calculate it every time, but let's use a very fast query (no ORM hydration, no multiple records, let's just read a single database value).