### PR TITLE
[5.7] use original value in select value translations

### DIFF
--- a/web/concrete/attributes/select/option.php
+++ b/web/concrete/attributes/select/option.php
@@ -113,7 +113,7 @@ class Option extends Object {
         $r = $db->Execute('select ID from atSelectOptions order by ID asc');
         while ($row = $r->FetchRow()) {
             $opt = static::getByID($row['ID']);
-            $translations->insert('SelectAttributeValue', $opt->getSelectAttributeOptionValue());
+            $translations->insert('SelectAttributeValue', $opt->getSelectAttributeOptionValue(false));
         }
         return $translations;
     }


### PR DESCRIPTION
having a value like `R&D` causes the PO file to get messed up. It will be saved as `R&amp;D` and is thus not translatable.
