### PR TITLE
[v8] remove unused parameter

### DIFF
--- a/concrete/src/Entity/Attribute/Value/Value/SelectValueOption.php
+++ b/concrete/src/Entity/Attribute/Value/Value/SelectValueOption.php
@@ -128,7 +128,7 @@ class SelectValueOption
 
     public function getSelectAttributeOptionDisplayValue($format = 'html')
     {
-        $value = tc('SelectAttributeValue', $this->getSelectAttributeOptionValue(false));
+        $value = tc('SelectAttributeValue', $this->getSelectAttributeOptionValue());
         switch ($format) {
             case 'html':
                 return h($value);


### PR DESCRIPTION
I was trying to figure out if that bug https://github.com/concrete5/concrete5/pull/4573 can be found in 5.8 too and saw this parameter which I think isn't necessary.
