### PR TITLE
Make tests conform to cID changes

### DIFF
--- a/tests/tests/Core/Routing/URLTest.php
+++ b/tests/tests/Core/Routing/URLTest.php
@@ -302,7 +302,7 @@ class URLTest extends PHPUnit_Framework_TestCase
         $home->siteTree = new \Concrete\Core\Entity\Site\SiteTree();
 
         $url = \URL::to($home);
-        $this->assertEquals('http://www.dummyco.com/path/to/server/index.php', (string) $url);
+        $this->assertEquals('http://www.dummyco.com/path/to/server/index.php?cID='.$home->cID, (string) $url);
 
         $url = \URL::to('/');
         $this->assertEquals('http://www.dummyco.com/path/to/server/index.php', (string) $url);

--- a/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
+++ b/tests/tests/Core/Url/Resolver/PageUrlResolverTest.php
@@ -34,14 +34,14 @@ class PageUrlResolverTest extends ResolverTestCase
             ->willReturn(HOME_CID);
 
         $this->assertEquals(
-            (string) $this->canonicalUrlWithPath('/'),
+            (string) $this->canonicalUrlWithPath('/')->setQuery('cID='.HOME_CID),
             (string) $this->urlResolver->resolve([$page]));
     }
 
     public function testUnapproved()
     {
         $page = $this->createMockFromClass('\Concrete\Core\Page\Page');
-        $page->expects($this->exactly(2))
+        $page->expects($this->once())
             ->method('getCollectionID')
             ->willReturn(1337);
 


### PR DESCRIPTION
Due to recent edits in the way cID variables were added, these tests needed revising.
