### PR TITLE
Fix to match select2 padding, font sizes to other form elements

### DIFF
--- a/concrete/css/build/core/app/flatten.less
+++ b/concrete/css/build/core/app/flatten.less
@@ -27,18 +27,18 @@
 
   .select2-container-multi {
     .select2-choices {
-      border-radius: 4px;
+      border-radius: 2px;
       background-color: white;
       background-image: none;
       border: 1px solid #ccc;
-      padding: 4px 4px 0 4px;
-      min-height: 34px;
+      padding: 7px 16px 4px 8px;
+      min-height: 40px;
 
       .select2-search-choice {
         margin: 0 3px 3px 0;
         background: none;
         padding: 5px 5px 4px 18px;
-        font-size: 14px;
+        font-size: 16px;
         box-shadow: none;
         -webkit-box-shadow: none;
         color: #555;
@@ -53,7 +53,7 @@
         input {
           padding: 0;
           padding-left: 8px;
-          font-size: 14px;
+          font-size: 16px;
           color: #555;
         }
       }


### PR DESCRIPTION
This updates the select2 appearance to have border radius, font size and padding/height matching other form elements.
(previous work wasn't compiling bootstrap)
