### PR TITLE
Fix installation and CONCRETE5_ENV

### DIFF
--- a/concrete/src/Foundation/EnvironmentDetector.php
+++ b/concrete/src/Foundation/EnvironmentDetector.php
@@ -23,8 +23,8 @@ class EnvironmentDetector
      */
     public function detect($environments, $consoleArgs = null)
     {
-        if ($consoleArgs) {
-            return $this->detectConsoleEnvironment($environments, $consoleArgs);
+        if ($consoleArgs && $env = $this->detectConsoleEnvironment($environments, $consoleArgs)) {
+            return $env;
         } elseif ($env = $this->detectClosureEnvironment($environments)) {
             return $env;
         } elseif ($env = $this->detectVariableEnvironment($environments)) {
@@ -71,8 +71,6 @@ class EnvironmentDetector
         // will check the environment as a "web" request like a typical HTTP request.
         if (!is_null($value = $this->getEnvironmentArgument($args))) {
             return head(array_slice(explode('=', $value), 1));
-        } else {
-            return $this->detectVariableEnvironment($environments);
         }
     }
 

--- a/concrete/src/Foundation/EnvironmentDetector.php
+++ b/concrete/src/Foundation/EnvironmentDetector.php
@@ -25,9 +25,12 @@ class EnvironmentDetector
     {
         if ($consoleArgs) {
             return $this->detectConsoleEnvironment($environments, $consoleArgs);
-        } else {
-            return $this->detectVariableEnvironment($environments);
+        } elseif ($env = $this->detectClosureEnvironment($environments)) {
+            return $env;
+        } elseif ($env = $this->detectVariableEnvironment($environments)) {
+            return $env;
         }
+        return $this->detectWebEnvironment($environments);
     }
 
     /**
@@ -39,13 +42,6 @@ class EnvironmentDetector
      */
     protected function detectWebEnvironment($environments)
     {
-        // If the given environment is just a Closure, we will defer the environment check
-        // to the Closure the developer has provided, which allows them to totally swap
-        // the webs environment detection logic with their own custom Closure's code.
-        if ($environments instanceof Closure) {
-            return call_user_func($environments);
-        }
-
         foreach ($environments as $environment => $hosts) {
             // To determine the current environment, we'll simply iterate through the possible
             // environments and look for the host that matches the host for this request we
@@ -85,14 +81,30 @@ class EnvironmentDetector
      *
      * @param mixed $environments
      *
-     * @return string
+     * @return string|null
      */
     protected function detectVariableEnvironment($environments)
     {
         if (($env = $this->getEnvironmentFromVariable()) !== false) {
             return $env;
-        } else {
-            return $this->detectWebEnvironment($environments);
+        }
+    }
+
+    /**
+     * Set the application environment from the passed closure in case a closure
+     * was passed.
+     *
+     * @param mixed $environments
+     *
+     * @return string|null
+     */
+    protected function detectClosureEnvironment($environments)
+    {
+        // If the given environment is just a Closure, we will defer the environment check
+        // to the Closure the developer has provided, which allows them to totally swap
+        // the webs environment detection logic with their own custom Closure's code.
+        if ($environments instanceof Closure) {
+            return call_user_func($environments);
         }
     }
 
@@ -112,7 +124,7 @@ class EnvironmentDetector
 
     /**
      * Gets the environment from the CONCRETE5_ENV environment variable.
-     * 
+     *
      * @return string|bool
      */
     protected function getEnvironmentFromVariable()


### PR DESCRIPTION
This fixes installation in case CONCRETE5_ENV has been defined. Currently the installation screen throws an exception in this case.

I also refactored the detection code a little bit to make it more easily understandable (check the commit).