### PR TITLE
Add back request based urls to the canonical url resolver

### DIFF
--- a/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -112,6 +112,15 @@ class CanonicalUrlResolver implements UrlResolverInterface
             elseif (intval($canonical->getPort()->get()) > 0) {
                 $url = $url->setPort($canonical->getPort());
             }
+        } else {
+            // This fallthrough is dangerous. Make sure that you define your canonical URL so that we don't have to guess!
+            $host = $this->request->getHost();
+            $scheme = $this->request->getScheme();
+            if ($scheme && $host) {
+                $url = $url->setScheme($scheme)
+                    ->setHost($host)
+                    ->setPort($this->request->getPort());
+            }
         }
 
         if ($relative_path = $this->app['app_relative_path']) {


### PR DESCRIPTION
See discussion in #4564 

Before I forget to do this, I am adding back request based urls to the canonical url resolver so that we don't set an example of returning just paths from the url resolver stack. 

I want to go on the record here and say that I don't really think we should actually merge this since the release candidate has been released now but I think it's important enough that we can make the decision in this pull request.

I'd like to revisit this stuff in 8.1 and make it so that we have actually stacked resolver stack. Today the Page and Path url resolvers require references to other url resolvers which is cool and all but it's super confusing. Instead they should be stacked so that the path url resolver only handles passed paths while the page url resolver only handles passed pages. They should be applying changes to the resolved value instead of simply returning it if passed.

