### PR TITLE
Make it so that the sitemap doesnt jump on first click

### DIFF
--- a/concrete/js/build/core/sitemap/sitemap.js
+++ b/concrete/js/build/core/sitemap/sitemap.js
@@ -138,6 +138,8 @@
 			my.$element.append(_sitemap);
 			my.$sitemap = my.$element.find('div.ccm-sitemap-tree');
     		$(my.$sitemap).fancytree({
+				tabindex: null,
+				titlesTabbable: false,
 				extensions: extensions,
 				glyph: {
 					map: {


### PR DESCRIPTION
This fixes that annoying sitemap jump. Turns out it's caused by jquery ui. https://github.com/mar10/fancytree/issues/577