### PR TITLE
Fix local cache issue with share_this_page block

### DIFF
--- a/concrete/blocks/share_this_page/controller.php
+++ b/concrete/blocks/share_this_page/controller.php
@@ -59,7 +59,7 @@ class Controller extends BlockController
 
     protected function getSelectedServices()
     {
-        $links = array();
+        $this->services = array();
         $db = Database::get();
         $services = $db->GetCol('select service from btShareThisPage where bID = ? order by displayOrder asc',
             array($this->bID)


### PR DESCRIPTION
The share_this_page block used to push the services multiple times to the local "cache" array in case `getSelectedServices()` was called multiple times.

This fixes the issue by setting the local cache empty every time the `getSelectedServices()` method gets called.

To reproduce:

```php
$bc->export($xmlNode);
$bc->export($otherXmlNode);
```

After these calls, the social links appear twice in the XML generated from `$otherXmlNode`.