### PR TITLE
Fix for failed cached thumbnails

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1299,6 +1299,7 @@ return array(
             'class' => \Concrete\Core\Http\Middleware\ApplicationMiddleware::class
         ],
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
-        'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class
+        'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
+        'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class
     ]
 );

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -4348,6 +4348,9 @@
     <field name="path" type="text">
       <notnull/>
     </field>
+    <field name="isBuilt" type="boolean">
+      <notnull/>
+    </field>
 
     <index name="thumbnailPathID">
       <unique/>

--- a/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -4,11 +4,11 @@ namespace Concrete\Core\File\Image\Thumbnail\Path;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\File\File;
+use Concrete\Core\Entity\File\Version;
 use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailVersion;
 use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
 use Concrete\Core\File\StorageLocation\Configuration\DeferredConfigurationInterface;
-use Concrete\Core\File\StorageLocation\StorageLocation;
-use Concrete\Core\Entity\File\Version;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
 
 class Resolver
 {
@@ -48,6 +48,7 @@ class Resolver
         $version_id = $file_version->getFileVersionID();
         $storage_location_id = $storage_location->getID();
         $thumbnail_handle = $thumbnail->getHandle();
+        $realPath = null;
 
         $path = $this->getStoredPath(
             $file_id,
@@ -55,21 +56,24 @@ class Resolver
             $storage_location_id,
             $thumbnail_handle);
 
-        if ($path) {
-            if ($configuration instanceof DeferredConfigurationInterface) {
-                return $configuration->getPublicURLToFile($path);
+        if (!$path) {
+            if ($path = $this->determinePath($file_version, $thumbnail, $storage_location, $configuration)) {
+                $realPath = $this->getBuiltPath($path, $file_version, $thumbnail, $storage_location, $configuration);
+                $this->storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle, $realPath == $path);
             }
-
-            return $path;
-        } elseif ($path = $this->determinePath($file_version, $thumbnail, $storage_location, $configuration)) {
-            $this->storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle);
-
-            if ($configuration instanceof DeferredConfigurationInterface) {
-                return $configuration->getPublicURLToFile($path);
-            }
-
-            return $path;
         }
+
+        if (!$realPath) {
+            $realPath = $this->getBuiltPath($path, $file_version, $thumbnail, $storage_location, $configuration);
+        }
+
+        if ($path == $realPath) {
+            if ($configuration instanceof DeferredConfigurationInterface) {
+                return $configuration->getPublicURLToFile($path);
+            }
+        }
+
+        return $realPath;
     }
 
     /**
@@ -110,15 +114,20 @@ class Resolver
      * @param $storage_location_id
      * @param $thumbnail_handle
      */
-    protected function storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle)
+    protected function storePath($path, $file_id, $version_id, $storage_location_id, $thumbnail_handle, $isBuilt = true)
     {
-        $this->connection->insert('FileImageThumbnailPaths', array(
-            'path' => $path,
-            'fileID' => $file_id,
-            'fileVersionID' => $version_id,
-            'storageLocationID' => $storage_location_id,
-            'thumbnailTypeHandle' => $thumbnail_handle
-        ));
+        try {
+            $this->connection->insert('FileImageThumbnailPaths', array(
+                'path' => $path,
+                'fileID' => $file_id,
+                'fileVersionID' => $version_id,
+                'storageLocationID' => $storage_location_id,
+                'thumbnailTypeHandle' => $thumbnail_handle,
+                'isBuilt' => $isBuilt
+            ));
+        } catch (InvalidFieldNameException $e) {
+            // User needs to run the database upgrade routine
+        }
     }
 
     /**
@@ -136,18 +145,23 @@ class Resolver
         \Concrete\Core\Entity\File\StorageLocation\StorageLocation $storage,
         ConfigurationInterface $configuration
     ) {
-        $fss = $storage->getFileSystemObject();
         $path = $thumbnail->getFilePath($file_version);
 
-        if ($fss->has($path)) {
-            if ($configuration instanceof DeferredConfigurationInterface) {
-                return $path;
-            }
-
-            return $configuration->getPublicURLToFile($path);
+        if ($configuration instanceof DeferredConfigurationInterface) {
+            return $path;
         }
 
-        return $this->getDefaultPath($file_version, $thumbnail, $storage, $configuration);
+        return $configuration->getPublicURLToFile($path);
+    }
+
+    protected function getBuiltPath(
+        $path,
+        Version $file_version,
+        ThumbnailVersion $thumbnail,
+        \Concrete\Core\Entity\File\StorageLocation\StorageLocation $storage,
+        ConfigurationInterface $configuration
+    ) {
+        return $path;
     }
 
     /**

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Concrete\Core\File\Image\Thumbnail;
+
+
+use Concrete\Core\File\StorageLocation\StorageLocationInterface;
+use Imagine\Image\ImagineInterface;
+
+/**
+ * Interface ThumbnailerInterface
+ * An interface for classes tasked with creating thumbnails. This interace requires imagine
+ * @package Concrete\Core\File\Image\Thumbnail
+ */
+interface ThumbnailerInterface
+{
+
+    /**
+     * Set the storage location to use. Note that the $savePath is going to be relative to this location
+     * @param \Concrete\Core\File\StorageLocation\StorageLocationInterface $location
+     * @return self
+     */
+    public function setStorageLocation(StorageLocationInterface $location);
+
+    /**
+     * Create a thumbnail given an image (or a path to an image)
+     *
+     * @param ImagineInterface|string $image
+     * @param string $savePath The path to save the thumbnail to
+     * @param int $width
+     * @param int $height
+     * @param bool $fit Fit to bounds
+     * @return void
+     */
+    public function create($image, $savePath, $width, $height, $fit = false);
+
+}

--- a/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
+++ b/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Concrete\Core\File\Image\Thumbnail\Type;
+
+use Concrete\Core\Entity\File\Version;
+use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailVersion;
+
+class CustomThumbnail extends ThumbnailVersion
+{
+
+    protected $path;
+
+    /**
+     * CustomThumbnail constructor.
+     * @param int $width
+     * @param int $height
+     * @param string $path The full path to the file (whether it exists or not)
+     */
+    public function __construct($width, $height, $path, $cropped)
+    {
+        $width = intval($width);
+        $height = intval($height);
+        $cropped = intval($cropped);
+        $this->path = $path;
+        parent::__construct(REL_DIR_FILES_CACHE, "ccm_{$width}x{$height}_{$cropped}", 'Custom', $width, $height);
+    }
+
+    public function getFilePath(Version $fv)
+    {
+        return $this->path;
+    }
+
+}

--- a/concrete/src/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/File/StorageLocation/StorageLocation.php
@@ -2,34 +2,42 @@
 namespace Concrete\Core\File\StorageLocation;
 
 use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
+use Concrete\Core\Support\Facade\Application;
 use Database;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Class StorageLocation
+ * @deprecated Functionality moved to StorageLocationFactory
+ * @package Concrete\Core\File\StorageLocation
+ */
 class StorageLocation
 {
 
+    /**
+     * @deprecated use:
+     *     $location = $storageLocationFactory->create($configuration, $fslName);
+     *     $storageLocationFactory->persist($location);
+     *
+     * @param \Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface $configuration
+     * @param string $fslName
+     * @param bool $fslIsDefault
+     * @return \Concrete\Core\Entity\File\StorageLocation\StorageLocation
+     */
     public static function add(ConfigurationInterface $configuration, $fslName, $fslIsDefault = false)
     {
-        $default = self::getDefault();
+        $app = Application::getFacadeApplication();
+        /** @var StorageLocationFactory $factory */
+        $factory = $app[StorageLocationFactory::class];
 
-        $em = \ORM::entityManager();
-        $o = new \Concrete\Core\Entity\File\StorageLocation\StorageLocation();
-        $o->setName($fslName);
-        $o->setIsDefault($fslIsDefault);
-        $o->setConfigurationObject($configuration);
-        $em->persist($o);
+        $location = $factory->create($configuration, $fslName, $fslIsDefault);
+        $location->setIsDefault($fslIsDefault);
 
-        if ($fslIsDefault && is_object($default)) {
-            $default->setIsDefault(false);
-            $em->persist($default);
-        }
-
-        $em->flush();
-
-        return $o;
+        return $factory->persist($location);
     }
 
     /**
+     * @deprecated use FileStorageFactory::fetchByID()
      * @param int $id
      * @return null|StorageLocation
      * @throws \Doctrine\ORM\ORMException
@@ -38,34 +46,28 @@ class StorageLocation
      */
     public static function getByID($id)
     {
-        $em = \ORM::entityManager();
-        $r = $em->find('\Concrete\Core\Entity\File\StorageLocation\StorageLocation', intval($id));
-
-        return $r;
+        $app = Application::getFacadeApplication();
+        return $app[StorageLocationFactory::class]->fetchByID($id);
     }
 
     /**
+     * @deprecated use FileStorageFactory::fetchList()
      * @return StorageLocation[]
      */
     public static function getList()
     {
-        $em = \ORM::entityManager();
-        return $em->getRepository('\Concrete\Core\Entity\File\StorageLocation\StorageLocation')->findBy(
-            array(), array('fslID' => 'asc')
-        );
+        $app = Application::getFacadeApplication();
+        return $app[StorageLocationFactory::class]->fetchList();
     }
 
     /**
+     * @deprecated use StorageLocationFactory::fetchDefault()
      * @return StorageLocation
      */
     public static function getDefault()
     {
-        $em = \ORM::entityManager();
-        $location = $em->getRepository('\Concrete\Core\Entity\File\StorageLocation\StorageLocation')->findOneBy(
-            array('fslIsDefault' => true,
-            ));
-
-        return $location;
+        $app = Application::getFacadeApplication();
+        return $app[StorageLocationFactory::class]->fetchDefault();
     }
 
 

--- a/concrete/src/File/StorageLocation/StorageLocationFactory.php
+++ b/concrete/src/File/StorageLocation/StorageLocationFactory.php
@@ -3,7 +3,7 @@
 namespace Concrete\Core\File\StorageLocation;
 
 use Concrete\Core\Database\DatabaseManagerORM;
-use Concrete\Core\Entity\File\StorageLocation\StorageLocation;
+use Concrete\Core\Entity\File\StorageLocation\StorageLocation as StorageLocationEntity;
 use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -27,11 +27,11 @@ class StorageLocationFactory
      * Create a new StorageLocation, pass this to StorageLocationFactory->persist() to store this location
      * @param \Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface $configuration
      * @param $name
-     * @return StorageLocation
+     * @return StorageLocationEntity
      */
     public function create(ConfigurationInterface $configuration, $name)
     {
-        $location = new StorageLocation();
+        $location = new StorageLocationEntity();
         $location->setConfigurationObject($configuration);
         $location->setName($name);
 
@@ -40,13 +40,13 @@ class StorageLocationFactory
 
     /**
      * Store a created storage location to the database
-     * @param StorageLocation $storageLocation
-     * @return StorageLocation The persisted location, may not be the same as the passed in object
+     * @param StorageLocationEntity $storageLocation
+     * @return StorageLocationEntity The persisted location, may not be the same as the passed in object
      */
-    public function persist(StorageLocation $storageLocation)
+    public function persist(StorageLocationEntity $storageLocation)
     {
         return $this->entityManager->transactional(function (EntityManagerInterface $em) use ($storageLocation) {
-            $em->createQueryBuilder()->update(StorageLocation::class, 'l')->set('fslIsDefault', false);
+            $em->createQueryBuilder()->update(StorageLocationEntity::class, 'l')->set('fslIsDefault', false);
             $em->persist($storageLocation);
 
             return $storageLocation;
@@ -56,46 +56,46 @@ class StorageLocationFactory
     /**
      * Fetch a storage location by its ID
      * @param int $id
-     * @return null|StorageLocation
+     * @return null|StorageLocationEntity
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      * @throws \Doctrine\ORM\TransactionRequiredException
      */
     public function fetchByID($id)
     {
-        return $this->entityManager->find(StorageLocation::class, (int)$id);
+        return $this->entityManager->find(StorageLocationEntity::class, (int)$id);
     }
 
     /**
      * Fetch a storage location by its name
      * @param string $name
-     * @return null|StorageLocation
+     * @return null|StorageLocationEntity
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      * @throws \Doctrine\ORM\TransactionRequiredException
      */
     public function fetchByName($name)
     {
-        return $this->entityManager->getRepository(StorageLocation::class, 'l')->findBy(['fslName' => $name]);
+        return $this->entityManager->getRepository(StorageLocationEntity::class, 'l')->findBy(['fslName' => $name]);
     }
 
     /**
      * Fetch a list of storage locations
-     * @return StorageLocation[]
+     * @return StorageLocationEntity[]
      */
     public function fetchList()
     {
-        $repository = $this->entityManager->getRepository(StorageLocation::class);
+        $repository = $this->entityManager->getRepository(StorageLocationEntity::class);
         return $repository->findBy([], ['fslID' => 'asc']);
     }
 
     /**
      * Fetch the default storage location
-     * @return StorageLocation
+     * @return StorageLocationEntity
      */
     public function fetchDefault()
     {
-        $repository = $this->entityManager->getRepository(StorageLocation::class);
+        $repository = $this->entityManager->getRepository(StorageLocationEntity::class);
         return $repository->findOneBy([
             'fslIsDefault' => true
         ]);

--- a/concrete/src/File/StorageLocation/StorageLocationFactory.php
+++ b/concrete/src/File/StorageLocation/StorageLocationFactory.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Concrete\Core\File\StorageLocation;
+
+use Concrete\Core\Database\DatabaseManagerORM;
+use Concrete\Core\Entity\File\StorageLocation\StorageLocation;
+use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Class StorageLocationFactory
+ * Get ahold of existing storage locations and create new ones
+ * @package Concrete\Core\File\StorageLocation
+ */
+class StorageLocationFactory
+{
+
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    public function __construct(DatabaseManagerORM $manager)
+    {
+        $this->entityManager = $manager->entityManager();
+    }
+
+    /**
+     * Create a new StorageLocation, pass this to StorageLocationFactory->persist() to store this location
+     * @param \Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface $configuration
+     * @param $name
+     * @return StorageLocation
+     */
+    public function create(ConfigurationInterface $configuration, $name)
+    {
+        $location = new StorageLocation();
+        $location->setConfigurationObject($configuration);
+        $location->setName($name);
+
+        return $location;
+    }
+
+    /**
+     * Store a created storage location to the database
+     * @param StorageLocation $storageLocation
+     * @return StorageLocation The persisted location, may not be the same as the passed in object
+     */
+    public function persist(StorageLocation $storageLocation)
+    {
+        return $this->entityManager->transactional(function (EntityManagerInterface $em) use ($storageLocation) {
+            $em->createQueryBuilder()->update(StorageLocation::class, 'l')->set('fslIsDefault', false);
+            $em->persist($storageLocation);
+
+            return $storageLocation;
+        });
+    }
+
+    /**
+     * Fetch a storage location by its ID
+     * @param int $id
+     * @return null|StorageLocation
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     */
+    public function fetchByID($id)
+    {
+        return $this->entityManager->find(StorageLocation::class, (int)$id);
+    }
+
+    /**
+     * Fetch a storage location by its name
+     * @param string $name
+     * @return null|StorageLocation
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     */
+    public function fetchByName($name)
+    {
+        return $this->entityManager->getRepository(StorageLocation::class, 'l')->findBy(['fslName' => $name]);
+    }
+
+    /**
+     * Fetch a list of storage locations
+     * @return StorageLocation[]
+     */
+    public function fetchList()
+    {
+        $repository = $this->entityManager->getRepository(StorageLocation::class);
+        return $repository->findBy([], ['fslID' => 'asc']);
+    }
+
+    /**
+     * Fetch the default storage location
+     * @return StorageLocation
+     */
+    public function fetchDefault()
+    {
+        $repository = $this->entityManager->getRepository(StorageLocation::class);
+        return $repository->findOneBy([
+            'fslIsDefault' => true
+        ]);
+    }
+
+}

--- a/concrete/src/Foundation/Runtime/DefaultRuntime.php
+++ b/concrete/src/Foundation/Runtime/DefaultRuntime.php
@@ -12,7 +12,7 @@ class DefaultRuntime implements RuntimeInterface, ApplicationAwareInterface
     const STATUS_INACTIVE = 0;
     const STATUS_ACTIVE = 1;
     const STATUS_ENDED = 2;
-    
+
     use ApplicationAwareTrait;
 
     /** @var string */

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -36,7 +36,6 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
         $app = $this->app;
 
         include DIR_APPLICATION . '/bootstrap/app.php';
-
         if ($this->app->isInstalled()) {
             /*
              * ----------------------------------------------------------------------------

--- a/concrete/src/Http/Middleware/ThumbnailMiddleware.php
+++ b/concrete/src/Http/Middleware/ThumbnailMiddleware.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Concrete\Core\Http\Middleware;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\File\Image\BasicThumbnailer;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class ThumbnailMiddleware
+ * Middleware used to populate thumbnails at the end of each request
+ *
+ * This middleware requires the following to be defined on the Application:
+ * "database" DatabaseManager
+ * "BasicThumbnailer::class" Basic thumbnailer
+ *
+ * @package Concrete\Core\Http\Middleware
+ */
+class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterface
+{
+
+    use ApplicationAwareTrait;
+
+    /**
+     * Process the request and return a response
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param DelegateInterface $frame
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        $response = $frame->next($request);
+
+        if ($response->getStatusCode() == 200) {
+            /** @var Connection $database */
+            try {
+                $database = $this->app->make('database')->connection();
+            } catch (\InvalidArgumentException $e) {
+                // Don't die here if there's no available database connection
+            }
+
+            if ($database) {
+                try {
+                    $paths = $database->fetchAll('SELECT * FROM FileImageThumbnailPaths WHERE isBuilt=0 LIMIT 5');
+                    $this->generateThumbnails($paths, $database);
+                } catch (InvalidFieldNameException $e) {
+                    // Ignore this, user probably needs to run an upgrade.
+                }
+            }
+        }
+
+        return $response;
+    }
+
+    private function generateThumbnails($paths, Connection $database)
+    {
+        $database->transactional(function(Connection $database) use ($paths) {
+            foreach ($paths as $thumbnail) {
+                /** @var EntityManagerInterface $orm */
+                $orm = $this->app->make('database/orm')->entityManager();
+                /** @var File $file */
+                $file = $orm->find(File::class, $thumbnail['fileID']);
+
+                if ($dimensions = $this->getDimensions($thumbnail)) {
+                    list($width, $height, $crop) = $dimensions;
+
+                    /** @var BasicThumbnailer $thumbnailer */
+                    $thumbnailer = $this->app->make(BasicThumbnailer::class);
+                    $thumbnailer->getThumbnail($file, $width, $height, !!$crop);
+
+                    $database->query(
+                        'UPDATE FileImageThumbnailPaths set isBuilt=1 where fileID=? AND fileVersionID=? AND thumbnailTypeHandle=? AND path=?',
+                        [
+                            $thumbnail['fileID'],
+                            $thumbnail['fileVersionID'],
+                            $thumbnail['thumbnailTypeHandle'],
+                            $thumbnail['path']
+                        ])->execute();
+                }
+            }
+        });
+    }
+
+    private function getDimensions($thumbnail)
+    {
+        $matches = null;
+
+        if (preg_match('/ccm_(\d+)x(\d+)(?:_([10]))?/', $thumbnail['thumbnailTypeHandle'], $matches)) {
+            return array_pad(array_slice($matches, 1), 3, 0);
+        }
+    }
+
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20161108113202.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161108113202.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161108113202 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->version->getConfiguration()->getOutputWriter()->write(t('Updating tables found in doctrine xml...'));
+        // Update tables that still exist in db.xml
+        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema(array(
+            'FileImageThumbnailPaths'
+        ));
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->up();
+    }
+
+}


### PR DESCRIPTION
We are in RC now so if we are adhering to what I set forth in the pull request that wasn't merged here: https://github.com/KorvinSzanto/concrete5/blob/d81ff1a4ea72436f70639013104fbc8d785503d2/README.md

This change falls under:

* **Controversial > Feature improvements**: Improves the FileImageThumbnailPath stack allowing it to track the built status of cached thumbnails
* **Accepted > Known bug fixes**: There is a known bug out there that if a user cancels a request prematurely or a request dies that is building the cache for a page (Read generating thumbnails) the pages thumbnails might be broken. If they are broken there's no way for them to currently get rebuilt leaving a users site broken. And to boot, if the issue happens every time they will never get their site displaying properly!

This change is entirely backwards compatible (Please double check to hold me to it) and bolts on a middleware that **will generate at most 5 thumbnails** from cached pages that failed to build. This only works if the cached file does not exist, if for some reason the cached thumbnail exists but is corrupted this change does not have an answer. So with this change if your cached thumbnails fail to build, they will display as 404s to users viewing the page cache version of the page until someone navigates to a non-cached page enough to ensure that all thumbnails have been built. This has the added effect of making it so that real users aren't often the ones tasked with waiting for the thumbnail building to complete.

The thumbnail generation happens AFTER a request that is not fully page cached. See [here]() how we get the response from concrete5 in our middleware and run the thumbnailing generation before we return the response. 

Please let me know what you think, I'm confident that this change falls under the allowed (but controversial) change categories for the RC stage.