### PR TITLE
Add interactive install flag

### DIFF
--- a/concrete/src/Validator/ValidatorManagerInterface.php
+++ b/concrete/src/Validator/ValidatorManagerInterface.php
@@ -35,15 +35,4 @@ interface ValidatorManagerInterface extends ValidatorInterface
      */
     public function setValidator($handle, ValidatorInterface $validator = null);
 
-    /*
-     * Is this mixed value valid based on the added validators
-     *
-     * @param mixed             $mixed Can be any value
-     * @param \ArrayAccess|null $error The error object that will contain the error strings
-     * @return bool
-     * @throws \InvalidArgumentException Invalid mixed value type passed.
-     * @todo Move out of this comment so that we can properly hint
-     *
-    public function isValid($mixed, \ArrayAccess $error = null);
-     */
 }


### PR DESCRIPTION
I threw this together this morning and in my down time today. I think if we're following #4295 this would fall under:

* **Controversial > Feature improvements**
* **Controversial > Usability improvements**

This I think is an important change. It adds the ability to install concrete5 via the command line interactively.

Today the best way to install over CLI is to:

A. Already know the required options
B. Look at the InstallCommand class to determine the options via code
C. Try over and over until the errors stop and c5 gets installed

If you're like me, you do C every single time. This is a super painful time waste, so instead lets do a wizardy interactive install:

![out](https://cloud.githubusercontent.com/assets/1007419/20200184/834d3d3a-a764-11e6-95b7-305440db8792.gif)

To test install in interactive mode:
`$ concrete5 c5:install -i`

I'm personally going to use this every time I install concrete5 moving forward. Once v8 is released we can fully install concrete5 start to finish by doing:

```bash
$ composer create-project concrete5/concrete5
$ cd concrete5
$ concrete5 c5:install -i
```
:beers:
