### PR TITLE
Update search indexing stack to be easily extendable

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -127,6 +127,7 @@ return array(
         'core_user' => '\Concrete\Core\User\UserServiceProvider',
         'core_service_manager' => '\Concrete\Core\Service\Manager\ServiceManagerServiceProvider',
         'core_site' => '\Concrete\Core\Site\ServiceProvider',
+        'core_search' => \Concrete\Core\Search\SearchServiceProvider::class,
 
         // Authentication
         'core_oauth' => '\Concrete\Core\Authentication\Type\OAuth\ServiceProvider',

--- a/concrete/jobs/index_search_all.php
+++ b/concrete/jobs/index_search_all.php
@@ -1,22 +1,43 @@
 <?php
 namespace Concrete\Job;
 
-use Loader;
-use QueueableJob;
-use Concrete\Core\Page\Search\IndexedSearch;
 use CollectionAttributeKey;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\File\File;
+use Concrete\Core\Job\QueueableJob;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Search\Index\IndexManagerInterface;
+use Concrete\Core\User\User;
 use FileAttributeKey;
+use Loader;
 use UserAttributeKey;
-use Page;
-use ZendQueue\Queue as ZendQueue;
 use ZendQueue\Message as ZendQueueMessage;
+use ZendQueue\Queue as ZendQueue;
 
 class IndexSearchAll extends QueueableJob
 {
+
+    // A flag for clearing the index
+    const CLEAR = "-1";
+
     public $jNotUninstallable = 1;
     public $jSupportsQueue = true;
 
-    protected $indexedSearch;
+    protected $usersIndexed = 0;
+    protected $pagesIndexed = 0;
+    protected $filesIndexed = 0;
+    protected $sitesIndexed = 0;
+
+    /*
+     * @var \Concrete\Core\Search\Index\IndexManagerInterface
+     */
+    protected $indexManager;
+
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $connection;
 
     public function getJobName()
     {
@@ -28,46 +49,161 @@ class IndexSearchAll extends QueueableJob
         return t("Empties the page search index and reindexes all pages.");
     }
 
-    public function start(ZendQueue $q)
+    public function __construct(IndexManagerInterface $indexManager, Connection $connection)
     {
-        $this->indexedSearch = new IndexedSearch();
+        $this->indexManager = $indexManager;
+        $this->connection = $connection;
+    }
 
-        $attributes = CollectionAttributeKey::getList();
-        $attributes = array_merge($attributes, FileAttributeKey::getList());
-        $attributes = array_merge($attributes, UserAttributeKey::getList());
-        foreach ($attributes as $ak) {
-            $indexer = $ak->getSearchIndexer();
-            $indexer->updateSearchIndexKeyColumns($ak->getAttributeCategory(), $ak);
+    public function start(ZendQueue $queue)
+    {
+        // Send a "clear" queue item to clear out the index
+        $queue->send(self::CLEAR);
+
+        // Queue everything
+        foreach ($this->queueMessages() as $message) {
+            $queue->send($message);
         }
+    }
 
-        $db = Loader::db();
-        $db->Execute('truncate table PageSearchIndex');
-        $r = $db->Execute(
-            'select Pages.cID
-            from Pages
-                left join CollectionSearchIndexAttributes csia
-                    on Pages.cID = csia.cID
-            where (ak_exclude_search_index is null or ak_exclude_search_index = 0) and cIsActive = 1'
-        );
-        while ($row = $r->FetchRow()) {
-            $q->send($row['cID']);
+    /**
+     * Messages to add to the queue
+     * @return \Iterator
+     */
+    protected function queueMessages()
+    {
+        foreach ($this->pagesToQueue() as $id) {
+            yield "P{$id}";
+        }
+        foreach ($this->usersToQueue() as $id) {
+            yield "U($id}";
+        }
+        foreach ($this->filesToQueue() as $id) {
+            yield "F{$id}";
+        }
+        foreach ($this->sitesToQueue() as $id) {
+            yield "S{$id}";
+        }
+    }
+
+    public function processQueueItem(ZendQueueMessage $msg)
+    {
+        $index = $this->indexManager;
+
+        // Handle a "clear" message
+        if ($msg->body == self::CLEAR) {
+            $this->clearIndex($index);
+        } else {
+            $message = substr($msg->body, 1);
+            $type = substr($msg->body, 0, 1);
+
+            switch ($type) {
+                case 'P':
+                    $this->pagesIndexed++;
+                    return $index->index(Page::class, $message);
+                case 'U':
+                    $this->usersIndexed++;
+                    return $index->index(User::class, $message);
+                case 'F':
+                    $this->filesIndexed++;
+                    return $index->index(File::class, $message);
+                case 'S':
+                    $this->sitesIndexed++;
+                    return $index->index(Site::class, $message);
+            }
         }
     }
 
     public function finish(ZendQueue $q)
     {
-        $db = Loader::db();
-        $total = $db->GetOne('select count(*) from PageSearchIndex');
-
-        return t('Index updated. %s pages indexed.', $total);
+        return t(
+            'Indexed %s Pages, %s Users, %s Files, and %s Sites.',
+            $this->pagesIndexed,
+            $this->usersIndexed,
+            $this->filesIndexed,
+            $this->sitesIndexed
+        );
     }
 
-    public function processQueueItem(ZendQueueMessage $msg)
+    /**
+     * Clear out all indexes
+     * @param $index
+     */
+    protected function clearIndex($index)
     {
-        $c = Page::getByID($msg->body, 'ACTIVE');
-        $cv = $c->getVersionObject();
-        if (is_object($cv)) {
-            $c->reindex($this->indexedSearch, true);
+        $index->clear(Page::class);
+        $index->clear(User::class);
+        $index->clear(File::class);
+        $index->clear(Site::class);
+    }
+
+    /**
+     * Get Pages to add to the queue
+     * @return \Iterator
+     */
+    protected function pagesToQueue()
+    {
+        $qb = $this->connection->createQueryBuilder();
+
+        // Find all pages that need indexing
+        $query = $qb
+            ->select('p.cID')
+            ->from('Pages', 'p')
+            ->leftJoin('p', 'CollectionSearchIndexAttributes', 'a', 'p.cID = a.cID')
+            ->where('cIsActive = 1')
+            ->andWhere($qb->expr()->orX(
+                'a.ak_exclude_search_index is null',
+                'a.ak_exclude_search_index = 0'
+            ))->execute();
+
+        while ($id = $query->fetchColumn()) {
+            yield $id;
         }
     }
+
+    /**
+     * Get Users to add to the queue
+     * @return \Iterator
+     */
+    protected function usersToQueue()
+    {
+        /** @var Connection $db */
+        $db = $this->connection;
+
+        $query = $db->executeQuery('SELECT uID FROM Users WHERE uIsActive = 1');
+        while ($id = $query->fetchColumn()) {
+            yield $id;
+        }
+    }
+
+    /**
+     * Get Files to add to the queue
+     * @return \Iterator
+     */
+    protected function filesToQueue()
+    {
+        /** @var Connection $db */
+        $db = $this->connection;
+
+        $query = $db->executeQuery('SELECT fID FROM Files');
+        while ($id = $query->fetchColumn()) {
+            yield $id;
+        }
+    }
+
+    /**
+     * Get Sites to add to the queue
+     * @return \Iterator
+     */
+    protected function sitesToQueue()
+    {
+        /** @var Connection $db */
+        $db = $this->connection;
+
+        $query = $db->executeQuery('SELECT siteID FROM Sites');
+        while ($id = $query->fetchColumn()) {
+            yield $id;
+        }
+    }
+
 }

--- a/concrete/src/Page/Search/Index/PageIndex.php
+++ b/concrete/src/Page/Search/Index/PageIndex.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Concrete\Core\Page\Search\Index;
+
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Attribute\Category\PageCategory;
+use Concrete\Core\Attribute\Key\SearchIndexer\SearchIndexerInterface;
+use Concrete\Core\Entity\Attribute\Key\PageKey;
+use Concrete\Core\Search\Index\AbstractIndex;
+use Concrete\Core\Search\Index\Driver\IndexingDriverInterface;
+use Concrete\Core\Search\Index\Driver\SearchingDriverInterface;
+
+class PageIndex extends AbstractIndex implements ApplicationAwareInterface
+{
+
+    use ApplicationAwareTrait;
+
+    /**
+     * PageIndex constructor.
+     * Doesn't require any constructor arguments
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return DefaultPageDriver|IndexingDriverInterface
+     */
+    protected function getIndexer()
+    {
+        if (!$this->indexDriver) {
+            $this->indexDriver = $this->app[PageIndexer::class];
+        }
+
+        return $this->indexDriver;
+    }
+
+    /**
+     * Clear out all indexed items
+     * @return void
+     */
+    public function clear()
+    {
+        /** @var PageCategory $pageCategory */
+        $pageCategory = $this->app[PageCategory::class];
+
+        /** @var PageKey $key */
+        foreach ($pageCategory->getList() as $key) {
+            /** @var SearchIndexerInterface $indexer */
+            $indexer = $key->getSearchIndexer();
+
+            // Update the key tables
+            $indexer->updateSearchIndexKeyColumns($pageCategory, $key);
+        }
+
+        // Truncate the existing search index
+        $database = $this->app['database']->connection();
+        $database->Execute('truncate table PageSearchIndex');
+    }
+
+}

--- a/concrete/src/Page/Search/Index/PageIndexer.php
+++ b/concrete/src/Page/Search/Index/PageIndexer.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Concrete\Core\Page\Search\Index;
+
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Page\Collection\Collection;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Search\IndexedSearch;
+use Concrete\Core\Search\Index\Driver\IndexingDriverInterface;
+use Concrete\Core\Search\Index\Driver\Iterator;
+
+class PageIndexer implements IndexingDriverInterface, ApplicationAwareInterface
+{
+
+    use ApplicationAwareTrait;
+
+    /**
+     * @var \Concrete\Core\Page\Search\IndexedSearch
+     */
+    private $search;
+
+    /**
+     * DefaultPageDriver constructor.
+     * @param \Concrete\Core\Page\Search\IndexedSearch $search
+     */
+    public function __construct(IndexedSearch $search)
+    {
+        $this->search = $search;
+    }
+
+    /**
+     * Add a page to the index
+     * @param string|int|Page $page Page to index. String is path, int is cID
+     * @return bool Success or fail
+     */
+    public function index($page)
+    {
+        if ($page = $this->getPage($page)) {
+            if ($page->getVersionObject()) {
+                return $page->reindex($this->search, true);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove a page from the index
+     * @param string|int|Page $page. String is path, int is cID
+     * @return bool Success or fail
+     */
+    public function forget($page)
+    {
+        if ($page = $this->getPage($page)) {
+            /** @todo Implement forgetting pages completely */
+
+            /** @var Connection $database */
+            $database = $this->app['database']->connection();
+            $database->executeQuery('DELETE FROM PageSearchIndex WHERE cID=?', $page->getCollectionID());
+        }
+
+        return false;
+    }
+
+    /**
+     * Get a page based on criteria
+     * @param string|int|Page|Collection $page
+     * @return \Concrete\Core\Page\Page
+     */
+    protected function getPage($page)
+    {
+        // Handle passed cID
+        if (is_numeric($page)) {
+            return Page::getByID($page);
+        }
+
+        // Handle passed /path/to/collection
+        if (is_string($page)) {
+            return Page::getByPath($page);
+        }
+
+        // If it's a page, just return the page
+        if ($page instanceof Page) {
+            return $page;
+        }
+
+        // If it's not a page but it's a collection, lets try getting a page by id
+        if ($page instanceof Collection) {
+            return $this->getPage($page->getCollectionID());
+        }
+    }
+
+}

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -2,6 +2,9 @@
 namespace Concrete\Core\Page\Search;
 
 use Concrete\Core\Cache\Cache;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Search\Index\IndexManagerInterface;
+use Concrete\Core\Support\Facade\Application;
 use Loader;
 use Config;
 use PageList;
@@ -160,6 +163,9 @@ class IndexedSearch
     {
         Cache::disableAll();
 
+        /** @var IndexManagerInterface $indexStack */
+        $indexStack = Application::getFacadeApplication()->make(IndexManagerInterface::class);
+
         $db = Loader::db();
 
         if ($fullReindex) {
@@ -179,16 +185,7 @@ class IndexedSearch
 
         $num = 0;
         foreach ($pages as $c) {
-
-            // make sure something is approved
-            $cv = $c->getVersionObject();
-            if (!$cv->cvIsApproved) {
-                continue;
-            }
-
-            $c->reindex($this, true);
-            ++$num;
-            unset($c);
+            $indexStack->index(Page::class, $c);
         }
 
         $pnum = Collection::reindexPendingPages();

--- a/concrete/src/Search/Index/AbstractIndex.php
+++ b/concrete/src/Search/Index/AbstractIndex.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Concrete\Core\Search\Index;
+
+use Concrete\Core\Search\Index\Driver\IndexingDriverInterface;
+
+/**
+ * Pretty much all the Index anyone ever needs.
+ * @package Concrete\Core\Search\Index
+ */
+abstract class AbstractIndex implements IndexInterface
+{
+
+    /** @var IndexingDriverInterface */
+    protected $indexDriver;
+
+    /**
+     * AbstractIndex constructor.
+     * @param \Concrete\Core\Search\Index\Driver\IndexingDriverInterface $indexDriver
+     */
+    public function __construct(IndexingDriverInterface $indexDriver)
+    {
+        $this->indexDriver = $indexDriver;
+    }
+
+    /**
+     * Add an object to the index
+     * @param mixed $object Object to index
+     * @return bool Success or fail
+     */
+    public function index($object)
+    {
+        return $this->getIndexer()->index($object);
+    }
+
+    /**
+     * Remove an object from the index
+     * @param mixed $object Object to forget
+     * @return bool Success or fail
+     */
+    public function forget($object)
+    {
+        return $this->getIndexer()->forget($object);
+    }
+
+    /**
+     * @return \Concrete\Core\Search\Index\Driver\IndexingDriverInterface
+     */
+    protected function getIndexer()
+    {
+        return $this->indexDriver;
+    }
+
+}

--- a/concrete/src/Search/Index/DefaultManager.php
+++ b/concrete/src/Search/Index/DefaultManager.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Concrete\Core\Search\Index;
+
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
+
+/**
+ * Default Search Index Manager
+ * This manager allows indexing a type against all applicable registered indexes.
+ * When searching, it returns the first result set found.
+ *
+ * @package Concrete\Core\Search\Index
+ */
+class DefaultManager implements IndexManagerInterface, ApplicationAwareInterface
+{
+
+    use ApplicationAwareTrait;
+
+    /** The type to use when you want to apply to all types */
+    const TYPE_ALL = "-1";
+
+    /**
+     * @var array [ "TYPE" => [ $index1, $index2 ] ]
+     */
+    protected $indexes = [];
+
+    protected $inflated = [];
+
+    /**
+     * Get the indexes for a type
+     * @param string $type
+     * @param bool $includeGlobal
+     * @return \Concrete\Core\Search\Index\IndexInterface[]|\Concrete\Core\Search\Index\Iterator
+     */
+    public function getIndexes($type, $includeGlobal=true)
+    {
+        // Yield all indexes registered against this type
+        if (isset($this->indexes[$type])) {
+            foreach ($this->indexes[$type] as $index) {
+                yield $type => $this->inflateIndex($index);
+            }
+        }
+
+        $all = self::TYPE_ALL;
+        if ($type !== $all && $includeGlobal) {
+            // Yield all indexes registered against ALL types
+            if (isset($this->indexes[$all])) {
+                foreach ($this->index[$all] as $key => $index) {
+                    yield $all => $this->inflateIndex($index);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the proper index from the stored value
+     * @param $class
+     * @return IndexInterface
+     */
+    protected function inflateIndex($class)
+    {
+        if ($class instanceof IndexInterface) {
+            return $class;
+        }
+
+        if (!isset($this->inflated[$class])) {
+            $this->inflated[$class] = $this->app->make($class);
+        }
+
+        return $this->inflated[$class];
+    }
+
+    /**
+     * Get all indexes registered against this manager
+     * @return \Generator
+     */
+    public function getAllIndexes()
+    {
+        foreach ($this->indexes as $type => $indexList) {
+            // If we hit the "ALL" type, skip it for now
+            if ($type == self::TYPE_ALL) {
+                continue;
+            }
+
+            // Otherwise yield all indexes registered against this type
+            foreach ($this->getIndexes($type, false) as $index) {
+                yield $type => $index;
+            }
+        }
+
+        foreach ($this->getIndexes(self::TYPE_ALL) as $index) {
+            yield self::TYPE_ALL => $index;
+        }
+    }
+
+    /**
+     * Add an index to this manager
+     * @param string $type The type to index. Use DefaultManager::TYPE_ALL to apply to all types.
+     * @param IndexInterface|string $index
+     */
+    public function addIndex($type, $index)
+    {
+        if (!isset($this->indexes[$type])) {
+            $this->indexes[$type] = [];
+        }
+
+        $this->indexes[$type][] = $index;
+    }
+
+    /**
+     * Index an object
+     * @param string $type
+     * @param mixed $object
+     * @return void
+     */
+    public function index($type, $object)
+    {
+        foreach ($this->getIndexes($type) as $index) {
+            $index->index($object);
+        }
+    }
+
+    /**
+     * Forget an object
+     * @param string $type
+     * @param mixed $object
+     * @return void
+     */
+    public function forget($type, $object)
+    {
+        foreach ($this->getIndexes($type) as $index) {
+            $index->forget($object);
+        }
+    }
+
+    /**
+     * Clear out a type.
+     * Passing DefaultManager::TYPE_ALL will clear out ALL types, not just types registered against ALL
+     * @param string $type The type to clear
+     */
+    public function clear($type)
+    {
+        if ($type == self::TYPE_ALL) {
+            $indexes = $this->getAllIndexes();
+        } else {
+            $indexes = $this->getIndexes($type);
+        }
+
+        foreach ($indexes as $index) {
+            $index->clear();
+        }
+    }
+
+}

--- a/concrete/src/Search/Index/Driver/IndexingDriverInterface.php
+++ b/concrete/src/Search/Index/Driver/IndexingDriverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Core\Search\Index\Driver;
+
+interface IndexingDriverInterface
+{
+
+    /**
+     * Add an object to the index
+     * @param mixed $object Object to index
+     * @return bool Success or fail
+     */
+    public function index($object);
+
+    /**
+     * Remove an object from the index
+     * @param mixed $object Object to forget
+     * @return bool Success or fail
+     */
+    public function forget($object);
+
+}

--- a/concrete/src/Search/Index/IndexInterface.php
+++ b/concrete/src/Search/Index/IndexInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Search\Index;
+
+use Concrete\Core\Search\Index\Driver\IndexingDriverInterface;
+
+/**
+ * Interface IndexInterface
+ * @package Concrete\Core\Search\Index
+ */
+interface IndexInterface extends IndexingDriverInterface
+{
+
+    /**
+     * Clear out all indexed items
+     * @return void
+     */
+    public function clear();
+
+}

--- a/concrete/src/Search/Index/IndexManagerInterface.php
+++ b/concrete/src/Search/Index/IndexManagerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Concrete\Core\Search\Index;
+
+interface IndexManagerInterface
+{
+
+    /**
+     * Get the indexes for a type
+     * @param string $type
+     * @return Iterator
+     */
+    public function getIndexes($type);
+
+    /**
+     * Index an object
+     * @param $type
+     * @param $object
+     * @return void
+     */
+    public function index($type, $object);
+
+    /**
+     * Forget an object
+     * @param string $type
+     * @param mixed $object
+     * @return void
+     */
+    public function forget($type, $object);
+
+
+    /**
+     * Clear out a type.
+     * @param string $type The type to clear
+     */
+    public function clear($type);
+
+}

--- a/concrete/src/Search/SearchServiceProvider.php
+++ b/concrete/src/Search/SearchServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Concrete\Core\Search;
+
+use Concrete\Core\Foundation\Service\Provider;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Search\Index\PageIndex;
+use Concrete\Core\Search\Index\DefaultManager;
+use Concrete\Core\Search\Index\IndexManagerInterface;
+
+class SearchServiceProvider extends Provider
+{
+
+    /**
+     * Registers the services provided by this provider.
+     */
+    public function register()
+    {
+        $this->app->bindIf(IndexManagerInterface::class, DefaultManager::class);
+        $this->app->resolving(DefaultManager::class, function(DefaultManager $manager) {
+            $manager->addIndex(Page::class, PageIndex::class);
+        });
+    }
+
+}


### PR DESCRIPTION
Sorry about this single mega commit, I think you'll find the changes are rather straight forward if you take a minute or two to look at them.

I'm working on implementing a secondary search index for a client and I'm finding it extremely difficult. Without this change, you have to essentially replace the entire stack top to bottom. 

If this change lands, you can add your own custom index to the stack with the following code:

```php
$customDriver = new \My\Package\IndexDriver();

$manager = $app->make(IndexManagerInterface::class);

// Add an index for pages
$manager->addIndex(Page::class, new Index($customDriver));
```

and a custom driver would look like this:
```php

class IndexDriver implements IndexingDriverInterface {

    function index($object) { ... }

    function forget($object) { ... }

}
```

It is no more complicated than that.


Caveats:

* These jobs currently send Users, Files, Pages, and Sites down the pipe. Only Pages actually have any kind of indexing at this point
* This does nothing to help with getting data OUT of a search index. Unfortunately that will still be difficult, but it's easy to wave away at the moment since we can provide custom blocks for searching custom indexes.


If we're following #4295, this is certainly `Controversial > Feature Improvements` but it also really really skirts the line of being `Not Accepted > New Features` and this change certainly could introduce bugs so lets give it a solid look and test before merging.
