### PR TITLE
[V8]RC1 fix text overflow in add block panel

### DIFF
--- a/concrete/css/build/core/app/panels/add-block.less
+++ b/concrete/css/build/core/app/panels/add-block.less
@@ -143,6 +143,8 @@ a.ccm-panel-add-block-draggable-block-type {
 		padding-top: 6px;
 		padding-bottom: 6px;
 		.border-bottom-radius(4px);
+		text-overflow: ellipsis;
+		overflow: hidden;		
 	}
 
 	img {


### PR DESCRIPTION
It's not perfect, but if we don't have more space we at least don't have an overflow.

Before:
![image](https://cloud.githubusercontent.com/assets/129864/20297446/e5993f48-ab10-11e6-9e5f-e256e1f506bd.png)

After:
![image](https://cloud.githubusercontent.com/assets/129864/20297416/b998001e-ab10-11e6-9f93-7e1efc9d78c1.png)

I didn't recreate the CSS files, not sure if you do that, but I don't with my own projects to avoid merge conflicts.
