### PR TITLE
Fix #4084 user select timezone

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -389,7 +389,7 @@ class Search extends DashboardPageController
         foreach ($timezones as $timezoneID => $timezoneName) {
             if (($query === '') || (stripos($timezoneName, $query) !== false)) {
                 $obj = new stdClass();
-                $obj->id = $timezoneID;
+                $obj->value = $timezoneID;
                 $obj->text = $timezoneName;
                 $result[] = $obj;
             }

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -103,7 +103,7 @@
     ?>data-editable-field-type="xeditable"
                                         data-source="<?= $view->action('get_timezones') ?>"
                                         data-url="<?= $view->action('update_timezone', $user->getUserID()) ?>"
-                                        data-type="select2" data-name="uTimezone"
+                                        data-type="select" data-name="uTimezone"
                                         data-value="<?= h($uTimezone) ?>"<?php
 }
     ?>><?= $dh->getTimezoneDisplayName($uTimezone) ?></span>


### PR DESCRIPTION
Fixes #4084

Change the "select2" field to a "select" field.

I also had to update the get_timezones source to change the "id" property to "value", in order to work properly with x-editable as documented here - https://vitalets.github.io/x-editable/docs.html#select