### PR TITLE
[v8] More Test for ...Database\EntityManager\ 

### DIFF
--- a/concrete/src/Database/EntityManager/Driver/Driver.php
+++ b/concrete/src/Database/EntityManager/Driver/Driver.php
@@ -18,7 +18,7 @@ class Driver implements DriverInterface
      * Constructor
      * 
      * @param string $namespace
-     * @param \Doctrine\Common\Persistence\Mapping\DriverMappingDriver $driver
+     * @param \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver $driver
      */
     public function __construct($namespace, MappingDriver $driver)
     {

--- a/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
+++ b/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
@@ -23,11 +23,12 @@ class DefaultPackageProvider extends AbstractPackageProvider
      */
     public function getDrivers()
     {
-        // First, we check to see if this package has a custom deprecated getPackageEntityPath method. If so
-        // We return a single annotation driver using legacy annotations, pointing to that entity path.
-        if (method_exists($this->pkg, 'getPackageEntityPath')) {
-            return new AnnotationDriver($this->getLegacyAnnotationReader(), $this->pkg->getPackageEntityPath());
-        }
+
+        // The support for a custom Entity path location using the method 
+        // 'getPackageEntityPath' was removed in version 8.0.0. Even though 
+        // packages using this method still will to work in version 8.0.0, please
+        // make sure to migrate your package by using one of the 
+        // PackageProvider classes
 
         // Now, we check to see if no src/ directory exists. If none exists, we return no entity manager
         if (!is_dir($this->pkg->getPackagePath() . DIRECTORY_SEPARATOR . DIRNAME_CLASSES)) {

--- a/tests/tests/Core/Database/EntityManager/Driver/DriverTest.php
+++ b/tests/tests/Core/Database/EntityManager/Driver/DriverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Driver;
+
+use Concrete\Core\Database\EntityManager\Driver\Driver;
+use Doctrine\ORM\Mapping\Driver\YamlDriver;
+
+/**
+ * DriverTest
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ * @group orm_setup
+ */
+class DriverTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        $driver = new YamlDriver('config/yaml');
+        $this->driver = new Driver('Test\Namespace', $driver);
+    }
+
+    /**
+     * @covers Driver::getDriver
+     */
+    public function testGetDriver()
+    {
+        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver', $this->driver->getDriver());
+    }
+
+    /**
+     * @covers Driver::getNamespace
+     */
+    public function testGetNamespace()
+    {
+        $this->assertEquals('Test\Namespace', $this->driver->getNamespace());
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
@@ -5,7 +5,7 @@ namespace Concrete\Tests\Core\Database\EntityManager\Provider;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Database\EntityManager\Provider\DefaultPackageProvider;
 use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerWithgetPackageEntityPath;
-use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerXml;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerDefault;
 
 /**
  * PackageProviderFactoryTest
@@ -51,12 +51,8 @@ class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
     {
         $package = new PackageControllerDefault($this->app);
         $dpp = new DefaultPackageProvider($this->app, $package);
-        
         $drivers = $dpp->getDrivers();
-        
         $this->assertInternalType('array',$drivers);
-        
-        var_dump($drivers);
         $this->assertEmpty($drivers);
     }
     

--- a/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
@@ -6,6 +6,10 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Database\EntityManager\Provider\DefaultPackageProvider;
 use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerWithgetPackageEntityPath;
 use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerDefault;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerLegacy;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerDefaultWithAdditionalNamespaces;
+use Illuminate\Filesystem\Filesystem;
+use Concrete\Tests\Core\Database\Traits\DirectoryHelpers;
 
 /**
  * PackageProviderFactoryTest
@@ -16,11 +20,13 @@ use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControll
 class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
 {
     
+    use DirectoryHelpers;
+    
     /**
      * @var \Concrete\Core\Application\Application 
      */
     protected $app;
-    
+
     /**
      * Set up
      */
@@ -28,20 +34,25 @@ class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->app = Application::getFacadeApplication();
+        $this->filesystem = new Filesystem();
     }
-    
+
     /**
      * Test packages with getPackageEntityPath() method
      * 
      * @covers DefaultPackageProvider::getDrivers
      */
-    public function testGetDriversWithGetPackageEntityPath()
-    {
-        $package = new PackageControllerWithgetPackageEntityPath($this->app);
-        $dpp = new DefaultPackageProvider($this->app, $package);
-        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $dpp->getDrivers());
-    }
-    
+//    public function testGetDriversWithGetPackageEntityPath()
+//    {
+//        $package = new PackageControllerWithgetPackageEntityPath($this->app);
+//        $dpp = new DefaultPackageProvider($this->app, $package);
+//        $drivers = $dpp->getDrivers();
+//        $this->assertInternalType('array', $drivers);
+//        $c5Driver = $drivers[0];
+//        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver);
+//        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $c5Driver->getDriver());     
+//    }
+
     /**
      * Test package with default driver and not existing source directory
      * 
@@ -52,8 +63,169 @@ class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
         $package = new PackageControllerDefault($this->app);
         $dpp = new DefaultPackageProvider($this->app, $package);
         $drivers = $dpp->getDrivers();
-        $this->assertInternalType('array',$drivers);
-        $this->assertEmpty($drivers);
+        $this->assertInternalType('array', $drivers);
+        $this->assertEquals(0, count($drivers));
+    }
+
+    /**
+     * Covers real word case of a package with $appVersionRequired < 8.0.0
+     * 
+     * @covers DefaultPackageProvider::getDrivers
+     */
+    public function testGetDriversWithPackageWithLegacyNamespaceAndLegacyAnnotationReader()
+    {
+        $this->createPackageFolderOfTestMetadataDriverLegacy();
+
+        $package = new PackageControllerLegacy($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        $drivers = $dpp->getDrivers();
+        $this->assertInternalType('array', $drivers);
+        $c5Driver = $drivers[0];
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $c5Driver->getDriver());
+        $this->assertEquals($package->getNamespace() . '\Src', $c5Driver->getNamespace());
+
+        $this->removePackageFolderOfTestMetadataDriverLegacy();
+    }
+
+    /**
+     * Covers real word case of a package with $appVersionRequired >= 8.0.0
+     * 
+     * @covers DefaultPackageProvider::getDrivers
+     */
+    public function testGetDriversWithPackageWithDefaultNamespaceAndDefaultAnnotationReader()
+    {
+        $this->createPackageFolderOfTestMetadatadriverDefault();
+
+        $package = new PackageControllerDefault($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        $drivers = $dpp->getDrivers();
+        $this->assertInternalType('array', $drivers);
+        $c5Driver = $drivers[0];
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $c5Driver->getDriver());
+        $this->assertEquals($package->getNamespace() . '\Entity', $c5Driver->getNamespace());
+
+        $this->removePackageFolderOfTestMetadataDriverDefault();
     }
     
+    /**
+     * Covers package with additional namespaces and with $appVersionRewuired >= 8.0.0
+     * 
+     * @covers DefaultPackageProvider::getDrivers
+     */
+    public function testGetDriversWithPackageWithAdditionalNamespaces()
+    {
+        $this->createPackageFolderOfTestMetadataDriverAdditionalNamespace();
+        
+        $package = new PackageControllerDefaultWithAdditionalNamespaces($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        $drivers = $dpp->getDrivers();
+
+        $this->assertInternalType('array', $drivers);
+        $this->assertEquals(3, count($drivers), 'Not all MappingDrivers have bin loaded');
+        $c5Driver1 = $drivers[1];
+        $driver1 = $c5Driver1->getDriver();
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver1);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $driver1);
+        $this->assertEquals('PortlandLabs\Concrete5\MigrationTool', $c5Driver1->getNamespace());
+        
+        $pathsOfDriver1 = $driver1->getPaths();
+        $this->assertEquals('src/PortlandLabs/Concrete5/MigrationTool', $this->folderPathCleaner($pathsOfDriver1[0], 4));
+        
+        $this->removePackageFolderOfTestMetadataDriverAdditionalNamespace();
+    }
+    
+    private function createPackageFolderOfTestMetadataDriverAdditionalNamespace()
+    {
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_additional_namespace');
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_additional_namespace' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES);
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_additional_namespace' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES . DIRECTORY_SEPARATOR .
+                'Concrete');
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_additional_namespace' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES . DIRECTORY_SEPARATOR .
+                'Concrete' . DIRECTORY_SEPARATOR . DIRNAME_ENTITIES);
+    }
+
+    private function removePackageFolderOfTestMetadataDriverAdditionalNamespace()
+    {
+        $this->filesystem->deleteDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_additional_namespace');
+    }
+
+    private function createPackageFolderOfTestMetadatadriverDefault()
+    {
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_default');
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_default' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES);
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_default' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES . DIRECTORY_SEPARATOR .
+                'Concrete');
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_default' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES . DIRECTORY_SEPARATOR .
+                'Concrete' . DIRECTORY_SEPARATOR . DIRNAME_ENTITIES);
+    }
+
+    private function removePackageFolderOfTestMetadataDriverDefault()
+    {
+        $packagePath = DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_default';
+
+        if ($this->filesystem->isDirectory($packagePath)) {
+            $this->filesystem->deleteDirectory($packagePath);
+        }
+    }
+
+    private function createPackageFolderOfTestMetadataDriverLegacy()
+    {
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_legacy');
+        $this->filesystem->makeDirectory(DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_legacy' . DIRECTORY_SEPARATOR .
+                DIRNAME_CLASSES);
+    }
+
+    private function removePackageFolderOfTestMetadataDriverLegacy()
+    {
+        $packagePath = DIR_BASE . DIRECTORY_SEPARATOR .
+                DIRNAME_PACKAGES . DIRECTORY_SEPARATOR .
+                'test_metadatadriver_legacy';
+
+        if ($this->filesystem->isDirectory($packagePath)) {
+            $this->filesystem->deleteDirectory($packagePath);
+        }
+    }
+
+    /**
+     * Clean up if a Exception is thrown
+     */
+    protected function onNotSuccessfulTest($e)
+    {
+        $this->removePackageFolderOfTestMetadataDriverDefault();
+        $this->removePackageFolderOfTestMetadataDriverDefault();
+        $this->removePackageFolderOfTestMetadataDriverAdditionalNamespace();
+    }
+
 }

--- a/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Database\EntityManager\Provider\DefaultPackageProvider;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerWithgetPackageEntityPath;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerXml;
+
+/**
+ * PackageProviderFactoryTest
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ * @group orm_setup
+ */
+class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
+{
+    
+    /**
+     * @var \Concrete\Core\Application\Application 
+     */
+    protected $app;
+    
+    /**
+     * Set up
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->app = Application::getFacadeApplication();
+    }
+    
+    /**
+     * Test packages with getPackageEntityPath() method
+     * 
+     * @covers DefaultPackageProvider::getDrivers
+     */
+    public function testGetDriversWithGetPackageEntityPath()
+    {
+        $package = new PackageControllerWithgetPackageEntityPath($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $dpp->getDrivers());
+    }
+    
+    /**
+     * Test package with default driver and not existing source directory
+     * 
+     * @covers DefaultPackageProvider::getDrivers
+     */
+    public function testGetDriversWithNoExistingSrcDirectory()
+    {
+        $package = new PackageControllerDefault($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        
+        $drivers = $dpp->getDrivers();
+        
+        $this->assertInternalType('array',$drivers);
+        
+        var_dump($drivers);
+        $this->assertEmpty($drivers);
+    }
+    
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/DefaultPackageProviderTest.php
@@ -38,20 +38,21 @@ class DefaultPackageProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test packages with getPackageEntityPath() method
+     * Test packages with removed getPackageEntityPath() method
      * 
      * @covers DefaultPackageProvider::getDrivers
      */
-//    public function testGetDriversWithGetPackageEntityPath()
-//    {
-//        $package = new PackageControllerWithgetPackageEntityPath($this->app);
-//        $dpp = new DefaultPackageProvider($this->app, $package);
-//        $drivers = $dpp->getDrivers();
-//        $this->assertInternalType('array', $drivers);
-//        $c5Driver = $drivers[0];
-//        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver);
-//        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $c5Driver->getDriver());     
-//    }
+    public function testGetDriversWithGetPackageEntityPath()
+    {
+        $package = new PackageControllerWithgetPackageEntityPath($this->app);
+        $dpp = new DefaultPackageProvider($this->app, $package);
+        $drivers = $dpp->getDrivers();
+        $this->assertInternalType('array', $drivers);
+        $c5Driver = $drivers[0];
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Driver\Driver', $c5Driver);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $c5Driver->getDriver());
+        $this->assertEquals($package->getNamespace() . '\Src', $c5Driver->getNamespace());
+    }
 
     /**
      * Test package with default driver and not existing source directory

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerBlank.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerBlank.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
+
+use Concrete\Core\Package\Package;
+use Concrete\Core\Application\Application;
+
+/**
+ * Controller test addon - testing metadatadriver with default annotation driver
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ */
+class PackageControllerBlank extends Package
+{
+
+    protected $pkgHandle = 'test_metadatadriver_default';
+    protected $appVersionRequired = '5.8.0';
+    protected $pkgVersion = '0.0.1';
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getPackageDescription()
+    {
+        return t("Test addon registers entities via standard annotation driver");
+    }
+
+    public function getPackageName()
+    {
+        return t("Test addon - uses standard annotation driver");
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefault.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefault.php
@@ -2,8 +2,8 @@
 
 namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
 
-use Concrete\Core\Package\Package;
 use Concrete\Core\Application\Application;
+use Concrete\Core\Package\Package;
 
 /**
  * Controller test addon - testing metadatadriver with default annotation driver
@@ -14,8 +14,9 @@ class PackageControllerDefault extends Package
 {
 
     protected $pkgHandle = 'test_metadatadriver_default';
-    protected $appVersionRequired = '5.8.0';
+    protected $appVersionRequired = '8.0.0';
     protected $pkgVersion = '0.0.1';
+    protected $pkgEnableLegacyNamespace = false;
 
     public function __construct(Application $app)
     {

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefault.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefault.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
+
+use Concrete\Core\Package\Package;
+use Concrete\Core\Application\Application;
+
+/**
+ * Controller test addon - testing metadatadriver with default annotation driver
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ */
+class PackageControllerDefault extends Package
+{
+
+    protected $pkgHandle = 'test_metadatadriver_default';
+    protected $appVersionRequired = '5.8.0';
+    protected $pkgVersion = '0.0.1';
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getPackageDescription()
+    {
+        return t("Test addon registers entities via standard annotation driver");
+    }
+
+    public function getPackageName()
+    {
+        return t("Test addon - uses standard annotation driver");
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefaultWithAdditionalNamespaces.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerDefaultWithAdditionalNamespaces.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Package\Package;
+
+/**
+ * Controller test addon - testing metadatadriver with default annotation driver
+ * and additional namespaces
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ */
+class PackageControllerDefaultWithAdditionalNamespaces extends Package
+{
+
+    protected $pkgHandle = 'test_metadatadriver_additional_namespace';
+    protected $appVersionRequired = '8.0.0';
+    protected $pkgVersion = '0.0.1';
+    protected $pkgEnableLegacyNamespace = false;
+    
+    // The value we want to test
+    protected $pkgAutoloaderRegistries = array(
+        'src/PortlandLabs/Concrete5/MigrationTool' => '\PortlandLabs\Concrete5\MigrationTool',
+        'src/Dummy' => '\Dummy'
+    );
+    
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getPackageDescription()
+    {
+        return t("Test addon registers entities via standard annotation driver");
+    }
+
+    public function getPackageName()
+    {
+        return t("Test addon - uses standard annotation driver");
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerLegacy.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerLegacy.php
@@ -2,34 +2,35 @@
 
 namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
 
-use Concrete\Core\Package\Package;
 use Concrete\Core\Application\Application;
+use Concrete\Core\Package\Package;
 
 /**
  * Controller test addon - testing metadatadriver with default annotation driver
  *
  * @author Markus Liechti <markus@liechti.io>
  */
-class PackageControllerBlank extends Package
+class PackageControllerLegacy extends Package
 {
 
-    protected $pkgHandle = 'test_metadatadriver_default';
-    protected $appVersionRequired = '5.8.0';
+    protected $pkgHandle = 'test_metadatadriver_legacy';
+    protected $appVersionRequired = '5.7.0';
     protected $pkgVersion = '0.0.1';
-
+    protected $pkgEnableLegacyNamespace = true;
+    
     public function __construct(Application $app)
     {
         parent::__construct($app);
     }
-
+    
     public function getPackageDescription()
     {
-        return t("Test addon registers entities via standard annotation driver");
+        return t("Test addon registers entities via the xml driver");
     }
 
     public function getPackageName()
     {
-        return t("Test addon - uses standard annotation driver");
+        return t("Test addon - uses xml driver");
     }
 
 }

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithNotSupportedMappingDriver.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithNotSupportedMappingDriver.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
+
+use Concrete\Core\Package\Package;
+use Concrete\Core\Database\EntityManager\Provider\ProviderAggregateInterface;
+
+/**
+ * Controller test addon - testing metadatadriver which is not support -> custom EntityManager
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ */
+class PackageControllerWithNotSupportedMappingDriver extends Package implements ProviderAggregateInterface
+{
+
+    protected $pkgHandle = 'test_metadatadriver_php_array';
+    protected $appVersionRequired = '5.8.0';
+    protected $pkgVersion = '0.0.1';
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getPackageDescription()
+    {
+        return t("Test addon registers entities via the xml driver");
+    }
+
+    public function getPackageName()
+    {
+        return t("Test addon - uses xml driver");
+    }
+
+    public function getEntityManagerProvider()
+    {
+        
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithgetPackageEntityPath.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithgetPackageEntityPath.php
@@ -8,6 +8,7 @@ use Concrete\Core\Package\Package;
 /**
  * Controller test addon - testing legacy annotation driver 
  * with deprecated getPackageEntityPath() method
+ * and no adjustemens
  *
  * @author Markus Liechti <markus@liechti.io>
  */
@@ -17,6 +18,8 @@ class PackageControllerWithgetPackageEntityPath extends Package
     protected $pkgHandle = 'test_metadatadriver_legacy_with_getpackageentitypath';
     protected $appVersionRequired = '5.7.0';
     protected $pkgVersion = '0.0.1';
+    // just making jure that test will not break after version 8.1.0
+    protected $pkgEnableLegacyNamespace = true;
 
     public function __construct(Application $app)
     {
@@ -35,7 +38,9 @@ class PackageControllerWithgetPackageEntityPath extends Package
 
     public function getPackageEntityPath()
     {
-        return 'foo/bar';
+        // This file path should be ignored by the DefaultPackageProvider
+        return $this->getRelativePath() . DIRECTORY_SEPARATOR . DIRNAME_CLASSES
+                . DIRECTORY_SEPARATOR . 'Entities';
     }
 
 }

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithgetPackageEntityPath.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerWithgetPackageEntityPath.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Package\Package;
+
+/**
+ * Controller test addon - testing legacy annotation driver 
+ * with deprecated getPackageEntityPath() method
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ */
+class PackageControllerWithgetPackageEntityPath extends Package
+{
+
+    protected $pkgHandle = 'test_metadatadriver_legacy_with_getpackageentitypath';
+    protected $appVersionRequired = '5.7.0';
+    protected $pkgVersion = '0.0.1';
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getPackageDescription()
+    {
+        return t("Test addon registers entities via the xml driver");
+    }
+
+    public function getPackageName()
+    {
+        return t("Test addon - uses xml driver");
+    }
+
+    public function getPackageEntityPath()
+    {
+        return 'foo/bar';
+    }
+
+}

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerXml.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerXml.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
 
 use Concrete\Core\Database\EntityManager\Provider\XmlProvider;
@@ -8,33 +9,37 @@ use Concrete\Core\Database\EntityManager\Provider\ProviderInterface;
 defined('C5_EXECUTE') or die(_("Access Denied."));
 
 /**
- * Controller test addon - testing metadatadriver with legacy annotation driver
+ * Controller test addon - testing xml metadatadriver
  *
  * @author @author Markus Liechti <markus@liechti.io>
  */
-class PackageControllerXml extends Package implements ProviderInterface{
+class PackageControllerXml extends Package implements ProviderInterface
+{
 
     protected $pkgHandle = 'test_metadatadriver_xml';
     protected $appVersionRequired = '5.8.0';
     protected $pkgVersion = '0.0.1';
 
-    public function getPackageDescription() {
+    public function getPackageDescription()
+    {
         return t("Test addon registers entities via the xml driver");
     }
 
-    public function getPackageName(){
+    public function getPackageName()
+    {
         return t("Test addon - uses xml driver");
     }
-    
+
     /**
      * Return customized metadata driver wrapped in a XMLProvider for doctrine orm
      * Path: {package}/config/xml
      * 
      * @return XmlProvider
      */
-    public function getDrivers(){
-        
+    public function getDrivers()
+    {
         $xmlProvider = new XmlProvider($this);
         return $xmlProvider->getDrivers();
     }
+
 }

--- a/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerYaml.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/Fixtures/PackageControllerYaml.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures;
 
 use Concrete\Core\Database\EntityManager\Provider\YamlProvider;
@@ -9,11 +10,12 @@ use Concrete\Core\Application\Application;
 defined('C5_EXECUTE') or die(_("Access Denied."));
 
 /**
- * Controller test addon - testing metadatadriver with legacy annotation driver
+ * Controller test addon - testing yaml metadatadriver
  *
  * @author Markus Liechti <markus@liechti.io>
  */
-class PackageControllerYaml extends Package implements ProviderInterface{
+class PackageControllerYaml extends Package implements ProviderInterface
+{
 
     protected $pkgHandle = 'test_metadatadriver_yaml';
     protected $appVersionRequired = '5.8.0';
@@ -23,23 +25,27 @@ class PackageControllerYaml extends Package implements ProviderInterface{
     {
         parent::__construct($app);
     }
-    
-    public function getPackageDescription() {
+
+    public function getPackageDescription()
+    {
         return t("Test addon registers entities via the yaml driver");
     }
 
-    public function getPackageName(){
+    public function getPackageName()
+    {
         return t("Test addon - uses yaml driver");
     }
-    
+
     /**
      * Return customized metadata driver wrapped in a YamlProvider for doctrine orm
      * Path: {package}/config/yaml
      * 
      * @return YamlProvider
      */
-    public function getDrivers(){
+    public function getDrivers()
+    {
         $yamlProvider = new YamlProvider($this);
         return $yamlProvider->getDrivers();
     }
+
 }

--- a/tests/tests/Core/Database/EntityManager/Provider/PackageProviderFactoryTest.php
+++ b/tests/tests/Core/Database/EntityManager/Provider/PackageProviderFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Concrete\Tests\Core\Database\EntityManager\Provider;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Database\EntityManager\Provider\PackageProviderFactory;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerDefault;
+use Concrete\Tests\Core\Database\EntityManager\Provider\Fixtures\PackageControllerYaml;
+
+/**
+ * PackageProviderFactoryTest
+ *
+ * @author Markus Liechti <markus@liechti.io>
+ * @group orm_setup
+ */
+class PackageProviderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \Concrete\Core\Application\Application 
+     */
+    protected $app;
+
+    /**
+     * Setup
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->app = Application::getFacadeApplication();
+    }
+
+    /**
+     * Test PackageProviderFactory if a package controller with no interfaces is passed
+     * This is de default behavior
+     * 
+     * @covers PackageProviderFactory::getEntityManagerProvider
+     */
+    public function testGetEntityManagerProviderDefaultBehavior()
+    {
+        $package = new PackageControllerDefault($this->app);
+        $ppf = new PackageProviderFactory($this->app, $package);
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Provider\DefaultPackageProvider', $ppf->getEntityManagerProvider());
+    }
+
+    /**
+     * Test PackageProviderFactory if a package controller with a 
+     * ProviderInterface interface is passed
+     * 
+     * @covers PackageProviderFactory::getEntityManagerProvider
+     */
+    public function testGetEntityManagerProviderWithProviderInterface()
+    {
+        $package = new PackageControllerYaml($this->app);
+        $ppf = new PackageProviderFactory($this->app, $package);
+        $this->assertInstanceOf('Concrete\Core\Database\EntityManager\Provider\ProviderInterface', $ppf->getEntityManagerProvider());
+    }
+
+    /**
+     * Test PackageProviderFactory if a package controller with a
+     * ProviderAggregateInterface is passed
+     * 
+     * @covers PackageProviderFactory::getEntityManagerProvider
+     */
+//    public function testGetEntityManagerProviderWithProviderAggregateInterface()
+//    {
+//        // not yeat coverd
+//    }
+
+}

--- a/tests/tests/Core/Database/Traits/DirectoryHelpers.php
+++ b/tests/tests/Core/Database/Traits/DirectoryHelpers.php
@@ -22,7 +22,7 @@ trait DirectoryHelpers
      */
     private function folderPathCleaner($folderPath, $returnLastFolders = 2)
     {
-        //J:\xampp\htdocs\concrete5800/packages/test_metadatadriver_yaml\config\yaml
+        //...\htdocs\concrete5800/packages/test_metadatadriver_yaml\config\yaml
         $folderPathCleaned = str_replace("\\", "/", $folderPath);
 
         $linkParts = explode('/', rtrim($folderPathCleaned, '/'));
@@ -30,12 +30,10 @@ trait DirectoryHelpers
 
         $shortenedPath = '';
 
-        for ($i = 2; $i >= 1; $i--) {
+        for ($i = $returnLastFolders; $i >= 1; $i--) {
             $shortenedPath .= $linkParts[$count - $i] . '/';
         }
 
-        //$shortenedPath = $linkParts[$count-2].'/'.$linkParts[$count-1];
-        var_dump(rtrim($shortenedPath, '/'));
         return rtrim($shortenedPath, '/');
     }
 

--- a/tests/tests/Core/Database/Traits/DirectoryHelpers.php
+++ b/tests/tests/Core/Database/Traits/DirectoryHelpers.php
@@ -6,7 +6,7 @@ namespace Concrete\Tests\Core\Database\Traits;
  */
 trait DirectoryHelpers
 {
-        /**
+    /**
      * Clean up and shorten absolut folder paths, 
      * so they can be passed with assert methods
      * 

--- a/tests/tests/Core/Database/Traits/DirectoryHelpers.php
+++ b/tests/tests/Core/Database/Traits/DirectoryHelpers.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Tests\Core\Database\Traits;
 
 /**
@@ -6,6 +7,7 @@ namespace Concrete\Tests\Core\Database\Traits;
  */
 trait DirectoryHelpers
 {
+
     /**
      * Clean up and shorten absolut folder paths, 
      * so they can be passed with assert methods
@@ -18,15 +20,23 @@ trait DirectoryHelpers
      * @param type $folderPath
      * @return string
      */
-    private function folderPathCleaner($folderPath)
+    private function folderPathCleaner($folderPath, $returnLastFolders = 2)
     {
         //J:\xampp\htdocs\concrete5800/packages/test_metadatadriver_yaml\config\yaml
         $folderPathCleaned = str_replace("\\", "/", $folderPath);
 
-        $linkParts = explode('/',rtrim($folderPathCleaned,'/'));
+        $linkParts = explode('/', rtrim($folderPathCleaned, '/'));
         $count = count($linkParts);
 
-        $shortenedPath = $linkParts[$count-2].'/'.$linkParts[$count-1];
-        return $shortenedPath;
+        $shortenedPath = '';
+
+        for ($i = 2; $i >= 1; $i--) {
+            $shortenedPath .= $linkParts[$count - $i] . '/';
+        }
+
+        //$shortenedPath = $linkParts[$count-2].'/'.$linkParts[$count-1];
+        var_dump(rtrim($shortenedPath, '/'));
+        return rtrim($shortenedPath, '/');
     }
+
 }


### PR DESCRIPTION
Added more unit tests:
- DriverTest
- PackageProviderFactoryTest
- DefaultPackageProviderTest

**In the Concrete\Core\Database\EntityManger\Provider\DefaultPackageProvider is still a bug**. [See here](https://github.com/concrete5/concrete5/blob/dc762a1f2920ddca8584e23b9780eb5717e4fd5f/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php#L28-L30)  

If a package still has the method "getPackageEntityPath" it, will throw a exception because a Doctrine MappingDriver is returned instaed of a ....\EntityManger\Driver\DriverInterface which is required in the [EntityManagerConfigUpdater class ](https://github.com/concrete5/concrete5/blob/dc762a1f2920ddca8584e23b9780eb5717e4fd5f/concrete/src/Database/EntityManagerConfigUpdater.php#L34).

What should be the behaviour in this case? If a ...Driver/Driver should be returned what should be the namespace of this driver?

As soon as I know what the behaviour is, I'll add an other test which covers this case.

 
 