### PR TITLE
Make number field a bit wider

### DIFF
--- a/concrete/attributes/number/controller.php
+++ b/concrete/attributes/number/controller.php
@@ -57,7 +57,7 @@ class Controller extends AttributeTypeController
         } else {
             $value = null;
         }
-        echo $this->app->make('helper/form')->number($this->field('value'), $value, ['style' => 'width:80px']);
+        echo $this->app->make('helper/form')->number($this->field('value'), $value, ['style' => 'width:100px']);
     }
 
     public function validateForm($p)


### PR DESCRIPTION
The width of a number field should be at least as wide as to accomodate 4 digits for years, for example