### PR TITLE
Add method to attribute controllers to return label ID

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -778,4 +778,9 @@ class Controller extends AttributeTypeController
         return $this->entityManager->find(SelectSettings::class, $this->attributeKey);
     }
 
+    public function getLabelID()
+    {
+        return $this->field('atSelectOptionValue');
+    }
+
 }

--- a/concrete/elements/express/form/form/attribute_key.php
+++ b/concrete/elements/express/form/form/attribute_key.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
 <div class="form-group">
-    <label class="control-label"><?=$label?>
+    <label class="control-label" for="<?= $key->getController()->getLabelID() ?>"><?=$label?>
         <?php
 
         if ($control->isRequired()) {

--- a/concrete/src/Attribute/AttributeKeyInterface.php
+++ b/concrete/src/Attribute/AttributeKeyInterface.php
@@ -5,9 +5,24 @@ use Concrete\Core\Attribute\Key\SearchIndexer\SearchIndexerInterface;
 
 interface AttributeKeyInterface
 {
+    /**
+     * @return int
+     */
     public function getAttributeKeyID();
+
+    /**
+     * @return string
+     */
     public function getAttributeKeyHandle();
+
+    /**
+     * @return \Concrete\Core\Entity\Attribute\Type
+     */
     public function getAttributeType();
+
+    /**
+     * @return bool
+     */
     public function isAttributeKeySearchable();
 
     /**

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -136,7 +136,15 @@ class Controller extends AbstractController
         }
         /** @var \Concrete\Core\Form\Service\Form $form */
         $form = Core::make('helper/form');
-        echo $form->label($this->field('value'), $text);
+        echo $form->label($this->getLabelID(), $text);
+    }
+
+    /**
+     * Get the ID to use for label elements
+     */
+    public function getLabelID()
+    {
+        return $this->field('value');
     }
 
     /**


### PR DESCRIPTION
Following #4295 this is a known bug fix so good to accept. This makes it so that the express form block outputs its label elements with proper `for=""` attributes.