### PR TITLE
Use database sessions without transactions to prevent mysql errors

### DIFF
--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -96,6 +96,7 @@ class SessionFactory implements SessionFactoryInterface
                 'db_data_col' => 'sessionValue',
                 'db_time_col' => 'sessionTime',
                 'db_lifetime_col' => 'sessionLifeTime',
+                'lock_mode' => PdoSessionHandler::LOCK_ADVISORY
             ));
         } else {
             $savePath = $config->get('concrete.session.save_path') ?: null;


### PR DESCRIPTION
This fixes the `There is already an active transaction` error people have been seeing.