### PR TITLE
Fix updating from 5.7.x

### DIFF
--- a/concrete/bin/concrete5.php
+++ b/concrete/bin/concrete5.php
@@ -70,17 +70,18 @@ if (!defined('APP_UPDATED_PASSTHRU')) {
     if (is_file($updates)) {
         $updates = (array) include $updates;
         if (isset($updates['core']) && is_dir(DIR_BASE.'/updates/'.$updates['core'].'/concrete')) {
-            define('APP_UPDATED_PASSTHRU', $updates['core']);
+            define('APP_UPDATED_PASSTHRU', true);
+            define('DIRNAME_APP_UPDATED', $updates['core']);
         }
     }
     unset($updates);
     if (defined('APP_UPDATED_PASSTHRU')) {
-        return require DIR_BASE.'/updates/'.APP_UPDATED_PASSTHRU.'/concrete/bin/concrete5.php';
+        return require DIR_BASE.'/updates/'.DIRNAME_APP_UPDATED.'/concrete/bin/concrete5.php';
     }
     define('APP_UPDATED_PASSTHRU', false);
 }
 if (APP_UPDATED_PASSTHRU === false) {
     return require DIR_BASE.'/concrete/dispatcher.php';
 } else {
-    return require DIR_BASE.'/updates/'.APP_UPDATED_PASSTHRU.'/concrete/dispatcher.php';
+    return require DIR_BASE.'/updates/'.DIRNAME_APP_UPDATED.'/concrete/dispatcher.php';
 }

--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -44,11 +44,12 @@ if (!defined('APP_UPDATED_PASSTHRU')) {
     if (file_exists($update_file)) {
         $updates = (array) include $update_file;
         if (isset($updates['core'])) {
-            define('APP_UPDATED_PASSTHRU', $updates['core']);
-            if (is_dir(DIR_BASE . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU)) {
-                require DIR_BASE . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
-            } elseif (file_exists(DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php')) {
-                require DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
+            define('APP_UPDATED_PASSTHRU', true);
+            define('DIRNAME_APP_UPDATED', $updates['core']);
+            if (is_dir(DIR_BASE . '/' . DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED)) {
+                require DIR_BASE . '/' . DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
+            } elseif (file_exists(DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED . '/' . DIRNAME_CORE . '/' . 'dispatcher.php')) {
+                require DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED . '/' . DIRNAME_CORE . '/' . 'dispatcher.php';
             } else {
                 die(sprintf('Invalid "%s" defined. Please remove it from %s.', 'update.core', $update_file));
             }
@@ -56,6 +57,10 @@ if (!defined('APP_UPDATED_PASSTHRU')) {
         }
     }
     define('APP_UPDATED_PASSTHRU', false);
+}
+
+if (!defined('DIRNAME_APP_UPDATED') && isset($updates['core'])) {
+    define('DIRNAME_APP_UPDATED', $updates['core']);
 }
 
 /*

--- a/concrete/bootstrap/paths.php
+++ b/concrete/bootstrap/paths.php
@@ -10,7 +10,7 @@ defined('C5_EXECUTE') or define('C5_EXECUTE', md5(uniqid()));
 if (APP_UPDATED_PASSTHRU === false) {
     $ap = $app['app_relative_path'] . '/' . DIRNAME_CORE;
 } else {
-    $ap = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . APP_UPDATED_PASSTHRU . '/' . DIRNAME_CORE;
+    $ap = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED . '/' . DIRNAME_CORE;
 }
 
 define('ASSETS_URL', $ap);


### PR DESCRIPTION
This changes the `APP_UPDATED_PASSTHRU` constant back to a `boolean` and adds a new constant `DIRNAME_APP_UPDATED`. As we work to get rid of these remaining procedural files we can find a better way to rework this stuff if there is one.