### PR TITLE
Image slider view.php:: add option For arrow + bullets

### DIFF
--- a/concrete/blocks/image_slider/view.php
+++ b/concrete/blocks/image_slider/view.php
@@ -26,14 +26,16 @@ $(document).ready(function(){
         $("#ccm-image-slider-<?php echo $bID ?>").responsiveSlides({
             prevText: "",   // String: Text for the "previous" button
             nextText: "",
-            <?php if ($navigationType == 0) {
-    ?>
-            nav:true,
-            <?php
-} else {
-    ?>
-            pager: true,
-            <?php } ?>
+		<?php if ($navigationType == 0) {?>
+		nav:true,
+		<?php
+		}elseif($navigationType == 1) {?> 
+		pager: true,
+		<?php }
+		else{?>
+		nav:true,
+		pager: true,
+		<?php }?>
             <?php if ($timeout) { echo "timeout: $timeout,"; } ?>
             <?php if ($speed) { echo "speed: $speed,"; } ?>
             <?php if ($pause) { echo "pause: true,"; } ?>


### PR DESCRIPTION
#In sliders a lot of times you want arrow & bullets **together** for better **user experience**. I only made small change inside <script> tag (will work fine in future updates from 5.X to 5.8).

I also made small change in "`form_setup_html.php`" to complete this task.
#4689 

- This is "how" the result should look like (demo of the slider in conrete5 site deafult theme):
 http://www.siton-systems.co.il/slider

- Example of this pattern in swiper.js plugin:
-http://idangero.us/swiper/demos/14-nav-arrows.html

