### PR TITLE
Remove fake countries from CountryList::getCountriesForLanguage

### DIFF
--- a/concrete/src/Localization/Service/CountryList.php
+++ b/concrete/src/Localization/Service/CountryList.php
@@ -63,6 +63,10 @@ class CountryList
      */
     public function getCountriesForLanguage($languageCode)
     {
-        return \Punic\Territory::getTerritoriesForLanguage($languageCode);
+        $territories = \Punic\Territory::getTerritoriesForLanguage($languageCode);
+        $excludedTerritories = ['IM', 'JE'];
+        $result = array_diff($territories, $excludedTerritories);
+
+        return array_values($result);
     }
 }

--- a/concrete/src/Localization/Service/CountryList.php
+++ b/concrete/src/Localization/Service/CountryList.php
@@ -64,8 +64,8 @@ class CountryList
     public function getCountriesForLanguage($languageCode)
     {
         $territories = \Punic\Territory::getTerritoriesForLanguage($languageCode);
-        $excludedTerritories = ['IM', 'JE'];
-        $result = array_diff($territories, $excludedTerritories);
+        $validCountryCodes = array_keys($this->getCountries());
+        $result = array_intersect($territories, $validCountryCodes);
 
         return array_values($result);
     }

--- a/concrete/src/Localization/Service/CountryList.php
+++ b/concrete/src/Localization/Service/CountryList.php
@@ -6,7 +6,7 @@ use Localization;
 
 class CountryList
 {
-    protected $countries = array();
+    protected $countries = [];
 
     public function __construct()
     {


### PR DESCRIPTION
`CountryList::getCountriesForLanguage` may return a couple of country codes that we explicitly removed from the recognized countries (see [CountryList::loadCountries](https://github.com/mlocati/concrete5/blob/08a696b1fc67978c46a7c3389e81ba6b7bc2bf9e/concrete/src/Localization/Service/CountryList.php#L19-L23)).