### PR TITLE
Fix getTotalResults and createPaginationObject of DatabaseItemList

### DIFF
--- a/concrete/src/Express/EntryList.php
+++ b/concrete/src/Express/EntryList.php
@@ -47,7 +47,7 @@ class EntryList extends DatabaseItemList implements PermissionableListItemInterf
     public function getTotalResults()
     {
         $query = $this->deliverQueryObject();
-        return $query->select('count(distinct e.exEntryID)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct e.exEntryID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 
     public function sortByDisplayOrderAscending()
@@ -77,7 +77,7 @@ class EntryList extends DatabaseItemList implements PermissionableListItemInterf
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct e.exEntryID)')->setMaxResults(1);
+            $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct e.exEntryID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -71,7 +71,7 @@ class FileList extends DatabaseItemList implements PermissionableListItemInterfa
         if ($this->permissionsChecker === -1) {
             $query = $this->deliverQueryObject();
 
-            return $query->select('count(distinct f.fID)')->setMaxResults(1)->execute()->fetchColumn();
+            return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct f.fID)')->setMaxResults(1)->execute()->fetchColumn();
         } else {
             return -1; // unknown
         }
@@ -81,7 +81,7 @@ class FileList extends DatabaseItemList implements PermissionableListItemInterfa
     {
         if ($this->permissionsChecker === -1) {
             $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-                $query->select('count(distinct f.fID)')->setMaxResults(1);
+                $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct f.fID)')->setMaxResults(1);
             });
             $pagination = new Pagination($this, $adapter);
         } else {

--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -56,7 +56,7 @@ class FolderItemList extends ItemList implements PermissionableListItemInterface
         if (isset($this->permissionsChecker) && $this->permissionsChecker === -1) {
             $query = $this->deliverQueryObject();
 
-            return $query->select('count(distinct n.treeNodeID)')->setMaxResults(1)->execute()->fetchColumn();
+            return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct n.treeNodeID)')->setMaxResults(1)->execute()->fetchColumn();
         } else {
             return -1; // unknown
         }
@@ -66,7 +66,7 @@ class FolderItemList extends ItemList implements PermissionableListItemInterface
     {
         if (isset($this->permissionsChecker) && $this->permissionsChecker === -1) {
             $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-                $query->select('count(distinct n.treeNodeID)')->setMaxResults(1);
+                $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct n.treeNodeID)')->setMaxResults(1);
             });
             $pagination = new Pagination($this, $adapter);
         } else {

--- a/concrete/src/Logging/Query/LogList.php
+++ b/concrete/src/Logging/Query/LogList.php
@@ -28,7 +28,7 @@ class LogList extends ItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(ql.query)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct ql.query)')->setMaxResults(1)->execute()->fetchColumn();
     }
 
     /**
@@ -39,9 +39,7 @@ class LogList extends ItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->resetQueryParts()->select('count(distinct query)')
-                ->from('SystemDatabaseQueryLog', 'ql')
-                ->setMaxResults(1);
+            $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct ql.query)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -205,7 +205,7 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
             // We need to reset the potential custom order by here because otherwise, if we've added
             // items to the select parts, and we're ordering by them, we get a SQL error
             // when we get total results, because we're resetting the select
-            return $query->select('count(distinct p.cID)')->resetQueryPart('orderBy')->setMaxResults(1)->execute()->fetchColumn();
+            return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct p.cID)')->setMaxResults(1)->execute()->fetchColumn();
         } else {
             return -1; // unknown
         }
@@ -219,7 +219,7 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
                 // We need to reset the potential custom order by here because otherwise, if we've added
                 // items to the select parts, and we're ordering by them, we get a SQL error
                 // when we get total results, because we're resetting the select
-                $query->select('count(distinct p.cID)')->resetQueryPart('orderBy')->setMaxResults(1);
+                $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct p.cID)')->setMaxResults(1);
             });
             $pagination = new Pagination($this, $adapter);
         } else {

--- a/concrete/src/User/Group/GroupList.php
+++ b/concrete/src/User/Group/GroupList.php
@@ -104,7 +104,7 @@ class GroupList extends DatabaseItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(g.gID)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct g.gID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 
     /**
@@ -115,7 +115,7 @@ class GroupList extends DatabaseItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->resetQueryPart('orderBy')->select('count(g.gID)')->setMaxResults(1);
+            $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct g.gID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 

--- a/concrete/src/User/UserList.php
+++ b/concrete/src/User/UserList.php
@@ -65,7 +65,7 @@ class UserList extends DatabaseItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(distinct u.uID)')->resetQueryPart('orderBy')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct u.uID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 
     /**
@@ -76,7 +76,7 @@ class UserList extends DatabaseItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct u.uID)')->resetQueryPart('orderBy')->setMaxResults(1);
+            $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct u.uID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 


### PR DESCRIPTION
This is needed when MySQL runs in strict mode (`sql-mode` contains ONLY_FULL_GROUP_BY and/or STRICT_TRANS_TABLES)