### PR TITLE
Update dashboard.js add_favorite event firing too many times

### DIFF
--- a/concrete/js/build/core/dashboard.js
+++ b/concrete/js/build/core/dashboard.js
@@ -45,6 +45,7 @@ var ConcreteDashboard = function() {
 							$link.attr('data-bookmark-action', 'remove-favorite');
 							$link.html('<i class="fa fa-lg fa-bookmark"></i>');
 						}
+						$link.off('click');
 						setupFavorites();
 					}
 				});


### PR DESCRIPTION
The click event handler is being fired too many times (all the old ones too). Resulting in multiple unnecessary ajax calls.
Before setting up a new event handler, remove the old one.
Other solution would be: setup both handlers, don't recall setupFavorites()