### PR TITLE
Add a semi colon to separate JS scripts in cache

### DIFF
--- a/concrete/src/Asset/JavascriptAsset.php
+++ b/concrete/src/Asset/JavascriptAsset.php
@@ -75,7 +75,7 @@ class JavascriptAsset extends Asset
                         if ($asset->assetSupportsMinification()) {
                             $contents = \JShrink\Minifier::minify($contents);
                         }
-                        $js .= $contents."\n\n";
+                        $js .= $contents.";\n\n";
                     }
                 }
                 @file_put_contents($cacheFile, $js);


### PR DESCRIPTION
This should always work, you can test by opening you browser console and running `();;;();;;;;();;()` javascript is super lenient with extra semicolons.

That said, omitting a semicolon is also allowed by javascript so the issue I was running into was this:

Script 1:
```javascript
$().click(function() {
})
```

Script 2:

```javascript
(function() {
}())
```


Due to the way we we concat, we end up with the following:

```javascript
$().click(function() {
})
(function() {
}())
```

A keen eye will notice that that essentially boils down to: `$().click()()` which IS valid javascript, but certainly isn't what was intended. Not just that but `$().click()` doesn't return a function so this will always error.

This is a known issue with IIFE's in JS which is why it's always recommended to start your IIFE with a terminating character like the semicolon:

```javascript
;(function() { 
}());
```

Since this isn't something that people always do, I propose we always add a semicolon between scripts to ensure that they are completely separate. For example with the `$().click()()`, adding a semicolon between the scripts we get `$().click();()` which works as expected.