### PR TITLE
CKEditor toolbarGroups

### DIFF
--- a/concrete/js/ckeditor4/core/ckeditor.css
+++ b/concrete/js/ckeditor4/core/ckeditor.css
@@ -18,3 +18,6 @@
     white-space: pre-wrap !important;
 }
 
+.cke_float {
+    max-width: 600px;
+}

--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -80,7 +80,34 @@ EOL;
                     'content-editor-image-left',
                     'content-editor-image-center',
                     'content-editor-image-right'
-                )
+                ),
+                'toolbarGroups' => [
+                    ['name' => 'mode', 'groups' => ['mode']],
+                    ['name' => 'document', 'groups' => ['document']],
+                    ['name' => 'doctools', 'groups' => ['doctools']],
+                    ['name' => 'clipboard', 'groups' => ['clipboard']],
+                    ['name' => 'undo', 'groups' => ['undo']],
+                    ['name' => 'find', 'groups' => ['find']],
+                    ['name' => 'selection', 'groups' => ['selection']],
+                    ['name' => 'spellchecker', 'groups' => ['spellchecker']],
+                    ['name' => 'editing', 'groups' => ['editing']],
+                    ['name' => 'basicstyles', 'groups' => ['basicstyles']],
+                    ['name' => 'cleanup', 'groups' => ['cleanup']],
+                    ['name' => 'list', 'groups' => ['list']],
+                    ['name' => 'indent', 'groups' => ['indent']],
+                    ['name' => 'blocks', 'groups' => ['blocks']],
+                    ['name' => 'align', 'groups' => ['align']],
+                    ['name' => 'bidi', 'groups' => ['bidi']],
+                    ['name' => 'paragraph', 'groups' => ['paragraph']],
+                    ['name' => 'links', 'groups' => ['links']],
+                    ['name' => 'insert', 'groups' => ['insert']],
+                    ['name' => 'forms', 'groups' => ['forms']],
+                    ['name' => 'styles', 'groups' => ['styles']],
+                    ['name' => 'colors', 'groups' => ['colors']],
+                    ['name' => 'tools', 'groups' => ['tools']],
+                    ['name' => 'others', 'groups' => ['others']],
+                    ['name' => 'about', 'groups' => ['about']],
+                ]
             )
         );
         $options = json_encode($options);


### PR DESCRIPTION
This pull request:
- breaks up the default button groups into the smallest groups allowed
- removes the toolbar line breaks, which allows the buttons to wrap onto a new line depending on the width of the toolbar
- adds a 600px toolbar max-width to the inline editor, preventing the toolbar from being one long row

