### PR TITLE
Avoid cycle in ResponseFactory->forbidden

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -124,7 +124,8 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $item = '/page_forbidden';
         $c = Page::getByPath($item);
         if (is_object($c) && !$c->isError()) {
-            return $this->collection($c, $code, $headers);
+            $this->request->setCurrentPage($c);
+            return $this->controller($c->getPageController(), $code, $headers);
         }
 
         $cnt = $this->app->make(PageForbidden::class);


### PR DESCRIPTION
The problem was that $factory->collection() was calling $factory->forbidden which was then calling $factory->collection() again.

This change just renders via the controller instead which seems to work.