### PR TITLE
Fix #4658

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -487,7 +487,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 // certain older blocks don't know that the last param ought to be a $bID. If they're equal it's zero
                 // which is best. and if they're greater that's ok too.
                 $bID = array_pop($parameters);
-                if ((is_string($bID) || is_int($bID)) && $bID == $this->bID) {
+                if (((is_string($bID) || is_int($bID)) && $bID == $this->bID) || $bID === 'blockAdd' || $bID === 'blockEdit') {
                     return true;
                 }
             }

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -106,6 +106,7 @@ class BlockView extends AbstractView
                     urlencode($this->area->getAreaHandle()),
                     $this->blockType->getBlockTypeID(),
                     $task,
+                    'blockAdd'
                 );
 
                 return call_user_func_array(array('\URL', 'to'), $arguments);
@@ -123,6 +124,7 @@ class BlockView extends AbstractView
                         urlencode($this->area->getAreaHandle()),
                         $b->getBlockID(),
                         $task,
+                        'blockEdit'
                     );
 
                     return call_user_func_array(array('\URL', 'to'), $arguments);

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -106,7 +106,7 @@ class BlockView extends AbstractView
                     urlencode($this->area->getAreaHandle()),
                     $this->blockType->getBlockTypeID(),
                     $task,
-                    'blockAdd'
+                    "blockAdd"
                 );
 
                 return call_user_func_array(array('\URL', 'to'), $arguments);
@@ -124,7 +124,7 @@ class BlockView extends AbstractView
                         urlencode($this->area->getAreaHandle()),
                         $b->getBlockID(),
                         $task,
-                        'blockEdit'
+                        "blockEdit"
                     );
 
                     return call_user_func_array(array('\URL', 'to'), $arguments);

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -301,15 +301,15 @@ class PageController extends Controller
             foreach ($blocks as $b) {
                 $controller = $b->getController();
                 list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
-                // [NOUR] if it's a proxyblock let's grab that
+                // If it's a proxyblock let's grab that
                 if (is_object($b->getProxyBlock())) {
                     $b = $b->getProxyBlock();
                 }
-                // [NOUR] let's add the block's ID at the end of the parameters array
+                // Let's add the block's ID at the end of the parameters array
                 // so we can implement the bID checking routine in the block's isValidControllerTask() function
                 $parameters[] = $b->getBlockID();
                 if ($controller->isValidControllerTask($method, $parameters)) {
-                    // [NOUR] it was a valid block task, let's remove the bID we added in the parameters array and run the task
+                    // It was a valid block task, let's remove the bID we added in the parameters array and run the task
                     array_pop($parameters);
                     $controller->on_start();
                     $response = $controller->runAction($method, $parameters);

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -301,7 +301,16 @@ class PageController extends Controller
             foreach ($blocks as $b) {
                 $controller = $b->getController();
                 list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
+                // [NOUR] if it's a proxyblock let's grab that
+                if (is_object($b->getProxyBlock())) {
+                    $b = $b->getProxyBlock();
+                }
+                // [NOUR] let's add the block's ID at the end of the parameters array
+                // so we can implement the bID checking routine in the block's isValidControllerTask() function
+                $parameters[] = $b->getBlockID();
                 if ($controller->isValidControllerTask($method, $parameters)) {
+                    // [NOUR] it was a valid block task, let's remove the bID we added in the parameters array and run the task
+                    array_pop($parameters);
                     $controller->on_start();
                     $response = $controller->runAction($method, $parameters);
                     if ($response instanceof Response) {

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -292,41 +292,86 @@ class PageController extends Controller
     public function validateRequest()
     {
         $valid = true;
-
         if (!$this->isValidControllerTask($this->action, $this->parameters)) {
+            // This is not a page tas let's check blocks'
             $valid = false;
-            // we check the blocks on the page.
-            $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
-
-            foreach ($blocks as $b) {
-                $controller = $b->getController();
-                list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
-                // If it's a proxyblock let's grab that
-                if (is_object($b->getProxyBlock())) {
-                    $b = $b->getProxyBlock();
+            
+            // check if we are dealing with a task called by a block's add or edit mode
+            // 2 checks are used: presence of a specific path OR presence of a specific parameter
+            $blockAddRequest = ((strpos($this->request->getPath(), '/ccm/system/block/action/add') !== false) || (array_slice($this->parameters, -1)[0] === "blockAdd"));
+            $blockEditRequest = ((strpos($this->request->getPath(), '/ccm/system/block/action/edit') !== false) || (array_slice($this->parameters, -1)[0] === "blockEdit"));
+            
+            // If we are dealing with a block in add or edit mode, let's do this
+            if ($blockAddRequest || $blockEditRequest) {
+                // in Add mode, let's grab the block type's controller
+                if ($blockAddRequest) {
+                    $controller = BlockType::getByID($this->parameters[7])->controller;
                 }
-                // Let's add the block's ID at the end of the parameters array
-                // so we can implement the bID checking routine in the block's isValidControllerTask() function
-                $parameters[] = $b->getBlockID();
+                // In edit mode, let's grab the block's controller
+                if ($blockEditRequest) {
+                    $controller = Block::getByID($this->parameters[7])->getController();
+                }
+                // let's remove everything in this->parameters that is not what we need. We need the task and its parameters
+                // everything before that is just the different components of the path
+                list($method, $parameters) = $controller->getPassThruActionAndParameters(array_slice($this->parameters, 8));
+
+                // let's check that we're dealing with a valid task
                 if ($controller->isValidControllerTask($method, $parameters)) {
-                    // It was a valid block task, let's remove the bID we added in the parameters array and run the task
-                    array_pop($parameters);
-                    $controller->on_start();
-                    $response = $controller->runAction($method, $parameters);
-                    if ($response instanceof Response) {
-                        return $response;
+                        // pretty good. Let's get rid of the strings we added in BlockView.php ("blockAdd" or "blockEdit")
+                        // in both the local $this->parameters variable and $parameters variable we're sending to the task function
+                        // then run the task
+                        array_pop($this->parameters);
+                        array_pop($parameters);
+                        $controller->on_start();
+                        $response = $controller->runAction($method, $parameters);
+                        if ($response instanceof Response) {
+                            return $response;
+                        }
+                        // old school blocks have already terminated at this point. They are redirecting
+                        // or exiting. But new blocks like topics, etc... can actually rely on their $set
+                        // data persisting and being passed into the view.
+
+                        // so if we make it down here we have to return true –so that we don't fire a 404.
+                        $valid = true;
+
+                        // then, we need to save the persisted data that may have been set.
+                        $controller->setPassThruBlockController($this);
                     }
-                    // old school blocks have already terminated at this point. They are redirecting
-                    // or exiting. But new blocks like topics, etc... can actually rely on their $set
-                    // data persisting and being passed into the view.
+            } else {
+                // We're not in add or edit mode so it must be a view for a block from the page
+                $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
+                foreach ($blocks as $b) {
+                    $controller = $b->getController();
+                    list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
+                    // if it's a proxy let's grab that
+                    if (is_object($b->getProxyBlock())) {
+                        $b = $b->getProxyBlock();
+                    }
+                    // we add the bID as the last value in our parameters array for checking purposes
+                    $parameters[] = $b->getBlockID();
 
-                    // so if we make it down here we have to return true –so that we don't fire a 404.
-                    $valid = true;
+                    if ($controller->isValidControllerTask($method, $parameters)) {
+                        // it's a valid task for this block's instance
+                        // let's remove the bID we added to parameters and run the task
+                        array_pop($parameters);
+                        $controller->on_start();
+                        $response = $controller->runAction($method, $parameters);
+                        if ($response instanceof Response) {
+                            return $response;
+                        }
+                        // old school blocks have already terminated at this point. They are redirecting
+                        // or exiting. But new blocks like topics, etc... can actually rely on their $set
+                        // data persisting and being passed into the view.
 
-                    // then, we need to save the persisted data that may have been set.
-                    $controller->setPassThruBlockController($this);
+                        // so if we make it down here we have to return true –so that we don't fire a 404.
+                        $valid = true;
+
+                        // then, we need to save the persisted data that may have been set.
+                        $controller->setPassThruBlockController($this);
+                    }
                 }
             }
+            
 
             if (!$valid) {
                 // finally, we check additional page paths.

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -20,7 +20,8 @@ class PageController extends Controller
     protected $passThruBlocks = array();
     protected $parameters = array();
     protected $replacement = null;
-
+    protected $request;
+    
     /**
      * array of method names that can't be called through the url
      * @var array
@@ -200,6 +201,7 @@ class PageController extends Controller
 
     public function setupRequestActionAndParameters(Request $request)
     {
+        $this->request = $request;
         $requestPath = $this->getCustomRequestPath();
         if ($requestPath === null) {
             $requestPath = $request->getPath();


### PR DESCRIPTION
@mlocati rightfully pointed out that when using a block's task we needed a way to know which instance of the block launched the call.

He submitted a solution that worked in some situations but not all.

For instance, it broke the topic list block.

This pull request builds on top of his solution.

@mlocati solution only worked when the check on the task was done by the block's controller. In that case the checking function automatically adds the bID to the parameters and @mlocati check works.

But sometimes, the task will first go through the page's controller.

I modified the task checking function in the page's controller to also add the bID to the list of parameters before running the check. If the check is succesful, the bID is removed from parameters and the task is processed.