### PR TITLE
[v8] Fix declaration error

### DIFF
--- a/concrete/src/Attribute/StandardValidator.php
+++ b/concrete/src/Attribute/StandardValidator.php
@@ -57,7 +57,7 @@ class StandardValidator implements ValidatorInterface
         return $response;
     }
 
-    public function validateCurrentAttributeValue(Controller $controller, Value $value)
+    public function validateCurrentAttributeValue(Controller $controller, AttributeValueInterface $value)
     {
         $key = $controller->getAttributeKey();
         $controller->setAttributeValue($value);

--- a/concrete/src/Attribute/ValidatorInterface.php
+++ b/concrete/src/Attribute/ValidatorInterface.php
@@ -38,7 +38,7 @@ interface ValidatorInterface
     /**
      * @param Controller $controller
      */
-    function validateCurrentAttributeValue(Controller $controller, Value $value);
+    function validateCurrentAttributeValue(Controller $controller, AttributeValueInterface $value);
 
 
 }


### PR DESCRIPTION
> Argument 2 passed to Concrete\Core\Attribute\StandardValidator::validateCurrentAttributeValue() must be an instance of Concrete\Core\Entity\Attribute\Value\Value, instance of Concrete\Core\Entity\Attribute\Value\PageValue given, called in C:\www\concrete\src\Page\Type\Composer\Control\CollectionAttributeControl.php on line 191

I change Concrete\Core\Entity\Attribute\Value\Value to Concrete\Core\Attribute\AttributeValueInterface for fix it