### PR TITLE
Feature/exception response flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](http://img.shields.io/travis/concrete5/concrete5/develop.svg)](https://travis-ci.org/concrete5/concrete5)
+[![Build Status](http://img.shields.io/travis/concrete5/concrete5/feature/exception-response-flow.svg)](https://travis-ci.org/concrete5/concrete5)
 [![Issues Ready To Start](https://badge.waffle.io/concrete5/concrete5.png?label=Accepted:Ready%20to%20start&title=Ready)](https://github.com/concrete5/concrete5/labels/accepted%3Aready%20to%20start)
 
 Welcome to the official repository for concrete5 development! concrete5 is an open source CMS built by people from 

--- a/concrete/authentication/twitter/controller.php
+++ b/concrete/authentication/twitter/controller.php
@@ -126,9 +126,7 @@ class Controller extends GenericOauth1aTypeController
             $flashbag->set('username', parent::getUsername());
             $flashbag->set('token', $this->getToken());
 
-            $response = \Redirect::to('/login/callback/twitter/handle_register/', id(new Token())->generate('twitter_register'));
-            $response->send();
-            exit;
+            $this->redirect('/login/callback/twitter/handle_register/', id(new Token())->generate('twitter_register'));
         }
 
         return null;
@@ -149,7 +147,6 @@ class Controller extends GenericOauth1aTypeController
         if (!$token_helper->validate('twitter_register', $token) && !$token_helper->validate('twitter_register') ||
             !$this->token) {
             $this->redirect('/login/');
-            exit;
         }
         if (\Request::request('uEmail', false)) {
             $this->email = \Request::request('uEmail');

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -610,8 +610,7 @@ class Controller extends BlockController
                     $url = $response->getTargetUrl() . "?surveySuccess=1&qsid=".$this->questionSetId."#formblock".$this->bID;
                     $response->setTargetUrl($url);
                 }
-                $response->send();
-                exit;
+                return $response;
             }
         }
     }

--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -36,16 +36,13 @@ class Controller extends BlockController
                 $relatedID = $lang->getTranslatedPageID($page);
                 if ($relatedID) {
                     $pc = \Page::getByID($relatedID);
-                    Redirect::page($pc)->send();
-                    exit;
+                    return Redirect::page($pc);
                 }
             }
-            Redirect::page($lang)->send();
-            exit;
+            return Redirect::page($lang);
         }
 
-        Redirect::to('/');
-        exit;
+        return Redirect::to('/');
     }
 
     public function action_set_current_language()
@@ -62,7 +59,7 @@ class Controller extends BlockController
             }
         }
 
-        $this->action_switch_language($this->post('rcID'), $this->post('language'));
+        return $this->action_switch_language($this->post('rcID'), $this->post('language'));
     }
 
     public function add()

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1304,6 +1304,7 @@ return array(
         ],
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
         'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
+        'core_http_exceptions' => \Concrete\Core\Http\Middleware\HttpExceptionMiddleware::class,
         'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class
     ]
 );

--- a/concrete/controllers/panel/page/devices.php
+++ b/concrete/controllers/panel/page/devices.php
@@ -57,8 +57,7 @@ class Devices extends BackendInterfacePageController
             \Request::setInstance($request);
 
             $response->setContent($content);
-            $response->send();
-            exit;
+            return $response;
         }
     }
 }

--- a/concrete/controllers/panel/page/preview_as_user.php
+++ b/concrete/controllers/panel/page/preview_as_user.php
@@ -50,7 +50,7 @@ class PreviewAsUser extends Controller
 
             $response = new \Response();
             $response->setContent($view->render());
-            $response->send();
+            return $response;
         }
     }
 }

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -611,10 +611,9 @@ class Stacks extends DashboardSitePageController
         foreach ($moveFolders as $moveFolder) {
             $moveFolder->getPage()->move($destinationPage);
         }
-        JsonResponse::create(
+        return JsonResponse::create(
             t2('%d item has been moved under the folder %s', '%d items have been moved under the folder %s', count($sourceIDs), count($sourceIDs), h($destinationPage->getCollectionName()))
-        )->send();
-        exit;
+        );
     }
 
     public function duplicate($cID)

--- a/concrete/controllers/single_page/dashboard/blocks/types.php
+++ b/concrete/controllers/single_page/dashboard/blocks/types.php
@@ -76,9 +76,11 @@ class Types extends DashboardPageController
         if ($tp->canInstallPackages()) {
             try {
                 $resp = BlockType::installBlockType($btHandle);
-                $this->redirect('/dashboard/blocks/types', 'installed');
             } catch (\Exception $e) {
                 $this->error->add($e);
+            }
+            if (!$this->error->has()) {
+                $this->redirect('/dashboard/blocks/types', 'installed');
             }
         } else {
             $this->error->add(t('You do not have permission to install custom block types or add-ons.'));

--- a/concrete/controllers/single_page/dashboard/pages/themes.php
+++ b/concrete/controllers/single_page/dashboard/pages/themes.php
@@ -117,13 +117,12 @@ class Themes extends DashboardPageController
         }
 
         $v = Loader::helper('validation/error');
+        $t = null;
         try {
-            if (is_object($th)) {
-                $t = PageTheme::add($pThemeHandle);
-                $this->redirect('/dashboard/pages/themes/inspect', $t->getThemeID(), 'install');
-            } else {
+            if (!is_object($th)) {
                 throw new Exception('Invalid Theme');
             }
+            $t = PageTheme::add($pThemeHandle);
         } catch (Exception $e) {
             switch ($e->getMessage()) {
                 case PageTheme::E_THEME_INSTALLED:
@@ -135,6 +134,9 @@ class Themes extends DashboardPageController
             }
 
             $this->set('error', $v);
+        }
+        if ($t !== null) {
+            $this->redirect('/dashboard/pages/themes/inspect', $t->getThemeID(), 'install');
         }
         $this->view();
     }

--- a/concrete/controllers/single_page/dashboard/pages/types/output.php
+++ b/concrete/controllers/single_page/dashboard/pages/types/output.php
@@ -43,7 +43,7 @@ class Output extends DashboardPageController
             // we load up the master template for this composer/template combination.
             $c = $this->pagetype->getPageTypePageTemplateDefaultPageObject($template);
             Session::set('mcEditID', $c->getCollectionID());
-            Redirect::url(\URL::to($c))->send();
+            return Redirect::url(\URL::to($c));
         }
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/backup/update.php
+++ b/concrete/controllers/single_page/dashboard/system/backup/update.php
@@ -176,8 +176,7 @@ class Update extends DashboardPageController
                 }
             } else {
                 $token = Loader::helper("validation/token");
-                \Redirect::to('/ccm/system/upgrade/submit?ccm_token=' . $token->generate('Concrete\Controller\Upgrade'))->send();
-                exit;
+                return \Redirect::to('/ccm/system/upgrade/submit?ccm_token=' . $token->generate('Concrete\Controller\Upgrade'));
             }
         }
     }
@@ -218,8 +217,7 @@ class Update extends DashboardPageController
                 }
             } else {
                 $token = Loader::helper("validation/token");
-                \Redirect::to('/ccm/system/upgrade/submit?ccm_token=' . $token->generate('Concrete\Controller\Upgrade'))->send();
-                exit;
+                return Redirect::to('/ccm/system/upgrade/submit?ccm_token=' . $token->generate('Concrete\Controller\Upgrade'));
             }
             */
 

--- a/concrete/controllers/single_page/dashboard/system/conversations/editor.php
+++ b/concrete/controllers/single_page/dashboard/system/conversations/editor.php
@@ -47,8 +47,6 @@ class Editor extends DashboardPageController
         $db = Loader::db();
         if (!isset($this->editors[$active])) {
             $this->redirect('/dashboard/system/conversations/editor/error');
-
-            return;
         }
         $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=0');
         $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));

--- a/concrete/controllers/single_page/dashboard/system/conversations/settings.php
+++ b/concrete/controllers/single_page/dashboard/system/conversations/settings.php
@@ -58,8 +58,6 @@ class Settings extends DashboardPageController
         $db = Core::make('Concrete\Core\Database\Connection\Connection');
         if (!isset($this->editors[$active])) {
             $this->redirect('/dashboard/system/conversations/editor/error');
-
-            return;
         }
         $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=0');
         $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));

--- a/concrete/controllers/single_page/dashboard/system/mail/method/test.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method/test.php
@@ -58,9 +58,11 @@ class Test extends DashboardPageController
                 }
                 $mail->setBody($body);
                 $mail->sendMail();
-                $this->redirect('/dashboard/system/mail/method/test/', 'successful', rawurlencode($mailRecipient));
             } catch (Exception $x) {
                 $this->error->add(t('The following error was found while trying to send the test email:') . '<br />' . nl2br(h($x->getMessage())));
+            }
+            if (!$this->error->has()) {
+                $this->redirect('/dashboard/system/mail/method/test/', 'successful', rawurlencode($mailRecipient));
             }
         }
         $this->set('mailRecipient', $mailRecipient);

--- a/concrete/controllers/single_page/dashboard/system/permissions/workflows.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/workflows.php
@@ -26,10 +26,11 @@ class Workflows extends DashboardPageController
             }
 
             $wf->delete();
-
-            $this->redirect("/dashboard/system/permissions/workflows", 'workflow_deleted');
         } catch (Exception $e) {
             $this->error->add($e);
+        }
+        if (!$this->error->has()) {
+            $this->redirect('/dashboard/system/permissions/workflows', 'workflow_deleted');
         }
         $this->view();
     }

--- a/concrete/controllers/single_page/dashboard/system/registration/authentication.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/authentication.php
@@ -53,18 +53,12 @@ class Authentication extends DashboardPageController
 
     public function enable($atid)
     {
+        if (!$this->token->validate("auth_type_toggle.{$atid}")) {
+            $this->app->make('session')->set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
+            $this->redirect('dashboard/system/registration/authentication/');
+        }
         try {
             $at = AuthenticationType::getByID($atid);
-
-            /** @var Token $token */
-            $token = \Core::make('token');
-
-            if (!$token->validate("auth_type_toggle.{$atid}")) {
-                Session::set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
-                $this->redirect('dashboard/system/registration/authentication/');
-                exit;
-            }
-
             $at->enable();
             $this->set('message', t('The %s authentication type has been enabled.', $at->getAuthenticationTypeName()));
         } catch (Exception $e) {
@@ -75,18 +69,13 @@ class Authentication extends DashboardPageController
 
     public function disable($atid)
     {
+        if (!$this->token->validate("auth_type_toggle.{$atid}")) {
+            $this->app->make('session')->set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
+            $this->redirect('dashboard/system/registration/authentication/');
+        }
+
         try {
             $at = AuthenticationType::getByID($atid);
-
-            /** @var Token $token */
-            $token = \Core::make('token');
-
-            if (!$token->validate("auth_type_toggle.{$atid}")) {
-                Session::set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
-                $this->redirect('dashboard/system/registration/authentication/');
-                exit;
-            }
-
             $at->disable();
             $this->set('message', t('The %s authentication type has been disabled.', $at->getAuthenticationTypeName()));
         } catch (Exception $e) {
@@ -97,30 +86,23 @@ class Authentication extends DashboardPageController
 
     public function save($atid)
     {
+        if (!$this->token->validate("auth_type_save.{$atid}")) {
+            $this->app->make('session')->set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
+            $this->redirect('dashboard/system/registration/authentication/');
+        }
+
         $values = $this->post();
         try {
             $at = AuthenticationType::getByID($atid);
-
-            /** @var Token $token */
-            $token = \Core::make('token');
-
-            if (!$token->validate("auth_type_save.{$atid}")) {
-                Session::set('authenticationTypesErrorCode', self::ERROR_INVALID_TOKEN);
-                $this->redirect('dashboard/system/registration/authentication/');
-                exit;
-            }
-
             try {
                 $at->controller->saveAuthenticationType($values);
-                $this->set('message',
-                    t('The %s authentication type has been saved.', $at->getAuthenticationTypeName()));
+                $this->set('message', t('The %s authentication type has been saved.', $at->getAuthenticationTypeName()));
             } catch (Exception $e) {
                 $this->error->add($e->getMessage());
             }
         } catch (Exception $e) {
-            Session::set('authenticationTypesErrorCode', self::ERROR_INVALID_TYPE);
+            $this->app->make('session')->set('authenticationTypesErrorCode', self::ERROR_INVALID_TYPE);
             $this->redirect('dashboard/system/registration/authentication/');
-            exit;
         }
         $this->view();
     }
@@ -132,7 +114,6 @@ class Authentication extends DashboardPageController
         } catch (Exception $e) {
             Session::set('authenticationTypesErrorCode', self::ERROR_INVALID_TYPE);
             $this->redirect('dashboard/system/registration/authentication/');
-            exit;
         }
         $this->set('at', $at);
         $this->set('editmode', true);

--- a/concrete/controllers/single_page/dashboard/system/seo/bulk.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/bulk.php
@@ -117,8 +117,7 @@ class Bulk extends DashboardPageController
         $newHandle = $text->urlify($cHandle);
         $result = array('success' => $success, 'cID' => $cID, 'cHandle' => $newHandle, 'newPath' => $newHandle, 'newLink' => $newPath);
 
-        JsonResponse::create($result)->send();
-        exit;
+        return JsonResponse::create($result);
     }
 
     /**

--- a/concrete/controllers/single_page/dashboard/users.php
+++ b/concrete/controllers/single_page/dashboard/users.php
@@ -2,12 +2,11 @@
 namespace Concrete\Controller\SinglePage\Dashboard;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Routing\RedirectResponse;
 
 class Users extends DashboardPageController
 {
     public function validateRequest()
     {
-        return new RedirectResponse($this->app->make('url/manager')->resolve(['/dashboard/users/search']));
+        $this->redirect('/dashboard/users/search');
     }
 }

--- a/concrete/single_pages/!drafts/view.php
+++ b/concrete/single_pages/!drafts/view.php
@@ -3,4 +3,3 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 $this->controller->redirect('/');
-exit;

--- a/concrete/single_pages/!stacks/view.php
+++ b/concrete/single_pages/!stacks/view.php
@@ -3,4 +3,3 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 $this->controller->redirect('/');
-exit;

--- a/concrete/single_pages/!trash/view.php
+++ b/concrete/single_pages/!trash/view.php
@@ -3,4 +3,3 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 $this->controller->redirect('/');
-exit;

--- a/concrete/src/Controller/AbstractController.php
+++ b/concrete/src/Controller/AbstractController.php
@@ -2,7 +2,9 @@
 namespace Concrete\Core\Controller;
 
 use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Http\Exception\RedirectException;
 use Concrete\Core\Http\ResponseAssetGroup;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Core;
 use Request;
 use View;
@@ -152,10 +154,8 @@ abstract class AbstractController implements ApplicationAwareInterface
 
     public function redirect()
     {
-        $args = func_get_args();
-        $r = call_user_func_array(array('Redirect', 'to'), $args);
-        $r->send();
-        exit;
+        $redirectUrl = $this->app->make(ResolverManagerInterface::class)->resolve(func_get_args());
+        throw new RedirectException($redirectUrl);
     }
 
     public function runTask($action, $parameters)

--- a/concrete/src/Error/Exception.php
+++ b/concrete/src/Error/Exception.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Error;
+
+use Exception as PHPException;
+
+class Exception extends PHPException
+{
+
+}

--- a/concrete/src/Http/Exception/ForbiddenException.php
+++ b/concrete/src/Http/Exception/ForbiddenException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Http\Exception;
+
+use Concrete\Core\Http\Response;
+
+/**
+ * Class ForbiddenException
+ * An exception to show that the requestor does not have permission to view the requested content
+ * @package Concrete\Core\Http\Exception
+ */
+class ForbiddenException extends HttpResponseException
+{
+
+    public function __construct($message, array $headers = [], \Exception $previous = null)
+    {
+        parent::__construct($message, Response::HTTP_FORBIDDEN, $headers, $previous);
+    }
+
+}

--- a/concrete/src/Http/Exception/HttpException.php
+++ b/concrete/src/Http/Exception/HttpException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Http\Exception;
+
+use Concrete\Core\Error\Exception;
+
+class HttpException extends Exception
+{
+
+}

--- a/concrete/src/Http/Exception/HttpResponseException.php
+++ b/concrete/src/Http/Exception/HttpResponseException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Concrete\Core\Http\Exception;
+
+/**
+ * Class HttpResponseException
+ * An http exception that is meant to generate a specific response
+ *
+ * This class is abstract because it looks great to throw but it's probably not what you want.
+ * @package Concrete\Core\Http\Exception
+ */
+abstract class HttpResponseException extends HttpException
+{
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * HttpResponseException constructor.
+     * @param string $message
+     * @param int $code
+     * @param array $headers
+     * @param \Exception|null $previous
+     */
+    public function __construct($message, $code, $headers = [], \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->headers = $headers;
+    }
+
+    /**
+     * Get the response status code
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->getCode();
+    }
+
+    /**
+     * Get the attached headers
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+}

--- a/concrete/src/Http/Exception/RedirectException.php
+++ b/concrete/src/Http/Exception/RedirectException.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Concrete\Core\Http\Exception;
+
+use Concrete\Core\Http\Response;
+
+/**
+ * Class RedirectException
+ * An exception to show that the requested content is located elsewhere
+ * @package Concrete\Core\Http\Exception
+ */
+class RedirectException extends HttpResponseException
+{
+
+    /**
+     * @var array
+     */
+    private $headers;
+    /**
+     * @var string
+     */
+    private $to;
+
+    /**
+     * RedirectException constructor.
+     * @param string $to The url to redirect to
+     * @param int $code The response code, usually 302 (temporary) or 301 (permanent)
+     * @param array $headers
+     * @param \Exception $previous
+     */
+    public function __construct($to, $code = Response::HTTP_FOUND, $headers = array(), \Exception $previous = null)
+    {
+        parent::__construct("{$code} Redirect", $code, $headers, $previous);
+        $this->headers = $headers;
+        $this->to = $to;
+    }
+
+    /**
+     * The url to redirect to.
+     * @return string
+     */
+    public function getRedirectUrl()
+    {
+        return $this->to;
+    }
+
+}

--- a/concrete/src/Http/Exception/UserFacingException.php
+++ b/concrete/src/Http/Exception/UserFacingException.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Concrete\Core\Http\Exception;
+
+use Concrete\Core\Http\Response;
+use Exception;
+
+/**
+ * Class UserFacingException
+ * An exception whose message is safe to output to the user
+ * @package Concrete\Core\Http\Exception
+ */
+class UserFacingException extends HttpResponseException
+{
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * UserFacingException constructor.
+     * @param string $message The error message
+     * @param string $title The error title
+     * @param int $code The error code
+     * @param array $headers
+     * @param \Exception $previous
+     */
+    public function __construct($message, $title = null, $code = Response::HTTP_INTERNAL_SERVER_ERROR, array $headers = [], Exception $previous = null)
+    {
+        parent::__construct($message, $code, $headers, $previous);
+        $this->title = $title;
+    }
+
+    /**
+     * Get the title of the error
+     * @return string
+     */
+    public function getTitle()
+    {
+        if ($this->title === null) {
+            return t('An unexpected error occurred');
+        }
+
+        return $this->title;
+    }
+
+}

--- a/concrete/src/Http/Middleware/HttpExceptionMiddleware.php
+++ b/concrete/src/Http/Middleware/HttpExceptionMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Concrete\Core\Http\Middleware;
+
+use Concrete\Core\Http\Exception\ForbiddenException;
+use Concrete\Core\Http\Exception\RedirectException;
+use Concrete\Core\Http\Exception\UserFacingException;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpExceptionMiddleware implements MiddlewareInterface
+{
+
+    /**
+     * @var \Concrete\Core\Http\ResponseFactoryInterface
+     */
+    private $factory;
+
+    public function __construct(ResponseFactoryInterface $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * Process the request and return a response
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param DelegateInterface $frame
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        // Attempt to load the next frame
+        try {
+            return $frame->next($request);
+        } catch (RedirectException $e) {
+            // Redirect
+            return $this->handleRedirect($e);
+        } catch (ForbiddenException $e) {
+            // Forbidden
+            return $this->handleForbidden($e, $request);
+        } catch (UserFacingException $e) {
+            // Generic error to output
+            return $this->handleUserFacingException($e);
+        }
+    }
+
+    private function handleRedirect(RedirectException $e)
+    {
+        return $this->factory->redirect($e->getRedirectUrl(), $e->getStatus(), $e->getHeaders());
+    }
+
+    private function handleForbidden(ForbiddenException $e, Request $request)
+    {
+        return $this->factory->forbidden($request->getRequestUri(), $e->getStatus(), $e->getHeaders());
+    }
+
+    private function handleUserFacingException(UserFacingException $e)
+    {
+        $error = (object) [
+            'content' => $e->getMessage(),
+            'title' => $e->getTitle()
+        ];
+
+        return $this->factory->error($error, $e->getStatus(), $e->getHeaders());
+    }
+
+}

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -19,6 +19,7 @@ use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Routing\RouterInterface;
 use Concrete\Core\User\User;
+use Concrete\Core\View\ErrorView;
 use Concrete\Core\View\View;
 use Detection\MobileDetect;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -109,7 +110,8 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function error($content, $code = Response::HTTP_INTERNAL_SERVER_ERROR, $headers = array())
     {
-        return $this->create($content, $code, $headers);
+        $view = new ErrorView($content);
+        return $this->create($view->render(), $code, $headers);
     }
 
     /**

--- a/concrete/src/Page/Controller/DashboardAttributesPageController.php
+++ b/concrete/src/Page/Controller/DashboardAttributesPageController.php
@@ -14,6 +14,7 @@ use Concrete\Core\Entity\Attribute\Category;
 use Concrete\Core\Entity\Attribute\SetKey;
 use Concrete\Core\Entity\Attribute\Type;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Exception;
 
 abstract class DashboardAttributesPageController extends DashboardPageController
 {
@@ -159,7 +160,7 @@ abstract class DashboardAttributesPageController extends DashboardPageController
         $entity = $this->getCategoryObject();
         try {
             if (!$this->token->validate('delete_attribute')) {
-                throw new \Exception($this->token->getErrorMessage());
+                throw new Exception($this->token->getErrorMessage());
             }
 
             $this->entityManager->remove($key);
@@ -168,12 +169,12 @@ abstract class DashboardAttributesPageController extends DashboardPageController
             if ($onComplete instanceof \Closure) {
                 $onComplete();
             }
-
-            $this->flash('success', t('Attribute deleted successfully.'));
-            $this->redirect($successURL);
         } catch (Exception $e) {
             $this->error = $e;
+            return;
         }
+        $this->flash('success', t('Attribute deleted successfully.'));
+        $this->redirect($successURL);
     }
 
     public function sort_attribute_set()

--- a/tests/tests/Core/Http/Middleware/HttpExceptionMiddlewareTest.php
+++ b/tests/tests/Core/Http/Middleware/HttpExceptionMiddlewareTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Concrete\Tests\Core\Http\Middleware;
+
+use Concrete\Core\Http\Exception\ForbiddenException;
+use Concrete\Core\Http\Exception\RedirectException;
+use Concrete\Core\Http\Exception\UserFacingException;
+use Concrete\Core\Http\Middleware\DelegateInterface;
+use Concrete\Core\Http\Middleware\HttpExceptionMiddleware;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ResponseFactoryInterface;
+
+class HttpExceptionMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRedirectException()
+    {
+        // The args we expect to see passed through
+        $args = ['http://some.url/', 1337, ['test=true']];
+
+        // The middleware frame that throws the exception
+        $frame = $this->getMiddlewareFrame(function() use ($args) {
+            throw new RedirectException($args[0], $args[1], $args[2]);
+        });
+
+        // Response Factory
+        $factory = $this->getMock(ResponseFactoryInterface::class);
+        $factory
+            ->expects($this->once())
+            ->method('redirect')
+            ->willReturnCallback(function() {
+                return func_get_args();
+            });
+
+        // Request
+        $request = $this->getMock(Request::class);
+
+        // Run the middleware
+        $middleware = new HttpExceptionMiddleware($factory);
+        $result = $middleware->process($request, $frame);
+
+        // Make sure we have the same array values.
+        $this->assertSame($args, $result);
+    }
+
+    public function testForbiddenException()
+    {
+
+        // The args we expect to see passed through
+        $args = ['http://request.url/', 403, ['test=true']];
+
+        // The middleware frame that throws the exception
+        $frame = $this->getMiddlewareFrame(function() use ($args) {
+            throw new ForbiddenException($args[0], $args[2]);
+        });
+
+        // Response Factory
+        $factory = $this->getMock(ResponseFactoryInterface::class);
+        $factory
+            ->expects($this->once())
+            ->method('forbidden')
+            ->willReturnCallback(function() {
+                return func_get_args();
+            });
+
+        // Request
+        $request = $this->getMock(Request::class);
+        $request
+            ->method('getRequestUri')
+            ->willReturn('http://request.url/');
+
+        // Run the middleware
+        $middleware = new HttpExceptionMiddleware($factory);
+        $result = $middleware->process($request, $frame);
+
+        // Make sure we have the same array values.
+        $this->assertSame($args, $result);
+    }
+
+    public function testUserFacingException()
+    {
+
+        // The args we expect to see passed through
+        $args = ['ERROR!!!!', 'Title', 1337, ['test=true']];
+        $expected = [ (object) ['content' => $args[0], 'title' => $args[1] ], $args[2], $args[3]];
+
+        // The middleware frame that throws the exception
+        $frame = $this->getMiddlewareFrame(function() use ($args) {
+            throw new UserFacingException($args[0], $args[1], $args[2], $args[3]);
+        });
+
+        // Response Factory
+        $factory = $this->getMock(ResponseFactoryInterface::class);
+        $factory
+            ->expects($this->once())
+            ->method('error')
+            ->willReturnCallback(function() {
+                return func_get_args();
+            });
+
+        // Request
+        $request = $this->getMock(Request::class);
+
+        // Run the middleware
+        $middleware = new HttpExceptionMiddleware($factory);
+        $result = $middleware->process($request, $frame);
+
+        // Make sure we have the same array values.
+        $this->assertEquals($expected, $result);
+    }
+
+
+    /**
+     * @param callable $callback
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMiddlewareFrame(callable $callback)
+    {
+        $frame = $this->getMockForAbstractClass(DelegateInterface::class);
+        $frame
+            ->expects($this->once())
+            ->method('next')
+            ->willReturnCallback($callback);
+
+        return $frame;
+    }
+
+}


### PR DESCRIPTION
This seems to work great. See #4487 for more info.

The only potential caveat I can see is if a middleware catches all exceptions instead of just the ones they are trying to catch, they may filter out these redirects. Luckily that is an easy thing to fix.


```php
try {
    $response = $frame->next($request);
} catch (\Exception $e) {
    if ($e instanceof HttpResponseException) {
        throw $e; // Re-throw http response exceptions
    }
}
```

The build will break for this since develop is currently breaking. Let's not merge this unless we've tested and the build is successful.

--- 

Note: it's important that we get the order of this middleware set up properly. Do we want this exception to fall through all middleware (run the handler middleware first in the stack) or should our exception handler catch the exception first thing and return a proper response through the stack? (run the handler middleware just before the dispatcher middleware)