### PR TITLE
Fix #4658

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -486,8 +486,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 // how do we get <= 1? If it's 1, that means that the method has one fewer param. That's ok because
                 // certain older blocks don't know that the last param ought to be a $bID. If they're equal it's zero
                 // which is best. and if they're greater that's ok too.
+                // sometimes we will get the bID to work with but sometimes (add mode) the bID is not accessible
+                // in those situations the mode (add or edit) is indicated by the presence of a string blockAdd or blockEdit
+                // Now let's see if the action is for this block instance
                 $bID = array_pop($parameters);
-                if ((is_string($bID) || is_int($bID)) && $bID == $this->bID) {
+                if (((is_string($bID) || is_int($bID)) && $bID == $this->bID) || $bID === 'blockAdd' || $bID === 'blockEdit') {
                     return true;
                 }
             }

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -98,6 +98,8 @@ class BlockView extends AbstractView
      */
     public function action($task)
     {
+        // both strings 'blockAdd' and 'blockEdit' are used to indicate the status of the block
+        // later on when checking a task's validity
         try {
             if ($this->viewToRender == 'add') {
                 $c = $this->area->getAreaCollectionObject();
@@ -106,6 +108,7 @@ class BlockView extends AbstractView
                     urlencode($this->area->getAreaHandle()),
                     $this->blockType->getBlockTypeID(),
                     $task,
+                    'blockAdd',
                 );
 
                 return call_user_func_array(array('\URL', 'to'), $arguments);
@@ -123,6 +126,7 @@ class BlockView extends AbstractView
                         urlencode($this->area->getAreaHandle()),
                         $b->getBlockID(),
                         $task,
+                        'blockEdit',
                     );
 
                     return call_user_func_array(array('\URL', 'to'), $arguments);

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -20,7 +20,7 @@ class PageController extends Controller
     protected $passThruBlocks = array();
     protected $parameters = array();
     protected $replacement = null;
-
+    protected $request;
     /**
      * array of method names that can't be called through the url
      * @var array
@@ -200,6 +200,8 @@ class PageController extends Controller
 
     public function setupRequestActionAndParameters(Request $request)
     {
+        // this request will be used when checking the task so let's make it global
+        $this->request = $request;
         $requestPath = $this->getCustomRequestPath();
         if ($requestPath === null) {
             $requestPath = $request->getPath();
@@ -292,16 +294,36 @@ class PageController extends Controller
     public function validateRequest()
     {
         $valid = true;
-
         if (!$this->isValidControllerTask($this->action, $this->parameters)) {
+            // This is not a page tas let's check blocks'
             $valid = false;
-            // we check the blocks on the page.
-            $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
+            
+            // check if we are dealing with a task called by a block's add or edit mode
+            // 2 checks are used: presence of a specific path OR presence of a specific parameter
+            $blockAddRequest = ((strpos($this->request->getPath(), '/ccm/system/block/action/add') !== false) || (array_slice($this->parameters, -1)[0] === "blockAdd"));
+            $blockEditRequest = ((strpos($this->request->getPath(), '/ccm/system/block/action/edit') !== false) || (array_slice($this->parameters, -1)[0] === "blockEdit"));
+            
+            // If we are dealing with a block in add or edit mode, let's do this
+            if ($blockAddRequest || $blockEditRequest) {
+                // in Add mode, let's grab the block type's controller
+                if ($blockAddRequest) {
+                    $controller = BlockType::getByID($this->parameters[7])->controller;
+                }
+                // In edit mode, let's grab the block's controller
+                if ($blockEditRequest) {
+                    $controller = Block::getByID($this->parameters[7])->getController();
+                }
+                // let's remove everything in this->parameters that is not what we need. We need the task and its parameters
+                // everything before that is just the different components of the path
+                list($method, $parameters) = $controller->getPassThruActionAndParameters(array_slice($this->parameters, 8));
 
-            foreach ($blocks as $b) {
-                $controller = $b->getController();
-                list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
+                // let's check that we're dealing with a valid task
                 if ($controller->isValidControllerTask($method, $parameters)) {
+                    // pretty good. Let's get rid of the strings we added in BlockView.php ("blockAdd" or "blockEdit")
+                    // in both the local $this->parameters variable and $parameters variable we're sending to the task function
+                    // then run the task
+                    array_pop($this->parameters);
+                    array_pop($parameters);
                     $controller->on_start();
                     $response = $controller->runAction($method, $parameters);
                     if ($response instanceof Response) {
@@ -317,8 +339,41 @@ class PageController extends Controller
                     // then, we need to save the persisted data that may have been set.
                     $controller->setPassThruBlockController($this);
                 }
-            }
+            } else {
+                // We're not in add or edit mode so it must be a view for a block from the page
+                $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
+                foreach ($blocks as $b) {
+                    $controller = $b->getController();
+                    list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
+                    // if it's a proxy let's grab that
+                    if (is_object($b->getProxyBlock())) {
+                        $b = $b->getProxyBlock();
+                    }
+                    // we add the bID as the last value in our parameters array for checking purposes
+                    $parameters[] = $b->getBlockID();
 
+                    if ($controller->isValidControllerTask($method, $parameters)) {
+                        // it's a valid task for this block's instance
+                        // let's remove the bID we added to parameters and run the task
+                        array_pop($parameters);
+                        $controller->on_start();
+                        $response = $controller->runAction($method, $parameters);
+                        if ($response instanceof Response) {
+                            return $response;
+                        }
+                        // old school blocks have already terminated at this point. They are redirecting
+                        // or exiting. But new blocks like topics, etc... can actually rely on their $set
+                        // data persisting and being passed into the view.
+
+                        // so if we make it down here we have to return true –so that we don't fire a 404.
+                        $valid = true;
+
+                        // then, we need to save the persisted data that may have been set.
+                        $controller->setPassThruBlockController($this);
+                    }
+                }
+            }
+            
             if (!$valid) {
                 // finally, we check additional page paths.
                 $paths = $this->getPageObject()->getAdditionalPagePaths();


### PR DESCRIPTION
@mlocati rightfully pointed out that when using a block's task we needed
a way to know which instance of the block launched the call.

He submitted a solution that worked in some situations but not all.

For instance, it broke the topic list block because the action was
called from the page's controller and missing the bID parameter.

It also didn't work when tasks were called from a block's Add (no bID)
or edit mode.

This pull request builds on top of his solution.

@mlocati solution only worked when the check on the task was done by the
block's controller. In that case the checking function automatically
adds the bID to the parameters and @mlocati check works.

But sometimes, the task will first go through the page's controller.

I modified the task checking function in the page's controller to also
add the bID to the list of parameters before running the check. If the
check is successful, the bID is removed from parameters and the task is
processed.
My modification also deals with a block's add and edit mode.

@aembler suggested the following tests:

1. Built-in Blog List page, filtering page titles, page list and the topics list properly.
2. Form Submit
3. Survey Submit.
4. Form submission when block is in a stack.
5. Form submission when a block is in a clipboard
6. Form submission when multiple forms are on a page, only the proper form submits and shows the message.

Here are my results:
After running the tests suggested by @aembler
1- Works fine
2- works fine
3- works fine
4- doesn't work
5- It submits properly but it's actually weird.
I add a form in a stack and add the stack to the page.
I copy the form that's in the stack to the clipboard and I add the form from the clipboard to the page. Then I add the same form from the clipboard to the page a second time. If I submit the first form from the clipboard, both this one and the form in the stack get the success message. No other form is affected. I checked they do have different bID. However, after I edited the first form copied from the clipboard (just modified the button's label) it fixed the problem.
But if I submit the second form from the clipboard it works as expected and doesn't interfere with any other.
6- works except for what I explain above.

I also ran into a problem with an action in a block's add form since there is no bID yet. I fixed that as well. So as far as I could see tasks now work when:
1- in a block's add or edit screen
2- in a block's view
3- when called through a URL and going through the page's controller

The only problem still to be solved is with the block in a stack. I'm working on it.