### PR TITLE
Form Control Display

### DIFF
--- a/concrete/css/build/themes/dashboard/form-and-set-builder.less
+++ b/concrete/css/build/themes/dashboard/form-and-set-builder.less
@@ -1,35 +1,28 @@
-div.ccm-item-set,
-div.ccm-page-type-composer-form-layout-control-set {
+div.ccm-item-set {
   margin-top: 20px;
 }
 
-div.ccm-item-set:last-child,
-div.ccm-page-type-composer-form-layout-control-set:last-child {
+div.ccm-item-set:last-child {
   margin-bottom: 20px;
 }
 
-.panel-heading .ccm-item-set-controls,
-.panel-heading .ccm-page-type-composer-item-controls {
+.panel-heading .ccm-item-set-controls {
   float: right;
 }
 
-ul.ccm-item-set-controls a,
-ul.ccm-page-type-composer-item-controls a {
+ul.ccm-item-set-controls a {
   color: #333;
 }
 
-ul.ccm-item-set-controls a i,
-ul.ccm-page-type-composer-item-controls a i {
+ul.ccm-item-set-controls a i {
   position: relative;
 }
 
-ul.ccm-item-set-controls a:hover,
-ul.ccm-page-type-composer-item-controls a:hover {
+ul.ccm-item-set-controls a:hover {
   text-decoration: none;
 }
 
-ul.ccm-item-set-controls,
-ul.ccm-page-type-composer-item-controls {
+ul.ccm-item-set-controls {
   padding: 0px !important;
   margin: 0 !important;
   width: 120px;
@@ -40,8 +33,7 @@ ul.ccm-page-type-composer-item-controls {
 .ccm-item-set-item:hover .ccm-item-set-controls li {
 }
 
-.ccm-item-set-controls li,
-.ccm-page-type-composer-item-controls li {
+.ccm-item-set-controls li {
   list-style-type: none;
   display: inline-block;
 
@@ -57,9 +49,7 @@ ul.ccm-page-type-composer-item-controls {
 }
 
 .ccm-item-set th,
-.ccm-item-set td,
-.ccm-page-type-composer-form-layout-control-set th,
-.ccm-page-type-composer-form-layout-control-set td {
+.ccm-item-set td {
   padding-left: 15px !important;
   padding-right: 15px !important;
 }

--- a/concrete/css/build/themes/dashboard/form-and-set-builder.less
+++ b/concrete/css/build/themes/dashboard/form-and-set-builder.less
@@ -1,29 +1,35 @@
-
-div.ccm-item-set {
+div.ccm-item-set,
+div.ccm-page-type-composer-form-layout-control-set {
   margin-top: 20px;
 }
 
-div.ccm-item-set:last-child {
+div.ccm-item-set:last-child,
+div.ccm-page-type-composer-form-layout-control-set:last-child {
   margin-bottom: 20px;
 }
 
-.panel-heading .ccm-item-set-controls {
+.panel-heading .ccm-item-set-controls,
+.panel-heading .ccm-page-type-composer-item-controls {
   float: right;
 }
 
-ul.ccm-item-set-controls a {
+ul.ccm-item-set-controls a,
+ul.ccm-page-type-composer-item-controls a {
   color: #333;
 }
 
-ul.ccm-item-set-controls a i {
+ul.ccm-item-set-controls a i,
+ul.ccm-page-type-composer-item-controls a i {
   position: relative;
 }
 
-ul.ccm-item-set-controls a:hover {
+ul.ccm-item-set-controls a:hover,
+ul.ccm-page-type-composer-item-controls a:hover {
   text-decoration: none;
 }
 
-ul.ccm-item-set-controls {
+ul.ccm-item-set-controls,
+ul.ccm-page-type-composer-item-controls {
   padding: 0px !important;
   margin: 0 !important;
   width: 120px;
@@ -34,19 +40,26 @@ ul.ccm-item-set-controls {
 .ccm-item-set-item:hover .ccm-item-set-controls li {
 }
 
-.ccm-item-set-controls li {
+.ccm-item-set-controls li,
+.ccm-page-type-composer-item-controls li {
   list-style-type: none;
   display: inline-block;
 
   a {
     opacity: 0.5;
-    &:hover, &:focus, &:active {
+
+    &:hover,
+    &:focus,
+    &:active {
       opacity: 1.0;
     }
   }
 }
 
-.ccm-item-set th, .ccm-item-set td {
+.ccm-item-set th,
+.ccm-item-set td,
+.ccm-page-type-composer-form-layout-control-set th,
+.ccm-page-type-composer-form-layout-control-set td {
   padding-left: 15px !important;
   padding-right: 15px !important;
 }

--- a/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -10,7 +10,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 }
 
 ?>
-<tr class="ccm-page-type-composer-form-layout-control-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
+<tr class="ccm-item-set-control" data-page-type-composer-form-layout-control-set-control-id="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>">
 	<td style="white-space: nowrap; width: 20%;">
 		<?= $control->getPageTypeComposerControlDisplayLabel(); ?>
 	</td>
@@ -27,7 +27,7 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 	</td>
 
 	<td style="text-align: right; white-space: nowrap;">
-		<ul class="ccm-page-type-composer-item-controls">
+		<ul class="ccm-item-set-controls">
 			<li><a href="#" data-command="move-set-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
 			<li><a data-command="edit-form-set-control" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/edit_control?ptComposerFormLayoutSetControlID=<?=$control->getPageTypeComposerFormLayoutSetControlID()?>" class="dialog-launch" dialog-width="400" dialog-height="auto" dialog-modal="true" dialog-title="<?=t('Edit Form Control')?>"><i class="fa fa-pencil"></i></a></li>
 			<li><a href="#" data-delete-set-control="<?=$control->getPageTypeComposerFormLayoutSetControlID()?>"><i class="fa fa-trash-o"></i></a></li>

--- a/concrete/elements/page_types/composer/output/control.php
+++ b/concrete/elements/page_types/composer/output/control.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 <div class="ccm-page-type-composer-output-control" data-page-type-composer-output-control-id="<?=$control->getPageTypeComposerOutputControlID()?>">
 <div class="ccm-page-type-composer-item-control-bar">
-	<ul class="ccm-page-type-composer-item-controls">
+	<ul class="ccm-item-set-controls">
 		<li><a href="#" data-command="move-output-control" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
 	</ul>
 <div class="ccm-page-type-composer-output-control-inner">

--- a/concrete/single_pages/dashboard/pages/types/form.php
+++ b/concrete/single_pages/dashboard/pages/types/form.php
@@ -100,14 +100,14 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFo
 			</table>
 		</div>
 
-	<?php 
+	<?php
     }
     ?>
-<?php 
+<?php
 } else {
     ?>
 	<p><?=t('You have not added any composer form layout control sets.')?></p>
-<?php 
+<?php
 } ?>
 
 </div>
@@ -251,53 +251,3 @@ $(function() {
 
 });
 </script>
-
-<style type="text/css">
-
-div.ccm-page-type-composer-form-layout-control-set {
-	margin-top: 20px;
-}
-
-div.ccm-page-type-composer-form-layout-control-set:last-child {
-	margin-bottom: 20px;
-}
-
-.panel-heading .ccm-page-type-composer-item-controls {
-	float: right;
-}
-
-ul.ccm-page-type-composer-item-controls a {
-	color: #333;
-}
-
-ul.ccm-page-type-composer-item-controls a i {
-	position: relative;
-}
-
-ul.ccm-page-type-composer-item-controls a:hover {
-	text-decoration: none;
-}
-
-ul.ccm-page-type-composer-item-controls {
-	padding: 0;
-	margin: 0;
-	width: 100px;
-	text-align: right; 
-}
-
-.panel-heading:hover > .ccm-page-type-composer-item-controls li,
-.ccm-page-type-composer-form-layout-control-set-control:hover .ccm-page-type-composer-item-controls li {
-	display: inline-block;
-}
-
-.ccm-page-type-composer-item-controls li {
-	display: none;
-	list-style-type: none;
-}
-
-th, td {
-	padding-left: 15px !important;
-	padding-right: 15px !important;
-}
-
-</style>

--- a/concrete/single_pages/dashboard/pages/types/form.php
+++ b/concrete/single_pages/dashboard/pages/types/form.php
@@ -39,15 +39,15 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFo
     foreach ($sets as $set) {
         ?>
 
-		<div class="ccm-page-type-composer-form-layout-control-set panel panel-default" data-page-type-composer-form-layout-control-set-id="<?= $set->getPageTypeComposerFormLayoutSetID()?>">
+		<div class="ccm-item-set panel panel-default" data-page-type-composer-form-layout-control-set-id="<?= $set->getPageTypeComposerFormLayoutSetID()?>">
 			<div class="panel-heading">
-				<ul class="ccm-page-type-composer-item-controls">
+				<ul class="ccm-item-set-controls">
 					<li><a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/page_types/composer/form/add_control?ptComposerFormLayoutSetID=<?=$set->getPageTypeComposerFormLayoutSetID()?>" dialog-title="<?=t('Add Form Control')?>" dialog-width="640" dialog-height="400" data-command="add-form-set-control"><i class="fa fa-plus"></i></a></li>
 					<li><a href="#" data-command="move_set" style="cursor: move"><i class="fa fa-arrows"></i></a></li>
 					<li><a href="#" data-edit-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="fa fa-pencil"></i></a></li>
 					<li><a href="#" data-delete-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="fa fa-trash-o"></i></a></li>
 				</ul>
-				<div class="ccm-page-type-composer-form-layout-control-set-name" ><?php
+				<div class="ccm-item-set-name" ><?php
                     if ($set->getPageTypeComposerFormLayoutSetDisplayName()) {
                         echo $set->getPageTypeComposerFormLayoutSetDisplayName();
                     } else {
@@ -90,7 +90,7 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFo
 			</div>
 
 			<table class="table table-hover" style="width: 100%;">
-				<tbody class="ccm-page-type-composer-form-layout-control-set-inner">
+				<tbody class="ccm-item-set-inner">
 					<?php $controls = PageTypeComposerFormLayoutSetControl::getList($set);
         foreach ($controls as $cnt) {
             echo Loader::element('page_types/composer/form/layout_set/control', array('control' => $cnt));
@@ -173,7 +173,7 @@ $(function() {
 	});
 	$('div.ccm-pane-body').sortable({
 		handle: 'a[data-command=move_set]',
-		items: '.ccm-page-type-composer-form-layout-control-set',
+		items: '.ccm-item-set',
 		cursor: 'move',
 		axis: 'y',
 		stop: function() {
@@ -184,7 +184,7 @@ $(function() {
 				'name': 'ptID',
 				'value': <?=$pagetype->getPageTypeID()?>
 			}];
-			$('.ccm-page-type-composer-form-layout-control-set').each(function() {
+			$('.ccm-item-set').each(function() {
 				formData.push({'name': 'ptComposerFormLayoutSetID[]', 'value': $(this).attr('data-page-type-composer-form-layout-control-set-id')});
 			});
 			$.ajax({
@@ -200,9 +200,9 @@ $(function() {
 	$('a[data-command=add-form-set-control]').dialog();
 	$('a[data-command=edit-form-set-control]').dialog();
 
-	$('.ccm-page-type-composer-form-layout-control-set-inner').sortable({
+	$('.ccm-item-set-inner').sortable({
 		handle: 'a[data-command=move-set-control]',
-		items: '.ccm-page-type-composer-form-layout-control-set-control',
+		items: '.ccm-item-set-control',
 		cursor: 'move',
 		axis: 'y',
 		helper: function(e, ui) { // prevent table columns from collapsing
@@ -223,7 +223,7 @@ $(function() {
 				'value': $(this).parent().parent().attr('data-page-type-composer-form-layout-control-set-id')
 			}];
 
-			$(this).find('.ccm-page-type-composer-form-layout-control-set-control').each(function() {
+			$(this).find('.ccm-item-set-control').each(function() {
 				formData.push({'name': 'ptComposerFormLayoutSetControlID[]', 'value': $(this).attr('data-page-type-composer-form-layout-control-set-control-id')});
 			});
 
@@ -237,7 +237,7 @@ $(function() {
 		}
 	});
 
-	$('.ccm-page-type-composer-form-layout-control-set-inner').on('click', 'a[data-delete-set-control]', function() {
+	$('.ccm-item-set-inner').on('click', 'a[data-delete-set-control]', function() {
 		var ptComposerFormLayoutSetControlID = $(this).attr('data-delete-set-control');
         jQuery.fn.dialog.open({
             element: 'div[data-delete-set-control-dialog=' + ptComposerFormLayoutSetControlID + ']',

--- a/concrete/tools/page_types/composer/form/add_control.php
+++ b/concrete/tools/page_types/composer/form/add_control.php
@@ -44,14 +44,14 @@ if ($cp->canViewPage()) {
 			<li><a href="#" data-control-type-id="<?=$t->getPageTypeComposerControlTypeID()?>" data-control-identifier="<?=$cnt->getPageTypeComposerControlIdentifier()?>">
                     <?=$cnt->getPageTypeComposerControlIcon()?>
                     <?=$cnt->getPageTypeComposerControlDisplayName()?></a></li>
-		<?php 
+		<?php
         }
         ?>
 	</ul>
 	</div>
 
 
-	<?php 
+	<?php
     }
     ?>
 
@@ -86,7 +86,7 @@ $(function() {
 			success: function(html) {
 				jQuery.fn.dialog.hideLoader();
 				jQuery.fn.dialog.closeTop();
-				$('div[data-page-type-composer-form-layout-control-set-id=<?=$set->getPageTypeComposerFormLayoutSetID()?>] tbody.ccm-page-type-composer-form-layout-control-set-inner').append(html);
+				$('div[data-page-type-composer-form-layout-control-set-id=<?=$set->getPageTypeComposerFormLayoutSetID()?>] tbody.ccm-item-set-inner').append(html);
 				$('a[data-command=edit-form-set-control]').dialog();
 			}
 		});


### PR DESCRIPTION
This pull request:
- matches the Compose Form form control display with the current Form Details form control display
- removes the inline Compose Form form control CSS and merges it with the Form Details form control CSS (they use the same CSS)

After watching the latest Express videos, I saw that the Form Details form controls were always shown while the Compose Form form controls were hidden until hovered. Always displaying the form controls looks to be a much better approach and more intuitive.

## Current:

**Form Details**

![form_details-current](https://cloud.githubusercontent.com/assets/10898145/21032897/c934adac-bd7a-11e6-8b0f-72fd7489eecf.png)

**Compose Form**

![compose_form-current](https://cloud.githubusercontent.com/assets/10898145/21032907/e0480c50-bd7a-11e6-8ec5-4f1dc6a93844.png)

## Changes:

**Compose Form**

![compose_form-changes](https://cloud.githubusercontent.com/assets/10898145/21032923/f4962782-bd7a-11e6-9429-4630045f5b8e.png)
