### PR TITLE
remove backup page

### DIFF
--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -1020,18 +1020,11 @@
                 </attributekey>
             </attributes>
         </page>
-        <page name="Backup &amp; Restore" path="/dashboard/system/backup" filename="/dashboard/system/backup/view.php"
-              pagetype="" description="Backup or restore your website." package="">
-            <attributes>
-                <attributekey handle="meta_keywords">
-                    <value>export, backup, database, sql, mysql, encryption, restore</value>
-                </attributekey>
-            </attributes>
+        <page name="Update concrete5" path="/dashboard/system/update" filename="/dashboard/system/update/view.php"
+              pagetype="" description="" package="">
         </page>
-        <page name="Backup Database" path="/dashboard/system/backup/backup"
-              filename="/dashboard/system/backup/backup.php" pagetype="" description="" package=""/>
-        <page name="Update concrete5" path="/dashboard/system/backup/update"
-              filename="/dashboard/system/backup/update.php" pagetype="" description="" package="">
+        <page name="Apply Update" path="/dashboard/system/update/update"
+              filename="/dashboard/system/update/update.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
                     <value>upgrade, new version, update</value>

--- a/concrete/controllers/single_page/dashboard/system/backup/backup.php
+++ b/concrete/controllers/single_page/dashboard/system/backup/backup.php
@@ -1,8 +1,0 @@
-<?php
-namespace Concrete\Controller\SinglePage\Dashboard\System\Backup;
-
-use Concrete\Core\Page\Controller\DashboardPageController;
-
-class Backup extends DashboardPageController
-{
-}

--- a/concrete/controllers/single_page/dashboard/system/update.php
+++ b/concrete/controllers/single_page/dashboard/system/update.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System;
 
-use Concrete\Core\Page\Controller\DashboardPageController;
+use \Concrete\Core\Page\Controller\DashboardPageController;
 
-class Backup extends DashboardPageController
+class Update extends DashboardPageController
 {
     /**
      * Dashboard view - automatically redirects to a default
@@ -11,6 +11,6 @@ class Backup extends DashboardPageController
      */
     public function view()
     {
-        $this->redirect('/dashboard/system/backup/backup');
+        $this->redirect('/dashboard/system/update/update');
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/update/update.php
+++ b/concrete/controllers/single_page/dashboard/system/update/update.php
@@ -1,5 +1,5 @@
 <?php
-namespace Concrete\Controller\SinglePage\Dashboard\System\Backup;
+namespace Concrete\Controller\SinglePage\Dashboard\System\Update;
 
 use Concrete\Controller\Upgrade;
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -34,7 +34,7 @@ class Update extends DashboardPageController
     {
         Config::clear('concrete.misc.latest_version');
         \Concrete\Core\Updater\Update::getLatestAvailableVersionNumber();
-        $this->redirect('/dashboard/system/backup/update');
+        $this->redirect('/dashboard/system/update/update');
     }
 
     public function on_start()

--- a/concrete/single_pages/dashboard/system/backup/backup.php
+++ b/concrete/single_pages/dashboard/system/backup/backup.php
@@ -1,8 +1,0 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
-
-<div class="alert alert-warning">
-    <p><?php echo t(
-        'Backing up your site is important. Typically your web host can help you make a complete backup of your environment from your hosting control panel. Alternatively, there are <a href="%s" target="_blank">additional backup solutions available in the concrete5.org marketplace</a>.',
-        h('https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup')
-    ); ?></p>
-</div>

--- a/concrete/single_pages/dashboard/system/update/update.php
+++ b/concrete/single_pages/dashboard/system/update/update.php
@@ -62,7 +62,7 @@ if ($canUpgrade) {
         ?>
                         <p><?=t('No add-ons installed.')?></p>
 
-                    <?php 
+                    <?php
     }
     foreach ($list as $pkg) {
         ?>
@@ -79,7 +79,7 @@ if ($canUpgrade) {
                             </div>
                         </div>
 
-                    <?php 
+                    <?php
     }
     ?>
 
@@ -225,7 +225,7 @@ if ($canUpgrade) {
         </script>
 
 
-    <?php 
+    <?php
 } else {
     ?>
 
@@ -266,11 +266,6 @@ if ($canUpgrade) {
             <h2><?= t('Apply Downloaded Update') ?></h2>
         <?php if (count($updates)) {
     ?>
-            <div class="alert alert-warning">
-                <i class="fa fa-warning"></i> <?= t(
-                    'Make sure you <a href="%s">backup your database</a> before updating.',
-                    $view->url('/dashboard/system/backup/backup')) ?>
-            </div>
             <?php
             $ih = Loader::helper('concrete/ui');
     ?>
@@ -307,16 +302,16 @@ if ($canUpgrade) {
     ?>
             <p><?=t('No updates are ready to be installed.')?></p>
 
-        <?php 
+        <?php
 }
     ?>
-    <?php 
+    <?php
 }
     ?>
 
-<?php 
+<?php
 } else {
     ?>
     <p><?=t('You do not have permission to upgrade this installation of concrete5.')?></p>
-<?php 
+<?php
 } ?>

--- a/concrete/single_pages/dashboard/system/update/view.php
+++ b/concrete/single_pages/dashboard/system/update/view.php
@@ -1,0 +1,1 @@
+<?php defined('C5_EXECUTE') or die("Access Denied.");

--- a/concrete/src/Updater/Migrations/Migrations/Version20161213000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161213000000.php
@@ -1,0 +1,34 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Single as SinglePage;
+
+class Version20161213000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        Page::getByPath('/dashboard/system/backup')->delete();
+        Page::getByPath('/dashboard/system/backup/backup')->delete();
+        Page::getByPath('/dashboard/system/backup/update')->delete();
+
+        $page = Page::getByPath('/dashboard/system/update');
+        if (!is_object($page) || $page->isError()) {
+            $sp = SinglePage::add('/dashboard/system/update');
+            $sp->update(array('cName' => 'Update concrete5'));
+        }
+
+        $page = Page::getByPath('/dashboard/system/update/update');
+        if (!is_object($page) || $page->isError()) {
+            $sp = SinglePage::add('/dashboard/system/update/update');
+            $sp->update(array('cName' => 'Apply Update'));
+            $sp->setAttribute('meta_keywords', 'upgrade, new version, update');
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
I think removing this in v8 would allow for a clean break and prevent the confusion and expectations people are voicing in the forum. It appears that there are many people who are making the assumption that a database backup is a full backup and are not taking steps to properly backup there site.

https://www.concrete5.org/community/forums/5-7-discussion/whats-happening-with-backup-for-5.7

I tested this pull request by updating 5.7.5.12 to 8.1.0a1 and then 8.1.0a1 to a dummy 8.3 update to make sure the updater was working as expected.

**Current:**

![remove_backup-current](https://cloud.githubusercontent.com/assets/10898145/20618439/02e1d4b2-b2bd-11e6-9517-8a12d5f2caf9.png)

**Changes:**

![remove_backup-changes](https://cloud.githubusercontent.com/assets/10898145/20618451/0f17dcf4-b2bd-11e6-84ff-eb267cbdd8d0.png)

Previous pull request:
https://github.com/concrete5/concrete5/pull/4724