### PR TITLE
Custom Element Attribute and Custom ID

### DIFF
--- a/concrete/css/build/core/app/inline-toolbar.less
+++ b/concrete/css/build/core/app/inline-toolbar.less
@@ -461,6 +461,8 @@
 
     hr {
       border-color: #666;
+      margin-bottom: 14px;
+      margin-top: 14px;
     }
   }
 }

--- a/concrete/elements/block_area_header_view.php
+++ b/concrete/elements/block_area_header_view.php
@@ -5,9 +5,24 @@ $css = $c->getAreaCustomStyle($a);
 
 if (isset($css)) {
     $class = $css->getContainerClass();
+    $id = $css->getCustomStyleID();
+    $elementAttribute = $css->getCustomStyleElementAttribute();
 } else {
     $class = '';
+    $id = '';
+    $elementAttribute = '';
 }
-if ($class !== '') {
-    ?><div class="<?=$class?>"><?php 
-}
+
+if ($class || $id || $elementAttribute) { ?>
+<div
+<?php if ($class) { ?>
+class="<?php echo $class; ?>"
+<?php } ?>
+<?php if ($id) { ?>
+id="<?php echo $id; ?>"
+<?php } ?>
+<?php if ($elementAttribute) { ?>
+<?php echo $elementAttribute; ?>
+<?php } ?>
+>
+<?php }

--- a/concrete/elements/block_header_view.php
+++ b/concrete/elements/block_header_view.php
@@ -31,6 +31,9 @@ if ($showMenu) {
     <?php if ($css->getCustomStyleID()) { ?>
     id="<?php echo $css->getCustomStyleID(); ?>"
     <?php } ?>
+    <?php if ($css->getCustomStyleElementAttribute()) { ?>
+    <?php echo $css->getCustomStyleElementAttribute(); ?>
+    <?php } ?>
     >
 <?php
 } ?>
@@ -100,6 +103,9 @@ if ($showMenu) {
     <?php if ($css->getCustomStyleID()) { ?>
     id="<?php echo $css->getCustomStyleID(); ?>"
     <?php } ?>
+    <?php if ($css->getCustomStyleElementAttribute()) { ?>
+    <?php echo $css->getCustomStyleElementAttribute(); ?>
+    <?php } ?>
     >
     <?php
 }
@@ -130,6 +136,9 @@ if ($showMenu) {
     <div class="<?php echo $css->getContainerClass(); ?>"
     <?php if ($css->getCustomStyleID()) { ?>
     id="<?php echo $css->getCustomStyleID(); ?>"
+    <?php } ?>
+    <?php if ($css->getCustomStyleElementAttribute()) { ?>
+    <?php echo $css->getCustomStyleElementAttribute(); ?>
     <?php } ?>
     >
     <?php

--- a/concrete/elements/custom_style.php
+++ b/concrete/elements/custom_style.php
@@ -33,6 +33,7 @@ $boxShadowSpread = '';
 $boxShadowColor = '';
 $customClass = '';
 $customID = '';
+$customElementAttribute = '';
 $sliderMin = \Config::get('concrete.limits.style_customizer.size_min', -50);
 $sliderMax = \Config::get('concrete.limits.style_customizer.size_max', 200);
 
@@ -67,6 +68,7 @@ if (is_object($set)) {
     $boxShadowColor = $set->getBoxShadowColor();
     $customClass = $set->getCustomClass();
     $customID = $set->getCustomID();
+    $customElementAttribute = $set->getCustomElementAttribute();
 }
 
 $repeatOptions = array(
@@ -424,6 +426,12 @@ $form = Core::make('helper/form');
                         <?= $form->text('customID', $customID, array('style' => 'height: 38px; font-size: 16px; margin-bottom: 0;')); ?>
                     </div>
                     <hr/>
+
+                    <div>
+                        <?= t('Custom Element Attribute'); ?>
+                        <?= $form->textarea('customElementAttribute', $customElementAttribute, array('style' => 'height: 38px; font-size: 16px; margin: 5px 0 0 0;')); ?>
+                    </div>
+                    <hr>
                 <?php } ?>
 
                 <?php if ($displayBlockContainerSettings) { ?>

--- a/concrete/elements/custom_style.php
+++ b/concrete/elements/custom_style.php
@@ -420,19 +420,17 @@ $form = Core::make('helper/form');
                 </div>
                 <hr/>
 
-                <?php if ($style instanceof \Concrete\Core\Block\CustomStyle) { ?>
-                    <div>
-                        <?= t('Custom ID'); ?>
-                        <?= $form->text('customID', $customID, array('style' => 'height: 38px; font-size: 16px; margin-bottom: 0;')); ?>
-                    </div>
-                    <hr/>
+                <div>
+                    <?= t('Custom ID'); ?>
+                    <?= $form->text('customID', $customID, array('style' => 'height: 38px; font-size: 16px; margin-bottom: 0;')); ?>
+                </div>
+                <hr/>
 
-                    <div>
-                        <?= t('Custom Element Attribute'); ?>
-                        <?= $form->textarea('customElementAttribute', $customElementAttribute, array('style' => 'height: 38px; font-size: 16px; margin: 5px 0 0 0;')); ?>
-                    </div>
-                    <hr>
-                <?php } ?>
+                <div>
+                    <?= t('Custom Element Attribute'); ?>
+                    <?= $form->textarea('customElementAttribute', $customElementAttribute, array('style' => 'height: 38px; font-size: 16px; margin: 5px 0 0 0;')); ?>
+                </div>
+                <hr>
 
                 <?php if ($displayBlockContainerSettings) { ?>
                     <div class="ccm-inline-select-container">

--- a/concrete/src/Area/CustomStyle.php
+++ b/concrete/src/Area/CustomStyle.php
@@ -137,4 +137,28 @@ class CustomStyle extends AbstractCustomStyle
 
         return implode(' ', $classes);
     }
+
+    public function getCustomStyleID()
+    {
+        $id = null;
+        if (is_object($this->set)) {
+            if ($this->set->getCustomID()) {
+                $id = $this->set->getCustomID();
+            }
+        }
+
+        return $id;
+    }
+
+    public function getCustomStyleElementAttribute()
+    {
+        $elementAttribute = null;
+        if (is_object($this->set)) {
+            if ($this->set->getCustomElementAttribute()) {
+                $elementAttribute = $this->set->getCustomElementAttribute();
+            }
+        }
+
+        return $elementAttribute;
+    }
 }

--- a/concrete/src/Block/CustomStyle.php
+++ b/concrete/src/Block/CustomStyle.php
@@ -156,4 +156,16 @@ class CustomStyle extends AbstractCustomStyle
 
         return $id;
     }
+
+    public function getCustomStyleElementAttribute()
+    {
+        $elementAttribute = null;
+        if (is_object($this->set)) {
+            if ($this->set->getCustomElementAttribute()) {
+                $elementAttribute = $this->set->getCustomElementAttribute();
+            }
+        }
+
+        return $elementAttribute;
+    }
 }

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -64,6 +64,27 @@ class StyleSet
     /**
      * @ORM\Column(type="string", nullable=true)
      */
+    protected $customElementAttribute;
+
+    /**
+     * @param mixed $customElementAttribute
+     */
+    public function setCustomElementAttribute($customElementAttribute)
+    {
+        $this->customElementAttribute = $customElementAttribute;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCustomElementAttribute()
+    {
+        return $this->customElementAttribute;
+    }
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     protected $backgroundColor;
 
     /**
@@ -756,6 +777,7 @@ class StyleSet
         $node->addChild('boxShadowColor', $this->getBoxShadowColor());
         $node->addChild('customClass', $this->getCustomClass());
         $node->addChild('customID', $this->getCustomID());
+        $node->addChild('customElementAttribute', $this->getCustomElementAttribute());
         $node->addChild('hideOnExtraSmallDevice', $this->getHideOnExtraSmallDevice());
         $node->addChild('hideOnSmallDevice', $this->getHideOnSmallDevice());
         $node->addChild('hideOnMediumDevice', $this->getHideOnMediumDevice());

--- a/concrete/src/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/StyleCustomizer/Inline/StyleSet.php
@@ -60,6 +60,7 @@ class StyleSet
         $o->setBoxShadowColor((string) $node->boxShadowColor);
         $o->setCustomClass((string) $node->customClass);
         $o->setCustomID((string) $node->customID);
+        $o->setCustomElementAttribute((string) $node->customElementAttribute);
 
         $o->save();
 
@@ -211,6 +212,11 @@ class StyleSet
 
         if (isset($r['customID']) && trim($r['customID'])) {
             $set->setCustomID(trim($r['customID']));
+            $return = true;
+        }
+
+        if (isset($r['customElementAttribute']) && trim($r['customElementAttribute'])) {
+            $set->setCustomElementAttribute(trim($r['customElementAttribute']));
             $return = true;
         }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170519000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170519000000.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170519000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshEntities(['Concrete\Core\Entity\StyleCustomizer\Inline\StyleSet']);
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/tests/tests/Core/StyleCustomizer/InlineStyleSetTest.php
+++ b/tests/tests/Core/StyleCustomizer/InlineStyleSetTest.php
@@ -128,6 +128,7 @@ class InlineStyleSetTest extends ConcreteDatabaseTestCase
             'boxShadowSpread' => '60px',
             'customClass' => ['testclass'],
             'customID' => 'testid',
+            'customElementAttribute' => 'data-test="test"',
             'backgroundSize' => 'auto',
             'backgroundPosition' => 'left top',
         );
@@ -162,5 +163,6 @@ class InlineStyleSetTest extends ConcreteDatabaseTestCase
         $this->assertEquals('60px', $set->getBoxShadowSpread());
         $this->assertEquals('testclass', $set->getCustomClass());
         $this->assertEquals('testid', $set->getCustomID());
+        $this->assertEquals('data-test="test"', $set->getCustomElementAttribute());
     }
 }


### PR DESCRIPTION
This pull request:
- adds a free-form element attribute input to blocks, custom layouts, and areas
- adds the custom ID input to areas (currently it is only added to blocks and custom layouts)

A common use case for these changes will be for creating anchor links and adding data attributes.

As a working example, the following site uses the pull request code to add data attributes to blocks, custom layouts, and areas for controlling page animation.
http://cea.stellar.software/index.php.

The Custom Element Attribute input has basic validation. To prevent duplicate class and ID attributes from being added, it strips them before saving. If there are odd numbers of quotes (double or single), an error is thrown.

Notes on behavior:
- areas
			- while in edit mode, Custom ID and Custom Element Attribute are not applied, only the Custom Class is
			- after publishing or saving the page, the area is wrapped in a custom style wrapper div, and the Custom ID and Custom Element Attribute are applied
- blocks
the Custom Class, Custom ID, and Custom Element Attribute are all applied after the Design toolbar is saved

## Current:

**Blocks**

![advanced_blocks-current](https://cloud.githubusercontent.com/assets/10898145/21291019/e2d6eb5a-c49e-11e6-9360-54cef3bcc452.png)

**Areas**

![advanced_areas-current](https://cloud.githubusercontent.com/assets/10898145/21291021/e687acc6-c49e-11e6-8632-e3f4559abcac.png)

## Changes

**Blocks**

![advanced_blocks-changes](https://cloud.githubusercontent.com/assets/10898145/21291024/03ab2a58-c49f-11e6-912b-faab9afe44c7.png)

**Areas**

![advanced_areas-changes](https://cloud.githubusercontent.com/assets/10898145/21291025/07da09dc-c49f-11e6-87fb-2b62d9536763.png)

