### PR TITLE
Token helper: avoid deprecated methods and detect ajax calls

### DIFF
--- a/concrete/src/Http/RequestBase.php
+++ b/concrete/src/Http/RequestBase.php
@@ -211,4 +211,20 @@ class RequestBase extends SymfonyRequest
     {
         return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'POST';
     }
+
+    /**
+     * Check if the request is an Ajax call.
+     *
+     * @return bool
+     */
+    public function isAjax()
+    {
+        $result = false;
+        $requestedWith = $this->server->get('HTTP_X_REQUESTED_WITH');
+        if (is_string($requestedWith) && strcasecmp($requestedWith, 'xmlhttprequest') === 0) {
+            $result = true;
+        }
+
+        return $result;
+    }
 }

--- a/concrete/src/Http/RequestBase.php
+++ b/concrete/src/Http/RequestBase.php
@@ -211,20 +211,4 @@ class RequestBase extends SymfonyRequest
     {
         return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'POST';
     }
-
-    /**
-     * Check if the request is an Ajax call.
-     *
-     * @return bool
-     */
-    public function isAjax()
-    {
-        $result = false;
-        $requestedWith = $this->server->get('HTTP_X_REQUESTED_WITH');
-        if (is_string($requestedWith) && strcasecmp($requestedWith, 'xmlhttprequest') === 0) {
-            $result = true;
-        }
-
-        return $result;
-    }
 }

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -23,6 +23,7 @@ use Concrete\Core\View\View;
 use Detection\MobileDetect;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Concrete\Core\Http\Service\Ajax;
 
 class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInterface
 {
@@ -76,7 +77,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = array())
     {
-        if (strcasecmp($this->request->server->get('HTTP_X_REQUESTED_WITH', ''), 'xmlhttprequest') === 0) {
+        if ($this->app->make(Ajax::class)->isAjaxRequest($this->request)) {
             $loc = $this->localization;
             $changeContext = $this->shouldChangeContext();
             if ($changeContext) {

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -76,7 +76,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = array())
     {
-        if (strcasecmp($this->request->server->get('HTTP_X_REQUESTED_WITH', ''), 'xmlhttprequest') === 0) {
+        if ($this->request->isAjax()) {
             $loc = $this->localization;
             $changeContext = $this->shouldChangeContext();
             if ($changeContext) {

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -76,7 +76,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = array())
     {
-        if ($this->request->isAjax()) {
+        if (strcasecmp($this->request->server->get('HTTP_X_REQUESTED_WITH', ''), 'xmlhttprequest') === 0) {
             $loc = $this->localization;
             $changeContext = $this->shouldChangeContext();
             if ($changeContext) {

--- a/concrete/src/Http/Service/Ajax.php
+++ b/concrete/src/Http/Service/Ajax.php
@@ -2,9 +2,28 @@
 namespace Concrete\Core\Http\Service;
 
 use Exception;
+use Concrete\Core\Http\Request;
 
 class Ajax
 {
+    /**
+     * Check if a request is an Ajax call.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function isAjaxRequest(Request $request)
+    {
+        $result = false;
+        $requestedWith = $request->server->get('HTTP_X_REQUESTED_WITH');
+        if (is_string($requestedWith) && strcasecmp($requestedWith, 'XMLHttpRequest') === 0) {
+            $result = true;
+        }
+
+        return $result;
+    }
+
     /**
      * Sends a result to the client and ends the execution.
      *

--- a/concrete/src/Http/Service/Ajax.php
+++ b/concrete/src/Http/Service/Ajax.php
@@ -5,8 +5,13 @@ use Exception;
 
 class Ajax
 {
-    /** Sends a result to the client and ends the execution.
+    /**
+     * Sends a result to the client and ends the execution.
+     *
      * @param mixed $result
+     *
+     * @deprecated You should switch to something like:
+     * return \Core::make(\Concrete\Core\Http\ResponseFactoryInterface::class)->json(...)
      */
     public function sendResult($result)
     {
@@ -22,8 +27,14 @@ class Ajax
         die();
     }
 
-    /** Sends an error to the client and ends the execution.
-     * @param string|Exception|\Concrete\Core\Error\Error $result The error to send to the client.
+    /**
+     * Sends an error to the client and ends the execution.
+     *
+     * @param string|Exception|\Concrete\Core\Error\Error $result the error to send to the client
+     * @param mixed $error
+     *
+     * @deprecated You should switch to something like:
+     * return \Core::make(\Concrete\Core\Http\ResponseFactoryInterface::class)->json(...)
      */
     public function sendError($error)
     {

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -40,7 +40,7 @@ class Token
     /**
      * Create the HTML code of a token.
      *
-     * @param string $action An optional identiier of the token
+     * @param string $action An optional identifier of the token
      * @param bool $return Set to true to return the generated code, false to print it out
      *
      * @return string|void
@@ -59,7 +59,7 @@ class Token
     /**
      * Generates a token for a given action. This is a token in the form of time:hash, where hash is md5(time:userID:action:pepper).
      *
-     * @param string $action An optional identiier of the token
+     * @param string $action An optional identifier of the token
      * @param int $time The UNIX timestamp to be used to determine the token expiration
      *
      * @return string
@@ -82,7 +82,7 @@ class Token
     }
 
     /**
-     * Generate a token and returns it as a query string variable (eg 'ccm_token=...').
+     * Generate a token and return it as a query string variable (eg 'ccm_token=...').
      *
      * @param string $action
      *

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -30,7 +30,7 @@ class Token
     {
         $app = Application::getFacadeApplication();
         $request = $app->make(Request::class);
-        if ($request->isAjax()) {
+        if (strcasecmp($request->server->get('HTTP_X_REQUESTED_WITH', ''), 'xmlhttprequest') === 0) {
             return t("Invalid token. Please reload the page and retry.");
         } else {
             return t("Invalid form token. Please reload this form and submit again.");

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -6,10 +6,17 @@ use User;
 
 class Token
 {
-    const VALID_HASH_TIME_THRESHOLD = 86400; // 24 hours (in seconds)
+    /**
+     * Duration (in seconds) of a token.
+     *
+     * @var int
+     */
+    const VALID_HASH_TIME_THRESHOLD = 86400; // 24 hours
 
     /**
-     * For localization we can't just store this as a constant, unfortunately.
+     * Get the error message to be shown to the users when a token is not valid.
+     *
+     * @return string
      */
     public function getErrorMessage()
     {
@@ -17,12 +24,12 @@ class Token
     }
 
     /**
-     * Prints out a generated token as a hidden form field.
+     * Create the HTML code of a token.
      *
-     * @param string $action
-     * @param bool   $return
+     * @param string $action An optional identiier of the token
+     * @param bool $return Set to true to return the generated code, false to print it out
      *
-     * @return string
+     * @return string|void
      */
     public function output($action = '', $return = false)
     {
@@ -36,11 +43,10 @@ class Token
     }
 
     /**
-     * Generates a unique token for a given action. This is a token in the form of
-     * time:hash, where hash is md5(time:userID:action:pepper).
+     * Generates a token for a given action. This is a token in the form of time:hash, where hash is md5(time:userID:action:pepper).
      *
-     * @param string $action
-     * @param int    $time
+     * @param string $action An optional identiier of the token
+     * @param int $time The UNIX timestamp to be used to determine the token expiration
      *
      * @return string
      */
@@ -61,7 +67,7 @@ class Token
     }
 
     /**
-     * Returns a generated token as a query string variable.
+     * Generate a token and returns it as a query string variable (eg 'ccm_token=...').
      *
      * @param string $action
      *
@@ -75,12 +81,14 @@ class Token
     }
 
     /**
-     * Validates against a given action. Basically, we check the passed hash to see if
+     * Validate a token against a given action.
+     *
+     * Basically, we check the passed hash to see if:
      * a. the hash is valid. That means it computes in the time:action:pepper format
      * b. the time included next to the hash is within the threshold.
      *
-     * @param string $action
-     * @param string $token
+     * @param string $action The action that should be associated to the token
+     * @param string $token The token to be validated (if empty we'll retrieve it from the current request)
      *
      * @return bool
      */

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -1,8 +1,9 @@
 <?php
 namespace Concrete\Core\Validation\CSRF;
 
-use Config;
-use User;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
+use Concrete\Core\Http\Request;
 
 class Token
 {
@@ -57,10 +58,11 @@ class Token
         if (!$uID) {
             $uID = 0;
         }
-        if ($time == null) {
+        if (!$time) {
             $time = time();
         }
-        $config = \Core::make('config/database');
+        $app = Application::getFacadeApplication();
+        $config = $app->make('config/database');
         $hash = $time . ':' . md5($time . ':' . $uID . ':' . $action . ':' . $config->get('concrete.security.token.validation'));
 
         return $hash;
@@ -95,7 +97,9 @@ class Token
     public function validate($action = '', $token = null)
     {
         if ($token == null) {
-            $token = isset($_REQUEST['ccm_token']) ? $_REQUEST['ccm_token'] : '';
+            $app = Application::getFacadeApplication();
+            $request = $app->make(Request::class);
+            $token = $request->get('ccm_token');
         }
         $parts = explode(':', $token);
         if ($parts[0]) {

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -101,17 +101,19 @@ class Token
             $request = $app->make(Request::class);
             $token = $request->get('ccm_token');
         }
-        $parts = explode(':', $token);
-        if ($parts[0]) {
-            $time = $parts[0];
-            $hash = $parts[1];
-            $compHash = $this->generate($action, $time);
-            $now = time();
-
-            if (substr($compHash, strpos($compHash, ':') + 1) == $hash) {
-                $diff = $now - $time;
-                //hash is only valid if $diff is less than VALID_HASH_TIME_RECORD
-                return $diff <= static::VALID_HASH_TIME_THRESHOLD;
+        if (is_string($token)) {
+            $parts = explode(':', $token);
+            if ($parts[0] && isset($parts[1])) {
+                $time = $parts[0];
+                $hash = $parts[1];
+                $compHash = $this->generate($action, $time);
+                $now = time();
+    
+                if (substr($compHash, strpos($compHash, ':') + 1) == $hash) {
+                    $diff = $now - $time;
+                    //hash is only valid if $diff is less than VALID_HASH_TIME_RECORD
+                    return $diff <= static::VALID_HASH_TIME_THRESHOLD;
+                }
             }
         }
 

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -15,6 +15,13 @@ class Token
     const VALID_HASH_TIME_THRESHOLD = 86400; // 24 hours
 
     /**
+     * The default name of the token parameters.
+     *
+     * @var string
+     */
+    const DEFAULT_TOKEN_NAME = 'ccm_token';
+
+    /**
      * Get the error message to be shown to the users when a token is not valid.
      *
      * @return string
@@ -35,7 +42,7 @@ class Token
     public function output($action = '', $return = false)
     {
         $hash = $this->generate($action);
-        $token = '<input type="hidden" name="ccm_token" value="' . $hash . '" />';
+        $token = '<input type="hidden" name="' . static::DEFAULT_TOKEN_NAME . '" value="' . $hash . '" />';
         if (!$return) {
             echo $token;
         } else {
@@ -79,7 +86,7 @@ class Token
     {
         $hash = $this->generate($action);
 
-        return 'ccm_token=' . $hash;
+        return static::DEFAULT_TOKEN_NAME . '=' . $hash;
     }
 
     /**
@@ -99,7 +106,7 @@ class Token
         if ($token == null) {
             $app = Application::getFacadeApplication();
             $request = $app->make(Request::class);
-            $token = $request->get('ccm_token');
+            $token = $request->get(static::DEFAULT_TOKEN_NAME);
         }
         if (is_string($token)) {
             $parts = explode(':', $token);
@@ -108,7 +115,7 @@ class Token
                 $hash = $parts[1];
                 $compHash = $this->generate($action, $time);
                 $now = time();
-    
+
                 if (substr($compHash, strpos($compHash, ':') + 1) == $hash) {
                     $diff = $now - $time;
                     //hash is only valid if $diff is less than VALID_HASH_TIME_RECORD

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Validation\CSRF;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Http\Service\Ajax;
 
 class Token
 {
@@ -30,7 +31,8 @@ class Token
     {
         $app = Application::getFacadeApplication();
         $request = $app->make(Request::class);
-        if (strcasecmp($request->server->get('HTTP_X_REQUESTED_WITH', ''), 'xmlhttprequest') === 0) {
+        $ajax = $app->make(Ajax::class);
+        if ($ajax->isAjaxRequest($request)) {
             return t("Invalid token. Please reload the page and retry.");
         } else {
             return t("Invalid form token. Please reload this form and submit again.");

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -28,7 +28,13 @@ class Token
      */
     public function getErrorMessage()
     {
-        return t("Invalid form token. Please reload this form and submit again.");
+        $app = Application::getFacadeApplication();
+        $request = $app->make(Request::class);
+        if ($request->isAjax()) {
+            return t("Invalid token. Please reload the page and retry.");
+        } else {
+            return t("Invalid form token. Please reload this form and submit again.");
+        }
     }
 
     /**


### PR DESCRIPTION
When an ajax call fails, showing the message "Invalid form token. Please reload this form and submit again." doesn't make much sense, since 99.99% of ajax calls are not for form submissions.

So, what about detecting if the call was an ajax call and show a message like "Invalid token. Please reload the page and retry." in that case?

I also took the opportunity to:
1. fix the phpdocs of the Token class
2. avoid deprecated methods
3. centralize the detection of ajax calls in the Request instance
4. move the ccm_token string to a constant
