### PR TITLE
DateTime widget - change default displayed past years from 10 to 100

### DIFF
--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -175,6 +175,7 @@ EOT;
                     altField: "#' . $id . '_dt",
                     changeYear: true,
                     showAnim: \'fadeIn\',
+                    yearRange: "c-100:c+10",
                     ' . $beforeShow . '
                     onClose: function(dateText, inst) {
                         if(dateText == "") {
@@ -259,6 +260,7 @@ EOS;
                     altField: "#' . $id . '",
                     changeYear: true,
                     showAnim: \'fadeIn\',
+                    yearRange: "c-100:c+10",
                     onClose: function(dateText, inst) {
                         if(dateText == "") {
                             var altField = $(inst.settings["altField"]);


### PR DESCRIPTION
This pull request changes the default jQuery UI date picker behavior so that the year drop-down displays the last 100 years instead of 10.

Some users may not know that the year can be entered manually into the date text input. For entering dates like birthdays, having more years may reduce possible confusion.
https://github.com/concrete5/concrete5/issues/4862

The jQuery UI datepicker default for yearRange is `c-10:c+10`. This means that the year select drop-down displays 10 years in the past and 10 years in the future (relative to the current year). To select a year outside of that 10 year range, you must select the last available year in the past or future, which adds an additional 10 years to the year select drop-down.
http://api.jqueryui.com/datepicker/#option-yearRange

Example: select the year 1990
- on first selection, the year select drop-down shows a range of 2006 to 2026
- click select 2006 from the year drop-down
- click select 2006 from the drop-down a second time (10 more years are added and 1996 is now available)
- click select 1996 from the year drop-down
- click select 1996 from the drop-down a second time (10 more years are added and 1986 is now available)
- select 1990

## Current:

**Past Years**

![year_past-current](https://cloud.githubusercontent.com/assets/10898145/21301901/977854d2-c57f-11e6-9d6f-9b3cc67a6cc7.png)

**Future Years**

![year_future-current](https://cloud.githubusercontent.com/assets/10898145/21301904/9c17c996-c57f-11e6-98c8-3e1395c34ce3.png)

## Changes:

![year_past-changes](https://cloud.githubusercontent.com/assets/10898145/21301905/9fc6cc86-c57f-11e6-86e8-af1e2920c3d2.png)


