### PR TITLE
File Block - change label and validation text to reduce confusion

### DIFF
--- a/concrete/blocks/file/add.php
+++ b/concrete/blocks/file/add.php
@@ -7,7 +7,7 @@ $al = Loader::helper('concrete/asset_library');
 	<?=$al->file('ccm-b-file', 'fID', t('Choose File'));?>
 </div>
 <div class="form-group">
-	<?=$form->label('fileLinkText', t('Link'))?>
+	<?=$form->label('fileLinkText', t('Link Text'))?>
 	<?=$form->text('fileLinkText')?>
 </div>
 <div class="form-group">

--- a/concrete/blocks/file/controller.php
+++ b/concrete/blocks/file/controller.php
@@ -17,7 +17,7 @@ class Controller extends BlockController
 
     protected $btExportFileColumns = array('fID');
 
-    /** 
+    /**
      * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
@@ -74,7 +74,7 @@ class Controller extends BlockController
             $e->add(t('You must select a file.'));
         }
         if (trim($args['fileLinkText']) == '') {
-            $e->add(t('You must give your file a link.'));
+            $e->add(t('You must enter the link text.'));
         }
 
         return $e;

--- a/concrete/blocks/file/edit.php
+++ b/concrete/blocks/file/edit.php
@@ -11,7 +11,7 @@
 	<?=$al->file('ccm-b-file', 'fID', t('Choose File'), $bf);?>
 </div>
 <div class="form-group">
-	<?=$form->label('fileLinkText', t('Text for Linked File'))?>
+	<?=$form->label('fileLinkText', t('Link Text'))?>
 	<?=$form->text('fileLinkText', $controller->getLinkText())?>
 </div>
 


### PR DESCRIPTION
This pull request makes the File block label and validation text match what the input does.