### PR TITLE
Fix the view of the users/search dashboard page

### DIFF
--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -193,7 +193,7 @@ if (isset($user) && is_object($user)) {
         <section>
             <h4><?= t('Other Attributes') ?></h4>
             <?php
-            Loader::element('attribute/editable_list', [
+            View::element('attribute/editable_list', [
                 'attributes' => $attributes,
                 'object' => $user,
                 'saveAction' => $view->action('update_attribute', $user->getUserID()),
@@ -333,12 +333,13 @@ if (isset($user) && is_object($user)) {
     </script>
     <?php
 } else {
-    $tp = Loader::helper('concrete/user');
+    $tp = Core::make('helper/concrete/user');
+    dd($tp);
     if ($tp->canAccessUserSearchInterface()) {
         ?>
 
         <div class="ccm-dashboard-content-full">
-            <?php Loader::element('users/search', ['result' => $result])?>
+            <?php View::element('users/search', ['result' => $result])?>
         </div>
 
         <script type="text/javascript">

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -194,16 +194,16 @@ if (isset($user) && is_object($user)) {
         <section>
             <h4><?= t('Other Attributes') ?></h4>
             <?php
-            Loader::element('attribute/editable_list', array(
+            Loader::element('attribute/editable_list', [
                 'attributes' => $attributes,
                 'object' => $user,
                 'saveAction' => $view->action('update_attribute', $user->getUserID()),
                 'clearAction' => $view->action('clear_attribute', $user->getUserID()),
-                'permissionsArguments' => array('attributes' => $allowedEditAttributes),
+                'permissionsArguments' => ['attributes' => $allowedEditAttributes],
                 'permissionsCallback' => function ($ak, $permissionsArguments) {
                     return is_array($permissionsArguments['attributes']) && in_array($ak->getAttributeKeyID(), $permissionsArguments['attributes']);
                 },
-            ));
+            ]);
             ?>
         </section>
 
@@ -219,12 +219,12 @@ if (isset($user) && is_object($user)) {
 
                     <div class="form-group">
                         <?= $form->label('uPassword', t('Password')) ?>
-                        <?= $form->password('uPassword', array('autocomplete' => 'off')) ?>
+                        <?= $form->password('uPassword', ['autocomplete' => 'off']) ?>
                     </div>
 
                     <div class="form-group">
                         <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
-                        <?= $form->password('uPasswordConfirm', array('autocomplete' => 'off')) ?>
+                        <?= $form->password('uPasswordConfirm', ['autocomplete' => 'off']) ?>
                     </div>
 
                     <div class="dialog-buttons">
@@ -339,7 +339,7 @@ if (isset($user) && is_object($user)) {
         ?>
 
         <div class="ccm-dashboard-content-full">
-            <?php Loader::element('users/search', array('result' => $result))?>
+            <?php Loader::element('users/search', ['result' => $result])?>
         </div>
 
         <script type="text/javascript">

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -1,4 +1,5 @@
-<?php if (isset($user) && is_object($user)) {
+<?php
+if (isset($user) && is_object($user)) {
     $token_validator = \Core::make('helper/validation/token');
 
     $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
@@ -18,70 +19,78 @@
 
         <section>
             <div class="row">
+
                 <div class="col-md-6">
                     <h4><?= t('Basic Details') ?></h4>
-
                     <div class="row">
                         <div class="col-md-4"><p><?= t('Username') ?></p></div>
-                        <div class="col-md-8"><p><span <?php if ($canEditUserName) {
-    ?>data-editable-field-type="xeditable"
-                                                       data-url="<?= $view->action('update_username', $user->getUserID()) ?>"
-                                                       data-type="text"
-                                                       data-name="uName" <?php
-}
-    ?>><?= h($user->getUserName()) ?></span></p>
-                        </div>
+                        <div class="col-md-8"><p><span
+                            <?php
+                            if ($canEditUserName) {
+                                ?>
+                                data-editable-field-type="xeditable"
+                                data-url="<?= $view->action('update_username', $user->getUserID()) ?>"
+                                data-type="text"
+                                data-name="uName"
+                                <?php
+                            }
+                            ?>
+                        ><?= h($user->getUserName()) ?></span></p></div>
                     </div>
                     <div class="row">
                         <div class="col-md-4"><p><?= t('Email Address') ?></p></div>
-                        <div class="col-md-8"><p><span <?php if ($canEditEmail) {
-    ?>data-editable-field-type="xeditable"
-                                                       data-url="<?= $view->action('update_email', $user->getUserID()) ?>"
-                                                       data-type="email"
-                                                       data-name="uEmail"<?php
-}
-    ?>><?= h($user->getUserEmail()) ?></span></p>
+                        <div class="col-md-8"><p><span
+                        <?php
+                            if ($canEditEmail) {
+                                ?>
+                                data-editable-field-type="xeditable"
+                                data-url="<?= $view->action('update_email', $user->getUserID()) ?>"
+                                data-type="email"
+                                data-name="uEmail"
+                                <?php
+                            }
+                            ?>
+                        ><?= h($user->getUserEmail()) ?></span></p>
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-4"><p><?= t('Password') ?></p></div>
-                        <div class="col-md-8"><p><?php if ($canEditPassword) {
-    ?><a href="#" class="btn btn-xs btn-default"
-                                                                                 data-button="change-password"><?= t('Change') ?></a><?php
-} else {
-    ?>*********<?php
-}
-    ?>
-                            </p></div>
+                        <div class="col-md-8"><p>
+                            <?php
+                            if ($canEditPassword) {
+                                ?><a href="#" class="btn btn-xs btn-default" data-button="change-password"><?= t('Change') ?></a><?php
+                            } else {
+                                ?>*********<?php
+                            }
+                            ?>
+                        </p></div>
                     </div>
                     <div class="row">
                         <div class="col-md-4"><p><?= t('Profile Picture') ?></p></div>
-                        <div class="col-md-8"><p>
-
-                            <div <?php if ($canEditAvatar) {
-    ?>data-editable-field-type="image"
-                                 data-editable-field-inline-commands="true"
-                                 data-url="<?= $view->action('update_avatar', $user->getUserID()) ?>"<?php
-}
-    ?>>
-                                <ul class="ccm-edit-mode-inline-commands">
-                                    <li><a href="#" data-editable-field-command="clear"><i
-                                                class="fa fa-trash-o"></i></a></li>
-                                </ul>
-	                <span class="editable-image-wrapper">
-	                    <input type="file" id="file-avatar" name="avatar"/>
-	                    <div
-                            class="editable-image-display"><?=$user->getUserAvatar()->output() ?></div>
-					</span>
-                            </div>
-                            </p>
-                        </div>
+                        <div class="col-md-8"><p><div
+                            <?php
+                            if ($canEditAvatar) {
+                                ?>
+                                data-editable-field-type="image"
+                                data-editable-field-inline-commands="true"
+                                data-url="<?= $view->action('update_avatar', $user->getUserID()) ?>"
+                                <?php
+                            }
+                            ?>
+                        >
+                            <ul class="ccm-edit-mode-inline-commands">
+                                <li><a href="#" data-editable-field-command="clear"><i class="fa fa-trash-o"></i></a></li>
+                            </ul>
+                            <span class="editable-image-wrapper">
+                                <input type="file" id="file-avatar" name="avatar"/>
+                                <div class="editable-image-display"><?=$user->getUserAvatar()->output() ?></div>
+                            </span>
+                        </div></p></div>
                     </div>
                 </div>
 
                 <div class="col-md-6">
                     <h4><?= t('Account') ?></h4>
-
                     <div class="row">
                         <div class="col-md-4"><p><?= t('Date Created') ?></p></div>
                         <div class="col-md-8"><p><?= $dh->formatDateTime($user->getUserDateAdded()) ?></p></div>
@@ -90,79 +99,82 @@
                         <div class="col-md-4"><p><?= t('Last IP Address') ?></p></div>
                         <div class="col-md-8"><p><?= $user->getLastIPAddress() ?></p></div>
                     </div>
-                    <?php if (Config::get('concrete.misc.user_timezones')) {
-    $uTimezone = $user->getUserTimezone();
-    if (empty($uTimezone)) {
-        $uTimezone = date_default_timezone_get();
-    }
-    ?>
+                    <?php
+                    if (Config::get('concrete.misc.user_timezones')) {
+                        $uTimezone = $user->getUserTimezone();
+                        if (empty($uTimezone)) {
+                            $uTimezone = date_default_timezone_get();
+                        }
+                        ?>
                         <div class="row">
                             <div class="col-md-4"><p><?= t('Timezone') ?></p></div>
                             <div class="col-md-8"><p><span
-                                        <?php if ($canEditTimezone) {
-    ?>data-editable-field-type="xeditable"
-                                        data-source="<?= $view->action('get_timezones') ?>"
-                                        data-url="<?= $view->action('update_timezone', $user->getUserID()) ?>"
-                                        data-type="select" data-name="uTimezone"
-                                        data-value="<?= h($uTimezone) ?>"<?php
-}
-    ?>><?= $dh->getTimezoneDisplayName($uTimezone) ?></span>
-                                </p></div>
+                            <?php
+                            if ($canEditTimezone) {
+                                ?>
+                                data-editable-field-type="xeditable"
+                                data-source="<?= $view->action('get_timezones') ?>"
+                                data-url="<?= $view->action('update_timezone', $user->getUserID()) ?>"
+                                data-type="select" data-name="uTimezone"
+                                data-value="<?= h($uTimezone) ?>"
+                                <?php
+                            }
+                            ?>
+                            ><?= $dh->getTimezoneDisplayName($uTimezone) ?></span></p></div>
                         </div>
                     <?php
-}
-    ?>
-                    <?php
+                    }
                     $languages = Localization::getAvailableInterfaceLanguages();
-    if (count($languages) > 0) {
-        ?>
+                    if (count($languages) > 0) {
+                        ?>
                         <div class="row">
                             <div class="col-md-4"><p><?= t('Language') ?></p></div>
                             <div class="col-md-8"><p><span
-                                        <?php if ($canEditLanguage) {
-    ?>data-editable-field-type="xeditable"
-                                        data-source="<?= $view->action('get_languages') ?>"
-                                        data-url="<?= $view->action('update_language', $user->getUserID()) ?>"
-                                        data-type="select"
-                                        data-name="uDefaultLanguage"<?php
-}
-        ?>><?= h($user->getUserDefaultLanguage());
-        ?></span>
-                                </p></div>
+                            <?php
+                            if ($canEditLanguage) {
+                                ?>
+                                data-editable-field-type="xeditable"
+                                data-source="<?= $view->action('get_languages') ?>"
+                                data-url="<?= $view->action('update_language', $user->getUserID()) ?>"
+                                data-type="select"
+                                data-name="uDefaultLanguage"
+                                <?php
+                            }
+                            ?>
+                            ><?= h($user->getUserDefaultLanguage()) ?></span></p></div>
                         </div>
-                    <?php
-    }
-    ?>
-                    <?php if (Config::get('concrete.user.registration.validate_email')) {
-    ?>
+                        <?php
+                    }
+                    if (Config::get('concrete.user.registration.validate_email')) {
+                        ?>
                         <div class="row">
                             <div class="col-md-4"><p><?= t('Full Record') ?></p></div>
                             <div class="col-md-8"><p><?= ($user->isFullRecord()) ? "Yes" : "No" ?></p></div>
                         </div>
                         <div class="row">
                             <div class="col-md-4"><p><?= t('Email Validated') ?></p></div>
-                            <div class="col-md-8"><p><?php
-                                    switch ($user->isValidated()) {
-                                        case '-1':
-                                            print t('Unknown');
-                                            break;
-                                        case '0':
-                                            print t('No');
-                                            break;
-                                        case '1':
-                                            print t('Yes');
-                                            break;
-                                    }
-    ?></p></div>
+                            <div class="col-md-8"><p>
+                                <?php
+                                switch ($user->isValidated()) {
+                                    case '-1':
+                                        print t('Unknown');
+                                        break;
+                                    case '0':
+                                        print t('No');
+                                        break;
+                                    case '1':
+                                        print t('Yes');
+                                        break;
+                                }
+                                ?>
+                            </p></div>
                         </div>
-                    <?php
-}
-    ?>
+                        <?php
+                    }
+                    ?>
 
                     <h4><?= t('Groups') ?></h4>
-
                     <div data-container="group-list"></div>
-
                     <?php
                     if ($canAddGroup) {
                         ?>
@@ -171,9 +183,9 @@
                            dialog-height="480" dialog-modal="true"
                            href="<?= URL::to('/ccm/system/dialogs/group/search') ?>?filter=assign"
                            dialog-title="<?= t('Add Groups') ?>" dialog-modal="false"><?= t('Add Group') ?></a>
-                    <?php
+                        <?php
                     }
-    ?>
+                    ?>
                 </div>
 
             </div>
@@ -181,7 +193,8 @@
 
         <section>
             <h4><?= t('Other Attributes') ?></h4>
-            <?php Loader::element('attribute/editable_list', array(
+            <?php
+            Loader::element('attribute/editable_list', array(
                 'attributes' => $attributes,
                 'object' => $user,
                 'saveAction' => $view->action('update_attribute', $user->getUserID()),
@@ -191,18 +204,17 @@
                     return is_array($permissionsArguments['attributes']) && in_array($ak->getAttributeKeyID(), $permissionsArguments['attributes']);
                 },
             ));
-    ?>
+            ?>
         </section>
 
     </div>
 
-    <?php if ($canEditPassword) {
-    ?>
-
+    <?php
+    if ($canEditPassword) {
+        ?>
         <div style="display: none">
             <div data-dialog="change-password" class="ccm-ui">
-                <form data-dialog-form="change-password"
-                      action="<?= $view->action('change_password', $user->getUserID()) ?>">
+                <form data-dialog-form="change-password" action="<?= $view->action('change_password', $user->getUserID()) ?>">
                     <?= $token_validator->output('change_password') ?>
 
                     <div class="form-group">
@@ -216,30 +228,26 @@
                     </div>
 
                     <div class="dialog-buttons">
-                        <button class="btn btn-default pull-left"
-                                data-dialog-action="cancel"><?= t('Cancel') ?></button>
-                        <button type="button" data-dialog-action="submit"
-                                class="btn btn-primary pull-right"><?= t('Update') ?></button>
+                        <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+                        <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?= t('Update') ?></button>
                     </div>
-
 
                 </form>
             </div>
         </div>
-    <?php
-}
+        <?php
+    }
     ?>
 
     <script type="text/template" data-template="user-add-groups">
         <% _.each(groups, function(group) { %>
-        <div class="row" data-editable-field-inline-commands="true" data-group-id="<%=group.gID%>">
-            <ul class="ccm-edit-mode-inline-commands">
-                <li><a href="#" data-group-id="<%=group.gID%>" data-button="delete-group"><i class="fa fa-trash-o"></i></a>
-                </li>
-            </ul>
-            <div class="col-md-6"><p><%=group.gDisplayName%></p></div>
-            <div class="col-md-6"><p><%=group.gDateTimeEntered%></p></div>
-        </div>
+            <div class="row" data-editable-field-inline-commands="true" data-group-id="<%=group.gID%>">
+                <ul class="ccm-edit-mode-inline-commands">
+                    <li><a href="#" data-group-id="<%=group.gID%>" data-button="delete-group"><i class="fa fa-trash-o"></i></a></li>
+                </ul>
+                <div class="col-md-6"><p><%=group.gDisplayName%></p></div>
+                <div class="col-md-6"><p><%=group.gDateTimeEntered%></p></div>
+            </div>
         <% }); %>
     </script>
 
@@ -273,7 +281,6 @@
                         ccm_token: '<?= $token_validator->generate('add_group') ?>'
                     },
                     success: function (r) {
-
                         $('div[data-container=group-list]').append(
                             _addGroupsTemplate({'groups': r.groups})
                         );
@@ -325,7 +332,7 @@
 
         });
     </script>
-<?php
+    <?php
 } else {
     $tp = Loader::helper('concrete/user');
     if ($tp->canAccessUserSearchInterface()) {
@@ -349,13 +356,11 @@
             });
         </script>
 
-    <?php
+        <?php
     } else {
         ?>
         <p><?= t('You do not have access to user search. This setting may be changed in the access section of the dashboard settings page.') ?></p>
-    <?php
+        <?php
     }
-    ?>
 
-<?php
-} ?>
+}

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -139,7 +139,7 @@ if (isset($user) && is_object($user)) {
                                 <?php
                             }
                             ?>
-                            ><?= h($user->getUserDefaultLanguage()) ?></span></p></div>
+                            ><?= h(Punic\Language::getName($user->getUserDefaultLanguage())) ?></span></p></div>
                         </div>
                         <?php
                     }

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -136,6 +136,7 @@ if (isset($user) && is_object($user)) {
                                 data-url="<?= $view->action('update_language', $user->getUserID()) ?>"
                                 data-type="select"
                                 data-name="uDefaultLanguage"
+                                data-value="<?= h($user->getUserDefaultLanguage()) ?>"
                                 <?php
                             }
                             ?>

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -334,7 +334,6 @@ if (isset($user) && is_object($user)) {
     <?php
 } else {
     $tp = Core::make('helper/concrete/user');
-    dd($tp);
     if ($tp->canAccessUserSearchInterface()) {
         ?>
 

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -1,7 +1,5 @@
 <?php
 if (isset($user) && is_object($user)) {
-    $token_validator = \Core::make('helper/validation/token');
-
     $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
     ?>
 
@@ -215,7 +213,7 @@ if (isset($user) && is_object($user)) {
         <div style="display: none">
             <div data-dialog="change-password" class="ccm-ui">
                 <form data-dialog-form="change-password" action="<?= $view->action('change_password', $user->getUserID()) ?>">
-                    <?= $token_validator->output('change_password') ?>
+                    <?= $token->output('change_password') ?>
 
                     <div class="form-group">
                         <?= $form->label('uPassword', t('Password')) ?>
@@ -261,7 +259,7 @@ if (isset($user) && is_object($user)) {
             $('div[data-container=editable-fields]').concreteEditableFieldContainer({
                 url: '<?=$view->action('save', $user->getUserID())?>',
                 data: {
-                    ccm_token: '<?=$token_validator->generate()?>'
+                    ccm_token: '<?=$token->generate()?>'
                 }
             });
 
@@ -278,7 +276,7 @@ if (isset($user) && is_object($user)) {
                     data: {
                         gID: data.gID,
                         uID: '<?=$user->getUserID()?>',
-                        ccm_token: '<?= $token_validator->generate('add_group') ?>'
+                        ccm_token: '<?= $token->generate('add_group') ?>'
                     },
                     success: function (r) {
                         $('div[data-container=group-list]').append(
@@ -312,7 +310,7 @@ if (isset($user) && is_object($user)) {
                     data: {
                         gID: $(this).attr('data-group-id'),
                         uID: '<?=$user->getUserID()?>',
-                        ccm_token: '<?= $token_validator->generate('remove_group') ?>'
+                        ccm_token: '<?= $token->generate('remove_group') ?>'
                     },
                     success: function (r) {
                         $('div[data-container=group-list] div[data-group-id=' + r.group.gID + ']').queue(function () {

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -352,7 +352,7 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
             if (isset($data['uTimezone'])) {
                 $uTimezone = $data['uTimezone'];
             }
-            if (isset($data['uDefaultLanguage']) && $data['uDefaultLanguage'] != '') {
+            if (isset($data['uDefaultLanguage'])) {
                 $uDefaultLanguage = $data['uDefaultLanguage'];
             }
 


### PR DESCRIPTION
Main changes:

1. Show the language name, not its code
2. When clicking on a language, preselect the current value

### Before
![image](https://cloud.githubusercontent.com/assets/928116/21355450/4a62b8fe-c6ce-11e6-8428-bae48638674f.png)

### After
![image](https://cloud.githubusercontent.com/assets/928116/21355437/3e3ba770-c6ce-11e6-8edd-c513199772a9.png)

I think that the style of the select needs some love from @MrKarlDilkington: as you can see from the screenshots:
- The style for `.ccm-ui select.input-sm` has a `line-height: 35px;` that forces the selected item to have an offset (it's cutted) (se both screenshots)
- If the item initially selected is quite long, and if the window is quite narrow, the popup is too narrow (see second screenshot). It seems that the popup width is somehow related to the width of the container of the attribute ([see this video](https://youtu.be/NDPzKbMRKtw))