### PR TITLE
Coding style rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -27,11 +27,23 @@ return PhpCsFixer\Config::create()
         'no_blank_lines_before_namespace' => true,
         'blank_line_after_opening_tag' => false,
 
+        // Ensure there is no code on the same line as the PHP open tag.
+        'linebreak_after_opening_tag' => true,
+
         // Don't vertically align phpdoc tags
         'phpdoc_align' => false,
 
+        // Phpdoc should contain @param for all params
+        'phpdoc_add_missing_param_annotation' => ['only_untyped' => false],
+
+        // Annotations in phpdocs should be ordered (parameters, then throws, then return).
+        'phpdoc_order' => true,
+
         // Allow double-quoted strings, don't force single-quoted strings
         'single_quote' => false,
+
+		// Replaces intval, floatval, doubleval, strval and boolval function calls with according type casting operator.
+		modernize_types_casting => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,7 +6,8 @@ if (!class_exists('PhpCsFixer\Config', true)) {
 }
 
 return PhpCsFixer\Config::create()
-    ->setCacheFile(__DIR__.'/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
     ->setRules([
         // Let's start with the standard Symfony rules
         '@Symfony' => true,
@@ -42,8 +43,8 @@ return PhpCsFixer\Config::create()
         // Allow double-quoted strings, don't force single-quoted strings
         'single_quote' => false,
 
-		// Replaces intval, floatval, doubleval, strval and boolval function calls with according type casting operator.
-		modernize_types_casting => true,
+        // Replaces intval, floatval, doubleval, strval and boolval function calls with according type casting operator.
+        'modernize_types_casting' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()


### PR DESCRIPTION
What about adding those rules?

And what about asking to include a `@concrete5` ruleset to PHP-CS-Fixer? That way, we'd simply need to call ` php-cs-fixer fix --rules=@concrete5` without the need to specify the path to the .php-cs.dist file...