### PR TITLE
Create the CSRF Middleware (off by deafult for now)

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1304,6 +1304,7 @@ return array(
         ],
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
         'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
-        'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class
+        'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class,
+        'core_csrf' => \Concrete\Core\Http\Middleware\CSRFMiddleware::class
     ]
 );

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -785,6 +785,13 @@ return array(
              * @var bool|string DENY, SAMEORIGIN, ALLOW-FROM uri
              */
             'x_frame_options' => 'SAMEORIGIN',
+
+            /**
+             * Enable the CSRF middleware
+             *
+             * @var bool true to enable the middleware
+             */
+            'csrf_middleware' => false,
         ),
     ),
 

--- a/concrete/src/Http/Middleware/CSRFMiddleware.php
+++ b/concrete/src/Http/Middleware/CSRFMiddleware.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Concrete\Core\Http\Middleware;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Validation\CSRF\Token;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Middleware for checking for a CSRF token in a http response
+ * @package Concrete\Core\Http
+ */
+class CSRFMiddleware implements MiddlewareInterface
+{
+
+    /**
+     * @var \Concrete\Core\Validation\CSRF\Token
+     */
+    private $token;
+
+    /**
+     * @var Repository
+     */
+    private $config;
+
+    public function __construct(Token $token, Repository $repository)
+    {
+        $this->token = $token;
+        $this->config = $repository;
+    }
+
+    /**
+     * Check the request to see if there is a valid CSRF token included
+     * @param Request $request
+     * @param \Concrete\Core\Http\Middleware\DelegateInterface $frame
+     * @return Response
+     * @throws \Exception
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        $enabled = $this->config->get('concrete.security.misc.csrf_middleware');
+        if ($enabled && !$this->isReading($request)) {
+            $header = $request->headers->get('X-CSRF-TOKEN');
+            $post = $request->query->get('ccm_token');
+            if (!$this->token->validate($header) && !$this->token->validate($post)) {
+                throw new \Exception('Invalid token provided');
+            }
+        }
+
+        /** @var Response $response */
+        $response = $frame->next($request);
+
+        return $response;
+    }
+
+    /**
+     * Determine if the HTTP request uses a ‘read’ verb.
+     * Taken from Laravel
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @return bool
+     */
+    protected function isReading($request)
+    {
+        return in_array($request->getMethod(), [$request::METHOD_HEAD, $request::METHOD_GET, $request::METHOD_OPTIONS]);
+    }
+
+}


### PR DESCRIPTION
This is the middleware to enable checking for CSRF tokens automatically by POST or header.

This is **disabled** by default for now but can easily be enabled. Currently this will break basically everything when enabled.