### PR TITLE
Uniform way for "Connect to community" button/block + social links fix

### DIFF
--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -322,7 +322,7 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
                 <div class="well clearfix" style="padding:10px 20px;">
                     <h4><?= t('Connect to Community'); ?></h4>
                     <p><?= t('Your site is not connected to the concrete5 community. Connecting lets you easily extend a site with themes and add-ons.'); ?></p>
-                    <p><a class="btn btn-primary pull-right" href="<?= $view->url('/dashboard/extend/connect', 'register_step1'); ?>"><?= t("Connect to Community"); ?></a></p>
+                    <p><a class="btn btn-primary" href="<?= $view->url('/dashboard/extend/connect', 'register_step1'); ?>"><?= t("Connect to Community"); ?></a></p>
                 </div>
                 <?php
             }

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -166,7 +166,7 @@ if (!$tp->canInstallPackages()) {
 			<div class="well" style="padding:10px 20px;">
 				<h3><?=t('Connect to Community')?></h3>
 				<p><?=t('Your site is not connected to the concrete5 community. Connecting lets you easily extend a site with themes and add-ons. Connecting enables automatic updates.')?></p>
-				<p><a class="btn success" href="<?=$view->url('/dashboard/extend/connect', 'register_step1')?>"><?=t("Connect to Community")?></a></p>
+				<p><a class="btn btn-primary" href="<?=$view->url('/dashboard/extend/connect', 'register_step1')?>"><?=t("Connect to Community")?></a></p>
 			</div>
 
 		<?php 

--- a/concrete/single_pages/dashboard/system/basics/social.php
+++ b/concrete/single_pages/dashboard/system/basics/social.php
@@ -94,7 +94,6 @@
 
     <?php if (count($links) > 0) {
     ?>
-        <div class="col-md-8">
         <table class="table table-striped">
         <?php foreach ($links as $link) {
     $service = $link->getServiceObject();
@@ -108,9 +107,7 @@
 }
     ?>
         </table>
-        </div>
-
-    <?php 
+    <?php
 } else {
     ?>
         <p><?=t("You have not added any social links.")?></p>


### PR DESCRIPTION
The button on the "Add Functionality" page was floating on the right and the one on "Update Add-Ons" had no btn class on it (only success, which should have been btn-success, but since the other one is btn-primary, I assume that's the correct one).