### PR TITLE
Connect to community button standardized

### DIFF
--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -322,7 +322,7 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
                 <div class="well clearfix" style="padding:10px 20px;">
                     <h4><?= t('Connect to Community'); ?></h4>
                     <p><?= t('Your site is not connected to the concrete5 community. Connecting lets you easily extend a site with themes and add-ons.'); ?></p>
-                    <p><a class="btn btn-primary pull-right" href="<?= $view->url('/dashboard/extend/connect', 'register_step1'); ?>"><?= t("Connect to Community"); ?></a></p>
+                    <p><a class="btn btn-primary" href="<?= $view->url('/dashboard/extend/connect', 'register_step1'); ?>"><?= t("Connect to Community"); ?></a></p>
                 </div>
                 <?php
             }

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -166,7 +166,7 @@ if (!$tp->canInstallPackages()) {
 			<div class="well" style="padding:10px 20px;">
 				<h3><?=t('Connect to Community')?></h3>
 				<p><?=t('Your site is not connected to the concrete5 community. Connecting lets you easily extend a site with themes and add-ons. Connecting enables automatic updates.')?></p>
-				<p><a class="btn success" href="<?=$view->url('/dashboard/extend/connect', 'register_step1')?>"><?=t("Connect to Community")?></a></p>
+				<p><a class="btn btn-primary" href="<?=$view->url('/dashboard/extend/connect', 'register_step1')?>"><?=t("Connect to Community")?></a></p>
 			</div>
 
 		<?php 

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -122,7 +122,7 @@ foreach ($locales as $locale) {
 
     <div class="form-group">
         <?php echo Loader::helper('validation/token')->output('set_default') ?>
-        <button class="btn btn-default pull-left" type="submit" name="save"><?= t('Save Settings') ?></button>
+        <button class="btn btn-default" type="submit" name="save"><?= t('Save Settings') ?></button>
     </div>
 </form>
 

--- a/concrete/single_pages/dashboard/system/optimization/clearcache.php
+++ b/concrete/single_pages/dashboard/system/optimization/clearcache.php
@@ -4,7 +4,7 @@
 	<?php echo $this->controller->token->output('clear_cache')?>
     <p><?php echo t('If your site is displaying out-dated information, or behaving unexpectedly, it may help to clear your cache.')?></p>
     <br/>
-    <?php echo $interface->submit(t('Clear Cache'), 'clear-cache-form', 'left', 'btn-primary'); ?>
+    <?php echo $interface->submit(t('Clear Cache'), 'clear-cache-form', '', 'btn-primary'); ?>
 </form>
 
 


### PR DESCRIPTION
Connect to community button had different styling and one was on the right one on the left. Now both have the btn-primary class and are on the left (people read left-to-right, right?)

-- Sorry for having 2 branches in here (which is already in another PR), other one is this PR: https://github.com/concrete5/concrete5/pull/4886 -- New to this and couldn't figure a way out to correct this