### PR TITLE
Use short array syntax in configuration files

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -3,15 +3,14 @@
 use Concrete\Core\Asset\Asset;
 use Concrete\Core\File\Type\Type as FileType;
 
-return array(
-
+return [
     'debug' => false,
     'namespace' => 'Application',
 
     /*
      * Core Aliases
      */
-    'aliases' => array(
+    'aliases' => [
         'Area' => '\Concrete\Core\Area\Area',
         'Asset' => '\Concrete\Core\Asset\Asset',
         'AssetList' => '\Concrete\Core\Asset\AssetList',
@@ -84,12 +83,12 @@ return array(
         'UserList' => '\Concrete\Core\User\UserList',
         'View' => '\Concrete\Core\View\View',
         'Workflow' => '\Concrete\Core\Workflow\Workflow',
-    ),
+    ],
 
     /*
      * Core Providers
      */
-    'providers' => array(
+    'providers' => [
         // Router service provider
         'core_router' => 'Concrete\Core\Routing\RoutingServiceProvider',
 
@@ -143,13 +142,13 @@ return array(
         'core_express' => '\Concrete\Core\Express\ExpressServiceProvider',
 
         // Tracker
-        'core_usagetracker' => '\Concrete\Core\Statistics\UsageTracker\ServiceProvider'
-    ),
+        'core_usagetracker' => '\Concrete\Core\Statistics\UsageTracker\ServiceProvider',
+    ],
 
     /*
      * Core Facades
      */
-    'facades' => array(
+    'facades' => [
         'Core' => '\Concrete\Core\Support\Facade\Application',
         'Session' => '\Concrete\Core\Support\Facade\Session',
         'Cookie' => '\Concrete\Core\Support\Facade\Cookie',
@@ -164,9 +163,9 @@ return array(
         'Image' => '\Concrete\Core\Support\Facade\Image',
         'Config' => '\Concrete\Core\Support\Facade\Config',
         'URL' => '\Concrete\Core\Support\Facade\Url',
-    ),
+    ],
 
-    'package_items' => array(
+    'package_items' => [
         'antispam_library',
         'attribute_key_category',
         'attribute_key',
@@ -198,9 +197,9 @@ return array(
         'workflow_progress_category',
         'workflow_type',
         'workflow',
-    ),
+    ],
 
-    'importer_routines' => array(
+    'importer_routines' => [
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSiteTypesRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportGroupsRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSinglePageStructureRoutine',
@@ -251,1059 +250,1054 @@ return array(
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportConfigValuesRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSystemCaptchaLibrariesRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSystemContentEditorSnippetsRoutine',
-    ),
+    ],
 
     /*
      * Core Routes
      */
-    'routes' => array(
-
+    'routes' => [
         /*
          * Dialogs
          */
-        "/ccm/system/dialogs/area/design/" => array('\Concrete\Controller\Dialog\Area\Design::view'),
-        "/ccm/system/dialogs/area/design/reset" => array('\Concrete\Controller\Dialog\Area\Design::reset'),
-        "/ccm/system/dialogs/area/design/submit" => array('\Concrete\Controller\Dialog\Area\Design::submit'),
-        "/ccm/system/dialogs/area/layout/presets/manage/" => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::viewPresets'),
-        "/ccm/system/dialogs/area/layout/presets/manage/delete" => array('\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::delete'),
-        "/ccm/system/dialogs/area/layout/presets/{arLayoutID}" => array('\Concrete\Controller\Dialog\Area\Layout\Presets::view'),
-        "/ccm/system/dialogs/area/layout/presets/{arLayoutID}/submit" => array('\Concrete\Controller\Dialog\Area\Layout\Presets::submit'),
-        "/ccm/system/dialogs/area/layout/presets/get/{cID}/{arLayoutPresetID}" => array('\Concrete\Controller\Dialog\Area\Layout\Presets::getPresetData'),
+        '/ccm/system/dialogs/area/design/' => ['\Concrete\Controller\Dialog\Area\Design::view'],
+        '/ccm/system/dialogs/area/design/reset' => ['\Concrete\Controller\Dialog\Area\Design::reset'],
+        '/ccm/system/dialogs/area/design/submit' => ['\Concrete\Controller\Dialog\Area\Design::submit'],
+        '/ccm/system/dialogs/area/layout/presets/manage/' => ['\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::viewPresets'],
+        '/ccm/system/dialogs/area/layout/presets/manage/delete' => ['\Concrete\Controller\Dialog\Area\Layout\Presets\Manage::delete'],
+        '/ccm/system/dialogs/area/layout/presets/{arLayoutID}' => ['\Concrete\Controller\Dialog\Area\Layout\Presets::view'],
+        '/ccm/system/dialogs/area/layout/presets/{arLayoutID}/submit' => ['\Concrete\Controller\Dialog\Area\Layout\Presets::submit'],
+        '/ccm/system/dialogs/area/layout/presets/get/{cID}/{arLayoutPresetID}' => ['\Concrete\Controller\Dialog\Area\Layout\Presets::getPresetData'],
 
-        "/ccm/system/dialogs/block/aliasing/" => array('\Concrete\Controller\Dialog\Block\Aliasing::view'),
-        "/ccm/system/dialogs/block/aliasing/submit" => array('\Concrete\Controller\Dialog\Block\Aliasing::submit'),
-        "/ccm/system/dialogs/block/edit/" => array('\Concrete\Controller\Dialog\Block\Edit::view'),
-        "/ccm/system/dialogs/block/edit/submit/" => array('\Concrete\Controller\Dialog\Block\Edit::submit'),
-        "/ccm/system/dialogs/block/cache/" => array('\Concrete\Controller\Dialog\Block\Cache::view'),
-        "/ccm/system/dialogs/block/cache/submit" => array('\Concrete\Controller\Dialog\Block\Cache::submit'),
-        "/ccm/system/dialogs/block/design/" => array('\Concrete\Controller\Dialog\Block\Design::view'),
-        "/ccm/system/dialogs/block/design/reset" => array('\Concrete\Controller\Dialog\Block\Design::reset'),
-        "/ccm/system/dialogs/block/design/submit" => array('\Concrete\Controller\Dialog\Block\Design::submit'),
-        "/ccm/system/dialogs/block/permissions/detail/" => array('\Concrete\Controller\Dialog\Block\Permissions::viewDetail'),
-        "/ccm/system/dialogs/block/permissions/guest_access/" => array('\Concrete\Controller\Dialog\Block\Permissions\GuestAccess::__construct'),
-        "/ccm/system/dialogs/block/permissions/list/" => array('\Concrete\Controller\Dialog\Block\Permissions::viewList'),
-        "/ccm/system/dialogs/block/delete/" => array('\Concrete\Controller\Dialog\Block\Delete::view'),
-        "/ccm/system/dialogs/block/delete/submit/" => array('\Concrete\Controller\Dialog\Block\Delete::submit'),
-        "/ccm/system/dialogs/block/delete/submit_all/" => array('\Concrete\Controller\Dialog\Block\Delete::submit_all'),
+        '/ccm/system/dialogs/block/aliasing/' => ['\Concrete\Controller\Dialog\Block\Aliasing::view'],
+        '/ccm/system/dialogs/block/aliasing/submit' => ['\Concrete\Controller\Dialog\Block\Aliasing::submit'],
+        '/ccm/system/dialogs/block/edit/' => ['\Concrete\Controller\Dialog\Block\Edit::view'],
+        '/ccm/system/dialogs/block/edit/submit/' => ['\Concrete\Controller\Dialog\Block\Edit::submit'],
+        '/ccm/system/dialogs/block/cache/' => ['\Concrete\Controller\Dialog\Block\Cache::view'],
+        '/ccm/system/dialogs/block/cache/submit' => ['\Concrete\Controller\Dialog\Block\Cache::submit'],
+        '/ccm/system/dialogs/block/design/' => ['\Concrete\Controller\Dialog\Block\Design::view'],
+        '/ccm/system/dialogs/block/design/reset' => ['\Concrete\Controller\Dialog\Block\Design::reset'],
+        '/ccm/system/dialogs/block/design/submit' => ['\Concrete\Controller\Dialog\Block\Design::submit'],
+        '/ccm/system/dialogs/block/permissions/detail/' => ['\Concrete\Controller\Dialog\Block\Permissions::viewDetail'],
+        '/ccm/system/dialogs/block/permissions/guest_access/' => ['\Concrete\Controller\Dialog\Block\Permissions\GuestAccess::__construct'],
+        '/ccm/system/dialogs/block/permissions/list/' => ['\Concrete\Controller\Dialog\Block\Permissions::viewList'],
+        '/ccm/system/dialogs/block/delete/' => ['\Concrete\Controller\Dialog\Block\Delete::view'],
+        '/ccm/system/dialogs/block/delete/submit/' => ['\Concrete\Controller\Dialog\Block\Delete::submit'],
+        '/ccm/system/dialogs/block/delete/submit_all/' => ['\Concrete\Controller\Dialog\Block\Delete::submit_all'],
 
-        "/ccm/system/dialogs/file/upload_complete" => array('\Concrete\Controller\Dialog\File\UploadComplete::view'),
-        "/ccm/system/dialogs/file/bulk/delete" => array('\Concrete\Controller\Dialog\File\Bulk\Delete::view'),
-        "/ccm/system/dialogs/file/bulk/delete/delete_files" => array('\Concrete\Controller\Dialog\File\Bulk\Delete::deleteFiles'),
-        "/ccm/system/dialogs/file/bulk/properties" => array('\Concrete\Controller\Dialog\File\Bulk\Properties::view'),
-        "/ccm/system/dialogs/file/bulk/sets" => array('\Concrete\Controller\Dialog\File\Bulk\Sets::view'),
-        "/ccm/system/dialogs/file/bulk/sets/submit" => array('\Concrete\Controller\Dialog\File\Bulk\Sets::submit'),
-        "/ccm/system/dialogs/file/bulk/properties/clear_attribute" => array('\Concrete\Controller\Dialog\File\Bulk\Properties::clearAttribute'),
-        "/ccm/system/dialogs/file/bulk/properties/update_attribute" => array('\Concrete\Controller\Dialog\File\Bulk\Properties::updateAttribute'),
-        "/ccm/system/dialogs/file/bulk/storage" => array('\Concrete\Controller\Dialog\File\Bulk\Storage::view'),
-        "/ccm/system/dialogs/file/bulk/storage/submit" => array('\Concrete\Controller\Dialog\File\Bulk\Storage::submit'),
-        "/ccm/system/dialogs/file/sets" => array('\Concrete\Controller\Dialog\File\Sets::view'),
-        "/ccm/system/dialogs/file/sets/submit" => array('\Concrete\Controller\Dialog\File\Sets::submit'),
-        "/ccm/system/dialogs/file/properties" => array('\Concrete\Controller\Dialog\File\Properties::view'),
-        "/ccm/system/dialogs/file/advanced_search" => array('\Concrete\Controller\Dialog\File\AdvancedSearch::view'),
-        "/ccm/system/dialogs/file/advanced_search/add_field" => array('\Concrete\Controller\Dialog\File\AdvancedSearch::addField'),
-        "/ccm/system/dialogs/file/advanced_search/submit" => array('\Concrete\Controller\Dialog\File\AdvancedSearch::submit'),
-        "/ccm/system/dialogs/file/advanced_search/save_preset" => array('\Concrete\Controller\Dialog\File\AdvancedSearch::savePreset'),
-        "/ccm/system/dialogs/file/properties/clear_attribute" => array('\Concrete\Controller\Dialog\File\Properties::clear_attribute'),
-        "/ccm/system/dialogs/file/properties/save" => array('\Concrete\Controller\Dialog\File\Properties::save'),
-        "/ccm/system/dialogs/file/properties/update_attribute" => array('\Concrete\Controller\Dialog\File\Properties::update_attribute'),
-        "/ccm/system/dialogs/file/search" => array('\Concrete\Controller\Dialog\File\Search::view'),
-        "/ccm/system/dialogs/file/thumbnails" => array('\Concrete\Controller\Dialog\File\Thumbnails::view'),
-        "/ccm/system/dialogs/file/thumbnails/edit" => array('\Concrete\Controller\Dialog\File\Thumbnails\Edit::view'),
-        "/ccm/system/dialogs/file/usage/{fID}" => array('\Concrete\Controller\Dialog\File\Usage::view'),
+        '/ccm/system/dialogs/file/upload_complete' => ['\Concrete\Controller\Dialog\File\UploadComplete::view'],
+        '/ccm/system/dialogs/file/bulk/delete' => ['\Concrete\Controller\Dialog\File\Bulk\Delete::view'],
+        '/ccm/system/dialogs/file/bulk/delete/delete_files' => ['\Concrete\Controller\Dialog\File\Bulk\Delete::deleteFiles'],
+        '/ccm/system/dialogs/file/bulk/properties' => ['\Concrete\Controller\Dialog\File\Bulk\Properties::view'],
+        '/ccm/system/dialogs/file/bulk/sets' => ['\Concrete\Controller\Dialog\File\Bulk\Sets::view'],
+        '/ccm/system/dialogs/file/bulk/sets/submit' => ['\Concrete\Controller\Dialog\File\Bulk\Sets::submit'],
+        '/ccm/system/dialogs/file/bulk/properties/clear_attribute' => ['\Concrete\Controller\Dialog\File\Bulk\Properties::clearAttribute'],
+        '/ccm/system/dialogs/file/bulk/properties/update_attribute' => ['\Concrete\Controller\Dialog\File\Bulk\Properties::updateAttribute'],
+        '/ccm/system/dialogs/file/bulk/storage' => ['\Concrete\Controller\Dialog\File\Bulk\Storage::view'],
+        '/ccm/system/dialogs/file/bulk/storage/submit' => ['\Concrete\Controller\Dialog\File\Bulk\Storage::submit'],
+        '/ccm/system/dialogs/file/sets' => ['\Concrete\Controller\Dialog\File\Sets::view'],
+        '/ccm/system/dialogs/file/sets/submit' => ['\Concrete\Controller\Dialog\File\Sets::submit'],
+        '/ccm/system/dialogs/file/properties' => ['\Concrete\Controller\Dialog\File\Properties::view'],
+        '/ccm/system/dialogs/file/advanced_search' => ['\Concrete\Controller\Dialog\File\AdvancedSearch::view'],
+        '/ccm/system/dialogs/file/advanced_search/add_field' => ['\Concrete\Controller\Dialog\File\AdvancedSearch::addField'],
+        '/ccm/system/dialogs/file/advanced_search/submit' => ['\Concrete\Controller\Dialog\File\AdvancedSearch::submit'],
+        '/ccm/system/dialogs/file/advanced_search/save_preset' => ['\Concrete\Controller\Dialog\File\AdvancedSearch::savePreset'],
+        '/ccm/system/dialogs/file/properties/clear_attribute' => ['\Concrete\Controller\Dialog\File\Properties::clear_attribute'],
+        '/ccm/system/dialogs/file/properties/save' => ['\Concrete\Controller\Dialog\File\Properties::save'],
+        '/ccm/system/dialogs/file/properties/update_attribute' => ['\Concrete\Controller\Dialog\File\Properties::update_attribute'],
+        '/ccm/system/dialogs/file/search' => ['\Concrete\Controller\Dialog\File\Search::view'],
+        '/ccm/system/dialogs/file/thumbnails' => ['\Concrete\Controller\Dialog\File\Thumbnails::view'],
+        '/ccm/system/dialogs/file/thumbnails/edit' => ['\Concrete\Controller\Dialog\File\Thumbnails\Edit::view'],
+        '/ccm/system/dialogs/file/usage/{fID}' => ['\Concrete\Controller\Dialog\File\Usage::view'],
 
-        "/ccm/system/dialogs/group/search" => array('\Concrete\Controller\Dialog\Group\Search::view'),
+        '/ccm/system/dialogs/group/search' => ['\Concrete\Controller\Dialog\Group\Search::view'],
 
-        "/ccm/system/dialogs/page/add" => array('\Concrete\Controller\Dialog\Page\Add::view'),
-        "/ccm/system/dialogs/page/add_block" => array('\Concrete\Controller\Dialog\Page\AddBlock::view'),
-        "/ccm/system/dialogs/page/add_block/submit" => array('\Concrete\Controller\Dialog\Page\AddBlock::submit'),
-        "/ccm/system/dialogs/page/add_block_list" => array('\Concrete\Controller\Dialog\Page\AddBlockList::view'),
-        "/ccm/system/dialogs/page/add_external" => array('\Concrete\Controller\Dialog\Page\AddExternal::view'),
-        "/ccm/system/dialogs/page/add_external/submit" => array('\Concrete\Controller\Dialog\Page\AddExternal::submit'),
-        "/ccm/system/dialogs/page/add/compose/{ptID}/{cParentID}" => array('\Concrete\Controller\Dialog\Page\Add\Compose::view'),
-        "/ccm/system/dialogs/page/add/compose/submit" => array('\Concrete\Controller\Dialog\Page\Add\Compose::submit'),
-        "/ccm/system/dialogs/page/attributes" => array('\Concrete\Controller\Dialog\Page\Attributes::view'),
-        "/ccm/system/dialogs/page/bulk/properties" => array('\Concrete\Controller\Dialog\Page\Bulk\Properties::view'),
-        "/ccm/system/dialogs/page/bulk/properties/clear_attribute" => array('\Concrete\Controller\Dialog\Page\Bulk\Properties::clearAttribute'),
-        "/ccm/system/dialogs/page/bulk/properties/update_attribute" => array('\Concrete\Controller\Dialog\Page\Bulk\Properties::updateAttribute'),
-        "/ccm/system/dialogs/page/clipboard" => array('\Concrete\Controller\Dialog\Page\Clipboard::view'),
-        "/ccm/system/dialogs/page/delete" => array('\Concrete\Controller\Dialog\Page\Delete::view'),
-        "/ccm/system/dialogs/page/delete/submit" => array('\Concrete\Controller\Dialog\Page\Delete::submit'),
-        "/ccm/system/dialogs/page/delete_alias" => array('\Concrete\Controller\Dialog\Page\DeleteAlias::view'),
-        "/ccm/system/dialogs/page/delete_alias/submit" => array('\Concrete\Controller\Dialog\Page\DeleteAlias::submit'),
-        "/ccm/system/dialogs/page/delete_from_sitemap" => array('\Concrete\Controller\Dialog\Page\Delete::viewFromSitemap'),
-        "/ccm/system/dialogs/page/design" => array('\Concrete\Controller\Dialog\Page\Design::view'),
-        "/ccm/system/dialogs/page/design/submit" => array('\Concrete\Controller\Dialog\Page\Design::submit'),
-        "/ccm/system/dialogs/page/design/css" => array('\Concrete\Controller\Dialog\Page\Design\Css::view'),
-        "/ccm/system/dialogs/page/design/css/submit" => array('\Concrete\Controller\Dialog\Page\Design\Css::submit'),
-        "/ccm/system/dialogs/page/edit_external" => array('\Concrete\Controller\Dialog\Page\EditExternal::view'),
-        "/ccm/system/dialogs/page/edit_external/submit" => array('\Concrete\Controller\Dialog\Page\EditExternal::submit'),
-        "/ccm/system/dialogs/page/location" => array('\Concrete\Controller\Dialog\Page\Location::view'),
-        "/ccm/system/dialogs/page/search" => array('\Concrete\Controller\Dialog\Page\Search::view'),
-        "/ccm/system/dialogs/page/search/customize" => array('\Concrete\Controller\Dialog\Page\Search\Customize::view'),
-        "/ccm/system/dialogs/page/search/customize/submit" => array('\Concrete\Controller\Dialog\Page\Search\Customize::submit'),
-        "/ccm/system/dialogs/page/seo" => array('\Concrete\Controller\Dialog\Page\Seo::view'),
+        '/ccm/system/dialogs/page/add' => ['\Concrete\Controller\Dialog\Page\Add::view'],
+        '/ccm/system/dialogs/page/add_block' => ['\Concrete\Controller\Dialog\Page\AddBlock::view'],
+        '/ccm/system/dialogs/page/add_block/submit' => ['\Concrete\Controller\Dialog\Page\AddBlock::submit'],
+        '/ccm/system/dialogs/page/add_block_list' => ['\Concrete\Controller\Dialog\Page\AddBlockList::view'],
+        '/ccm/system/dialogs/page/add_external' => ['\Concrete\Controller\Dialog\Page\AddExternal::view'],
+        '/ccm/system/dialogs/page/add_external/submit' => ['\Concrete\Controller\Dialog\Page\AddExternal::submit'],
+        '/ccm/system/dialogs/page/add/compose/{ptID}/{cParentID}' => ['\Concrete\Controller\Dialog\Page\Add\Compose::view'],
+        '/ccm/system/dialogs/page/add/compose/submit' => ['\Concrete\Controller\Dialog\Page\Add\Compose::submit'],
+        '/ccm/system/dialogs/page/attributes' => ['\Concrete\Controller\Dialog\Page\Attributes::view'],
+        '/ccm/system/dialogs/page/bulk/properties' => ['\Concrete\Controller\Dialog\Page\Bulk\Properties::view'],
+        '/ccm/system/dialogs/page/bulk/properties/clear_attribute' => ['\Concrete\Controller\Dialog\Page\Bulk\Properties::clearAttribute'],
+        '/ccm/system/dialogs/page/bulk/properties/update_attribute' => ['\Concrete\Controller\Dialog\Page\Bulk\Properties::updateAttribute'],
+        '/ccm/system/dialogs/page/clipboard' => ['\Concrete\Controller\Dialog\Page\Clipboard::view'],
+        '/ccm/system/dialogs/page/delete' => ['\Concrete\Controller\Dialog\Page\Delete::view'],
+        '/ccm/system/dialogs/page/delete/submit' => ['\Concrete\Controller\Dialog\Page\Delete::submit'],
+        '/ccm/system/dialogs/page/delete_alias' => ['\Concrete\Controller\Dialog\Page\DeleteAlias::view'],
+        '/ccm/system/dialogs/page/delete_alias/submit' => ['\Concrete\Controller\Dialog\Page\DeleteAlias::submit'],
+        '/ccm/system/dialogs/page/delete_from_sitemap' => ['\Concrete\Controller\Dialog\Page\Delete::viewFromSitemap'],
+        '/ccm/system/dialogs/page/design' => ['\Concrete\Controller\Dialog\Page\Design::view'],
+        '/ccm/system/dialogs/page/design/submit' => ['\Concrete\Controller\Dialog\Page\Design::submit'],
+        '/ccm/system/dialogs/page/design/css' => ['\Concrete\Controller\Dialog\Page\Design\Css::view'],
+        '/ccm/system/dialogs/page/design/css/submit' => ['\Concrete\Controller\Dialog\Page\Design\Css::submit'],
+        '/ccm/system/dialogs/page/edit_external' => ['\Concrete\Controller\Dialog\Page\EditExternal::view'],
+        '/ccm/system/dialogs/page/edit_external/submit' => ['\Concrete\Controller\Dialog\Page\EditExternal::submit'],
+        '/ccm/system/dialogs/page/location' => ['\Concrete\Controller\Dialog\Page\Location::view'],
+        '/ccm/system/dialogs/page/search' => ['\Concrete\Controller\Dialog\Page\Search::view'],
+        '/ccm/system/dialogs/page/search/customize' => ['\Concrete\Controller\Dialog\Page\Search\Customize::view'],
+        '/ccm/system/dialogs/page/search/customize/submit' => ['\Concrete\Controller\Dialog\Page\Search\Customize::submit'],
+        '/ccm/system/dialogs/page/seo' => ['\Concrete\Controller\Dialog\Page\Seo::view'],
 
-        "/ccm/system/dialogs/page/advanced_search" => array('\Concrete\Controller\Dialog\Page\AdvancedSearch::view'),
-        "/ccm/system/dialogs/page/advanced_search/add_field" => array('\Concrete\Controller\Dialog\Page\AdvancedSearch::addField'),
-        "/ccm/system/dialogs/page/advanced_search/submit" => array('\Concrete\Controller\Dialog\Page\AdvancedSearch::submit'),
-        "/ccm/system/dialogs/page/advanced_search/save_preset" => array('\Concrete\Controller\Dialog\Page\AdvancedSearch::savePreset'),
+        '/ccm/system/dialogs/page/advanced_search' => ['\Concrete\Controller\Dialog\Page\AdvancedSearch::view'],
+        '/ccm/system/dialogs/page/advanced_search/add_field' => ['\Concrete\Controller\Dialog\Page\AdvancedSearch::addField'],
+        '/ccm/system/dialogs/page/advanced_search/submit' => ['\Concrete\Controller\Dialog\Page\AdvancedSearch::submit'],
+        '/ccm/system/dialogs/page/advanced_search/save_preset' => ['\Concrete\Controller\Dialog\Page\AdvancedSearch::savePreset'],
 
-        "/ccm/system/dialogs/user/bulk/properties" => array('\Concrete\Controller\Dialog\User\Bulk\Properties::view'),
-        "/ccm/system/dialogs/user/bulk/properties/clear_attribute" => array('\Concrete\Controller\Dialog\User\Bulk\Properties::clearAttribute'),
-        "/ccm/system/dialogs/user/bulk/properties/update_attribute" => array('\Concrete\Controller\Dialog\User\Bulk\Properties::updateAttribute'),
-        "/ccm/system/dialogs/user/search" => array('\Concrete\Controller\Dialog\User\Search::view'),
-        "/ccm/system/dialogs/user/search/customize" => array('\Concrete\Controller\Dialog\User\Search\Customize::view'),
-        "/ccm/system/dialogs/user/search/customize/submit" => array('\Concrete\Controller\Dialog\User\Search\Customize::submit'),
+        '/ccm/system/dialogs/user/bulk/properties' => ['\Concrete\Controller\Dialog\User\Bulk\Properties::view'],
+        '/ccm/system/dialogs/user/bulk/properties/clear_attribute' => ['\Concrete\Controller\Dialog\User\Bulk\Properties::clearAttribute'],
+        '/ccm/system/dialogs/user/bulk/properties/update_attribute' => ['\Concrete\Controller\Dialog\User\Bulk\Properties::updateAttribute'],
+        '/ccm/system/dialogs/user/search' => ['\Concrete\Controller\Dialog\User\Search::view'],
+        '/ccm/system/dialogs/user/search/customize' => ['\Concrete\Controller\Dialog\User\Search\Customize::view'],
+        '/ccm/system/dialogs/user/search/customize/submit' => ['\Concrete\Controller\Dialog\User\Search\Customize::submit'],
 
-        "/ccm/system/dialogs/user/advanced_search" => array('\Concrete\Controller\Dialog\User\AdvancedSearch::view'),
-        "/ccm/system/dialogs/user/advanced_search/add_field" => array('\Concrete\Controller\Dialog\User\AdvancedSearch::addField'),
-        "/ccm/system/dialogs/user/advanced_search/submit" => array('\Concrete\Controller\Dialog\User\AdvancedSearch::submit'),
-        "/ccm/system/dialogs/user/advanced_search/save_preset" => array('\Concrete\Controller\Dialog\User\AdvancedSearch::savePreset'),
+        '/ccm/system/dialogs/user/advanced_search' => ['\Concrete\Controller\Dialog\User\AdvancedSearch::view'],
+        '/ccm/system/dialogs/user/advanced_search/add_field' => ['\Concrete\Controller\Dialog\User\AdvancedSearch::addField'],
+        '/ccm/system/dialogs/user/advanced_search/submit' => ['\Concrete\Controller\Dialog\User\AdvancedSearch::submit'],
+        '/ccm/system/dialogs/user/advanced_search/save_preset' => ['\Concrete\Controller\Dialog\User\AdvancedSearch::savePreset'],
 
         /*
          * Conversations
          */
-        "/ccm/system/dialogs/conversation/subscribe/{cnvID}" => array('\Concrete\Controller\Dialog\Conversation\Subscribe::view'),
-        "/ccm/system/dialogs/conversation/subscribe/subscribe/{cnvID}" => array('\Concrete\Controller\Dialog\Conversation\Subscribe::subscribe'),
-        "/ccm/system/dialogs/conversation/subscribe/unsubscribe/{cnvID}" => array('\Concrete\Controller\Dialog\Conversation\Subscribe::unsubscribe'),
+        '/ccm/system/dialogs/conversation/subscribe/{cnvID}' => ['\Concrete\Controller\Dialog\Conversation\Subscribe::view'],
+        '/ccm/system/dialogs/conversation/subscribe/subscribe/{cnvID}' => ['\Concrete\Controller\Dialog\Conversation\Subscribe::subscribe'],
+        '/ccm/system/dialogs/conversation/subscribe/unsubscribe/{cnvID}' => ['\Concrete\Controller\Dialog\Conversation\Subscribe::unsubscribe'],
 
         /*
          * Help
          */
-        "/ccm/system/dialogs/help/introduction/" => array('\Concrete\Controller\Dialog\Help\Introduction::view'),
+        '/ccm/system/dialogs/help/introduction/' => ['\Concrete\Controller\Dialog\Help\Introduction::view'],
 
         /*
          * Files
          */
-        "/ccm/system/file/approve_version" => array('\Concrete\Controller\Backend\File::approveVersion'),
-        "/ccm/system/file/delete_version" => array('\Concrete\Controller\Backend\File::deleteVersion'),
-        "/ccm/system/file/duplicate" => array('\Concrete\Controller\Backend\File::duplicate'),
-        "/ccm/system/file/get_json" => array('\Concrete\Controller\Backend\File::getJSON'),
-        "/ccm/system/file/rescan" => array('\Concrete\Controller\Backend\File::rescan'),
-        "/ccm/system/file/rescan_multiple" => array('\Concrete\Controller\Backend\File::rescanMultiple'),
-        "/ccm/system/file/star" => array('\Concrete\Controller\Backend\File::star'),
-        "/ccm/system/file/upload" => array('\Concrete\Controller\Backend\File::upload'),
-        "/ccm/system/file/folder/add" => array('\Concrete\Controller\Backend\File\Folder::add'),
-        "/ccm/system/file/folder/contents" => array('\Concrete\Controller\Search\FileFolder::submit'),
+        '/ccm/system/file/approve_version' => ['\Concrete\Controller\Backend\File::approveVersion'],
+        '/ccm/system/file/delete_version' => ['\Concrete\Controller\Backend\File::deleteVersion'],
+        '/ccm/system/file/duplicate' => ['\Concrete\Controller\Backend\File::duplicate'],
+        '/ccm/system/file/get_json' => ['\Concrete\Controller\Backend\File::getJSON'],
+        '/ccm/system/file/rescan' => ['\Concrete\Controller\Backend\File::rescan'],
+        '/ccm/system/file/rescan_multiple' => ['\Concrete\Controller\Backend\File::rescanMultiple'],
+        '/ccm/system/file/star' => ['\Concrete\Controller\Backend\File::star'],
+        '/ccm/system/file/upload' => ['\Concrete\Controller\Backend\File::upload'],
+        '/ccm/system/file/folder/add' => ['\Concrete\Controller\Backend\File\Folder::add'],
+        '/ccm/system/file/folder/contents' => ['\Concrete\Controller\Search\FileFolder::submit'],
 
         /*
          * Users
          */
-        "/ccm/system/user/add_group" => array('\Concrete\Controller\Backend\User::addGroup'),
-        "/ccm/system/user/remove_group" => array('\Concrete\Controller\Backend\User::removeGroup'),
-        "/ccm/system/user/get_json" => array('\Concrete\Controller\Backend\User::getJSON'),
+        '/ccm/system/user/add_group' => ['\Concrete\Controller\Backend\User::addGroup'],
+        '/ccm/system/user/remove_group' => ['\Concrete\Controller\Backend\User::removeGroup'],
+        '/ccm/system/user/get_json' => ['\Concrete\Controller\Backend\User::getJSON'],
 
         /*
          * Page actions - non UI
          */
-        "/ccm/system/page/arrange_blocks/" => array('\Concrete\Controller\Backend\Page\ArrangeBlocks::arrange'),
-        "/ccm/system/page/check_in/{cID}/{token}" => array('\Concrete\Controller\Backend\Page::exitEditMode'),
-        "/ccm/system/page/create/{ptID}" => array('\Concrete\Controller\Backend\Page::create'),
-        "/ccm/system/page/create/{ptID}/{parentID}" => array('\Concrete\Controller\Backend\Page::create'),
-        "/ccm/system/page/get_json" => array('\Concrete\Controller\Backend\Page::getJSON'),
-        "/ccm/system/page/multilingual/assign" => array('\Concrete\Controller\Backend\Page\Multilingual::assign'),
-        "/ccm/system/page/multilingual/create_new" => array('\Concrete\Controller\Backend\Page\Multilingual::create_new'),
-        "/ccm/system/page/multilingual/ignore" => array('\Concrete\Controller\Backend\Page\Multilingual::ignore'),
-        "/ccm/system/page/multilingual/unmap" => array('\Concrete\Controller\Backend\Page\Multilingual::unmap'),
-        "/ccm/system/page/select_sitemap" => array('\Concrete\Controller\Backend\Page\SitemapSelector::view'),
+        '/ccm/system/page/arrange_blocks/' => ['\Concrete\Controller\Backend\Page\ArrangeBlocks::arrange'],
+        '/ccm/system/page/check_in/{cID}/{token}' => ['\Concrete\Controller\Backend\Page::exitEditMode'],
+        '/ccm/system/page/create/{ptID}' => ['\Concrete\Controller\Backend\Page::create'],
+        '/ccm/system/page/create/{ptID}/{parentID}' => ['\Concrete\Controller\Backend\Page::create'],
+        '/ccm/system/page/get_json' => ['\Concrete\Controller\Backend\Page::getJSON'],
+        '/ccm/system/page/multilingual/assign' => ['\Concrete\Controller\Backend\Page\Multilingual::assign'],
+        '/ccm/system/page/multilingual/create_new' => ['\Concrete\Controller\Backend\Page\Multilingual::create_new'],
+        '/ccm/system/page/multilingual/ignore' => ['\Concrete\Controller\Backend\Page\Multilingual::ignore'],
+        '/ccm/system/page/multilingual/unmap' => ['\Concrete\Controller\Backend\Page\Multilingual::unmap'],
+        '/ccm/system/page/select_sitemap' => ['\Concrete\Controller\Backend\Page\SitemapSelector::view'],
 
         /*
          * Block actions - non UI
          */
-        "/ccm/system/block/render/" => array('\Concrete\Controller\Backend\Block::render'),
-        "/ccm/system/block/action/add/{cID}/{arHandle}/{btID}/{action}" => array('\Concrete\Controller\Backend\Block\Action::add'),
-        "/ccm/system/block/action/edit/{cID}/{arHandle}/{bID}/{action}" => array('\Concrete\Controller\Backend\Block\Action::edit'),
-        "/ccm/system/block/action/add_composer/{ptComposerFormLayoutSetControlID}/{action}" => array('\Concrete\Controller\Backend\Block\Action::add_composer'),
-        "/ccm/system/block/action/edit_composer/{cID}/{arHandle}/{ptComposerFormLayoutSetControlID}/{action}" => array('\Concrete\Controller\Backend\Block\Action::edit_composer'),
+        '/ccm/system/block/render/' => ['\Concrete\Controller\Backend\Block::render'],
+        '/ccm/system/block/action/add/{cID}/{arHandle}/{btID}/{action}' => ['\Concrete\Controller\Backend\Block\Action::add'],
+        '/ccm/system/block/action/edit/{cID}/{arHandle}/{bID}/{action}' => ['\Concrete\Controller\Backend\Block\Action::edit'],
+        '/ccm/system/block/action/add_composer/{ptComposerFormLayoutSetControlID}/{action}' => ['\Concrete\Controller\Backend\Block\Action::add_composer'],
+        '/ccm/system/block/action/edit_composer/{cID}/{arHandle}/{ptComposerFormLayoutSetControlID}/{action}' => ['\Concrete\Controller\Backend\Block\Action::edit_composer'],
 
         /*
          * Misc
          */
-        "/ccm/system/css/layout/{arLayoutID}" => array('\Concrete\Controller\Frontend\Stylesheet::layout'),
-        "/ccm/system/css/page/{cID}/{stylesheet}/{cvID}" => array('\Concrete\Controller\Frontend\Stylesheet::page_version'),
-        "/ccm/system/css/page/{cID}/{stylesheet}" => array('\Concrete\Controller\Frontend\Stylesheet::page'),
-        "/ccm/system/backend/editor_data/" => array('\Concrete\Controller\Backend\EditorData::view'),
-        "/ccm/system/backend/get_remote_help/" => array('\Concrete\Controller\Backend\GetRemoteHelp::view'),
-        "/ccm/system/backend/intelligent_search/" => array('\Concrete\Controller\Backend\IntelligentSearch::view'),
-        "/ccm/system/jobs" => array('\Concrete\Controller\Frontend\Jobs::view'),
-        "/ccm/system/jobs/run_single" => array('\Concrete\Controller\Frontend\Jobs::run_single'),
-        "/ccm/system/jobs/check_queue" => array('\Concrete\Controller\Frontend\Jobs::check_queue'),
+        '/ccm/system/css/layout/{arLayoutID}' => ['\Concrete\Controller\Frontend\Stylesheet::layout'],
+        '/ccm/system/css/page/{cID}/{stylesheet}/{cvID}' => ['\Concrete\Controller\Frontend\Stylesheet::page_version'],
+        '/ccm/system/css/page/{cID}/{stylesheet}' => ['\Concrete\Controller\Frontend\Stylesheet::page'],
+        '/ccm/system/backend/editor_data/' => ['\Concrete\Controller\Backend\EditorData::view'],
+        '/ccm/system/backend/get_remote_help/' => ['\Concrete\Controller\Backend\GetRemoteHelp::view'],
+        '/ccm/system/backend/intelligent_search/' => ['\Concrete\Controller\Backend\IntelligentSearch::view'],
+        '/ccm/system/jobs' => ['\Concrete\Controller\Frontend\Jobs::view'],
+        '/ccm/system/jobs/run_single' => ['\Concrete\Controller\Frontend\Jobs::run_single'],
+        '/ccm/system/jobs/check_queue' => ['\Concrete\Controller\Frontend\Jobs::check_queue'],
         // @TODO remove the line below
-        "/tools/required/jobs" => array('\Concrete\Controller\Frontend\Jobs::view'),
-        "/tools/required/jobs/check_queue" => array('\Concrete\Controller\Frontend\Jobs::check_queue'),
-        "/tools/required/jobs/run_single" => array('\Concrete\Controller\Frontend\Jobs::run_single'),
+        '/tools/required/jobs' => ['\Concrete\Controller\Frontend\Jobs::view'],
+        '/tools/required/jobs/check_queue' => ['\Concrete\Controller\Frontend\Jobs::check_queue'],
+        '/tools/required/jobs/run_single' => ['\Concrete\Controller\Frontend\Jobs::run_single'],
         // end removing lines
-        "/ccm/system/upgrade/" => array('\Concrete\Controller\Upgrade::view'),
-        "/ccm/system/upgrade/submit" => array('\Concrete\Controller\Upgrade::submit'),
+        '/ccm/system/upgrade/' => ['\Concrete\Controller\Upgrade::view'],
+        '/ccm/system/upgrade/submit' => ['\Concrete\Controller\Upgrade::submit'],
 
         /*
          * Notification
          */
-        "/ccm/system/notification/alert/archive/" => array('\Concrete\Controller\Backend\Notification\Alert::archive'),
+        '/ccm/system/notification/alert/archive/' => ['\Concrete\Controller\Backend\Notification\Alert::archive'],
 
         /*
          * General Attribute
          */
-        "/ccm/system/attribute/action/{action}" => array(
+        '/ccm/system/attribute/action/{action}' => [
             '\Concrete\Controller\Backend\Attribute\Action::dispatch',
             'attribute_action',
-            array('action' => ".+"),
-        ),
+            ['action' => '.+'],
+        ],
 
         /*
          * Trees
          */
-        "/ccm/system/tree/load" => array('\Concrete\Controller\Backend\Tree::load'),
-        "/ccm/system/tree/node/load" => array('\Concrete\Controller\Backend\Tree\Node::load'),
-        "/ccm/system/tree/node/load_starting" => array('\Concrete\Controller\Backend\Tree\Node::load_starting'),
-        "/ccm/system/tree/node/drag_request" => array('\Concrete\Controller\Backend\Tree\Node\DragRequest::execute'),
-        "/ccm/system/tree/node/duplicate" => array('\Concrete\Controller\Backend\Tree\Node\Duplicate::execute'),
+        '/ccm/system/tree/load' => ['\Concrete\Controller\Backend\Tree::load'],
+        '/ccm/system/tree/node/load' => ['\Concrete\Controller\Backend\Tree\Node::load'],
+        '/ccm/system/tree/node/load_starting' => ['\Concrete\Controller\Backend\Tree\Node::load_starting'],
+        '/ccm/system/tree/node/drag_request' => ['\Concrete\Controller\Backend\Tree\Node\DragRequest::execute'],
+        '/ccm/system/tree/node/duplicate' => ['\Concrete\Controller\Backend\Tree\Node\Duplicate::execute'],
 
-        "/ccm/system/dialogs/tree/node/add/category" => array('\Concrete\Controller\Dialog\Tree\Node\Category\Add::view'),
-        "/ccm/system/dialogs/tree/node/add/category/add_category_node" => array('\Concrete\Controller\Dialog\Tree\Node\Category\Add::add_category_node'),
+        '/ccm/system/dialogs/tree/node/add/category' => ['\Concrete\Controller\Dialog\Tree\Node\Category\Add::view'],
+        '/ccm/system/dialogs/tree/node/add/category/add_category_node' => ['\Concrete\Controller\Dialog\Tree\Node\Category\Add::add_category_node'],
 
-        "/ccm/system/dialogs/tree/node/add/topic" => array('\Concrete\Controller\Dialog\Tree\Node\Topic\Add::view'),
-        "/ccm/system/dialogs/tree/node/add/topic/add_topic_node" => array('\Concrete\Controller\Dialog\Tree\Node\Topic\Add::add_topic_node'),
+        '/ccm/system/dialogs/tree/node/add/topic' => ['\Concrete\Controller\Dialog\Tree\Node\Topic\Add::view'],
+        '/ccm/system/dialogs/tree/node/add/topic/add_topic_node' => ['\Concrete\Controller\Dialog\Tree\Node\Topic\Add::add_topic_node'],
 
-        "/ccm/system/dialogs/tree/node/edit/topic" => array('\Concrete\Controller\Dialog\Tree\Node\Topic\Edit::view'),
-        "/ccm/system/dialogs/tree/node/edit/topic/update_topic_node" => array('\Concrete\Controller\Dialog\Tree\Node\Topic\Edit::update_topic_node'),
+        '/ccm/system/dialogs/tree/node/edit/topic' => ['\Concrete\Controller\Dialog\Tree\Node\Topic\Edit::view'],
+        '/ccm/system/dialogs/tree/node/edit/topic/update_topic_node' => ['\Concrete\Controller\Dialog\Tree\Node\Topic\Edit::update_topic_node'],
 
-        "/ccm/system/dialogs/tree/node/edit/category" => array('\Concrete\Controller\Dialog\Tree\Node\Category\Edit::view'),
-        "/ccm/system/dialogs/tree/node/edit/category/update_category_node" => array('\Concrete\Controller\Dialog\Tree\Node\Category\Edit::update_category_node'),
+        '/ccm/system/dialogs/tree/node/edit/category' => ['\Concrete\Controller\Dialog\Tree\Node\Category\Edit::view'],
+        '/ccm/system/dialogs/tree/node/edit/category/update_category_node' => ['\Concrete\Controller\Dialog\Tree\Node\Category\Edit::update_category_node'],
 
-        "/ccm/system/dialogs/tree/node/delete" => array('\Concrete\Controller\Dialog\Tree\Node\Delete::view'),
-        "/ccm/system/dialogs/tree/node/delete/remove_tree_node" => array('\Concrete\Controller\Dialog\Tree\Node\Delete::remove_tree_node'),
-        "/ccm/system/dialogs/tree/node/permissions" => array('\Concrete\Controller\Dialog\Tree\Node\Permissions::view'),
+        '/ccm/system/dialogs/tree/node/delete' => ['\Concrete\Controller\Dialog\Tree\Node\Delete::view'],
+        '/ccm/system/dialogs/tree/node/delete/remove_tree_node' => ['\Concrete\Controller\Dialog\Tree\Node\Delete::remove_tree_node'],
+        '/ccm/system/dialogs/tree/node/permissions' => ['\Concrete\Controller\Dialog\Tree\Node\Permissions::view'],
 
         /*
          * Marketplace
          */
-        "/ccm/system/dialogs/marketplace/checkout" => array('\Concrete\Controller\Dialog\Marketplace\Checkout::view'),
-        "/ccm/system/dialogs/marketplace/download" => array('\Concrete\Controller\Dialog\Marketplace\Download::view'),
-        "/ccm/system/marketplace/connect" => array('\Concrete\Controller\Backend\Marketplace\Connect::view'),
-        "/ccm/system/marketplace/search" => array('\Concrete\Controller\Backend\Marketplace\Search::view'),
+        '/ccm/system/dialogs/marketplace/checkout' => ['\Concrete\Controller\Dialog\Marketplace\Checkout::view'],
+        '/ccm/system/dialogs/marketplace/download' => ['\Concrete\Controller\Dialog\Marketplace\Download::view'],
+        '/ccm/system/marketplace/connect' => ['\Concrete\Controller\Backend\Marketplace\Connect::view'],
+        '/ccm/system/marketplace/search' => ['\Concrete\Controller\Backend\Marketplace\Search::view'],
 
         /*
          * Express
          */
-        "/ccm/system/dialogs/express/entry/search/{entityID}" => array('\Concrete\Controller\Dialog\Express\Search::entries'),
-        "/ccm/system/search/express/entries/submit/{entityID}" => array('\Concrete\Controller\Search\Express\Entries::submit'),
-        "/ccm/system/express/entry/get_json" => array('\Concrete\Controller\Backend\Express\Entry::getJSON'),
+        '/ccm/system/dialogs/express/entry/search/{entityID}' => ['\Concrete\Controller\Dialog\Express\Search::entries'],
+        '/ccm/system/search/express/entries/submit/{entityID}' => ['\Concrete\Controller\Search\Express\Entries::submit'],
+        '/ccm/system/express/entry/get_json' => ['\Concrete\Controller\Backend\Express\Entry::getJSON'],
 
         /*
          * Search Routes
          */
-        "/ccm/system/search/files/basic" => array('\Concrete\Controller\Search\Files::searchBasic'),
-        "/ccm/system/search/files/current" => array('\Concrete\Controller\Search\Files::searchCurrent'),
-        "/ccm/system/search/files/preset/{presetID}" => array('\Concrete\Controller\Search\Files::searchPreset'),
-        "/ccm/system/search/files/clear" => array('\Concrete\Controller\Search\Files::clearSearch'),
-        "/ccm/system/search/pages/basic" => array('\Concrete\Controller\Search\Pages::searchBasic'),
-        "/ccm/system/search/pages/current" => array('\Concrete\Controller\Search\Pages::searchCurrent'),
-        "/ccm/system/search/pages/preset/{presetID}" => array('\Concrete\Controller\Search\Pages::searchPreset'),
-        "/ccm/system/search/pages/clear" => array('\Concrete\Controller\Search\Pages::clearSearch'),
+        '/ccm/system/search/files/basic' => ['\Concrete\Controller\Search\Files::searchBasic'],
+        '/ccm/system/search/files/current' => ['\Concrete\Controller\Search\Files::searchCurrent'],
+        '/ccm/system/search/files/preset/{presetID}' => ['\Concrete\Controller\Search\Files::searchPreset'],
+        '/ccm/system/search/files/clear' => ['\Concrete\Controller\Search\Files::clearSearch'],
+        '/ccm/system/search/pages/basic' => ['\Concrete\Controller\Search\Pages::searchBasic'],
+        '/ccm/system/search/pages/current' => ['\Concrete\Controller\Search\Pages::searchCurrent'],
+        '/ccm/system/search/pages/preset/{presetID}' => ['\Concrete\Controller\Search\Pages::searchPreset'],
+        '/ccm/system/search/pages/clear' => ['\Concrete\Controller\Search\Pages::clearSearch'],
 
+        '/ccm/system/search/users/basic' => ['\Concrete\Controller\Search\Users::searchBasic'],
+        '/ccm/system/search/users/current' => ['\Concrete\Controller\Search\Users::searchCurrent'],
+        '/ccm/system/search/users/preset/{presetID}' => ['\Concrete\Controller\Search\Users::searchPreset'],
+        '/ccm/system/search/users/clear' => ['\Concrete\Controller\Search\Users::clearSearch'],
 
-        "/ccm/system/search/users/basic" => array('\Concrete\Controller\Search\Users::searchBasic'),
-        "/ccm/system/search/users/current" => array('\Concrete\Controller\Search\Users::searchCurrent'),
-        "/ccm/system/search/users/preset/{presetID}" => array('\Concrete\Controller\Search\Users::searchPreset'),
-        "/ccm/system/search/users/clear" => array('\Concrete\Controller\Search\Users::clearSearch'),
-
-
-        "/ccm/system/search/groups/submit" => array('\Concrete\Controller\Search\Groups::submit'),
+        '/ccm/system/search/groups/submit' => ['\Concrete\Controller\Search\Groups::submit'],
 
         /*
          * Panels - top level
          */
-        "/ccm/system/panels/add" => array('\Concrete\Controller\Panel\Add::view'),
-        "/ccm/system/panels/dashboard" => array('\Concrete\Controller\Panel\Dashboard::view'),
-        "/ccm/system/panels/dashboard/add_favorite" => array('\Concrete\Controller\Panel\Dashboard::addFavorite'),
-        "/ccm/system/panels/dashboard/remove_favorite" => array('\Concrete\Controller\Panel\Dashboard::removeFavorite'),
-        "/ccm/system/panels/page/relations" => array('\Concrete\Controller\Panel\PageRelations::view'),
-        "/ccm/system/panels/page" => array('\Concrete\Controller\Panel\Page::view'),
-        "/ccm/system/panels/page/attributes" => array('\Concrete\Controller\Panel\Page\Attributes::view'),
-        "/ccm/system/panels/page/check_in" => array('\Concrete\Controller\Panel\Page\CheckIn::__construct'),
-        "/ccm/system/panels/page/check_in/submit" => array('\Concrete\Controller\Panel\Page\CheckIn::submit'),
-        "/ccm/system/panels/page/design" => array('\Concrete\Controller\Panel\Page\Design::view'),
-        "/ccm/system/panels/page/design/customize/reset_page_customizations" => array('\Concrete\Controller\Panel\Page\Design\Customize::reset_page_customizations'),
-        "/ccm/system/panels/page/design/customize/apply_to_page/{pThemeID}" => array('\Concrete\Controller\Panel\Page\Design\Customize::apply_to_page'),
-        "/ccm/system/panels/page/design/customize/apply_to_site/{pThemeID}" => array('\Concrete\Controller\Panel\Page\Design\Customize::apply_to_site'),
-        "/ccm/system/panels/page/design/customize/preview/{pThemeID}" => array('\Concrete\Controller\Panel\Page\Design\Customize::preview'),
-        "/ccm/system/panels/page/design/customize/reset_site_customizations/{pThemeID}" => array('\Concrete\Controller\Panel\Page\Design\Customize::reset_site_customizations'),
-        "/ccm/system/panels/page/design/customize/{pThemeID}" => array('\Concrete\Controller\Panel\Page\Design\Customize::view'),
-        "/ccm/system/panels/page/design/preview_contents" => array('\Concrete\Controller\Panel\Page\Design::preview_contents'),
-        "/ccm/system/panels/page/design/submit" => array('\Concrete\Controller\Panel\Page\Design::submit'),
-        "/ccm/system/panels/page/preview_as_user" => array('\Concrete\Controller\Panel\Page\PreviewAsUser::view'),
-        "/ccm/system/panels/page/preview_as_user/preview" => array('\Concrete\Controller\Panel\Page\PreviewAsUser::frame_page'),
-        "/ccm/system/panels/page/preview_as_user/render" => array('\Concrete\Controller\Panel\Page\PreviewAsUser::preview_page'),
-        "/ccm/system/panels/page/versions" => array('\Concrete\Controller\Panel\Page\Versions::view'),
-        "/ccm/system/panels/page/versions/get_json" => array('\Concrete\Controller\Panel\Page\Versions::get_json'),
-        "/ccm/system/panels/page/versions/duplicate" => array('\Concrete\Controller\Panel\Page\Versions::duplicate'),
-        "/ccm/system/panels/page/versions/new_page" => array('\Concrete\Controller\Panel\Page\Versions::new_page'),
-        "/ccm/system/panels/page/versions/delete" => array('\Concrete\Controller\Panel\Page\Versions::delete'),
-        "/ccm/system/panels/page/versions/approve" => array('\Concrete\Controller\Panel\Page\Versions::approve'),
-        "/ccm/system/panels/page/devices" => array('\Concrete\Controller\Panel\Page\Devices::view'),
-        "/ccm/system/panels/page/devices/preview" => array('\Concrete\Controller\Panel\Page\Devices::preview'),
-        "/ccm/system/panels/sitemap" => array('\Concrete\Controller\Panel\Sitemap::view'),
+        '/ccm/system/panels/add' => ['\Concrete\Controller\Panel\Add::view'],
+        '/ccm/system/panels/dashboard' => ['\Concrete\Controller\Panel\Dashboard::view'],
+        '/ccm/system/panels/dashboard/add_favorite' => ['\Concrete\Controller\Panel\Dashboard::addFavorite'],
+        '/ccm/system/panels/dashboard/remove_favorite' => ['\Concrete\Controller\Panel\Dashboard::removeFavorite'],
+        '/ccm/system/panels/page/relations' => ['\Concrete\Controller\Panel\PageRelations::view'],
+        '/ccm/system/panels/page' => ['\Concrete\Controller\Panel\Page::view'],
+        '/ccm/system/panels/page/attributes' => ['\Concrete\Controller\Panel\Page\Attributes::view'],
+        '/ccm/system/panels/page/check_in' => ['\Concrete\Controller\Panel\Page\CheckIn::__construct'],
+        '/ccm/system/panels/page/check_in/submit' => ['\Concrete\Controller\Panel\Page\CheckIn::submit'],
+        '/ccm/system/panels/page/design' => ['\Concrete\Controller\Panel\Page\Design::view'],
+        '/ccm/system/panels/page/design/customize/reset_page_customizations' => ['\Concrete\Controller\Panel\Page\Design\Customize::reset_page_customizations'],
+        '/ccm/system/panels/page/design/customize/apply_to_page/{pThemeID}' => ['\Concrete\Controller\Panel\Page\Design\Customize::apply_to_page'],
+        '/ccm/system/panels/page/design/customize/apply_to_site/{pThemeID}' => ['\Concrete\Controller\Panel\Page\Design\Customize::apply_to_site'],
+        '/ccm/system/panels/page/design/customize/preview/{pThemeID}' => ['\Concrete\Controller\Panel\Page\Design\Customize::preview'],
+        '/ccm/system/panels/page/design/customize/reset_site_customizations/{pThemeID}' => ['\Concrete\Controller\Panel\Page\Design\Customize::reset_site_customizations'],
+        '/ccm/system/panels/page/design/customize/{pThemeID}' => ['\Concrete\Controller\Panel\Page\Design\Customize::view'],
+        '/ccm/system/panels/page/design/preview_contents' => ['\Concrete\Controller\Panel\Page\Design::preview_contents'],
+        '/ccm/system/panels/page/design/submit' => ['\Concrete\Controller\Panel\Page\Design::submit'],
+        '/ccm/system/panels/page/preview_as_user' => ['\Concrete\Controller\Panel\Page\PreviewAsUser::view'],
+        '/ccm/system/panels/page/preview_as_user/preview' => ['\Concrete\Controller\Panel\Page\PreviewAsUser::frame_page'],
+        '/ccm/system/panels/page/preview_as_user/render' => ['\Concrete\Controller\Panel\Page\PreviewAsUser::preview_page'],
+        '/ccm/system/panels/page/versions' => ['\Concrete\Controller\Panel\Page\Versions::view'],
+        '/ccm/system/panels/page/versions/get_json' => ['\Concrete\Controller\Panel\Page\Versions::get_json'],
+        '/ccm/system/panels/page/versions/duplicate' => ['\Concrete\Controller\Panel\Page\Versions::duplicate'],
+        '/ccm/system/panels/page/versions/new_page' => ['\Concrete\Controller\Panel\Page\Versions::new_page'],
+        '/ccm/system/panels/page/versions/delete' => ['\Concrete\Controller\Panel\Page\Versions::delete'],
+        '/ccm/system/panels/page/versions/approve' => ['\Concrete\Controller\Panel\Page\Versions::approve'],
+        '/ccm/system/panels/page/devices' => ['\Concrete\Controller\Panel\Page\Devices::view'],
+        '/ccm/system/panels/page/devices/preview' => ['\Concrete\Controller\Panel\Page\Devices::preview'],
+        '/ccm/system/panels/sitemap' => ['\Concrete\Controller\Panel\Sitemap::view'],
 
         /*
          * Panel Details
          */
-        "/ccm/system/panels/details/page/attributes" => array('\Concrete\Controller\Panel\Detail\Page\Attributes::view'),
-        "/ccm/system/panels/details/page/attributes/add_attribute" => array('\Concrete\Controller\Panel\Detail\Page\Attributes::add_attribute'),
-        "/ccm/system/panels/details/page/attributes/submit" => array('\Concrete\Controller\Panel\Detail\Page\Attributes::submit'),
-        "/ccm/system/panels/details/page/caching" => array('\Concrete\Controller\Panel\Detail\Page\Caching::view'),
-        "/ccm/system/panels/details/page/caching/purge" => array('\Concrete\Controller\Panel\Detail\Page\Caching::purge'),
-        "/ccm/system/panels/details/page/caching/submit" => array('\Concrete\Controller\Panel\Detail\Page\Caching::submit'),
-        "/ccm/system/panels/details/page/composer" => array('\Concrete\Controller\Panel\Detail\Page\Composer::view'),
-        "/ccm/system/panels/details/page/composer/autosave" => array('\Concrete\Controller\Panel\Detail\Page\Composer::autosave'),
-        "/ccm/system/panels/details/page/composer/discard" => array('\Concrete\Controller\Panel\Detail\Page\Composer::discard'),
-        "/ccm/system/panels/details/page/composer/publish" => array('\Concrete\Controller\Panel\Detail\Page\Composer::publish'),
-        "/ccm/system/panels/details/page/composer/save_and_exit" => array('\Concrete\Controller\Panel\Detail\Page\Composer::saveAndExit'),
-        "/ccm/system/panels/details/page/location" => array('\Concrete\Controller\Panel\Detail\Page\Location::view'),
-        "/ccm/system/panels/details/page/location/submit" => array('\Concrete\Controller\Panel\Detail\Page\Location::submit'),
-        "/ccm/system/panels/details/page/permissions" => array('\Concrete\Controller\Panel\Detail\Page\Permissions::view'),
-        "/ccm/system/panels/details/page/permissions/save_simple" => array('\Concrete\Controller\Panel\Detail\Page\Permissions::save_simple'),
-        "/ccm/system/panels/details/page/preview" => array('\Concrete\Controller\Panel\Page\Design::preview'),
-        "/ccm/system/panels/details/page/seo" => array('\Concrete\Controller\Panel\Detail\Page\Seo::view'),
-        "/ccm/system/panels/details/page/seo/submit" => array('\Concrete\Controller\Panel\Detail\Page\Seo::submit'),
-        "/ccm/system/panels/details/page/versions" => array('\Concrete\Controller\Panel\Detail\Page\Versions::view'),
-        "/ccm/system/panels/details/page/devices" => array('\Concrete\Controller\Panel\Page\Devices::detail'),
+        '/ccm/system/panels/details/page/attributes' => ['\Concrete\Controller\Panel\Detail\Page\Attributes::view'],
+        '/ccm/system/panels/details/page/attributes/add_attribute' => ['\Concrete\Controller\Panel\Detail\Page\Attributes::add_attribute'],
+        '/ccm/system/panels/details/page/attributes/submit' => ['\Concrete\Controller\Panel\Detail\Page\Attributes::submit'],
+        '/ccm/system/panels/details/page/caching' => ['\Concrete\Controller\Panel\Detail\Page\Caching::view'],
+        '/ccm/system/panels/details/page/caching/purge' => ['\Concrete\Controller\Panel\Detail\Page\Caching::purge'],
+        '/ccm/system/panels/details/page/caching/submit' => ['\Concrete\Controller\Panel\Detail\Page\Caching::submit'],
+        '/ccm/system/panels/details/page/composer' => ['\Concrete\Controller\Panel\Detail\Page\Composer::view'],
+        '/ccm/system/panels/details/page/composer/autosave' => ['\Concrete\Controller\Panel\Detail\Page\Composer::autosave'],
+        '/ccm/system/panels/details/page/composer/discard' => ['\Concrete\Controller\Panel\Detail\Page\Composer::discard'],
+        '/ccm/system/panels/details/page/composer/publish' => ['\Concrete\Controller\Panel\Detail\Page\Composer::publish'],
+        '/ccm/system/panels/details/page/composer/save_and_exit' => ['\Concrete\Controller\Panel\Detail\Page\Composer::saveAndExit'],
+        '/ccm/system/panels/details/page/location' => ['\Concrete\Controller\Panel\Detail\Page\Location::view'],
+        '/ccm/system/panels/details/page/location/submit' => ['\Concrete\Controller\Panel\Detail\Page\Location::submit'],
+        '/ccm/system/panels/details/page/permissions' => ['\Concrete\Controller\Panel\Detail\Page\Permissions::view'],
+        '/ccm/system/panels/details/page/permissions/save_simple' => ['\Concrete\Controller\Panel\Detail\Page\Permissions::save_simple'],
+        '/ccm/system/panels/details/page/preview' => ['\Concrete\Controller\Panel\Page\Design::preview'],
+        '/ccm/system/panels/details/page/seo' => ['\Concrete\Controller\Panel\Detail\Page\Seo::view'],
+        '/ccm/system/panels/details/page/seo/submit' => ['\Concrete\Controller\Panel\Detail\Page\Seo::submit'],
+        '/ccm/system/panels/details/page/versions' => ['\Concrete\Controller\Panel\Detail\Page\Versions::view'],
+        '/ccm/system/panels/details/page/devices' => ['\Concrete\Controller\Panel\Page\Devices::detail'],
 
         /*
          * RSS Feeds
          */
-        "/rss/{identifier}" => array(
+        '/rss/{identifier}' => [
             '\Concrete\Controller\Feed::output',
             'rss',
-            array('identifier' => '[A-Za-z0-9_/.]+'),
-        ),
+            ['identifier' => '[A-Za-z0-9_/.]+'],
+        ],
 
         /*
          * Special Dashboard
          */
-        "/dashboard/blocks/stacks/list" => array('\Concrete\Controller\SinglePage\Dashboard\Blocks\Stacks::list_page'),
+        '/dashboard/blocks/stacks/list' => ['\Concrete\Controller\SinglePage\Dashboard\Blocks\Stacks::list_page'],
 
         /*
          * Assets localization
          */
-        '/ccm/assets/localization/core/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getCoreJavascript'),
-        '/ccm/assets/localization/select2/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getSelect2Javascript'),
-        '/ccm/assets/localization/redactor/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getRedactorJavascript'),
-        '/ccm/assets/localization/fancytree/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getFancytreeJavascript'),
-        '/ccm/assets/localization/imageeditor/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getImageEditorJavascript'),
-        '/ccm/assets/localization/jquery/ui/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getJQueryUIJavascript'),
-        '/ccm/assets/localization/translator/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getTranslatorJavascript'),
-        '/ccm/assets/localization/dropzone/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getDropzoneJavascript'),
-        '/ccm/assets/localization/conversations/js' => array('\Concrete\Controller\Frontend\AssetsLocalization::getConversationsJavascript'),
-    ),
+        '/ccm/assets/localization/core/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getCoreJavascript'],
+        '/ccm/assets/localization/select2/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getSelect2Javascript'],
+        '/ccm/assets/localization/redactor/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getRedactorJavascript'],
+        '/ccm/assets/localization/fancytree/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getFancytreeJavascript'],
+        '/ccm/assets/localization/imageeditor/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getImageEditorJavascript'],
+        '/ccm/assets/localization/jquery/ui/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getJQueryUIJavascript'],
+        '/ccm/assets/localization/translator/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getTranslatorJavascript'],
+        '/ccm/assets/localization/dropzone/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getDropzoneJavascript'],
+        '/ccm/assets/localization/conversations/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getConversationsJavascript'],
+    ],
 
     /*
      * Route themes
      */
-    'theme_paths' => array(
+    'theme_paths' => [
         '/dashboard' => 'dashboard',
         '/dashboard/*' => 'dashboard',
         '/account' => VIEW_CORE_THEME,
         '/account/*' => VIEW_CORE_THEME,
         '/install' => VIEW_CORE_THEME,
-        '/login' => array(
+        '/login' => [
             VIEW_CORE_THEME,
             VIEW_CORE_THEME_TEMPLATE_BACKGROUND_IMAGE,
-        ),
-        '/register'         => VIEW_CORE_THEME,
+        ],
+        '/register' => VIEW_CORE_THEME,
         '/frontend/maintenance_mode' => VIEW_CORE_THEME,
-        '/upgrade'          => VIEW_CORE_THEME
-    ),
+        '/upgrade' => VIEW_CORE_THEME,
+    ],
 
     /*
      * File Types
      */
-    'file_types' => array(
-        'JPEG' => array('jpg,jpeg,jpe', FileType::T_IMAGE, 'image', 'image', 'image'),
-        'GIF' => array('gif', FileType::T_IMAGE, 'image', 'image', 'image'),
-        'PNG' => array('png', FileType::T_IMAGE, 'image', 'image', 'image'),
-        'Windows Bitmap' => array('bmp', FileType::T_IMAGE, 'image'),
-        'TIFF' => array('tif,tiff', FileType::T_IMAGE, 'image'),
-        'HTML' => array('htm,html', FileType::T_IMAGE),
-        'Flash' => array('swf', FileType::T_IMAGE, 'image'),
-        'Icon' => array('ico', FileType::T_IMAGE),
-        'SVG' => array('svg', FileType::T_IMAGE),
-        'Windows Video' => array('asf,wmv', FileType::T_VIDEO, false, 'video'),
-        'Quicktime' => array('mov,qt', FileType::T_VIDEO, false, 'video'),
-        'AVI' => array('avi', FileType::T_VIDEO, false, 'video'),
-        '3GP' => array('3gp', FileType::T_VIDEO, false, 'video'),
-        'Plain Text' => array('txt', FileType::T_TEXT, false, 'text'),
-        'CSV' => array('csv', FileType::T_TEXT, false, 'text'),
-        'XML' => array('xml', FileType::T_TEXT),
-        'PHP' => array('php', FileType::T_TEXT),
-        'MS Word' => array('doc,docx', FileType::T_DOCUMENT),
-        'Stylesheet' => array('css', FileType::T_TEXT),
-        'MP4' => array('mp4', FileType::T_VIDEO),
-        'FLV' => array('flv', FileType::T_VIDEO, 'flv'),
-        'MP3' => array('mp3', FileType::T_AUDIO, false, 'audio'),
-        'MP4 Audio' => array('m4a', FileType::T_AUDIO, false, 'audio'),
-        'Realaudio' => array('ra,ram', FileType::T_AUDIO),
-        'Windows Audio' => array('wma', FileType::T_AUDIO),
-        'Rich Text' => array('rtf', FileType::T_DOCUMENT),
-        'JavaScript' => array('js', FileType::T_TEXT),
-        'PDF' => array('pdf', FileType::T_DOCUMENT),
-        'Photoshop' => array('psd', FileType::T_IMAGE),
-        'MPEG' => array('mpeg,mpg', FileType::T_VIDEO),
-        'MS Excel' => array('xla,xls,xlsx,xlt,xlw', FileType::T_DOCUMENT),
-        'MS Powerpoint' => array('pps,ppt,pptx,pot', FileType::T_DOCUMENT),
-        'TAR Archive' => array('tar', FileType::T_APPLICATION),
-        'Zip Archive' => array('zip', FileType::T_APPLICATION),
-        'GZip Archive' => array('gz,gzip', FileType::T_APPLICATION),
-        'OGG' => array('ogg', FileType::T_AUDIO),
-        'OGG Video' => array('ogv', FileType::T_VIDEO),
-        'WebM' => array('webm', FileType::T_VIDEO),
-    ),
+    'file_types' => [
+        'JPEG' => ['jpg,jpeg,jpe', FileType::T_IMAGE, 'image', 'image', 'image'],
+        'GIF' => ['gif', FileType::T_IMAGE, 'image', 'image', 'image'],
+        'PNG' => ['png', FileType::T_IMAGE, 'image', 'image', 'image'],
+        'Windows Bitmap' => ['bmp', FileType::T_IMAGE, 'image'],
+        'TIFF' => ['tif,tiff', FileType::T_IMAGE, 'image'],
+        'HTML' => ['htm,html', FileType::T_IMAGE],
+        'Flash' => ['swf', FileType::T_IMAGE, 'image'],
+        'Icon' => ['ico', FileType::T_IMAGE],
+        'SVG' => ['svg', FileType::T_IMAGE],
+        'Windows Video' => ['asf,wmv', FileType::T_VIDEO, false, 'video'],
+        'Quicktime' => ['mov,qt', FileType::T_VIDEO, false, 'video'],
+        'AVI' => ['avi', FileType::T_VIDEO, false, 'video'],
+        '3GP' => ['3gp', FileType::T_VIDEO, false, 'video'],
+        'Plain Text' => ['txt', FileType::T_TEXT, false, 'text'],
+        'CSV' => ['csv', FileType::T_TEXT, false, 'text'],
+        'XML' => ['xml', FileType::T_TEXT],
+        'PHP' => ['php', FileType::T_TEXT],
+        'MS Word' => ['doc,docx', FileType::T_DOCUMENT],
+        'Stylesheet' => ['css', FileType::T_TEXT],
+        'MP4' => ['mp4', FileType::T_VIDEO],
+        'FLV' => ['flv', FileType::T_VIDEO, 'flv'],
+        'MP3' => ['mp3', FileType::T_AUDIO, false, 'audio'],
+        'MP4 Audio' => ['m4a', FileType::T_AUDIO, false, 'audio'],
+        'Realaudio' => ['ra,ram', FileType::T_AUDIO],
+        'Windows Audio' => ['wma', FileType::T_AUDIO],
+        'Rich Text' => ['rtf', FileType::T_DOCUMENT],
+        'JavaScript' => ['js', FileType::T_TEXT],
+        'PDF' => ['pdf', FileType::T_DOCUMENT],
+        'Photoshop' => ['psd', FileType::T_IMAGE],
+        'MPEG' => ['mpeg,mpg', FileType::T_VIDEO],
+        'MS Excel' => ['xla,xls,xlsx,xlt,xlw', FileType::T_DOCUMENT],
+        'MS Powerpoint' => ['pps,ppt,pptx,pot', FileType::T_DOCUMENT],
+        'TAR Archive' => ['tar', FileType::T_APPLICATION],
+        'Zip Archive' => ['zip', FileType::T_APPLICATION],
+        'GZip Archive' => ['gz,gzip', FileType::T_APPLICATION],
+        'OGG' => ['ogg', FileType::T_AUDIO],
+        'OGG Video' => ['ogv', FileType::T_VIDEO],
+        'WebM' => ['webm', FileType::T_VIDEO],
+    ],
 
     /*
      * Importer Attributes
      */
-    'importer_attributes' => array(
-        'width' => array('Width', 'NUMBER', false),
-        'height' => array('Height', 'NUMBER', false),
-        'duration' => array('Duration', 'NUMBER', false),
-    ),
+    'importer_attributes' => [
+        'width' => ['Width', 'NUMBER', false],
+        'height' => ['Height', 'NUMBER', false],
+        'duration' => ['Duration', 'NUMBER', false],
+    ],
 
     /*
      * Assets
      */
-    'assets' => array(
-
-        'google-charts' => array(
-            array(
+    'assets' => [
+        'google-charts' => [
+            [
                 'javascript',
                 'https://www.gstatic.com/charts/loader.js',
-                array('local' => false),
-            ),
-        ),
+                ['local' => false],
+            ],
+        ],
 
-        'jquery' => array(
-            array(
+        'jquery' => [
+            [
                 'javascript',
                 'js/jquery.js',
-                array('position' => Asset::ASSET_POSITION_HEADER, 'minify' => false, 'combine' => false),
-            ),
-        ),
-        'jquery/ui' => array(
-            array('javascript', 'js/jquery-ui.js', array('minify' => false, 'combine' => false)),
-            array('javascript-localized', '/ccm/assets/localization/jquery/ui/js'),
-            array('css', 'css/jquery-ui.css', array('minify' => false)),
-        ),
-        'jquery/visualize' => array(
-            array('javascript', 'js/jquery-visualize.js', array('minify' => false, 'combine' => false)),
-            array('css', 'css/jquery-visualize.css', array('minify' => false)),
-        ),
-        'jquery/touch-punch' => array(
-            array('javascript', 'js/jquery-ui-touch-punch.js'),
-        ),
-        'jquery/tristate' => array(
-            array('javascript', 'js/jquery-tristate.js'),
-        ),
-        'select2' => array(
-            array('javascript', 'js/select2.js', array('minify' => false, 'combine' => false)),
-            array('javascript-localized', '/ccm/assets/localization/select2/js'),
-            array('css', 'css/select2.css', array('minify' => false)),
-        ),
-        'selectize' => array(
-            array('javascript', 'js/selectize.js', array('minify' => false, 'combine' => false)),
-            array('css', 'css/selectize.css', array('minify' => false)),
-        ),
-        'underscore' => array(
-            array('javascript', 'js/underscore.js', array('minify' => false)),
-        ),
-        'backbone' => array(
-            array('javascript', 'js/backbone.js', array('minify' => false)),
-        ),
-        'dropzone' => array(
-            array('javascript', 'js/dropzone.js'),
-            array('javascript-localized', '/ccm/assets/localization/dropzone/js'),
-            array('css', 'css/dropzone.css', array('minify' => false)),
-        ),
-        'jquery/form' => array(
-            array('javascript', 'js/jquery-form.js'),
-        ),
-        'picturefill' => array(
-            array('javascript', 'js/picturefill.js', array('minify' => false)),
-        ),
-        'responsive-slides' => array(
-            array('javascript', 'js/responsive-slides.js', array('minify' => false)),
-            array('css', 'css/responsive-slides.css', array('minify' => false)),
-        ),
-        'html5-shiv' => array(
-            array('javascript-conditional', 'js/ie/html5-shiv.js',
-                array('conditional' => 'lt IE 9'),
-            ),
-        ),
-        'respond' => array(
-            array('javascript-conditional', 'js/ie/respond.js',
-                array('conditional' => 'lt IE 9'),
-            ),
-        ),
-        'spectrum' => array(
-            array('javascript', 'js/spectrum.js', array('minify' => false)),
-            array('css', 'css/spectrum.css', array('minify' => false)),
-        ),
-        'core/composer-save-coordinator' => array(
-            array('javascript', 'js/composer-save-coordinator.js', array('minify' => false)),
-        ),
-        'font-awesome' => array(
-            array('css', 'css/font-awesome.css', array('minify' => false)),
-        ),
-        'core/events' => array(
-            array('javascript', 'js/events.js', array('minify' => false)),
-        ),
-        'core/style-customizer' => array(
-            array('javascript', 'js/style-customizer.js', array('minify' => false)),
-            array('css', 'css/style-customizer.css', array('minify' => false)),
-        ),
-        'core/localization' => array(
-            array('javascript-localized', '/ccm/assets/localization/core/js'),
-        ),
-        'core/frontend/parallax-image' => array(
-            array('javascript', 'js/frontend/parallax-image.js', array('minify' => false)),
-        ),
-        'core/imageeditor/control/position' => array(
-            array('css', 'css/image-editor/controls/position.css'),
-            array('javascript', 'js/image-editor/controls/position.js'),
-        ),
-        'core/imageeditor/control/filter' => array(
-            array('css', 'css/image-editor/controls/filter.css'),
-            array('javascript', 'js/image-editor/controls/filter.js'),
-        ),
-        'core/imageeditor/filter/gaussian_blur' => array(
-            array('css', 'css/image-editor/filters/gaussian_blur.css'),
-            array('javascript', 'js/image-editor/filters/gaussian_blur.js'),
-        ),
-        'core/imageeditor/filter/none' => array(
-            array('css', 'css/image-editor/filters/none.css'),
-            array('javascript', 'js/image-editor/filters/none.js'),
-        ),
-        'core/imageeditor/filter/sepia' => array(
-            array('css', 'css/image-editor/filters/sepia.css'),
-            array('javascript', 'js/image-editor/filters/sepia.js'),
-        ),
-        'core/imageeditor/filter/vignette' => array(
-            array('css', 'css/image-editor/filters/vignette.css'),
-            array('javascript', 'js/image-editor/filters/vignette.js'),
-        ),
-        'core/imageeditor/filter/grayscale' => array(
-            array('css', 'css/image-editor/filters/grayscale.css'),
-            array('javascript', 'js/image-editor/filters/grayscale.js'),
-        ),
-        'jquery/awesome-rating' => array(
-            array('javascript', 'js/jquery-awesome-rating.js', array('minify' => false)),
-            array('css', 'css/jquery-awesome-rating.css', array('minify' => false)),
-        ),
-        'jquery/fileupload' => array(
-            array('javascript', 'js/jquery-fileupload.js'),
-        ),
-        'jquery/textcounter' => array(
-            array('javascript', 'js/textcounter.js'),
-        ),
-        'swfobject' => array(
-            array('javascript', 'js/swfobject.js'),
-        ),
-        'redactor' => array(
-            array('javascript', 'js/redactor.js', array('minify' => false)),
-            array('javascript-localized', '/ccm/assets/localization/redactor/js'),
-            array('css', 'css/redactor.css'),
-        ),
-        'ace' => array(
-            array('javascript', 'js/ace/ace.js', array('minify' => false)),
-        ),
-        'backstretch' => array(
-            array('javascript', 'js/backstretch.js'),
-        ),
-        'background-check' => array(
-            array('javascript', 'js/background-check.js'),
-        ),
+                ['position' => Asset::ASSET_POSITION_HEADER, 'minify' => false, 'combine' => false],
+            ],
+        ],
+        'jquery/ui' => [
+            ['javascript', 'js/jquery-ui.js', ['minify' => false, 'combine' => false]],
+            ['javascript-localized', '/ccm/assets/localization/jquery/ui/js'],
+            ['css', 'css/jquery-ui.css', ['minify' => false]],
+        ],
+        'jquery/visualize' => [
+            ['javascript', 'js/jquery-visualize.js', ['minify' => false, 'combine' => false]],
+            ['css', 'css/jquery-visualize.css', ['minify' => false]],
+        ],
+        'jquery/touch-punch' => [
+            ['javascript', 'js/jquery-ui-touch-punch.js'],
+        ],
+        'jquery/tristate' => [
+            ['javascript', 'js/jquery-tristate.js'],
+        ],
+        'select2' => [
+            ['javascript', 'js/select2.js', ['minify' => false, 'combine' => false]],
+            ['javascript-localized', '/ccm/assets/localization/select2/js'],
+            ['css', 'css/select2.css', ['minify' => false]],
+        ],
+        'selectize' => [
+            ['javascript', 'js/selectize.js', ['minify' => false, 'combine' => false]],
+            ['css', 'css/selectize.css', ['minify' => false]],
+        ],
+        'underscore' => [
+            ['javascript', 'js/underscore.js', ['minify' => false]],
+        ],
+        'backbone' => [
+            ['javascript', 'js/backbone.js', ['minify' => false]],
+        ],
+        'dropzone' => [
+            ['javascript', 'js/dropzone.js'],
+            ['javascript-localized', '/ccm/assets/localization/dropzone/js'],
+            ['css', 'css/dropzone.css', ['minify' => false]],
+        ],
+        'jquery/form' => [
+            ['javascript', 'js/jquery-form.js'],
+        ],
+        'picturefill' => [
+            ['javascript', 'js/picturefill.js', ['minify' => false]],
+        ],
+        'responsive-slides' => [
+            ['javascript', 'js/responsive-slides.js', ['minify' => false]],
+            ['css', 'css/responsive-slides.css', ['minify' => false]],
+        ],
+        'html5-shiv' => [
+            ['javascript-conditional', 'js/ie/html5-shiv.js',
+                ['conditional' => 'lt IE 9'],
+            ],
+        ],
+        'respond' => [
+            ['javascript-conditional', 'js/ie/respond.js',
+                ['conditional' => 'lt IE 9'],
+            ],
+        ],
+        'spectrum' => [
+            ['javascript', 'js/spectrum.js', ['minify' => false]],
+            ['css', 'css/spectrum.css', ['minify' => false]],
+        ],
+        'core/composer-save-coordinator' => [
+            ['javascript', 'js/composer-save-coordinator.js', ['minify' => false]],
+        ],
+        'font-awesome' => [
+            ['css', 'css/font-awesome.css', ['minify' => false]],
+        ],
+        'core/events' => [
+            ['javascript', 'js/events.js', ['minify' => false]],
+        ],
+        'core/style-customizer' => [
+            ['javascript', 'js/style-customizer.js', ['minify' => false]],
+            ['css', 'css/style-customizer.css', ['minify' => false]],
+        ],
+        'core/localization' => [
+            ['javascript-localized', '/ccm/assets/localization/core/js'],
+        ],
+        'core/frontend/parallax-image' => [
+            ['javascript', 'js/frontend/parallax-image.js', ['minify' => false]],
+        ],
+        'core/imageeditor/control/position' => [
+            ['css', 'css/image-editor/controls/position.css'],
+            ['javascript', 'js/image-editor/controls/position.js'],
+        ],
+        'core/imageeditor/control/filter' => [
+            ['css', 'css/image-editor/controls/filter.css'],
+            ['javascript', 'js/image-editor/controls/filter.js'],
+        ],
+        'core/imageeditor/filter/gaussian_blur' => [
+            ['css', 'css/image-editor/filters/gaussian_blur.css'],
+            ['javascript', 'js/image-editor/filters/gaussian_blur.js'],
+        ],
+        'core/imageeditor/filter/none' => [
+            ['css', 'css/image-editor/filters/none.css'],
+            ['javascript', 'js/image-editor/filters/none.js'],
+        ],
+        'core/imageeditor/filter/sepia' => [
+            ['css', 'css/image-editor/filters/sepia.css'],
+            ['javascript', 'js/image-editor/filters/sepia.js'],
+        ],
+        'core/imageeditor/filter/vignette' => [
+            ['css', 'css/image-editor/filters/vignette.css'],
+            ['javascript', 'js/image-editor/filters/vignette.js'],
+        ],
+        'core/imageeditor/filter/grayscale' => [
+            ['css', 'css/image-editor/filters/grayscale.css'],
+            ['javascript', 'js/image-editor/filters/grayscale.js'],
+        ],
+        'jquery/awesome-rating' => [
+            ['javascript', 'js/jquery-awesome-rating.js', ['minify' => false]],
+            ['css', 'css/jquery-awesome-rating.css', ['minify' => false]],
+        ],
+        'jquery/fileupload' => [
+            ['javascript', 'js/jquery-fileupload.js'],
+        ],
+        'jquery/textcounter' => [
+            ['javascript', 'js/textcounter.js'],
+        ],
+        'swfobject' => [
+            ['javascript', 'js/swfobject.js'],
+        ],
+        'redactor' => [
+            ['javascript', 'js/redactor.js', ['minify' => false]],
+            ['javascript-localized', '/ccm/assets/localization/redactor/js'],
+            ['css', 'css/redactor.css'],
+        ],
+        'ace' => [
+            ['javascript', 'js/ace/ace.js', ['minify' => false]],
+        ],
+        'backstretch' => [
+            ['javascript', 'js/backstretch.js'],
+        ],
+        'background-check' => [
+            ['javascript', 'js/background-check.js'],
+        ],
         /*
-        'dynatree' => array(
-            array('javascript', 'js/dynatree.js', array('minify' => false)),
-            array('javascript-localized', '/ccm/assets/localization/dynatree/js', array('minify' => false)),
-            array('css', 'css/dynatree.css', array('minify' => false)),
-        ),
+        'dynatree' => [
+            ['javascript', 'js/dynatree.js', ['minify' => false]],
+            ['javascript-localized', '/ccm/assets/localization/dynatree/js', ['minify' => false]],
+            ['css', 'css/dynatree.css', ['minify' => false]],
+        ],
         */
-        'fancytree' => array(
-            array('javascript', 'js/fancytree.js', array('minify' => false, 'version' => '2.18.0')),
-            array('javascript-localized', '/ccm/assets/localization/fancytree/js', array('minify' => false)),
-            array('css', 'css/fancytree.css', array('minify' => false)),
-        ),
-        'bootstrap/dropdown' => array(
-            array('javascript', 'js/bootstrap/dropdown.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/tooltip' => array(
-            array('javascript', 'js/bootstrap/tooltip.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/popover' => array(
-            array('javascript', 'js/bootstrap/popover.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/collapse' => array(
-            array('javascript', 'js/bootstrap/collapse.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/alert' => array(
-            array('javascript', 'js/bootstrap/alert.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/button' => array(
-            array('javascript', 'js/bootstrap/button.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap/transition' => array(
-            array('javascript', 'js/bootstrap/transition.js'),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap' => array(
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'core/app' => array(
-            array('javascript', 'js/app.js', array('minify' => false, 'combine' => false)),
-            array('css', 'css/app.css', array('minify' => false)),
-        ),
-        'bootstrap-editable' => array(
-            array('javascript', 'js/bootstrap-editable.js', array('minify' => false)),
-        ),
-        'core/app/editable-fields' => array(
-            array('css', 'css/editable-fields.css', array('minify' => false)),
-        ),
-        'kinetic' => array(
-            array('javascript', 'js/kinetic.js'),
-        ),
-        'core/imageeditor' => array(
-            array('javascript', 'js/image-editor.js'),
-            array('javascript-localized', '/ccm/assets/localization/imageeditor/js'),
-            array('css', 'css/image-editor.css'),
-        ),
-        'dashboard' => array(
-            array('javascript', 'js/dashboard.js'),
-        ),
-        'core/frontend/captcha' => array(
-            array('css', 'css/frontend/captcha.css'),
-        ),
-        'core/frontend/pagination' => array(
-            array('css', 'css/frontend/pagination.css'),
-        ),
-        'core/frontend/errors' => array(
-            array('css', 'css/frontend/errors.css'),
-        ),
-        'core/file-manager' => array(
-            array('javascript', 'js/file-manager.js', array('minify' => false)),
-            array('css', 'css/file-manager.css', array('minify' => false)),
-        ),
-        'core/express' => array(
-            array('javascript', 'js/express.js', array('minify' => false)),
-        ),
-        'core/sitemap' => array(
-            array('javascript', 'js/sitemap.js', array('minify' => false)),
-            array('css', 'css/sitemap.css', array('minify' => false)),
-        ),
-        'core/users' => array(
-            array('javascript', 'js/users.js', array('minify' => false)),
-        ),
-        'core/notification' => array(
-            array('javascript', 'js/notification.js', array('minify' => false)),
-        ),
-        'core/tree' => array(
-            array('javascript', 'js/tree.js', array('minify' => false)),
-        ),
-        'core/groups' => array(
-            array('javascript', 'js/groups.js', array('minify' => false)),
-        ),
-        'core/gathering' => array(
-            array('javascript', 'js/gathering.js'),
-        ),
-        'core/gathering/display' => array(
-            array('css', 'css/gathering/display.css'),
-        ),
-        'core/gathering/base' => array(
-            array('css', 'css/gathering/base.css'),
-        ),
-        'core/conversation' => array(
-            array('javascript', 'js/conversations.js'),
-            array('javascript-localized', '/ccm/assets/localization/conversations/js'),
-            array('css', 'css/conversations.css'),
-        ),
-        'core/lightbox' => array(
-            array('javascript', 'js/jquery-magnific-popup.js'),
-            array('css', 'css/jquery-magnific-popup.css'),
-        ),
-        'core/lightbox/launcher' => array(
-            array('javascript', 'js/lightbox.js'),
-        ),
-        'core/account' => array(
-            array('javascript', 'js/account.js'),
-            array('css', 'css/account.css'),
-        ),
-        'core/translator' => array(
-            array('javascript', 'js/translator.js', array('minify' => false)),
-            array('javascript-localized', '/ccm/assets/localization/translator/js'),
-            array('css', 'css/translator.css', array('minify' => false)),
-        ),
-    ),
-    'asset_groups' => array(
-
-        'jquery/ui' => array(
-            array(
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('css', 'jquery/ui'),
-            ),
-        ),
-        'jquery/visualize' => array(
-            array(
-                array('javascript', 'jquery/visualize'),
-                array('css', 'jquery/visualize'),
-            ),
-        ),
-        /**
+        'fancytree' => [
+            ['javascript', 'js/fancytree.js', ['minify' => false, 'version' => '2.18.0']],
+            ['javascript-localized', '/ccm/assets/localization/fancytree/js', ['minify' => false]],
+            ['css', 'css/fancytree.css', ['minify' => false]],
+        ],
+        'bootstrap/dropdown' => [
+            ['javascript', 'js/bootstrap/dropdown.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/tooltip' => [
+            ['javascript', 'js/bootstrap/tooltip.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/popover' => [
+            ['javascript', 'js/bootstrap/popover.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/collapse' => [
+            ['javascript', 'js/bootstrap/collapse.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/alert' => [
+            ['javascript', 'js/bootstrap/alert.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/button' => [
+            ['javascript', 'js/bootstrap/button.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap/transition' => [
+            ['javascript', 'js/bootstrap/transition.js'],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap' => [
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'core/app' => [
+            ['javascript', 'js/app.js', ['minify' => false, 'combine' => false]],
+            ['css', 'css/app.css', ['minify' => false]],
+        ],
+        'bootstrap-editable' => [
+            ['javascript', 'js/bootstrap-editable.js', ['minify' => false]],
+        ],
+        'core/app/editable-fields' => [
+            ['css', 'css/editable-fields.css', ['minify' => false]],
+        ],
+        'kinetic' => [
+            ['javascript', 'js/kinetic.js'],
+        ],
+        'core/imageeditor' => [
+            ['javascript', 'js/image-editor.js'],
+            ['javascript-localized', '/ccm/assets/localization/imageeditor/js'],
+            ['css', 'css/image-editor.css'],
+        ],
+        'dashboard' => [
+            ['javascript', 'js/dashboard.js'],
+        ],
+        'core/frontend/captcha' => [
+            ['css', 'css/frontend/captcha.css'],
+        ],
+        'core/frontend/pagination' => [
+            ['css', 'css/frontend/pagination.css'],
+        ],
+        'core/frontend/errors' => [
+            ['css', 'css/frontend/errors.css'],
+        ],
+        'core/file-manager' => [
+            ['javascript', 'js/file-manager.js', ['minify' => false]],
+            ['css', 'css/file-manager.css', ['minify' => false]],
+        ],
+        'core/express' => [
+            ['javascript', 'js/express.js', ['minify' => false]],
+        ],
+        'core/sitemap' => [
+            ['javascript', 'js/sitemap.js', ['minify' => false]],
+            ['css', 'css/sitemap.css', ['minify' => false]],
+        ],
+        'core/users' => [
+            ['javascript', 'js/users.js', ['minify' => false]],
+        ],
+        'core/notification' => [
+            ['javascript', 'js/notification.js', ['minify' => false]],
+        ],
+        'core/tree' => [
+            ['javascript', 'js/tree.js', ['minify' => false]],
+        ],
+        'core/groups' => [
+            ['javascript', 'js/groups.js', ['minify' => false]],
+        ],
+        'core/gathering' => [
+            ['javascript', 'js/gathering.js'],
+        ],
+        'core/gathering/display' => [
+            ['css', 'css/gathering/display.css'],
+        ],
+        'core/gathering/base' => [
+            ['css', 'css/gathering/base.css'],
+        ],
+        'core/conversation' => [
+            ['javascript', 'js/conversations.js'],
+            ['javascript-localized', '/ccm/assets/localization/conversations/js'],
+            ['css', 'css/conversations.css'],
+        ],
+        'core/lightbox' => [
+            ['javascript', 'js/jquery-magnific-popup.js'],
+            ['css', 'css/jquery-magnific-popup.css'],
+        ],
+        'core/lightbox/launcher' => [
+            ['javascript', 'js/lightbox.js'],
+        ],
+        'core/account' => [
+            ['javascript', 'js/account.js'],
+            ['css', 'css/account.css'],
+        ],
+        'core/translator' => [
+            ['javascript', 'js/translator.js', ['minify' => false]],
+            ['javascript-localized', '/ccm/assets/localization/translator/js'],
+            ['css', 'css/translator.css', ['minify' => false]],
+        ],
+    ],
+    'asset_groups' => [
+        'jquery/ui' => [
+            [
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['css', 'jquery/ui'],
+            ],
+        ],
+        'jquery/visualize' => [
+            [
+                ['javascript', 'jquery/visualize'],
+                ['css', 'jquery/visualize'],
+            ],
+        ],
+        /*
          * @deprecated
          */
-        'select2' => array(
-            array(
-                array('javascript', 'select2'),
-                array('javascript-localized', 'select2'),
-                array('css', 'select2'),
-            ),
-        ),
-        'selectize' => array(
-            array(
-                array('javascript', 'selectize'),
-                array('css', 'selectize'),
-            ),
-        ),
-        'dropzone' => array(
-            array(
-                array('javascript', 'dropzone'),
-                array('javascript-localized', 'dropzone'),
-                array('css', 'dropzone'),
-            ),
-        ),
-        'responsive-slides' => array(
-            array(
-                array('javascript', 'responsive-slides'),
-                array('css', 'responsive-slides'),
-            ),
-        ),
-        'ace' => array(
-            array(
-                array('javascript', 'ace'),
-            ),
-        ),
-        'core/notification' => array(
-            array(
-                array('javascript', 'core/notification'),
-            ),
-        ),
-        'core/colorpicker' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'core/events'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'spectrum'),
-                array('css', 'spectrum'),
-            ),
-        ),
-        'font-awesome' => array(
-            array(
-                array('css', 'font-awesome'),
-            ),
-        ),
-        'core/rating' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'jquery/awesome-rating'),
-                array('css', 'font-awesome'),
-                array('css', 'jquery/awesome-rating'),
-            ),
-        ),
-        'core/style-customizer' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript', 'core/colorpicker'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('javascript', 'jquery/fileupload'),
-                array('javascript', 'core/file-manager'),
-                array('javascript', 'core/style-customizer'),
-                array('css', 'core/app'),
-                array('css', 'core/file-manager'),
-                array('css', 'jquery/ui'),
-                array('css', 'core/colorpicker'),
-                array('css', 'core/style-customizer'),
-            ),
-        ),
-        'jquery/fileupload' => array(
-            array(
-                array('javascript', 'jquery/fileupload'),
-            ),
-        ),
-        'swfobject' => array(
-            array(
-                array('javascript', 'swfobject'),
-            ),
-        ),
-        'redactor' => array(
-            array(
-                array('javascript', 'redactor'),
-                array('javascript-localized', 'redactor'),
-                array('css', 'redactor'),
-                array('css', 'font-awesome'),
-            ),
-        ),
-        'fancytree' => array(
-            array(
-                array('javascript', 'fancytree'),
-                array('javascript-localized', 'fancytree'),
-                array('css', 'fancytree'),
-            ),
-        ),
-        'core/app' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript', 'bootstrap/dropdown'),
-                array('javascript', 'bootstrap/tooltip'),
-                array('javascript', 'bootstrap/popover'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('css', 'core/app'),
-                array('css', 'font-awesome'),
-                array('css', 'jquery/ui'),
-            ),
-        ),
-        'core/app/editable-fields' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'bootstrap/dropdown'),
-                array('javascript', 'bootstrap/tooltip'),
-                array('javascript', 'bootstrap/popover'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('javascript', 'bootstrap-editable'),
-                array('css', 'core/app/editable-fields'),
-                array('javascript', 'jquery/fileupload'),
-            ),
-        ),
-        'core/imageeditor' => array(
-            array(
-                array('javascript', 'kinetic'),
-                array('javascript-localized', 'core/imageeditor'),
-                array('javascript', 'core/imageeditor'),
-                array('css', 'core/imageeditor'),
-            ),
-        ),
-        'dashboard' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'jquery/touch-punch'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript', 'dashboard'),
-                array('javascript', 'core/events'),
-                array('javascript', 'bootstrap/dropdown'),
-                array('javascript', 'bootstrap/tooltip'),
-                array('javascript', 'bootstrap/collapse'),
-                array('javascript', 'bootstrap/popover'),
-                array('javascript', 'bootstrap/transition'),
-                array('javascript', 'bootstrap/alert'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('javascript', 'redactor'),
-                array('javascript-localized', 'redactor'),
-                array('javascript-conditional', 'respond'),
-                array('javascript-conditional', 'html5-shiv'),
-                array('css', 'core/app'),
-                array('css', 'redactor'),
-                array('css', 'jquery/ui'),
-                array('css', 'font-awesome'),
-            ),
-        ),
-        'core/file-manager' => array(
-            array(
-                array('css', 'core/app'),
-                array('css', 'jquery/ui'),
-                array('css', 'core/file-manager'),
-                array('css', 'selectize'),
-                array('javascript', 'core/events'),
-                array('javascript', 'bootstrap/tooltip'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'selectize'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('javascript', 'jquery/fileupload'),
-                array('javascript', 'core/tree'),
-                array('javascript', 'core/file-manager'),
-            ),
-        ),
-        'core/sitemap' => array(
-            array(
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'backbone'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'fancytree'),
-                array('javascript', 'selectize'),
-                array('javascript-localized', 'fancytree'),
-                array('javascript-localized', 'core/localization'),
-                array('javascript', 'core/app'),
-                array('javascript', 'core/sitemap'),
-                array('css', 'fancytree'),
-                array('css', 'selectize'),
-                array('css', 'core/sitemap'),
-            ),
-        ),
-        'core/users' => array(
-            array(
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'core/users'),
-            ),
-        ),
-        'core/express' => array(
-            array(
-                array('css', 'core/express'),
-                array('javascript', 'core/express'),
-            ),
-        ),
-        'core/topics' => array(
-            array(
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'fancytree'),
-                array('javascript-localized', 'fancytree'),
-                array('javascript', 'core/tree'),
-                array('css', 'fancytree'),
-            ),
-        ),
-        'core/tree' => array(
-            array(
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'fancytree'),
-                array('javascript-localized', 'fancytree'),
-                array('javascript', 'core/tree'),
-                array('css', 'fancytree'),
-            ),
-        ),
-        'core/groups' => array(
-            array(
-                array('javascript', 'core/events'),
-                array('javascript', 'underscore'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'fancytree'),
-                array('javascript-localized', 'fancytree'),
-                array('javascript', 'core/tree'),
-                array('css', 'fancytree'),
-            ),
-        ),
-        'core/gathering' => array(
-            array(
-                array('javascript', 'core/gathering'),
-                array('javascript', 'redactor'),
-                array('javascript-localized', 'redactor'),
-                array('css', 'core/gathering/base'),
-                array('css', 'core/conversation'),
-                array('css', 'core/gathering/display'),
-                array('css', 'redactor'),
-            ),
-        ),
-        'core/conversation' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'jquery/ui'),
-                array('javascript-localized', 'jquery/ui'),
-                array('javascript', 'underscore'),
-                array('javascript', 'core/lightbox'),
-                array('javascript', 'dropzone'),
-                array('javascript-localized', 'dropzone'),
-                array('javascript', 'bootstrap/dropdown'),
-                array('javascript', 'core/events'),
-                array('javascript', 'core/conversation'),
-                array('javascript-localized', 'core/conversation'),
-                array('css', 'core/conversation'),
-                array('css', 'core/frontend/errors'),
-                array('css', 'font-awesome'),
-                array('css', 'bootstrap/dropdown'),
-                array('css', 'core/lightbox'),
-                array('css', 'jquery/ui'),
-            ),
+        'select2' => [
+            [
+                ['javascript', 'select2'],
+                ['javascript-localized', 'select2'],
+                ['css', 'select2'],
+            ],
+        ],
+        'selectize' => [
+            [
+                ['javascript', 'selectize'],
+                ['css', 'selectize'],
+            ],
+        ],
+        'dropzone' => [
+            [
+                ['javascript', 'dropzone'],
+                ['javascript-localized', 'dropzone'],
+                ['css', 'dropzone'],
+            ],
+        ],
+        'responsive-slides' => [
+            [
+                ['javascript', 'responsive-slides'],
+                ['css', 'responsive-slides'],
+            ],
+        ],
+        'ace' => [
+            [
+                ['javascript', 'ace'],
+            ],
+        ],
+        'core/notification' => [
+            [
+                ['javascript', 'core/notification'],
+            ],
+        ],
+        'core/colorpicker' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'core/events'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'spectrum'],
+                ['css', 'spectrum'],
+            ],
+        ],
+        'font-awesome' => [
+            [
+                ['css', 'font-awesome'],
+            ],
+        ],
+        'core/rating' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'jquery/awesome-rating'],
+                ['css', 'font-awesome'],
+                ['css', 'jquery/awesome-rating'],
+            ],
+        ],
+        'core/style-customizer' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript', 'core/colorpicker'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['javascript', 'jquery/fileupload'],
+                ['javascript', 'core/file-manager'],
+                ['javascript', 'core/style-customizer'],
+                ['css', 'core/app'],
+                ['css', 'core/file-manager'],
+                ['css', 'jquery/ui'],
+                ['css', 'core/colorpicker'],
+                ['css', 'core/style-customizer'],
+            ],
+        ],
+        'jquery/fileupload' => [
+            [
+                ['javascript', 'jquery/fileupload'],
+            ],
+        ],
+        'swfobject' => [
+            [
+                ['javascript', 'swfobject'],
+            ],
+        ],
+        'redactor' => [
+            [
+                ['javascript', 'redactor'],
+                ['javascript-localized', 'redactor'],
+                ['css', 'redactor'],
+                ['css', 'font-awesome'],
+            ],
+        ],
+        'fancytree' => [
+            [
+                ['javascript', 'fancytree'],
+                ['javascript-localized', 'fancytree'],
+                ['css', 'fancytree'],
+            ],
+        ],
+        'core/app' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript', 'bootstrap/dropdown'],
+                ['javascript', 'bootstrap/tooltip'],
+                ['javascript', 'bootstrap/popover'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['css', 'core/app'],
+                ['css', 'font-awesome'],
+                ['css', 'jquery/ui'],
+            ],
+        ],
+        'core/app/editable-fields' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'bootstrap/dropdown'],
+                ['javascript', 'bootstrap/tooltip'],
+                ['javascript', 'bootstrap/popover'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['javascript', 'bootstrap-editable'],
+                ['css', 'core/app/editable-fields'],
+                ['javascript', 'jquery/fileupload'],
+            ],
+        ],
+        'core/imageeditor' => [
+            [
+                ['javascript', 'kinetic'],
+                ['javascript-localized', 'core/imageeditor'],
+                ['javascript', 'core/imageeditor'],
+                ['css', 'core/imageeditor'],
+            ],
+        ],
+        'dashboard' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'jquery/touch-punch'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript', 'dashboard'],
+                ['javascript', 'core/events'],
+                ['javascript', 'bootstrap/dropdown'],
+                ['javascript', 'bootstrap/tooltip'],
+                ['javascript', 'bootstrap/collapse'],
+                ['javascript', 'bootstrap/popover'],
+                ['javascript', 'bootstrap/transition'],
+                ['javascript', 'bootstrap/alert'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['javascript', 'redactor'],
+                ['javascript-localized', 'redactor'],
+                ['javascript-conditional', 'respond'],
+                ['javascript-conditional', 'html5-shiv'],
+                ['css', 'core/app'],
+                ['css', 'redactor'],
+                ['css', 'jquery/ui'],
+                ['css', 'font-awesome'],
+            ],
+        ],
+        'core/file-manager' => [
+            [
+                ['css', 'core/app'],
+                ['css', 'jquery/ui'],
+                ['css', 'core/file-manager'],
+                ['css', 'selectize'],
+                ['javascript', 'core/events'],
+                ['javascript', 'bootstrap/tooltip'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'selectize'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['javascript', 'jquery/fileupload'],
+                ['javascript', 'core/tree'],
+                ['javascript', 'core/file-manager'],
+            ],
+        ],
+        'core/sitemap' => [
+            [
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'backbone'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'fancytree'],
+                ['javascript', 'selectize'],
+                ['javascript-localized', 'fancytree'],
+                ['javascript-localized', 'core/localization'],
+                ['javascript', 'core/app'],
+                ['javascript', 'core/sitemap'],
+                ['css', 'fancytree'],
+                ['css', 'selectize'],
+                ['css', 'core/sitemap'],
+            ],
+        ],
+        'core/users' => [
+            [
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'core/users'],
+            ],
+        ],
+        'core/express' => [
+            [
+                ['css', 'core/express'],
+                ['javascript', 'core/express'],
+            ],
+        ],
+        'core/topics' => [
+            [
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'fancytree'],
+                ['javascript-localized', 'fancytree'],
+                ['javascript', 'core/tree'],
+                ['css', 'fancytree'],
+            ],
+        ],
+        'core/tree' => [
+            [
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'fancytree'],
+                ['javascript-localized', 'fancytree'],
+                ['javascript', 'core/tree'],
+                ['css', 'fancytree'],
+            ],
+        ],
+        'core/groups' => [
+            [
+                ['javascript', 'core/events'],
+                ['javascript', 'underscore'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'fancytree'],
+                ['javascript-localized', 'fancytree'],
+                ['javascript', 'core/tree'],
+                ['css', 'fancytree'],
+            ],
+        ],
+        'core/gathering' => [
+            [
+                ['javascript', 'core/gathering'],
+                ['javascript', 'redactor'],
+                ['javascript-localized', 'redactor'],
+                ['css', 'core/gathering/base'],
+                ['css', 'core/conversation'],
+                ['css', 'core/gathering/display'],
+                ['css', 'redactor'],
+            ],
+        ],
+        'core/conversation' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'jquery/ui'],
+                ['javascript-localized', 'jquery/ui'],
+                ['javascript', 'underscore'],
+                ['javascript', 'core/lightbox'],
+                ['javascript', 'dropzone'],
+                ['javascript-localized', 'dropzone'],
+                ['javascript', 'bootstrap/dropdown'],
+                ['javascript', 'core/events'],
+                ['javascript', 'core/conversation'],
+                ['javascript-localized', 'core/conversation'],
+                ['css', 'core/conversation'],
+                ['css', 'core/frontend/errors'],
+                ['css', 'font-awesome'],
+                ['css', 'bootstrap/dropdown'],
+                ['css', 'core/lightbox'],
+                ['css', 'jquery/ui'],
+            ],
             true,
-        ),
-        'core/lightbox' => array(
-            array(
-                array('javascript', 'jquery'),
-                array('javascript', 'core/lightbox'),
-                array('javascript', 'core/lightbox/launcher'),
-                array('css', 'core/lightbox'),
-            ),
-        ),
-        'core/account' => array(
-            array(
-                array('javascript', 'core/account'),
-                array('javascript', 'bootstrap/dropdown'),
-                array('css', 'bootstrap/dropdown'),
-                array('css', 'core/account'),
-            ),
-        ),
-        'core/translator' => array(
-            array(
-                array('javascript', 'core/translator'),
-                array('javascript-localized', 'core/translator'),
-                array('css', 'core/translator'),
-            ),
-        ),
+        ],
+        'core/lightbox' => [
+            [
+                ['javascript', 'jquery'],
+                ['javascript', 'core/lightbox'],
+                ['javascript', 'core/lightbox/launcher'],
+                ['css', 'core/lightbox'],
+            ],
+        ],
+        'core/account' => [
+            [
+                ['javascript', 'core/account'],
+                ['javascript', 'bootstrap/dropdown'],
+                ['css', 'bootstrap/dropdown'],
+                ['css', 'core/account'],
+            ],
+        ],
+        'core/translator' => [
+            [
+                ['javascript', 'core/translator'],
+                ['javascript-localized', 'core/translator'],
+                ['css', 'core/translator'],
+            ],
+        ],
         /* @deprecated keeping this around because certain themes reference it and we don't want to break them. */
-        'core/legacy' => array(
-            array(
-            ),
-        ),
-    ),
-    'curl' => array(
+        'core/legacy' => [
+            [
+            ],
+        ],
+    ],
+    'curl' => [
         'verifyPeer' => true,
         'connectionTimeout' => 5,
-    ),
+    ],
 
     // HTTP middleware for processing http requests
     'middleware' => [
         [
             'priority' => 1,
-            'class' => \Concrete\Core\Http\Middleware\ApplicationMiddleware::class
+            'class' => \Concrete\Core\Http\Middleware\ApplicationMiddleware::class,
         ],
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
         'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
-        'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class
-    ]
-);
+        'core_thumbnails' => \Concrete\Core\Http\Middleware\ThumbnailMiddleware::class,
+    ],
+];

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1,7 +1,6 @@
 <?php
 
-return array(
-
+return [
     /*
      * Current Version
      *
@@ -38,7 +37,7 @@ return array(
      * Debug settings
      * ------------------------------------------------------------------------
      */
-    'debug' => array(
+    'debug' => [
         /*
          * Display errors
          *
@@ -52,27 +51,26 @@ return array(
          * @var string (message|debug)
          */
         'detail' => 'message',
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Proxy Settings
      * ------------------------------------------------------------------------
      */
-    'proxy' => array(
+    'proxy' => [
         'host' => null,
         'port' => null,
         'user' => null,
         'password' => null,
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * File upload settings
      * ------------------------------------------------------------------------
      */
-    'upload' => array(
-
+    'upload' => [
         /*
          * Allowed file extensions
          *
@@ -81,51 +79,46 @@ return array(
         'extensions' => '*.flv;*.jpg;*.gif;*.jpeg;*.ico;*.docx;*.xla;*.png;*.psd;*.swf;*.doc;*.txt;*.xls;*.xlsx;' .
             '*.csv;*.pdf;*.tiff;*.rtf;*.m4a;*.mov;*.wmv;*.mpeg;*.mpg;*.wav;*.3gp;*.avi;*.m4v;*.mp4;*.mp3;*.qt;*.ppt;' .
             '*.pptx;*.kml;*.xml;*.svg;*.webm;*.ogg;*.ogv',
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Interface settings
      * ------------------------------------------------------------------------
      */
-    'interface' => array(
-
-        'panel' => array(
-
-            /**
+    'interface' => [
+        'panel' => [
+            /*
              * Enable the page relations panel
              */
             'page_relations' => false,
-
-        ),
-
-    ),
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Mail settings
      * ------------------------------------------------------------------------
      */
-    'mail' => array(
+    'mail' => [
         'method' => 'PHP_MAIL',
-        'methods' => array(
-            'smtp' => array(
+        'methods' => [
+            'smtp' => [
                 'server' => '',
                 'port' => '',
                 'username' => '',
                 'password' => '',
                 'encryption' => '',
-            ),
-        ),
-    ),
+            ],
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Cache settings
      * ------------------------------------------------------------------------
      */
-    'cache' => array(
-
+    'cache' => [
         /*
          * Enabled
          *
@@ -209,63 +202,61 @@ return array(
          * @var string|null
          */
         'directory_relative' => null,
-        'page' => array(
+        'page' => [
             'directory' => DIR_FILES_UPLOADED_STANDARD . '/cache/pages',
             'adapter' => 'file',
-        ),
-        'environment' => array(
+        ],
+        'environment' => [
             'file' => 'environment.cache',
-        ),
+        ],
 
-        'levels' => array(
-            'expensive' => array(
-                'drivers' => array(
-                    'core_ephemeral' => array(
+        'levels' => [
+            'expensive' => [
+                'drivers' => [
+                    'core_ephemeral' => [
                         'class' => '\Stash\Driver\Ephemeral',
-                        'options' => array(),
-                    ),
+                        'options' => [],
+                    ],
 
-                    'core_filesystem' => array(
+                    'core_filesystem' => [
                         'class' => '\Stash\Driver\FileSystem',
-                        'options' => array(
+                        'options' => [
                             'path' => DIR_FILES_UPLOADED_STANDARD . '/cache',
                             'dirPermissions' => DIRECTORY_PERMISSIONS_MODE_COMPUTED,
                             'filePermissions' => FILE_PERMISSIONS_MODE_COMPUTED,
-                        ),
-                    ),
-                ),
-            ),
-            'object' => array(
-                'drivers' => array(
-                    'core_ephemeral' => array(
+                        ],
+                    ],
+                ],
+            ],
+            'object' => [
+                'drivers' => [
+                    'core_ephemeral' => [
                         'class' => '\Stash\Driver\Ephemeral',
-                        'options' => array(),
-                    ),
-                ),
-            ),
-        ),
+                        'options' => [],
+                    ],
+                ],
+            ],
+        ],
+    ],
 
-    ),
-
-    'multilingual' => array(
+    'multilingual' => [
         'redirect_home_to_default_locale' => false,
         'use_browser_detected_locale' => false,
         'default_locale' => false,
         'default_source_locale' => 'en_US',
-    ),
+    ],
 
-    'design' => array(
+    'design' => [
         'enable_custom' => true,
         'enable_layouts' => true,
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Logging settings
      * ------------------------------------------------------------------------
      */
-    'log' => array(
-
+    'log' => [
         /*
          * Log emails
          *
@@ -287,8 +278,7 @@ return array(
          */
         'spam' => false,
 
-        'queries' => array(
-
+        'queries' => [
             /*
              * Whether to log database queries or not.
              *
@@ -297,62 +287,58 @@ return array(
             'log' => false,
 
             'clear_on_reload' => false,
-
-        ),
-    ),
-    'jobs' => array(
-
+        ],
+    ],
+    'jobs' => [
         'enable_scheduling' => true,
+    ],
 
-    ),
-
-    'filesystem' => array(
+    'filesystem' => [
         /* Temporary directory.
          * @link \Concrete\Core\File\Service\File::getTemporaryDirectory
          */
         'temp_directory' => null,
-        'permissions' => array(
+        'permissions' => [
             'file' => FILE_PERMISSIONS_MODE_COMPUTED,
             'directory' => DIRECTORY_PERMISSIONS_MODE_COMPUTED,
-        ),
-    ),
+        ],
+    ],
 
 /*
      * ------------------------------------------------------------------------
      * Email settings
      * ------------------------------------------------------------------------
      */
-    'email' => array(
-
+    'email' => [
         /*
          * Enable emails
          *
          * @var bool
          */
         'enabled' => true,
-        'default' => array(
+        'default' => [
             'address' => 'concrete5-noreply@concrete5',
             'name' => '',
-        ),
-        'form_block' => array(
+        ],
+        'form_block' => [
             'address' => false,
-        ),
-        'forgot_password' => array(
+        ],
+        'forgot_password' => [
             'address' => null,
             'name' => null,
-        ),
-        'validate_registration' => array(
+        ],
+        'validate_registration' => [
             'address' => null,
             'name' => null,
-        ),
-    ),
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Marketplace settings
      * ------------------------------------------------------------------------
      */
-    'marketplace' => array(
+    'marketplace' => [
         /*
          * Enable marketplace integration
          *
@@ -394,15 +380,14 @@ return array(
          * @var bool concrete.marketplace.log_requests
          */
         'log_requests' => false,
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Getting external news and help from concrete5.org
      * ------------------------------------------------------------------------
      */
-    'external' => array(
-
+    'external' => [
         /*
          * Provide help within the intelligent search
          *
@@ -423,14 +408,14 @@ return array(
          * @var bool concrete.external.news
          */
         'news' => true,
-    ),
+    ],
 
     /*
      * --------------------------------------------------------------------
      * Miscellaneous settings
      * --------------------------------------------------------------------
      */
-    'misc' => array(
+    'misc' => [
         'user_timezones' => false,
         'package_backup_directory' => DIR_FILES_UPLOADED_STANDARD . '/trash',
         'enable_progressive_page_reindex' => true,
@@ -442,78 +427,76 @@ return array(
         'app_version_display_in_header' => true,
         'default_jpeg_image_compression' => 80,
         'help_overlay' => true,
-        'require_version_comments'      => false,
-    ),
+        'require_version_comments' => false,
+    ],
 
-    'theme' => array(
-
+    'theme' => [
         'compress_preprocessor_output' => true,
         'generate_less_sourcemap' => false,
-    ),
+    ],
 
-    'updates' => array(
-
+    'updates' => [
         'enable_auto_update_packages' => false,
         'enable_permissions_protection' => true,
         'check_threshold' => 172800,
-        'services' => array(
+        'services' => [
             'get_available_updates' => 'http://www.concrete5.org/tools/update_core',
             'inspect_update' => 'http://www.concrete5.org/tools/inspect_update',
-        ),
-    ),
-    'paths' => array(
+        ],
+    ],
+    'paths' => [
         'trash' => '/!trash',
         'drafts' => '/!drafts',
-    ),
-    'icons' => array(
-        'page_template' => array(
+    ],
+    'icons' => [
+        'page_template' => [
             'width' => 120,
             'height' => 90,
-        ),
-        'theme_thumbnail' => array(
+        ],
+        'theme_thumbnail' => [
             'width' => 120,
             'height' => 90,
-        ),
-        'file_manager_listing' => array(
+        ],
+        'file_manager_listing' => [
             'handle' => 'file_manager_listing',
             'width' => 60,
             'height' => 60,
-        ),
-        'file_manager_detail' => array(
+        ],
+        'file_manager_detail' => [
             'handle' => 'file_manager_detail',
             'width' => 400,
-        ),
-        'user_avatar' => array(
+        ],
+        'user_avatar' => [
             'width' => 80,
             'height' => 80,
             'default' => ASSETS_URL_IMAGES . '/avatar_none.png',
-        ),
-    ),
+        ],
+    ],
 
-    'file_manager' => array(
-        'images' => array(
+    'file_manager' => [
+        'images' => [
             'use_exif_data_to_rotate_images' => false,
-            'manipulation_library' => 'gd'
-        ),
-        'results' => 10
-    ),
+            'manipulation_library' => 'gd',
+        ],
+        'results' => 10,
+    ],
 
-    'search_users' => array(
-        'results' => 10
-    ),
+    'search_users' => [
+        'results' => 10,
+    ],
 
-    'sitemap_xml' => array(
+    'sitemap_xml' => [
         'file' => 'sitemap.xml',
         'frequency' => 'weekly',
         'priority' => 0.5,
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Accessibility
      * ------------------------------------------------------------------------
      */
-    'accessibility' => array(
+    'accessibility' => [
         /*
          * Show titles in the concrete5 toolbars
          *
@@ -534,24 +517,22 @@ return array(
          * @var bool
          */
         'display_help_system' => true,
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Internationalization
      * ------------------------------------------------------------------------
      */
-    'i18n' => array(
-
+    'i18n' => [
         /*
          * Allow users to choose language on login
          *
          * @var bool
          */
         'choose_language_login' => false,
-
-    ),
-    'urls' => array(
+    ],
+    'urls' => [
         'concrete5' => 'http://www.concrete5.org',
         'concrete5_secure' => 'https://www.concrete5.org',
         'newsflow' => 'http://newsflow.concrete5.org',
@@ -559,16 +540,16 @@ return array(
         'background_feed_secure' => 'https://backgroundimages.concrete5.org/wallpaper',
         'background_info' => 'http://backgroundimages.concrete5.org/get_image_data.php',
         'videos' => 'https://www.youtube.com/user/concrete5cms/videos',
-        'help' => array(
+        'help' => [
             'developer' => 'http://documentation.concrete5.org/developers',
             'user' => 'http://documentation.concrete5.org/editors',
             'forum' => 'http://www.concrete5.org/community/forums',
-        ),
-        'paths' => array(
+        ],
+        'paths' => [
             'menu_help_service' => '/tools/get_remote_help_list/',
             'site_page' => '/private/sites',
             'newsflow_slot_content' => '/tools/slot_content/',
-            'marketplace' => array(
+            'marketplace' => [
                 'connect' => '/marketplace/connect',
                 'connect_success' => '/marketplace/connect/-/connected',
                 'connect_validate' => '/marketplace/connect/-/validate',
@@ -578,17 +559,16 @@ return array(
                 'item_information' => '/marketplace/connect/-/get_item_information',
                 'item_free_license' => '/marketplace/connect/-/enable_free_license',
                 'remote_item_list' => '/marketplace/',
-            ),
-        ),
-    ),
+            ],
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * White labeling.
      * ------------------------------------------------------------------------
      */
-    'white_label' => array(
-
+    'white_label' => [
         /*
          * Custom Logo source path relative to the public directory.
          *
@@ -609,35 +589,33 @@ return array(
          * @var null|string
          */
         'dashboard_background' => null,
-    ),
-    'session' => array(
-
+    ],
+    'session' => [
         'name' => 'CONCRETE5',
         'handler' => 'file',
         'save_path' => null,
         'max_lifetime' => 7200,
-        'cookie' => array(
+        'cookie' => [
             'cookie_path' => false, // set a specific path here if you know it, otherwise it'll default to relative
             'cookie_lifetime' => 0,
             'cookie_domain' => false,
             'cookie_secure' => false,
             'cookie_httponly' => true,
-        ),
-    ),
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * User information and registration settings.
      * ------------------------------------------------------------------------
      */
-    'user' => array(
+    'user' => [
         /*
          * --------------------------------------------------------------------
          * Registration settings.
          * --------------------------------------------------------------------
          */
-        'registration' => array(
-
+        'registration' => [
             /*
              * Registration
              *
@@ -686,48 +664,43 @@ return array(
              * @var bool|string Email to notify
              */
             'notification' => false,
-        ),
+        ],
 
         /*
          * --------------------------------------------------------------------
          * Gravatar Settings
          * --------------------------------------------------------------------
          */
-        'group' => array(
-
-            'badge' => array(
-
+        'group' => [
+            'badge' => [
                 'default_point_value' => 50,
-            ),
+            ],
+        ],
 
-        ),
-
-        'username' => array(
+        'username' => [
             'maximum' => 64,
             'minimum' => 3,
             'allow_spaces' => false,
-
-        ),
-        'password' => array(
+        ],
+        'password' => [
             'maximum' => 128,
             'minimum' => 5,
             'hash_portable' => false,
             'hash_cost_log2' => 12,
             'legacy_salt' => '',
-        ),
-        'private_messages' => array(
+        ],
+        'private_messages' => [
             'throttle_max' => 20,
             'throttle_max_timespan' => 15, // minutes
-        ),
-
-    ),
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Spam
      * ------------------------------------------------------------------------
      */
-    'spam' => array(
+    'spam' => [
         /*
          * Whitelist group ID
          *
@@ -741,24 +714,21 @@ return array(
          * @var string
          */
         'notify_email' => '',
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Security
      * ------------------------------------------------------------------------
      */
-    'security' => array(
-        'session' => array(
-
+    'security' => [
+        'session' => [
             'invalidate_on_user_agent_mismatch' => true,
 
             'invalidate_on_ip_mismatch' => true,
-
-        ),
-        'ban' => array(
-            'ip' => array(
-
+        ],
+        'ban' => [
+            'ip' => [
                 'enabled' => true,
 
                 /*
@@ -775,25 +745,24 @@ return array(
                  * Ban length in minutes
                  */
                 'length' => 10,
-            ),
-        ),
-        'misc' => array(
-
-            /**
+            ],
+        ],
+        'misc' => [
+            /*
              * Defence Click Jacking.
              *
              * @var bool|string DENY, SAMEORIGIN, ALLOW-FROM uri
              */
             'x_frame_options' => 'SAMEORIGIN',
-        ),
-    ),
+        ],
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Permissions and behaviors toggles.
      * ------------------------------------------------------------------------
      */
-    'permissions' => array(
+    'permissions' => [
         /*
          * Forward to login if access is denied
          *
@@ -807,16 +776,15 @@ return array(
          * @var string The permission model (simple|advanced)
          */
         'model' => 'simple',
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * SEO Settings
      * ------------------------------------------------------------------------
      */
-    'seo' => array(
-
-        'tracking' => array(
+    'seo' => [
+        'tracking' => [
             /*
              * User defined tracking code
              *
@@ -830,8 +798,7 @@ return array(
              * @var string (top|bottom)
              */
             'code_position' => 'bottom',
-
-        ),
+        ],
         'exclude_words' => 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, ' .
             'since, than, the, this, that, to, up, via, with',
 
@@ -855,32 +822,32 @@ return array(
         'group_name_separator' => ' / ',
         'segment_max_length' => 128,
         'paging_string' => 'ccm_paging_p',
-    ),
+    ],
 
     /*
      * ------------------------------------------------------------------------
      * Statistics Settings
      * ------------------------------------------------------------------------
      */
-    'statistics' => array(
+    'statistics' => [
         'track_downloads' => true,
-    ),
-    'limits' => array(
+    ],
+    'limits' => [
         'sitemap_pages' => 100,
         'delete_pages' => 100,
         'copy_pages' => 10,
         'page_search_index_batch' => 200,
         'job_queue_batch' => 10,
-        'style_customizer' => array(
+        'style_customizer' => [
             'size_min' => -50,
             'size_max' => 200,
-        ),
-    ),
+        ],
+    ],
 
-    'page' => array(
-        'search' => array(
+    'page' => [
+        'search' => [
             // Always reindex pages (usually it isn't performed when approving workflows)
             'always_reindex' => false,
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/concrete/config/conversations.php
+++ b/concrete/config/conversations.php
@@ -9,20 +9,20 @@
  * @namespace null
  * -----------------------------------------------------------------------------
  */
-return array(
+return [
     'attachments_enabled' => true,
     'attachments_pending_file_set' => 'Conversation Messages (Pending)',
     'attachments_file_set' => 'Conversation Messages',
     'subscription_enabled' => false,
-    'files' => array(
+    'files' => [
         'allowed_types' => '*.jpg;*.gif;*.jpeg;*.png;*.doc;*.docx;*.zip',
-        'guest' => array(
+        'guest' => [
             'max_size' => 1,
             'max' => 3,
-        ),
-        'registered' => array(
+        ],
+        'registered' => [
             'max_size' => 10,
             'max' => 5,
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/concrete/config/database.php
+++ b/concrete/config/database.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
-    'drivers' => array(
+return [
+    'drivers' => [
         'c5_pdo_mysql' => '\Concrete\Core\Database\Driver\PDOMySqlConcrete5\Driver',
-    ),
+    ],
 
     /*
      * The location of the doctrine Proxy Classes
@@ -13,7 +13,7 @@ return array(
     /*
      * Paths to exclude from the doctrine proxy classes
      */
-    'proxy_exclusions' => array(
+    'proxy_exclusions' => [
         DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Support/',
-    ),
-);
+    ],
+];

--- a/concrete/config/devices.php
+++ b/concrete/config/devices.php
@@ -7,12 +7,11 @@ use Concrete\Core\Device\DeviceInterface as DeviceType;
  * Make sure to make the "width" the larger number
  */
 
-return array(
-
-    # APPLE
+return [
+    // APPLE
 
     /* iPhone 6, 1334x750 @2x */
-    'iphone6' => array(
+    'iphone6' => [
         'type' => DeviceType::MOBILE,
         'name' => 'iPhone 6',
         'class' => '\Concrete\Core\Device\Apple\IPhone\IPhone6Device',
@@ -21,10 +20,10 @@ return array(
         'pixel_ratio' => 2,
         'default_orientation' => 'portrait',
         'agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4',
-    ),
+    ],
 
     /* iPhone 6 Plus, 1920x1080 @2.6x */
-    'iphone6plus' => array(
+    'iphone6plus' => [
         'type' => DeviceType::MOBILE,
         'name' => 'iPhone 6 Plus',
         'class' => '\Concrete\Core\Device\Apple\IPhone\IPhone6PlusDevice',
@@ -33,10 +32,10 @@ return array(
         'pixel_ratio' => 2.6,
         'default_orientation' => 'portrait',
         'agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4',
-    ),
+    ],
 
     /* iPhone 5, 1136x640 @2x */
-    'iphone5' => array(
+    'iphone5' => [
         'type' => DeviceType::MOBILE,
         'name' => 'iPhone 5s',
         'class' => '\Concrete\Core\Device\Apple\IPhone\IPhone5Device',
@@ -45,22 +44,22 @@ return array(
         'pixel_ratio' => 2,
         'default_orientation' => 'portrait',
         'agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4',
-    ),
+    ],
 
     /* iPad, 2048x1536 @2x*/
-    'ipad' => array(
+    'ipad' => [
         'type' => DeviceType::TABLET,
         'name' => 'iPad',
         'class' => '\Concrete\Core\Device\Apple\IPad\IPadDevice',
         'width' => 2048,
         'height' => 1536,
         'pixel_ratio' => 2,
-    ),
+    ],
 
-    # SAMSUNG
+    // SAMSUNG
 
     /* Galaxy S5 */
-    's5' => array(
+    's5' => [
         'type' => DeviceType::MOBILE,
         'name' => 'Samsung Galaxy S5',
         'class' => '\Concrete\Core\Device\Samsung\Galaxy\S5Device',
@@ -69,6 +68,5 @@ return array(
         'pixel_ratio' => 3,
         'default_orientation' => 'portrait',
         'agent' => 'Mozilla/5.0 (Linux; Android 5.0; pl-pl; SAMSUNG SM-G900F/G900FXXU1BNL9 Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Version/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36',
-    ),
-
-);
+    ],
+];

--- a/concrete/config/i18n.php
+++ b/concrete/config/i18n.php
@@ -1,13 +1,13 @@
 <?php
 
-return array(
-    'adapters' => array(
-        'zend' => array(
-            'loaders' => array(
+return [
+    'adapters' => [
+        'zend' => [
+            'loaders' => [
                 'core' => 'Concrete\Core\Localization\Translator\Adapter\Zend\Translation\Loader\Gettext\CoreTranslationLoader',
                 'packages' => 'Concrete\Core\Localization\Translator\Adapter\Zend\Translation\Loader\Gettext\PackagesTranslationLoader',
                 'site' => 'Concrete\Core\Localization\Translator\Adapter\Zend\Translation\Loader\Gettext\SiteTranslationLoader',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/concrete/config/imageeditor.php
+++ b/concrete/config/imageeditor.php
@@ -1,128 +1,126 @@
 <?php
 
 
-return array(
-    'extensions' => array(
-
-        ##
-        # Controls
-        ##
+return [
+    'extensions' => [
+        //#
+        // Controls
+        //#
 
         /*
          * Extension that provides image placement and other default core functionality
          *
          * @var array imageeditor.extensions.core/position
          */
-        'core/position' => array(
+        'core/position' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionControl,
             'name' => tc('ImageEditorControlSetName', 'Position'),
             'handle' => 'position',
             'src' => 'core/imageeditor/control/position',
             'view' => 'image-editor/controls/position',
-            'assets' => array(
-                'core/imageeditor/control/position' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/control/position' => ['css'],
+            ],
+        ],
 
         /*
          * Extension for adding filter management and slideout
          *
          * @var array imageeditor.extensions.core/filter
          */
-        'core/filter' => array(
+        'core/filter' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionControl,
             'name' => tc('ImageEditorControlSetName', 'Filter'),
             'handle' => 'filter',
             'src' => 'core/imageeditor/control/filter',
             'view' => 'image-editor/controls/filter',
-            'assets' => array(
-                'core/imageeditor/control/filter' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/control/filter' => ['css'],
+            ],
+        ],
 
-        ##
-        # Filters
-        ##
+        //#
+        // Filters
+        //#
 
         /*
          * Gaussian blur filter
          *
          * @var array imageeditor.extensions.core/filter/gaussian_blur
          */
-        'core/filter/gaussian_blur' => array(
+        'core/filter/gaussian_blur' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionFilter,
             'name' => tc('ImageEditorFilterName', 'Gaussian Blur'),
             'handle' => 'gaussian_blur',
             'src' => 'core/imageeditor/filter/gaussian_blur',
             'view' => 'image-editor/filters/gaussian_blur',
-            'assets' => array(
-                'core/imageeditor/filter/gaussian_blur' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/filter/gaussian_blur' => ['css'],
+            ],
+        ],
 
         /*
          * Grayscale filter
          *
          * @var array imageeditor.extensions.core/filter/grayscale
          */
-        'core/filter/grayscale' => array(
+        'core/filter/grayscale' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionFilter,
             'name' => tc('ImageEditorFilterName', 'Grayscale'),
             'handle' => 'grayscale',
             'src' => 'core/imageeditor/filter/grayscale',
             'view' => 'image-editor/filters/grayscale',
-            'assets' => array(
-                'core/imageeditor/filter/grayscale' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/filter/grayscale' => ['css'],
+            ],
+        ],
 
         /*
          * No filter
          *
          * @var array imageeditor.extensions.core/filter/none
          */
-        'core/filter/none' => array(
+        'core/filter/none' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionFilter,
             'name' => tc('ImageEditorFilterName', 'None'),
             'handle' => 'none',
             'src' => 'core/imageeditor/filter/none',
             'view' => 'image-editor/filters/none',
-            'assets' => array(
-                'core/imageeditor/filter/none' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/filter/none' => ['css'],
+            ],
+        ],
 
         /*
          * Sepia filter
          *
          * @var array imageeditor.extensions.core/filter/sepia
          */
-        'core/filter/sepia' => array(
+        'core/filter/sepia' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionFilter,
             'name' => tc('ImageEditorFilterName', 'Sepia'),
             'handle' => 'sepia',
             'src' => 'core/imageeditor/filter/sepia',
             'view' => 'image-editor/filters/sepia',
-            'assets' => array(
-                'core/imageeditor/filter/sepia' => array('css'),
-            ),
-        ),
+            'assets' => [
+                'core/imageeditor/filter/sepia' => ['css'],
+            ],
+        ],
 
         /*
          * Vignette filter
          *
          * @var array imageeditor.extensions.core/filter/vignette
          */
-        'core/filter/vignette' => array(
-
+        'core/filter/vignette' => [
             'type' => Concrete\Core\ImageEditor\ImageEditor::ImageEditorExtensionFilter,
             'name' => tc('ImageEditorFilterName', 'Vignette'),
             'handle' => 'vignette',
             'src' => 'core/imageeditor/filter/vignette',
             'view' => 'image-editor/filters/vignette',
-            'assets' => array(
-                'core/imageeditor/filter/vignette' => array('css'),
-            ),
-        ),
-    ),
-);
+            'assets' => [
+                'core/imageeditor/filter/vignette' => ['css'],
+            ],
+        ],
+    ],
+];

--- a/concrete/config/install/app.php
+++ b/concrete/config/install/app.php
@@ -1,14 +1,12 @@
 <?php
 
-return array(
-
-    'routes' => array(
-        '/install' => array('\Concrete\Controller\Install::view'),
-        '/install/select_language' => array('\Concrete\Controller\Install::select_language'),
-        '/install/setup' => array('\Concrete\Controller\Install::setup'),
-        '/install/test_url/{num1}/{num2}' => array('\Concrete\Controller\Install::test_url'),
-        '/install/configure' => array('\Concrete\Controller\Install::configure'),
-        '/install/run_routine/{pkgHandle}/{routine}' => array('\Concrete\Controller\Install::run_routine'),
-    ),
-
-);
+return [
+    'routes' => [
+        '/install' => ['\Concrete\Controller\Install::view'],
+        '/install/select_language' => ['\Concrete\Controller\Install::select_language'],
+        '/install/setup' => ['\Concrete\Controller\Install::setup'],
+        '/install/test_url/{num1}/{num2}' => ['\Concrete\Controller\Install::test_url'],
+        '/install/configure' => ['\Concrete\Controller\Install::configure'],
+        '/install/run_routine/{pkgHandle}/{routine}' => ['\Concrete\Controller\Install::run_routine'],
+    ],
+];

--- a/concrete/config/install/concrete.php
+++ b/concrete/config/install/concrete.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
+return [
     'installed' => false,
 
-    'cache' => array(
+    'cache' => [
         'enabled' => false,
-    ),
-);
+    ],
+];

--- a/concrete/config/services.php
+++ b/concrete/config/services.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
     'apache' => 'Concrete\Core\Service\HTTP\Apache',
     'nginx' => 'Concrete\Core\Service\HTTP\Nginx',
-);
+];

--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -1,26 +1,21 @@
 <?php
 
 return [
-
     'default' => 'default',
 
     'sites' => [
-
         'default' => [
-
             'handle' => 'default',
 
             'name' => 'concrete5',
 
             'user' => [
-
                 'profiles_enabled' => false,
                 'gravatar' => [
                     'enabled' => false,
                     'max_level' => 0,
                     'image_set' => 0,
                 ],
-
             ],
 
             'editor' => [
@@ -67,7 +62,7 @@ return [
                             'tabletools',
                             'toolbar',
                             'undo',
-                            'wysiwygarea'
+                            'wysiwygarea',
                         ],
                         'selected_hidden' => [
                             'concrete5filemanager',
@@ -80,8 +75,8 @@ return [
                             'resize',
                             'toolbar',
                             'wysiwygarea',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'plugins' => [
                     'selected' => [
@@ -92,8 +87,6 @@ return [
                     ],
                 ],
             ],
-
         ],
-
     ],
 ];

--- a/concrete/config/statistics.php
+++ b/concrete/config/statistics.php
@@ -3,6 +3,6 @@
 return [
     'trackers' => [
         'core_stack' => \Concrete\Core\Page\Stack\UsageTracker::class,
-        'core_file' => \Concrete\Core\File\Tracker\UsageTracker::class
-    ]
+        'core_file' => \Concrete\Core\File\Tracker\UsageTracker::class,
+    ],
 ];


### PR DESCRIPTION
I think that PHP short array syntax is much more readable.

I run php-cs-fixer to fix the configuration files.

PS: both CLI and web still correctly fail with the message `concrete5 requires PHP 5.5.9+ to run.`, since the PHP version check is performed before reading the configuration files.