### PR TITLE
Wrapped div paging not needed ("Actions" page)

### DIFF
--- a/concrete/single_pages/dashboard/users/points/actions.php
+++ b/concrete/single_pages/dashboard/users/points/actions.php
@@ -141,10 +141,7 @@
     }
     ?>
 	
-<div class="ccm-pane-footer">
-<?=$actionList->displayPagingV2();
-    ?>
-</div>
+<?=$actionList->displayPagingV2();?>
 
 <?php 
 } ?>


### PR DESCRIPTION
Makes no real sense if other paging doesn't have a div wrapping it, so delete it on the "Actions" page (Members - Community Points - Actions) too. Shorter **and** cleaner! :)