### PR TITLE
Page "Location" dialog update

### DIFF
--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -74,8 +74,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 		<button class="btn btn-info pull-right" type="button" data-action="add-url"><?=t('Add URL')?></button>
 
-		<br/><br/>
-		<span class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></span>
+		<div class="clearfix"></div>
+		<p class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></p>
 
 		</div>
 


### PR DESCRIPTION
Make sure everything that comes after the "Add URL" is not floating next to the button and wrap the help-text in a paragraph instead.

Not sure if we should actually float the button to the right still? But hey, not up to me. For now, this code is more valid and will work fine if we decide to change some CSS here or there! - who uses br's anyways these days haha