### PR TITLE
"Social links" page update (remove column)

### DIFF
--- a/concrete/single_pages/dashboard/system/basics/social.php
+++ b/concrete/single_pages/dashboard/system/basics/social.php
@@ -94,7 +94,6 @@
 
     <?php if (count($links) > 0) {
     ?>
-        <div class="col-md-8">
         <table class="table table-striped">
         <?php foreach ($links as $link) {
     $service = $link->getServiceObject();
@@ -108,7 +107,6 @@
 }
     ?>
         </table>
-        </div>
 
     <?php 
 } else {

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -74,8 +74,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 		<button class="btn btn-info pull-right" type="button" data-action="add-url"><?=t('Add URL')?></button>
 
-		<br/><br/>
-		<span class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></span>
+		<div class="clearfix"></div>
+		<p class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></p>
 
 		</div>
 

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -74,8 +74,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 		<button class="btn btn-info pull-right" type="button" data-action="add-url"><?=t('Add URL')?></button>
 
-		<div class="clearfix"></div>
-		<p class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></p>
+		<br/><br/>
+		<span class="help-block"><?=t('Note: Additional page paths are not versioned. They will be available immediately.')?></span>
 
 		</div>
 


### PR DESCRIPTION
A column (col) which isn't needed - it makes the table fairly small. Also, it hadn't got a row wrapped around it, so it more or less breaks the pattern too (floating without clearing which causes ugly designs when using different CSS).