### PR TITLE
Add functions to autofix PHP time zone

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/basics/timezone.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/timezone.php
@@ -4,51 +4,40 @@ namespace Concrete\Controller\SinglePage\Dashboard\System\Basics;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Database\Connection\Connection;
 use DateTime;
+use DateTimeZone;
+use Exception;
 
 class Timezone extends DashboardPageController
 {
     public function view()
     {
-        $dh = $this->app->make('helper/date');
+        $dh = $this->app->make('date');
         $config = $this->app->make('config');
         $this->set('user_timezones', $config->get('concrete.misc.user_timezones'));
         $this->set('timezone', $config->get('app.timezone'));
         $this->set('timezones', $dh->getGroupedTimezones());
         $phpTimezone = $config->get('app.server_timezone');
         $this->set('serverTimezonePHP', $dh->getTimezoneName($phpTimezone));
-        $deltaError = null;
         $db = $this->app->make(Connection::class);
         /* @var Connection $db */
         $this->set('serverTimezoneDB', $db->fetchColumn('select @@time_zone'));
-        $tsNow = time();
-        $ts180Days = $tsNow + 180 * 24 * 60 * 60;
-        $rs = $db->executeQuery("select FROM_UNIXTIME($tsNow) as d0, FROM_UNIXTIME($ts180Days) as d1");
-        $row = $rs->fetch();
-        $rs->closeCursor();
-        $dbNow = new DateTime($row['d0']);
-        $db180Days = new DateTime($row['d1']);
-        $phpNow = DateTime::createFromFormat('U', $tsNow);
-        $php180Days = DateTime::createFromFormat('U', $ts180Days);
-        $delta = (int) floor(($phpNow->getTimestamp() - $dbNow->getTimestamp()) / 60);
-        if ($delta !== 0) {
-            $interval = $dh->describeInterval(60 * abs($delta), true);
-            if ($delta > 0) {
-                $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The database timezone has times greater by %s compared to the PHP timezone.', $interval);
-            } else {
-                $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The database timezone has times smaller by %s compared to the PHP timezone.', $interval);
-            }
-        } else {
-            $delta = (int) floor(($php180Days->getTimestamp() - $db180Days->getTimestamp()) / 60);
-            if ($delta !== 0) {
-                $interval = $dh->describeInterval(60 * abs($delta), true);
-                $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The way PHP and database handle daylight saving times differs by %s.', $interval);
-            }
-        }
+        $deltaError = $this->getDeltaTimezone($phpTimezone);
         if ($deltaError === null) {
             $this->set('dbTimezoneOk', true);
         } else {
+            $interval = $dh->describeInterval(60 * abs($deltaError['maxDeltaMinutes']), true);
+            if ($deltaError['dstProblems']) {
+                $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The way PHP and database handle daylight saving times differs by %s.', $interval);
+            } else {
+                if ($deltaError['maxDeltaMinutes'] > 0) {
+                    $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The database timezone has times greater by %s compared to the PHP timezone.', $interval);
+                } else {
+                    $deltaError = t(/*i18n: %s is an interval, like "3 hours and 30 minutes"*/'The database timezone has times smaller by %s compared to the PHP timezone.', $interval);
+                }
+            }
             $this->set('dbTimezoneOk', false);
             $this->set('dbDeltaDescription', $deltaError);
+            $this->set('compatibleTimezones', $this->getCompatibleTimezones());
         }
     }
 
@@ -88,5 +77,128 @@ class Timezone extends DashboardPageController
             $this->error->add($this->token->getErrorMessage());
             $this->view();
         }
+    }
+
+    public function setSystemTimezone()
+    {
+        if ($this->token->validate('set_system_timezone')) {
+            $timezoneName = $this->post('new-timezone');
+            $timezone = null;
+            if (is_string($timezoneName) && $timezoneName !== '') {
+                try {
+                    $timezone = new DateTimeZone($timezoneName);
+                } catch (Exception $x) {
+                }
+            }
+            if ($timezone === null) {
+                $this->error->add(t('Invalid time zone specified.'));
+            } else {
+                $this->app->make('config')->save('app.server_timezone', $timezoneName);
+            }
+        } else {
+            $this->error->add($this->token->getErrorMessage());
+        }
+        if ($this->error->has()) {
+            $this->view();
+        } else {
+            $this->flash('message', t('The system PHP time zone has been updated.'));
+            $this->redirect($this->action(''));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCompatibleTimezones()
+    {
+        $dh = $this->app->make('date');
+        $validTimezones = [];
+        foreach ($dh->getTimezones() as $timezoneID => $timezoneName) {
+            if ($this->getDeltaTimezone($timezoneID) === null) {
+                $validTimezones[$timezoneID] = $timezoneName;
+            }
+        }
+
+        return $validTimezones;
+    }
+
+    /**
+     * Check if a PHP time zone is compatible with the database timezone.
+     *
+     * @param DateTimeZone|string $phpTimezone
+     *
+     * @return null|array If the time zone matches, we'll return null, otherwise an array with the keys 'dstProblems' (boolean) and 'maxDeltaMinutes' (int)
+     */
+    protected function getDeltaTimezone($phpTimezone)
+    {
+        static $databaseData;
+        if (!($phpTimezone instanceof DateTimeZone)) {
+            $phpTimezone = new DateTimeZone($phpTimezone);
+        }
+        $db = $this->app->make(Connection::class);
+        // Let's check 3 different days (with an interval of about 4 months),
+        // to be sure we also check potential daylight saving time changes.
+        $timestamps = [
+            time(),
+            time() + 120 * 24 * 60 * 60,
+            time() + 240 * 24 * 60 * 60,
+        ];
+        if (!isset($databaseData) || ($timestamps[0] - $databaseData['timestamp']) > 10) {
+            $databaseData = [
+                'timestamp' => $timestamps[0],
+                'datetimes' => $this->getDatabaseDatetimes($timestamps),
+            ];
+        }
+        $databaseDatetimes = $databaseData['datetimes'];
+        $sometimesSame = false;
+        $maxDeltaMinutes = 0;
+        foreach ($timestamps as $index => $timestamp) {
+            $databaseValue = new DateTime($databaseDatetimes[$index], $phpTimezone);
+            $phpValue = DateTime::createFromFormat('U', $timestamp, $phpTimezone);
+            $deltaMinutes = (int) floor(($phpValue->getTimestamp() - $databaseValue->getTimestamp()) / 60);
+            if ($deltaMinutes === 0) {
+                $sometimesSame = true;
+            } else {
+                if (abs($deltaMinutes) > abs($maxDeltaMinutes)) {
+                    $maxDeltaMinutes = $deltaMinutes;
+                }
+            }
+        }
+
+        if ($maxDeltaMinutes === 0) {
+            return null;
+        } else {
+            return [
+                'dstProblems' => $sometimesSame,
+                'maxDeltaMinutes' => $maxDeltaMinutes,
+            ];
+        }
+    }
+
+    /**
+     * @param int[] $timestamps
+     *
+     * @return string[]
+     */
+    protected function getDatabaseDatetimes(array $timestamps)
+    {
+        $db = $this->app->make(Connection::class);
+        /* @var Connection $db */
+        $sql = 'SELECT ';
+        foreach ($timestamps as $index => $timestamp) {
+            if ($index > 0) {
+                $sql .= ', ';
+            }
+            $sql .= "FROM_UNIXTIME($timestamp) as datetime_$index";
+        }
+        $rs = $db->executeQuery($sql);
+        $row = $rs->fetch();
+        $rs->closeCursor();
+        $result = [];
+        foreach (array_keys($timestamps) as $index) {
+            $result[$index] = $row["datetime_$index"];
+        }
+
+        return $result;
     }
 }

--- a/concrete/single_pages/dashboard/system/basics/timezone.php
+++ b/concrete/single_pages/dashboard/system/basics/timezone.php
@@ -92,11 +92,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
     </div>
 
 </form>
-<?
+<?php
 if (isset($compatibleTimezones) && !empty($compatibleTimezones)) {
     ?>
-    <div id="user-timezone-autofix-dialog" style="display: none" title="<?=t('Select time zone')?>">
-        <form method="POST" action="<?= $view->action('setSystemTimezone') ?>" class="ccm-ui">
+    <div id="user-timezone-autofix-dialog" style="display: none" class="ccm-ui" title="<?=t('Select time zone')?>">
+        <form method="POST" action="<?= $view->action('setSystemTimezone') ?>" class="ccm-ui" id="user-timezone-autofix-form">
             <?php $token->output('set_system_timezone') ?>
             <div class="form-group">
                 <select class="form-control" size="15" name="new-timezone">
@@ -108,6 +108,10 @@ if (isset($compatibleTimezones) && !empty($compatibleTimezones)) {
                 </select>
             </div>
         </form>
+        <div class="dialog-buttons">
+            <button type="button" onclick="jQuery.fn.dialog.closeTop()" class="btn btn-default pull-left"><?=t('Cancel')?></button>
+            <button type="button" onclick="$('#user-timezone-autofix-form').submit()" class="btn btn-primary pull-right"><?=t('Save')?></button>
+        </div>
     </div>
     <?php
 }
@@ -121,27 +125,10 @@ $(document).ready(function() {
             window.alert(<?=json_encode("No PHP compatible time zone is compatible with the database time zone.\nYou should change the database default timezone.")?>);
             return;
         }
-        $dlg.dialog({
-            modal: true,
+        jQuery.fn.dialog.open({
+            element: $dlg,
             resizable: false,
-            buttons: [
-            	{
-                    text: <?=json_encode(t('Cancel'))?>,
-                    click: function() {
-                        $dlg.dialog('close');
-                    }
-            	},
-            	{
-                    text: <?=json_encode(t('Apply'))?>,
-                    click: function() {
-                        if (!$dlg.find('[name="new-timezone"]').val()) {
-                        	window.alert(<?=json_encode("Please select one of the listed time zones.")?>);
-                            return;
-                        }
-                        $dlg.find('form').submit();
-                    }
-            	}
-            ]
+            height: 370
         });
     });
 });

--- a/concrete/single_pages/dashboard/system/basics/timezone.php
+++ b/concrete/single_pages/dashboard/system/basics/timezone.php
@@ -31,7 +31,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <div>
                 <?php if (!$dbTimezoneOk) { ?>
                     <div class="text-warning"><i class="fa fa-warning"></i>
-                        <?= $dbDeltaDescription ?>
+                        <?= $dbDeltaDescription ?><br />
+                        <a href="#" id="user-timezone-autofix" class="btn btn-warning"><?=t('Fix PHP timezone')?></a>
                     </div>
                 <?php } else { ?>
                     <div class="text-success"><i class="fa fa-check"></i>
@@ -91,3 +92,57 @@ defined('C5_EXECUTE') or die('Access Denied.');
     </div>
 
 </form>
+<?
+if (isset($compatibleTimezones) && !empty($compatibleTimezones)) {
+    ?>
+    <div id="user-timezone-autofix-dialog" style="display: none" title="<?=t('Select time zone')?>">
+        <form method="POST" action="<?= $view->action('setSystemTimezone') ?>" class="ccm-ui">
+            <?php $token->output('set_system_timezone') ?>
+            <div class="form-group">
+                <select class="form-control" size="15" name="new-timezone">
+                    <?php
+                    foreach ($compatibleTimezones as $timezoneID => $timezoneName) {
+                        ?><option value="<?=h($timezoneID)?>"><?=h($timezoneName)?></option><?php
+                    }
+                    ?>
+                </select>
+            </div>
+        </form>
+    </div>
+    <?php
+}
+?>
+<script>
+$(document).ready(function() {
+    $('#user-timezone-autofix').on('click', function(e) {
+        e.preventDefault();
+        var $dlg = $('#user-timezone-autofix-dialog');
+        if ($dlg.length === 0) {
+            window.alert(<?=json_encode("No PHP compatible time zone is compatible with the database time zone.\nYou should change the database default timezone.")?>);
+            return;
+        }
+        $dlg.dialog({
+            modal: true,
+            resizable: false,
+            buttons: [
+            	{
+                    text: <?=json_encode(t('Cancel'))?>,
+                    click: function() {
+                        $dlg.dialog('close');
+                    }
+            	},
+            	{
+                    text: <?=json_encode(t('Apply'))?>,
+                    click: function() {
+                        if (!$dlg.find('[name="new-timezone"]').val()) {
+                        	window.alert(<?=json_encode("Please select one of the listed time zones.")?>);
+                            return;
+                        }
+                        $dlg.find('form').submit();
+                    }
+            	}
+            ]
+        });
+    });
+});
+</script>


### PR DESCRIPTION
Add a function to suggest time zones compatible with the database one.
Users will pick a time zone, that will set the `app.server_timezone` concrete5 configuration key.

To test this, you can change the `date.timezone` PHP.ini configuration key to something different from the MySQL timezone.