### PR TITLE
Page List & Date Navigation: Make other action available for multibyte language users #4624

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -357,7 +357,7 @@ class Controller extends BlockController
                 $parameters[1] = intval($parameters[1]);
             }
         } else {
-            $parameters = $method = null;
+            return parent::getPassThruActionAndParameters($parameters);
         }
 
         return [$method, $parameters];


### PR DESCRIPTION
I'm re-sending another PR #4624

This is more likely only the problem for multibyte users.

A Japanese user had problem that site editor always create a blog post which URL slug is just contains the year (e.g., "2016") which will interfere date navigation block's action URL.

When you create a new page in English alphabet, you could get unique URL slug...

For example if the page title is `Happy New Year 2017`, URL slug will become `happy-new-year-2017`.

![image](https://cloud.githubusercontent.com/assets/485751/20183632/58dbbab4-a7a9-11e6-9108-2dda05421b3e.png)

However, when you use multibyte character as page title, only the number and alphabet characters become the part of the URL.

For example, the page title of `2017年あけましておめでとうございます` (Happy New Year 2017)  will become `2017` URL slug.

![image](https://cloud.githubusercontent.com/assets/485751/20183659/6d582518-a7a9-11e6-9156-258fd4e8c63f.png)

This is not good for blog page which has a Page List block with Date Navigation block.

It's hard for some Japanese users, who with little English skill, to decide URL slug in English.
So they don't change URL slug.
Only the year become the URL slug which caused the 404 error with Date Navigation block.

![image](https://cloud.githubusercontent.com/assets/485751/20183897/40848f94-a7aa-11e6-827c-8b9c044332e1.png)

My solution is to make Page List block to accept filter_by_XXX action.
I've added the multibyte option of Date Navigation block's custom templates.

This may not be a huge deal for many English speakers.

But I can see that this will be a huge problem for Japanese, Chinese, Korean, Thai, Russian and other users who uses Multibyte characters.