### PR TITLE
Community Points

### DIFF
--- a/concrete/single_pages/dashboard/users/points/actions.php
+++ b/concrete/single_pages/dashboard/users/points/actions.php
@@ -10,17 +10,17 @@
     ?>
     <div class="row">
         <div class="col-md-12">
-    
-            <?php 
+
+            <?php
                 echo $form->hidden('upaID', $upaID);
-    ?>               
-        	
+    ?>
+
         	<div class="checkbox">
                 <label>
                     <?=$form->checkbox('upaIsActive', 1, ($upaIsActive == 1 || (!$upaID)))?> <?=t('Enabled')?>
                 </label>
             </div>
-	
+
         	<div class="form-group">
         	    <?=$form->label('upaHandle', t('Action Handle'));
     ?>
@@ -35,7 +35,7 @@
     ?>
         		</div>
         	</div>
-	
+
         	<div class="form-group">
         	    <?=$form->label('upaName', t('Action Name'));
     ?>
@@ -44,7 +44,7 @@
     ?>
         		</div>
         	</div>
-	
+
         	<div class="form-group">
                 <?=$form->label('upaDefaultPoints', t('Default Points'));
     ?>
@@ -53,7 +53,7 @@
     ?>
         		</div>
         	</div>
-	
+
         	<div class="form-group">
         	    <?=$form->label('gBadgeID', t('Badge Associated'));
     ?>
@@ -69,7 +69,7 @@
         $label = t('Update Action');
     }
     ?>
-    
+
             <div class="ccm-dashboard-form-actions-wrapper">
                 <div class="ccm-dashboard-form-actions">
                     <a href="<?=$view->url('/dashboard/users/points/actions')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
@@ -78,14 +78,14 @@
             </div>
         </div>
     </div>
-</form>		
-<?php 
+</form>
+<?php
 } else {
-    ?>	
+    ?>
 	<div class="ccm-dashboard-header-buttons">
 	    <a href="<?=$view->action('add')?>" class="btn btn-primary"><?=t('Add Action')?></a>
 	</div>
-	
+
 	<?php
         if (!$mode) {
             $mode = $_REQUEST['mode'];
@@ -94,59 +94,63 @@
     $keywords = $_REQUEST['keywords'];
 
     if (count($actions) > 0) {
-        ?>	
-			<table border="0" cellspacing="0" cellpadding="0" class="table table-striped">
-    			<tr>
-    				<th><?=t("Active")?></th>
+        ?>
+        <div class="table-responsive">
+			<table class="ccm-search-results-table compact-results">
+    			<thead>
+    				<th><span><?=t("Active")?></span></th>
     				<th class="<?=$actionList->getSearchResultsClass('upaName')?>"><a href="<?=$actionList->getSortByURL('upaName', 'asc')?>"><?=t('Action Name')?></a></th>
     				<th class="<?=$actionList->getSearchResultsClass('upaHandle')?>"><a href="<?=$actionList->getSortByURL('upaHandle', 'asc')?>"><?=t('Action Handle')?></a></th>
     				<th class="<?=$actionList->getSearchResultsClass('upaDefaultPoints')?>"><a href="<?=$actionList->getSortByURL('upaDefaultPoints', 'asc')?>"><?=t('Default Points')?></a></th>
     				<th class="<?=$actionList->getSearchResultsClass('upaBadgeGroupID')?>"><a href="<?=$actionList->getSortByURL('upaBadgeGroupID', 'asc')?>"><?=t('Group')?></a></th>
     				<th></th>
-    			</tr>
-    			
-        		<?php 
-                foreach ($actions as $upa) {
-                    ?>
-        		<tr class="">
-        			<td style="text-align: center"><?php if ($upa['upaIsActive']) {
-    ?><i class="fa fa-check"></i><?php 
-}
-                    ?></td>
-        			<td><?=h($upa['upaName'])?></td>
-        			<td><?=h($upa['upaHandle'])?></td>
-        			<td><?=number_format($upa['upaDefaultPoints'])?></td>
-        			<td><?php echo h($upa['gName']);
-                    ?></td>
-        			<td style="text-align: right">
-                        <?php
-                        $delete_url = \League\Url\Url::createFromUrl($view->action('delete', $upa['upaID']));
-                    $delete_url = $delete_url->setQuery(array(
-                            'ccm_token' => \Core::make('helper/validation/token')->generate('delete_action'),
-                        ));
-                    ?>
-        			    <a href="<?=$view->action($upa['upaID'])?>" class="btn btn-sm btn-default"><?=t('Edit')?></a>
-        			    <a href="<?=$delete_url?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
-        			</td>
-        		</tr>
-        		<?php 
-                }
-        ?>
-		</table>
-		<?php 
+    			</thead>
+
+                <tbody>
+            		<?php
+                    foreach ($actions as $upa) {
+                        ?>
+            		<tr class="">
+            			<td style="text-align: center"><?php if ($upa['upaIsActive']) {
+        ?><i class="fa fa-check"></i><?php
+    }
+                        ?></td>
+            			<td><?=h($upa['upaName'])?></td>
+            			<td><?=h($upa['upaHandle'])?></td>
+            			<td><?=number_format($upa['upaDefaultPoints'])?></td>
+            			<td><?php echo h($upa['gName']);
+                        ?></td>
+            			<td style="text-align: right">
+                            <?php
+                            $delete_url = \League\Url\Url::createFromUrl($view->action('delete', $upa['upaID']));
+                        $delete_url = $delete_url->setQuery(array(
+                                'ccm_token' => \Core::make('helper/validation/token')->generate('delete_action'),
+                            ));
+                        ?>
+            			    <a href="<?=$view->action($upa['upaID'])?>" class="btn btn-sm btn-default"><?=t('Edit')?></a>
+            			    <a href="<?=$delete_url?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
+            			</td>
+            		</tr>
+            		<?php
+                    }
+            ?>
+                </tbody>
+    		</table>
+        </div>
+		<?php
     } else {
         ?>
 			<p><?=t('No Actions found.')?></p>
-		<?php 
+		<?php
     }
     ?>
-	
+
 <div class="ccm-pane-footer">
 <?=$actionList->displayPagingV2();
     ?>
 </div>
 
-<?php 
+<?php
 } ?>
 
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>

--- a/concrete/single_pages/dashboard/users/points/view.php
+++ b/concrete/single_pages/dashboard/users/points/view.php
@@ -7,69 +7,75 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
     <div class="ccm-dashboard-header-buttons">
 	    <a href="<?=View::url('/dashboard/users/points/assign')?>" class="btn btn-primary"><?=t('Add Points')?></a>
 	</div>
-	
+
     <div class="ccm-pane-options">
         <div class="ccm-pane-options-permanent-search">
             <?=$form->label('uName', t('User'))?>
             <?php echo $form_user_selector->quickSelect('uName', $_GET['uName'], array('form-control'));?>
-            <input type="submit" value="<?=t('Search')?>" class="btn" />
-
-
         </div>
     </div>
+
+    <div class="clearfix" style="margin-top: 30px;">
+        <input type="submit" value="<?=t('Search')?>" class="btn btn-primary pull-right" />
+    </div>
 </form>
-<br />
 <?php
 if (count($entries) > 0) {
-    ?>	
-	<table border="0" cellspacing="0" cellpadding="0" id="ccm-product-list" class="table table-striped">
-	<tr>
-		<th class="<?=$upEntryList->getSearchResultsClass('uName')?>"><a href="<?=$upEntryList->getSortByURL('uName', 'asc')?>"><?=t('User')?></a></th>
-		<th class="<?=$upEntryList->getSearchResultsClass('upaName')?>"><a href="<?=$upEntryList->getSortByURL('upaName', 'asc')?>"><?=t('Action')?></a></th>
-		<th class="<?=$upEntryList->getSearchResultsClass('upPoints')?>"><a href="<?=$upEntryList->getSortByURL('upPoints', 'asc')?>"><?=t('Points')?></a></th>
-		<th class="<?=$upEntryList->getSearchResultsClass('timestamp')?>"><a href="<?=$upEntryList->getSortByURL('timestamp', 'asc')?>"><?=t('Date Assigned')?></a></th>
-		<th><?=t("Details")?></th>
-		<th></th>
-	</tr>
-    <?php 
-    foreach ($entries as $up) {
-        ?>
-    	<tr>
-    		<?php
-                $ui = $up->getUserPointEntryUserObject();
-        $action = $up->getUserPointEntryActionObject();
-        ?>
-    		<td><?php if (is_object($ui)) {
-    ?><?php echo h($ui->getUserName())?><?php 
-}
-        ?></td>
-    		<td><?php if (is_object($action)) {
-    ?><?=h($action->getUserPointActionName())?><?php 
-}
-        ?></td>
-    		<td><?php echo number_format($up->getUserPointEntryValue())?></td>
-    		<td><?php echo $dh->formatDateTime($up->getUserPointEntryTimestamp());
-        ?></td>
-    		<td><?=h($up->getUserPointEntryDescription())?></td>
-    		<td style="Text-align: right">
-                <?php
-                $delete = \Concrete\Core\Url\Url::createFromUrl($view->action('deleteEntry', $up->getUserPointEntryID()));
-
-        $delete->setQuery(array(
-                    'ccm_token' => \Core::make('helper/validation/token')->generate('delete_community_points'),
-                ));
-        ?>
-    		    <a href="<?=$delete?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
-    		</td>
-    	</tr>
-    <?php 
-    }
     ?>
-</table>
-<?php 
+<br>
+<div class="table-responsive">
+	<table id="ccm-product-list" class="ccm-search-results-table compact-results">
+    	<thead>
+    		<th class="<?=$upEntryList->getSearchResultsClass('uName')?>"><a href="<?=$upEntryList->getSortByURL('uName', 'asc')?>"><?=t('User')?></a></th>
+    		<th class="<?=$upEntryList->getSearchResultsClass('upaName')?>"><a href="<?=$upEntryList->getSortByURL('upaName', 'asc')?>"><?=t('Action')?></a></th>
+    		<th class="<?=$upEntryList->getSearchResultsClass('upPoints')?>"><a href="<?=$upEntryList->getSortByURL('upPoints', 'asc')?>"><?=t('Points')?></a></th>
+    		<th class="<?=$upEntryList->getSearchResultsClass('timestamp')?>"><a href="<?=$upEntryList->getSortByURL('timestamp', 'asc')?>"><?=t('Date Assigned')?></a></th>
+    		<th><span><?=t("Details")?></span></th>
+    		<th></th>
+    	</thead>
+
+        <tbody>
+        <?php
+        foreach ($entries as $up) {
+            ?>
+        	<tr>
+        		<?php
+                    $ui = $up->getUserPointEntryUserObject();
+            $action = $up->getUserPointEntryActionObject();
+            ?>
+        		<td><?php if (is_object($ui)) {
+        ?><?php echo h($ui->getUserName())?><?php
+    }
+            ?></td>
+        		<td><?php if (is_object($action)) {
+        ?><?=h($action->getUserPointActionName())?><?php
+    }
+            ?></td>
+        		<td><?php echo number_format($up->getUserPointEntryValue())?></td>
+        		<td><?php echo $dh->formatDateTime($up->getUserPointEntryTimestamp());
+            ?></td>
+        		<td><?=h($up->getUserPointEntryDescription())?></td>
+        		<td style="Text-align: right">
+                    <?php
+                    $delete = \Concrete\Core\Url\Url::createFromUrl($view->action('deleteEntry', $up->getUserPointEntryID()));
+
+            $delete->setQuery(array(
+                        'ccm_token' => \Core::make('helper/validation/token')->generate('delete_community_points'),
+                    ));
+            ?>
+        		    <a href="<?=$delete?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
+        		</td>
+        	</tr>
+        <?php
+        }
+        ?>
+        </tbody>
+    </table>
+</div>
+<?php
 } else {
     ?>
 	<div id="ccm-list-none"><?=t('No entries found.')?></div>
-<?php 
+<?php
 }
 $upEntryList->displayPaging(); ?>


### PR DESCRIPTION
This pull request:
- wraps the results tables in div.table-responsive
- switches to the ccm-search-results-table.compact-results class from the table-striped class
- adds missing span, thead, and tbody tags
- add the btn-primary class to the Search button and positions it to the right

The "ccm-search-results-table" class adds the ascending/descending sorting column arrows.

This pull request uses the new "compact-results" class and depends on https://github.com/concrete5/concrete5/pull/4912 being accepted.

**Current:**

![community_points-current1](https://cloud.githubusercontent.com/assets/10898145/21539428/dc6571fe-cd74-11e6-8a39-2fbebbb2f0cb.png)

![community_points-current2](https://cloud.githubusercontent.com/assets/10898145/21539430/dfe81f48-cd74-11e6-913f-e1cb6ed4d309.png)

**Changes:**

![community_points-changes1](https://cloud.githubusercontent.com/assets/10898145/21539438/ec65f4ca-cd74-11e6-999d-51a9186b90e9.png)

![community_points-changes2](https://cloud.githubusercontent.com/assets/10898145/21539439/efdb86a6-cd74-11e6-8f77-87a268c74f4c.png)