### PR TITLE
Fixing Adding Stack message (reported by @hayaka26)

### DIFF
--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -62,7 +62,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                      data-has-add-template="no"
                      data-supports-inline-add="no"
                      data-btID="0"
-                     data-dragging-avatar="<p><img src='<?=DIR_REL?>/concrete/images/stack.png' /><span>' . t('Stack') . '</span></p>"
+                     data-dragging-avatar="<p><img src='<?=DIR_REL?>/concrete/images/stack.png' /><span><?= t('Stack')?>'</span></p>"
             data-block-id="<?= intval($stack->getCollectionID()) ?>">
                     <div class="stack-name">
                         <span class="handle"><?= htmlspecialchars($stack->getStackName()) ?></span>


### PR DESCRIPTION
When adding a stack block (drag a stack onto an area), you will see stack icon.

That Stack icon message was not properly wrap with t().

![fixing-t](https://cloud.githubusercontent.com/assets/485751/21545123/4a223972-ce18-11e6-8145-b6b683cc3b7a.png)

Here is the fix.

This bug is reported by @hayaka26