### PR TITLE
Page Attribute Display block - add delimiter option to topics

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -77,7 +77,7 @@ class Controller extends BlockController
                         ); //<-- set these 2 numbers to max width and height of thumbnails
                         $content = "<img src=\"{$thumb->src}\" width=\"{$thumb->width}\" height=\"{$thumb->height}\" alt=\"\" />";
                     } else {
-                        $image = Core::make('html/image', array($content));
+                        $image = Core::make('html/image', [$content]);
                         $content = (string) $image->getTag();
                     }
                 } elseif (is_object($content_alt)) {
@@ -97,9 +97,9 @@ class Controller extends BlockController
             $content = $this->getPlaceHolderText($this->attributeHandle);
         }
 
-        if(!empty($this->delimiter)) {
+        if (!empty($this->delimiter)) {
             $parts = explode("\n", $content);
-            if(count($parts)>1){
+            if (count($parts) > 1) {
                 switch ($this->delimiter) {
                     case 'comma':
                         $delimiter = ',';
@@ -167,13 +167,13 @@ class Controller extends BlockController
 
     public function getAvailablePageValues()
     {
-        return array(
+        return [
             'rpv_pageName' => t('Page Name'),
             'rpv_pageDescription' => t('Page Description'),
             'rpv_pageDateCreated' => t('Page Date Created'),
             'rpv_pageDatePublic' => t('Page Date Published'),
             'rpv_pageDateLastModified' => t('Page Date Modified'),
-        );
+        ];
     }
 
     public function getAvailableAttributes()
@@ -235,7 +235,7 @@ class Controller extends BlockController
     public function view()
     {
         $templateHandle = $this->getTemplateHandle();
-        if (in_array($templateHandle, array('date_time', 'boolean'))) {
+        if (in_array($templateHandle, ['date_time', 'boolean'])) {
             $this->render('templates/' . $templateHandle);
         }
     }

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -80,11 +80,14 @@ class Controller extends BlockController
                         $image = Core::make('html/image', array($content));
                         $content = (string) $image->getTag();
                     }
-                } else if ($content instanceof SelectValue) {
-                    // so stupid. This entire block should be done in a better way.
-                    // we pass our $content object down below so it can be spit.
-                } else if (is_object($content_alt)) {
-                    $content = $content_alt->getDisplayValue();
+                } elseif (is_object($content_alt)) {
+                    if (is_array($content) && $content[0] instanceof \Concrete\Core\Tree\Node\Type\Topic) {
+                        $content = str_replace(', ', "\n", $content_alt->getDisplayValue());
+                    } elseif ($content instanceof SelectValue) {
+                        $content = (string) $content;
+                    } else {
+                        $content = $content_alt->getDisplayValue();
+                    }
                 }
                 break;
         }
@@ -93,7 +96,7 @@ class Controller extends BlockController
         if (!strlen(trim(strip_tags($content))) && ($c->isMasterCollection() || $is_stack)) {
             $content = $this->getPlaceHolderText($this->attributeHandle);
         }
-        
+
         if(!empty($this->delimiter)) {
             $parts = explode("\n", $content);
             if(count($parts)>1){


### PR DESCRIPTION
Currently, delimiters are not applied to topics. They are displayed with comma space separation.

This pull request "normalizes" them so that a delimiter can be applied.