### PR TITLE
Add --env option to all cli commands

### DIFF
--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -14,6 +14,7 @@ class ClearCacheCommand extends Command
         $this
             ->setName('c5:clear-cache')
             ->setDescription('Clear the concrete5 cache')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -17,7 +17,9 @@ class CompareSchemaCommand extends Command
     {
         $this
             ->setName('c5:compare-schema')
-            ->setDescription('Compares db.xml in concrete5 XML schema, concrete5 entities, and all installed package schemas and entities with the contents of the database and prints the difference.');
+            ->setDescription('Compares db.xml in concrete5 XML schema, concrete5 entities, and all installed package schemas and entities with the contents of the database and prints the difference.')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -33,6 +33,7 @@ class ConfigCommand extends Command
             ->addArgument('item', InputArgument::REQUIRED, 'The configuration item (eg: concrete.debug.display_errors)')
             ->addArgument('value', InputArgument::OPTIONAL, 'The new value of the configuration item')
             ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->addOption('generated-overrides', 'g', InputOption::VALUE_NONE, 'Set this option to save configurations to the generated_overrides folder')
         ;
         $this->setHelp(<<<EOT

--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -16,6 +16,7 @@ class ExecCommand extends Command
             ->setDescription('Execute a PHP script within the concrete5 environment')
             ->addArgument('script', InputArgument::REQUIRED, 'The path of the script to be executed')
             ->addArgument('arguments', InputArgument::IS_ARRAY, 'The arguments to pass to the script')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
         ->setHelp(<<<EOT
 In the included script you'll have these variables:
 - \$input: an instance of \Symfony\Component\Console\Input\InputInterface

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -18,6 +18,7 @@ class GenerateIDESymbolsCommand extends Command
             ->setName('c5:ide-symbols')
             ->setDescription('Generate IDE symbols')
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', array('all'))
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -15,6 +15,7 @@ class InfoCommand extends Command
         $this
             ->setName('c5:info')
             ->setDescription('Get server and concrete5 detailed informations.')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -44,6 +44,7 @@ class InstallCommand extends Command
             ->addOption('attach', null, InputOption::VALUE_NONE, 'Attach if database contains an existing concrete5 instance')
             ->addOption('force-attach', null, InputOption::VALUE_NONE, 'Always attach')
             ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Install using interactive (wizard) mode')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -20,6 +20,7 @@ class InstallPackageCommand extends Command
             ->setDescription('Install a concrete5 package')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -21,6 +21,7 @@ class JobCommand extends Command
             ->setDescription(t('Run a concrete5 job'))
             ->addOption('set', null, InputOption::VALUE_NONE, t('Find jobs by set instead of job handle'))
             ->addOption('list', null, InputOption::VALUE_NONE, t('List available jobs'))
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->addArgument(
                 'jobs',
                 InputArgument::IS_ARRAY,

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -46,6 +46,7 @@ final class PackPackageCommand extends Command
             ->addOption('keep', 'k', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Which files should be stored in the zip archive ['.static::KEEP_DOT.'|'.static::KEEP_SOURCES.']')
             ->addOption('update-source-directory', 'u', InputOption::VALUE_NONE, 'Update the files of the source directory (otherwise it remains untouched)')
             ->addOption('zip', 'z', InputOption::VALUE_OPTIONAL, 'Create a zip archive of the package (and optionally set its path)', static::ZIPOUT_AUTO)
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 You have to specify at least the -z option (to create a zip file) and/or the -u option (to update the package directory).
 

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -18,6 +18,7 @@ class ResetCommand extends Command
             ->setName('c5:reset')
             ->setDescription('Reset the concrete5 installation, deleting files and emptying the database')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/ServiceCommand.php
+++ b/concrete/src/Console/Command/ServiceCommand.php
@@ -59,6 +59,7 @@ EOT
             ->addArgument('service', InputArgument::REQUIRED, 'The web server to use ('.implode('|', $serviceHandles).')')
             ->addArgument('operation', InputArgument::REQUIRED, 'The operation to perform (check|update)')
             ->addArgument('rule-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the rules (example: foo=bar baz=foo)')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(trim($help))
         ;
     }

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -23,6 +23,7 @@ class TranslatePackageCommand extends Command
             ->addOption('contact', 'c', InputOption::VALUE_REQUIRED, 'Contact information to be put in the language files to report bugs to (eg the "Report-Msgid-Bugs-To" gettext header)', '')
             ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')
             ->addOption('exclude-3rdparty', 'x', InputOption::VALUE_NONE, 'Specify this option to avoid parsing 3rd party folders')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setDescription('Creates or updates translations of a concrete5 package')
             ->setHelp(<<<EOT
 If the locale option(s) is not specified, we'll generate/update translations for the currently defined locales for the package.

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -18,6 +18,7 @@ class UninstallPackageCommand extends Command
             ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')
             ->setDescription('Uninstall a concrete5 package')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -21,6 +21,7 @@ class UpdateCommand extends Command
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the update')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -18,6 +18,7 @@ class UpdatePackageCommand extends Command
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the installed packages')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')
             ->addArgument('packages', InputArgument::IS_ARRAY, 'The handle of the package to be updated (multiple values allowed)')
+            ->addOption('env', null, InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->setDescription('Update a concrete5 package')
             ->setHelp(<<<EOT
 Returns codes:


### PR DESCRIPTION
In cli, it is enable to specify environment with `--env` argument.
See: `\Concrete\Core\Foundation\EnvironmentDetector::detectConsoleEnvironment`

However, we can't add `--env` option because of "Too many arguments" error. We can avoid it with this pull request.