### PR TITLE
filterByPath fix

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -182,7 +182,7 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
         // StackList (which extends PageList) needs to have it available.
         $query->setParameter('siteTreeID', $tree->getSiteTreeID());
 
-        if ($this->query->getParameter('cParentID') < 1) {
+        if (($this->query->getParameter('cParentID') < 1) && ($this->query->getParameter('cPath') == '')) {
 
             if (!$this->includeSystemPages) {
                 $query->andWhere('p.siteTreeID = :siteTreeID');


### PR DESCRIPTION
Add a condition in case filterByPath used. Otherwise filterByPath returns no rows