### PR TITLE
Re: Fix: unable to install in locale != en_US

### DIFF
--- a/concrete/config/install/base/gathering.xml
+++ b/concrete/config/install/base/gathering.xml
@@ -140,12 +140,12 @@
     <permissionkeys>
         <permissionkey handle="edit_gatherings" name="Edit Gatherings" description="Can edit the footprint and items in all gatherings." package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
         <permissionkey handle="edit_gathering_items" name="Edit Gathering Items" description="" package="" category="gathering">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
     </permissionkeys>

--- a/concrete/config/install/base/permissions.xml
+++ b/concrete/config/install/base/permissions.xml
@@ -51,12 +51,12 @@
         <!-- block types //-->
         <permissionkey handle="add_block" has-custom-class="true" name="Add Block" description="Can add a block to any area on the site. If someone is added here they can add blocks to any area (unless that area has permissions that override these global permissions.)" package="" category="block_type">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
         <permissionkey handle="add_stack" name="Add Stack" package="" description="Can add a stack or block from a stack to any area on the site. If someone is added here they can add stacks to any area (unless that area has permissions that override these global permissions.)" category="block_type">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
@@ -134,19 +134,19 @@
         <!-- users //-->
         <permissionkey handle="edit_user_properties" has-custom-class="true" name="Edit User Details" package="" category="user">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="view_user_attributes" has-custom-class="true" name="View User Attributes" package="" category="user">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="activate_user" name="Activate/Deactivate User" package="" category="user" can-trigger-workflow="true">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
@@ -155,19 +155,19 @@
 
         <permissionkey handle="upgrade" name="Upgrade concrete5" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="access_group_search" name="Access Group Search" package="" category="user">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="delete_user" name="Delete User" package="" category="user" can-trigger-workflow="true">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
@@ -205,7 +205,7 @@
 
         <permissionkey handle="access_page_type_permissions" name="Access Page Type Permissions" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
@@ -214,79 +214,79 @@
 
         <permissionkey handle="access_sitemap" name="Access Sitemap" package="" category="sitemap">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="access_page_defaults" name="Access Page Type Defaults" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="customize_themes" name="Customize Themes" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="manage_layout_presets" name="Manage Layout Presets" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="empty_trash" name="Empty Trash" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="add_topic_tree" name="Add Topic Tree" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="remove_topic_tree" name="Remove Topic Tree" package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="view_in_maintenance_mode" name="View Site in Maintenance Mode" description="Ability to see and use the website when concrete5 is in maintenance mode." package="" category="admin">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="uninstall_packages" name="Uninstall Packages" package="" category="marketplace_newsflow">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="install_packages" name="Install Packages" package="" category="marketplace_newsflow">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="view_newsflow" name="View Newsflow" package="" category="marketplace_newsflow">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="access_user_search_export" name="Export Site Users" description="Controls whether a user can export site users or not" package="" category="user">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 
         <permissionkey handle="access_user_search" name="Access User Search" description="Controls whether a user can view the search user interface." package="" category="user">
             <access>
-                <group name="Administrators"/>
+                <group name="Administrators" description=""/>
             </access>
         </permissionkey>
 

--- a/concrete/controllers/single_page/dashboard/users/points/assign.php
+++ b/concrete/controllers/single_page/dashboard/users/points/assign.php
@@ -101,7 +101,7 @@ class Assign extends DashboardPageController
         $userPointActions = $upal->get(0);
         if (is_array($userPointActions) && count($userPointActions)) {
             foreach ($userPointActions as $upa) {
-                $res[$upa['upaID']] = h($upa['upaDefaultPoints']." - ".$upa['upaName']);
+                $res[$upa['upaID']] = h($upa['upaDefaultPoints']." - ".t($upa['upaName']));
             }
         }
 

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPermissionsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPermissionsRoutine.php
@@ -39,7 +39,7 @@ class ImportPermissionsRoutine extends AbstractRoutine
                              */
                             $g = Group::getByName($ch['name']);
                             if (!is_object($g)) {
-                                $g = Group::add($g['name'], $g['description']);
+                                $g = Group::add($ch['name'], $ch['description']);
                             }
                             $pae = GroupEntity::getOrCreate($g);
                             $assignments[] = $pae;

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -250,10 +250,10 @@ class StartingPointPackage extends BasePackage
 
     public function import_files()
     {
-        $type = \Concrete\Core\File\StorageLocation\Type\Type::add('default', t('Default'));
-        \Concrete\Core\File\StorageLocation\Type\Type::add('local', t('Local'));
+        $type = \Concrete\Core\File\StorageLocation\Type\Type::add('default', 'Default');
+        \Concrete\Core\File\StorageLocation\Type\Type::add('local', 'Local');
         $configuration = $type->getConfigurationObject();
-        $fsl = \Concrete\Core\File\StorageLocation\StorageLocation::add($configuration, t('Default'), true);
+        $fsl = \Concrete\Core\File\StorageLocation\StorageLocation::add($configuration, 'Default', true);
 
         $filesystem = new Filesystem();
         $tree = $filesystem->create();
@@ -261,7 +261,7 @@ class StartingPointPackage extends BasePackage
 
         $thumbnailType = new \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type();
         $thumbnailType->requireType();
-        $thumbnailType->setName(tc('ThumbnailTypeName', 'File Manager Thumbnails'));
+        $thumbnailType->setName('File Manager Thumbnails');
         $thumbnailType->setHandle(Config::get('concrete.icons.file_manager_listing.handle'));
         $thumbnailType->setWidth(Config::get('concrete.icons.file_manager_listing.width'));
         $thumbnailType->setHeight(Config::get('concrete.icons.file_manager_listing.height'));
@@ -269,7 +269,7 @@ class StartingPointPackage extends BasePackage
 
         $thumbnailType = new \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type();
         $thumbnailType->requireType();
-        $thumbnailType->setName(tc('ThumbnailTypeName', 'File Manager Detail Thumbnails'));
+        $thumbnailType->setName('File Manager Detail Thumbnails');
         $thumbnailType->setHandle(Config::get('concrete.icons.file_manager_detail.handle'));
         $thumbnailType->setWidth(Config::get('concrete.icons.file_manager_detail.width'));
         $thumbnailType->save();
@@ -372,18 +372,18 @@ class StartingPointPackage extends BasePackage
         // create the groups our site users
         // specify the ID's since auto increment may not always be +1
         $g1 = Group::add(
-            tc("GroupName", "Guest"),
-            tc("GroupDescription", "The guest group represents unregistered visitors to your site."),
+            "Guest",
+            "The guest group represents unregistered visitors to your site.",
             false,
             false,
             GUEST_GROUP_ID);
         $g2 = Group::add(
-            tc("GroupName", "Registered Users"),
-            tc("GroupDescription", "The registered users group represents all user accounts."),
+            "Registered Users",
+            "The registered users group represents all user accounts.",
             false,
             false,
             REGISTERED_GROUP_ID);
-        $g3 = Group::add(tc("GroupName", "Administrators"), "", false, false, ADMIN_GROUP_ID);
+        $g3 = Group::add("Administrators", "", false, false, ADMIN_GROUP_ID);
 
         // insert admin user into the user table
         if (defined('INSTALL_USER_PASSWORD')) {
@@ -400,7 +400,7 @@ class StartingPointPackage extends BasePackage
         $u = User::getByUserID(USER_SUPER_ID, true, false);
 
         MailImporter::add(['miHandle' => 'private_message']);
-        UserPointAction::add('won_badge', t('Won a Badge'), 5, false, true);
+        UserPointAction::add('won_badge', 'Won a Badge', 5, false, true);
 
         // Install conversation default email
         \Conversation::setDefaultSubscribedUsers([$superuser]);


### PR DESCRIPTION
Re-fixing #4933

@mlocati I think we should add below translation texts to transifix. How can we do it? These are not exists in any source code.

* "Default" of file storage location
* "Local" of file storage location type