### PR TITLE
Move file thumbnails when moving the original file

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Entity\File;
 
 use Carbon\Carbon;
@@ -16,7 +17,6 @@ use Concrete\Core\File\Importer;
 use Concrete\Core\File\Menu;
 use Concrete\Core\File\Type\TypeList as FileTypeList;
 use Concrete\Core\Http\FlysystemFileResponse;
-use Doctrine\Common\Collections\ArrayCollection;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FileNotFoundException;
 use Core;
@@ -180,7 +180,7 @@ class Version
 
     public static function cleanTags($tagsStr)
     {
-        $tagsArray = explode("\n", str_replace(["\r", ","], "\n", $tagsStr));
+        $tagsArray = explode("\n", str_replace(["\r", ','], "\n", $tagsStr));
         $cleanTags = [];
         foreach ($tagsArray as $tag) {
             if (!strlen(trim($tag))) {
@@ -189,7 +189,7 @@ class Version
             $cleanTags[] = trim($tag);
         }
         //the leading and trailing line break char is for searching: fvTag like %\ntag\n%
-        return "\n" . implode("\n", $cleanTags) . "\n";
+        return "\n".implode("\n", $cleanTags)."\n";
     }
 
     public function setFilename($filename)
@@ -268,7 +268,7 @@ class Version
             $category->deleteValue($attribute);
         }
 
-        $db->Execute("DELETE FROM FileVersionLog WHERE fID = ? AND fvID = ?", [$this->getFileID(), $this->fvID]);
+        $db->Execute('DELETE FROM FileVersionLog WHERE fID = ? AND fvID = ?', [$this->getFileID(), $this->fvID]);
 
         $types = Type::getVersionList();
 
@@ -307,25 +307,27 @@ class Version
         }
     }
 
-	/**
-	 * Move the thumbnails for the current file version to a new storage location
-	 *
-	 * @param string $type
-	 * @param StorageLocation $location
-	 */
-    public function updateThumbnailStorageLocation($type, StorageLocation $location) {
-	    if (!($type instanceof ThumbnailTypeVersion)) {
-		    $type = ThumbnailTypeVersion::getByHandle($type);
-	    }
-	    $fsl = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
-	    $path = $type->getFilePath($this);
-	    $manager = new \League\Flysystem\MountManager([
-		    'current' => $fsl,
-		    'new' => $location->getFileSystemObject(),
-	    ]);
-	    try {
-		    $manager->move('current://' . $path, 'new://' . $path);
-	    } catch (FileNotFoundException $e) {}
+    /**
+     * Move the thumbnails for the current file version to a new storage location.
+     *
+     * @param string          $type
+     * @param StorageLocation $location
+     */
+    public function updateThumbnailStorageLocation($type, StorageLocation $location)
+    {
+        if (!($type instanceof ThumbnailTypeVersion)) {
+            $type = ThumbnailTypeVersion::getByHandle($type);
+        }
+        $fsl = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+        $path = $type->getFilePath($this);
+        $manager = new \League\Flysystem\MountManager([
+            'current' => $fsl,
+            'new' => $location->getFileSystemObject(),
+        ]);
+        try {
+            $manager->move('current://'.$path, 'new://'.$path);
+        } catch (FileNotFoundException $e) {
+        }
     }
 
     /**
@@ -523,7 +525,7 @@ class Version
                     break;
                 case self::UT_EXTENDED_ATTRIBUTE:
                     $val = $db->GetOne(
-                        "SELECT akName FROM AttributeKeys WHERE akID = ?",
+                        'SELECT akName FROM AttributeKeys WHERE akID = ?',
                         [$a['fvUpdateTypeAttributeID']]
                     );
                     if ($val != '') {
@@ -673,7 +675,7 @@ class Version
         $fo = $this->getFile();
         $fo->reindex();
 
-        \Core::make('cache/request')->delete('file/version/approved/' . $this->getFileID());
+        \Core::make('cache/request')->delete('file/version/approved/'.$this->getFileID());
     }
 
     /**
@@ -951,7 +953,7 @@ class Version
             $baseSrc = $this->getThumbnailURL($type->getBaseVersion());
             $doubledSrc = $this->getThumbnailURL($type->getDoubledVersion());
 
-            return '<img src="' . $baseSrc . '" data-at2x="' . $doubledSrc . '" />';
+            return '<img src="'.$baseSrc.'" data-at2x="'.$doubledSrc.'" />';
         } else {
             return $this->getTypeObject()->getThumbnail();
         }

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -307,6 +307,12 @@ class Version
         }
     }
 
+	/**
+	 * Move the thumbnails for the current file version to a new storage location
+	 *
+	 * @param string $type
+	 * @param StorageLocation $location
+	 */
     public function updateThumbnailStorageLocation($type, StorageLocation $location) {
 	    if (!($type instanceof ThumbnailTypeVersion)) {
 		    $type = ThumbnailTypeVersion::getByHandle($type);

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -6,6 +6,7 @@ use Concrete\Core\Attribute\Key\FileKey;
 use Concrete\Core\Attribute\ObjectTrait;
 use Concrete\Core\Entity\Attribute\Value\FileValue;
 use Concrete\Core\Entity\Attribute\Value\Value\Value;
+use Concrete\Core\Entity\File\StorageLocation\StorageLocation;
 use Concrete\Core\File\Exception\InvalidDimensionException;
 use Concrete\Core\File\Image\Thumbnail\Path\Resolver;
 use Concrete\Core\File\Image\Thumbnail\Thumbnail;
@@ -304,6 +305,21 @@ class Version
         if ($fsl->has($path)) {
             $fsl->delete($path);
         }
+    }
+
+    public function updateThumbnailStorageLocation($type, StorageLocation $location) {
+	    if (!($type instanceof ThumbnailTypeVersion)) {
+		    $type = ThumbnailTypeVersion::getByHandle($type);
+	    }
+	    $fsl = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+	    $path = $type->getFilePath($this);
+	    $manager = new \League\Flysystem\MountManager([
+		    'current' => $fsl,
+		    'new' => $location->getFileSystemObject(),
+	    ]);
+	    try {
+		    $manager->move('current://' . $path, 'new://' . $path);
+	    } catch (FileNotFoundException $e) {}
     }
 
     /**


### PR DESCRIPTION
When moving a file to a new storage location, the thumbnails would be left behind in the previous storage location, but all links in the front end (and file manager) would point to the new storage location which would 404.

I also updated the move code to use flysystem's actual move functionality (which should reduce memory use as it will stream the files)

Before:
Move file to new storage location
All thumbnails 404

After:
All thumbnails work!

Testing:

1. Selected a file in the file manager
2. Permissions->Storage Location->S3
3. Refresh page
  -Thumbnail shows in file list
5. Click on Thumbnails
 -Thumbnails populated