### PR TITLE
Fix localization issue with Punic

### DIFF
--- a/concrete/src/Localization/Localization.php
+++ b/concrete/src/Localization/Localization.php
@@ -145,7 +145,8 @@ class Localization
     public function popActiveContext()
     {
         if (!empty($this->activeContextQueue)) {
-            $this->activeContext = array_pop($this->activeContextQueue);
+            $oldContext = array_pop($this->activeContextQueue);
+            $this->setActiveContext($oldContext);
         }
     }
 


### PR DESCRIPTION
This fixes and issue where Punic's locale was set incorrectly in case the active context was reverted back using the `popActiveContext()` method. In this situation, the Punic's locale was left to the previous locale set when `pushActiveContext()` got called. This caused the Punic translated site context's translations to be incorrect.

A visible occurrence of this issue was e.g. the `date_navigation` block where the month names should be translated according to the site's context.