### PR TITLE
Use the resolver to track cache thumbnails

### DIFF
--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -5,6 +5,7 @@ use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Entity\File\StorageLocation\StorageLocation;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailerInterface;
+use Concrete\Core\File\Image\Thumbnail\Type\CustomThumbnail;
 use Concrete\Core\File\StorageLocation\Configuration\DefaultConfiguration;
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
 use Doctrine\ORM\EntityManager;
@@ -275,30 +276,34 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
 
         $abspath = '/cache/' . $filename;
 
-        $src = $configuration->getPublicURLToFile($abspath);
+        if ($obj instanceof File) {
+	        $customThumb = new CustomThumbnail($maxWidth, $maxHeight, $abspath, false);
 
-        /* Attempt to create the image */
-        if (!$filesystem->has($abspath)) {
-            try {
-                if ($obj instanceof File && $fr->exists()) {
-                    $image = Image::load($fr->read());
-                } else {
-                    $image = Image::open($obj);
+	        $path_resolver = $this->app->make('Concrete\Core\File\Image\Thumbnail\Path\Resolver');
+	        $path_resolver->getPath($obj->getVersion(), $customThumb);
+        } else { // @TODO This is a path or url and doesn't have a file object, so we just make the thumbnail now...
+	        if (!$filesystem->has($abspath)) {
+	            try {
+                    $image = \Image::open($obj);
+                    // create image there
+                    $this->create($image,
+                        $abspath,
+                        $maxWidth,
+                        $maxHeight,
+                        $crop,
+                        $thumbnailsFormat);
+                } catch (\Exception $e) {
+	                $abspath = false;
                 }
-                // create image there
-                $this->create($image,
-                    $abspath,
-                    $maxWidth,
-                    $maxHeight,
-                    $crop,
-                    $thumbnailsFormat
-                );
-            } catch (\Exception $e) {
-                $src = '';
-            }
+	        }
         }
 
-        $thumb = new stdClass();
+        $src = '';
+        if ($abspath) {
+            $src = $configuration->getPublicURLToFile($abspath);
+        }
+
+	    $thumb = new \stdClass();
         $thumb->src = $src;
 
         // this is a hack, but we shouldn't go out on the network if we don't have to. We should probably

--- a/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
+++ b/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
@@ -15,6 +15,7 @@ class CustomThumbnail extends ThumbnailVersion
      * @param int $width
      * @param int $height
      * @param string $path The full path to the file (whether it exists or not)
+     * @param bool $cropped
      */
     public function __construct($width, $height, $path, $cropped)
     {

--- a/concrete/src/Http/Middleware/ThumbnailMiddleware.php
+++ b/concrete/src/Http/Middleware/ThumbnailMiddleware.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Http\Middleware;
 
 use Concrete\Core\Application\ApplicationAwareInterface;
@@ -109,7 +108,7 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
     }
 
     /**
-     * Try building an unbuilt thumbnail
+     * Try building an unbuilt thumbnail.
      *
      * @param \Concrete\Core\Entity\File\File $file
      * @param array                           $thumbnail
@@ -258,7 +257,7 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
     private function failBuild(File $file, $thumbnail)
     {
         $this->app->make(LoggerInterface::class)
-            ->critical('Failed to generate or locate the thumbnail for file "'.$file->getFileID().'"');
+            ->critical('Failed to generate or locate the thumbnail for file "' . $file->getFileID() . '"');
 
         // Complete the build anyway.
         // Cache must be cleared to remove this and attempt rebuild


### PR DESCRIPTION
Store thumbnail paths for files generated in /cache/

Does not work for files not in the filemanager, so those aren't stored, (there is an `@todo` in there)

tested by using the image block and setting different widths, rows were added and thumbnails generated.

@KorvinSzanto look good to you?