### PR TITLE
Fix localized installation process

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -375,9 +375,6 @@ class Install extends Controller
         $spl = StartingPointPackage::getClass($pkgHandle);
         require DIR_CONFIG_SITE . '/site_install.php';
         @include DIR_CONFIG_SITE . '/site_install_user.php';
-        if (defined('APP_INSTALL_LANGUAGE') && APP_INSTALL_LANGUAGE) {
-            Localization::changeLocale(APP_INSTALL_LANGUAGE);
-        }
         $jsx = $this->app->make('helper/json');
         $js = new stdClass();
 
@@ -385,7 +382,7 @@ class Install extends Controller
             if ($spl === null) {
                 throw new Exception(t('Invalid starting point: %s', $pkgHandle));
             }
-            call_user_func([$spl, $routine]);
+            $spl->executeInstallRoutine($routine);
             $js->error = false;
         } catch (Exception $e) {
             $js->error = true;

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -174,7 +174,7 @@ EOT
                     }
 
                     $output->writeln($r->getProgress() . '%: ' . $r->getText());
-                    call_user_func(array($spl, $r->getMethod()));
+                    $spl->executeInstallRoutine($r->getMethod());
                 }
             } catch (Exception $ex) {
                 $cnt->reset();

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -44,7 +44,7 @@ class InstallCommand extends Command
             ->addOption('attach', null, InputOption::VALUE_NONE, 'Attach if database contains an existing concrete5 instance')
             ->addOption('force-attach', null, InputOption::VALUE_NONE, 'Always attach')
             ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Install using interactive (wizard) mode')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 Returns codes:
   0 operation completed successfully
   1 errors occurred
@@ -91,15 +91,15 @@ EOT
             }
 
             Database::extend('install', function () use ($options) {
-                return Database::getFactory()->createConnection(array(
+                return Database::getFactory()->createConnection([
                     'host' => $options['db-server'],
                     'user' => $options['db-username'],
                     'password' => $options['db-password'],
                     'database' => $options['db-database'],
-                ));
+                ]);
             });
             Database::setDefaultConnection('install');
-            Config::set('database.connections.install', array());
+            Config::set('database.connections.install', []);
 
             $cnt = $app->make(\Concrete\Controller\Install::class);
 
@@ -188,11 +188,11 @@ EOT
                 ($options['demo-username'] !== '') && ($options['demo-password'] !== '') && ($options['demo-email'] !== '')
             ) {
                 $output->write('Adding demo user... ');
-                \UserInfo::add(array(
+                \UserInfo::add([
                     'uName' => $options['demo-username'],
                     'uEmail' => $options['demo-email'],
                     'uPassword' => $options['demo-password'],
-                ))->getUserObject()->enterGroup(
+                ])->getUserObject()->enterGroup(
                     \Group::getByID(ADMIN_GROUP_ID)
                 );
                 $output->writeln('done.');
@@ -266,9 +266,11 @@ EOT
     }
 
     /**
-     * Do some procedural work to a row in the wizard step list to turn it into a proper question
+     * Do some procedural work to a row in the wizard step list to turn it into a proper question.
+     *
      * @param $row
      * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
      * @return \Symfony\Component\Console\Question\Question
      */
     private function getQuestion($row, InputInterface $input)
@@ -276,7 +278,7 @@ EOT
         $definition = $this->getDefinition();
 
         // Define default values
-        $row = (array)$row;
+        $row = (array) $row;
         $default = null;
         $mutator = null;
 
@@ -319,8 +321,10 @@ EOT
     }
 
     /**
-     * A wizard generator
+     * A wizard generator.
+     *
      * @param $input
+     *
      * @return \Generator|Question[]
      */
     private function getWizard(InputInterface $input)
@@ -329,15 +333,17 @@ EOT
 
         // Loop over the questions, parse them, then yield them out
         foreach ($questions as $question) {
-            $question = (array)$question;
+            $question = (array) $question;
             yield $question[0] => $this->getQuestion($question, $input);
         }
     }
 
     /**
-     * Take an option and return a question string
+     * Take an option and return a question string.
+     *
      * @param \Symfony\Component\Console\Input\InputOption $option
      * @param $default
+     *
      * @return string
      */
     private function getQuestionString(InputOption $option, $default)
@@ -351,7 +357,8 @@ EOT
 
     /**
      * An array of steps
-     * Items: [ "option-name", "default-value", function($question, $input, $option) : $question ]
+     * Items: [ "option-name", "default-value", function($question, $input, $option) : $question ].
+     *
      * @return array
      */
     private function wizardSteps()
@@ -364,7 +371,7 @@ EOT
                 'db-password',
                 function (Question $question, InputInterface $input) {
                     return $question->setHidden(true);
-                }
+                },
             ],
             ['site', 'concrete5'],
             'canonical-url',
@@ -375,7 +382,7 @@ EOT
                 function (Question $question, InputInterface $input) {
                     return new ChoiceQuestion($question->getQuestion(), ['elemental_full', 'elemental_blank'],
                         $question->getDefault());
-                }
+                },
             ],
             'admin-email',
             [
@@ -389,8 +396,9 @@ EOT
 
                         throw new \Exception(implode("\n", $error->getArrayCopy()));
                     });
+
                     return $question->setHidden(true);
-                }
+                },
             ],
             'demo-username',
             'demo-email',
@@ -398,7 +406,7 @@ EOT
                 'demo-password',
                 function (Question $question, InputInterface $input) {
                     return $question->setHidden(true);
-                }
+                },
             ],
             ['language', 'en_US'],
             [
@@ -406,11 +414,11 @@ EOT
                 function (Question $question, InputInterface $input, InputOption $option) {
                     $newDefault = $input->getOption('language');
                     $newQuestion = $this->getQuestionString($option, $newDefault);
+
                     return new Question($newQuestion, $newDefault);
-                }
+                },
             ],
-            ['config', 'none']
+            ['config', 'none'],
         ];
     }
-
 }

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -309,11 +309,11 @@ class StartingPointPackage extends BasePackage
         }
         $installDirectory = DIR_BASE_CORE . '/config';
         try {
-            // Retrieving metadata from the entityManager created with \ORM::entityManager() 
+            // Retrieving metadata from the entityManager created with \ORM::entityManager()
             // will result in a empty metadata array. Because all drivers are wrapped in a driverChain
             // the method getAllMetadata() of Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory
             // is going to return a empty array. To overcome this issue a new EntityManager is create with the
-            // only purpose to be used during the installation. 
+            // only purpose to be used during the installation.
             $config = Setup::createConfiguration(true, \Config::get('database.proxy_classes'));
             \Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('subpackages');
             \Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('package');
@@ -410,11 +410,10 @@ class StartingPointPackage extends BasePackage
 
     public function make_directories()
     {
-
         // Delete generated overrides and doctrine
         $fh = new File();
-        if (is_dir(DIR_CONFIG_SITE.'/generated_overrides')) {
-            $fh->removeAll(DIR_CONFIG_SITE.'/generated_overrides');
+        if (is_dir(DIR_CONFIG_SITE . '/generated_overrides')) {
+            $fh->removeAll(DIR_CONFIG_SITE . '/generated_overrides');
         }
         if (is_dir(Config::get('database.proxy_classes'))) {
             $fh->removeAll(Config::get('database.proxy_classes'));
@@ -674,7 +673,7 @@ class StartingPointPackage extends BasePackage
         $pt->assignPermissionAccess($pa);
 
         try {
-            Core::make('helper/file')->makeExecutable(DIR_BASE_CORE.'/bin/concrete5', 'all');
+            Core::make('helper/file')->makeExecutable(DIR_BASE_CORE . '/bin/concrete5', 'all');
         } catch (\Exception $x) {
         }
     }

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -33,6 +33,9 @@ use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use PermissionKey;
 use User;
 use UserInfo;
+use Localization;
+use Exception;
+use Throwable;
 
 class StartingPointPackage extends BasePackage
 {
@@ -143,12 +146,36 @@ class StartingPointPackage extends BasePackage
         return $this->routines;
     }
 
-    public function add_home_page()
+    /**
+     * @param string $routineName
+     *
+     * @throws Exception
+     * @throws Throwable
+     */
+    public function executeInstallRoutine($routineName)
+    {
+        $localization = Localization::getInstance();
+        $localization->pushActiveContext('system');
+        $error = null;
+        try {
+            $this->$routineName();
+        } catch (Exception $x) {
+            $error = $x;
+        } catch (Throwable $x) {
+            $error = $x;
+        }
+        $localization->popActiveContext();
+        if ($error !== null) {
+            throw $error;
+        }
+    }
+
+    protected function add_home_page()
     {
         Page::addHomePage();
     }
 
-    public function install_data_objects()
+    protected function install_data_objects()
     {
         \Concrete\Core\Tree\Node\NodeType::add('category');
         \Concrete\Core\Tree\Node\NodeType::add('express_entry_category');
@@ -175,7 +202,7 @@ class StartingPointPackage extends BasePackage
         );
     }
 
-    public function install_attributes()
+    protected function install_attributes()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/attributes.xml');
@@ -184,50 +211,44 @@ class StartingPointPackage extends BasePackage
         $topicNodeType = \Concrete\Core\Tree\Node\NodeType::add('topic');
     }
 
-    public function install_dashboard()
+    protected function install_dashboard()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/dashboard.xml');
     }
 
-    public function install_gathering()
+    protected function install_gathering()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/gathering.xml');
     }
 
-    public function install_page_types()
+    protected function install_page_types()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/page_types.xml');
     }
 
-    public function install_page_templates()
-    {
-        $ci = new ContentImporter();
-        $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/page_templates.xml');
-    }
-
-    public function install_required_single_pages()
+    protected function install_required_single_pages()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/global.xml');
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/root.xml');
     }
 
-    public function install_image_editor()
+    protected function install_image_editor()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/image_editor.xml');
     }
 
-    public function install_blocktypes()
+    protected function install_blocktypes()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes.xml');
     }
 
-    public function install_themes()
+    protected function install_themes()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/themes.xml');
@@ -236,19 +257,19 @@ class StartingPointPackage extends BasePackage
         }
     }
 
-    public function install_jobs()
+    protected function install_jobs()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/jobs.xml');
     }
 
-    public function install_config()
+    protected function install_config()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/config.xml');
     }
 
-    public function import_files()
+    protected function import_files()
     {
         $type = \Concrete\Core\File\StorageLocation\Type\Type::add('default', t('Default'));
         \Concrete\Core\File\StorageLocation\Type\Type::add('local', t('Local'));
@@ -284,19 +305,19 @@ class StartingPointPackage extends BasePackage
         }
     }
 
-    public function install_content()
+    protected function install_content()
     {
         $ci = new ContentImporter();
         $ci->importContentFile($this->getPackagePath() . '/content.xml');
     }
 
-    public function install_desktops()
+    protected function install_desktops()
     {
         $desktop = \Page::getByPath('/dashboard/welcome');
         $desktop->movePageDisplayOrderToTop();
     }
 
-    public function install_database()
+    protected function install_database()
     {
         $db = Database::get();
         $num = $db->GetCol("show tables");
@@ -349,7 +370,7 @@ class StartingPointPackage extends BasePackage
         $db->Execute('ALTER TABLE UserBannedIPs ADD UNIQUE INDEX (ipFrom (32), ipTo(32))');
     }
 
-    public function add_users()
+    protected function add_users()
     {
         // Firstly, install the core authentication types
         $cba = AuthenticationType::add('concrete', 'Standard');
@@ -408,7 +429,7 @@ class StartingPointPackage extends BasePackage
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/conversation.xml');
     }
 
-    public function make_directories()
+    protected function make_directories()
     {
         // Delete generated overrides and doctrine
         $fh = new File();
@@ -434,7 +455,7 @@ class StartingPointPackage extends BasePackage
         }
     }
 
-    public function finish()
+    protected function finish()
     {
         $config = \Core::make('config');
         $site_install = $config->getLoader()->load(null, 'site_install');
@@ -476,13 +497,13 @@ class StartingPointPackage extends BasePackage
         Core::make('cache')->flush();
     }
 
-    public function install_permissions()
+    protected function install_permissions()
     {
         $ci = new ContentImporter();
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/permissions.xml');
     }
 
-    public function install_site()
+    protected function install_site()
     {
         \Core::make('site/type')->installDefault();
         $site = \Site::installDefault(SITE_INSTALL_LOCALE);
@@ -496,7 +517,7 @@ class StartingPointPackage extends BasePackage
         Config::save('concrete.misc.login_redirect', 'DESKTOP');
     }
 
-    public function install_site_permissions()
+    protected function install_site_permissions()
     {
         $g1 = Group::getByID(GUEST_GROUP_ID);
         $g2 = Group::getByID(REGISTERED_GROUP_ID);


### PR DESCRIPTION
Installing concrete5 with a language that's not `en_US` fails.

Let's be sure that the active locale is `en_US` in the install routines.

- Fix #4933 (it's still valid)
- Supersedes #4955

I also removed the `install_page_templates` method of the `StartingPointPackage` class, since it's not used anywhere (and the referenced file `/config/install/base/page_templates.xml` does not exist)