### PR TITLE
Fix redirect responses

### DIFF
--- a/concrete/src/Routing/ClosureRouteCallback.php
+++ b/concrete/src/Routing/ClosureRouteCallback.php
@@ -14,7 +14,7 @@ class ClosureRouteCallback extends RouteCallback
         $arguments = $argumentsResolver->getArguments($request, $this->callback);
         $callback_response = call_user_func_array($this->callback, $arguments);
 
-        if ($callback_response instanceof \Concrete\Core\Http\Response) {
+        if ($callback_response instanceof \Symfony\Component\HttpFoundation\Response) {
             return $callback_response;
         }
 


### PR DESCRIPTION
Redirects (after oauth) were not redirecting properly as the class we were checking against wasn't low enough in the inheritance chain.