### PR TITLE
Fix an issue where concrete.permissions.forward_to_login didn't work

### DIFF
--- a/concrete/controllers/single_page/page_forbidden.php
+++ b/concrete/controllers/single_page/page_forbidden.php
@@ -9,7 +9,7 @@ class PageForbidden extends PageController
 {
     protected $viewPath = '/frontend/page_forbidden';
 
-    public function view()
+    public function on_start()
     {
         $u = new User();
         if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...


### PR DESCRIPTION
Verified that setting `concrete.permissions.forward_to_login` to false does not show the login page (defaults to true)