### PR TITLE
Update controller to not ignore Custom Templates

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -236,9 +236,8 @@ class Controller extends BlockController
     public function view()
     {
       // only use the type specific template if there is NOT a custom template defined
-      $db = Database::Connection(); 
-      $template = $db->getOne('SELECT bFilename FROM Blocks WHERE bID = ? ', array($this->bID));
-      if ($template){
+      $b = $this->getBlockObject();
+      if ($b->getBlockFilename()) {      
         // custom template  
       } else {
         $templateHandle = $this->getTemplateHandle();

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -4,6 +4,7 @@ namespace Concrete\Block\PageAttributeDisplay;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Attribute\Key\CollectionKey as CollectionAttributeKey;
 use Concrete\Core\Entity\Attribute\Value\Value\SelectValue;
+use Database;
 use Core;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -234,9 +235,16 @@ class Controller extends BlockController
 
     public function view()
     {
+      // only use the type specific template if there is NOT a custom template defined
+      $db = Database::Connection(); 
+      $template = $db->getOne('SELECT bFilename FROM Blocks WHERE bID = ? ', array($this->bID));
+      if ($template){
+        // custom template  
+      } else {
         $templateHandle = $this->getTemplateHandle();
         if (in_array($templateHandle, ['date_time', 'boolean'])) {
             $this->render('templates/' . $templateHandle);
         }
+      }
     }
 }


### PR DESCRIPTION
The controller currently ignores custom templates because of the type specific templates for date_time and boolean.  Change the code to see if there is a custom template and don't execute render() if there is allowing the base view() to do the job.