### PR TITLE
Fix CKEditor problem with view HTML source in IE11

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -139,6 +139,20 @@ EOL;
             ckeditor.on('remove', function(){
                 $(this).destroy();
             });
+            if (CKEDITOR.env.ie) {
+                ckeditor.on('ariaWidget', function (e) {
+                    setTimeout(function() {
+                        var \$contents = $(e.editor.ui.contentsElement.$),
+                            \$textarea = \$contents.find('textarea');
+                        if (\$contents.length === 1) {
+                            \$textarea.css({
+                                width: \$contents.innerWidth() + 'px',
+                                height: \$contents.innerHeight() + 'px',
+                            });
+                        }
+                    }, 50);
+                });
+            }
         }
 EOL;
 

--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -143,11 +143,11 @@ EOL;
                 ckeditor.on('ariaWidget', function (e) {
                     setTimeout(function() {
                         var \$contents = $(e.editor.ui.contentsElement.$),
-                            \$textarea = \$contents.find('textarea');
-                        if (\$contents.length === 1) {
+                            \$textarea = \$contents.find('>textarea.cke_source');
+                        if (\$textarea.length === 1) {
                             \$textarea.css({
                                 width: \$contents.innerWidth() + 'px',
-                                height: \$contents.innerHeight() + 'px',
+                                height: \$contents.innerHeight() + 'px'
                             });
                         }
                     }, 50);


### PR DESCRIPTION
Fix https://www.concrete5.org/developers/bugs/8-1-0/feature-block-ckeditor-source-view-empty-if-no-resized/#866545