### PR TITLE
[Fix] Image file options text

### DIFF
--- a/concrete/attributes/image_file/type_form.php
+++ b/concrete/attributes/image_file/type_form.php
@@ -1,5 +1,5 @@
 <fieldset>
-<legend><?php echo t('Text Area Options')?></legend>
+<legend><?php echo t('Image/File Options')?></legend>
 
 <div class="form-group">
 	<?php echo $form->label('mode', t('Input Format'))?>


### PR DESCRIPTION
Just changed the title of image file attribute, from "Text area options" to "Image/File Options".