### PR TITLE
Thumbnail fixes

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -700,7 +700,6 @@ return [
             'throttle_max' => 20,
             'throttle_max_timespan' => 15, // minutes
         ],
-
     ],
 
     /*

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -425,7 +425,18 @@ return [
         'page_search_index_lifetime' => 259200,
         'enable_trash_can' => true,
         'app_version_display_in_header' => true,
+        /*
+         * The JPEG compression level (in range 0... 100)
+         */
         'default_jpeg_image_compression' => 80,
+        /*
+         * The PNG compression level (in range 0... 9)
+         */
+        'default_png_image_compression' => 9,
+        /*
+         * The default thumbnail format: jpeg, png, auto (if auto: we'll create a png if the source image is png, we'll create a jpeg otherwise).
+         */
+        'default_thumbnail_format' => 'jpeg',
         'help_overlay' => true,
         'require_version_comments' => false,
     ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -436,7 +436,7 @@ return [
         /*
          * The default thumbnail format: jpeg, png, auto (if auto: we'll create a jpeg if the source image is jpeg, we'll create a png otherwise).
          */
-        'default_thumbnail_format' => 'jpeg',
+        'default_thumbnail_format' => 'auto',
         'help_overlay' => true,
         'require_version_comments' => false,
     ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -434,7 +434,7 @@ return [
          */
         'default_png_image_compression' => 9,
         /*
-         * The default thumbnail format: jpeg, png, auto (if auto: we'll create a png if the source image is png, we'll create a jpeg otherwise).
+         * The default thumbnail format: jpeg, png, auto (if auto: we'll create a jpeg if the source image is jpeg, we'll create a png otherwise).
          */
         'default_thumbnail_format' => 'jpeg',
         'help_overlay' => true,

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.1.0',
     'version_installed' => '8.1.0',
-    'version_db' => '20170123000000', // the key of the latest database migration
+    'version_db' => '20170131000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -692,6 +692,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Thumbnail Options" path="/dashboard/system/files/thumbnails/options"
+              filename="/dashboard/system/files/thumbnails/options.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="Image Uploading" path="/dashboard/system/files/image_uploading"
               filename="/dashboard/system/files/image_uploading.php" pagetype="" description="" package="">
             <attributes>

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -695,6 +695,9 @@
         <page name="Thumbnail Options" path="/dashboard/system/files/thumbnails/options"
               filename="/dashboard/system/files/thumbnails/options.php" pagetype="" description="" package="">
             <attributes>
+                <attributekey handle="exclude_nav">
+                    <value>1</value>
+                </attributekey>
                 <attributekey handle="meta_keywords">
                     <value>thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency</value>
                 </attributekey>

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -46,8 +46,8 @@ class Options extends DashboardPageController
                 $config->save('concrete.misc.default_jpeg_image_compression', $jpeg_compression);
                 $config->save('concrete.misc.default_png_image_compression', $png_compression);
                 $config->save('concrete.file_manager.images.manipulation_library', $manipulation_library);
-                $this->flash('message', t('ok'));
-                $this->redirect($this->action(''));
+                $this->flash('message', t('Thumbnail options have been succesfully saved.'));
+                $this->redirect($this->app->make('url/manager')->resolve(['/dashboard/system/files/thumbnails']));
             }
         } else {
             $this->error->add($this->token->getErrorMessage());

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -1,0 +1,101 @@
+<?php
+namespace Concrete\Controller\SinglePage\Dashboard\System\Files\Thumbnails;
+
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Http\Response;
+use Exception;
+use Throwable;
+use Imagine\Image\Box;
+
+class Options extends DashboardPageController
+{
+    public function view()
+    {
+        $config = $this->app->make('config');
+        $this->set('thumbnail_formats', $this->getThumbnailsFormats());
+        $this->set('thumbnail_format', $config->get('concrete.misc.default_thumbnail_format'));
+        $this->set('jpeg_compression', $config->get('concrete.misc.default_jpeg_image_compression'));
+        $this->set('png_compression', $config->get('concrete.misc.default_png_image_compression'));
+        $this->set('manipulation_library', $config->get('concrete.file_manager.images.manipulation_library'));
+        $this->set('manipulation_libraries', $this->getManipulationLibraries());
+    }
+
+    public function submit()
+    {
+        if ($this->token->validate('thumbnails-options')) {
+            $config = $this->app->make('config');
+            $thumbnail_format = $this->request->request('thumbnail_format', '');
+            if (!array_key_exists($thumbnail_format, $this->getThumbnailsFormats())) {
+                $this->error->add(t('Invalid thumbnail format'));
+            }
+            $jpeg_compression = (int) $this->request->request('jpeg_compression', -1);
+            if ($jpeg_compression < 0 || $jpeg_compression > 100) {
+                $this->error->add(t('Invalid JPEG compression level'));
+            }
+            $png_compression = (int) $this->request->request('png_compression', -1);
+            if ($png_compression < 0 || $png_compression > 9) {
+                $this->error->add(t('Invalid PNG compression level'));
+            }
+            $manipulation_library = $this->request->request('manipulation_library', '');
+            if (!array_key_exists($manipulation_library, $this->getManipulationLibraries())) {
+                $this->error->add(t('Invalid image manipulation library'));
+            }
+            if (!$this->error->has()) {
+                $config->save('concrete.misc.default_thumbnail_format', $thumbnail_format);
+                $config->save('concrete.misc.default_jpeg_image_compression', $jpeg_compression);
+                $config->save('concrete.misc.default_png_image_compression', $png_compression);
+                $config->save('concrete.file_manager.images.manipulation_library', $manipulation_library);
+                $this->flash('message', t('ok'));
+                $this->redirect($this->action(''));
+            }
+        } else {
+            $this->error->add($this->token->getErrorMessage());
+            $this->view();
+        }
+    }
+
+    protected function getThumbnailsFormats()
+    {
+        return [
+            'png' => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
+            'jpg' => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
+            'auto' => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
+        ];
+    }
+
+    protected function getManipulationLibraries()
+    {
+        return [
+            'gd' => t('GD Library: faster, available in almost any environment, but less powerful'),
+            'imagick' => t('ImageMagick Library: much more powerful, but often not available or misconfigured'),
+        ];
+    }
+
+    public function test_manipulation_library($handle, $token)
+    {
+        $rf = $this->app->make(ResponseFactoryInterface::class);
+        if ($this->token->validate('thumbnail-check-library-' . $handle, $token)) {
+            if ($this->app->bound('image/' . $handle)) {
+                $error = null;
+                try {
+                    $library = $this->app->make('image/' . $handle);
+                    $image = $library->create(new Box(1, 1));
+                    $image->show('png');
+                    die();
+                } catch (Exception $x) {
+                    $error = $x;
+                } catch (Throwable $x) {
+                    $error = $x;
+                }
+                $response = $rf->create($error->getMessage(), Response::HTTP_SERVICE_UNAVAILABLE);
+            } else {
+                $response = $rf->create($handle, Response::HTTP_SERVICE_UNAVAILABLE);
+            }
+        } else {
+            $response = $rf->create($this->token->getErrorMessage(), Response::HTTP_BAD_REQUEST);
+        }
+
+        return $response;
+    }
+}

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -106,6 +106,7 @@
     ?>
 
     <div class="ccm-dashboard-header-buttons">
+        <a href="<?php echo $view->action('options')?>" class="btn btn-default"><?php echo t('Options')?></a>
         <a href="<?php echo $view->action('add')?>" class="btn btn-primary"><?php echo t("Add Type")?></a>
     </div>
 

--- a/concrete/single_pages/dashboard/system/files/thumbnails/options.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails/options.php
@@ -1,0 +1,105 @@
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+// Arguments
+/* @var Concrete\Core\Page\View\PageView $this */
+/* @var Concrete\Core\Html\Service\Html $html */
+/* @var Concrete\Core\Application\Service\UserInterface $interface */
+/* @var Concrete\Core\Application\Service\Dashboard $dashboard */
+/* @var bool $hideDashboardPanel */
+/* @var bool $_bookmarked */
+/* @var string $pageTitle */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Error\ErrorList\ErrorList $error */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Controller\SinglePage\Dashboard\System\Files\Thumbnails\Options $controller */
+/* @var Concrete\Core\Page\Page $c */
+/* @var Concrete\Theme\Dashboard\PageTheme $theme */
+
+/* @var array $thumbnail_formats */
+/* @var string $thumbnail_format */
+/* @var int $jpeg_compression */
+/* @var int $png_compression */
+/* @var array $manipulation_libraries */
+/* @var string $manipulation_library */
+
+?>
+<form method="post" action="<?=$view->action('submit')?>">
+
+    <?php $token->output('thumbnails-options') ?>
+
+    <div class="form-group">
+        <?= $form->label('thumbnail_format', t('Thumbnails Format')) ?>
+        <?php
+        foreach ($thumbnail_formats as $id => $name) {
+            ?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('thumbnail_format', $id, $id === $thumbnail_format, ['required' => 'required']) ?>
+                    <?= h($name) ?>
+                </label>
+            </div>
+            <?php
+        }
+        ?>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('manipulation_library', t('Image Manipulation Library')) ?>
+        <?php
+        foreach ($manipulation_libraries as $id => $name) {
+            ?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('manipulation_library', $id, $id === $manipulation_library, ['required' => 'required']) ?>
+                    <?= h($name) ?>
+                    <?= t('(currently working: %s)', '<span class="ccm-check-manipulation-library" data-check-src="' . h($view->action('test_manipulation_library', $id, $token->generate('thumbnail-check-library-' . $id))) . '"><i class="fa fa-spinner fa-spin"></i></span>')?>
+                </label>
+            </div>
+            <?php
+        }
+        ?>
+    </div>
+
+	<div class="form-group">
+		<?= $form->label('jpeg_compression', t('JPEG compression level'), ['class' => 'launch-tooltip control-label', 'title' => 'JPEG compression level ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file)']) ?>
+    	<?= $form->number('jpeg_compression', $jpeg_compression, ['required' => 'required', 'min' => '0', 'max' => '100']) ?>
+	</div>
+
+    <div class="form-group">
+        <?= $form->label('png_compression', t('PNG compression quality'), ['class' => 'launch-tooltip control-label', 'title' => 'PNG compression quality ranges from 0 (no compression) to 9 (maximum compression)']) ?>
+        <?= $form->number('png_compression', $png_compression, ['required' => 'required', 'min' => '0', 'max' => '9']) ?>
+    </div>
+
+
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <a href="<?=URL::to('/dashboard/system/files/thumbnails')?>" class="btn btn-default"><?=t('Cancel')?></a>
+            <button class="pull-right btn btn-primary" type="submit"><?=t('Save')?></button>
+        </div>
+    </div>
+
+</form>
+
+<script>
+$(window).load(function() {
+    function checked($container, ok) {
+        $container.html(
+            ok ? '<i class="fa fa-check" style="color: green"></i>' : '<i class="fa fa-remove" style="color: red"></i>'
+        );
+    }
+    $('.ccm-check-manipulation-library').each(function() {
+        var $container = $(this);
+        $container.append($('<img style="visibility: hidden; width: 1px; height: 1px" />')
+            .on('load', function() {
+                checked($container, true);
+            })
+            .on('error', function() {
+                checked($container, false);
+            })
+            .attr('src', $container.data('check-src'))
+        );
+    });
+});
+</script>

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -13,6 +13,8 @@ use Image;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
 use Concrete\Core\Entity\File\File;
+use Exception;
+use stdClass;
 
 class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterface
 {
@@ -49,7 +51,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     }
 
     /**
-     * @param \Concrete\Core\File\StorageLocation\StorageLocationInterface $storageLocation
+     * @param StorageLocationInterface $storageLocation
      *
      * @return self
      */
@@ -91,7 +93,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     /**
      * Create a thumbnail.
      *
-     * @param \Imagine\Image\ImagineInterface|string $mixed
+     * @param ImagineInterface|string $mixed
      * @param string $newPath
      * @param int $width
      * @param int $height
@@ -103,7 +105,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         $filesystem = $this->getStorageLocation()
           ->getFileSystemObject();
 
-        if ($mixed instanceof \Imagine\Image\ImageInterface) {
+        if ($mixed instanceof ImageInterface) {
             $image = $mixed;
         } else {
             $image = Image::open($mixed);
@@ -143,7 +145,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      * @param int $maxHeight
      * @param bool $crop
      *
-     * @return \stdClass Object that has the following properties: src, width, height
+     * @return stdClass Object that has the following properties: src, width, height
      */
     public function getThumbnail($obj, $maxWidth, $maxHeight, $crop = false)
     {
@@ -160,7 +162,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
                 $fID = $obj->getFileID();
                 $filename = md5(implode(':', [$fID, $maxWidth, $maxHeight, $crop, $fr->getTimestamp()]))
                   . '.' . $fh->getExtension($fr->getPath());
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $filename = '';
             }
         } else {
@@ -175,9 +177,9 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         /* Attempt to create the image */
         if (!$filesystem->has($abspath)) {
             if ($obj instanceof File && $fr->exists()) {
-                $image = \Image::load($fr->read());
+                $image = Image::load($fr->read());
             } else {
-                $image = \Image::open($obj);
+                $image = Image::open($obj);
             }
             // create image there
             $this->create($image,
@@ -187,7 +189,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
                 $crop);
         }
 
-        $thumb = new \stdClass();
+        $thumb = new stdClass();
         $thumb->src = $src;
 
         // this is a hack, but we shouldn't go out on the network if we don't have to. We should probably
@@ -204,7 +206,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
             $dimensions = getimagesize($dimensionsPath);
             $thumb->width = $dimensions[0];
             $thumb->height = $dimensions[1];
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
 
         return $thumb;

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -99,7 +99,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      */
     public function create($mixed, $newPath, $width, $height, $fit = false)
     {
-        $thumbnailOptions = ['jpeg_quality' => \Config::get('concrete.misc.default_jpeg_image_compression')];
+        $thumbnailOptions = ['jpeg_quality' => $this->getJpegCompression()];
         $filesystem = $this->getStorageLocation()
           ->getFileSystemObject();
 

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -72,8 +72,8 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      */
     public function setJpegCompression($level)
     {
-        if (is_int($level)) {
-            $this->jpegCompression = min(max($level, 0), 100);
+        if (is_int($level) || is_float($level) || (is_string($level) && is_numeric($level))) {
+            $this->jpegCompression = min(max((int) $level, 0), 100);
         }
 
         return $this;

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -178,7 +178,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     {
         $format = $this->getThumbnailsFormat();
         if ($format === 'auto') {
-            if (preg_match('/\.jpe?g($|^)/i', $savePath)) {
+            if (preg_match('/\.jpe?g($|\?)/i', $savePath)) {
                 $format = 'jpeg';
             } else {
                 $format = 'png';

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -4,12 +4,9 @@ namespace Concrete\Core\File\Image;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Entity\File\StorageLocation\StorageLocation;
-use Concrete\Core\File\Image\Thumbnail\Path\Resolver;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailerInterface;
-use Concrete\Core\File\Image\Thumbnail\Type\CustomThumbnail;
 use Concrete\Core\File\StorageLocation\Configuration\DefaultConfiguration;
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
-use Config;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Image;
@@ -19,7 +16,6 @@ use Concrete\Core\Entity\File\File;
 
 class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterface
 {
-
     use ApplicationAwareTrait;
 
     protected $jpegCompression;
@@ -42,7 +38,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         if ($this->storageLocation === null) {
             /** @var EntityManagerInterface $orm */
             $orm = $this->app['database/orm']->entityManager();
-            $storageLocation = $orm->getRepository(StorageLocation::class)->findOneBy([ 'fslIsDefault' => true ]);
+            $storageLocation = $orm->getRepository(StorageLocation::class)->findOneBy(['fslIsDefault' => true]);
 
             if ($storageLocation) {
                 $this->storageLocation = $storageLocation;
@@ -54,11 +50,13 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
 
     /**
      * @param \Concrete\Core\File\StorageLocation\StorageLocationInterface $storageLocation
+     *
      * @return self
      */
     public function setStorageLocation(StorageLocationInterface $storageLocation)
     {
         $this->storageLocation = $storageLocation;
+
         return $this;
     }
 
@@ -69,6 +67,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      * to the default system setting (DEFINE or 80).
      *
      * @param int $level the level of compression
+     *
      * @return self
      */
     public function setJpegCompression($level)
@@ -90,7 +89,8 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     }
 
     /**
-     * Create a thumbnail
+     * Create a thumbnail.
+     *
      * @param \Imagine\Image\ImagineInterface|string $mixed
      * @param string $newPath
      * @param int $width
@@ -99,7 +99,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      */
     public function create($mixed, $newPath, $width, $height, $fit = false)
     {
-        $thumbnailOptions = array('jpeg_quality' => \Config::get('concrete.misc.default_jpeg_image_compression'));
+        $thumbnailOptions = ['jpeg_quality' => \Config::get('concrete.misc.default_jpeg_image_compression')];
         $filesystem = $this->getStorageLocation()
           ->getFileSystemObject();
 
@@ -114,11 +114,10 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
               $newPath,
               $thumb->get('jpeg', $thumbnailOptions)
             );
-
         } else {
             if ($height < 1) {
                 $thumb = $image->thumbnail($image->getSize()->widen($width));
-            } else if ($width < 1) {
+            } elseif ($width < 1) {
                 $thumb = $image->thumbnail($image->getSize()->heighten($height));
             } else {
                 $thumb = $image->thumbnail(new Box($width, $height));
@@ -133,15 +132,17 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     /**
      * Deprecated.
      */
+
     /**
      * Returns a path to the specified item, resized and/or cropped to meet max width and height. $obj can either be
      * a string (path) or a file object.
-     * Returns an object with the following properties: src, width, height
+     * Returns an object with the following properties: src, width, height.
      *
      * @param File|string $obj
      * @param int $maxWidth
      * @param int $maxHeight
      * @param bool $crop
+     *
      * @return \stdClass Object that has the following properties: src, width, height
      */
     public function getThumbnail($obj, $maxWidth, $maxHeight, $crop = false)
@@ -157,13 +158,13 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
             try {
                 $fr = $obj->getFileResource();
                 $fID = $obj->getFileID();
-                $filename = md5(implode(':', array($fID, $maxWidth, $maxHeight, $crop, $fr->getTimestamp())))
+                $filename = md5(implode(':', [$fID, $maxWidth, $maxHeight, $crop, $fr->getTimestamp()]))
                   . '.' . $fh->getExtension($fr->getPath());
             } catch (\Exception $e) {
                 $filename = '';
             }
         } else {
-            $filename = md5(implode(':', array($obj, $maxWidth, $maxHeight, $crop, filemtime($obj))))
+            $filename = md5(implode(':', [$obj, $maxWidth, $maxHeight, $crop, filemtime($obj)]))
                 . '.' . $fh->getExtension($obj);
         }
 
@@ -171,7 +172,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
 
         $src = $configuration->getPublicURLToFile($abspath);
 
-        /** Attempt to create the image */
+        /* Attempt to create the image */
         if (!$filesystem->has($abspath)) {
             if ($obj instanceof File && $fr->exists()) {
                 $image = \Image::load($fr->read());
@@ -204,7 +205,6 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
             $thumb->width = $dimensions[0];
             $thumb->height = $dimensions[1];
         } catch (\Exception $e) {
-
         }
 
         return $thumb;

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -82,7 +82,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     protected function getJpegCompression()
     {
         if (!isset($this->jpegCompression)) {
-            $this->jpegCompression = \Config::get('concrete.misc.default_jpeg_image_compression');
+            $this->jpegCompression = $this->app->make('config')->get('concrete.misc.default_jpeg_image_compression');
         }
 
         return $this->jpegCompression;
@@ -153,7 +153,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         $configuration = $storage->getConfigurationObject();
         $version = null;
 
-        $fh = \Core::make('helper/file');
+        $fh = $this->app->make('helper/file');
         if ($obj instanceof File) {
             try {
                 $fr = $obj->getFileResource();

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -178,7 +178,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     {
         $format = $this->getThumbnailsFormat();
         if ($format === 'auto') {
-            if (preg_match('/\.jpe?g($|?)/i', $savePath)) {
+            if (preg_match('/\.jpe?g($|^)/i', $savePath)) {
                 $format = 'jpeg';
             } else {
                 $format = 'png';

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -30,7 +30,7 @@ interface ThumbnailerInterface
      * Overrides the default JPEG compression level per instance of the image helper.
      * This allows for a single-use for a particularly low or high compression value.
      *
-     * @param int $level the level of compression
+     * @param int $level the level of compression (in the range 0...100)
      *
      * @return static
      */
@@ -41,7 +41,40 @@ interface ThumbnailerInterface
      *
      * @return int
      */
-    public function getJpegCompression($level);
+    public function getJpegCompression();
+
+    /**
+     * Overrides the default PNG compression level per instance of the image helper.
+     * This allows for a single-use for a particularly low or high compression value.
+     *
+     * @param int $level the level of compression (in the range 0...9)
+     *
+     * @return static
+     */
+    public function setPngCompression($level);
+
+    /**
+     * Get the currently set PNG compression level.
+     *
+     * @return int
+     */
+    public function getPngCompression();
+
+    /**
+     * Set the format of the generated thumbnails.
+     *
+     * @param string $thumbnailsFormat valid values: 'auto', 'jpeg', 'png'
+     *
+     * @return static
+     */
+    public function setThumbnailsFormat($thumbnailsFormat);
+
+    /**
+     * Get the format of the generated thumbnails.
+     *
+     * @return string one of 'auto', 'jpeg', 'png'
+     */
+    public function getThumbnailsFormat();
 
     /**
      * Create a thumbnail given an image (or a path to an image).

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -11,22 +11,59 @@ use Imagine\Image\ImagineInterface;
 interface ThumbnailerInterface
 {
     /**
+     * Get the storage location to use.
+     *
+     * @return StorageLocationInterface
+     */
+    public function getStorageLocation();
+
+    /**
      * Set the storage location to use. Note that the $savePath is going to be relative to this location.
      *
-     * @param StorageLocationInterface $location
+     * @param StorageLocationInterface $storageLocation
      *
      * @return self
      */
-    public function setStorageLocation(StorageLocationInterface $location);
+    public function setStorageLocation(StorageLocationInterface $storageLocation);
+
+    /**
+     * Overrides the default JPEG compression level per instance of the image helper.
+     * This allows for a single-use for a particularly low or high compression value.
+     *
+     * @param int $level the level of compression
+     *
+     * @return static
+     */
+    public function setJpegCompression($level);
+
+    /**
+     * Get the currently set JPEG compression level.
+     *
+     * @return int
+     */
+    public function getJpegCompression($level);
 
     /**
      * Create a thumbnail given an image (or a path to an image).
      *
-     * @param ImagineInterface|string $image
+     * @param ImagineInterface|string $image the image for which you want the thumbnail (or its path)
      * @param string $savePath The path to save the thumbnail to
-     * @param int $width
-     * @param int $height
-     * @param bool $fit Fit to bounds
+     * @param int|null $width The thumbnail width (may be empty if $fit is false and $height is specified)
+     * @param int|null $height The thumbnail height (may be empty if $fit is false and $width is specified)
+     * @param bool $fit Fit to bounds?
      */
     public function create($image, $savePath, $width, $height, $fit = false);
+
+    /**
+     * Returns a path to the specified item, resized and/or cropped to meet max width and height. $obj can e
+     * Returns an object with the following properties: src, width, height.
+     *
+     * @param \Concrete\Core\Entity\File\File|string $obj a string (path) or a file object
+     * @param int|null $maxWidth The maximum width of the thumbnail (may be empty if $crop is false and $maxHeight is specified)
+     * @param int|null $maxHeight The maximum height of the thumbnail (may be empty if $crop is false and $maxWidth is specified)
+     * @param bool $crop Fit to bounds?
+     *
+     * @return stdClass Object that has the following properties: src (the public URL to the file), width (null if unable to determine it), height (null if unable to determine it)
+     */
+    public function getThumbnail($obj, $maxWidth, $maxHeight, $crop = false);
 }

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -1,36 +1,32 @@
 <?php
-
 namespace Concrete\Core\File\Image\Thumbnail;
-
 
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
 use Imagine\Image\ImagineInterface;
 
 /**
  * Interface ThumbnailerInterface
- * An interface for classes tasked with creating thumbnails. This interace requires imagine
- * @package Concrete\Core\File\Image\Thumbnail
+ * An interface for classes tasked with creating thumbnails. This interace requires imagine.
  */
 interface ThumbnailerInterface
 {
-
     /**
-     * Set the storage location to use. Note that the $savePath is going to be relative to this location
-     * @param \Concrete\Core\File\StorageLocation\StorageLocationInterface $location
+     * Set the storage location to use. Note that the $savePath is going to be relative to this location.
+     *
+     * @param StorageLocationInterface $location
+     *
      * @return self
      */
     public function setStorageLocation(StorageLocationInterface $location);
 
     /**
-     * Create a thumbnail given an image (or a path to an image)
+     * Create a thumbnail given an image (or a path to an image).
      *
      * @param ImagineInterface|string $image
      * @param string $savePath The path to save the thumbnail to
      * @param int $width
      * @param int $height
      * @param bool $fit Fit to bounds
-     * @return void
      */
     public function create($image, $savePath, $width, $height, $fit = false);
-
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170131000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170131000000.php
@@ -1,0 +1,27 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Page\Page;
+use SinglePage;
+
+
+class Version20170131000000 extends AbstractMigration
+{
+
+    public function up(Schema $schema)
+    {
+        $sp = Page::getByPath('/dashboard/system/files/thumbnails/options');
+        if (!is_object($sp) || $sp->isError()) {
+            $sp = SinglePage::add('/dashboard/system/files/thumbnails/options');
+            $sp->update(array('cName' => 'Thumbnail Options'));
+            $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
+        }
+        
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170131000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170131000000.php
@@ -16,6 +16,7 @@ class Version20170131000000 extends AbstractMigration
         if (!is_object($sp) || $sp->isError()) {
             $sp = SinglePage::add('/dashboard/system/files/thumbnails/options');
             $sp->update(array('cName' => 'Thumbnail Options'));
+            $sp->setAttribute('exclude_nav', true);
             $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
         }
         

--- a/tests/tests/Core/File/Service/ImageTest.php
+++ b/tests/tests/Core/File/Service/ImageTest.php
@@ -9,6 +9,7 @@ namespace Concrete\Tests\Core\File\Service;
 use Concrete\Core\File\StorageLocation\Configuration\LocalConfiguration;
 use Concrete\Tests\Core\File\Service\Fixtures\TestStorageLocation;
 use Core;
+use Concrete\Core\Support\Facade\Application;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,7 +63,11 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $sl = $this->storageLocation;
         $fsl = $sl->getFileSystemObject();
         $service = new \Concrete\Core\File\Image\BasicThumbnailer($sl);
-
+        $service->setApplication(Application::getFacadeApplication());
+        $service->setJpegCompression(80);
+        $service->setPngCompression(9);
+        $service->setThumbnailsFormat('auto');
+        
         $this->assertFalse($fsl->has($this->output1));
         $service->create(
             $path, $this->output1, $width, $height, $fit


### PR DESCRIPTION
`BasicThumbnailer` always generated thumbnails in the JPEG format.

This PR fixes the following problems with that:

- the file extension of the thumbnails is always the same as the one of the original image (that could lead to some problems / misunderstandings)
- we loose the transparency, leading to problems like the one [described here](https://www.concrete5.org/developers/bugs/8-1-0/resizingconstraining-images-with-transparent-backgrounds-causes-/)

This pull requests fixes these problems by:
- allowing saving in JPEG or in PNG format (so that transparency is kept)
- the file extension of the thumbnails is `.jpg` for JPEG files and `.png` for PNG files

Currently, this PR doesn't change the behavior: thumbnails are always created in JEPG format. BTW, we can change that by setting the `concrete.misc.default_thumbnail_format` configuration key ([see here](https://github.com/concrete5/concrete5/commit/06baa7bb592793b90eedcd8bdba243a4d75dd73d#diff-811b2ea07d25d52de3464e687fbd6ad2R437))