### PR TITLE
SVG images - do not generate thumbnail if getImagineImage() returns false

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1020,31 +1020,33 @@ class Version
         try {
             $image = $this->getImagineImage();
 
-            /* @var \Imagine\Imagick\Image $image */
-            if (!$imagewidth) {
-                $imagewidth = $image->getSize()->getWidth();
-            }
-            if (!$imageheight) {
-                $imageheight = $image->getSize()->getHeight();
-            }
-
-            foreach ($types as $type) {
-                // delete the file if it exists
-                $this->deleteThumbnail($type);
-
-                // if image is smaller than width, don't create thumbnail
-                if ($imagewidth < $type->getWidth()) {
-                    continue;
+            if ($image) {
+                /* @var \Imagine\Imagick\Image $image */
+                if (!$imagewidth) {
+                    $imagewidth = $image->getSize()->getWidth();
+                }
+                if (!$imageheight) {
+                    $imageheight = $image->getSize()->getHeight();
                 }
 
-                // if image is the same width as thumbnail, and there's no thumbnail height set,
-                // or if a thumbnail height set and the image has a smaller or equal height, don't create thumbnail
-                if ($imagewidth == $type->getWidth() && (!$type->getHeight() || $imageheight <= $type->getHeight())) {
-                    continue;
-                }
+                foreach ($types as $type) {
+                    // delete the file if it exists
+                    $this->deleteThumbnail($type);
 
-                // otherwise file is bigger than thumbnail in some way, proceed to create thumbnail
-                $this->generateThumbnail($type);
+                    // if image is smaller than width, don't create thumbnail
+                    if ($imagewidth < $type->getWidth()) {
+                        continue;
+                    }
+
+                    // if image is the same width as thumbnail, and there's no thumbnail height set,
+                    // or if a thumbnail height set and the image has a smaller or equal height, don't create thumbnail
+                    if ($imagewidth == $type->getWidth() && (!$type->getHeight() || $imageheight <= $type->getHeight())) {
+                        continue;
+                    }
+
+                    // otherwise file is bigger than thumbnail in some way, proceed to create thumbnail
+                    $this->generateThumbnail($type);
+                }
             }
         } catch (\Imagine\Exception\InvalidArgumentException $e) {
             return false;


### PR DESCRIPTION
A user on the forum reported that using an SVG image caused errors when upgrading from 8.0.3 to 8.1.0.

"after upgrading my site from 8.0.3, where everything works fine, to 8.1.0 i got the following error on every page, including dashboard:
Call to a member function getSize() on boolean"
https://www.concrete5.org/community/forums/installation/error-after-upgrade-from-8.0.3-to-8.1.0/

![image](https://cloud.githubusercontent.com/assets/10898145/22623525/182077a0-eb2c-11e6-94d8-e1b2f1fe0540.png)

I was able to reproduce the error when uploading SVG images through the file manager.

**Steps to reproduce:**
- upload an SVG image in the file manager
- this will trigger an "Upload Failed" error modal with the filename and `Call to a member function getSize() on boolean` error
- close the error modal
- refresh the page
- the SVG image is uploaded and listed, but has a size of 0.00 KB

When an SVG image is uploaded/rescanned and ImageMagick is not available, then getImagineImage() returns false:
https://github.com/concrete5/concrete5/blob/develop/concrete/src/Entity/File/Version.php#L997