### PR TITLE
SVG thumbnails and "Invalid file dimensions, please rescan this file." error

### DIFF
--- a/concrete/elements/files/properties.php
+++ b/concrete/elements/files/properties.php
@@ -82,7 +82,7 @@ if ($downloadUrl !== $url) {
 <?php
 } ?>
 
-<?php if ($fv->getTypeObject()->getGenericType() == \Concrete\Core\File\Type\Type::T_IMAGE) {
+<?php if ($fv->getTypeObject()->supportsThumbnails()) {
     try {
         $thumbnails = $fv->getThumbnails();
     } catch (\Concrete\Core\File\Exception\InvalidDimensionException $e) {

--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -415,6 +415,18 @@ class Type
     }
 
     /**
+     * Does the file type support thumbnails.
+     *
+     * @return bool|null Return true if the type supports thumbnails, null otherwise
+     */
+    public function supportsThumbnails()
+    {
+        if ($this->getName() == 'PNG' || $this->getName() == 'JPEG') {
+            return true;
+        }
+    }
+
+    /**
      * Get the name of a generic file type.
      *
      * @param int $type Generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants)


### PR DESCRIPTION
This pull request checks to see if the file has the mime type of image/svg+xml before getting thumbnails, displaying the Thumbnail form row and Rescan button, and displaying a thumbnail error. It is based on this pull request https://github.com/concrete5/concrete5/pull/5069 being merged first.

**Current:**

![svg_thumbnail_error-upload-current](https://cloud.githubusercontent.com/assets/10898145/22624061/ad516d0e-eb3e-11e6-82bf-710f1baea96e.png)

![svg_thumbnail_error-properties-current](https://cloud.githubusercontent.com/assets/10898145/22624069/e7edf32e-eb3e-11e6-87ee-5e0d4dad61c8.png)

**Changes:**

![svg_thumbnail_error-upload-changes](https://cloud.githubusercontent.com/assets/10898145/22624072/ef3fd386-eb3e-11e6-8d17-70cf5e638085.png)

![svg_thumbnail_error-properties-changes](https://cloud.githubusercontent.com/assets/10898145/22624073/f1fa2824-eb3e-11e6-9484-0e3ab9e50353.png)

