### PR TITLE
Refactor default template of page list block

### DIFF
--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -61,7 +61,7 @@ if ($c->isEditMode() && $controller->isBlockEmpty()) {
                     }
                 } else {
                     $url = $page->getCollectionLink();
-                    $page->getAttribute('nav_target')
+                    $page->getAttribute('nav_target');
                 }
                 $target = empty($target) ? '_self' : $target;
                 $description = $page->getCollectionDescription();

--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -1,175 +1,181 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$th = Loader::helper('text');
-$c = Page::getCurrentPage();
-$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
-?>
 
-<?php if ($c->isEditMode() && $controller->isBlockEmpty()) {
+$c = Page::getCurrentPage();
+
+/** @var \Concrete\Core\Utility\Service\Text $th */
+$th = Core::make('helper/text');
+/** @var \Concrete\Core\Localization\Service\Date $dh */
+$dh = Core::make('helper/date');
+
+if ($c->isEditMode() && $controller->isBlockEmpty()) {
     ?>
-    <div class="ccm-edit-mode-disabled-item"><?=t('Empty Page List Block.')?></div>
-<?php
+    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Page List Block.') ?></div>
+    <?php
 } else {
     ?>
 
-<div class="ccm-block-page-list-wrapper">
+    <div class="ccm-block-page-list-wrapper">
 
-    <?php if (isset($pageListTitle) && $pageListTitle): ?>
-        <div class="ccm-block-page-list-header">
-            <h5><?=h($pageListTitle)?></h5>
-        </div>
-    <?php endif;
-    ?>
+        <?php if (isset($pageListTitle) && $pageListTitle) {
+            ?>
+            <div class="ccm-block-page-list-header">
+                <h5><?php echo h($pageListTitle) ?></h5>
+            </div>
+            <?php
+        } ?>
 
-    <?php if (isset($rssUrl) && $rssUrl): ?>
-        <a href="<?php echo $rssUrl ?>" target="_blank" class="ccm-block-page-list-rss-feed"><i class="fa fa-rss"></i></a>
-    <?php endif;
-    ?>
+        <?php if (isset($rssUrl) && $rssUrl) {
+            ?>
+            <a href="<?php echo $rssUrl ?>" target="_blank" class="ccm-block-page-list-rss-feed">
+                <i class="fa fa-rss"></i>
+            </a>
+            <?php
+        } ?>
 
-    <div class="ccm-block-page-list-pages">
+        <div class="ccm-block-page-list-pages">
+
+            <?php
+
+            $includeEntryText = false;
+            if (
+                (isset($includeName) && $includeName)
+                ||
+                (isset($includeDescription) && $includeDescription)
+                ||
+                (isset($useButtonForLink) && $useButtonForLink)
+            ) {
+                $includeEntryText = true;
+            }
+
+            foreach ($pages as $page) {
+
+                // Prepare data for each page being listed...
+                $buttonClasses = 'ccm-block-page-list-read-more';
+                $entryClasses = 'ccm-block-page-list-page-entry';
+                $title = $page->getCollectionName();
+                if ($page->getCollectionPointerExternalLink() != '') {
+                    $url = $page->getCollectionPointerExternalLink();
+                    if ($page->openCollectionPointerExternalLinkInNewWindow()) {
+                        $target = '_blank';
+                    }
+                } else {
+                    $url = $page->getCollectionLink();
+                    $page->getAttribute('nav_target')
+                }
+                $target = empty($target) ? '_self' : $target;
+                $description = $page->getCollectionDescription();
+                $description = $controller->truncateSummaries ? $th->wordSafeShortText($description, $controller->truncateChars) : $description;
+                $thumbnail = false;
+                if ($displayThumbnail) {
+                    $thumbnail = $page->getAttribute('thumbnail');
+                }
+                if (is_object($thumbnail) && $includeEntryText) {
+                    $entryClasses = 'ccm-block-page-list-page-entry-horizontal';
+                }
+
+                $date = $dh->formatDateTime($page->getCollectionDatePublic(), true);
+
+                //Other useful page data...
+
+                //$last_edited_by = $page->getVersionObject()->getVersionAuthorUserName();
+
+                /* DISPLAY PAGE OWNER NAME
+                 * $page_owner = UserInfo::getByID($page->getCollectionUserID());
+                 * if (is_object($page_owner)) {
+                 *     echo $page_owner->getUserDisplayName();
+                 * }
+                 */
+
+                /* CUSTOM ATTRIBUTE EXAMPLES:
+                 * $example_value = $page->getAttribute('example_attribute_handle', 'display');
+                 *
+                 * When you need the raw attribute value or object:
+                 * $example_value = $page->getAttribute('example_attribute_handle');
+                 */
+
+                /* End data preparation. */
+
+                /* The HTML from here through "endforeach" is repeated for every item in the list... */ ?>
+
+                <div class="<?php echo $entryClasses ?>">
+
+                    <?php if (is_object($thumbnail)) {
+                        ?>
+                        <div class="ccm-block-page-list-page-entry-thumbnail">
+                            <?php
+                            $img = Core::make('html/image', array($thumbnail));
+                            $tag = $img->getTag();
+                            $tag->addClass('img-responsive');
+                            echo $tag; ?>
+                        </div>
+                        <?php
+                    } ?>
+
+                    <?php if ($includeEntryText) {
+                        ?>
+                        <div class="ccm-block-page-list-page-entry-text">
+
+                            <?php if (isset($includeName) && $includeName) {
+                                ?>
+                                <div class="ccm-block-page-list-title">
+                                    <?php if (isset($useButtonForLink) && $useButtonForLink) {
+                                        ?>
+                                        <?php echo h($title); ?>
+                                        <?php
+
+                                    } else {
+                                        ?>
+                                        <a href="<?php echo h($url) ?>"
+                                           target="<?php echo h($target) ?>"><?php echo h($title) ?></a>
+                                        <?php
+
+                                    } ?>
+                                </div>
+                                <?php
+                            } ?>
+
+                            <?php if (isset($includeDate) && $includeDate) {
+                                ?>
+                                <div class="ccm-block-page-list-date"><?php echo h($date) ?></div>
+                                <?php
+                            } ?>
+
+                            <?php if (isset($includeDescription) && $includeDescription) {
+                                ?>
+                                <div class="ccm-block-page-list-description"><?php echo h($description) ?></div>
+                                <?php
+                            } ?>
+
+                            <?php if (isset($useButtonForLink) && $useButtonForLink) {
+                                ?>
+                                <div class="ccm-block-page-list-page-entry-read-more">
+                                    <a href="<?php echo h($url) ?>" target="<?php echo h($target) ?>"
+                                       class="<?php echo h($buttonClasses) ?>"><?php echo h($buttonLinkText) ?></a>
+                                </div>
+                                <?php
+                            } ?>
+
+                        </div>
+                        <?php
+                    } ?>
+                </div>
+
+                <?php
+            } ?>
+        </div><!-- end .ccm-block-page-list-pages -->
+
+        <?php if (count($pages) == 0) { ?>
+            <div class="ccm-block-page-list-no-pages"><?php echo h($noResultsMessage) ?></div>
+        <?php } ?>
+
+    </div><!-- end .ccm-block-page-list-wrapper -->
+
+
+    <?php if ($showPagination) { ?>
+        <?php echo $pagination; ?>
+    <?php } ?>
 
     <?php
 
-    $includeEntryText = false;
-    if (
-        (isset($includeName) && $includeName)
-        ||
-        (isset($includeDescription) && $includeDescription)
-        ||
-        (isset($useButtonForLink) && $useButtonForLink)
-    ) {
-        $includeEntryText = true;
-    }
-
-    foreach ($pages as $page):
-
-        // Prepare data for each page being listed...
-        $buttonClasses = 'ccm-block-page-list-read-more';
-    $entryClasses = 'ccm-block-page-list-page-entry';
-    $title = $th->entities($page->getCollectionName());
-    $url = ($page->getCollectionPointerExternalLink() != '') ? $page->getCollectionPointerExternalLink() : $nh->getLinkToCollection($page);
-    $target = ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) ? '_blank' : $page->getAttribute('nav_target');
-    $target = empty($target) ? '_self' : $target;
-    $description = $page->getCollectionDescription();
-    $description = $controller->truncateSummaries ? $th->wordSafeShortText($description, $controller->truncateChars) : $description;
-    $description = $th->entities($description);
-    $thumbnail = false;
-    if ($displayThumbnail) {
-        $thumbnail = $page->getAttribute('thumbnail');
-    }
-    if (is_object($thumbnail) && $includeEntryText) {
-        $entryClasses = 'ccm-block-page-list-page-entry-horizontal';
-    }
-
-    $date = $dh->formatDateTime($page->getCollectionDatePublic(), true);
-
-        //Other useful page data...
-
-        //$last_edited_by = $page->getVersionObject()->getVersionAuthorUserName();
-
-        //$original_author = Page::getByID($page->getCollectionID(), 1)->getVersionObject()->getVersionAuthorUserName();
-
-        /* CUSTOM ATTRIBUTE EXAMPLES:
-         * $example_value = $page->getAttribute('example_attribute_handle');
-         *
-         * HOW TO USE IMAGE ATTRIBUTES:
-         * 1) Uncomment the "$ih = Loader::helper('image');" line up top.
-         * 2) Put in some code here like the following 2 lines:
-         *      $img = $page->getAttribute('example_image_attribute_handle');
-         *      $thumb = $ih->getThumbnail($img, 64, 9999, false);
-         *    (Replace "64" with max width, "9999" with max height. The "9999" effectively means "no maximum size" for that particular dimension.)
-         *    (Change the last argument from false to true if you want thumbnails cropped.)
-         * 3) Output the image tag below like this:
-         *		<img src="<?php echo $thumb->src ?>" width="<?php echo $thumb->width ?>" height="<?php echo $thumb->height ?>" alt="" />
-         *
-         * ~OR~ IF YOU DO NOT WANT IMAGES TO BE RESIZED:
-         * 1) Put in some code here like the following 2 lines:
-         * 	    $img_src = $img->getRelativePath();
-         *      $img_width = $img->getAttribute('width');
-         *      $img_height = $img->getAttribute('height');
-         * 2) Output the image tag below like this:
-         * 	    <img src="<?php echo $img_src ?>" width="<?php echo $img_width ?>" height="<?php echo $img_height ?>" alt="" />
-         */
-
-        /* End data preparation. */
-
-        /* The HTML from here through "endforeach" is repeated for every item in the list... */ ?>
-
-        <div class="<?=$entryClasses?>">
-
-        <?php if (is_object($thumbnail)): ?>
-            <div class="ccm-block-page-list-page-entry-thumbnail">
-                <?php
-                $img = Core::make('html/image', array($thumbnail));
-    $tag = $img->getTag();
-    $tag->addClass('img-responsive');
-    echo $tag;
-    ?>
-            </div>
-        <?php endif;
-    ?>
-
-        <?php if ($includeEntryText): ?>
-            <div class="ccm-block-page-list-page-entry-text">
-
-                <?php if (isset($includeName) && $includeName): ?>
-                <div class="ccm-block-page-list-title">
-                    <?php if (isset($useButtonForLink) && $useButtonForLink) {
-    ?>
-                        <?php echo $title;
-    ?>
-                    <?php
-} else {
-    ?>
-                        <a href="<?php echo $url ?>" target="<?php echo $target ?>"><?php echo $title ?></a>
-                    <?php
-}
-    ?>
-                </div>
-                <?php endif;
-    ?>
-
-                <?php if (isset($includeDate) && $includeDate): ?>
-                    <div class="ccm-block-page-list-date"><?=$date?></div>
-                <?php endif;
-    ?>
-
-                <?php if (isset($includeDescription) && $includeDescription): ?>
-                    <div class="ccm-block-page-list-description">
-                        <?php echo $description ?>
-                    </div>
-                <?php endif;
-    ?>
-
-                <?php if (isset($useButtonForLink) && $useButtonForLink): ?>
-                <div class="ccm-block-page-list-page-entry-read-more">
-                    <a href="<?=$url?>" target="<?=$target?>" class="<?=$buttonClasses?>"><?=$buttonLinkText?></a>
-                </div>
-                <?php endif;
-    ?>
-
-                </div>
-        <?php endif;
-    ?>
-        </div>
-
-	<?php endforeach;
-    ?>
-    </div>
-
-    <?php if (count($pages) == 0): ?>
-        <div class="ccm-block-page-list-no-pages"><?=h($noResultsMessage)?></div>
-    <?php endif;
-    ?>
-
-</div><!-- end .ccm-block-page-list -->
-
-
-<?php if ($showPagination): ?>
-    <?php echo $pagination;
-    ?>
-<?php endif;
-    ?>
-
-<?php
 } ?>


### PR DESCRIPTION
* Remove deprecated `Loader`
* Add html comment to show closing tag
* Fix indent lines
* Simplify using external links
* Get the page owner instead of the author of initial version
* Use second option of `getAttribute` (because most designer don't use `is_object()`)
* Remove example of image attribute (because default template use thumbnail attribute)