### PR TITLE
Fix default site installed with wrong plural form

### DIFF
--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -80,6 +80,9 @@ class Service
         $locale->setLanguage($data[0]);
         $locale->setCountry($data[1]);
 
+        $localeService = new \Concrete\Core\Localization\Locale\Service($this->entityManager);
+        $localeService->updatePluralSettings($locale);
+
         $this->entityManager->persist($locale);
         $this->entityManager->flush();
 

--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -178,7 +178,11 @@ class Service
         $type = $service->getDefault();
         $site->setType($type);
 
+        $localeService = new \Concrete\Core\Localization\Locale\Service($this->entityManager);
+        $localeService->updatePluralSettings($locale);
+
         $this->entityManager->persist($site);
+        $this->entityManager->persist($locale);
         $this->entityManager->flush();
 
         return $site;


### PR DESCRIPTION
Before:

![_mysql_5_5_5-10_1_18-mariadb__localhost_concrete5_sitelocales_and_concrete5_ _-bash_ _114x29](https://cloud.githubusercontent.com/assets/514294/22630227/756adbfe-ec39-11e6-841a-0e41e69ae1a8.jpg)

After:

![_mysql_5_5_5-10_1_18-mariadb__localhost_concrete5_sitelocales](https://cloud.githubusercontent.com/assets/514294/22630229/7a521f9c-ec39-11e6-8668-704c540d0fe0.jpg)
