### PR TITLE
Load site interface translation by default

### DIFF
--- a/concrete/src/Localization/Translator/Adapter/Zend/Translation/Loader/Gettext/SiteTranslationLoader.php
+++ b/concrete/src/Localization/Translator/Adapter/Zend/Translation/Loader/Gettext/SiteTranslationLoader.php
@@ -19,12 +19,10 @@ class SiteTranslationLoader extends AbstractTranslationLoader
      */
     public function loadTranslations(TranslatorAdapterInterface $translatorAdapter)
     {
-        if ($this->app->make('multilingual/detector')->isEnabled()) {
-            $languageFile = DIR_LANGUAGES_SITE_INTERFACE . "/" . $translatorAdapter->getLocale() . ".mo";
-            if (is_file($languageFile)) {
-                $translator = $translatorAdapter->getTranslator();
-                $translator->addTranslationFile('gettext', $languageFile);
-            }
+        $languageFile = DIR_LANGUAGES_SITE_INTERFACE . "/" . $translatorAdapter->getLocale() . ".mo";
+        if (is_file($languageFile)) {
+            $translator = $translatorAdapter->getTranslator();
+            $translator->addTranslationFile('gettext', $languageFile);
         }
     }
 


### PR DESCRIPTION
Since v8, user can translate site interface by default. Why don't we enable loading site interface translation by default?

Note: Please merge this PR after merging #5073.