### PR TITLE
Fix/date format issues

### DIFF
--- a/concrete/blocks/date_navigation/controller.php
+++ b/concrete/blocks/date_navigation/controller.php
@@ -56,7 +56,7 @@ class Controller extends BlockController
 
     public function getDateLabel($dateArray)
     {
-        return \Punic\Calendar::getMonthName($dateArray['month']).' '.$dateArray['year'];
+        return \Punic\Calendar::getMonthName($dateArray['month'], 'wide', '', true).' '.$dateArray['year'];
     }
 
     public function getPassThruActionAndParameters($parameters)

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -316,7 +316,8 @@ class Controller extends BlockController
             $this->list->filterByPublicDate($end, '<=');
 
             $seo = Core::make('helper/seo');
-            $seo->addTitleSegment($dh->date('F Y', $start));
+            $date = ucfirst(\Punic\Calendar::getMonthName($month, 'wide', '', true).' '.$year);
+            $seo->addTitleSegment($date);
         }
         $this->view();
     }


### PR DESCRIPTION
This fixes a couple of issues with date formatting.

First of the fixes is regarding the date navigation that currently displays e.g. in Finnish "Marraskuuta 2016" which in English means something similar to "Day of November 2016". This format would be more suitable in case we are displaying the day in front of the month name as in "1. marraskuuta 2016". Without the day it just feels incorrect.

The other fix is for the custom page title in the Page List block in case the date filter is enabled. It wasn't properly translated before.