### PR TITLE
Ignore .iml files from IntelliJ IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __MACOSX
 ._*
 .*swp
 .*swo
+*.iml
 
 # ignore composer files
 composer.phar


### PR DESCRIPTION
These are project files generated by IntelliJ IDE, they should be ignored to avoid erroneous commits.