### PR TITLE
Tags block - add class to selected tag on tag filtered pages

### DIFF
--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -150,4 +150,12 @@ class Controller extends BlockController
     {
         return $stack->getCollectionParentID() == Page::getByPath(STACKS_PAGE_PATH)->getCollectionID();
     }
+
+    public function action_tag($tag = false)
+    {
+        if ($tag) {
+            $this->set('selectedTag', $tag);
+        }
+        $this->view();
+    }
 }

--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -101,13 +101,13 @@ class Controller extends BlockController
         }
 
         // grab selected tag, if we're linking to a page with a tag block on it.
-        if (is_array($_REQUEST['akID'])) {
+        if (isset($_REQUEST['akID']) && is_array($_REQUEST['akID'])) {
             $res = $_REQUEST['akID'][$ak->getAttributeKeyID()]['atSelectOptionID'][0];
             if (is_numeric($res) && $res > 0) {
                 $selectedOptionID = $res;
             }
         }
-        $this->set('selectedOptionID', $selectedOptionID);
+        $this->set('selectedOptionID', isset($selectedOptionID) ? $selectedOptionID : '');
         $this->set('options', $options);
         $this->set('akc', $controller);
         $this->set('ak', $ak);

--- a/concrete/blocks/tags/tag_form.php
+++ b/concrete/blocks/tags/tag_form.php
@@ -1,5 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
-$form = Loader::helper('form');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$form = $app->make('helper/form');
 $c = Page::getCurrentPage();
 ?>
 
@@ -44,7 +45,7 @@ $c = Page::getCurrentPage();
 	<div class="form-group">
     	<label class="control-label"><?php echo t('Link Tags to Filtered Page List')?></label>
 		<?php
-        $form_selector = Loader::helper('form/page_selector');
+        $form_selector = $app->make('helper/form/page_selector');
         echo $form_selector->selectPage('targetCID', $targetCID);
         ?>
 	</div>

--- a/concrete/blocks/tags/tag_form.php
+++ b/concrete/blocks/tags/tag_form.php
@@ -1,23 +1,19 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $form = Loader::helper('form');
 $c = Page::getCurrentPage();
+?>
 
-if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) {
-    ?>
-	<div class="ccm-error"><?=t('Error: The required page attribute with the handle of: "%s" doesn\'t exist', $controller->attributeHandle)?><br/><br/></div>
-<?php
-} else {
-    ?>
-<input type="hidden" name="attributeHandle" value="<?=$controller->attributeHandle?>" />
-
+<?php if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) { ?>
+<div class="ccm-error"><?php echo t('Error: The required page attribute with the handle of: "%s" doesn\'t exist', $controller->attributeHandle)?><br/><br/></div>
+<?php } else { ?>
+<input type="hidden" name="attributeHandle" value="<?php echo $controller->attributeHandle?>" />
 	<div class="form-group">
-        <?=$form->label('title', t('Title'))?>
-		<?php echo $form->text('title', $title);
-    ?>
+        <?php echo $form->label('title', t('Title'))?>
+		<?php echo $form->text('title', $title); ?>
 	</div>
 
     <div class="form-group">
-        <label class="control-label"><?=t('Display a List of Tags From')?></label>
+        <label class="control-label"><?php echo t('Display a List of Tags From')?></label>
         <div class="radio">
             <label>
                 <?php echo $form->radio('displayMode', 'page', $displayMode)?><?php echo t('The Current Page.')?>
@@ -30,36 +26,30 @@ if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) {
         </div>
     </div>
 
-	<?php if (!$inStackDashboardPage) {
-    ?>
+	<?php if (!$inStackDashboardPage) { ?>
 	<div id="ccm-tags-display-page" class="form-group">
-	<label class="control-label"><?php echo $ak->getAttributeKeyDisplayName();
-    ?></label>
-            <?php
-                $av = $c->getAttributeValueObject($ak);
-    $ak->render(new \Concrete\Core\Attribute\Context\StandardFormContext(), $av);
-    ?>
+    	<label class="control-label"><?php echo $ak->getAttributeKeyDisplayName(); ?></label>
+        <?php
+        $av = $c->getAttributeValueObject($ak);
+        $ak->render(new \Concrete\Core\Attribute\Context\StandardFormContext(), $av);
+        ?>
 	</div>
-	<?php
-}
-    ?>
+	<?php } ?>
 
 	<div id="ccm-tags-display-cloud" class="form-group">
-     <?=$form->label('cloudCount', t('Number to Display'))?>
+        <?php echo $form->label('cloudCount', t('Number to Display'))?>
 		<?php echo $form->text('cloudCount', $cloudCount, array('size' => 4))?>
 	</div>
 
-
 	<div class="form-group">
-	<label class="control-label"><?=t('Link Tags to Filtered Page List')?></label>
+    	<label class="control-label"><?php echo t('Link Tags to Filtered Page List')?></label>
 		<?php
         $form_selector = Loader::helper('form/page_selector');
-    echo $form_selector->selectPage('targetCID', $targetCID);
-    ?>
+        echo $form_selector->selectPage('targetCID', $targetCID);
+        ?>
 	</div>
+<?php } ?>
 
-<?php
-} ?>
 <script>
     $(function(){ tags.init(); });
 </script>

--- a/concrete/blocks/tags/tag_form.php
+++ b/concrete/blocks/tags/tag_form.php
@@ -5,7 +5,7 @@ $c = Page::getCurrentPage();
 if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) {
     ?>
 	<div class="ccm-error"><?=t('Error: The required page attribute with the handle of: "%s" doesn\'t exist', $controller->attributeHandle)?><br/><br/></div>
-<?php 
+<?php
 } else {
     ?>
 <input type="hidden" name="attributeHandle" value="<?=$controller->attributeHandle?>" />
@@ -33,14 +33,14 @@ if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) {
 	<?php if (!$inStackDashboardPage) {
     ?>
 	<div id="ccm-tags-display-page" class="form-group">
-	<label><?php echo $ak->getAttributeKeyDisplayName();
+	<label class="control-label"><?php echo $ak->getAttributeKeyDisplayName();
     ?></label>
             <?php
                 $av = $c->getAttributeValueObject($ak);
     $ak->render(new \Concrete\Core\Attribute\Context\StandardFormContext(), $av);
     ?>
 	</div>
-	<?php 
+	<?php
 }
     ?>
 
@@ -58,7 +58,7 @@ if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) {
     ?>
 	</div>
 
-<?php 
+<?php
 } ?>
 <script>
     $(function(){ tags.init(); });

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -1,38 +1,21 @@
-<?php
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
-defined('C5_EXECUTE') or die("Access Denied.");
-
-?>
-
-<?php if (count($options) > 0): ?>
-
+<?php if (count($options) > 0) { ?>
 <div class="ccm-block-tags-wrapper">
+    <?php if ($title) { ?>
+    <div class="ccm-block-tags-header">
+        <h5><?=$title?></h5>
+    </div>
+    <?php } ?>
 
-    <?php if ($title): ?>
-        <div class="ccm-block-tags-header">
-            <h5><?=$title?></h5>
-        </div>
-    <?php endif; ?>
-
-    <?php foreach ($options as $option) {
-    ?>
-
-        <?php if ($target) {
-    ?>
-            <a href="<?=$controller->getTagLink($option) ?>">
-                <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
-            </a>
-        <?php 
-} else {
-    ?>
+    <?php foreach ($options as $option) { ?>
+        <?php if ($target) { ?>
+        <a href="<?=$controller->getTagLink($option) ?>">
             <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
-        <?php 
-}
-    ?>
-    <?php 
-} ?>
-
-
+        </a>
+        <?php } else { ?>
+        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+        <?php } ?>
+    <?php } ?>
 </div>
-
-<?php endif; ?>
+<?php } ?>

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -10,11 +10,19 @@
 
     <?php foreach ($options as $option) { ?>
         <?php if ($target) { ?>
-        <a href="<?=$controller->getTagLink($option) ?>">
-            <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
-        </a>
+            <a href="<?=$controller->getTagLink($option) ?>">
+                <?php if (isset($selectedTag) && $option->getSelectAttributeOptionValue() == $selectedTag) { ?>
+                <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php } else { ?>
+                <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php } ?>
+            </a>
         <?php } else { ?>
-        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+            <?php if (isset($selectedTag) && $option->getSelectAttributeOptionValue() == $selectedTag) { ?>
+            <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+            <?php } else { ?>
+            <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+            <?php } ?>
         <?php } ?>
     <?php } ?>
 </div>

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -9,7 +9,7 @@
     <?php } ?>
 
     <?php foreach ($options as $option) { ?>
-        <?php if ($target) { ?>
+        <?php if (isset($target) && $target) { ?>
             <a href="<?=$controller->getTagLink($option) ?>">
                 <?php if (isset($selectedTag) && $option->getSelectAttributeOptionValue() == $selectedTag) { ?>
                 <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>

--- a/concrete/themes/elemental/css/build/blocks/tags.less
+++ b/concrete/themes/elemental/css/build/blocks/tags.less
@@ -18,6 +18,10 @@ span.ccm-block-tags-tag {
   border-width: 1px;
   border-style: solid;
   color: @body-type-color;
+
+    &.ccm-block-tags-tag-selected {
+      border-color: darken(@footer-social-icon-hover-color, 10%);
+    }
 }
 
 div.ccm-block-tags-wrapper a:hover span.ccm-block-tags-tag {


### PR DESCRIPTION
https://www.concrete5.org/community/forums/customizing_c5/get-selected-tag-on-tag-block-for-page-list-filtering/

The selected tag on tag filtered pages will receive the "ccm-block-tags-tag-selected" class. In the Elemental theme the selected tag has a change to its border color.

**Changes:**

_selected tag_
![tag_selected-changes1](https://cloud.githubusercontent.com/assets/10898145/22867068/3cbf818c-f14e-11e6-9d54-04c60c06e972.png)

_selected tag and tag hover_
![tag_selected-changes2](https://cloud.githubusercontent.com/assets/10898145/22867070/3fcbd196-f14e-11e6-9d2a-b4db6cb86b2d.png)

