### PR TITLE
Share This Page block - open links in new window

### DIFF
--- a/concrete/blocks/share_this_page/view.php
+++ b/concrete/blocks/share_this_page/view.php
@@ -2,8 +2,10 @@
 
 <div class="ccm-block-share-this-page">
     <ul class="list-inline">
-    <?php foreach($selected as $service) { ?>
-        <li><a href="<?php echo h($service->getServiceLink()) ?>" aria-label="<?php echo h($service->getDisplayName()) ?>"><?php echo $service->getServiceIconHTML()?></a></li>
+    <?php foreach ($selected as $service) { ?>
+        <li>
+            <a href="<?php echo h($service->getServiceLink()) ?>" target="_blank" aria-label="<?php echo h($service->getDisplayName()) ?>"><?php echo $service->getServiceIconHTML()?></a>
+        </li>
     <?php } ?>
     </ul>
 </div>


### PR DESCRIPTION
https://www.concrete5.org/community/forums/usage/share-this-page-open-in-new-window/

Based on the behavior of the default widgets from Twitter, Facebook, and Google, share links should open in a new window.