### PR TITLE
Enable printing exception details in CLI commands

### DIFF
--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -3,9 +3,66 @@ namespace Concrete\Core\Console;
 
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Exception;
+use Throwable;
 
 abstract class Command extends SymfonyCommand
 {
+    /**
+     * The return code we should return when an exception is thrown while running the command.
+     *
+     * @var int
+     */
+    const RETURN_CODE_ON_FAILURE = 1;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        $error = null;
+        try {
+            return parent::run($input, $output);
+        } catch (Exception $x) {
+            $error = $x;
+        } catch (Throwable $x) {
+            $error = $x;
+        }
+        $this->writeError($output, $error);
+
+        return static::RETURN_CODE_ON_FAILURE;
+    }
+
+    /**
+     * Write an exception.
+     *
+     * @param OutputInterface $output
+     * @param Exception|Throwable $error
+     */
+    protected function writeError(OutputInterface $output, $error)
+    {
+        $message = trim($error->getMessage()) . "\n";
+        if ($output->getVerbosity() >= $output::VERBOSITY_VERBOSE) {
+            $file = $error->getFile();
+            if ($file) {
+                $message .= "\nFile:\n$file";
+                if ($error->getLine()) {
+                    $message .= ':' . $error->getLine();
+                }
+                $message .= "\n";
+            }
+            if ($output->getVerbosity() >= $output::VERBOSITY_VERY_VERBOSE) {
+                $trace = $error->getTraceAsString();
+                if ($trace) {
+                    $message .= "\nTrace:\n$trace\n";
+                }
+            }
+        }
+        $output->writeln('<error>' . $message . '</error>');
+    }
+
     /**
      * Add the "env" option to the command options.
      *

--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -22,7 +22,6 @@ abstract class Command extends SymfonyCommand
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
-        $error = null;
         try {
             return parent::run($input, $output);
         } catch (Exception $x) {

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -11,14 +11,15 @@ class ClearCacheCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:clear-cache')
             ->setDescription('Clear the concrete5 cache')
             ->addEnvOption()
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-clear-cache
 EOT
@@ -28,17 +29,9 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            $output->write('Clearing the concrete5 cache... ');
-            $cms = Core::make('app');
-            $cms->clearCaches();
-            $output->writeln('<info>done.</info>');
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
-        }
-
-        return $rc;
+        $output->write('Clearing the concrete5 cache... ');
+        $cms = Core::make('app');
+        $cms->clearCaches();
+        $output->writeln('<info>done.</info>');
     }
 }

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -5,7 +5,6 @@ use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Core;
-use Exception;
 
 class ClearCacheCommand extends Command
 {

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -15,10 +15,17 @@ class CompareSchemaCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:compare-schema')
             ->setDescription('Compares db.xml in concrete5 XML schema, concrete5 entities, and all installed package schemas and entities with the contents of the database and prints the difference.')
             ->addEnvOption()
+            ->setHelp(<<<EOT
+Returns codes:
+  0 operation completed successfully
+  $errExitCode errors occurred
+EOT
+            )
         ;
     }
 

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -39,7 +39,7 @@ EOT
         $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
         $schemas = [];
         $sm = $db->getSchemaManager();
-        /**
+        /*
          * @var MySqlSchemaManager $sm
          */
         $dbSchema = $sm->createSchema();

--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -11,13 +11,14 @@ class ExecCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:exec')
             ->setDescription('Execute a PHP script within the concrete5 environment')
             ->addEnvOption()
             ->addArgument('script', InputArgument::REQUIRED, 'The path of the script to be executed')
             ->addArgument('arguments', InputArgument::IS_ARRAY, 'The arguments to pass to the script')
-        ->setHelp(<<<EOT
+            ->setHelp(<<<EOT
 In the included script you'll have these variables:
 - \$input: an instance of \Symfony\Component\Console\Input\InputInterface
 - \$output: an instance of \Symfony\Component\Console\Input\OutputInterface
@@ -27,30 +28,23 @@ To specify the command return code, define an int variable named '\$rc'.
 
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-exec
 EOT
             )
-            ;
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        try {
-            if (!is_file($input->getArgument('script'))) {
-                throw new Exception(sprintf('Unable to find the file %s', $input->getArgument('script')));
-            }
-            $args = $input->getArgument('arguments');
-            require $input->getArgument('script');
-            if (!isset($rc)) {
-                $rc = 0;
-            }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+        $this->lookForWebserverProcessOwner();
+        if (!is_file($input->getArgument('script'))) {
+            throw new Exception(sprintf('Unable to find the file %s', $input->getArgument('script')));
         }
+        $args = $input->getArgument('arguments');
+        require $input->getArgument('script');
 
-        return $rc;
+        return isset($rc) ? $rc : 0;
     }
 }

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -14,15 +14,16 @@ class GenerateIDESymbolsCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:ide-symbols')
             ->setDescription('Generate IDE symbols')
             ->addEnvOption()
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', ['all'])
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-ide-symbols
 EOT
@@ -33,41 +34,36 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $rc = 0;
-        try {
-            $what = $input->getArgument('generate-what');
-            $p = array_search('ide-classes', $what);
-            if ($p !== false || in_array('all', $what)) {
-                if ($p !== false) {
-                    unset($what[$p]);
-                }
-                $output->write('Generating fake PHP classes to help IDE... ');
-                if (!Core::make('app')->isInstalled()) {
-                    $output->writeln('<error>failed: concrete5 is not installed.</error>');
-                    $rc = 1;
-                } else {
-                    $this->generateIDEClasses();
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-            $p = array_search('phpstorm', $what);
-            if ($p !== false || in_array('all', $what)) {
-                if ($p !== false) {
-                    unset($what[$p]);
-                }
-                $output->write('Generating PHP metadata for PHPStorm... ');
-                $this->generatePHPStorm();
-                $output->writeln('<info>done.</info>');
-            }
-            $p = array_search('all', $what);
+        $what = $input->getArgument('generate-what');
+        $p = array_search('ide-classes', $what);
+        if ($p !== false || in_array('all', $what)) {
             if ($p !== false) {
                 unset($what[$p]);
             }
-            if (!empty($what)) {
-                throw new Exception('Unrecognized arguments: ' . implode(', ', $what));
+            $output->write('Generating fake PHP classes to help IDE... ');
+            if (!Core::make('app')->isInstalled()) {
+                $output->writeln('<error>failed: concrete5 is not installed.</error>');
+                $rc = static::RETURN_CODE_ON_FAILURE;
+            } else {
+                $this->generateIDEClasses();
+                $output->writeln('<info>done.</info>');
             }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+        }
+        $p = array_search('phpstorm', $what);
+        if ($p !== false || in_array('all', $what)) {
+            if ($p !== false) {
+                unset($what[$p]);
+            }
+            $output->write('Generating PHP metadata for PHPStorm... ');
+            $this->generatePHPStorm();
+            $output->writeln('<info>done.</info>');
+        }
+        $p = array_search('all', $what);
+        if ($p !== false) {
+            unset($what[$p]);
+        }
+        if (!empty($what)) {
+            throw new Exception('Unrecognized arguments: ' . implode(', ', $what));
         }
 
         return $rc;

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Console\Command;
 use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Exception;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\System\Info;
 

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -12,14 +12,15 @@ class InfoCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:info')
             ->setDescription('Get server and concrete5 detailed informations.')
             ->addEnvOption()
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-info
 EOT
@@ -29,53 +30,44 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
+        $info = Facade::getFacadeApplication()->make(Info::class);
+        /* @var Info $info */
 
-        try {
-            $info = Facade::getFacadeApplication()->make(Info::class);
-            /* @var Info $info */
+        $output->writeln('<info># concrete5 Version</info>');
+        $output->writeln('Installed - ' . ($info->isInstalled() ? 'Yes' : 'No'));
+        $output->writeln($info->getCoreVersions());
 
-            $output->writeln('<info># concrete5 Version</info>');
-            $output->writeln('Installed - ' . ($info->isInstalled() ? 'Yes' : 'No'));
-            $output->writeln($info->getCoreVersions());
+        $output->writeln('');
+        $output->writeln('<info># Paths</info>');
+        $output->writeln('Web root - ' . $info->getWebRootDirectory());
+        $output->writeln('Core root - ' . $info->getCoreRootDirectory());
 
-            $output->writeln('');
-            $output->writeln('<info># Paths</info>');
-            $output->writeln('Web root - ' . $info->getWebRootDirectory());
-            $output->writeln('Core root - ' . $info->getCoreRootDirectory());
+        $output->writeln('');
+        $output->writeln('<info># concrete5 Packages</info>');
+        $output->writeln($info->getPackages() ?: 'None');
 
-            $output->writeln('');
-            $output->writeln('<info># concrete5 Packages</info>');
-            $output->writeln($info->getPackages() ?: 'None');
+        $output->writeln('');
+        $output->writeln('<info># concrete5 Overrides</info>');
+        $output->writeln($info->getOverrides() ?: 'None');
 
-            $output->writeln('');
-            $output->writeln('<info># concrete5 Overrides</info>');
-            $output->writeln($info->getOverrides() ?: 'None');
+        $output->writeln('');
+        $output->writeln('<info># concrete5 Cache Settings</info>');
+        $output->writeln($info->getCache());
 
-            $output->writeln('');
-            $output->writeln('<info># concrete5 Cache Settings</info>');
-            $output->writeln($info->getCache());
+        $output->writeln('');
+        $output->writeln('<info># Server API</info>');
+        $output->writeln($info->getServerAPI());
 
-            $output->writeln('');
-            $output->writeln('<info># Server API</info>');
-            $output->writeln($info->getServerAPI());
+        $output->writeln('');
+        $output->writeln('<info># PHP Version</info>');
+        $output->writeln($info->getPhpVersion());
 
-            $output->writeln('');
-            $output->writeln('<info># PHP Version</info>');
-            $output->writeln($info->getPhpVersion());
+        $output->writeln('');
+        $output->writeln('<info># PHP Extensions</info>');
+        $output->writeln(($info->getPhpExtensions() === false ? 'Unable to determine' : $info->getPhpExtensions()));
 
-            $output->writeln('');
-            $output->writeln('<info># PHP Extensions</info>');
-            $output->writeln(($info->getPhpExtensions() === false ? 'Unable to determine' : $info->getPhpExtensions()));
-
-            $output->writeln('');
-            $output->writeln('<info># PHP Settings</info>');
-            $output->writeln($info->getPhpSettings());
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
-        }
-
-        return $rc;
+        $output->writeln('');
+        $output->writeln('<info># PHP Settings</info>');
+        $output->writeln($info->getPhpSettings());
     }
 }

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -23,6 +23,7 @@ class InstallCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:install')
             ->setDescription('Install concrete5')
@@ -46,10 +47,10 @@ class InstallCommand extends Command
             ->addOption('attach', null, InputOption::VALUE_NONE, 'Attach if database contains an existing concrete5 instance')
             ->addOption('force-attach', null, InputOption::VALUE_NONE, 'Always attach')
             ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Install using interactive (wizard) mode')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-install
 EOT
@@ -58,154 +59,146 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            $app = Application::getFacadeApplication();
-            $options = $input->getOptions();
-            if (isset($options['config']) && $options['config'] && strtolower($options['config']) !== 'none') {
-                if (!is_file($options['config'])) {
-                    throw new Exception('Unable to find the configuration file ' . $options['config']);
-                }
-                $configOptions = include $options['config'];
-                if (!is_array($configOptions)) {
-                    throw new Exception('The configuration file did not returned an array.');
-                }
-                foreach ($configOptions as $k => $v) {
-                    if (!$input->hasParameterOption("--$k")) {
-                        $options[$k] = $v;
-                    }
+        $app = Application::getFacadeApplication();
+        $options = $input->getOptions();
+        if (isset($options['config']) && $options['config'] && strtolower($options['config']) !== 'none') {
+            if (!is_file($options['config'])) {
+                throw new Exception('Unable to find the configuration file ' . $options['config']);
+            }
+            $configOptions = include $options['config'];
+            if (!is_array($configOptions)) {
+                throw new Exception('The configuration file did not returned an array.');
+            }
+            foreach ($configOptions as $k => $v) {
+                if (!$input->hasParameterOption("--$k")) {
+                    $options[$k] = $v;
                 }
             }
-            if (file_exists(DIR_CONFIG_SITE . '/database.php')) {
-                throw new Exception('concrete5 is already installed.');
-            }
-            if (isset($options['site-locale'])) {
-                $locale = explode('_', $options['site-locale']);
-                $_POST['siteLocaleLanguage'] = $locale[0];
-                $_POST['siteLocaleCountry'] = $locale[1];
-            } else {
-                $_POST['siteLocaleLanguage'] = 'en';
-                $_POST['siteLocaleCountry'] = 'US';
-            }
-
-            if (isset($options['language'])) {
-                $_POST['locale'] = $options['language'];
-            }
-
-            Database::extend('install', function () use ($options) {
-                return Database::getFactory()->createConnection([
-                    'host' => $options['db-server'],
-                    'user' => $options['db-username'],
-                    'password' => $options['db-password'],
-                    'database' => $options['db-database'],
-                ]);
-            });
-            Database::setDefaultConnection('install');
-            Config::set('database.connections.install', []);
-
-            $cnt = $app->make(\Concrete\Controller\Install::class);
-
-            $force_attach = $input->getOption('force-attach');
-            $auto_attach = $force_attach || $input->getOption('attach');
-            $cnt->setAutoAttach($auto_attach);
-
-            $cnt->on_start();
-            $fileWriteErrors = clone $cnt->fileWriteErrors;
-            $e = $app->make('helper/validation/error');
-            if (!$cnt->get('imageTest')) {
-                $e->add('GD library must be enabled to install concrete5.');
-            }
-            if (!$cnt->get('mysqlTest')) {
-                $e->add($cnt->getDBErrorMsg());
-            }
-            if (!$cnt->get('xmlTest')) {
-                $e->add('SimpleXML and DOM must be enabled to install concrete5.');
-            }
-            if (!$cnt->get('phpVtest')) {
-                $e->add('concrete5 requires PHP ' . $cnt->getMinimumPhpVersion() . ' or greater.');
-            }
-            if (is_object($fileWriteErrors)) {
-                $e->add($fileWriteErrors);
-            }
-            $spl = StartingPointPackage::getClass($options['starting-point']);
-            if ($spl === null) {
-                $e->add('Invalid starting-point: ' . $options['starting-point']);
-            }
-            if (!$e->has()) {
-                $_POST['DB_SERVER'] = $options['db-server'];
-                $_POST['DB_USERNAME'] = $options['db-username'];
-                $_POST['DB_PASSWORD'] = $options['db-password'];
-                $_POST['DB_DATABASE'] = $options['db-database'];
-                $_POST['SITE'] = $options['site'];
-                $_POST['SAMPLE_CONTENT'] = $options['starting-point'];
-                $_POST['uEmail'] = $options['admin-email'];
-                $_POST['uPasswordConfirm'] = $_POST['uPassword'] = $options['admin-password'];
-                if ($options['canonical-url']) {
-                    $_POST['canonicalUrlChecked'] = '1';
-                    $_POST['canonicalUrl'] = $options['canonical-url'];
-                }
-                if ($options['canonical-ssl-url']) {
-                    $_POST['canonicalSSLUrlChecked'] = '1';
-                    $_POST['canonicalSSLUrl'] = $options['canonical-ssl-url'];
-                }
-                $e = $cnt->configure();
-            }
-            if ($e->has()) {
-                throw new Exception(implode("\n", $e->getList()));
-            }
-            try {
-                $attach_mode = $force_attach;
-
-                if (!$force_attach && $cnt->isAutoAttachEnabled()) {
-                    /** @var Connection $db */
-                    $db = $app->make('database')->connection();
-
-                    if ($db->query('show tables')->rowCount()) {
-                        $attach_mode = true;
-                    }
-                }
-
-                require DIR_CONFIG_SITE . '/site_install.php';
-                require DIR_CONFIG_SITE . '/site_install_user.php';
-                $routines = $spl->getInstallRoutines();
-                foreach ($routines as $r) {
-                    // If we're
-                    if ($attach_mode && !$r instanceof AttachModeCompatibleRoutineInterface) {
-                        $output->writeln("{$r->getProgress()}%: {$r->getText()} (Skipped)");
-                        continue;
-                    }
-
-                    $output->writeln($r->getProgress() . '%: ' . $r->getText());
-                    $spl->executeInstallRoutine($r->getMethod());
-                }
-            } catch (Exception $ex) {
-                $cnt->reset();
-                throw $ex;
-            }
-            if (
-                isset($options['demo-username']) && isset($options['demo-password']) && isset($options['demo-email'])
-                &&
-                is_string($options['demo-username']) && is_string($options['demo-password']) && is_string($options['demo-email'])
-                &&
-                ($options['demo-username'] !== '') && ($options['demo-password'] !== '') && ($options['demo-email'] !== '')
-            ) {
-                $output->write('Adding demo user... ');
-                \UserInfo::add([
-                    'uName' => $options['demo-username'],
-                    'uEmail' => $options['demo-email'],
-                    'uPassword' => $options['demo-password'],
-                ])->getUserObject()->enterGroup(
-                    \Group::getByID(ADMIN_GROUP_ID)
-                );
-                $output->writeln('done.');
-            }
-            $output->writeln('<info>Installation Complete!</info>');
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '(' . $x->getTraceAsString() . ')</error>');
-            $rc = 1;
+        }
+        if (file_exists(DIR_CONFIG_SITE . '/database.php')) {
+            throw new Exception('concrete5 is already installed.');
+        }
+        if (isset($options['site-locale'])) {
+            $locale = explode('_', $options['site-locale']);
+            $_POST['siteLocaleLanguage'] = $locale[0];
+            $_POST['siteLocaleCountry'] = $locale[1];
+        } else {
+            $_POST['siteLocaleLanguage'] = 'en';
+            $_POST['siteLocaleCountry'] = 'US';
         }
 
-        return $rc;
+        if (isset($options['language'])) {
+            $_POST['locale'] = $options['language'];
+        }
+
+        Database::extend('install', function () use ($options) {
+            return Database::getFactory()->createConnection([
+                'host' => $options['db-server'],
+                'user' => $options['db-username'],
+                'password' => $options['db-password'],
+                'database' => $options['db-database'],
+            ]);
+        });
+        Database::setDefaultConnection('install');
+        Config::set('database.connections.install', []);
+
+        $cnt = $app->make(\Concrete\Controller\Install::class);
+
+        $force_attach = $input->getOption('force-attach');
+        $auto_attach = $force_attach || $input->getOption('attach');
+        $cnt->setAutoAttach($auto_attach);
+
+        $cnt->on_start();
+        $fileWriteErrors = clone $cnt->fileWriteErrors;
+        $e = $app->make('helper/validation/error');
+        if (!$cnt->get('imageTest')) {
+            $e->add('GD library must be enabled to install concrete5.');
+        }
+        if (!$cnt->get('mysqlTest')) {
+            $e->add($cnt->getDBErrorMsg());
+        }
+        if (!$cnt->get('xmlTest')) {
+            $e->add('SimpleXML and DOM must be enabled to install concrete5.');
+        }
+        if (!$cnt->get('phpVtest')) {
+            $e->add('concrete5 requires PHP ' . $cnt->getMinimumPhpVersion() . ' or greater.');
+        }
+        if (is_object($fileWriteErrors)) {
+            $e->add($fileWriteErrors);
+        }
+        $spl = StartingPointPackage::getClass($options['starting-point']);
+        if ($spl === null) {
+            $e->add('Invalid starting-point: ' . $options['starting-point']);
+        }
+        if (!$e->has()) {
+            $_POST['DB_SERVER'] = $options['db-server'];
+            $_POST['DB_USERNAME'] = $options['db-username'];
+            $_POST['DB_PASSWORD'] = $options['db-password'];
+            $_POST['DB_DATABASE'] = $options['db-database'];
+            $_POST['SITE'] = $options['site'];
+            $_POST['SAMPLE_CONTENT'] = $options['starting-point'];
+            $_POST['uEmail'] = $options['admin-email'];
+            $_POST['uPasswordConfirm'] = $_POST['uPassword'] = $options['admin-password'];
+            if ($options['canonical-url']) {
+                $_POST['canonicalUrlChecked'] = '1';
+                $_POST['canonicalUrl'] = $options['canonical-url'];
+            }
+            if ($options['canonical-ssl-url']) {
+                $_POST['canonicalSSLUrlChecked'] = '1';
+                $_POST['canonicalSSLUrl'] = $options['canonical-ssl-url'];
+            }
+            $e = $cnt->configure();
+        }
+        if ($e->has()) {
+            throw new Exception(implode("\n", $e->getList()));
+        }
+        try {
+            $attach_mode = $force_attach;
+
+            if (!$force_attach && $cnt->isAutoAttachEnabled()) {
+                /** @var Connection $db */
+                $db = $app->make('database')->connection();
+
+                if ($db->query('show tables')->rowCount()) {
+                    $attach_mode = true;
+                }
+            }
+
+            require DIR_CONFIG_SITE . '/site_install.php';
+            require DIR_CONFIG_SITE . '/site_install_user.php';
+            $routines = $spl->getInstallRoutines();
+            foreach ($routines as $r) {
+                // If we're
+                if ($attach_mode && !$r instanceof AttachModeCompatibleRoutineInterface) {
+                    $output->writeln("{$r->getProgress()}%: {$r->getText()} (Skipped)");
+                    continue;
+                }
+
+                $output->writeln($r->getProgress() . '%: ' . $r->getText());
+                $spl->executeInstallRoutine($r->getMethod());
+            }
+        } catch (Exception $ex) {
+            $cnt->reset();
+            throw $ex;
+        }
+        if (
+            isset($options['demo-username']) && isset($options['demo-password']) && isset($options['demo-email'])
+            &&
+            is_string($options['demo-username']) && is_string($options['demo-password']) && is_string($options['demo-email'])
+            &&
+            ($options['demo-username'] !== '') && ($options['demo-password'] !== '') && ($options['demo-email'] !== '')
+        ) {
+            $output->write('Adding demo user... ');
+            \UserInfo::add([
+                'uName' => $options['demo-username'],
+                'uEmail' => $options['demo-email'],
+                'uPassword' => $options['demo-password'],
+            ])->getUserObject()->enterGroup(
+                \Group::getByID(ADMIN_GROUP_ID)
+            );
+            $output->writeln('done.');
+        }
+        $output->writeln('<info>Installation Complete!</info>');
     }
 
     /**

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -14,6 +14,7 @@ class InstallPackageCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:package-install')
             ->addOption('full-content-swap', null, InputOption::VALUE_NONE, 'If this option is specified a full content swap will be performed (if the package supports it)')
@@ -21,10 +22,10 @@ class InstallPackageCommand extends Command
             ->addEnvOption()
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-install
 EOT
@@ -34,79 +35,71 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            $pkgHandle = $input->getArgument('package');
-            $packageOptions = [];
-            foreach ($input->getArgument('package-options') as $keyValuePair) {
-                list($key, $value) = explode('=', $keyValuePair, 2);
-                $key = trim($key);
-                if (substr($key, -2) === '[]') {
-                    $isArray = true;
-                    $key = rtrim(substr($key, 0, -2));
-                } else {
-                    $isArray = false;
+        $pkgHandle = $input->getArgument('package');
+        $packageOptions = [];
+        foreach ($input->getArgument('package-options') as $keyValuePair) {
+            list($key, $value) = explode('=', $keyValuePair, 2);
+            $key = trim($key);
+            if (substr($key, -2) === '[]') {
+                $isArray = true;
+                $key = rtrim(substr($key, 0, -2));
+            } else {
+                $isArray = false;
+            }
+            if ($key === '' || !isset($value)) {
+                throw new Exception(sprintf("Unable to parse the package option '%s': it must be in the form of key=value", $keyValuePair));
+            }
+            if (isset($packageOptions[$key])) {
+                if (!($isArray && is_array($packageOptions[$key]))) {
+                    throw new Exception(sprintf("Duplicated package option '%s'", $key));
                 }
-                if ($key === '' || !isset($value)) {
-                    throw new Exception(sprintf("Unable to parse the package option '%s': it must be in the form of key=value", $keyValuePair));
-                }
-                if (isset($packageOptions[$key])) {
-                    if (!($isArray && is_array($packageOptions[$key]))) {
-                        throw new Exception(sprintf("Duplicated package option '%s'", $key));
-                    }
-                    $packageOptions[$key][] = $value;
-                } else {
-                    $packageOptions[$key] = $isArray ? ((array) $value) : $value;
-                }
+                $packageOptions[$key][] = $value;
+            } else {
+                $packageOptions[$key] = $isArray ? ((array) $value) : $value;
             }
-
-            $output->write("Looking for package '$pkgHandle'... ");
-            foreach (Package::getInstalledList() as $installed) {
-                if ($installed->getPackageHandle() === $pkgHandle) {
-                    throw new Exception(sprintf("The package '%s' (%s) is already installed", $pkgHandle, $installed->getPackageName()));
-                }
-            }
-            $pkg = null;
-            foreach (Package::getAvailablePackages() as $available) {
-                if ($available->getPackageHandle() === $pkgHandle) {
-                    $pkg = $available;
-                    break;
-                }
-            }
-            if ($pkg === null) {
-                throw new Exception(sprintf("No package with handle '%s' was found", $pkgHandle));
-            }
-            $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));
-
-            $output->write('Checking preconditions... ');
-            $test = $pkg->testForInstall();
-            if (is_object($test)) {
-                throw new Exception(implode("\n", $test->getList()));
-            }
-
-            $output->write('Preconditions good. Installing...');
-
-            $r = Package::install($pkg, []);
-            if ($r instanceof ErrorList) {
-                throw new Exception(implode("\n", $r->getList()));
-            }
-
-            $output->writeln('<info>Package Installed.</info>');
-            $swapper = $pkg->getContentSwapper();
-
-            if ($swapper->allowsFullContentSwap($pkg) && $input->getOption('full-content-swap')) {
-                $output->write('Performing full content swap... ');
-                $swapper->swapContent($pkg, []);
-                if (method_exists($pkg, 'on_after_swap_content')) {
-                    $pkg->on_after_swap_content([]);
-                }
-                $output->writeln('<info>done.</info>');
-            }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
         }
 
-        return $rc;
+        $output->write("Looking for package '$pkgHandle'... ");
+        foreach (Package::getInstalledList() as $installed) {
+            if ($installed->getPackageHandle() === $pkgHandle) {
+                throw new Exception(sprintf("The package '%s' (%s) is already installed", $pkgHandle, $installed->getPackageName()));
+            }
+        }
+        $pkg = null;
+        foreach (Package::getAvailablePackages() as $available) {
+            if ($available->getPackageHandle() === $pkgHandle) {
+                $pkg = $available;
+                break;
+            }
+        }
+        if ($pkg === null) {
+            throw new Exception(sprintf("No package with handle '%s' was found", $pkgHandle));
+        }
+        $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));
+
+        $output->write('Checking preconditions... ');
+        $test = $pkg->testForInstall();
+        if (is_object($test)) {
+            throw new Exception(implode("\n", $test->getList()));
+        }
+
+        $output->write('Preconditions good. Installing...');
+
+        $r = Package::install($pkg, []);
+        if ($r instanceof ErrorList) {
+            throw new Exception(implode("\n", $r->getList()));
+        }
+
+        $output->writeln('<info>Package Installed.</info>');
+        $swapper = $pkg->getContentSwapper();
+
+        if ($swapper->allowsFullContentSwap($pkg) && $input->getOption('full-content-swap')) {
+            $output->write('Performing full content swap... ');
+            $swapper->swapContent($pkg, []);
+            if (method_exists($pkg, 'on_after_swap_content')) {
+                $pkg->on_after_swap_content([]);
+            }
+            $output->writeln('<info>done.</info>');
+        }
     }
 }

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -16,6 +16,7 @@ class JobCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:job')
             ->setDescription(t('Run a concrete5 job'))
@@ -27,10 +28,10 @@ class JobCommand extends Command
                 InputArgument::IS_ARRAY,
                 t('Jobs to run (separate multiple jobs with a space)')
             )
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-job
 EOT
@@ -41,97 +42,90 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $rc = 0;
-        try {
-            $options = $input->getOptions();
-            $formatter = $this->getHelper('formatter');
+        $options = $input->getOptions();
+        $formatter = $this->getHelper('formatter');
 
-            if ($options['list']) {
-                $output->writeln(t('Available Jobs'));
-                $table = new Table($output);
-                $table->setHeaders([t('Job Handle'), t('Job Name')]);
-                foreach (Job::getList() as $job) {
-                    $table->addRow([$job->getJobHandle(), $job->getJobName()]);
+        if ($options['list']) {
+            $output->writeln(t('Available Jobs'));
+            $table = new Table($output);
+            $table->setHeaders([t('Job Handle'), t('Job Name')]);
+            foreach (Job::getList() as $job) {
+                $table->addRow([$job->getJobHandle(), $job->getJobName()]);
+            }
+            $table->render();
+
+            $output->writeln('');
+            $output->writeln(t('Available Job Sets'));
+            $table = new Table($output);
+            $table->setHeaders([t('Set Name'), t('Jobs')]);
+            foreach (JobSet::getList() as $jobSet) {
+                $jobsInSet = [];
+                foreach ($jobSet->getJobs() as $job) {
+                    $jobsInSet[] = $job->getJobName();
                 }
-                $table->render();
+                $table->addRow([$jobSet->getJobSetName(), implode(', ', $jobsInSet)]);
+            }
+            $table->render();
+        } else {
+            $jobs = [];
 
-                $output->writeln('');
-                $output->writeln(t('Available Job Sets'));
-                $table = new Table($output);
-                $table->setHeaders([t('Set Name'), t('Jobs')]);
-                foreach (JobSet::getList() as $jobSet) {
-                    $jobsInSet = [];
-                    foreach ($jobSet->getJobs() as $job) {
-                        $jobsInSet[] = $job->getJobName();
-                    }
-                    $table->addRow([$jobSet->getJobSetName(), implode(', ', $jobsInSet)]);
-                }
-                $table->render();
-            } else {
-                $jobs = [];
+            $jobsArg = $input->getArgument('jobs');
 
-                $jobsArg = $input->getArgument('jobs');
+            if (empty($jobsArg)) {
+                throw new RuntimeException(t('At least one job must be provided'));
+            }
 
-                if (empty($jobsArg)) {
-                    throw new RuntimeException(t('At least one job must be provided'));
-                }
-
-                if ($options['set']) {
-                    foreach ($jobsArg as $setName) {
-                        $set = JobSet::getByName($setName);
-                        if ($set) {
-                            $jobs = array_merge($jobs, $set->getJobs());
-                        } else {
-                            $rc = 1;
-                            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                                $output->writeln(
-                                    '<error>' . t('A job set with name "%s" was not found', $setName) . '</error>'
-                                );
-                            }
-                        }
-                    }
-                } else {
-                    foreach ($jobsArg as $jobHandle) {
-                        $job = Job::getByHandle($jobHandle);
-                        if ($job) {
-                            $jobs[] = $job;
-                        } else {
-                            $rc = 1;
-                            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                                $output->writeln(
-                                    '<error>' . t('A job with handle "%s" was not found', $jobHandle) . '</error>'
-                                );
-                            }
-                        }
-                    }
-                }
-
-                if (!empty($jobs)) {
-                    foreach ($jobs as $job) {
-                        $result = $job->executeJob();
-                        if ($result->isError()) {
-                            $rc = 1;
-                            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                                $output->writeln(
-                                    $formatter->formatSection(
-                                        $job->getJobHandle(), '<error>' . t('Job Failed') . '</error>'
-                                    )
-                                );
-                            }
-                            break;
-                        }
+            if ($options['set']) {
+                foreach ($jobsArg as $setName) {
+                    $set = JobSet::getByName($setName);
+                    if ($set) {
+                        $jobs = array_merge($jobs, $set->getJobs());
+                    } else {
+                        $rc = 1;
                         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln(
-                                $formatter->formatSection($job->getJobHandle(), $result->getResultMessage())
+                                '<error>' . t('A job set with name "%s" was not found', $setName) . '</error>'
+                            );
+                        }
+                    }
+                }
+            } else {
+                foreach ($jobsArg as $jobHandle) {
+                    $job = Job::getByHandle($jobHandle);
+                    if ($job) {
+                        $jobs[] = $job;
+                    } else {
+                        $rc = 1;
+                        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+                            $output->writeln(
+                                '<error>' . t('A job with handle "%s" was not found', $jobHandle) . '</error>'
                             );
                         }
                     }
                 }
             }
-        } catch (Exception $x) {
-            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                $output->writeln('<error>' . $x->getMessage() . '</error>');
+
+            if (!empty($jobs)) {
+                foreach ($jobs as $job) {
+                    $result = $job->executeJob();
+                    if ($result->isError()) {
+                        $rc = 1;
+                        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+                            $output->writeln(
+                                $formatter->formatSection(
+                                    $job->getJobHandle(), '<error>' . t('Job Failed') . '</error>'
+                                )
+                            );
+                        }
+                        break;
+                    }
+                    if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+                        $output->writeln(
+                            $formatter->formatSection($job->getJobHandle(), $result->getResultMessage())
+                        );
+                    }
+                }
             }
-            $rc = 1;
         }
 
         return $rc;

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Console\Command;
 use Job;
 use JobSet;
 use RuntimeException;
-use Exception;
 use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -36,6 +36,7 @@ final class PackPackageCommand extends Command
         $zipAuto = static::ZIPOUT_AUTO;
         $keepDot = static::KEEP_DOT;
         $keepSources = static::KEEP_SOURCES;
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:package-pack')
             ->setDescription('Process a package (expand PHP short tags, compile icons and translations, create zip archive)')
@@ -62,7 +63,7 @@ Please remark that this command can also parse legacy (pre-5.7) packages.
 
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-pack
 EOT
@@ -72,7 +73,6 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
         try {
             $state = static::parseInput($input);
             if ($state->updateSourceDirectory === false && $state->zipFilename === null) {
@@ -112,11 +112,8 @@ EOT
                 $state->zip = null;
                 @unlink($state->zipFilename);
             }
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+            throw $x;
         }
-
-        return $rc;
     }
 
     /**

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -14,15 +14,16 @@ class ResetCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:reset')
             ->setDescription('Reset the concrete5 installation, deleting files and emptying the database')
             ->addEnvOption()
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-reset
 EOT
@@ -32,108 +33,100 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            if (!$input->getOption('force')) {
-                if (!$input->isInteractive()) {
-                    throw new Exception("You have to specify the --force option in order to run this command");
-                }
-                $confirmQuestion = new ConfirmationQuestion(
-                    'Are you sure you want to reset this concrete5 installation? ' .
-                    'This will delete files and empty the database! (y/n)',
-                    false
-                );
-                if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                    throw new Exception("Operation aborted.");
-                }
+        if (!$input->getOption('force')) {
+            if (!$input->isInteractive()) {
+                throw new Exception("You have to specify the --force option in order to run this command");
             }
-            if (Database::getDefaultConnection()) {
-                $output->write("Listing tables... ");
-                $cn = Database::get();
-                /* @var $cn \Concrete\Core\Database\Connection\Connection */
-                $sm = $cn->getSchemaManager();
-                $tables = $sm->listTables();
-                $output->writeln('<info>done.</info>');
-                $tableNames = [];
-                foreach ($tables as $table) {
-                    $tableNames[] = $table->getName();
-                    foreach ($table->getForeignKeys() as $foreignKey) {
-                        $output->write("Dropping foreign key {$table->getName()}.{$foreignKey->getName()}... ");
-                        $sm->dropForeignKey($foreignKey, $table);
-                        $output->writeln('<info>done.</info>');
-                    }
-                }
-                foreach ($tableNames as $tableName) {
-                    $output->write("Dropping table $tableName... ");
-                    $sm->dropTable($tableName);
-                    $output->writeln('<info>done.</info>');
-                }
+            $confirmQuestion = new ConfirmationQuestion(
+                'Are you sure you want to reset this concrete5 installation? ' .
+                'This will delete files and empty the database! (y/n)',
+                false
+            );
+            if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
+                throw new Exception("Operation aborted.");
             }
-            $fh = Core::make('helper/file');
-            /* @var $fh \Concrete\Core\File\Service\File */
-            $createEmptyDirs = [
-                'application/files' => DIR_FILES_UPLOADED_STANDARD,
-            ];
-            $createEmptyFiles = [
-                'application/files/index.html' => DIR_FILES_UPLOADED_STANDARD . '/index.html',
-            ];
-            if (is_file(DIR_FILES_UPLOADED_STANDARD . '/.gitignore')) {
-                $createEmptyFiles['application/files/.gitignore'] = DIR_FILES_UPLOADED_STANDARD . '/.gitignore';
-            }
-            $deleteFiles = [
-                '.htaccess' => DIR_BASE . '/.htaccess',
-                'application/config/app.php' => DIR_CONFIG_SITE . '/app.php',
-                'application/config/database.php' => DIR_CONFIG_SITE . '/database.php',
-                'application/config/site.php' => DIR_CONFIG_SITE . '/site.php',
-                'application/config/site_install.php' => DIR_CONFIG_SITE . '/site_install.php',
-                'application/config/site_install_user.php' => DIR_CONFIG_SITE . '/site_install_user.php',
-            ];
-            foreach ($deleteFiles as $shownName => $fullpath) {
-                if (is_file($fullpath)) {
-                    $output->write("Deleting file $shownName... ");
-                    if (@unlink($fullpath) === false) {
-                        throw new Exception("Failed to delete file $fullpath");
-                    }
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-            $deleteDirs = [
-                'application/config/generated_overrides' => DIR_CONFIG_SITE . '/generated_overrides',
-                'application/config/doctrine' => DIR_CONFIG_SITE . '/doctrine',
-                'application/files' => DIR_FILES_UPLOADED_STANDARD,
-            ];
-            foreach ($deleteDirs as $shownName => $fullpath) {
-                if (is_dir($fullpath)) {
-                    $output->write("Deleting directory $shownName... ");
-                    if ($fh->removeAll($fullpath, true) === false) {
-                        throw new Exception("Failed to delete directory $fullpath");
-                    }
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-            foreach ($createEmptyDirs as $shownName => $fullpath) {
-                if (!file_exists($fullpath)) {
-                    $output->write("Creating directory $shownName... ");
-                    if (@mkdir($fullpath) === false) {
-                        throw new Exception("Failed to create directory $fullpath");
-                    }
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-            foreach ($createEmptyFiles as $shownName => $fullpath) {
-                if (!file_exists($fullpath)) {
-                    $output->write("Creating empty file $shownName... ");
-                    if (@touch($fullpath) === false) {
-                        throw new Exception("Failed to create empty file $fullpath");
-                    }
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
         }
-
-        return $rc;
+        if (Database::getDefaultConnection()) {
+            $output->write("Listing tables... ");
+            $cn = Database::get();
+            /* @var $cn \Concrete\Core\Database\Connection\Connection */
+            $sm = $cn->getSchemaManager();
+            $tables = $sm->listTables();
+            $output->writeln('<info>done.</info>');
+            $tableNames = [];
+            foreach ($tables as $table) {
+                $tableNames[] = $table->getName();
+                foreach ($table->getForeignKeys() as $foreignKey) {
+                    $output->write("Dropping foreign key {$table->getName()}.{$foreignKey->getName()}... ");
+                    $sm->dropForeignKey($foreignKey, $table);
+                    $output->writeln('<info>done.</info>');
+                }
+            }
+            foreach ($tableNames as $tableName) {
+                $output->write("Dropping table $tableName... ");
+                $sm->dropTable($tableName);
+                $output->writeln('<info>done.</info>');
+            }
+        }
+        $fh = Core::make('helper/file');
+        /* @var $fh \Concrete\Core\File\Service\File */
+        $createEmptyDirs = [
+            'application/files' => DIR_FILES_UPLOADED_STANDARD,
+        ];
+        $createEmptyFiles = [
+            'application/files/index.html' => DIR_FILES_UPLOADED_STANDARD . '/index.html',
+        ];
+        if (is_file(DIR_FILES_UPLOADED_STANDARD . '/.gitignore')) {
+            $createEmptyFiles['application/files/.gitignore'] = DIR_FILES_UPLOADED_STANDARD . '/.gitignore';
+        }
+        $deleteFiles = [
+            '.htaccess' => DIR_BASE . '/.htaccess',
+            'application/config/app.php' => DIR_CONFIG_SITE . '/app.php',
+            'application/config/database.php' => DIR_CONFIG_SITE . '/database.php',
+            'application/config/site.php' => DIR_CONFIG_SITE . '/site.php',
+            'application/config/site_install.php' => DIR_CONFIG_SITE . '/site_install.php',
+            'application/config/site_install_user.php' => DIR_CONFIG_SITE . '/site_install_user.php',
+        ];
+        foreach ($deleteFiles as $shownName => $fullpath) {
+            if (is_file($fullpath)) {
+                $output->write("Deleting file $shownName... ");
+                if (@unlink($fullpath) === false) {
+                    throw new Exception("Failed to delete file $fullpath");
+                }
+                $output->writeln('<info>done.</info>');
+            }
+        }
+        $deleteDirs = [
+            'application/config/generated_overrides' => DIR_CONFIG_SITE . '/generated_overrides',
+            'application/config/doctrine' => DIR_CONFIG_SITE . '/doctrine',
+            'application/files' => DIR_FILES_UPLOADED_STANDARD,
+        ];
+        foreach ($deleteDirs as $shownName => $fullpath) {
+            if (is_dir($fullpath)) {
+                $output->write("Deleting directory $shownName... ");
+                if ($fh->removeAll($fullpath, true) === false) {
+                    throw new Exception("Failed to delete directory $fullpath");
+                }
+                $output->writeln('<info>done.</info>');
+            }
+        }
+        foreach ($createEmptyDirs as $shownName => $fullpath) {
+            if (!file_exists($fullpath)) {
+                $output->write("Creating directory $shownName... ");
+                if (@mkdir($fullpath) === false) {
+                    throw new Exception("Failed to create directory $fullpath");
+                }
+                $output->writeln('<info>done.</info>');
+            }
+        }
+        foreach ($createEmptyFiles as $shownName => $fullpath) {
+            if (!file_exists($fullpath)) {
+                $output->write("Creating empty file $shownName... ");
+                if (@touch($fullpath) === false) {
+                    throw new Exception("Failed to create empty file $fullpath");
+                }
+                $output->writeln('<info>done.</info>');
+            }
+        }
     }
 }

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -16,6 +16,7 @@ class TranslatePackageCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:package-translate')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a concrete5 package)')
@@ -25,7 +26,7 @@ class TranslatePackageCommand extends Command
             ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')
             ->addOption('exclude-3rdparty', 'x', InputOption::VALUE_NONE, 'Specify this option to avoid parsing 3rd party folders')
             ->setDescription('Creates or updates translations of a concrete5 package')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 If the locale option(s) is not specified, we'll generate/update translations for the currently defined locales for the package.
 If currently no locale is defined, we'll generate/update translations for all the currently installed locales of the core of concrete5.
 In order to don't generate the locale files but only the master translations file (.pot), specify "--locale=-" (or "-l-")
@@ -40,7 +41,7 @@ Please remark that this command can also parse legacy (pre-5.7) packages.
 
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-translate
 EOT
@@ -50,204 +51,196 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            $vsh = Core::make('helper/validation/strings');
-            /* @var \Concrete\Core\Utility\Service\Validation\Strings $vsh */
-            $fh = Core::make('helper/file');
-            /* @var \Concrete\Core\File\Service\File $fh */
+        $vsh = Core::make('helper/validation/strings');
+        /* @var \Concrete\Core\Utility\Service\Validation\Strings $vsh */
+        $fh = Core::make('helper/file');
+        /* @var \Concrete\Core\File\Service\File $fh */
 
-            // Let's determine the package handle, directory and version
-            $packageHandle = null;
-            $packageDirectory = null;
-            $packageVersion = null;
-            $p = $input->getArgument('package');
-            if (is_dir($p) || !$vsh->handle($p)) {
-                $packageDirectory = @realpath($p);
-                if ($packageDirectory === false) {
-                    throw new Exception("Unable to find the directory '$p'");
-                }
-                $controllerFile = $packageDirectory . '/' . FILENAME_CONTROLLER;
-                if (!is_file($controllerFile)) {
-                    throw new Exception("The directory '$packageDirectory' does not seems to contain a valid concrete5 package");
-                }
-                $controllerContents = $fh->getContents($controllerFile);
-                if ($controllerContents) {
-                    $allTokens = @token_get_all($controllerContents);
-                    if ($allTokens) {
-                        $tokens = array_values(
-                            array_filter(
-                                $allTokens,
-                                function ($token) {
-                                    $keep = true;
-                                    if (is_array($token)) {
-                                        switch ($token[0]) {
-                                        case T_DOC_COMMENT:
-                                        case T_WHITESPACE:
-                                        case T_COMMENT:
-                                            $keep = false;
-                                            break;
-                                        }
+        // Let's determine the package handle, directory and version
+        $packageHandle = null;
+        $packageDirectory = null;
+        $packageVersion = null;
+        $p = $input->getArgument('package');
+        if (is_dir($p) || !$vsh->handle($p)) {
+            $packageDirectory = @realpath($p);
+            if ($packageDirectory === false) {
+                throw new Exception("Unable to find the directory '$p'");
+            }
+            $controllerFile = $packageDirectory . '/' . FILENAME_CONTROLLER;
+            if (!is_file($controllerFile)) {
+                throw new Exception("The directory '$packageDirectory' does not seems to contain a valid concrete5 package");
+            }
+            $controllerContents = $fh->getContents($controllerFile);
+            if ($controllerContents) {
+                $allTokens = @token_get_all($controllerContents);
+                if ($allTokens) {
+                    $tokens = array_values(
+                        array_filter(
+                            $allTokens,
+                            function ($token) {
+                                $keep = true;
+                                if (is_array($token)) {
+                                    switch ($token[0]) {
+                                    case T_DOC_COMMENT:
+                                    case T_WHITESPACE:
+                                    case T_COMMENT:
+                                        $keep = false;
+                                        break;
                                     }
-
-                                    return $keep;
                                 }
-                            )
-                        );
-                        // Look for package version
-                        for ($i = 0; $i < count($tokens) - 2; ++$i) {
-                            if (
-                                $packageHandle === null
-                                && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgHandle'
-                                && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
-                                && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
-                            ) {
-                                $packageHandle = @eval('return ' . $tokens[$i + 2][1] . ';');
+
+                                return $keep;
                             }
-                            if (
-                                $packageVersion === null
-                                && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgVersion'
-                                && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
-                                && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
-                            ) {
-                                $packageVersion = @eval('return ' . $tokens[$i + 2][1] . ';');
-                            }
-                        }
-                    }
-                }
-                if ($packageHandle === null) {
-                    $packageHandle = basename($packageDirectory);
-                }
-            } else {
-                foreach (Package::getAvailablePackages(false) as $pkg) {
-                    if (strcasecmp($p, $pkg->getPackageHandle()) === 0) {
-                        $packageHandle = $pkg->getPackageHandle();
-                        $packageDirectory = $pkg->getPackagePath();
-                        $packageVersion = $pkg->getPackageVersion();
-                        break;
-                    }
-                }
-                if ($packageHandle === null) {
-                    throw new Exception("Unable to find a package with handle '$p'");
-                }
-            }
-            $packageLanguagesDirectory = $packageDirectory . '/' . DIRNAME_LANGUAGES;
-
-            // Determine the locales to translate
-            $locales = [];
-            $localeOption = $input->getOption('locale');
-            if (in_array('-', $localeOption, true)) {
-                // We don't want any locale
-            } elseif (empty($localeOption)) {
-                // List the currently package locales
-                foreach ($fh->getDirectoryContents($packageLanguagesDirectory) as $item) {
-                    if (is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.mo") || is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.po")) {
-                        $locales[] = $item;
-                    }
-                }
-                if (empty($locales)) {
-                    // Let's use the core locales
-                    $locales = Localization::getAvailableInterfaceLanguages();
-                }
-            } else {
-                // Normalize the locales (eg from it-it to it_IT)
-                foreach ($localeOption as $lo) {
-                    $chunks = [];
-                    foreach (explode('_', str_replace('-', '_', $lo)) as $index => $chunk) {
-                        if ($index === 0) {
-                            // Language (eg zh)
-                            $chunks[] = strtolower($chunk);
-                        } elseif (strlen($chunk) === 4) {
-                            // Script (eg Hans)
-                            $chunks[] = ucfirst(strtolower($chunk));
-                        } else {
-                            // Territory (eg CN)
-                            $chunks[] = strtoupper($chunk);
-                        }
-                    }
-                    $locales[] = implode('_', $chunks);
-                }
-            }
-
-            // Initialize the master translations file (.pot)
-            $pot = new Translations();
-            $pot->setHeader('Project-Id-Version', "$packageHandle $packageVersion");
-            $pot->setLanguage(Localization::BASE_LOCALE);
-            $pot->setHeader('Report-Msgid-Bugs-To', $input->getOption('contact'));
-            $pot->setHeader('Last-Translator', $input->getOption('translator'));
-
-            // Parse the package directory
-            $output->writeln('Parsing package contents');
-            foreach (\C5TL\Parser::getAllParsers() as $parser) {
-                if ($parser->canParseDirectory()) {
-                    $output->write('- running parser "' . $parser->getParserName() . '"... ');
-                    $parser->parseDirectory(
-                        $packageDirectory,
-                        "packages/$packageHandle",
-                        $pot,
-                        false,
-                        $input->getOption('exclude-3rdparty')
+                        )
                     );
-                    $output->writeln('<info>done.</info>');
-                }
-            }
-
-            // Save the pot file
-            $output->write('Saving .pot file... ');
-            if (!is_dir($packageLanguagesDirectory)) {
-                @mkdir($packageLanguagesDirectory, 0775, true);
-                if (!is_dir($packageLanguagesDirectory)) {
-                    throw new Exception("Unable to create the directory $packageLanguagesDirectory");
-                }
-            }
-            $potFilename = "$packageLanguagesDirectory/messages.pot";
-            if ($pot->toPoFile($potFilename) === false) {
-                throw new Exception("Unable to save the .pot file to $potFilename");
-            }
-            $output->writeln('<info>done.</info>');
-
-            // Creating/updating the locale files
-            foreach ($locales as $locale) {
-                $output->writeln("Working on locale $locale");
-                $poDirectory = "$packageLanguagesDirectory/$locale/LC_MESSAGES";
-                $po = clone $pot;
-                $po->setLanguage($locale);
-                $poFile = "$poDirectory/messages.po";
-                $moFile = "$poDirectory/messages.mo";
-                if (is_file($poFile)) {
-                    $output->write("- reading current .po file... ");
-                    $oldPo = Translations::fromPoFile($poFile);
-                    $output->writeln('<info>done.</info>');
-                } elseif (is_file($moFile)) {
-                    $output->write("- decompiling current .mo file... ");
-                    $oldPo = Translations::fromMoFile($poFile);
-                    $output->writeln('<info>done.</info>');
-                } else {
-                    $oldPo = null;
-                }
-                if ($oldPo !== null) {
-                    $output->write("- merging translations... ");
-                    $po->mergeWith($oldPo, 0);
-                    $output->writeln('<info>done.</info>');
-                }
-                $output->write("- saving .po file... ");
-                if (!is_dir($poDirectory)) {
-                    @mkdir($poDirectory, 0775, true);
-                    if (!is_dir($poDirectory)) {
-                        throw new Exception("Unable to create the directory $poDirectory");
+                    // Look for package version
+                    for ($i = 0; $i < count($tokens) - 2; ++$i) {
+                        if (
+                            $packageHandle === null
+                            && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgHandle'
+                            && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
+                            && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
+                        ) {
+                            $packageHandle = @eval('return ' . $tokens[$i + 2][1] . ';');
+                        }
+                        if (
+                            $packageVersion === null
+                            && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgVersion'
+                            && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
+                            && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
+                        ) {
+                            $packageVersion = @eval('return ' . $tokens[$i + 2][1] . ';');
+                        }
                     }
                 }
-                $po->toPoFile($poFile);
-                $output->writeln('<info>done.</info>');
-                $output->write("- saving .mo file... ");
-                $po->toMoFile($moFile);
-                $output->writeln('<info>done.</info>');
             }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+            if ($packageHandle === null) {
+                $packageHandle = basename($packageDirectory);
+            }
+        } else {
+            foreach (Package::getAvailablePackages(false) as $pkg) {
+                if (strcasecmp($p, $pkg->getPackageHandle()) === 0) {
+                    $packageHandle = $pkg->getPackageHandle();
+                    $packageDirectory = $pkg->getPackagePath();
+                    $packageVersion = $pkg->getPackageVersion();
+                    break;
+                }
+            }
+            if ($packageHandle === null) {
+                throw new Exception("Unable to find a package with handle '$p'");
+            }
+        }
+        $packageLanguagesDirectory = $packageDirectory . '/' . DIRNAME_LANGUAGES;
+
+        // Determine the locales to translate
+        $locales = [];
+        $localeOption = $input->getOption('locale');
+        if (in_array('-', $localeOption, true)) {
+            // We don't want any locale
+        } elseif (empty($localeOption)) {
+            // List the currently package locales
+            foreach ($fh->getDirectoryContents($packageLanguagesDirectory) as $item) {
+                if (is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.mo") || is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.po")) {
+                    $locales[] = $item;
+                }
+            }
+            if (empty($locales)) {
+                // Let's use the core locales
+                $locales = Localization::getAvailableInterfaceLanguages();
+            }
+        } else {
+            // Normalize the locales (eg from it-it to it_IT)
+            foreach ($localeOption as $lo) {
+                $chunks = [];
+                foreach (explode('_', str_replace('-', '_', $lo)) as $index => $chunk) {
+                    if ($index === 0) {
+                        // Language (eg zh)
+                        $chunks[] = strtolower($chunk);
+                    } elseif (strlen($chunk) === 4) {
+                        // Script (eg Hans)
+                        $chunks[] = ucfirst(strtolower($chunk));
+                    } else {
+                        // Territory (eg CN)
+                        $chunks[] = strtoupper($chunk);
+                    }
+                }
+                $locales[] = implode('_', $chunks);
+            }
         }
 
-        return $rc;
+        // Initialize the master translations file (.pot)
+        $pot = new Translations();
+        $pot->setHeader('Project-Id-Version', "$packageHandle $packageVersion");
+        $pot->setLanguage(Localization::BASE_LOCALE);
+        $pot->setHeader('Report-Msgid-Bugs-To', $input->getOption('contact'));
+        $pot->setHeader('Last-Translator', $input->getOption('translator'));
+
+        // Parse the package directory
+        $output->writeln('Parsing package contents');
+        foreach (\C5TL\Parser::getAllParsers() as $parser) {
+            if ($parser->canParseDirectory()) {
+                $output->write('- running parser "' . $parser->getParserName() . '"... ');
+                $parser->parseDirectory(
+                    $packageDirectory,
+                    "packages/$packageHandle",
+                    $pot,
+                    false,
+                    $input->getOption('exclude-3rdparty')
+                );
+                $output->writeln('<info>done.</info>');
+            }
+        }
+
+        // Save the pot file
+        $output->write('Saving .pot file... ');
+        if (!is_dir($packageLanguagesDirectory)) {
+            @mkdir($packageLanguagesDirectory, 0775, true);
+            if (!is_dir($packageLanguagesDirectory)) {
+                throw new Exception("Unable to create the directory $packageLanguagesDirectory");
+            }
+        }
+        $potFilename = "$packageLanguagesDirectory/messages.pot";
+        if ($pot->toPoFile($potFilename) === false) {
+            throw new Exception("Unable to save the .pot file to $potFilename");
+        }
+        $output->writeln('<info>done.</info>');
+
+        // Creating/updating the locale files
+        foreach ($locales as $locale) {
+            $output->writeln("Working on locale $locale");
+            $poDirectory = "$packageLanguagesDirectory/$locale/LC_MESSAGES";
+            $po = clone $pot;
+            $po->setLanguage($locale);
+            $poFile = "$poDirectory/messages.po";
+            $moFile = "$poDirectory/messages.mo";
+            if (is_file($poFile)) {
+                $output->write("- reading current .po file... ");
+                $oldPo = Translations::fromPoFile($poFile);
+                $output->writeln('<info>done.</info>');
+            } elseif (is_file($moFile)) {
+                $output->write("- decompiling current .mo file... ");
+                $oldPo = Translations::fromMoFile($poFile);
+                $output->writeln('<info>done.</info>');
+            } else {
+                $oldPo = null;
+            }
+            if ($oldPo !== null) {
+                $output->write("- merging translations... ");
+                $po->mergeWith($oldPo, 0);
+                $output->writeln('<info>done.</info>');
+            }
+            $output->write("- saving .po file... ");
+            if (!is_dir($poDirectory)) {
+                @mkdir($poDirectory, 0775, true);
+                if (!is_dir($poDirectory)) {
+                    throw new Exception("Unable to create the directory $poDirectory");
+                }
+            }
+            $po->toPoFile($poFile);
+            $output->writeln('<info>done.</info>');
+            $output->write("- saving .mo file... ");
+            $po->toMoFile($moFile);
+            $output->writeln('<info>done.</info>');
+        }
     }
 }

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -16,15 +16,16 @@ class UpdateCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addEnvOption()
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the update')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 EOT
             )
         ;
@@ -32,28 +33,20 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
-        try {
-            if (!$input->getOption('force')) {
-                if (!$input->isInteractive()) {
-                    throw new Exception("You have to specify the --force option in order to run this command");
-                }
-                $confirmQuestion = new ConfirmationQuestion('Are you sure you want to update this concrete5 installation?');
-                if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                    throw new Exception("Operation aborted.");
-                }
+        if (!$input->getOption('force')) {
+            if (!$input->isInteractive()) {
+                throw new Exception("You have to specify the --force option in order to run this command");
             }
-            $configuration = new \Concrete\Core\Updater\Migrations\Configuration();
-            $output = new ConsoleOutput();
-            $configuration->setOutputWriter(new OutputWriter(function ($message) use ($output) {
-                $output->writeln($message);
-            }));
-            Update::updateToCurrentVersion($configuration);
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+            $confirmQuestion = new ConfirmationQuestion('Are you sure you want to update this concrete5 installation?');
+            if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
+                throw new Exception("Operation aborted.");
+            }
         }
-
-        return $rc;
+        $configuration = new \Concrete\Core\Updater\Migrations\Configuration();
+        $output = new ConsoleOutput();
+        $configuration->setOutputWriter(new OutputWriter(function ($message) use ($output) {
+            $output->writeln($message);
+        }));
+        Update::updateToCurrentVersion($configuration);
     }
 }

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -13,6 +13,7 @@ class UpdatePackageCommand extends Command
 {
     protected function configure()
     {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:package-update')
             ->addEnvOption()
@@ -20,10 +21,10 @@ class UpdatePackageCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')
             ->addArgument('packages', InputArgument::IS_ARRAY, 'The handle of the package to be updated (multiple values allowed)')
             ->setDescription('Update a concrete5 package')
-            ->setHelp(<<<'EOT'
+            ->setHelp(<<<EOT
 Returns codes:
   0 operation completed successfully
-  1 errors occurred
+  $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-update
 EOT
@@ -34,45 +35,40 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $rc = 0;
-        try {
-            $updatableHandles = [];
-            $force = $input->getOption('force');
-            if ($input->getOption('all')) {
-                if (count($input->getArgument('packages')) > 0) {
-                    throw new Exception('If you use the --all option you can\'t specify package handles.');
+        $updatableHandles = [];
+        $force = $input->getOption('force');
+        if ($input->getOption('all')) {
+            if (count($input->getArgument('packages')) > 0) {
+                throw new Exception('If you use the --all option you can\'t specify package handles.');
+            }
+            if ($force) {
+                foreach (Package::getInstalledHandles() as $pkgHandle) {
+                    $updatableHandles[] = $pkgHandle;
                 }
-                if ($force) {
-                    foreach (Package::getInstalledHandles() as $pkgHandle) {
-                        $updatableHandles[] = $pkgHandle;
-                    }
-                    if (empty($updatableHandles)) {
-                        $output->writeln("No package has been found.");
-                    }
-                } else {
-                    foreach (Package::getLocalUpgradeablePackages() as $pkg) {
-                        $updatableHandles[] = $pkg->getPackageHandle();
-                    }
-                    if (empty($updatableHandles)) {
-                        $output->writeln("No package needs to be updated.");
-                    }
+                if (empty($updatableHandles)) {
+                    $output->writeln("No package has been found.");
                 }
             } else {
-                $updatableHandles = $input->getArgument('packages');
+                foreach (Package::getLocalUpgradeablePackages() as $pkg) {
+                    $updatableHandles[] = $pkg->getPackageHandle();
+                }
                 if (empty($updatableHandles)) {
-                    throw new Exception('No package handle specified and the --all option has not been specified.');
+                    $output->writeln("No package needs to be updated.");
                 }
             }
-            foreach ($updatableHandles as $updatableHandle) {
-                try {
-                    $this->updatePackage($updatableHandle, $output, $force);
-                } catch (Exception $x) {
-                    $output->writeln('<error>' . $x->getMessage() . '</error>');
-                    $rc = 1;
-                }
+        } else {
+            $updatableHandles = $input->getArgument('packages');
+            if (empty($updatableHandles)) {
+                throw new Exception('No package handle specified and the --all option has not been specified.');
             }
-        } catch (Exception $x) {
-            $output->writeln('<error>' . $x->getMessage() . '</error>');
-            $rc = 1;
+        }
+        foreach ($updatableHandles as $updatableHandle) {
+            try {
+                $this->updatePackage($updatableHandle, $output, $force);
+            } catch (Exception $x) {
+                $this->writeError($output, $x);
+                $rc = 1;
+            }
         }
 
         return $rc;


### PR DESCRIPTION
When running CLI commands it's often useful to see where an error occurred.

What about adding support to show the file where the exception occurred (`-v` option) and the stack trace (`-vv` option)?