### PR TITLE
Cascade delete of attribute key settings

### DIFF
--- a/concrete/src/Entity/Attribute/Key/Settings/Settings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/Settings.php
@@ -14,7 +14,7 @@ abstract class Settings
     /**
      * @ORM\Id
      * @ORM\OneToOne(targetEntity="\Concrete\Core\Entity\Attribute\Key\Key")
-     * @ORM\JoinColumn(name="akID", referencedColumnName="akID")
+     * @ORM\JoinColumn(name="akID", referencedColumnName="akID", onDelete="CASCADE")
      */
     protected $key;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
@@ -3,10 +3,20 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
 use Concrete\Core\Page\Page;
 use SinglePage;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Entity\Attribute\Key\Key;
+use Concrete\Core\Entity\Attribute\Key\Settings\AddressSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\BooleanSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\ExpressSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\ImageFileSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\SelectSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\TextareaSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\TextSettings;
+use Concrete\Core\Entity\Attribute\Key\Settings\TopicsSettings;
 
 class Version20170202000000 extends AbstractMigration
 {
@@ -21,7 +31,17 @@ class Version20170202000000 extends AbstractMigration
             $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
         }
         $this->refreshEntities([
+            Key::class,
+            AddressSettings::class,
+            BooleanSettings::class,
             DateTimeSettings::class,
+            EmptySettings::class,
+            ExpressSettings::class,
+            ImageFileSettings::class,
+            SelectSettings::class,
+            TextareaSettings::class,
+            TextSettings::class,
+            TopicsSettings::class,
         ]);
         $config = $app->make('config');
         if (!$config->get('app.curl.verifyPeer')) {


### PR DESCRIPTION
I have a package that installs a custom attribute.

The package uninstallation fails because there are attribute key settings that are associated to the attribute key.

Let's cascade delete the attribute key settings when we delete the attribute keys.