### PR TITLE
Show white_label background when needed

### DIFF
--- a/concrete/themes/concrete/background_image.php
+++ b/concrete/themes/concrete/background_image.php
@@ -81,7 +81,7 @@ $(function() {
     <?php 
 } elseif (Config::get('concrete.white_label.background_url')) {
     ?>
-        $.backstretch("<?= Config::get('concrete.urls.background_url') ?>", {
+        $.backstretch("<?= Config::get('concrete.white_label.background_url') ?>", {
             fade: 500
         });
     <?php 


### PR DESCRIPTION
The check in the elseif is correct (concrete.white_label.background_url), only the config item that is used (concrete.urls.background_url) is different. (line 82-84)

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!