### PR TITLE
Display user attributes in set order

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -2,18 +2,19 @@
 namespace Concrete\Controller\SinglePage\Dashboard\Users;
 
 use Concrete\Controller\Element\Search\Users\Header;
-use Concrete\Core\Page\Controller\DashboardPageController;
-use Imagine\Image\Box;
-use Exception;
-use User;
-use UserInfo;
-use stdClass;
-use Permissions;
-use PermissionKey;
-use UserAttributeKey;
+use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\User\EditResponse as UserEditResponse;
 use Concrete\Core\Workflow\Progress\UserProgress as UserWorkflowProgress;
+use Exception;
+use Imagine\Image\Box;
+use Permissions;
+use PermissionKey;
+use stdClass;
+use User;
+use UserAttributeKey;
+use UserInfo;
 
 class Search extends DashboardPageController
 {
@@ -457,8 +458,16 @@ class Search extends DashboardPageController
                 $groups[] = $obj;
             }
             $this->set('groupsJSON', json_encode($groups));
-            $attributes = UserAttributeKey::getList(true);
-            $this->set('attributes', $attributes);
+
+            $service = $this->app->make(CategoryService::class);
+            $categoryEntity = $service->getByHandle('user');
+            $category = $categoryEntity->getController();
+            $setManager = $category->getSetManager();
+            $sets = $setManager->getAttributeSets();
+            $unassigned = $setManager->getUnassignedAttributeKeys();
+            $this->set('attributeSets', $sets);
+            $this->set('unassigned', $unassigned);
+
             $this->set('pageTitle', t('View/Edit %s', $this->user->getUserDisplayName()));
 
             $workflowRequestActions = [];

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -191,19 +191,38 @@ if (isset($user) && is_object($user)) {
         </section>
 
         <section>
-            <h4><?= t('Other Attributes') ?></h4>
-            <?php
-            View::element('attribute/editable_list', [
-                'attributes' => $attributes,
-                'object' => $user,
-                'saveAction' => $view->action('update_attribute', $user->getUserID()),
-                'clearAction' => $view->action('clear_attribute', $user->getUserID()),
-                'permissionsArguments' => ['attributes' => $allowedEditAttributes],
-                'permissionsCallback' => function ($ak, $permissionsArguments) {
-                    return is_array($permissionsArguments['attributes']) && in_array($ak->getAttributeKeyID(), $permissionsArguments['attributes']);
-                },
-            ]);
-            ?>
+
+            <?php foreach ($attributeSets as $set) : ?>
+                <h4><?php echo $set->getAttributeSetDisplayName()?></h4>
+                <?php
+                    View::element('attribute/editable_list', [
+                        'attributes' => $set->getAttributeKeys(),
+                        'object' => $user,
+                        'saveAction' => $view->action('update_attribute', $user->getUserID()),
+                        'clearAction' => $view->action('clear_attribute', $user->getUserID()),
+                        'permissionsArguments' => ['attributes' => $allowedEditAttributes],
+                        'permissionsCallback' => function ($ak, $permissionsArguments) {
+                            return is_array($permissionsArguments['attributes']) && in_array($ak->getAttributeKeyID(), $permissionsArguments['attributes']);
+                        },
+                    ]); ?>
+            <?php endforeach; ?>
+
+            <?php if (count($unassigned)) :
+                if (count($attributeSets)) { ?>
+                    <h4><?php echo t('Other')?></h4>
+                <?php
+                }
+                View::element('attribute/editable_list', [
+                    'attributes' => $unassigned,
+                    'object' => $user,
+                    'saveAction' => $view->action('update_attribute', $user->getUserID()),
+                    'clearAction' => $view->action('clear_attribute', $user->getUserID()),
+                    'permissionsArguments' => ['attributes' => $allowedEditAttributes],
+                    'permissionsCallback' => function ($ak, $permissionsArguments) {
+                        return is_array($permissionsArguments['attributes']) && in_array($ak->getAttributeKeyID(), $permissionsArguments['attributes']);
+                    },
+                ]); ?>
+            <?php endif; ?>
         </section>
 
     </div>

--- a/concrete/tools/workflow/dialogs/user_details.php
+++ b/concrete/tools/workflow/dialogs/user_details.php
@@ -53,7 +53,7 @@ $userGroup = $u->getUserGroups();
 
     <!-- user attribut starts -->
     <?php if(count($attributeSets) > 0) : ?>
-        <h3><?php echo t('Other Attributes')?></h3>
+        <h3><?php echo t('User Attributes')?></h3>
         <br>
         <?php foreach ($attributeSets as $set) : ?>
             <h4><?php echo $set->getAttributeSetDisplayName()?></h4>

--- a/concrete/tools/workflow/dialogs/user_details.php
+++ b/concrete/tools/workflow/dialogs/user_details.php
@@ -9,7 +9,13 @@ $u = User::getByUserID($_REQUEST['uID']);
 $uName = $ui->getUserName();
 $uEmail = $ui->getUserEmail();
 
-$attributeList = UserAttributeKey::getList();
+$service = Core::make('Concrete\Core\Attribute\Category\CategoryService');
+$categoryEntity = $service->getByHandle('user');
+$category = $categoryEntity->getController();
+$setManager = $category->getSetManager();
+$attributeSets = $setManager->getAttributeSets();
+$unassigned = $setManager->getUnassignedAttributeKeys();
+
 $userGroup = $u->getUserGroups();
 ?>
 
@@ -23,7 +29,7 @@ $userGroup = $u->getUserGroups();
             <p><strong><?=t(Username)?></strong></p>
         </div>
 
-        <div class="col-md-2">
+        <div class="col-md-4">
             <p><?=$uName?></p>
         </div>
     </div>
@@ -33,7 +39,7 @@ $userGroup = $u->getUserGroups();
             <p><strong><?=t(Email)?></strong></p>
         </div>
 
-        <div class="col-md-2">
+        <div class="col-md-4">
             <p><a href="mailto:<?=$uEmail?>"><?=$uEmail?></a></p>
         </div>
     </div>
@@ -46,21 +52,41 @@ $userGroup = $u->getUserGroups();
     <!-- user group ends -->
 
     <!-- user attribut starts -->
-    <?php 	if(count($attributeList) > 0) { ?>
-        <h3><?=t('User Attributes')?></h3>
+    <?php if(count($attributeSets) > 0) : ?>
+        <h3><?php echo t('Other Attributes')?></h3>
         <br>
-        <?php	foreach ($attributeList as $ak) { ?>
+        <?php foreach ($attributeSets as $set) : ?>
+            <h4><?php echo $set->getAttributeSetDisplayName()?></h4>
+            <?php foreach ($set->getAttributeKeys() as $ak) : ?>
+                <div class="row">
+                    <div class="col-md-8">
+                        <p><strong><?php echo t($ak->getAttributeKeyName()) ?></strong></p>
+                    </div>
+
+                    <div class="col-md-4">
+                        <p><?php echo $ui->getAttribute($ak, 'displaySanitized', 'display') ?></p>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        <?php endforeach; ?>
+    <?php endif; ?>
+    <?php if (count($unassigned)) :
+        if (count($attributeSets)) {?>
+            <h4><?php echo t('Other')?></h4>
+        <?php } ?>
+        <?php foreach ($unassigned as $ak) : ?>
             <div class="row">
                 <div class="col-md-8">
                     <p><strong><?php echo t($ak->getAttributeKeyName()) ?></strong></p>
                 </div>
 
-                <div class="col-md-2">
+                <div class="col-md-4">
                     <p><?php echo $ui->getAttribute($ak, 'displaySanitized', 'display') ?></p>
                 </div>
             </div>
-        <?php }
-    }?>
+        <?php endforeach; ?>
+    <?php endif; ?>
+
     <!-- // user attribut end -->
 
     <div class="dialog-buttons">


### PR DESCRIPTION
Changed the way user attributes are displayed on the user page and in the workflow user review pop-up dialog. Now the order is the same as on the attribute page, and with attribute set headers.
