### PR TITLE
Add an option to show permission inheritance in full sitemap

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -435,6 +435,7 @@ return [
         'enable_progressive_page_reindex' => true,
         'mobile_theme_id' => 0,
         'sitemap_approve_immediately' => true,
+        'sitemap_show_permission' => false,
         'enable_translate_locale_en_us' => false,
         'page_search_index_lifetime' => 259200,
         'enable_trash_can' => true,

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -171,6 +171,21 @@ class Sitemap
 
         $cvName = ($c->getCollectionName() !== '') ? $c->getCollectionName() : '(No Title)';
         $cvName = ($c->isSystemPage() || $cID == 1) ? t($cvName) : $cvName;
+        if (Config::get('concrete.misc.sitemap_show_permission'){
+            $inheritance = $c->getCollectionInheritance();
+            switch ($inheritance) {
+                case 'TEMPLATE':
+                    $inheritance = t("PageType");
+                    $node->title = $node->title . ' (' . $inheritance . ')';
+                    break;
+                case 'OVERRIDE':
+                    $inheritance = t("Manual");
+                    $node->title = $node->title . ' (' . $inheritance . ')';
+                    break;
+                case 'PARENT':
+                    break;
+            }
+        }
 
         $isInTrash = $c->isInTrash();
 

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -174,7 +174,7 @@ class Sitemap
         if (Config::get('concrete.misc.sitemap_show_permission')){
             switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
-                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType Permission.") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType Permission") .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'OVERRIDE':

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -176,11 +176,11 @@ class Sitemap
             switch ($inheritance) {
                 case 'TEMPLATE':
                     $inheritance = t("PageType");
-                    $node->title = $node->title . ' (' . $inheritance . ')';
+                    $cvName = $cvName . ' (' . $inheritance . ')';
                     break;
                 case 'OVERRIDE':
                     $inheritance = t("Manual");
-                    $node->title = $node->title . ' (' . $inheritance . ')';
+                    $cvName = $cvName . ' (' . $inheritance . ')';
                     break;
                 case 'PARENT':
                     break;

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -174,11 +174,11 @@ class Sitemap
         if (Config::get('concrete.misc.sitemap_show_permission')){
             switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
-                    $inheritance = '<i class="fa fa-object-group" title="'. t("PageType") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType") .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'OVERRIDE':
-                    $inheritance = '<i class="fa fa fa-code-fork" title="'. t("Manual") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa fa-code-fork" title="'. t("Manual") .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'PARENT':

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -174,11 +174,11 @@ class Sitemap
         if (Config::get('concrete.misc.sitemap_show_permission')){
             switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
-                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType Permission.") .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'OVERRIDE':
-                    $inheritance = ' <i class="fa fa fa-code-fork" title="'. t("Manual") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa fa-code-fork" title="'. t("Manual Permission") .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'PARENT':

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -171,7 +171,7 @@ class Sitemap
 
         $cvName = ($c->getCollectionName() !== '') ? $c->getCollectionName() : '(No Title)';
         $cvName = ($c->isSystemPage() || $cID == 1) ? t($cvName) : $cvName;
-        if (Config::get('concrete.misc.sitemap_show_permission'){
+        if (Config::get('concrete.misc.sitemap_show_permission')){
             $inheritance = $c->getCollectionInheritance();
             switch ($inheritance) {
                 case 'TEMPLATE':

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -172,8 +172,7 @@ class Sitemap
         $cvName = ($c->getCollectionName() !== '') ? $c->getCollectionName() : '(No Title)';
         $cvName = ($c->isSystemPage() || $cID == 1) ? t($cvName) : $cvName;
         if (Config::get('concrete.misc.sitemap_show_permission')){
-            $inheritance = $c->getCollectionInheritance();
-            switch ($inheritance) {
+            switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
                     $inheritance = t("PageType");
                     $cvName = $cvName . ' (' . $inheritance . ')';

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -174,12 +174,12 @@ class Sitemap
         if (Config::get('concrete.misc.sitemap_show_permission')){
             switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
-                    $inheritance = t("PageType");
-                    $cvName = $cvName . ' (' . $inheritance . ')';
+                    $inheritance = '<i class="fa fa-object-group" title="'. t("PageType") .'" aria-hidden="true"></i>';
+                    $cvName = $cvName . $inheritance;
                     break;
                 case 'OVERRIDE':
-                    $inheritance = t("Manual");
-                    $cvName = $cvName . ' (' . $inheritance . ')';
+                    $inheritance = '<i class="fa fa fa-code-fork" title="'. t("Manual") .'" aria-hidden="true"></i>';
+                    $cvName = $cvName . $inheritance;
                     break;
                 case 'PARENT':
                     break;

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -174,7 +174,7 @@ class Sitemap
         if (Config::get('concrete.misc.sitemap_show_permission')){
             switch ($c->getCollectionInheritance()) {
                 case 'TEMPLATE':
-                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType Permission") .'" aria-hidden="true"></i>';
+                    $inheritance = ' <i class="fa fa-object-group" title="'. t("PageType Permission") . ": " . $c->getPageTypeName() .'" aria-hidden="true"></i>';
                     $cvName = $cvName . $inheritance;
                     break;
                 case 'OVERRIDE':


### PR DESCRIPTION
This is the re-opening of #3726.

Originally written by @hissy.

When I was building large complicated permission site, we want to check which pages has manual permissions or not.

I would like to suggest to add an option to show the permission setting on full sitemap page, so that it would be easier to see which page has manual/page type permission or not.

![image](https://cloud.githubusercontent.com/assets/485751/23307914/9cdf4d98-faec-11e6-9b60-6d03bbe95fff.png)

Although Andrew said it could be an add-on, this approach is simple enough to be merged into the core.

Thanks