### PR TITLE
Use a FSL ID as a cache key for flysystem

### DIFF
--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -129,16 +129,12 @@ class StorageLocation implements StorageLocationInterface
     public function getFileSystemObject()
     {
         $adapter = $this->getConfigurationObject()->getAdapter();
-        /*
+
         $pool = \Core::make(ExpensiveCache::class)->pool;
-        $cache = new Psr6Cache($pool);
+        $cache = new Psr6Cache($pool, 'flysystem-id-' . $this->getID());
         $cachedAdapter = new CachedAdapter($adapter, $cache);
         $filesystem = new \League\Flysystem\Filesystem($cachedAdapter);
-        */
-        // The above code is buggy. When moving files between storage locations it thinks files
-        // already exist.
-        
-        $filesystem = new \League\Flysystem\Filesystem($adapter);
+
         return $filesystem;
     }
 


### PR DESCRIPTION
Resolves an issue when moving files between locations and it thinking it already exists.

This will invalidate the old cache, oh well