### PR TITLE
Fixes for File Search presets

### DIFF
--- a/concrete/controllers/dialog/search/advanced_search.php
+++ b/concrete/controllers/dialog/search/advanced_search.php
@@ -115,7 +115,6 @@ abstract class AdvancedSearch extends BackendInterfaceController
             $this->onAfterSavePreset($search);
 
             $provider = $this->getSearchProvider();
-            $provider->setSessionCurrentQuery($query);
             $result = $provider->getSearchResultFromQuery($query);
             $result->setBaseURL($this->getSavedSearchBaseURL($search));
 

--- a/concrete/controllers/search/file_folder.php
+++ b/concrete/controllers/search/file_folder.php
@@ -15,20 +15,17 @@ use Concrete\Core\Search\StickyRequest;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\SearchPreset;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Core;
 
 class FileFolder extends AbstractController
 {
     protected $list;
     protected $result;
     protected $filesystem;
-    protected $session;
 
     public function __construct()
     {
         parent::__construct();
         $this->filesystem = new Filesystem();
-        $this->session = \Core::make('session');
     }
 
     public function search(Query $query = null)
@@ -61,7 +58,6 @@ class FileFolder extends AbstractController
                 $search = $folder->getSavedSearchObject();
                 $query = $search->getQuery();
                 $provider = \Core::make('Concrete\Core\File\Search\SearchProvider');
-                $provider->setSessionCurrentQuery($query);
                 $ilr = $provider->getSearchResultFromQuery($query);
                 $ilr->setBaseURL(\URL::to('/ccm/system/search/files/preset', $search->getID()));
             }

--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -57,12 +57,21 @@
 		}
 	}
 
-	ConcreteAjaxSearch.prototype.setupResetButton = function(result) {
-		var my = this;
-		if (result.query) {
+	ConcreteAjaxSearch.prototype.setupResetButton = function (result) {
+		var my = this,
+			advancedSearchText;
+
+		if (result.query || (result.folder && result.folder.treeNodeTypeHandle === 'search_preset')) {
+			advancedSearchText = ccmi18n_filemanager.edit;
+		} else {
+			advancedSearchText = ccmi18n.advanced;
+		}
+
+		my.$advancedSearchButton.html(advancedSearchText);
+
+		if (result.query && result.folder && result.folder.treeNodeTypeHandle !== 'search_preset') {
 			my.$headerSearchInput.prop('disabled', true);
 			my.$headerSearchInput.attr('placeholder', '');
-			my.$advancedSearchButton.html(ccmi18n_filemanager.edit);
 			my.$resetSearchButton.show();
 		}
 	};

--- a/concrete/src/Search/AbstractSearchProvider.php
+++ b/concrete/src/Search/AbstractSearchProvider.php
@@ -4,6 +4,8 @@ namespace Concrete\Core\Search;
 use Concrete\Core\Entity\Search\Query;
 use Concrete\Core\Search\Column\AttributeKeyColumn;
 use Concrete\Core\Search\Column\Set;
+use Concrete\Core\Tree\Node\Node;
+use Concrete\Core\Tree\Node\Type\SearchPreset;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 abstract class AbstractSearchProvider implements ProviderInterface, SessionQueryProviderInterface
@@ -70,14 +72,25 @@ abstract class AbstractSearchProvider implements ProviderInterface, SessionQuery
     }
 
     /**
+     * Gets items per page from the current preset or from the session
+     *
      * @return int
      */
     public function getItemsPerPage()
     {
-        $sessionQuery = $this->getSessionCurrentQuery();
+        $searchRequest = new StickyRequest('file_manager_folder');
+        $searchParams = $searchRequest->getSearchRequest();
+        $node = Node::getByID($searchParams['folder']);
 
-        if ($sessionQuery instanceof Query) {
-            return $sessionQuery->getItemsPerPage() ? $sessionQuery->getItemsPerPage() : 10;
+        if ($node instanceof SearchPreset) {
+            $searchObj = $node->getSavedSearchObject();
+            return $searchObj->getQuery()->getItemsPerPage();
+        } else {
+            $sessionQuery = $this->getSessionCurrentQuery();
+
+            if ($sessionQuery instanceof Query) {
+                return $sessionQuery->getItemsPerPage();
+            }
         }
     }
 

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -628,6 +628,7 @@ abstract class Node extends Object implements \Concrete\Core\Permission\ObjectIn
         if ($row && $row['treeNodeID']) {
             $tt = TreeNodeType::getByID($row['treeNodeTypeID']);
             $node = Core::make($tt->getTreeNodeTypeClass());
+            $row['treeNodeTypeHandle'] = $tt->getTreeNodeTypeHandle();
             $node->setPropertiesFromArray($row);
             $node->loadDetails();
 


### PR DESCRIPTION
 * Hides "Reset Search" link when a preset is loaded.
 * Populates "Number of Results" from preset or session, in this order. 
 * Presets are not loaded into the session.