### PR TITLE
Specify that the attribute to create is a Rating type

### DIFF
--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -92,7 +92,7 @@ if (!$dateFormat) {
                     } else {
                         ?>
                         <div class="alert alert-info">
-                            <?= t('Create a `Rating` page attribute in order to aggregate ratings.') ?>
+                            <?= t('Create a page attribute of type "%s" in order to aggregate ratings.', tc('AttributeTypeName', 'Rating')) ?>
                         </div>
                         <?php
                     }


### PR DESCRIPTION
This string wasn't clear about what the code expects: an attribute with a Rating name or an attribute of type Rating.

Furthermore, avoid re-translating it: let's keep the current translation of the Rating attribute type.