### PR TITLE
Prepare the response before sending it

### DIFF
--- a/concrete/src/Foundation/Runtime/DefaultRuntime.php
+++ b/concrete/src/Foundation/Runtime/DefaultRuntime.php
@@ -115,6 +115,7 @@ class DefaultRuntime implements RuntimeInterface, ApplicationAwareInterface
      */
     protected function sendResponse(Response $response)
     {
+        $response->prepare(\Request::getInstance());
         $response->send();
 
         // Set the status to ended


### PR DESCRIPTION
Responses should be prepared before sending them to the client.

This is often optional, but it's mandatory in case of `BinaryFileResponse` responses.

PS: I'm pretty sure @KorvinSzanto will suggest a cleaner way to do this :wink: