### PR TITLE
Feature/improved default runner

### DIFF
--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -1,28 +1,52 @@
 <?php
 namespace Concrete\Core\Foundation\Runtime\Run;
 
-use Concrete\Core\Application\Application;
 use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\Request;
-use Concrete\Core\Http\Server;
+use Concrete\Core\Http\Response;
 use Concrete\Core\Http\ServerInterface;
 use Concrete\Core\Permission\Key\Key;
-use Concrete\Core\Support\Facade\Events;
-use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Routing\RouterInterface;
+use Concrete\Core\Site\Service as SiteService;
+use Concrete\Core\Url\Resolver\CanonicalUrlResolver;
+use Concrete\Core\Url\Resolver\UrlResolverInterface;
+use Exception;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * Default HTTP Runner
+ *
+ * @todo Replace pipeline style functionality with middleware
+ */
 class DefaultRunner implements RunInterface, ApplicationAwareInterface
 {
+
     use ApplicationAwareTrait;
 
     /** @var Repository */
     protected $config;
 
-    /**
-     * @var \Concrete\Core\Http\ServerInterface
-     */
+    /** @var UrlResolverInterface */
+    protected $urlResolver;
+
+    /** @var RouterInterface */
+    protected $router;
+
+    /** @var SiteService */
+    protected $siteService;
+
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
+    /** @var ServerInterface */
     private $server;
 
+    /**
+     * DefaultRunner constructor.
+     * @param ServerInterface $server
+     */
     public function __construct(ServerInterface $server)
     {
         $this->server = $server;
@@ -33,109 +57,389 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
      */
     public function run()
     {
-        $app = $this->app;
+        // Load in the /application/bootstrap/app.php file
+        $this->loadBootstrap();
 
-        include DIR_APPLICATION . '/bootstrap/app.php';
+        $response = null;
+
+        // Check if we're installed
         if ($this->app->isInstalled()) {
-            /*
-             * ----------------------------------------------------------------------------
-             * Now that we have languages out of the way, we can run our package on_start
-             * methods
-             * ----------------------------------------------------------------------------
-             */
-            $app->setupPackages();
 
-            /*
-             * ----------------------------------------------------------------------------
-             * Legacy Definitions. This has to come after packages because this
-             * essentially loads the entity manager, and the entity manager loads classes
-             * found in its config, which may be classes that haven't been autoloaded by initialPackages. It also
-             * has to come after setupPackages() in case an autoloader is configured in on_start()
-             * ----------------------------------------------------------------------------
-             */
-            $this->initializeLegacyURLDefinitions($app);
+            // Call each step in the line
+            // @todo Move these to individual middleware, this is basically a duplicated middleware pipeline
+            $response = $this->trySteps([
+                // Set up packages first.
+                // We do this because we don't want the entity manager to be loaded and we
+                // want to give packages an opportunity to replace classes and load new classes
+                'setupPackages',
 
+                // Define legacy urls, this may be the first thing that loads the entity manager
+                'initializeLegacyUrlDefinitions',
 
-            /*
-             * Handle automatic updating. Must come after setupPackages() because some things setup autoloaders in on_start() of their package
-             * controller
-             */
-            $app->handleAutomaticUpdates();
+                // Handle updating automatically
+                'handleUpdates',
 
+                // Register legacy tools routes
+                'registerLegacyRoutes',
 
-            // This is a crappy place for this, but it has to come AFTER the packages because sometimes packages
-            // want to replace legacy "tools" URLs with the new MVC, and the tools paths are so greedy they don't
-            // work unless they come at the end.
-            $this->registerLegacyRoutes();
+                // Register legacy config values
+                'registerLegacyConfigValues',
 
-            /* ----------------------------------------------------------------------------
-             * Register legacy routes
-             * ----------------------------------------------------------------------------
-             */
-            $this->registerLegacyRoutes();
+                // Handle loading permission keys
+                'handlePermissionKeys',
 
-            /* ----------------------------------------------------------------------------
-             * Register legacy config values
-             * ----------------------------------------------------------------------------
-             */
-            $this->registerLegacyConfigValues();
-
-
-            /*
-             * ----------------------------------------------------------------------------
-             * Load all permission keys into our local cache.
-             * ----------------------------------------------------------------------------
-             */
-            Key::loadAll();
+                // Handle eventing
+                'handleEventing'
+            ]);
         }
 
-        /*
-         * ----------------------------------------------------------------------------
-         * Fire an event for intercepting the dispatch
-         * ----------------------------------------------------------------------------
-         */
-        Events::dispatch('on_before_dispatch');
+        // Create the request to use
+        $request = $this->createRequest();
 
-        $request = Request::createFromGlobals();
-        $response = $this->server->handleRequest($request);
+        if (!$response) {
+            $response = $this->server->handleRequest($request);
+        }
 
         // Prepare and return the response
         return $response->prepare($request);
     }
 
     /**
-     * @param Repository $config
-     * @param Application $app
+     * Define the base url if not defined
+     * This will define `BASE_URL` to whatever is resolved from the resolver
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
      */
-    private function initializeLegacyURLDefinitions(Application $app)
+    protected function initializeLegacyURLDefinitions()
     {
         if (!defined('BASE_URL')) {
+            $resolver = $this->getUrlResolver();
+
             try {
-                define('BASE_URL', rtrim((string) $app->make('url/canonical'), '/'));
-            } catch (\Exception $x) {
-                echo $x->getMessage();
-                die(1);
+                $url = rtrim((string)$resolver->resolve([]), '/');
+                define('BASE_URL', $url);
+            } catch (Exception $x) {
+                return Response::create($x->getMessage(), 500);
             }
         }
     }
 
+    /**
+     * Set legacy config values
+     * This sets `concrete.site` to the current site's sitename
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
     protected function registerLegacyConfigValues()
     {
-        $config = $this->app->make('config');
-        $config->set('concrete.site', $this->app->make('site')->getSite()->getSiteName());
+        $config = $this->getConfig();
+        $name = $this->getSiteService()->getSite()->getSiteName();
+
+        $config->set('concrete.site', $name);
     }
 
+    /**
+     * Register routes that power legacy functionality
+     * This includes `/tools/tool_handle` and `/tools/blocks/block_handle/tool_handle`
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
     protected function registerLegacyRoutes()
     {
-        \Route::register("/tools/blocks/{btHandle}/{tool}",
+        $router = $this->getRouter();
+        $router->register(
+            '/tools/blocks/{btHandle}/{tool}',
             '\Concrete\Core\Legacy\Controller\ToolController::displayBlock',
             'blockTool',
-            array('tool' => '[A-Za-z0-9_/.]+')
+            ['tool' => '[A-Za-z0-9_/.]+']
         );
-        \Route::register("/tools/{tool}", '\Concrete\Core\Legacy\Controller\ToolController::display',
-            '   tool',
-            array('tool' => '[A-Za-z0-9_/.]+')
+        $router->register(
+            '/tools/{tool}',
+            '\Concrete\Core\Legacy\Controller\ToolController::display',
+            'tool',
+            ['tool' => '[A-Za-z0-9_/.]+']
         );
+    }
+
+    /**
+     * Create the request object to use
+     */
+    protected function createRequest()
+    {
+        $request = Request::createFromGlobals();
+        $request::setInstance($request);
+
+        return $request;
+    }
+
+    /**
+     * Setup concrete5 packages
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
+    protected function setupPackages()
+    {
+        $this->app->setupPackages();
+    }
+
+    /**
+     * Load in the `/application/bootstrap/app.php` file
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
+    protected function loadBootstrap()
+    {
+        // Set app so that the bootstrap file can access it
+        $app = $this->app;
+        include DIR_APPLICATION . '/bootstrap/app.php';
+    }
+
+    /**
+     * Update automatically
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
+    protected function handleUpdates()
+    {
+        $this->app->handleAutomaticUpdates();
+    }
+
+    /**
+     * Fire HTTP events
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
+    protected function handleEventing()
+    {
+        $this->getEventDispatcher()->dispatch('on_before_dispatch');
+    }
+
+    /**
+     * Load all permission keys
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Response|void Returns a response if an error occurs
+     */
+    protected function handlePermissionKeys()
+    {
+        /** @todo Replace this with a testable service */
+        Key::loadAll();
+    }
+
+    /**
+     * Try a list of steps. If a response is returned, halt progression and return the response;
+     * @param string[] $steps
+     * @return Response|null
+     */
+    protected function trySteps(array $steps)
+    {
+        foreach ($steps as $step) {
+            // Run each step and return if there's a result
+            if ($result = $this->$step()) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the config repository to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return Repository
+     */
+    protected function getConfig()
+    {
+        if (!$this->config) {
+            $this->config = $this->getDefaultConfig();
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * Get the default config repository to use
+     *
+     * @return Repository
+     */
+    private function getDefaultConfig()
+    {
+        return $this->app->make('config');
+    }
+
+    /**
+     * Set the config repository
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @param Repository $repository
+     * @return $this
+     */
+    public function setConfig(Repository $repository)
+    {
+        $this->config = $repository;
+        return $this;
+    }
+
+    /**
+     * Get the router to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return RouterInterface
+     */
+    protected function getRouter()
+    {
+        if (!$this->router) {
+            $this->router = $this->getDefaultRouter();
+        }
+
+        return $this->router;
+    }
+
+    /**
+     * Get the default router to use
+     *
+     * @return RouterInterface
+     */
+    private function getDefaultRouter()
+    {
+        return $this->app->make(RouterInterface::class);
+    }
+
+    /**
+     * Set the router
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @param RouterInterface $router
+     * @return $this
+     */
+    public function setRouter(RouterInterface $router)
+    {
+        $this->router = $router;
+        return $this;
+    }
+
+    /**
+     * Get the site service to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return SiteService
+     */
+    protected function getSiteService()
+    {
+        if (!$this->siteService) {
+            $this->siteService = $this->getDefaultSiteService();
+        }
+
+        return $this->siteService;
+    }
+
+    /**
+     * Get the default site service to use
+     *
+     * @return SiteService
+     */
+    private function getDefaultSiteService()
+    {
+        return $this->app->make('site');
+    }
+
+    /**
+     * Set the site service
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @param SiteService $site
+     * @return $this
+     */
+    public function setSiteService(SiteService $site)
+    {
+        $this->siteService = $site;
+        return $this;
+    }
+
+    /**
+     * Get the url resolver to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return UrlResolverInterface
+     */
+    protected function getUrlResolver()
+    {
+        if (!$this->urlResolver) {
+            $this->urlResolver = $this->getDefaultUrlResolver();
+        }
+
+        return $this->urlResolver;
+    }
+
+    /**
+     * Get the default url resolver to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return UrlResolverInterface
+     */
+    private function getDefaultUrlResolver()
+    {
+        return $this->app->make(CanonicalUrlResolver::class);
+    }
+
+    /**
+     * Set the url resolver
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @param UrlResolverInterface $urlResolver
+     * @return $this
+     */
+    public function setUrlResolver(UrlResolverInterface $urlResolver)
+    {
+        $this->urlResolver = $urlResolver;
+        return $this;
+    }
+
+    /**
+     * Get the url resolver to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return EventDispatcherInterface
+     */
+    protected function getEventDispatcher()
+    {
+        if (!$this->eventDispatcher) {
+            $this->eventDispatcher = $this->getDefaultEventDispatcher();
+        }
+
+        return $this->eventDispatcher;
+    }
+
+    /**
+     * Get the default url resolver to use
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @return EventDispatcherInterface
+     */
+    private function getDefaultEventDispatcher()
+    {
+        return $this->app->make('director');
+    }
+
+    /**
+     * Set the url resolver
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
+     * @param EventDispatcherInterface $urlResolver
+     * @return $this
+     */
+    public function setEventDispatcher(EventDispatcherInterface $urlResolver)
+    {
+        $this->eventDispatcher = $urlResolver;
+        return $this;
     }
 
 }

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -97,7 +97,10 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
         Events::dispatch('on_before_dispatch');
 
         $request = Request::createFromGlobals();
-        return $this->server->handleRequest($request);
+        $response = $this->server->handleRequest($request);
+
+        // Prepare and return the response
+        return $response->prepare($request);
     }
 
     /**

--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -197,11 +197,17 @@ class Service
         return $site;
     }
 
+    /**
+     * @return Site
+     */
     final public function getSite()
     {
         return $this->resolverFactory->createResolver($this)->getSite();
     }
 
+    /**
+     * @return Site
+     */
     final public function getActiveSiteForEditing()
     {
         return $this->resolverFactory->createResolver($this)->getActiveSiteForEditing();

--- a/tests/tests/Core/Foundation/Runtime/Run/DefaultRunnerTest.php
+++ b/tests/tests/Core/Foundation/Runtime/Run/DefaultRunnerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Tests\Core\Foundation\Runtime\Run;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Foundation\Runtime\Run\DefaultRunner;
+use Concrete\Core\Http\ServerInterface;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DefaultRunnerTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testReturnsResponseWhenNotInstalled()
+    {
+        // Setup Response
+        $expectedResponse = $this->getMock(Response::class);
+        $expectedResponse->expects($this->once())->method('prepare')->willReturnSelf();
+
+        // Create a mock server
+        $server = $this->getMock(ServerInterface::class);
+        $server->method('handleRequest')->willReturn($expectedResponse);
+
+        // Create a mock application
+        $app = $this->getMock(Application::class);
+        $app->method('isInstalled')->willReturn(false);
+
+        // Create the runner to test
+        $runner = new DefaultRunner($server);
+        $runner->setApplication($app);
+
+        // Test running while not installed
+        $this->assertEquals($expectedResponse, $runner->run());
+    }
+}


### PR DESCRIPTION
* bc48186f7 replaces #5174 
* c9466f1 adds a test that ensures that `->prepare` is called once and only once
* f0a5972 Does a few things:
    * Make it possible to replace all (other than `Keys` 😞 ) dependencies without overriding
    * Get away from using globals or facades by using a bunch of getters and setters
    * Make it easy to get away from having this runner do all this crap, it should be broken up into individual middleware instead
    * Deprecate any part of the public API that will likely get removed in v9
* 978fd1f adds a simple typehint to the `Site` service