### PR TITLE
Fix import of groups without path

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGroupsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGroupsRoutine.php
@@ -42,7 +42,7 @@ class ImportGroupsRoutine extends AbstractRoutine
                         $parentGroup = Group::getByPath($parentPath);
                     }
 
-                    $pkg = static::getPackageObject($g['package']);
+                    $pkg = static::getPackageObject($group['package']);
                     Group::add($group['name'], $group['description'], $parentGroup, $pkg);
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGroupsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGroupsRoutine.php
@@ -1,8 +1,6 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Permission\Category;
-
 class ImportGroupsRoutine extends AbstractRoutine
 {
     public function getHandle()
@@ -13,8 +11,7 @@ class ImportGroupsRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->groups)) {
-
-            $groups = array();
+            $groups = [];
             foreach ($sx->groups->group as $g) {
                 $groups[] = $g;
             }
@@ -31,7 +28,7 @@ class ImportGroupsRoutine extends AbstractRoutine
                 }
             });
 
-            foreach($groups as $group) {
+            foreach ($groups as $group) {
                 $existingGroup = \Concrete\Core\User\Group\Group::getByPath((string) $group['path']);
                 if (!is_object($existingGroup)) {
                     $parent = null;


### PR DESCRIPTION
If we import this XML:

```xml
<?xml version="1.0"?>
<concrete5-cif version="1.0">
    <groups>
        <group name="Test" />
    </groups>
</concrete5-cif>
```

The group `Test` will always be created, even if it already exists.

Let's fix this.