### PR TITLE
Fix getBlockTypeMappedClass for block types in packages

### DIFF
--- a/concrete/src/Block/BlockType/BlockType.php
+++ b/concrete/src/Block/BlockType/BlockType.php
@@ -103,7 +103,7 @@ class BlockType
     {
         $env = Environment::get();
         $txt = Core::make('helper/text');
-        $r = $env->getRecord(DIRNAME_BLOCKS . '/' . $btHandle . '/' . FILENAME_CONTROLLER);
+        $r = $env->getRecord(DIRNAME_BLOCKS . '/' . $btHandle . '/' . FILENAME_CONTROLLER, $pkgHandle);
 
         // Replace $pkgHandle if overridden via environment
         $r->pkgHandle and $pkgHandle = $r->pkgHandle;


### PR DESCRIPTION
This fix is required for block types included in packages