### PR TITLE
Simplify composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,14 +46,10 @@
     }
   },
   "scripts": {
-    "test": "./concrete/vendor/bin/phpunit",
+    "test": "phpunit",
     "phpcs": [
-      "./concrete/vendor/bin/phpcs -p -s --colors --report=full --standard=psr2 --sniffs=Generic.WhiteSpace.DisallowTabIndent,Generic.PHP.DisallowShortOpenTag concrete/src concrete/controllers",
-      "./concrete/vendor/bin/phpcs -p -s --colors --report=full --standard=psr2 --sniffs=Generic.PHP.DisallowShortOpenTag --ignore=\"*.js,*.css,*.less,concrete/vendor/*,concrete/src/*,concrete/controllers/*\" concrete"
-    ],
-    "phpcsw": [
-      ".\\concrete\\vendor\\bin\\phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.WhiteSpace.DisallowTabIndent,Generic.PHP.DisallowShortOpenTag concrete/src concrete/controllers",
-      ".\\concrete\\vendor\\bin\\phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.PHP.DisallowShortOpenTag --ignore=\"*.js,*.css,*.less,concrete/vendor/*,concrete/src/*,concrete/controllers/*\" concrete"
+      "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.WhiteSpace.DisallowTabIndent,Generic.PHP.DisallowShortOpenTag concrete/src concrete/controllers",
+      "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.PHP.DisallowShortOpenTag --ignore=\"*.js,*.css,*.less,concrete/vendor/*,concrete/src/*,concrete/controllers/*\" concrete"
     ],
     "post-create-project-cmd": [
       "composer config --unset platform.php"


### PR DESCRIPTION
Composer automatically adds to the PATH variable the `concrete/vendor/bin` directory, so we can call the scripts in it without specifying the folder.

This also implies that we can avoid duplicating script definitions for posix and Windows.

I had to remove the `--colors` option in the `phpcs` script, because PHP on Windows doesn't support VT100 control codes (well, from PHP 7.2 it will, thanks to [this contribution of mine](https://github.com/php/php-src/pull/2103) :wink: )