### PR TITLE
Display attributes by sets in the advanced user search

### DIFF
--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -36,11 +36,11 @@ class Manager extends FieldManager
 
         $attributes = [];
         foreach($attributeSets as $set) {
-          foreach($set->getAttributeKeys() as $key) {
-            $field = new AttributeKeyField($key);
-            $attributes[] = $field;
-          }
-          $this->addGroup($set->getAttributeSetDisplayName(), $attributes);
+            foreach($set->getAttributeKeys() as $key) {
+                $field = new AttributeKeyField($key);
+                $attributes[] = $field;
+            }
+            $this->addGroup($set->getAttributeSetDisplayName(), $attributes);
         }
         $attributes = [];
         foreach($unassigned as $key) {

--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -1,7 +1,9 @@
 <?php
 namespace Concrete\Core\User\Search\Field;
 
+use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 use Concrete\Core\Attribute\Category\UserCategory;
+use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Search\Field\AttributeKeyField;
 use Concrete\Core\Search\Field\Field\KeywordsField;
 use Concrete\Core\Search\Field\Manager as FieldManager;
@@ -26,11 +28,25 @@ class Manager extends FieldManager
             new GroupSetField()
 
         ]);
+
+        $service = \Core::make(CategoryService::class);
+        $setManager = $service->getByHandle('user')->getController()->getSetManager();
+        $attributeSets = $setManager->getAttributeSets();
+        $unassigned = $setManager->getUnassignedAttributeKeys();
+
         $attributes = [];
-        foreach($fileCategory->getSearchableList() as $key) {
+        foreach($attributeSets as $set) {
+          foreach($set->getAttributeKeys() as $key) {
+            $field = new AttributeKeyField($key);
+            $attributes[] = $field;
+          }
+          $this->addGroup($set->getAttributeSetDisplayName(), $attributes);
+        }
+        $attributes = [];
+        foreach($unassigned as $key) {
             $field = new AttributeKeyField($key);
             $attributes[] = $field;
         }
-        $this->addGroup(t('Custom Attributes'), $attributes);
+        $this->addGroup(t('Other Attributes'), $attributes);
     }
 }

--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Core\User\Search\Field;
 
-use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 use Concrete\Core\Attribute\Category\UserCategory;
 use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Search\Field\AttributeKeyField;
@@ -10,6 +9,7 @@ use Concrete\Core\Search\Field\Manager as FieldManager;
 use Concrete\Core\User\Search\Field\Field\DateAddedField;
 use Concrete\Core\User\Search\Field\Field\GroupSetField;
 use Concrete\Core\User\Search\Field\Field\IsActiveField;
+use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 use Concrete\Core\User\Search\Field\Field\UserGroupField;
 
 class Manager extends FieldManager

--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -9,8 +9,8 @@ use Concrete\Core\Search\Field\Manager as FieldManager;
 use Concrete\Core\User\Search\Field\Field\DateAddedField;
 use Concrete\Core\User\Search\Field\Field\GroupSetField;
 use Concrete\Core\User\Search\Field\Field\IsActiveField;
-use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 use Concrete\Core\User\Search\Field\Field\UserGroupField;
+use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 
 class Manager extends FieldManager
 {


### PR DESCRIPTION
In the advanced user search pop-up the user attributes were not sorted and displayed in the order of creation. This will sort the attributes by the sets also adding the set names to the list (Core properties, Set 1, Set 2, ..., Other Attributes). 