### PR TITLE
Fix #5166

### DIFF
--- a/concrete/controllers/search/standard.php
+++ b/concrete/controllers/search/standard.php
@@ -53,7 +53,7 @@ abstract class Standard extends AbstractController
     public function searchBasic()
     {
         if ($this->canAccess()) {
-            $result = $this->getDefaultBasicSearchResultObject();
+            $result = $this->getCurrentSearchObject();
             return new JsonResponse($result->getJSONObject());
         } else {
             $this->app->shutdown();


### PR DESCRIPTION
Fixes an issue with advanced search query: it was not being used when navigating to other pages or sorting by columns (unless you manually reload the page) - #5166  