### PR TITLE
Display attributes by sets in the advanced user search

### DIFF
--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\User\Search\Field;
 
 use Concrete\Core\Attribute\Category\UserCategory;
+use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Search\Field\AttributeKeyField;
 use Concrete\Core\Search\Field\Field\KeywordsField;
 use Concrete\Core\Search\Field\Manager as FieldManager;
@@ -9,6 +10,7 @@ use Concrete\Core\User\Search\Field\Field\DateAddedField;
 use Concrete\Core\User\Search\Field\Field\GroupSetField;
 use Concrete\Core\User\Search\Field\Field\IsActiveField;
 use Concrete\Core\User\Search\Field\Field\UserGroupField;
+use Concrete\Core\User\Search\Field\Field\IsValidatedField;
 
 class Manager extends FieldManager
 {
@@ -24,13 +26,27 @@ class Manager extends FieldManager
             new IsValidatedField(),
             new DateAddedField(),
             new GroupSetField()
-
         ]);
+
+        $service = \Core::make(CategoryService::class);
+        $setManager = $service->getByHandle('user')->getController()->getSetManager();
+        $attributeSets = $setManager->getAttributeSets();
+        $unassigned = $setManager->getUnassignedAttributeKeys();
+
         $attributes = [];
-        foreach($fileCategory->getSearchableList() as $key) {
+        foreach($attributeSets as $set) {
+            foreach($set->getAttributeKeys() as $key) {
+                $field = new AttributeKeyField($key);
+                $attributes[] = $field;
+            }
+            $this->addGroup($set->getAttributeSetDisplayName(), $attributes);
+        }
+
+        $attributes = [];
+        foreach($unassigned as $key) {
             $field = new AttributeKeyField($key);
             $attributes[] = $field;
         }
-        $this->addGroup(t('Custom Attributes'), $attributes);
+        $this->addGroup(t('Other Attributes'), $attributes);
     }
 }


### PR DESCRIPTION
In the advanced user search pop-up the user attributes were not sorted and displayed in the order of creation. This will sort the attributes by the sets also adding the set names to the list (Core properties, Set 1, Set 2, ..., Other Attributes).

Cleaned up version of PR. 