### PR TITLE
Display quick search results in 'system' locale

### DIFF
--- a/concrete/src/Application/Service/Dashboard.php
+++ b/concrete/src/Application/Service/Dashboard.php
@@ -247,6 +247,8 @@ class Dashboard
      */
     public function getIntelligentSearchMenu()
     {
+        $loc = Localization::getInstance();
+        $loc->setActiveContext('system');
         $dashboardMenus = Session::get('dashboardMenus', array());
         $dashboardMenusKey = Localization::activeLocale();
         if (array_key_exists($dashboardMenusKey, $dashboardMenus)) {
@@ -325,7 +327,7 @@ class Dashboard
 
                 ?>
                     <li><a href="<?=$navHelper->getLinkTocollection($subpage)?>"><?=t($subpage->getCollectionName())?></a><span><?php if ($page->getCollectionPath() != '/dashboard/system') {
-    ?><?=t($page->getCollectionName())?> <?=t($page->getAttribute('meta_keywords'))?> <?php 
+    ?><?=t($page->getCollectionName())?> <?=t($page->getAttribute('meta_keywords'))?> <?php
 }
                 ?><?=t($subpage->getCollectionName())?> <?=t($subpage->getAttribute('meta_keywords'))?></span></li>
                     <?php

--- a/concrete/src/Application/Service/Dashboard.php
+++ b/concrete/src/Application/Service/Dashboard.php
@@ -248,7 +248,7 @@ class Dashboard
     public function getIntelligentSearchMenu()
     {
         $loc = Localization::getInstance();
-        $loc->setActiveContext('system');
+        $loc->pushActiveContext(Localization::CONTEXT_UI);
         $dashboardMenus = Session::get('dashboardMenus', array());
         $dashboardMenusKey = Localization::activeLocale();
         if (array_key_exists($dashboardMenusKey, $dashboardMenus)) {
@@ -397,6 +397,8 @@ class Dashboard
         ob_end_clean();
         $dashboardMenus[$dashboardMenusKey] = str_replace(array("\n", "\r", "\t"), "", $html);
         Session::set('dashboardMenus', $dashboardMenus);
+
+        $loc->popActiveContext();
 
         return $dashboardMenus[$dashboardMenusKey];
     }


### PR DESCRIPTION
Currently, the "Quick Search" on the toolbar's right side provides results in the same language as the site is in. Instead, this should be in the system language (i.e. the language set to the logged in user account OR in case not set, system default).