### PR TITLE
Fix autolink text helper

### DIFF
--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -289,10 +289,10 @@ class Text
      */
     public function autolink($input, $newWindow = 0)
     {
-        $target = ($newWindow) ? ' target="_blank" ' : '';
+        $target = ($newWindow) ? ' target="_blank"' : '';
         $output = preg_replace(
             '/(http:\/\/|https:\/\/|(www\.))(([^\s<]{4,80})[^\s<]*)/',
-            '<a href="http://$2$3" ' . $target . ' rel="nofollow">http://$2$4</a>',
+            '<a href="http://$2$3"' . $target . ' rel="nofollow">http://$2$4</a>',
             $input);
 
         return $output;

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -283,16 +283,19 @@ class Text
      * Scans passed text and automatically hyperlinks any URL inside it.
      *
      * @param string $input
-     * @param int    $newWindow
+     * @param bool $newWindow
      *
      * @return string $output
      */
-    public function autolink($input, $newWindow = 0)
+    public function autolink($input, $newWindow = false)
     {
-        $target = ($newWindow) ? ' target="_blank"' : '';
-        $output = preg_replace(
+        $target = $newWindow ? ' target="_blank"' : '';
+        $output = preg_replace_callback(
             '/(http:\/\/|https:\/\/|(www\.))(([^\s<]{4,80})[^\s<]*)/',
-            '<a href="http://$2$3"' . $target . ' rel="nofollow">http://$2$4</a>',
+            function (array $matches) use ($target) {
+                $protocol = strpos($matches[1], ':') ? $matches[1] : 'http://';
+                return "<a href=\"{$protocol}{$matches[2]}{$matches[3]}\"{$target} rel=\"nofollow\">{$matches[2]}{$matches[4]}</a>";
+            },
             $input);
 
         return $output;

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -284,16 +284,17 @@ class Text
      *
      * @param string $input
      * @param bool $newWindow
+     * @param string $defaultProtocol
      *
      * @return string $output
      */
-    public function autolink($input, $newWindow = false)
+    public function autolink($input, $newWindow = false, $defaultProtocol = 'http://')
     {
         $target = $newWindow ? ' target="_blank"' : '';
         $output = preg_replace_callback(
             '/(http:\/\/|https:\/\/|(www\.))(([^\s<]{4,80})[^\s<]*)/',
-            function (array $matches) use ($target) {
-                $protocol = strpos($matches[1], ':') ? $matches[1] : 'http://';
+            function (array $matches) use ($target, $defaultProtocol) {
+                $protocol = strpos($matches[1], ':') ? $matches[1] : $defaultProtocol;
                 return "<a href=\"{$protocol}{$matches[2]}{$matches[3]}\"{$target} rel=\"nofollow\">{$matches[2]}{$matches[4]}</a>";
             },
             $input);

--- a/tests/tests/Core/Utility/Service/TextTest.php
+++ b/tests/tests/Core/Utility/Service/TextTest.php
@@ -9,8 +9,8 @@ class TextTest extends ConcreteDatabaseTestCase
      */
     protected $object;
 
-    protected $fixtures = array();
-    protected $tables = array('ConfigStore');
+    protected $fixtures = [];
+    protected $tables = ['ConfigStore'];
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -33,37 +33,37 @@ class TextTest extends ConcreteDatabaseTestCase
 
     public function asciifyDataProvider()
     {
-        return array(
-            array('Mixed with English and Germaen', 'Mixed with English and Germän', 'de_DE'),
-            array('Mixed with English and ', 'Mixed with English and 日本人', ''),
-            array('Mixed with English and .doc', 'Mixed with English and 日本人.doc', ''),
-            array('Mixed with English and .', 'Mixed with English and 日本人.日本人', ''),
-            array('', '日本人', ''),
-            array('.doc', '日本人.doc', ''),
-            array('.', '日本人.日本人', ''),
-        );
+        return [
+            ['Mixed with English and Germaen', 'Mixed with English and Germän', 'de_DE'],
+            ['Mixed with English and ', 'Mixed with English and 日本人', ''],
+            ['Mixed with English and .doc', 'Mixed with English and 日本人.doc', ''],
+            ['Mixed with English and .', 'Mixed with English and 日本人.日本人', ''],
+            ['', '日本人', ''],
+            ['.doc', '日本人.doc', ''],
+            ['.', '日本人.日本人', ''],
+        ];
     }
 
     public function urlifyDataProvider()
     {
-        return array(
-            array('jetudie-le-francais', " J'étudie le français "),
-            array('lo-siento-no-hablo-espanol', 'Lo siento, no hablo español.'),
-            array('f3pws', 'ΦΞΠΏΣ'),
-            array('yo-hablo-espanol', '¿Yo hablo español?'),
-        );
+        return [
+            ['jetudie-le-francais', " J'étudie le français "],
+            ['lo-siento-no-hablo-espanol', 'Lo siento, no hablo español.'],
+            ['f3pws', 'ΦΞΠΏΣ'],
+            ['yo-hablo-espanol', '¿Yo hablo español?'],
+        ];
     }
 
     public function shortenDataProvider()
     {
-        return array(
-            array('This is a simple test...', 'This is a simple test case', 24, '...'),
-            array('This is a simple test etc', 'This is a simple test case', 22, ' etc'),
-            array('This is a simple test.', 'This is a simple test case', 21, '.'),
-            array('The quick brown fox jumps over the lazy dog', 'The quick brown fox jumps over the lazy dog', 255, '…'),
-            array('The lazy fox jumps over the quick brown dog', 'The lazy fox jumps over the quick brown dog', 0, '…'),
-            array('This_is_a_simple_test_ca…', 'This_is_a_simple_test_case', 24, '…'),
-        );
+        return [
+            ['This is a simple test...', 'This is a simple test case', 24, '...'],
+            ['This is a simple test etc', 'This is a simple test case', 22, ' etc'],
+            ['This is a simple test.', 'This is a simple test case', 21, '.'],
+            ['The quick brown fox jumps over the lazy dog', 'The quick brown fox jumps over the lazy dog', 255, '…'],
+            ['The lazy fox jumps over the quick brown dog', 'The lazy fox jumps over the quick brown dog', 0, '…'],
+            ['This_is_a_simple_test_ca…', 'This_is_a_simple_test_case', 24, '…'],
+        ];
     }
 
     public function testTextHelper()

--- a/tests/tests/Core/Utility/Service/TextTest.php
+++ b/tests/tests/Core/Utility/Service/TextTest.php
@@ -117,25 +117,26 @@ class TextTest extends ConcreteDatabaseTestCase
     public function autolinkDataProvider()
     {
         return [
-            ['', '', false],
-            ['This is not a link', 'This is not a link', false],
-            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org', false],
+            ['', ''],
+            ['This is not a link', 'This is not a link'],
+            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org'],
             ['<a href="http://www.concrete5.org" target="_blank" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org', true],
-            ['Before <a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> after', 'Before www.concrete5.org after', false],
-            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org', false],
-            ['<a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'https://concrete5.org', false],
-            ['Before <a href="http://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before http://concrete5.org after', false],
-            ['Before <a href="https://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before https://concrete5.org after', false],
-            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org https://concrete5.org', false],
-            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'www.concrete5.org https://concrete5.org', false],
+            ['Before <a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> after', 'Before www.concrete5.org after'],
+            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org'],
+            ['<a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'https://concrete5.org'],
+            ['Before <a href="http://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before http://concrete5.org after'],
+            ['Before <a href="https://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before https://concrete5.org after'],
+            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org https://concrete5.org'],
+            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'www.concrete5.org https://concrete5.org'],
+            ['<a href="https://www.concrete5.org" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org', false, 'https://'],
         ];
     }
 
     /**
      * @dataProvider autolinkDataProvider
      */
-    public function testAutolink($expected, $input, $newWindow)
+    public function testAutolink($expected, $input, $newWindow = false, $defaultProtocol = 'http://')
     {
-        $this->assertSame($expected, $this->object->autolink($input, $newWindow));
+        $this->assertSame($expected, $this->object->autolink($input, $newWindow, $defaultProtocol));
     }
 }

--- a/tests/tests/Core/Utility/Service/TextTest.php
+++ b/tests/tests/Core/Utility/Service/TextTest.php
@@ -113,4 +113,29 @@ class TextTest extends ConcreteDatabaseTestCase
     {
         $this->assertEquals($expected, $this->object->wordSafeShortText($input1, $input2, $input3));
     }
+
+    public function autolinkDataProvider()
+    {
+        return [
+            ['', '', false],
+            ['This is not a link', 'This is not a link', false],
+            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org', false],
+            ['<a href="http://www.concrete5.org" target="_blank" rel="nofollow">www.concrete5.org</a>', 'www.concrete5.org', true],
+            ['Before <a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> after', 'Before www.concrete5.org after', false],
+            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org', false],
+            ['<a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'https://concrete5.org', false],
+            ['Before <a href="http://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before http://concrete5.org after', false],
+            ['Before <a href="https://concrete5.org" rel="nofollow">concrete5.org</a> after', 'Before https://concrete5.org after', false],
+            ['<a href="http://concrete5.org" rel="nofollow">concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'http://concrete5.org https://concrete5.org', false],
+            ['<a href="http://www.concrete5.org" rel="nofollow">www.concrete5.org</a> <a href="https://concrete5.org" rel="nofollow">concrete5.org</a>', 'www.concrete5.org https://concrete5.org', false],
+        ];
+    }
+
+    /**
+     * @dataProvider autolinkDataProvider
+     */
+    public function testAutolink($expected, $input, $newWindow)
+    {
+        $this->assertSame($expected, $this->object->autolink($input, $newWindow));
+    }
 }


### PR DESCRIPTION
The html generated by the current `autolink` method always uses the http protocol, even if the source text is something like `https://example.com`.

Let's improve `autolink`:
1. if the source text contains a protocol, use it
2. if the source text does not contain a protocol, allow users to specify their preferred protocol (fallsback to http)
3. let's hide the protocol from the link text