### PR TITLE
Call ccm_enableUserProfileMenu only if it's defined

### DIFF
--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -172,7 +172,7 @@ $v = View::getRequestInstance();
 $u = new User();
 if ($u->isRegistered()) {
     $v->requireAsset('core/account');
-    $v->addFooterItem('<script type="text/javascript">$(function() { ccm_enableUserProfileMenu(); });</script>');
+    $v->addFooterItem('<script type="text/javascript">$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
 }
 if ($cp) {
     View::element('page_controls_header', ['cp' => $cp, 'c' => $c]);


### PR DESCRIPTION
After #4974 we can now disable the account menu.

BTW the `core/account` asset is still included in the output asset list, and we always call the `ccm_enableUserProfileMenu` javascript function.

Theme developers can inhibit the inclusion of `core/account` by calling `ResponseAssetGroup::get()->markAssetAsIncluded('core/account')`.

That causes that the `ccm_enableUserProfileMenu` javascript function may not be defined: so let's call it only if it's available.