### PR TITLE
Fix stacks migration

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
@@ -3,17 +3,20 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
-use Concrete\Core\Page\Page;
-use SinglePage;
-use Concrete\Core\Support\Facade\Application;
 
 class Version20170313000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
         // Move all stacks to the root. Putting them in a site was a mistake.
-        $this->connection->executeQuery('update Pages set siteTreeID = 0 where ptID in (?, ?) or cFilename = ?', array(STACK_CATEGORY_PAGE_TYPE, STACKS_PAGE_TYPE, '/!stacks/view.php'));
+        $this->connection->executeQuery('
+            update Pages
+            left join PageTypes on Pages.ptID = PageTypes.ptID
+            set Pages.siteTreeID = 0
+            where PageTypes.ptHandle in (?, ?)
+            or Pages.cFilename = ?',
+            [STACK_CATEGORY_PAGE_TYPE, STACKS_PAGE_TYPE, '/!stacks/view.php']
+        );
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
This should fix this strange error:

```
An exception occurred while executing
'update Pages set siteTreeID = 0 where ptID in (?, ?) or cFilename = ?'
with params ["core_stack_category", "core_stack", "\/!stacks\/view.php"]:
SQLSTATE[22007]: Invalid datetime format:
1292 Truncated incorrect DOUBLE value: 'core_stack_category'
```