### PR TITLE
Better localized assets responses

### DIFF
--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -1,603 +1,628 @@
 <?php
 namespace Concrete\Controller\Frontend;
 
-use Controller;
 use Concrete\Core\File\Type\Type as FileType;
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Localization\Localization;
+use Controller;
 use Environment;
 
 class AssetsLocalization extends Controller
 {
-    protected static function sendJavascriptHeader()
+    /**
+     * @param string $content
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    private function createJavascriptResponse($content)
     {
-        header('Content-type: text/javascript; charset='.APP_CHARSET);
+        $rf = $this->app->make(ResponseFactoryInterface::class);
+
+        return $rf->create(
+            $content,
+            200,
+            [
+                'Content-Type' => 'application/javascript; charset=' . APP_CHARSET,
+                'Content-Length' => strlen($content),
+            ]
+        );
     }
 
-    public static function getCoreJavascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getCoreJavascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-var ccmi18n = {
-  expand: <?=json_encode(t('Expand'))?>,
-  loadingText: <?=json_encode(t('Loading'))?>,
-  cancel: <?=json_encode(t('Cancel'))?>,
-  collapse: <?=json_encode(t('Collapse'))?>,
-  error: <?=json_encode(t('Error'))?>,
-  deleteBlockConfirm: <?=json_encode(t('Delete Block'))?>,
-  deleteBlock: <?=json_encode(t('Block Deleted'))?>,
-  deleteBlockMsg: <?=json_encode(t('The block has been removed successfully.'))?>,
-  addBlock: <?=json_encode(t('Add Block'))?>,
-  addBlockNew: <?=json_encode(t('Add Block'))?>,
-  addBlockStack: <?=json_encode(t('Add Stack'))?>,
-  addBlockStackMsg: <?=json_encode(t('The stack has been added successfully'))?>,
-  addBlockPaste: <?=json_encode(t('Paste from Clipboard'))?>,
-  changeAreaCSS: <?=json_encode(t('Design'))?>,
-  editAreaLayout: <?=json_encode(t('Edit Layout'))?>,
-  addAreaLayout: <?=json_encode(t('Add Layout'))?>,
-  moveLayoutUp: <?=json_encode(t('Move Up'))?>,
-  moveLayoutDown: <?=json_encode(t('Move Down'))?>,
-  moveLayoutAtBoundary: <?=json_encode(t('This layout section can not be moved further in this direction.'))?>,
-  areaLayoutPresets: <?=json_encode(t('Layout Presets'))?>,
-  lockAreaLayout: <?=json_encode(t('Lock Layout'))?>,
-  unlockAreaLayout: <?=json_encode(t('Unlock Layout'))?>,
-  deleteLayout: <?=json_encode(t('Delete'))?>,
-  deleteLayoutOptsTitle: <?=json_encode(t('Delete Layout'))?>,
-  confirmLayoutPresetDelete: <?=json_encode(t('Are you sure you want to delete this layout preset?'))?>,
-  setAreaPermissions: <?=json_encode(t('Set Permissions'))?>,
-  addBlockMsg: <?=json_encode(t('The block has been added successfully.'))?>,
-  updateBlock: <?=json_encode(t('Update Block'))?>,
-  updateBlockMsg: <?=json_encode(t('The block has been saved successfully.'))?>,
-  copyBlockToScrapbookMsg: <?=json_encode(t('The block has been added to your clipboard.'))?>,
-  content: <?=json_encode(t('Content'))?>,
-  closeWindow: <?=json_encode(t('Close'))?>,
-  editBlock: <?=json_encode(t('Edit'))?>,
-  editBlockWithName: <?=json_encode(tc('%s is a block type name', 'Edit %s'))?>,
-  setPermissionsDeferredMsg: <?=json_encode(t('Permission setting saved. You must complete the workflow before this change is active.'))?>,
-  editStackContents: <?=json_encode(t('Manage Stack Contents'))?>,
-  compareVersions: <?=json_encode(t('Compare Versions'))?>,
-  blockAreaMenu: <?=json_encode(t('Add Block'))?>,
-  arrangeBlock: <?=json_encode(t('Move'))?>,
-  arrangeBlockMsg: <?=json_encode(t('Blocks arranged successfully.'))?>,
-  copyBlockToScrapbook: <?=json_encode(t('Copy to Clipboard'))?>,
-  changeBlockTemplate: <?=json_encode(t('Custom Template'))?>,
-  changeBlockCSS: <?=json_encode(t('Design'))?>,
-  errorCustomStylePresetNoName: <?=json_encode(t('You must give your custom style preset a name.'))?>,
-  changeBlockBaseStyle: <?=json_encode(t('Set Block Styles'))?>,
-  confirmCssReset: <?=json_encode(t('Are you sure you want to remove all of these custom styles?'))?>,
-  confirmCssPresetDelete: <?=json_encode(t('Are you sure you want to delete this custom style preset?'))?>,
-  setBlockPermissions: <?=json_encode(t('Set Permissions'))?>,
-  setBlockAlias: <?=json_encode(t('Setup on Child Pages'))?>,
-  setBlockComposerSettings: <?=json_encode(t('Composer Settings'))?>,
-  themeBrowserTitle: <?=json_encode(t('Get More Themes'))?>,
-  themeBrowserLoading: <?=json_encode(t('Retrieving theme data from concrete5.org marketplace.'))?>,
-  addonBrowserLoading: <?=json_encode(t('Retrieving add-on data from concrete5.org marketplace.'))?>,
-  clear: <?=json_encode(t('Clear'))?>,
-  requestTimeout: <?=json_encode(t('This request took too long.'))?>,
-  generalRequestError: <?=json_encode(t('An unexpected error occurred.'))?>,
-  helpPopup: <?=json_encode(t('Help'))?>,
-  community: <?=json_encode(t('concrete5 Marketplace'))?>,
-  communityCheckout: <?=json_encode(t('concrete5 Marketplace - Purchase & Checkout'))?>,
-  communityDownload: <?=json_encode(t('concrete5 Marketplace - Download'))?>,
-  noIE6: <?=json_encode(t('concrete5 does not support Internet Explorer 6 in edit mode.'))?>,
-  helpPopupLoginMsg: <?=json_encode(t('Get more help on your question by posting it to the concrete5 help center on concrete5.org'))?>,
-  marketplaceErrorMsg: <?=json_encode(t('<p>You package could not be installed.  An unknown error occured.</p>'))?>,
-  marketplaceInstallMsg: <?=json_encode(t('<p>Your package will now be downloaded and installed.</p>'))?>,
-  marketplaceLoadingMsg: <?=json_encode(t('<p>Retrieving information from the concrete5 Marketplace.</p>'))?>,
-  marketplaceLoginMsg: <?=json_encode(t('<p>You must be logged into the concrete5 Marketplace to install add-ons and themes.  Please log in.</p>'))?>,
-  marketplaceLoginSuccessMsg: <?=json_encode(t('<p>You have successfully logged into the concrete5 Marketplace.</p>'))?>,
-  marketplaceLogoutSuccessMsg: <?=json_encode(t('<p>You are now logged out of concrete5 Marketplace.</p>'))?>,
-  deleteAttributeValue: <?=json_encode(t('Are you sure you want to remove this value?'))?>,
-  search: <?=json_encode(t('Search'))?>,
-  advanced: <?=json_encode(t('Advanced'))?>,
-  customizeSearch: <?=json_encode(t('Customize Search'))?>,
-  properties: <?=json_encode(t('Page Saved'))?>,
-  savePropertiesMsg: <?=json_encode(t('Page Properties saved.'))?>,
-  saveSpeedSettingsMsg: <?=json_encode(t('Full page caching settings saved.'))?>,
-  saveUserSettingsMsg: <?=json_encode(t('User Settings saved.'))?>,
-  ok: <?=json_encode(t('Ok'))?>,
-  scheduleGuestAccess: <?=json_encode(t('Schedule Guest Access'))?>,
-  scheduleGuestAccessSuccess: <?=json_encode(t('Timed Access for Guest Users Updated Successfully.'))?>,
-  newsflowLoading: <?=json_encode(t('Checking for updates.'))?>,
-  x: <?=json_encode(t('x'))?>,
-  user_activate: <?=json_encode(t('Activate Users'))?>,
-  user_deactivate: <?=json_encode(t('Deactivate Users'))?>,
-  user_delete: <?=json_encode(t('Delete'))?>,
-  user_group_remove: <?=json_encode(t('Remove From Group'))?>,
-  user_group_add: <?=json_encode(t('Add to Group'))?>,
-  chooseUser: <?=json_encode(t('Choose a User'))?>,
-  none: <?=json_encode(t('None'))?>,
-  editModeMsg: <?=json_encode(t('Let\'s start editing a page.'))?>,
-  editMode: <?=json_encode(t('Edit Mode'))?>,
-  save: <?=json_encode(t('Save'))?>,
-  currentImage: <?=json_encode(t('Current Image'))?>,
-  image: <?=json_encode(t('Image'))?>,
-  size: <?=json_encode(t('Size'))?>,
-  chooseFont: <?=json_encode(t('Choose Font'))?>,
-  fontWeight: <?=json_encode(t('Font Weight'))?>,
-  italic: <?=json_encode(t('Italic'))?>,
-  underline: <?=json_encode(t('Underline'))?>,
-  uppercase: <?=json_encode(t('Uppercase'))?>,
-  fontSize: <?=json_encode(t('Font Size'))?>,
-  letterSpacing: <?=json_encode(t('Letter spacing'))?>,
-  lineHeight: <?=json_encode(t('Line Height'))?>,
-  emptyArea: <?=json_encode(t('Empty %s Area', '<%- area_handle %>'))?>,
-  fullArea: <?=json_encode(t('This area is full!'))?>
-};
-
-var ccmi18n_editor = {
-  insertLinkToFile: <?=json_encode(t('Insert Link to File'))?>,
-  insertImage: <?=json_encode(t('Insert Image'))?>,
-  insertLinkToPage: <?=json_encode(t('Link to Page'))?>
-};
-
-var ccmi18n_express = {
-    chooseEntry: <?=json_encode(t('Choose Entry'))?>,
-    entriesTitle: <?=json_encode(t('Entries'))?>
-};
-
-var ccmi18n_sitemap = {
-  seo: <?=json_encode(t('SEO'))?>,
-  pageLocation: <?=json_encode(t('Location'))?>,
-  pageLocationTitle: <?=json_encode(t('Location'))?>,
-  visitExternalLink: <?=json_encode(t('Visit'))?>,
-  editExternalLink: <?=json_encode(t('Edit External Link'))?>,
-  deleteExternalLink: <?=json_encode(t('Delete'))?>,
-  copyProgressTitle: <?=json_encode(t('Copy Progress'))?>,
-  addExternalLink: <?=json_encode(t('Add External Link'))?>,
-  sendToTop: <?=json_encode(t('Send To Top'))?>,
-  sendToBottom: <?=json_encode(t('Send To Bottom'))?>,
-  emptyTrash: <?=json_encode(t('Empty Trash'))?>,
-  restorePage: <?=json_encode(t('Restore Page'))?>,
-  deletePageForever: <?=json_encode(t('Delete Forever'))?>,
-  previewPage: <?=json_encode(t('Preview'))?>,
-  visitPage: <?=json_encode(t('Visit'))?>,
-  pageAttributes: <?=json_encode(t('Attributes'))?>,
-  speedSettings: <?=json_encode(t('Caching'))?>,
-  speedSettingsTitle: <?=json_encode(t('Caching'))?>,
-  pageAttributesTitle: <?=json_encode(t('Attributes'))?>,
-  pagePermissionsTitle: <?=json_encode(t('Page Permissions'))?>,
-  setPagePermissions: <?=json_encode(t('Permissions'))?>,
-  setPagePermissionsMsg: <?=json_encode(t('Page permissions updated successfully.'))?>,
-  pageDesignMsg: <?=json_encode(t('Theme and page type updated successfully.'))?>,
-  pageDesign: <?=json_encode(t('Design &amp; Type'))?>,
-  pageVersions: <?=json_encode(t('Versions'))?>,
-  deletePage: <?=json_encode(t('Delete'))?>,
-  deletePages: <?=json_encode(t('Delete Pages'))?>,
-  deletePageSuccessMsg: <?=json_encode(t('The page has been removed successfully.'))?>,
-  deletePageSuccessDeferredMsg: <?=json_encode(t('Delete request saved. You must complete the workflow before the page is fully removed.'))?>,
-  addPage: <?=json_encode(t('Add Page'))?>,
-  moveCopyPage: <?=json_encode(t('Move/Copy'))?>,
-  reorderPage: <?=json_encode(t('Change Page Order'))?>,
-  reorderPageMessage: <?=json_encode(t('Move or reorder pages by dragging their icons.'))?>,
-  moveCopyPageMessage: <?=json_encode(t('Choose a new parent page from the sitemap.'))?>,
-  editInComposer: <?=json_encode(t('Edit in Composer'))?>,
-  searchPages: <?=json_encode(t('Search Pages'))?>,
-  explorePages: <?=json_encode(t('Flat View'))?>,
-  backToSitemap: <?=json_encode(t('Back to Sitemap'))?>,
-  searchResults: <?=json_encode(t('Search Results'))?>,
-  createdBy: <?=json_encode(t('Created By'))?>,
-  choosePage: <?=json_encode(t('Choose a Page'))?>,
-  viewing: <?=json_encode(t('Viewing'))?>,
-  results: <?=json_encode(t('Result(s)'))?>,
-  max: <?=json_encode(t('max'))?>,
-  noResults: <?=json_encode(t('No results found.'))?>,
-  areYouSure: <?=json_encode(t('Are you sure?'))?>,
-  loadingText: <?=json_encode(t('Loading'))?>,
-  loadError: <?=json_encode(t('Unable to load sitemap data. Response received: '))?>,
-  loadErrorTitle: <?=json_encode(t('Unable to load sitemap data.'))?>,
-  on: <?=json_encode(t('on'))?>
-};
-
-var ccmi18n_spellchecker = {
-  resumeEditing: <?=json_encode(t('Resume Editing'))?>,
-  noSuggestions: <?=json_encode(t('No Suggestions'))?>
-};
-
-var ccmi18n_groups = {
-  editGroup: <?=json_encode(t('Edit Group'))?>,
-  editPermissions: <?=json_encode(t('Edit Permissions'))?>
-};
-
-var ccmi18n_filemanager = {
-  view: <?=json_encode(t('View'))?>,
-  download: <?=json_encode(t('Download'))?>,
-  select: <?=json_encode(t('Choose'))?>,
-  duplicateFile: <?=json_encode(t('Copy File'))?>,
-  clear: <?=json_encode(t('Clear'))?>,
-  edit: <?=json_encode(t('Edit'))?>,
-  thumbnailImages: <?=json_encode(t('Thumbnail Images'))?>,
-  replace: <?=json_encode(t('Replace'))?>,
-  duplicate: <?=json_encode(t('Copy'))?>,
-  chooseNew: <?=json_encode(t('Choose New File'))?>,
-  sets: <?=json_encode(t('Sets'))?>,
-  permissions: <?=json_encode(t('Permissions'))?>,
-  properties: <?=json_encode(t('Properties'))?>,
-  deleteFile: <?=json_encode(t('Delete'))?>,
-  title: <?=json_encode(t('File Manager'))?>,
-  uploadErrorChooseFile: <?=json_encode(t('You must choose a file.'))?>,
-  addFiles: <?=json_encode(t('Add Files'))?>,
-  rescan: <?=json_encode(t('Rescan'))?>,
-  pending: <?=json_encode(t('Pending'))?>,
-  uploadComplete: <?=json_encode(t('Upload Complete'))?>,
-  uploadFailed: <?=json_encode(t('Upload Failed'))?>,
-  uploadProgress: <?=json_encode(t('Upload Progress'))?>,
-  chosenTooMany: <?=json_encode(t('You may only select a single file.'))?>,
-  PTYPE_CUSTOM: <?=json_encode(/*FilePermissions::PTYPE_CUSTOM*/ '')?>,
-  PTYPE_NONE: <?=json_encode(/*FilePermissions::PTYPE_NONE*/ '')?>,
-  PTYPE_ALL: <?=json_encode(/*FilePermissions::PTYPE_ALL*/ '')?>,
-  FTYPE_IMAGE: <?=json_encode(FileType::T_IMAGE)?>,
-  FTYPE_VIDEO: <?=json_encode(FileType::T_VIDEO)?>,
-  FTYPE_TEXT: <?=json_encode(FileType::T_TEXT)?>,
-  FTYPE_AUDIO: <?=json_encode(FileType::T_AUDIO)?>,
-  FTYPE_DOCUMENT: <?=json_encode(FileType::T_DOCUMENT)?>,
-  FTYPE_APPLICATION: <?=json_encode(FileType::T_APPLICATION)?>
-};
-
-var ccmi18n_chosen = {
-  placeholder_text_multiple: <?=json_encode(t('Select Some Options'))?>,
-  placeholder_text_single: <?=json_encode(t('Select an Option'))?>,
-  no_results_text: <?=json_encode(t(/*i18n After this text we have a search criteria: for instance 'No results match "Criteria"'*/'No results match'))?>
-};
-
-var ccmi18n_topics = {
-  addCategory: <?=json_encode(t('Add Category'))?>,
-  editCategory: <?=json_encode(t('Edit Category'))?>,
-  deleteCategory: <?=json_encode(t('Delete Category'))?>,
-  cloneCategory: <?=json_encode(t('Clone Category'))?>,
-  addTopic: <?=json_encode(t('Add Topic'))?>,
-  editTopic: <?=json_encode(t('Edit Topic'))?>,
-  deleteTopic: <?=json_encode(t('Delete Topic'))?>,
-  cloneTopic: <?=json_encode(t('Clone Topic'))?>,
-  editPermissions: <?=json_encode(t('Edit Permissions'))?>
-};
-
-var ccmi18n_tree = {
-    add: <?=json_encode(t('Add'))?>,
-    edit: <?=json_encode(t('Edit'))?>,
-    delete: <?=json_encode(t('Delete'))?>
-};
-var ccmi18n_tourist = {
-  skipButton: <?=json_encode('<button class="btn btn-default btn-xs pull-right tour-next">'.t('Skip →').'</button>')?>,
-  nextButton: <?=json_encode('<button class="btn btn-primary btn-xs pull-right tour-next">'.t('Next →').'</button>')?>,
-  finalButton: <?=json_encode('<button class="btn btn-primary btn-xs pull-right tour-next">'.t('Done').'</button>')?>,
-  closeButton: <?=json_encode('<a class="btn btn-close tour-close" href="#"><i class="fa fa-remove"></i></a>')?>,
-  okButton: <?=json_encode('<button class="btn btn-xs tour-close btn-primary">'.t('Ok').'</button>')?>,
-  doThis: <?=json_encode(t('Do this:'))?>,
-  thenThis: <?=json_encode(t('Then this:'))?>,
-  nextThis: <?=json_encode(t('Next this:'))?>,
-  stepXofY: <?=json_encode(t('step %1$d of %2$d'))?>
-};
-
-var ccmi18n_helpGuides = {
-  'add-page': [
-    {title: <?=json_encode(t('Pages Panel'))?>, text: <?=json_encode(t('The pages is where you go to add a new page to your site, or jump between existing pages. To open the pages panel, click the icon.'))?>},
-    {title: <?=json_encode(t('Page Types'))?>, text: <?=json_encode(t('This is your list of page types. Click any of them to add a page.'))?>},
-    {title: <?=json_encode(t('Sitemap'))?>, text: <?=json_encode(t('This is your sitemap. Use it to easily navigate your site.'))?>}
-  ],
-  'change-content-edit-mode': [
-    {title: <?=json_encode(t('Edit Mode Active'))?>, text: <?=json_encode(t('The highlighted button makes it obvious you\'re in edit mode.'))?>},
-    {title: <?=json_encode(t('Edit the Block'))?>, text: <?=json_encode(t('Just roll over any content on the page. Click or tap to get the edit menu for that block.'))?>},
-    {title: <?=json_encode(t('Edit Menu'))?>, text: <?=json_encode(t('Use this menu to edit a block\'s contents, change its display, or remove it entirely.'))?>},
-    {title: <?=json_encode(t('Save Changes'))?>, text: <?=json_encode(t("When you're done editing you can Save Changes for other editors to see, or Publish Changes to make your changes live immediately."))?>}
-  ],
-    'add-content-edit-mode': [
-    {title: <?=json_encode(t('Add Mode Active'))?>, text: <?=json_encode(t('The highlighted button makes it obvious you\'re in Add Content mode.'))?>},
-    {title: <?=json_encode(t('Add Panel'))?>, text: <?=json_encode(t('This is the Add Content Panel.'))?>},
-    {title: <?=json_encode(t('Content Selector'))?>, text: <?=json_encode(t('Click here to choose between adding blocks, clipboard items, stacks and stack contents.'))?>},
-    {title: <?=json_encode(t('Search Blocks'))?>, text: <?=json_encode(t("You can easily filter the blocks in the panel by searching here."))?>},
-    {title: <?=json_encode(t('Add Blocks'))?>, text: <?=json_encode(t("Click and drag blocks from the add panel into the page to add them."))?>}
+        $content =
+'var ccmi18n = ' . json_encode([
+    'expand' => t('Expand'),
+    'loadingText' => t('Loading'),
+    'cancel' => t('Cancel'),
+    'collapse' => t('Collapse'),
+    'error' => t('Error'),
+    'deleteBlockConfirm' => t('Delete Block'),
+    'deleteBlock' => t('Block Deleted'),
+    'deleteBlockMsg' => t('The block has been removed successfully.'),
+    'addBlock' => t('Add Block'),
+    'addBlockNew' => t('Add Block'),
+    'addBlockStack' => t('Add Stack'),
+    'addBlockStackMsg' => t('The stack has been added successfully'),
+    'addBlockPaste' => t('Paste from Clipboard'),
+    'changeAreaCSS' => t('Design'),
+    'editAreaLayout' => t('Edit Layout'),
+    'addAreaLayout' => t('Add Layout'),
+    'moveLayoutUp' => t('Move Up'),
+    'moveLayoutDown' => t('Move Down'),
+    'moveLayoutAtBoundary' => t('This layout section can not be moved further in this direction.'),
+    'areaLayoutPresets' => t('Layout Presets'),
+    'lockAreaLayout' => t('Lock Layout'),
+    'unlockAreaLayout' => t('Unlock Layout'),
+    'deleteLayout' => t('Delete'),
+    'deleteLayoutOptsTitle' => t('Delete Layout'),
+    'confirmLayoutPresetDelete' => t('Are you sure you want to delete this layout preset?'),
+    'setAreaPermissions' => t('Set Permissions'),
+    'addBlockMsg' => t('The block has been added successfully.'),
+    'updateBlock' => t('Update Block'),
+    'updateBlockMsg' => t('The block has been saved successfully.'),
+    'copyBlockToScrapbookMsg' => t('The block has been added to your clipboard.'),
+    'content' => t('Content'),
+    'closeWindow' => t('Close'),
+    'editBlock' => t('Edit'),
+    'editBlockWithName' => tc('%s is a block type name', 'Edit %s'),
+    'setPermissionsDeferredMsg' => t('Permission setting saved. You must complete the workflow before this change is active.'),
+    'editStackContents' => t('Manage Stack Contents'),
+    'compareVersions' => t('Compare Versions'),
+    'blockAreaMenu' => t('Add Block'),
+    'arrangeBlock' => t('Move'),
+    'arrangeBlockMsg' => t('Blocks arranged successfully.'),
+    'copyBlockToScrapbook' => t('Copy to Clipboard'),
+    'changeBlockTemplate' => t('Custom Template'),
+    'changeBlockCSS' => t('Design'),
+    'errorCustomStylePresetNoName' => t('You must give your custom style preset a name.'),
+    'changeBlockBaseStyle' => t('Set Block Styles'),
+    'confirmCssReset' => t('Are you sure you want to remove all of these custom styles?'),
+    'confirmCssPresetDelete' => t('Are you sure you want to delete this custom style preset?'),
+    'setBlockPermissions' => t('Set Permissions'),
+    'setBlockAlias' => t('Setup on Child Pages'),
+    'setBlockComposerSettings' => t('Composer Settings'),
+    'themeBrowserTitle' => t('Get More Themes'),
+    'themeBrowserLoading' => t('Retrieving theme data from concrete5.org marketplace.'),
+    'addonBrowserLoading' => t('Retrieving add-on data from concrete5.org marketplace.'),
+    'clear' => t('Clear'),
+    'requestTimeout' => t('This request took too long.'),
+    'generalRequestError' => t('An unexpected error occurred.'),
+    'helpPopup' => t('Help'),
+    'community' => t('concrete5 Marketplace'),
+    'communityCheckout' => t('concrete5 Marketplace - Purchase & Checkout'),
+    'communityDownload' => t('concrete5 Marketplace - Download'),
+    'noIE6' => t('concrete5 does not support Internet Explorer 6 in edit mode.'),
+    'helpPopupLoginMsg' => t('Get more help on your question by posting it to the concrete5 help center on concrete5.org'),
+    'marketplaceErrorMsg' => t('<p>You package could not be installed.  An unknown error occured.</p>'),
+    'marketplaceInstallMsg' => t('<p>Your package will now be downloaded and installed.</p>'),
+    'marketplaceLoadingMsg' => t('<p>Retrieving information from the concrete5 Marketplace.</p>'),
+    'marketplaceLoginMsg' => t('<p>You must be logged into the concrete5 Marketplace to install add-ons and themes.  Please log in.</p>'),
+    'marketplaceLoginSuccessMsg' => t('<p>You have successfully logged into the concrete5 Marketplace.</p>'),
+    'marketplaceLogoutSuccessMsg' => t('<p>You are now logged out of concrete5 Marketplace.</p>'),
+    'deleteAttributeValue' => t('Are you sure you want to remove this value?'),
+    'search' => t('Search'),
+    'advanced' => t('Advanced'),
+    'customizeSearch' => t('Customize Search'),
+    'properties' => t('Page Saved'),
+    'savePropertiesMsg' => t('Page Properties saved.'),
+    'saveSpeedSettingsMsg' => t('Full page caching settings saved.'),
+    'saveUserSettingsMsg' => t('User Settings saved.'),
+    'ok' => t('Ok'),
+    'scheduleGuestAccess' => t('Schedule Guest Access'),
+    'scheduleGuestAccessSuccess' => t('Timed Access for Guest Users Updated Successfully.'),
+    'newsflowLoading' => t('Checking for updates.'),
+    'x' => t('x'),
+    'user_activate' => t('Activate Users'),
+    'user_deactivate' => t('Deactivate Users'),
+    'user_delete' => t('Delete'),
+    'user_group_remove' => t('Remove From Group'),
+    'user_group_add' => t('Add to Group'),
+    'chooseUser' => t('Choose a User'),
+    'none' => t('None'),
+    'editModeMsg' => t('Let\'s start editing a page.'),
+    'editMode' => t('Edit Mode'),
+    'save' => t('Save'),
+    'currentImage' => t('Current Image'),
+    'image' => t('Image'),
+    'size' => t('Size'),
+    'chooseFont' => t('Choose Font'),
+    'fontWeight' => t('Font Weight'),
+    'italic' => t('Italic'),
+    'underline' => t('Underline'),
+    'uppercase' => t('Uppercase'),
+    'fontSize' => t('Font Size'),
+    'letterSpacing' => t('Letter spacing'),
+    'lineHeight' => t('Line Height'),
+    'emptyArea' => t('Empty %s Area', '<%- area_handle %>'),
+    'fullArea' => t('This area is full!'),
+]) . ';
+var ccmi18n_editor = ' . json_encode([
+    'insertLinkToFile' => t('Insert Link to File'),
+    'insertImage' => t('Insert Image'),
+    'insertLinkToPage' => t('Link to Page'),
+]) . ';
+var ccmi18n_express = ' . json_encode([
+    'chooseEntry' => t('Choose Entry'),
+    'entriesTitle' => t('Entries'),
+]) . ';
+var ccmi18n_sitemap = ' . json_encode([
+    'seo' => t('SEO'),
+    'pageLocation' => t('Location'),
+    'pageLocationTitle' => t('Location'),
+    'visitExternalLink' => t('Visit'),
+    'editExternalLink' => t('Edit External Link'),
+    'deleteExternalLink' => t('Delete'),
+    'copyProgressTitle' => t('Copy Progress'),
+    'addExternalLink' => t('Add External Link'),
+    'sendToTop' => t('Send To Top'),
+    'sendToBottom' => t('Send To Bottom'),
+    'emptyTrash' => t('Empty Trash'),
+    'restorePage' => t('Restore Page'),
+    'deletePageForever' => t('Delete Forever'),
+    'previewPage' => t('Preview'),
+    'visitPage' => t('Visit'),
+    'pageAttributes' => t('Attributes'),
+    'speedSettings' => t('Caching'),
+    'speedSettingsTitle' => t('Caching'),
+    'pageAttributesTitle' => t('Attributes'),
+    'pagePermissionsTitle' => t('Page Permissions'),
+    'setPagePermissions' => t('Permissions'),
+    'setPagePermissionsMsg' => t('Page permissions updated successfully.'),
+    'pageDesignMsg' => t('Theme and page type updated successfully.'),
+    'pageDesign' => t('Design &amp; Type'),
+    'pageVersions' => t('Versions'),
+    'deletePage' => t('Delete'),
+    'deletePages' => t('Delete Pages'),
+    'deletePageSuccessMsg' => t('The page has been removed successfully.'),
+    'deletePageSuccessDeferredMsg' => t('Delete request saved. You must complete the workflow before the page is fully removed.'),
+    'addPage' => t('Add Page'),
+    'moveCopyPage' => t('Move/Copy'),
+    'reorderPage' => t('Change Page Order'),
+    'reorderPageMessage' => t('Move or reorder pages by dragging their icons.'),
+    'moveCopyPageMessage' => t('Choose a new parent page from the sitemap.'),
+    'editInComposer' => t('Edit in Composer'),
+    'searchPages' => t('Search Pages'),
+    'explorePages' => t('Flat View'),
+    'backToSitemap' => t('Back to Sitemap'),
+    'searchResults' => t('Search Results'),
+    'createdBy' => t('Created By'),
+    'choosePage' => t('Choose a Page'),
+    'viewing' => t('Viewing'),
+    'results' => t('Result(s)'),
+    'max' => t('max'),
+    'noResults' => t('No results found.'),
+    'areYouSure' => t('Are you sure?'),
+    'loadingText' => t('Loading'),
+    'loadError' => t('Unable to load sitemap data. Response received: '),
+    'loadErrorTitle' => t('Unable to load sitemap data.'),
+    'on' => t('on'),
+]) . ';
+var ccmi18n_spellchecker = ' . json_encode([
+    'resumeEditing' => t('Resume Editing'),
+    'noSuggestions' => t('No Suggestions'),
+]) . ';
+var ccmi18n_groups = ' . json_encode([
+    'editGroup' => t('Edit Group'),
+    'editPermissions' => t('Edit Permissions'),
+]) . ';
+var ccmi18n_filemanager = ' . json_encode([
+    'view' => t('View'),
+    'download' => t('Download'),
+    'select' => t('Choose'),
+    'duplicateFile' => t('Copy File'),
+    'clear' => t('Clear'),
+    'edit' => t('Edit'),
+    'thumbnailImages' => t('Thumbnail Images'),
+    'replace' => t('Replace'),
+    'duplicate' => t('Copy'),
+    'chooseNew' => t('Choose New File'),
+    'sets' => t('Sets'),
+    'permissions' => t('Permissions'),
+    'properties' => t('Properties'),
+    'deleteFile' => t('Delete'),
+    'title' => t('File Manager'),
+    'uploadErrorChooseFile' => t('You must choose a file.'),
+    'addFiles' => t('Add Files'),
+    'rescan' => t('Rescan'),
+    'pending' => t('Pending'),
+    'uploadComplete' => t('Upload Complete'),
+    'uploadFailed' => t('Upload Failed'),
+    'uploadProgress' => t('Upload Progress'),
+    'chosenTooMany' => t('You may only select a single file.'),
+    'PTYPE_CUSTOM' => '', // FilePermissions::PTYPE_CUSTOM
+    'PTYPE_NONE' => '', // FilePermissions::PTYPE_NONE
+    'PTYPE_ALL' => '', // /*FilePermissions::PTYPE_ALL
+    'FTYPE_IMAGE' => FileType::T_IMAGE,
+    'FTYPE_VIDEO' => FileType::T_VIDEO,
+    'FTYPE_TEXT' => FileType::T_TEXT,
+    'FTYPE_AUDIO' => FileType::T_AUDIO,
+    'FTYPE_DOCUMENT' => FileType::T_DOCUMENT,
+    'FTYPE_APPLICATION' => FileType::T_APPLICATION,
+]) . ';
+var ccmi18n_chosen = ' . json_encode([
+    'placeholder_text_multiple' => t('Select Some Options'),
+    'placeholder_text_single' => t('Select an Option'),
+    'no_results_text' => t(/*i18n After this text we have a search criteria: for instance 'No results match "Criteria"'*/'No results match'),
+]) . ';
+var ccmi18n_topics = ' . json_encode([
+    'addCategory' => t('Add Category'),
+    'editCategory' => t('Edit Category'),
+    'deleteCategory' => t('Delete Category'),
+    'cloneCategory' => t('Clone Category'),
+    'addTopic' => t('Add Topic'),
+    'editTopic' => t('Edit Topic'),
+    'deleteTopic' => t('Delete Topic'),
+    'cloneTopic' => t('Clone Topic'),
+    'editPermissions' => t('Edit Permissions'),
+]) . ';
+var ccmi18n_tree = ' . json_encode([
+    'add' => t('Add'),
+    'edit' => t('Edit'),
+    'delete' => t('Delete'),
+]) . ';
+var ccmi18n_tourist = ' . json_encode([
+    'skipButton' => '<button class="btn btn-default btn-xs pull-right tour-next">' . t('Skip →') . '</button>',
+    'nextButton' => '<button class="btn btn-primary btn-xs pull-right tour-next">' . t('Next →') . '</button>',
+    'finalButton' => '<button class="btn btn-primary btn-xs pull-right tour-next">' . t('Done') . '</button>',
+    'closeButton' => '<a class="btn btn-close tour-close" href="#"><i class="fa fa-remove"></i></a>',
+    'okButton' => '<button class="btn btn-xs tour-close btn-primary">' . t('Ok') . '</button>',
+    'doThis' => t('Do this:'),
+    'thenThis' => t('Then this:'),
+    'nextThis' => t('Next this:'),
+    'stepXofY' => t('step %1$d of %2$d'),
+]) . ';
+var ccmi18n_helpGuides = ' . json_encode([
+    'add-page' => [
+        ['title' => t('Pages Panel'), 'text' => t('The pages is where you go to add a new page to your site, or jump between existing pages. To open the pages panel, click the icon.')],
+        ['title' => t('Page Types'), 'text' => t('This is your list of page types. Click any of them to add a page.')],
+        ['title' => t('Sitemap'), 'text' => t('This is your sitemap. Use it to easily navigate your site.')],
     ],
-  'change-content': [
-    {title: <?=json_encode(t('Enter Edit Mode'))?>, text: <?=json_encode(t('First, click the "Edit Page" button. This will enter edit mode for this page.'))?>}
-  ],
-  'add-content': [
-    {title: <?=json_encode(t('Enter Edit Mode'))?>, text: <?=json_encode(t('Click the "Add Content" button to enter edit mode, with the Add Content panel active.'))?>}
-  ],
-  'dashboard': [
-    {title: <?=json_encode(t('Dashboard Panel'))?>, text: <?=json_encode(t('The dashboard is where you go to manage aspects of your site that have to do with more than the content on just one page. Click the sliders icon.'))?>},
-    {title: <?=json_encode(t('Sitemap'))?>, text: <?=json_encode(t("The sitemap lets manage the structure of your website. You can delete pages you don't need, or drag them around the tree to suit your needs."))?>}
-  ],
-  'location-panel': [
-    {title: <?=json_encode(t('Choose Location'))?>, text: <?=json_encode(t('Click this button to choose the location of the page in your sitemap. If saved, the page will be moved to this location.'))?>},
-    {title: <?=json_encode(t('Page URLs'))?>, text: <?=json_encode(t('Control the URLs used to access your page here. Non-canonical URLs will redirect to your page; canonical URLs can be either generated or automatically or overridden. Sub-pages to this page start with canonical URLs by default.'))?>}
-  ],
-  'personalize': [
-    {title: <?=json_encode(t('Properties Panel'))?>, text: <?=json_encode(t('The properties panel controls data and details about the current page including design customizations. To open the properties panel, click the gear icon.'))?>},
-    {title: <?=json_encode(t('Page Design'))?>, text: <?=json_encode(t('From here you can change your page template and customize your page\'s styles.'))?>},
-    {title: <?=json_encode(t('Customize'))?>, text: <?=json_encode(t('Click here to load the theme customizer for the page.'))?>}
-  ],
-  'toolbar': [
-    {title: <?=json_encode(t('Edit Mode'))?>, text: <?=json_encode(t('Edit anything on this page by clicking the pencil icon.'))?>},
-    {title: <?=json_encode(t('Settings'))?>, text: <?=json_encode(t('Change the general look and options like SEO and permissions. Delete the page or roll versions back from here as well.'))?>},
-    {title: <?=json_encode(t('Add Content'))?>, text: <?=json_encode(t('Place a new block on the page. Copy one using the clipboard, or try a reusable stack.'))?>},
-    {title: <?=json_encode(t('Intelligent Search'))?>, text: <?=json_encode(t('At a loss? Try searching here. You can find anything from pages in your site to settings and how-to documentation.'))?>},
-    {title: <?=json_encode(t('Add Page'))?>, text: <?=json_encode(t('Add a new page to your site, or quickly jump around your sitemap.'))?>},
-    {title: <?=json_encode(t('Dashboard'))?>, text: <?=json_encode(t('Anything that isn\'t specific to this page happens here. Manage users, files, reporting data, and site-wide settings.'))?>}
-  ]
-}
-<?php
+    'change-content-edit-mode' => [
+        ['title' => t('Edit Mode Active'), 'text' => t('The highlighted button makes it obvious you\'re in edit mode.')],
+        ['title' => t('Edit the Block'), 'text' => t('Just roll over any content on the page. Click or tap to get the edit menu for that block.')],
+        ['title' => t('Edit Menu'), 'text' => t('Use this menu to edit a block\'s contents, change its display, or remove it entirely.')],
+        ['title' => t('Save Changes'), 'text' => t("When you're done editing you can Save Changes for other editors to see, or Publish Changes to make your changes live immediately.")],
+    ],
+    'add-content-edit-mode' => [
+        ['title' => t('Add Mode Active'), 'text' => t('The highlighted button makes it obvious you\'re in Add Content mode.')],
+        ['title' => t('Add Panel'), 'text' => t('This is the Add Content Panel.')],
+        ['title' => t('Content Selector'), 'text' => t('Click here to choose between adding blocks, clipboard items, stacks and stack contents.')],
+        ['title' => t('Search Blocks'), 'text' => t('You can easily filter the blocks in the panel by searching here.')],
+        ['title' => t('Add Blocks'), 'text' => t('Click and drag blocks from the add panel into the page to add them.')],
+    ],
+    'change-content' => [
+        ['title' => t('Enter Edit Mode'), 'text' => t('First, click the "Edit Page" button. This will enter edit mode for this page.')],
+    ],
+    'add-content' => [
+        ['title' => t('Enter Edit Mode'), 'text' => t('Click the "Add Content" button to enter edit mode, with the Add Content panel active.')],
+    ],
+    'dashboard' => [
+        ['title' => t('Dashboard Panel'), 'text' => t('The dashboard is where you go to manage aspects of your site that have to do with more than the content on just one page. Click the sliders icon.')],
+        ['title' => t('Sitemap'), 'text' => t("The sitemap lets manage the structure of your website. You can delete pages you don't need, or drag them around the tree to suit your needs.")],
+    ],
+    'location-panel' => [
+        ['title' => t('Choose Location'), 'text' => t('Click this button to choose the location of the page in your sitemap. If saved, the page will be moved to this location.')],
+        ['title' => t('Page URLs'), 'text' => t('Control the URLs used to access your page here. Non-canonical URLs will redirect to your page; canonical URLs can be either generated or automatically or overridden. Sub-pages to this page start with canonical URLs by default.')],
+    ],
+    'personalize' => [
+        ['title' => t('Properties Panel'), 'text' => t('The properties panel controls data and details about the current page including design customizations. To open the properties panel, click the gear icon.')],
+        ['title' => t('Page Design'), 'text' => t('From here you can change your page template and customize your page\'s styles.')],
+        ['title' => t('Customize'), 'text' => t('Click here to load the theme customizer for the page.')],
+    ],
+    'toolbar' => [
+        ['title' => t('Edit Mode'), 'text' => t('Edit anything on this page by clicking the pencil icon.')],
+        ['title' => t('Settings'), 'text' => t('Change the general look and options like SEO and permissions. Delete the page or roll versions back from here as well.')],
+        ['title' => t('Add Content'), 'text' => t('Place a new block on the page. Copy one using the clipboard, or try a reusable stack.')],
+        ['title' => t('Intelligent Search'), 'text' => t('At a loss? Try searching here. You can find anything from pages in your site to settings and how-to documentation.')],
+        ['title' => t('Add Page'), 'text' => t('Add a new page to your site, or quickly jump around your sitemap.')],
+        ['title' => t('Dashboard'), 'text' => t('Anything that isn\'t specific to this page happens here. Manage users, files, reporting data, and site-wide settings.')],
+    ],
+]) . ';
+';
 
+        return $this->createJavascriptResponse($content);
     }
 
-    public static function getSelect2Javascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getSelect2Javascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
         $locale = str_replace('_', '-', Localization::activeLocale());
         if ($locale === 'en-US') {
-            echo '// No needs to translate '.$locale;
+            $content = "/* select2: no needs to translate $locale */\n";
         } else {
             $env = Environment::get();
             /* @var $env \Concrete\Core\Foundation\Environment */
             $language = Localization::activeLanguage();
-            $alternatives = array($locale);
+            $alternatives = [$locale];
             if (strcmp($locale, $language) !== 0) {
                 $alternatives[] = $language;
             }
             $found = null;
             foreach ($alternatives as $alternative) {
-                $r = $env->getRecord(DIRNAME_JAVASCRIPT."/i18n/select2_locale_{$alternative}.js");
+                $r = $env->getRecord(DIRNAME_JAVASCRIPT . "/i18n/select2_locale_{$alternative}.js");
                 if (is_file($r->file)) {
                     $found = $r->file;
                     break;
                 }
             }
             if (isset($found)) {
-                readfile($found);
+                $content = @file_get_contents($found);
+                if ($content === false) {
+                    $content = "/* select2: failed to read translations for $alternative */";
+                }
             } else {
-                echo '// No select2 translations for '.implode(', ', $alternatives);
+                $content = '/* select2: no translations for ' . implode(', ', $alternatives) . ' */';
             }
         }
+
+        return $this->createJavascriptResponse($content);
     }
 
-    public static function getRedactorJavascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getRedactorJavascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
         $locale = Localization::activeLocale();
-        ?>
-jQuery.Redactor.opts.langs[<?=json_encode($locale)?>] = {
-  html: <?=json_encode(t('HTML'))?>,
-  video: <?=json_encode(t('Insert Video'))?>,
-  image: <?=json_encode(t('Insert Image'))?>,
-  table: <?=json_encode(t('Table'))?>,
-  link: <?=json_encode(t('Link'))?>,
-  link_insert: <?=json_encode(t('Insert link'))?>,
-  link_edit: <?=json_encode(t('Edit link'))?>,
-  unlink: <?=json_encode(t('Unlink'))?>,
-  formatting: <?=json_encode(t('Formatting'))?>,
-  paragraph: <?=json_encode(t('Normal text'))?>,
-  quote: <?=json_encode(t('Quote'))?>,
-  code: <?=json_encode(t('Code'))?>,
-  header1: <?=json_encode(t('Header 1'))?>,
-  header2: <?=json_encode(t('Header 2'))?>,
-  header3: <?=json_encode(t('Header 3'))?>,
-  header4: <?=json_encode(t('Header 4'))?>,
-  header5: <?=json_encode(t('Header 5'))?>,
-  bold: <?=json_encode(t('Bold'))?>,
-  italic: <?=json_encode(t('Italic'))?>,
-  fontcolor: <?=json_encode(t('Font Color'))?>,
-  backcolor: <?=json_encode(t('Back Color'))?>,
-  unorderedlist: <?=json_encode(t('Unordered List'))?>,
-  orderedlist: <?=json_encode(t('Ordered List'))?>,
-  outdent: <?=json_encode(t('Outdent'))?>,
-  indent: <?=json_encode(t('Indent'))?>,
-  cancel: <?=json_encode(t('Cancel'))?>,
-  insert: <?=json_encode(t('Insert'))?>,
-  save: <?=json_encode(t('Save'))?>,
-  _delete: <?=json_encode(t('Delete'))?>,
-  insert_table: <?=json_encode(t('Insert Table'))?>,
-  insert_row_above: <?=json_encode(t('Add Row Above'))?>,
-  insert_row_below: <?=json_encode(t('Add Row Below'))?>,
-  insert_column_left: <?=json_encode(t('Add Column Left'))?>,
-  insert_column_right: <?=json_encode(t('Add Column Right'))?>,
-  delete_column: <?=json_encode(t('Delete Column'))?>,
-  delete_row: <?=json_encode(t('Delete Row'))?>,
-  delete_table: <?=json_encode(t('Delete Table'))?>,
-  rows: <?=json_encode(t('Rows'))?>,
-  columns: <?=json_encode(t('Columns'))?>,
-  add_head: <?=json_encode(t('Add Head'))?>,
-  delete_head: <?=json_encode(t('Delete Head'))?>,
-  title: <?=json_encode(t('Title'))?>,
-  image_position: <?=json_encode(t('Position'))?>,
-  none: <?=json_encode(t('None'))?>,
-  left: <?=json_encode(t('Left'))?>,
-  right: <?=json_encode(t('Right'))?>,
-  center: <?=json_encode(t('Center'))?>,
-  image_web_link: <?=json_encode(t('Image Web Link'))?>,
-  text: <?=json_encode(t('Text'))?>,
-  mailto: <?=json_encode(t('Email'))?>,
-  web: <?=json_encode(t('URL'))?>,
-  video_html_code: <?=json_encode(t('Video Embed Code or Youtube/Vimeo Link'))?>,
-  file: <?=json_encode(t('Insert File'))?>,
-  upload: <?=json_encode(t('Upload'))?>,
-  download: <?=json_encode(t('Download'))?>,
-  choose: <?=json_encode(t('Choose'))?>,
-  or_choose: <?=json_encode(t('Or choose'))?>,
-  drop_file_here: <?=json_encode(t('Drop file here'))?>,
-  align_left: <?=json_encode(t('Align text to the left'))?>,
-  align_center: <?=json_encode(t('Center text'))?>,
-  align_right: <?=json_encode(t('Align text to the right'))?>,
-  align_justify: <?=json_encode(t('Justify text'))?>,
-  horizontalrule: <?=json_encode(t('Insert Horizontal Rule'))?>,
-  deleted: <?=json_encode(t('Deleted'))?>,
-  anchor: <?=json_encode(t('Anchor'))?>,
-  open_link: <?=json_encode(t('Open Link'))?>,
-  link_new_tab: <?=json_encode(t('Open link in new tab'))?>,
-  /* concrete5 */
-  link_same_window: <?=json_encode(t('Open link in same window'))?>,
-  in_lightbox: <?=json_encode(t('Open link in Lightbox'))?>,
-  lightbox_link_type: <?=json_encode(t('Link Type'))?>,
-  lightbox_link_type_iframe: <?=json_encode(t('Web Page'))?>,
-  lightbox_link_type_image: <?=json_encode(t('Image'))?>,
-  lightbox_link_type_iframe_options: <?=json_encode(t('Frame Options'))?>,
-  lightbox_link_type_iframe_width: <?=json_encode(t('Width'))?>,
-  lightbox_link_type_iframe_height: <?=json_encode(t('Height'))?>,
-  customStyles: <?=json_encode(t('Custom Styles'))?>,
-  remove_font: <?=json_encode(t('Remove font'))?>,
-  change_font_family: <?=json_encode(t('Change Font Family'))?>,
-  remove_style: <?=json_encode(t('Remove Style'))?>,
-  insert_character: <?=json_encode(t('Insert Character'))?>,
-  undo: <?=json_encode(t('Undo'))?>,
-  redo: <?=json_encode(t('Redo'))?>,
-  remove_font_family: <?=json_encode(t('Remove Font Family'))?>,
-  remove_font_size: <?=json_encode(t('Remove Font Size'))?>,
-  change_font_size: <?=json_encode(t('Change Font Size'))?>,
-  /* end concrete5 */
-  underline: <?=json_encode(t('Underline'))?>,
-  alignment: <?=json_encode(t('Alignment'))?>,
-  filename: <?=json_encode(t('Name (optional)'))?>,
-  edit: <?=json_encode(t('Edit'))?>,
-  upload_label: <?=json_encode(t('Drop file here or '))?>
-};
-
-jQuery.Redactor.opts.lang = <?=json_encode($locale)?>;
+        $content =
+'jQuery.Redactor.opts.langs[' . json_encode($locale) . '] = ' . json_encode([
+    'html' => t('HTML'),
+    'video' => t('Insert Video'),
+    'image' => t('Insert Image'),
+    'table' => t('Table'),
+    'link' => t('Link'),
+    'link_insert' => t('Insert link'),
+    'link_edit' => t('Edit link'),
+    'unlink' => t('Unlink'),
+    'formatting' => t('Formatting'),
+    'paragraph' => t('Normal text'),
+    'quote' => t('Quote'),
+    'code' => t('Code'),
+    'header1' => t('Header 1'),
+    'header2' => t('Header 2'),
+    'header3' => t('Header 3'),
+    'header4' => t('Header 4'),
+    'header5' => t('Header 5'),
+    'bold' => t('Bold'),
+    'italic' => t('Italic'),
+    'fontcolor' => t('Font Color'),
+    'backcolor' => t('Back Color'),
+    'unorderedlist' => t('Unordered List'),
+    'orderedlist' => t('Ordered List'),
+    'outdent' => t('Outdent'),
+    'indent' => t('Indent'),
+    'cancel' => t('Cancel'),
+    'insert' => t('Insert'),
+    'save' => t('Save'),
+    '_delete' => t('Delete'),
+    'insert_table' => t('Insert Table'),
+    'insert_row_above' => t('Add Row Above'),
+    'insert_row_below' => t('Add Row Below'),
+    'insert_column_left' => t('Add Column Left'),
+    'insert_column_right' => t('Add Column Right'),
+    'delete_column' => t('Delete Column'),
+    'delete_row' => t('Delete Row'),
+    'delete_table' => t('Delete Table'),
+    'rows' => t('Rows'),
+    'columns' => t('Columns'),
+    'add_head' => t('Add Head'),
+    'delete_head' => t('Delete Head'),
+    'title' => t('Title'),
+    'image_position' => t('Position'),
+    'none' => t('None'),
+    'left' => t('Left'),
+    'right' => t('Right'),
+    'center' => t('Center'),
+    'image_web_link' => t('Image Web Link'),
+    'text' => t('Text'),
+    'mailto' => t('Email'),
+    'web' => t('URL'),
+    'video_html_code' => t('Video Embed Code or Youtube/Vimeo Link'),
+    'file' => t('Insert File'),
+    'upload' => t('Upload'),
+    'download' => t('Download'),
+    'choose' => t('Choose'),
+    'or_choose' => t('Or choose'),
+    'drop_file_here' => t('Drop file here'),
+    'align_left' => t('Align text to the left'),
+    'align_center' => t('Center text'),
+    'align_right' => t('Align text to the right'),
+    'align_justify' => t('Justify text'),
+    'horizontalrule' => t('Insert Horizontal Rule'),
+    'deleted' => t('Deleted'),
+    'anchor' => t('Anchor'),
+    'open_link' => t('Open Link'),
+    'link_new_tab' => t('Open link in new tab'),
+    /* concrete5 */
+    'link_same_window' => t('Open link in same window'),
+    'in_lightbox' => t('Open link in Lightbox'),
+    'lightbox_link_type' => t('Link Type'),
+    'lightbox_link_type_iframe' => t('Web Page'),
+    'lightbox_link_type_image' => t('Image'),
+    'lightbox_link_type_iframe_options' => t('Frame Options'),
+    'lightbox_link_type_iframe_width' => t('Width'),
+    'lightbox_link_type_iframe_height' => t('Height'),
+    'customStyles' => t('Custom Styles'),
+    'remove_font' => t('Remove font'),
+    'change_font_family' => t('Change Font Family'),
+    'remove_style' => t('Remove Style'),
+    'insert_character' => t('Insert Character'),
+    'undo' => t('Undo'),
+    'redo' => t('Redo'),
+    'remove_font_family' => t('Remove Font Family'),
+    'remove_font_size' => t('Remove Font Size'),
+    'change_font_size' => t('Change Font Size'),
+    /* end concrete5 */
+    'underline' => t('Underline'),
+    'alignment' => t('Alignment'),
+    'filename' => t('Name (optional)'),
+    'edit' => t('Edit'),
+    'upload_label' => t('Drop file here or '),
+]) . ';
+jQuery.Redactor.opts.lang = ' . json_encode($locale) . ';
 jQuery.each(jQuery.Redactor.opts.langs.en, function(key, value) {
-  if(!(key in jQuery.Redactor.opts.langs[<?=json_encode($locale)?>])) {
-    jQuery.Redactor.opts.langs[<?=json_encode($locale)?>][key] = value;
+  if(!(key in jQuery.Redactor.opts.langs[' . json_encode($locale) . '])) {
+    jQuery.Redactor.opts.langs[' . json_encode($locale) . '][key] = value;
   }
 });
-<?php
+';
 
+        return $this->createJavascriptResponse($content);
     }
 
-    public static function getFancytreeJavascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getFancytreeJavascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-jQuery.ui.fancytree.prototype.options.strings.loading = <?=json_encode(t('Loading...'))?>;
-jQuery.ui.fancytree.prototype.options.strings.loadError = <?=json_encode(t('Load error!'))?>;
-<?php
+        $content =
+'jQuery.ui.fancytree.prototype.options.strings.loading = ' . json_encode(t('Loading...')) . ';
+jQuery.ui.fancytree.prototype.options.strings.loadError = ' . json_encode(t('Load error!')) . ';
+';
 
+        return $this->createJavascriptResponse($content);
     }
 
-    public static function getImageEditorJavascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getImageEditorJavascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-var ccmi18n_imageeditor = {
-  loadingControlSets: <?=json_encode(t('Loading Control Sets...'))?>,
-  loadingComponents: <?=json_encode(t('Loading Components...'))?>,
-  loadingFilters: <?=json_encode(t('Loading Filters...'))?>,
-  loadingImage: <?=json_encode(t('Loading Image...'))?>,
-  areYouSure: <?=json_encode(t('Are you sure?'))?>
-};
-        <?php
+        $content =
+'var ccmi18n_imageeditor = ' . json_encode([
+    'loadingControlSets' => t('Loading Control Sets...'),
+    'loadingComponents' => t('Loading Components...'),
+    'loadingFilters' => t('Loading Filters...'),
+    'loadingImage' => t('Loading Image...'),
+    'areYouSure' => t('Are you sure?'),
+]) . ';
+';
 
+        return $this->createJavascriptResponse($content);
     }
 
-    public static function getJQueryUIJavascript($setResponseHeaders = true)
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getJQueryUIJavascript()
     {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
         $env = Environment::get();
         /* @var $env \Concrete\Core\Foundation\Environment */
-        $alternatives = array(Localization::activeLocale());
+        $alternatives = [Localization::activeLocale()];
         if (Localization::activeLocale() !== Localization::activeLanguage()) {
             $alternatives[] = Localization::activeLanguage();
         }
         $found = null;
         foreach ($alternatives as $alternative) {
-            $r = $env->getRecord(DIRNAME_JAVASCRIPT.'/i18n/jquery-ui/datepicker-'.str_replace('_', '-', $alternative).'.js');
+            $r = $env->getRecord(DIRNAME_JAVASCRIPT . '/i18n/jquery-ui/datepicker-' . str_replace('_', '-', $alternative) . '.js');
             if (is_file($r->file)) {
                 $found = $r->file;
                 break;
             }
         }
         if (isset($found)) {
-            readfile($found);
+            $content = @file_get_contents($found);
+            if ($content === false) {
+                $content = "/* jQueryUI: failed to read translations for $alternative */";
+            }
         } else {
-            echo '// No jQueryUI translations for '.Localization::activeLocale();
+            $content = '/* jQueryUI: no translations for ' . implode(', ', $alternatives) . ' */';
         }
-    }
-    public static function getTranslatorJavascript($setResponseHeaders = true)
-    {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-ccmTranslator.setI18NDictionart({
-  AskDiscardDirtyTranslation: <?=json_encode(t("The current item has changed.\nIf you proceed you will lose your changes.\n\nDo you want to proceed anyway?"))?>,
-  Approved: <?=json_encode(tc('Translation', 'Approved')); ?>,
-  Comments: <?=json_encode(t('Comments'))?>,
-  Context: <?=json_encode(t('Context'))?>,
-  ExamplePH: <?=json_encode(t('Example: %s'))?>,
-  Filter: <?=json_encode(t('Filter'))?>,
-  Original_String: <?=json_encode(t('Original String'))?>,
-  Please_fill_in_all_plurals: <?=json_encode(t('Please fill-in all plural forms'))?>,
-  Plural_Original_String: <?=json_encode(t('Plural Original String'))?>,
-  References: <?=json_encode(t('References'))?>,
-  Save_and_Continue: <?=json_encode(t('Save & Continue'))?>,
-  Search_for_: <?=json_encode(t('Search for...'))?>,
-  Search_in_contexts: <?=json_encode(t('Search in contexts'))?>,
-  Search_in_originals: <?=json_encode(t('Search in originals'))?>,
-  Search_in_translations: <?=json_encode(t('Search in translations'))?>,
-  Show_approved: <?=json_encode(t('Show approved'))?>,
-  Show_translated: <?=json_encode(t('Show translated'))?>,
-  Show_unapproved: <?=json_encode(t('Show unapproved'))?>,
-  Show_untranslated: <?=json_encode(t('Show untranslated'))?>,
-  Singular_Original_String: <?=json_encode(t('Singular Original String'))?>,
-  Toggle_Dropdown: <?=json_encode(t('Toggle Dropdown'))?>,
-  TAB: <?=json_encode(t('[TAB] Forward'))?>,
-  TAB_SHIFT: <?=json_encode(t('[SHIFT]+[TAB] Backward'))?>,
-  Translate: <?=json_encode(t('Translate'))?>,
-  Translation: <?=json_encode(t('Translation'))?>,
-  TranslationIsApproved_WillNeedApproval: <?=json_encode(t('This translation is approved: your changes will need approval.')); ?>,
-  TranslationIsNotApproved: <?=json_encode(t('This translation is not approved.')); ?>,
-  PluralNames: {
-    zero: <?=json_encode(tc('PluralCase', 'Zero'))?>,
-    one: <?=json_encode(tc('PluralCase', 'One'))?>,
-    two: <?=json_encode(tc('PluralCase', 'Two'))?>,
-    few: <?=json_encode(tc('PluralCase', 'Few'))?>,
-    many: <?=json_encode(tc('PluralCase', 'Many'))?>,
-    other: <?=json_encode(tc('PluralCase', 'Other'))?>
-  }
-});<?php
 
+        return $this->createJavascriptResponse($content);
     }
-    public static function getDropzoneJavascript($setResponseHeaders = true)
-    {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-Dropzone.prototype.defaultOptions.dictDefaultMessage = <?=json_encode(t('Drop files here or click to upload.'))?>;
-Dropzone.prototype.defaultOptions.dictFallbackMessage = <?=json_encode(t("Your browser does not support drag'n'drop file uploads."))?>;
-Dropzone.prototype.defaultOptions.dictFallbackText = <?=json_encode(t('Please use the fallback form below to upload your files like in the olden days.'))?>;
-    <?php
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getTranslatorJavascript()
+    {
+        $content =
+'ccmTranslator.setI18NDictionart(' . json_encode([
+    'AskDiscardDirtyTranslation' => t("The current item has changed.\nIf you proceed you will lose your changes.\n\nDo you want to proceed anyway?"),
+    'Approved' => tc('Translation', 'Approved'),
+    'Comments' => t('Comments'),
+    'Context' => t('Context'),
+    'ExamplePH' => t('Example: %s'),
+    'Filter' => t('Filter'),
+    'Original_String' => t('Original String'),
+    'Please_fill_in_all_plurals' => t('Please fill-in all plural forms'),
+    'Plural_Original_String' => t('Plural Original String'),
+    'References' => t('References'),
+    'Save_and_Continue' => t('Save & Continue'),
+    'Search_for_' => t('Search for...'),
+    'Search_in_contexts' => t('Search in contexts'),
+    'Search_in_originals' => t('Search in originals'),
+    'Search_in_translations' => t('Search in translations'),
+    'Show_approved' => t('Show approved'),
+    'Show_translated' => t('Show translated'),
+    'Show_unapproved' => t('Show unapproved'),
+    'Show_untranslated' => t('Show untranslated'),
+    'Singular_Original_String' => t('Singular Original String'),
+    'Toggle_Dropdown' => t('Toggle Dropdown'),
+    'TAB' => t('[TAB] Forward'),
+    'TAB_SHIFT' => t('[SHIFT]+[TAB] Backward'),
+    'Translate' => t('Translate'),
+    'Translation' => t('Translation'),
+    'TranslationIsApproved_WillNeedApproval' => t('This translation is approved: your changes will need approval.'),
+    'TranslationIsNotApproved' => t('This translation is not approved.'),
+    'PluralNames' => [
+        'zero' => tc('PluralCase', 'Zero'),
+        'one' => tc('PluralCase', 'One'),
+        'two' => tc('PluralCase', 'Two'),
+        'few' => tc('PluralCase', 'Few'),
+        'many' => tc('PluralCase', 'Many'),
+        'other' => tc('PluralCase', 'Other'),
+    ],
+]) . ');
+';
+
+        return $this->createJavascriptResponse($content);
     }
-    public static function getConversationsJavascript($setResponseHeaders = true)
-    {
-        if ($setResponseHeaders) {
-            static::sendJavascriptHeader();
-        }
-        ?>
-jQuery.fn.concreteConversation.localize({
-  Confirm_remove_message: <?=json_encode(t('Remove this message? Replies to it will not be removed'))?>,
-  Confirm_mark_as_spam: <?=json_encode(t('Are you sure you want to flag this message as spam?'))?>,
-  Warn_currently_editing: <?=json_encode(t('Please complete or cancel the current message editing session before editing this message.'))?>,
-  Unspecified_error_occurred: <?=json_encode(t('An unspecified error occurred.'))?>,
-  Error_deleting_message: <?=json_encode(t('Something went wrong while deleting this message, please refresh and try again.'))?>,
-  Error_flagging_message: <?=json_encode(t('Something went wrong while flagging this message, please refresh and try again.'))?>
-});
-jQuery.fn.concreteConversationAttachments.localize({
-  Too_many_files: <?=json_encode(t('Too many files'))?>,
-  Invalid_file_extension: <?=json_encode(t('Invalid file extension'))?>,
-  Max_file_size_exceeded: <?=json_encode(t('Max file size exceeded'))?>,
-  Error_deleting_attachment: <?=json_encode(t('Something went wrong while deleting this attachment, please refresh and try again.'))?>,
-  Confirm_remove_attachment: <?=json_encode(t('Remove this attachment?'))?>
-});
-        <?php
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getDropzoneJavascript()
+    {
+        $content =
+'Dropzone.prototype.defaultOptions.dictDefaultMessage = ' . json_encode(t('Drop files here or click to upload.')) . ';
+Dropzone.prototype.defaultOptions.dictFallbackMessage = ' . json_encode(t("Your browser does not support drag'n'drop file uploads.")) . ';
+Dropzone.prototype.defaultOptions.dictFallbackText = ' . json_encode(t('Please use the fallback form below to upload your files like in the olden days.')) . ';
+';
+
+        return $this->createJavascriptResponse($content);
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getConversationsJavascript()
+    {
+        $content =
+'jQuery.fn.concreteConversation.localize(' . json_encode([
+    'Confirm_remove_message' => t('Remove this message? Replies to it will not be removed'),
+    'Confirm_mark_as_spam' => t('Are you sure you want to flag this message as spam?'),
+    'Warn_currently_editing' => t('Please complete or cancel the current message editing session before editing this message.'),
+    'Unspecified_error_occurred' => t('An unspecified error occurred.'),
+    'Error_deleting_message' => t('Something went wrong while deleting this message, please refresh and try again.'),
+    'Error_flagging_message' => t('Something went wrong while flagging this message, please refresh and try again.'),
+]) . ';
+jQuery.fn.concreteConversationAttachments.localize(' . json_encode([
+    'Too_many_files' => t('Too many files'),
+    'Invalid_file_extension' => t('Invalid file extension'),
+    'Max_file_size_exceeded' => t('Max file size exceeded'),
+    'Error_deleting_attachment' => t('Something went wrong while deleting this attachment, please refresh and try again.'),
+    'Confirm_remove_attachment' => t('Remove this attachment?'),
+]) . ';
+';
+
+        return $this->createJavascriptResponse($content);
     }
 }

--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -1,14 +1,13 @@
 <?php
 namespace Concrete\Core\Asset;
 
-use Symfony\Component\HttpFoundation\Response;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Support\Facade\Application;
 use Environment;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class Asset implements AssetInterface
 {
-
     /**
      * @var string
      */
@@ -67,7 +66,7 @@ abstract class Asset implements AssetInterface
     /**
      * @var array
      */
-    protected $combinedAssetSourceFiles = array();
+    protected $combinedAssetSourceFiles = [];
 
     const ASSET_POSITION_HEADER = 'H';
     const ASSET_POSITION_FOOTER = 'F';
@@ -170,6 +169,7 @@ abstract class Asset implements AssetInterface
     public function getAssetPointer()
     {
         $pointer = new AssetPointer($this->getAssetType(), $this->getAssetHandle());
+
         return $pointer;
     }
 
@@ -181,6 +181,7 @@ abstract class Asset implements AssetInterface
         if (!$this->assetHasBeenMapped) {
             $this->mapAssetLocation($this->location);
         }
+
         return $this->assetPath;
     }
 
@@ -356,7 +357,7 @@ abstract class Asset implements AssetInterface
                 // Route matcher requires that paths ends with a slash
                 if (preg_match('/^(.*[^\/])($|\?.*)$/', $route, $m)) {
                     try {
-                        $matched = $matcher->match($m[1].'/'.(isset($m[2]) ? $m[2] : ''));
+                        $matched = $matcher->match($m[1] . '/' . (isset($m[2]) ? $m[2] : ''));
                     } catch (\Exception $x) {
                     }
                 }

--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -367,9 +367,11 @@ abstract class Asset implements AssetInterface
                 if (is_string($controller)) {
                     $chunks = explode('::', $controller, 2);
                     if (count($chunks) === 2) {
-                        $array = [Application::getFacadeApplication()->make($chunks[0]), $chunks[1]];
-                        if (is_callable($array)) {
-                            $callable = $array;
+                        if (class_exists($chunks[0])) {
+                            $array = [Application::getFacadeApplication()->make($chunks[0]), $chunks[1]];
+                            if (is_callable($array)) {
+                                $callable = $array;
+                            }
                         }
                     } else {
                         if (class_exists($controller) && method_exists($controller, '__invoke')) {


### PR DESCRIPTION
I keep getting errors like
```
Refused to execute script from
'https://www.example.com/ccm/assets/localization/jquery/ui/js'
because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.
```

Let's:
1. return Response instances from the `assets_localization.php` methods
2. greatly improve the performance of `assets_localization.php` by calling `json_encode` only on dictionaries instead of single strings
3. update the Asset method that retrieves the content of dynamic routes by:
3.1 taking in account the case when a route returns a Response instead of printing out some text directly
3.2 creating the route controller instead of performing static calls
