### PR TITLE
Fix enable to edit express entity handle

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/express/entities.php
+++ b/concrete/controllers/single_page/dashboard/system/express/entities.php
@@ -196,8 +196,8 @@ class Entities extends DashboardPageController
         if (!$vs->handle($handle)) {
             $this->error->add(t('You must create a handle for your data object. It may contain only lowercase letters and underscores.'), 'handle');
         } else {
-            $entity = Express::getObjectByHandle($handle);
-            if (is_object($entity) && $entity->getID() != $id) {
+            $exist = Express::getObjectByHandle($handle);
+            if (is_object($exist) && $exist->getID() != $id) {
                 $this->error->add(t('An express object with this handle already exists.'));
             }
         }


### PR DESCRIPTION
We cant clone null

```
199 $entity = Express::getObjectByHandle($handle); // returns null if the given handle is not exists
234 $previousEntity = clone $entity;
```