### PR TITLE
Create users with default attribute values when using authentication

### DIFF
--- a/concrete/attributes/boolean/controller.php
+++ b/concrete/attributes/boolean/controller.php
@@ -106,6 +106,18 @@ class Controller extends AttributeTypeController
         return $v;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see AttributeTypeController::createDefaultAttributeValue()
+     */
+    public function createDefaultAttributeValue()
+    {
+        $this->load();
+
+        return $this->createAttributeValue($this->akCheckedByDefault ? true : false);
+    }
+
     public function validateValue()
     {
         $v = $this->getAttributeValue()->getValue();

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -278,6 +278,16 @@ class Controller extends AbstractController implements AttributeInterface
         return new EmptyRequestAttributeValue();
     }
 
+    /**
+     * Create the default attribute value (if needed).
+     *
+     * @return \Concrete\Core\Entity\Attribute\Value\Value|null
+     */
+    public function createDefaultAttributeValue()
+    {
+        return null;
+    }
+
     public function createAttributeValue($mixed)
     {
         return $this->saveValue($mixed);

--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -331,6 +331,11 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
             }
         }
 
+        $attribs = \UserAttributeKey::getRegistrationList();
+        if (!empty($attribs)) {
+            $user_info->saveUserAttributesDefault($attribs);
+        }
+
         $key = \UserAttributeKey::getByHandle('first_name');
         if ($key) {
             $user_info->setAttribute($key, $first_name);

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -818,6 +818,25 @@ class UserInfo extends Object implements AttributeObjectInterface, PermissionObj
         Events::dispatch('on_user_attributes_saved', $ue);
     }
 
+    /**
+     * @param \Concrete\Core\Entity\Attribute\Key\UserKey[] $attributes
+     */
+    public function saveUserAttributesDefault(array $attributes)
+    {
+        foreach ($attributes as $uak) {
+            $controller = $uak->getController();
+            if (method_exists($controller, 'createDefaultAttributeValue')) {
+                $value = $controller->createDefaultAttributeValue();
+                if ($value !== null) {
+                    $this->setAttribute($uak, $value);
+                }
+            }
+        }
+        $ue = new \Concrete\Core\User\Event\UserInfoWithAttributes($this);
+        $ue->setAttributes($attributes);
+        Events::dispatch('on_user_attributes_saved', $ue);
+    }
+
     public function getObjectAttributeCategory()
     {
         return $this->application->make('\Concrete\Core\Attribute\Category\UserCategory');


### PR DESCRIPTION
In case users registered with OAuth, we don't have a way to set the default attribute values.

What about this approach?

Fix #5223