### PR TITLE
Block types: allow saving NULL values

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -152,7 +152,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             }
 
             foreach ($columns as $key) {
-                if (isset($args[$key])) {
+                if (array_key_exists($key, $args)) {
                     $this->record->{$key} = $args[$key];
                 }
             }


### PR DESCRIPTION
We must be able to save NULL values when we edit blocks.

So, we should check the values to be saved by using `array_key_exists($key, $args)` instead of `isset($args[$key])` (that returns `false` if `$args` does not contain `$key` or if `$args[$key]` is `null`).