### PR TITLE
Fix replace not in on_start

### DIFF
--- a/concrete/controllers/single_page/members/profile.php
+++ b/concrete/controllers/single_page/members/profile.php
@@ -24,7 +24,7 @@ class Profile extends PublicProfilePageController
             $profile = UserInfo::getByID($u->getUserID());
         } else {
             $this->set('intro_msg', t('You must sign in order to access this page!'));
-            $this->replace('/login');
+            return $this->replace('/login');
         }
         if (is_object($profile) && $profile->getUserID() == $u->getUserID()) {
             $canEdit = true;

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -182,6 +182,9 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
                 return $response;
             }
+            if ($controller->isReplaced()) {
+                return $this->controller($controller->getReplacement(), $code, $headers);
+            }
         } else {
             if ($response = $controller->runAction('view')) {
                 return $response;

--- a/concrete/src/Page/Controller/PublicProfilePageController.php
+++ b/concrete/src/Page/Controller/PublicProfilePageController.php
@@ -14,7 +14,7 @@ class PublicProfilePageController extends CorePageController
         $config = $site->getConfigRepository();
 
         if (!$config->get('user.profiles_enabled')) {
-            $this->replace('/page_not_found');
+            return $this->replace('/page_not_found');
         }
     }
 }


### PR DESCRIPTION
https://github.com/concrete5/concrete5/pull/4495 only considers the case when the `replace` method is called in the `on_start` method. Let's allow calling it in controller tasks too.

An example of why this is needed: be sure to not be logged in and browse to https://translate.concrete5.org/members/profile