### PR TITLE
Better mail log message

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -526,7 +526,11 @@ class Service
         if (Config::get('concrete.log.emails') && !$this->getTesting()) {
             $l = new GroupLogger(LOG_TYPE_EMAILS, Logger::INFO);
             if (Config::get('concrete.email.enabled')) {
-                $l->write('**'.t('EMAILS ARE ENABLED. THIS EMAIL WAS SENT TO mail()').'**');
+                if ($sent) {
+                    $l->write('**'.t('EMAILS ARE ENABLED. THIS EMAIL HAS BEEN SENT').'**');
+                } else {
+                    $l->write('**'.t('EMAILS ARE ENABLED. THIS EMAIL HAS NOT BEEN SENT').'**');
+                }
             } else {
                 $l->write('**'.t('EMAILS ARE DISABLED. THIS EMAIL WAS LOGGED BUT NOT SENT').'**');
             }


### PR DESCRIPTION
1. We may use SMTP, not only `mail()`: let's avoid writing references to `mail()`
2. Let's log if an email has been successfully sent or not