### PR TITLE
Date/time format fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1223,20 +1223,23 @@
         },
         {
             "name": "gettext/languages",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/cldr-to-gettext-plural-rules.git",
-                "reference": "bd19ab830291d9b74b23d21428233e06389ef7c2"
+                "reference": "49c39e51569963cc917a924b489e7025bfb9d8c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/cldr-to-gettext-plural-rules/zipball/bd19ab830291d9b74b23d21428233e06389ef7c2",
-                "reference": "bd19ab830291d9b74b23d21428233e06389ef7c2",
+                "url": "https://api.github.com/repos/mlocati/cldr-to-gettext-plural-rules/zipball/49c39e51569963cc917a924b489e7025bfb9d8c7",
+                "reference": "49c39e51569963cc917a924b489e7025bfb9d8c7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4"
             },
             "bin": [
                 "bin/export-plural-rules",
@@ -1277,7 +1280,7 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2017-02-06T14:30:42+00:00"
+            "time": "2017-03-23T17:02:28+00:00"
         },
         {
             "name": "hautelook/phpass",

--- a/composer.lock
+++ b/composer.lock
@@ -2893,16 +2893,16 @@
         },
         {
             "name": "punic/punic",
-            "version": "1.6.5",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/punic/punic.git",
-                "reference": "7bc85ce1137cf52db4d2a6298256a4c4a24da99a"
+                "reference": "a3dce50ddddfa48832eefb8c2c37f8571a12adc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/punic/punic/zipball/7bc85ce1137cf52db4d2a6298256a4c4a24da99a",
-                "reference": "7bc85ce1137cf52db4d2a6298256a4c4a24da99a",
+                "url": "https://api.github.com/repos/punic/punic/zipball/a3dce50ddddfa48832eefb8c2c37f8571a12adc7",
+                "reference": "a3dce50ddddfa48832eefb8c2c37f8571a12adc7",
                 "shasum": ""
             },
             "require": {
@@ -2954,7 +2954,7 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2017-02-03T16:13:09+00:00"
+            "time": "2017-03-23T14:26:42+00:00"
         },
         {
             "name": "sunra/php-simple-html-dom-parser",

--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -81,7 +81,7 @@ class Controller extends AttributeTypeController
         switch ($this->akDateDisplayMode) {
             case 'text':
                 $dh = $this->app->make('helper/date');
-                $format = t(/*i18n: Short date/time format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y g.i A');
+                $format = $dh->getPHPDateTimePattern();
                 if ($datetime === null) {
                     $value = '';
                     $placeholder = $dh->formatCustom($format, 'now');
@@ -204,7 +204,7 @@ class Controller extends AttributeTypeController
                     $dh = $this->app->make('helper/date');
                     try {
                         $datetime = DateTime::createFromFormat(
-                            t(/*i18n: Short date/time format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y g.i A'),
+                            $dh->getPHPDateTimePattern(),
                             $data['value'],
                             $dh->getTimezone('user')
                          );

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -42,6 +42,11 @@ class Controller extends BlockController
         return t("Page Attribute Display");
     }
 
+    public function add()
+    {
+        $this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
+    }
+
     /**
      * @return mixed AttributeValue
      */

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -61,7 +61,7 @@
     "zendframework/zend-i18n": "2.7.*",
     "nesbot/carbon": "1.*",
     "egulias/email-validator": "1.*",
-    "punic/punic": "1.*",
+    "punic/punic": "~2.1",
     "tedivm/stash": "0.14.*",
     "lusitanian/oauth": "0.8.*",
     "oryzone/oauth-user-data": "~1.0@dev",

--- a/concrete/elements/gathering/templates/tile/tweet/view.php
+++ b/concrete/elements/gathering/templates/tile/tweet/view.php
@@ -5,6 +5,6 @@
 	<div class="tweet">
 		<span class="tweet-body"><?=$description?></span>
 		<div style="clear: both;"></div>
-		<p class="tweet-info"><span class="elapsed"><?=date('m/d/y', strtotime($date_time))?></span><span class="who-from"><a href="https://twitter.com/<?php echo $author ?>"><?php echo $author ?></a></span></p>
+		<p class="tweet-info"><span class="elapsed"><?=Core::make('date')->formatDate($date_time)?></span><span class="who-from"><a href="https://twitter.com/<?php echo $author ?>"><?php echo $author ?></a></span></p>
 	</div>
 </div>

--- a/concrete/src/Conversation/Discussion/Discussion.php
+++ b/concrete/src/Conversation/Discussion/Discussion.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Conversation\Discussion;
 
 use Loader;
+use Core;
 use Concrete\Core\Foundation\Object;
 use Page;
 
@@ -44,7 +45,7 @@ class Discussion extends Object
     }
     public function getConversationDiscussionDateTimeOutput()
     {
-        return tc('Message posted date', 'Posted on %s', Loader::helper('date')->date('F d, Y \a\t g:i a', strtotime($this->cnvDiscussionDateCreated)));
+        return tc('Message posted date', 'Posted on %s', Core::make('date')->formatDateTime($this->cnvDiscussionDateCreated, true));
     }
 
     public static function getByID($cnvDiscussionID)

--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -180,7 +180,7 @@ class DateTime
         }
 
         // Build HTML
-        $shownDateFormat = t(/*i18n: Short date format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y');
+        $shownDateFormat = $dh->getPHPDatePattern();
         $disabled = '';
         $html = '<div class="form-inline">';
         if ($includeActivation) {
@@ -368,7 +368,7 @@ EOT;
         }
 
         // Build HTML
-        $shownDateFormat = t(/*i18n: Short date format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y');
+        $shownDateFormat = $dh->getPHPDatePattern();
         $html = '<div class="form-inline">';
         $html .= '<span class="ccm-input-date-wrapper" id="' . $id . '_dw">';
         $html .= '<input type="text" id="' . $id . '_pub" class="form-control ccm-input-date"';

--- a/concrete/src/Localization/Service/Date.php
+++ b/concrete/src/Localization/Service/Date.php
@@ -720,11 +720,11 @@ class Date
      */
     public function getJQueryUIDatePickerFormat($relatedPHPFormat = '')
     {
-        $phpFormat = (is_string($relatedPHPFormat) && strlen($relatedPHPFormat)) ?
-            $relatedPHPFormat :
-            t(/*i18n: Short date format: see http://www.php.net/manual/en/function.date.php */
-                'n/j/Y'
-            );
+        if (is_string($relatedPHPFormat) && $relatedPHPFormat !== '') {
+            $phpFormat = $relatedPHPFormat;
+        } else {
+            $phpFormat = $this->getPHPDatePattern();
+        }
         // Special chars that need to be escaped in the DatePicker format string
         $datepickerSpecials = ['d', 'o', 'D', 'm', 'M', 'y', '@', '!', '\''];
         // Map from php to DatePicker format

--- a/concrete/src/Localization/Service/Date.php
+++ b/concrete/src/Localization/Service/Date.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\Localization\Service;
 
-use Request;
-use Punic\Calendar;
 use Concrete\Core\Localization\Localization;
-use User;
-use Core;
 use Config;
+use Core;
+use Punic\Calendar;
 use Punic\Comparer;
 use Punic\Misc;
+use Request;
+use User;
 
 class Date
 {
@@ -369,12 +369,12 @@ class Date
                 $chunks[] = t2('%d hour', '%d hours', $hours, $hours);
             }
         } elseif ($hours > 0) {
-            $chunks[] =t2('%d hour', '%d hours', $hours, $hours);
+            $chunks[] = t2('%d hour', '%d hours', $hours, $hours);
             if ($precise) {
                 $chunks[] = t2('%d minute', '%d minutes', $minutes, $minutes);
             }
         } elseif ($minutes > 0) {
-            $chunks[] =t2('%d minute', '%d minutes', $minutes, $minutes);
+            $chunks[] = t2('%d minute', '%d minutes', $minutes, $minutes);
             if ($precise) {
                 $chunks[] = t2('%d second', '%d seconds', $seconds, $seconds);
             }
@@ -777,6 +777,49 @@ class Date
     public function getTimeFormat()
     {
         return \Punic\Calendar::has12HoursClock() ? 12 : 24;
+    }
+
+    public function getPHPDatePattern()
+    {
+        $isoFormat = \Punic\Calendar::getDateFormat('short');
+        $result = \Punic\Calendar::tryConvertIsoToPhpFormat($isoFormat);
+        if ($result === null) {
+            $result = t(/*i18n: Short date format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the PHP date format string for times.
+     *
+     * @return string
+     */
+    public function getPHPTimePattern()
+    {
+        $isoFormat = \Punic\Calendar::getTimeFormat('short');
+        $result = \Punic\Calendar::tryConvertIsoToPhpFormat($isoFormat);
+        if ($result === null) {
+            $result = t(/*i18n: Short time format: see http://www.php.net/manual/en/function.date.php */ 'g.i A');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the PHP date format string for dates/times.
+     *
+     * @return string
+     */
+    public function getPHPDateTimePattern()
+    {
+        $isoFormat = \Punic\Calendar::getDateTimeFormat('short');
+        $result = \Punic\Calendar::tryConvertIsoToPhpFormat($isoFormat);
+        if ($result === null) {
+            $result = t(/*i18n: Short date/time format: see http://www.php.net/manual/en/function.date.php */ 'n/j/Y g.i A');
+        }
+
+        return $result;
     }
 
     /**

--- a/concrete/views/panels/details/page/caching.php
+++ b/concrete/views/panels/details/page/caching.php
@@ -100,7 +100,7 @@ switch (Config::get('concrete.cache.full_page_lifetime')) {
         if ($rec instanceof \Concrete\Core\Cache\Page\PageCacheRecord) {
             ?>
 			<div class="alert alert-success">
-				<?=t('This page currently exists in the full page cache. It expires %s.', Loader::helper('date')->date('m/d/Y g:i a', $rec->getCacheRecordExpiration()))?>
+				<?=t('This page currently exists in the full page cache. It expires %s.', Core::make('date')->formatDateTime($rec->getCacheRecordExpiration()))?>
 				&nbsp;&nbsp;<button type="button" class="btn btn-xs btn-default pull-right" id="ccm-button-remove-page-from-cache"><?=t('Purge')?></button>
 			</div>
 		<?php


### PR DESCRIPTION
We currently have a problem with the date/time widget:

1. when we build the view, we use the Unicode format string (via Punic)
2. when we receive back the value posted by users, we parse the value by using a date format built by `t()`

If the two format does not coincide, we have problems (swapped months and days and/or exceptions). Let's fix this by using the brand new Punic 2.1 version (that offers the date format strings in PHP format) - see https://github.com/concrete5/concrete5/commit/64908c9ce126a6e643532a711cdddbf6e371911d

In https://github.com/concrete5/concrete5/commit/75735d480b9179aee43f617829388d9b31702eea I also suggested a localized date format for the `Page Attribute Display` block, and fixed some places where we formatted date/times with a fixed en_US pattern

PS:
- Punic release notes: [v2.0.0](https://github.com/punic/punic/releases/tag/2.0.0) and [v2.1.0](https://github.com/punic/punic/releases/tag/2.1.0)
- gettext/languages release notes: [v2.3.0](https://github.com/mlocati/cldr-to-gettext-plural-rules/releases/tag/2.3.0)