### PR TITLE
Fix authentication type links in user's profile

### DIFF
--- a/concrete/authentication/community/controller.php
+++ b/concrete/authentication/community/controller.php
@@ -88,4 +88,24 @@ class Controller extends GenericOauth2TypeController
         }
     }
 
+    /**
+     * Get the URL of the concrete5 account associated to a user.
+     *
+    * @param \Concrete\Core\User\User|\Concrete\Core\User\UserInfo|\Concrete\Core\Entity\User\User|int $user
+    *
+    * @return string|null Returns null if the user is not bound to a concrete5 account.
+    */
+    public function getConcrete5ProfileURL($user)
+    {
+        $result = null;
+        $binding = $this->getBindingForUser($user);
+        if ($binding !== null) {
+            $concrete5UserID = (int) $binding;
+            if ($concrete5UserID !== 0) {
+                $result = "https://www.concrete5.org/profile/-/view/$concrete5UserID/";
+            }
+        }
+
+        return $result;
+    }
 }

--- a/concrete/authentication/community/hook.php
+++ b/concrete/authentication/community/hook.php
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group">
     <a href="<?= \URL::to('/ccm/system/authentication/oauth2/community/attempt_attach'); ?>" class="btn btn-primary btn-community">
-        <img src="<?= \Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
+        <img src="<?= \Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
         <?= t('Attach a concrete5.org account') ?>
     </a>
 </div>

--- a/concrete/authentication/community/hooked.php
+++ b/concrete/authentication/community/hooked.php
@@ -1,0 +1,29 @@
+<?php
+/* @var Concrete\Authentication\Community\Controller $controller */
+$url = $controller->getConcrete5ProfileURL(new User())
+?>
+<div class="form-group">
+    <a href="<?= h($url) ?>" class="btn btn-primary btn-community">
+        <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
+        <?= t('View your concrete5 account') ?>
+    </a>
+</div>
+
+<style>
+    .ccm-ui .btn-community {
+        border-width: 0px;
+        background: rgb(31,186,232);
+        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
+        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
+    }
+
+    img.concrete5-icon {
+        width: 20px;
+        margin-right:5px;
+    }
+</style>

--- a/concrete/single_pages/account/edit_profile.php
+++ b/concrete/single_pages/account/edit_profile.php
@@ -44,20 +44,27 @@
     ?>
 	</fieldset>
 	<?php
-    $ats = AuthenticationType::getList(true, true);
+    $ats = [];
+    foreach (AuthenticationType::getList(true, true) as $at) {
+        /* @var AuthenticationType $at */
+        if ($at->isHooked($profile)) {
+            if ($at->hasHooked()) {
+                $ats[] = [$at, 'renderHooked'];
+            }
+        } else {
+            if ($at->hasHook()) {
+                $ats[] = [$at, 'renderHook'];
+            }
+        }
+    }
 
-    $ats = array_filter($ats, function (AuthenticationType $type) {
-        return $type->hasHook();
-    });
-
-    $count = count($ats);
-    if ($count) {
+    if (!empty($ats)) {
         ?>
 		<fieldset>
 			<legend><?=t('Authentication Types')?></legend>
 			<?php
             foreach ($ats as $at) {
-                $at->renderHook();
+                call_user_func($at);
             }
         ?>
 		</fieldset>

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -446,4 +446,56 @@ class AuthenticationType extends Object
 
         return method_exists($this->controller, 'hook') || $form_hook->exists();
     }
+
+    
+    /**
+     * Render the a form to be displayed when the authentication type is already hooked.
+     * All settings are expected to be saved by each individual authentication type.
+     */
+    public function renderHooked()
+    {
+        $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
+        if ($form_hooked->exists()) {
+            ob_start();
+            if (method_exists($this->controller, 'hooked')) {
+                $this->controller->hooked();
+            }
+            extract($this->controller->getSets());
+            require_once $form_hooked->file;
+            $out = ob_get_contents();
+            ob_end_clean();
+            echo $out;
+        }
+    }
+
+    /**
+     * Does this authentication type support rendering a form when it has already been hooked?
+     *
+     * @return bool
+     */
+    public function hasHooked()
+    {
+        $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
+        
+        return method_exists($this->controller, 'hooked') || $form_hooked->exists();
+    }
+
+    /**
+     * Is this authentication type already hooked for a specific user?
+     *
+     * @param \Concrete\Core\User\User|\Concrete\Core\User\UserInfo|\Concrete\Core\Entity\User\User|int $user
+     *
+     * @return bool|null Returns null if the controller does not implement a way to determine if a user is already hooked or not.
+     */
+    public function isHooked($user)
+    {
+        $result = null;
+        if (is_callable([$this->controller, 'getBindingForUser'])) {
+            $result = $this->controller->getBindingForUser($user) !== null;
+        } else {
+            $result = null;
+        }
+
+        return $result;
+    }
 }

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -427,13 +427,16 @@ class AuthenticationType extends Object
     public function renderHook()
     {
         $form_hook = $this->mapAuthenticationTypeFilePath('hook.php');
-        if ($form_hook->exists()) {
+        if (method_exists($this->controller, 'hook') || $form_hook->exists()) {
             ob_start();
             if (method_exists($this->controller, 'hook')) {
                 $this->controller->hook();
             }
-            extract($this->controller->getSets());
-            require_once $form_hook->file;
+            if ($form_hook->exists()) {
+                $controller = $this->controller;
+                extract($this->controller->getSets());
+                require_once $form_hook->file;
+            }
             $out = ob_get_contents();
             ob_end_clean();
             echo $out;
@@ -455,14 +458,16 @@ class AuthenticationType extends Object
     public function renderHooked()
     {
         $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
-        if ($form_hooked->exists()) {
+        if (method_exists($this->controller, 'hooked') || $form_hooked->exists()) {
             ob_start();
             if (method_exists($this->controller, 'hooked')) {
                 $this->controller->hooked();
             }
-            $controller = $this->controller;
-            extract($this->controller->getSets());
-            require_once $form_hooked->file;
+            if ($form_hooked->exists()) {
+                $controller = $this->controller;
+                extract($this->controller->getSets());
+                require_once $form_hooked->file;
+            }
             $out = ob_get_contents();
             ob_end_clean();
             echo $out;

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -460,6 +460,7 @@ class AuthenticationType extends Object
             if (method_exists($this->controller, 'hooked')) {
                 $this->controller->hooked();
             }
+            $controller = $this->controller;
             extract($this->controller->getSets());
             require_once $form_hooked->file;
             $out = ob_get_contents();

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -36,11 +36,11 @@ class AuthenticationType extends Object
      */
     public static function getList($sorted = false, $activeOnly = false)
     {
-        $list = array();
+        $list = [];
         $db = Loader::db();
-        $q = $db->query("SELECT * FROM AuthenticationTypes"
-            . ($activeOnly ? " WHERE authTypeIsEnabled=1 " : "")
-            . " ORDER BY " . ($sorted ? "authTypeDisplayOrder" : "authTypeID"));
+        $q = $db->query('SELECT * FROM AuthenticationTypes'
+            . ($activeOnly ? ' WHERE authTypeIsEnabled=1 ' : '')
+            . ' ORDER BY ' . ($sorted ? 'authTypeDisplayOrder' : 'authTypeID'));
         while ($row = $q->fetchRow()) {
             $list[] = self::load($row);
         }
@@ -67,14 +67,14 @@ class AuthenticationType extends Object
      */
     public static function load($arr)
     {
-        $extract = array(
+        $extract = [
             'authTypeID',
             'authTypeName',
             'authTypeHandle',
             'authTypeDisplayOrder',
             'authTypeIsEnabled',
             'pkgID',
-        );
+        ];
         $obj = new self();
         foreach ($extract as $key) {
             if (!isset($arr[$key])) {
@@ -97,7 +97,7 @@ class AuthenticationType extends Object
         $prefix = $r->override ? true : $this->getPackageHandle();
         $authTypeHandle = Core::make('helper/text')->camelcase($this->authTypeHandle);
         $class = core_class('Authentication\\' . $authTypeHandle . '\\Controller', $prefix);
-        $this->controller = Core::make($class, array($this));
+        $this->controller = Core::make($class, [$this]);
     }
 
     /**
@@ -119,9 +119,9 @@ class AuthenticationType extends Object
     public static function getListByPackage($pkg)
     {
         $db = Loader::db();
-        $list = array();
+        $list = [];
 
-        $q = $db->query('SELECT * FROM AuthenticationTypes WHERE pkgID=?', array($pkg->getPackageID()));
+        $q = $db->query('SELECT * FROM AuthenticationTypes WHERE pkgID=?', [$pkg->getPackageID()]);
         while ($row = $q->FetchRow()) {
             $list[] = self::load($row);
         }
@@ -133,11 +133,11 @@ class AuthenticationType extends Object
      * @param string $atHandle New AuthenticationType handle
      * @param string $atName New AuthenticationType name, expect this to be presented with "%s Authentication Type"
      * @param int $order Order int, used to order the display of AuthenticationTypes
-     * @param bool|\Package $pkg Package object to which this AuthenticationType is associated.
+     * @param bool|\Package $pkg package object to which this AuthenticationType is associated
      *
      * @throws \Exception
      *
-     * @return AuthenticationType Returns a loaded authentication type.
+     * @return AuthenticationType returns a loaded authentication type
      */
     public static function add($atHandle, $atName, $order = 0, $pkg = false)
     {
@@ -158,7 +158,7 @@ class AuthenticationType extends Object
         $db = Loader::db();
         $db->Execute(
            'INSERT INTO AuthenticationTypes (authTypeHandle, authTypeName, authTypeIsEnabled, authTypeDisplayOrder, pkgID) values (?, ?, ?, ?, ?)',
-           array($atHandle, $atName, 1, intval($order), $pkgID));
+           [$atHandle, $atName, 1, intval($order), $pkgID]);
         $est = self::getByHandle($atHandle);
         $r = $est->mapAuthenticationTypeFilePath(FILENAME_AUTHENTICATION_DB);
         if ($r->exists()) {
@@ -171,7 +171,7 @@ class AuthenticationType extends Object
     /**
      * Return loaded AuthenticationType with the given handle.
      *
-     * @param string $atHandle AuthenticationType handle.
+     * @param string $atHandle authenticationType handle
      *
      * @throws \Exception when an invalid handle is provided
      *
@@ -180,7 +180,7 @@ class AuthenticationType extends Object
     public static function getByHandle($atHandle)
     {
         $db = Loader::db();
-        $row = $db->GetRow('SELECT * FROM AuthenticationTypes WHERE authTypeHandle=?', array($atHandle));
+        $row = $db->GetRow('SELECT * FROM AuthenticationTypes WHERE authTypeHandle=?', [$atHandle]);
         if (!$row) {
             throw new Exception(t('Invalid Authentication Type Handle'));
         }
@@ -201,7 +201,7 @@ class AuthenticationType extends Object
     public static function getByID($authTypeID)
     {
         $db = Loader::db();
-        $row = $db->GetRow('SELECT * FROM AuthenticationTypes where authTypeID=?', array($authTypeID));
+        $row = $db->GetRow('SELECT * FROM AuthenticationTypes where authTypeID=?', [$authTypeID]);
         if (!$row) {
             throw new Exception(t('Invalid Authentication Type ID'));
         }
@@ -246,21 +246,21 @@ class AuthenticationType extends Object
         $db = Loader::db();
         $db->Execute(
            'UPDATE AuthenticationTypes SET authTypeName=? WHERE authTypeID=?',
-           array($authTypeName, $this->getAuthenticationTypeID()));
+           [$authTypeName, $this->getAuthenticationTypeID()]);
     }
 
     /**
      * AuthenticationType::setAuthenticationTypeDisplayOrder
      * Update the order for display.
      *
-     * @param int $order value from 0-n to signify order.
+     * @param int $order value from 0-n to signify order
      */
     public function setAuthenticationTypeDisplayOrder($order)
     {
         $db = Loader::db();
         $db->Execute(
            'UPDATE AuthenticationTypes SET authTypeDisplayOrder=? WHERE authTypeID=?',
-           array($order, $this->getAuthenticationTypeID()));
+           [$order, $this->getAuthenticationTypeID()]);
     }
 
     public function getAuthenticationTypeID()
@@ -299,7 +299,7 @@ class AuthenticationType extends Object
         $db = Loader::db();
         $db->Execute(
            'UPDATE AuthenticationTypes SET authTypeIsEnabled=0 WHERE AuthTypeID=?',
-           array($this->getAuthenticationTypeID()));
+           [$this->getAuthenticationTypeID()]);
     }
 
     /**
@@ -311,7 +311,7 @@ class AuthenticationType extends Object
         $db = Loader::db();
         $db->Execute(
            'UPDATE AuthenticationTypes SET authTypeIsEnabled=1 WHERE AuthTypeID=?',
-           array($this->getAuthenticationTypeID()));
+           [$this->getAuthenticationTypeID()]);
     }
 
     /**
@@ -325,13 +325,13 @@ class AuthenticationType extends Object
             $this->controller->deleteType();
         }
 
-        $db->Execute("DELETE FROM AuthenticationTypes WHERE authTypeID=?", array($this->authTypeID));
+        $db->Execute('DELETE FROM AuthenticationTypes WHERE authTypeID=?', [$this->authTypeID]);
     }
 
     /**
      * Return the path to a file.
      *
-     * @param string $_file the relative path to the file.
+     * @param string $_file the relative path to the file
      *
      * @return bool|string
      */
@@ -352,16 +352,16 @@ class AuthenticationType extends Object
      *  - /concrete/models/authentication/types/HANDLE
      *  - /concrete/core/models/authentication/types/HANDLE.
      *
-     * @param string $_file The filename you want.
+     * @param string $_file the filename you want
      *
-     * @return string This will return false if the file is not found.
+     * @return string this will return false if the file is not found
      */
     protected function mapAuthenticationTypeFilePath($_file)
     {
         $atHandle = $this->getAuthenticationTypeHandle();
         $env = Environment::get();
         $pkgHandle = PackageList::getHandle($this->pkgID);
-        $r = $env->getRecord(implode('/', array(DIRNAME_AUTHENTICATION, $atHandle, $_file)), $pkgHandle);
+        $r = $env->getRecord(implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $_file]), $pkgHandle);
 
         return $r;
     }
@@ -389,7 +389,7 @@ class AuthenticationType extends Object
             ob_end_clean();
             echo $out;
         } else {
-            echo "<p>" . t("This authentication type does not require any customization.") . "</p>";
+            echo '<p>' . t('This authentication type does not require any customization.') . '</p>';
         }
     }
 
@@ -399,7 +399,7 @@ class AuthenticationType extends Object
      * @param string $element
      * @param array  $params
      */
-    public function renderForm($element = 'form', $params = array())
+    public function renderForm($element = 'form', $params = [])
     {
         $this->controller->requireAsset('javascript', 'backstretch');
 
@@ -409,7 +409,7 @@ class AuthenticationType extends Object
         }
         ob_start();
         if (method_exists($this->controller, $element)) {
-            call_user_func_array(array($this->controller, $element), $params);
+            call_user_func_array([$this->controller, $element], $params);
         } else {
             $this->controller->view();
         }
@@ -450,7 +450,6 @@ class AuthenticationType extends Object
         return method_exists($this->controller, 'hook') || $form_hook->exists();
     }
 
-    
     /**
      * Render the a form to be displayed when the authentication type is already hooked.
      * All settings are expected to be saved by each individual authentication type.
@@ -482,7 +481,7 @@ class AuthenticationType extends Object
     public function hasHooked()
     {
         $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
-        
+
         return method_exists($this->controller, 'hooked') || $form_hooked->exists();
     }
 
@@ -491,7 +490,7 @@ class AuthenticationType extends Object
      *
      * @param \Concrete\Core\User\User|\Concrete\Core\User\UserInfo|\Concrete\Core\Entity\User\User|int $user
      *
-     * @return bool|null Returns null if the controller does not implement a way to determine if a user is already hooked or not.
+     * @return bool|null returns null if the controller does not implement a way to determine if a user is already hooked or not
      */
     public function isHooked($user)
     {


### PR DESCRIPTION
In the user's profile, we always present a link to bind oauth accounts.

BTW, if a user is already bound to an account via oauth, I'd avoid it.

Here's for instance what changes for a user already bound to concrete5 account:

Before:

![image](https://cloud.githubusercontent.com/assets/928116/24287515/57485542-107a-11e7-8c1b-97c71852a8fa.png)


After:

![image](https://cloud.githubusercontent.com/assets/928116/24287523/5d8f7552-107a-11e7-8325-925fcd8ee1f5.png)
