### PR TITLE
Fix users query when filtering accessible groups

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -563,7 +563,7 @@ class Search extends DashboardPageController
         $search = $this->app->make('Concrete\Controller\Search\Users');
         $searchResults = $search->getCurrentSearchObject();
 
-        $csvService = Core::make('helper/csv/user_list', [$searchResults, 'Users']);
+        $csvService = $this->app->make('helper/csv/user_list', [$searchResults, 'Users']);
         $csvService->generate();
     }
 }


### PR DESCRIPTION
When listing users with the `SearchProvider` (not as `admin`), we currently build a query like this:

```sql
SELECT distinct (u.uID)
FROM Users u
LEFT JOIN UserSearchIndexAttributes ua ON u.uID = ua.uID
LEFT JOIN UserGroups ugRequired ON ugRequired.uID = u.uID
WHERE ((ugRequired.gID IN (-1, 3, 4, 5, 6, 7)) OR (ugRequired.gID IS NULL))
    AND (u.uIsActive = 1)
    AND (u.uIsValidated != 0)
ORDER BY u.uDateAdded
```

When MySQL runs in strict mode (`ONLY_FULL_GROUP_BY` flag), since the order by field is not in the selected results, we have this error:

```
Expression #1 of ORDER BY clause is not in SELECT list,
references column 'u.uDateAdded' which is not in SELECT list;
this is incompatible with DISTINCT
```

To fix this issue, we need to switch to a query like this:

```sql
SELECT u.uID
FROM Users u
LEFT JOIN UserSearchIndexAttributes ua ON u.uID = ua.uID
LEFT JOIN UserGroups ugRequired ON ugRequired.uID = u.uID
WHERE ((ugRequired.gID IN (-1, 3, 4, 5, 6, 7)) OR (ugRequired.gID IS NULL))
    AND (u.uIsActive = 1)
    AND (u.uIsValidated != 0)
GROUP BY u.uID
ORDER BY u.uDateAdded desc
```