### PR TITLE
Update dashboard/users/points/assign.php: The controllers save() method calls an non existent UserInfo method: getByUserID()

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/points/assign.php
+++ b/concrete/controllers/single_page/dashboard/users/points/assign.php
@@ -57,7 +57,7 @@ class Assign extends DashboardPageController
         $user = $this->post('upUser');
         if (is_numeric($user)) {
             // rolling as user id
-            $ui = UserInfo::getByUserID($user);
+            $ui = UserInfo::getByID($user);
         } else {
             $ui = UserInfo::getByUserName($user);
             // look up userID


### PR DESCRIPTION
When trying to assign community points to a user at `/dashboard/users/points/assign/` an Exception is thrown.
The controllers save() method calls an non existent UserInfo method: getByUserID()
