### PR TITLE
add searchForm method to express attributes ctrlr

### DIFF
--- a/concrete/attributes/express/controller.php
+++ b/concrete/attributes/express/controller.php
@@ -55,6 +55,12 @@ class Controller extends AttributeTypeController
         $form_selector = $this->app->make('form/express/entry_selector');
         print $form_selector->selectEntry($this->getEntity(), $this->field('value'), $entry);
     }
+    
+    public function searchForm($list)
+    {
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), '%' . $this->request('value') . '%', 'like');
+        return $list;
+    }
 
 
     public function getSearchIndexValue()


### PR DESCRIPTION
concrete/attributes/express/controller.php was missing a searchForm function that led to a bug when searching for a user by an express object.