### PR TITLE
fix users list query when filtering accessible groups

### DIFF
--- a/web/concrete/controllers/search/users.php
+++ b/web/concrete/controllers/search/users.php
@@ -85,8 +85,8 @@ class Users extends Controller
             $ggp = new Permissions($gg);
             if ($ggp->canSearchUsersInGroup()) {
                 $whereGroups = $qb->expr()->orX(
-                        $whereGroups,
-                        $qb->expr()->isNull('ugRequired.gID')
+                    $whereGroups,
+                    $qb->expr()->isNull('ugRequired.gID')
                 );
             }
             $qb->leftJoin('u', 'UserGroups', 'ugRequired', 'ugRequired.uID = u.uID')


### PR DESCRIPTION
This fixes a user list SQL query issue that was solved for v8 with this PR but left unsolved in 5.7x so far.:
https://github.com/concrete5/concrete5/pull/5245

It addresses a Issue with sorting and distinct, When MySQL runs in strict mode (ONLY_FULL_GROUP_BY flag), since the order by field was not in the selected results, we got this error when trying to view the User List as a non-Superuser:
`An exception occurred while executing 'SELECT distinct (u.uID) FROM Users u LEFT JOIN UserSearchIndexAttributes ua ON u.uID = ua.uID LEFT JOIN UserGroups ugRequired ON ugRequired.uID = u.uID WHERE (ugRequired.gID in (-1,3,4,6,31,32)) OR (ugRequired.gID is null) ORDER BY u.uDateAdded desc LIMIT 10 OFFSET 0': SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column 'standards.u.uDateAdded' which is not in SELECT list; this is incompatible with DISTINCT`