### PR TITLE
Clone query object in ItemList class

### DIFF
--- a/concrete/src/Search/ItemList/Database/ItemList.php
+++ b/concrete/src/Search/ItemList/Database/ItemList.php
@@ -98,4 +98,9 @@ abstract class ItemList extends AbstractItemList
             )));
         }
     }
+
+    public function __clone()
+    {
+        $this->query = clone $this->query;
+    }
 }


### PR DESCRIPTION
If one tries to clone a PageList object, both instances will still reference to the same `$query` object. This PR will fix that problem.