### PR TITLE
Don’t clear the entire table when doing incremental updates

### DIFF
--- a/concrete/jobs/index_search.php
+++ b/concrete/jobs/index_search.php
@@ -9,6 +9,8 @@ class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
 
     use ApplicationAwareTrait;
 
+    protected $clearTable = false;
+
     public function getJobName()
     {
         return t("Index Search Engine - Updates");


### PR DESCRIPTION
Fixes #5264

also `index()` is a void function so changed the returns to breaks

The increments are obviously numbers, so use number formatting