### PR TITLE
Fix localization-related singletons

### DIFF
--- a/concrete/src/Localization/LocalizationServiceProvider.php
+++ b/concrete/src/Localization/LocalizationServiceProvider.php
@@ -7,23 +7,33 @@ class LocalizationServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $singletons = array(
-            'helper/localization/countries' => '\Concrete\Core\Localization\Service\CountryList',
-            'helper/localization/states_provinces' => '\Concrete\Core\Localization\Service\StatesProvincesList',
-            'helper/lists/countries' => '\Concrete\Core\Localization\Service\CountryList',
-            'helper/lists/states_provinces' => '\Concrete\Core\Localization\Service\StatesProvincesList',
-            'helper/date' => '\Concrete\Core\Localization\Service\Date',
+        $singletons = [
+            'Concrete\Core\Localization\Service\CountryList' => [
+                'helper/localization/countries',
+                'helper/lists/countries',
+                'localization/countries',
+                'lists/countries',
+            ],
+            'Concrete\Core\Localization\Service\StatesProvincesList' => [
+                'helper/localization/states_provinces',
+                'helper/lists/states_provinces',
+                'localization/states_provinces',
+                'lists/states_provinces',
+            ],
+            'Concrete\Core\Localization\Service\Date' => [
+                'helper/date',
+                'date',
+            ],
+            'Concrete\Core\Localization\Service\LanguageList' => [
+                'localization/languages',
+            ],
+        ];
 
-            'localization/countries' => '\Concrete\Core\Localization\Service\CountryList',
-            'localization/states_provinces' => '\Concrete\Core\Localization\Service\StatesProvincesList',
-            'localization/languages' => '\Concrete\Core\Localization\Service\LanguageList',
-            'lists/countries' => '\Concrete\Core\Localization\Service\CountryList',
-            'lists/states_provinces' => '\Concrete\Core\Localization\Service\StatesProvincesList',
-            'date' => '\Concrete\Core\Localization\Service\Date',
-        );
-
-        foreach ($singletons as $key => $value) {
-            $this->app->singleton($key, $value);
+        foreach ($singletons as $class => $aliases) {
+            $this->app->singleton($class);
+            foreach ($aliases as $alias) {
+                $this->app->alias($class, $alias);
+            }
         }
     }
 }


### PR DESCRIPTION
The current definition of localization-related services is quite odd (but other service providers have the same problem).

For instance, the output of this code:
```php
function checkSame($a, $b) {
	echo "$a === $b ? ", Core::make($a) === Core::make($b) ? 'yes' : 'no', "\n";
}
checkSame('helper/localization/countries', 'helper/localization/countries');
checkSame('Concrete\Core\Localization\Service\CountryList', 'Concrete\Core\Localization\Service\CountryList');
checkSame('helper/localization/countries', 'localization/countries');
checkSame('helper/localization/countries', 'Concrete\Core\Localization\Service\CountryList');
checkSame('localization/countries', 'Concrete\Core\Localization\Service\CountryList');
```

is currently:
```
helper/localization/countries === helper/localization/countries ? yes
Concrete\Core\Localization\Service\CountryList === Concrete\Core\Localization\Service\CountryList ? no
helper/localization/countries === localization/countries ? no
helper/localization/countries === Concrete\Core\Localization\Service\CountryList ? no
localization/countries === Concrete\Core\Localization\Service\CountryList ? no
```

but it should be:
```
helper/localization/countries === helper/localization/countries ? yes
Concrete\Core\Localization\Service\CountryList === Concrete\Core\Localization\Service\CountryList ? yes
helper/localization/countries === localization/countries ? yes
helper/localization/countries === Concrete\Core\Localization\Service\CountryList ? yes
localization/countries === Concrete\Core\Localization\Service\CountryList ? yes
```

We should define the classes as singletons, and we should define the aliases... well... as aliases :wink: