### PR TITLE
Avoid warnings in Number::getBytes()

### DIFF
--- a/concrete/src/Utility/Service/Number.php
+++ b/concrete/src/Utility/Service/Number.php
@@ -170,17 +170,22 @@ class Number
     public function getBytes($val)
     {
         $val = trim($val);
-        $last = strtolower($val[strlen($val) - 1]);
-        switch ($last) {
-            // The 'G' modifier is available since PHP 5.1.0
-            case 'g':
-                $val *= 1024;
-            case 'm':
-                $val *= 1024;
-            case 'k':
-                $val *= 1024;
+        if ($val !== '') {
+            $last = strtolower($val[strlen($val) - 1]);
+            if (!is_numeric($last)) {
+                $num = trim(substr($val, 0, -1));
+                switch ($last) {
+                    case 'g':
+                        $num *= 1024;
+                    case 'm':
+                        $num *= 1024;
+                    case 'k':
+                        $num *= 1024;
+                        $val = $num;
+                        break;
+                }
+            }
         }
-
         return $val;
     }
 }

--- a/concrete/src/Utility/Service/Number.php
+++ b/concrete/src/Utility/Service/Number.php
@@ -38,13 +38,13 @@ class Number
                 // Remove initial zeroes
                 $value = ltrim($value, '0');
                 if ($value === '' || $value[0] === '.') {
-                    $value = '0'.$value;
+                    $value = '0' . $value;
                 }
                 if (strpos($value, '.') !== false) {
                     // Remove trailing zeroes after the dot
                     $value = rtrim(rtrim($value, '0'), '.');
                 }
-                $result = $sign.$value;
+                $result = $sign . $value;
             }
         }
 
@@ -186,6 +186,7 @@ class Number
                 }
             }
         }
+
         return $val;
     }
 }


### PR DESCRIPTION
Let's avoid the warning `A non well formed numeric value encountered`

Ref: #4723