### PR TITLE
Remove references to undefined $step in bootstrap process.php

### DIFF
--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -122,7 +122,7 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
                 $u->unloadCollectionEdit($c);
                 $response = $pkr->trigger();
                 header(
-                    'Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID() . $step);
+                    'Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
                 exit;
             }
             break;
@@ -133,7 +133,7 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
                 $v->approve(false);
 
                 header('Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME .
-                    '?cID=' . $c->getCollectionID() . $step);
+                    '?cID=' . $c->getCollectionID());
 
                 exit;
             }


### PR DESCRIPTION
The definition of $step has been removed in [this commit](https://github.com/concrete5/concrete5/commit/be61564211174434206cb5cbdcc1951001eb2911#diff-36329fa02654b9d4b96bc7ecc8a36269L12).

Ref: #4723