### PR TITLE
Let page controllers decide about page language

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -90,8 +90,14 @@ class Detector
             $c = Page::getCurrentPage();
         }
         if ($c) {
-            $dh = $app->make('helper/concrete/dashboard');
-            if ($dh->inDashboard($c)) {
+            $pageController = $c->getPageController();
+            if (is_callable([$pageController, 'useUserLocale'])) {
+                $useUserLocale = $pageController->useUserLocale();
+            } else {
+                $dh = $app->make('helper/concrete/dashboard');
+                $useUserLocale = $dh->inDashboard($c);
+            }
+            if ($useUserLocale) {
                 $u = new User();
                 $locale = $u->getUserLanguageToDisplay();
             } else {

--- a/concrete/src/Page/Controller/AccountPageController.php
+++ b/concrete/src/Page/Controller/AccountPageController.php
@@ -55,4 +55,14 @@ class AccountPageController extends CorePageController
     {
         $this->set('error', $this->error);
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Page\Controller\PageController::useUserLocale()
+     */
+    public function useUserLocale()
+    {
+        return true;
+    }
 }

--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -68,4 +68,14 @@ class DashboardPageController extends PageController
     {
         return $this->entityManager;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Page\Controller\PageController::useUserLocale()
+     */
+    public function useUserLocale()
+    {
+        return true;
+    }
 }

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -341,4 +341,14 @@ class PageController extends Controller
 
         return $valid;
     }
+
+    /**
+     * Should this page be displayed using the user's language?
+     *
+     * @return bool
+     */
+    public function useUserLocale()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
User's account pages (those available at `/account/...` path) should use the user's language, not the site one.

What about adding a method to the page controllers to decide about that? This way, custom pages may control this behavior as well.