### PR TITLE
Make saving associations work when handles are not unique

### DIFF
--- a/concrete/src/Entity/Express/Entry.php
+++ b/concrete/src/Entity/Express/Entry.php
@@ -225,20 +225,46 @@ class Entry implements \JsonSerializable, PermissionObjectInterface, AttributeOb
         $this->associations = $associations;
     }
 
+
+    /**
+     * @deprecated See \Concrete\Core\Entity\Express\Entry::getEntryAssociation
+     */
     public function getAssociation($handle)
     {
         if ($handle instanceof Association) {
-            $handle = $handle->getTargetPropertyName();
+            return $this->getEntryAssociation($handle);
         }
 
         /**
-         * @var $association EntryAssociation
+         * @var $entryAssociation EntryAssociation
          */
-        foreach($this->associations as $association) {
-            if ($association->getAssociation()->getTargetPropertyName() == $handle) {
-                return $association;
+        foreach ($this->associations as $entryAssociation) {
+            if ($entryAssociation->getAssociation()->getTargetPropertyName() === $handle) {
+                return $entryAssociation;
             }
         }
+    }
+
+    /**
+     * Get the EntryAssociation for a given association
+     *
+     * @param \Concrete\Core\Entity\Express\Association $association
+     * @return \Concrete\Core\Entity\Express\Entry\Association|null
+     */
+    public function getEntryAssociation(Association $association)
+    {
+        $id = $association->getId();
+
+        /**
+         * @var $entryAssociation EntryAssociation
+         */
+        foreach ($this->associations as $entryAssociation) {
+            if ($entryAssociation->getAssociation()->getId() === $id) {
+                return $entryAssociation;
+            }
+        }
+
+        return null;
     }
 
     public function getOwnedByEntry()

--- a/concrete/src/Entity/Express/Entry/Association.php
+++ b/concrete/src/Entity/Express/Entry/Association.php
@@ -42,6 +42,11 @@ abstract class Association
     protected $selectedEntries;
 
     /**
+     * @var bool A boolean to track whether the selected entries are sorted
+     */
+    protected $sorted;
+
+    /**
      * @return \Concrete\Core\Entity\Express\Association
      */
     public function getAssociation()
@@ -99,14 +104,22 @@ abstract class Association
      */
     public function getSelectedEntries()
     {
+        if ($this->sorted) {
+            return $this->selectedEntries;
+        }
+
+        $this->sorted = true;
+
         // I would use criteria for this but once again Doctrine fails
         if ($this->getAssociation()->getTargetEntity()->supportsCustomDisplayOrder()) {
             $entries = $this->getSelectedEntriesCollection()->toArray();
             usort($entries, function($a, $b) {
                 return $a->getEntryDisplayOrder() - $b->getEntryDisplayOrder();
             });
-            return new ArrayCollection($entries);
+
+            $this->setSelectedEntries(new ArrayCollection($entries));
         }
+
         return $this->getSelectedEntriesCollection();
     }
 

--- a/concrete/src/Express/Association/Applier.php
+++ b/concrete/src/Express/Association/Applier.php
@@ -53,7 +53,7 @@ class Applier
     public function associateManyToOne(Association $association, Entry $entry, Entry $associatedEntry)
     {
         // First create the owning entry association
-        $oneAssociation = $entry->getAssociation($association->getTargetPropertyName());
+        $oneAssociation = $entry->getEntryAssociation($association);
         if (!is_object($oneAssociation)) {
             $oneAssociation = new Entry\OneAssociation();
             $oneAssociation->setAssociation($association);
@@ -68,11 +68,9 @@ class Applier
 
         // Now, on the associated entry, populate a Many association so we kee this up to date.
         // Let's see if there's an existing one we can use.
-        $manyAssociation = $associatedEntry->getAssociation($association->getInversedByPropertyName());
+        $inversedAssocation = $this->getInverseAssociation($association);
+        $manyAssociation = $associatedEntry->getEntryAssociation($inversedAssocation);
         if (!is_object($manyAssociation)) {
-            $inversedAssocation = $this->entityManager->getRepository(
-                'Concrete\Core\Entity\Express\Association')
-                ->findOneBy(['target_property_name' => $association->getInversedByPropertyName()]);
             $manyAssociation = new Entry\ManyAssociation();
             $manyAssociation->setAssociation($inversedAssocation);
         }
@@ -87,7 +85,7 @@ class Applier
     public function associateOneToMany(Association $association, Entry $entry, $associatedEntries)
     {
         // First create the owning entry association
-        $manyAssociation = $entry->getAssociation($association->getTargetPropertyName());
+        $manyAssociation = $entry->getEntryAssociation($association);
         if (!is_object($manyAssociation)) {
             $manyAssociation = new Entry\ManyAssociation();
             $manyAssociation->setAssociation($association);
@@ -103,11 +101,9 @@ class Applier
         $list->ignorePermissions();
         $possibleResults = $list->getResults();
         foreach($possibleResults as $possibleResult) {
-            $oneAssociation = $possibleResult->getAssociation($association->getInversedByPropertyName());
+            $inversedAssocation = $this->getInverseAssociation($association);
+            $oneAssociation = $possibleResult->getEntryAssociation($inversedAssocation);
             if (!is_object($oneAssociation)) {
-                $inversedAssocation = $this->entityManager->getRepository(
-                    'Concrete\Core\Entity\Express\Association')
-                    ->findOneBy(['target_property_name' => $association->getInversedByPropertyName()]);
                 $oneAssociation = new Entry\OneAssociation();
                 $oneAssociation->setAssociation($inversedAssocation);
             } else {
@@ -131,7 +127,7 @@ class Applier
     public function associateManyToMany(Association $association, Entry $entry, $associatedEntries)
     {
         // First create the owning entry association
-        $manyAssociation = $entry->getAssociation($association->getTargetPropertyName());
+        $manyAssociation = $entry->getEntryAssociation($association);
         if (!is_object($manyAssociation)) {
             $manyAssociation = new Entry\ManyAssociation();
             $manyAssociation->setAssociation($association);
@@ -143,11 +139,9 @@ class Applier
         // Now, on the associated entry, populate a Many association so we kee this up to date.
         // Let's see if there's an existing one we can use.
         foreach($associatedEntries as $associatedEntry) {
-            $manyAssociation = $associatedEntry->getAssociation($association->getInversedByPropertyName());
+            $inversedAssocation = $this->getInverseAssociation($association);
+            $manyAssociation = $associatedEntry->getEntryAssociation($inversedAssocation);
             if (!is_object($manyAssociation)) {
-                $inversedAssocation = $this->entityManager->getRepository(
-                    'Concrete\Core\Entity\Express\Association')
-                    ->findOneBy(['target_property_name' => $association->getInversedByPropertyName()]);
                 $manyAssociation = new Entry\ManyAssociation();
                 $manyAssociation->setAssociation($inversedAssocation);
             }
@@ -163,7 +157,7 @@ class Applier
     public function associateOneToOne(Association $association, Entry $entry, Entry $associatedEntry)
     {
         // First create the owning entry association
-        $oneAssociation = $entry->getAssociation($association->getTargetPropertyName());
+        $oneAssociation = $entry->getEntryAssociation($association);
         if (!is_object($oneAssociation)) {
             $oneAssociation = new Entry\OneAssociation();
             $oneAssociation->setAssociation($association);
@@ -176,11 +170,9 @@ class Applier
         $oneAssociation->setSelectedEntry($associatedEntry);
         $this->entityManager->persist($oneAssociation);
 
-        $oneAssociation = $associatedEntry->getAssociation($association->getInversedByPropertyName());
+        $inversedAssocation = $this->getInverseAssociation($association);
+        $oneAssociation = $associatedEntry->getEntryAssociation($inversedAssocation);
         if (!is_object($oneAssociation)) {
-            $inversedAssocation = $this->entityManager->getRepository(
-                'Concrete\Core\Entity\Express\Association')
-                ->findOneBy(['target_property_name' => $association->getInversedByPropertyName()]);
             $oneAssociation = new Entry\OneAssociation();
             $oneAssociation->setAssociation($inversedAssocation);
         } else {
@@ -196,15 +188,13 @@ class Applier
 
     public function removeAssociation(Association $association, Entry $entry)
     {
-        $entryAssociation = $entry->getAssociation($association);
+        $entryAssociation = $entry->getEntryAssociation($association);
         if ($entryAssociation) {
-            $inversedAssocation = $this->entityManager->getRepository(
-                'Concrete\Core\Entity\Express\Association')
-                ->findOneBy(['target_property_name' => $association->getInversedByPropertyName()]);
+            $inversedAssocation = $this->getInverseAssociation($association);
 
             $associatedEntries = $entryAssociation->getSelectedEntriesCollection();
             foreach($associatedEntries as $associatedEntry) {
-                $associatedEntryAssociation = $associatedEntry->getAssociation($inversedAssocation);
+                $associatedEntryAssociation = $associatedEntry->getEntryAssociation($inversedAssocation);
                 if (is_object($associatedEntryAssociation)) {
                     $associatedEntryAssociation->removeSelectedEntry($entry);
                     $this->entityManager->persist($associatedEntryAssociation);
@@ -215,4 +205,17 @@ class Applier
             $this->entityManager->flush();
         }
     }
+
+    protected function getInverseAssociation(Association $association)
+    {
+        return $this->entityManager->getRepository(Association::class)
+            ->findOneBy([
+                'target_property_name' => $association->getInversedByPropertyName(),
+                'inversed_by_property_name' => $association->getTargetPropertyName(),
+                'target_entity' => $association->getSourceEntity(),
+                'source_entity' => $association->getTargetEntity()
+            ]);
+    }
+
+
 }


### PR DESCRIPTION
Express currently saves associations by finding the first one with a matching inverse property handle. This currently breaks things because we end up resolving the wrong association when property handles are not unique. This pull request instead uses the association instance to find the entry association object.

Now there are still issues in the core where we have behavior that is still based on unique property handles. I'm not sure how best to handle those. You can find them in the core by searching for `->getAssociation\([^\)]` in PHPStorm.