### PR TITLE
Avoid accessing undefined properties in Menu Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# 8.2.0
-
-## Developer Updates
-
-* Added protected properties to class `Concrete\Core\Application\UserInterface\Menu\Item\Item` in order to avoid accessing undefined properties and optimize memory usage (See: https://github.com/concrete5/concrete5/issues/5307)
-
 # 8.1.0
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 8.2.0
+
+## Developer Updates
+
+* Added protected properties to class `Concrete\Core\Application\UserInterface\Menu\Item\Item` in order to avoid accessing undefined properties and optimize memory usage (See: https://github.com/concrete5/concrete5/issues/5307)
+
 # 8.1.0
 
 ## New Features

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -5,21 +5,9 @@ use Concrete\Core\Package\Package;
 
 class Item implements ItemInterface
 {
-    protected $controller = null;
+    protected $controller;
 
     protected $linkAttributes = [];
-
-    protected $handle = null;
-
-    protected $label = null;
-
-    protected $position = null;
-
-    protected $href = null;
-
-    protected $icon = null;
-
-    protected $pkgHandle = null;
 
     public function __construct($handle, $pkgHandle = false)
     {
@@ -29,12 +17,12 @@ class Item implements ItemInterface
 
     public function getHandle()
     {
-        return $this->handle;
+        return isset($this->handle) ? $this->handle : null;
     }
 
     public function getLabel()
     {
-        return $this->label;
+        return isset($this->label) ? $this->label : null;
     }
 
     public function setLabel($label)
@@ -44,12 +32,12 @@ class Item implements ItemInterface
 
     public function getPosition()
     {
-        return $this->position;
+        return isset($this->position) ? $this->position : null;
     }
 
     public function getLinkAttributes()
     {
-        return $this->linkAttributes;
+        return isset($this->linkAttributes) ? $this->linkAttributes : null;
     }
 
     public function setLinkAttributes($linkAttributes)
@@ -64,7 +52,7 @@ class Item implements ItemInterface
 
     public function getLink()
     {
-        return $this->href;
+        return isset($this->href) ? $this->href : null;
     }
 
     public function setIcon($icon)
@@ -74,7 +62,7 @@ class Item implements ItemInterface
 
     public function getIcon()
     {
-        return $this->icon;
+        return isset($this->icon) ? $this->icon : null;
     }
 
     public function setPosition($position)
@@ -84,7 +72,7 @@ class Item implements ItemInterface
 
     public function getPackageHandle()
     {
-        return $this->pkgHandle;
+        return isset($this->pkgHandle) ? $this->pkgHandle : null;
     }
 
     public function getPackageObject()

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -17,12 +17,12 @@ class Item implements ItemInterface
 
     public function getHandle()
     {
-        return $this->handle;
+        return isset($this->handle) ? $this->handle : null;
     }
 
     public function getLabel()
     {
-        return $this->label;
+        return isset($this->label) ? $this->label : null;
     }
 
     public function setLabel($label)
@@ -32,12 +32,12 @@ class Item implements ItemInterface
 
     public function getPosition()
     {
-        return $this->position;
+        return isset($this->position) ? $this->position : null;
     }
 
     public function getLinkAttributes()
     {
-        return $this->linkAttributes;
+        return isset($this->linkAttributes) ? $this->linkAttributes : null;
     }
 
     public function setLinkAttributes($linkAttributes)
@@ -52,7 +52,7 @@ class Item implements ItemInterface
 
     public function getLink()
     {
-        return $this->href;
+        return isset($this->href) ? $this->href : null;
     }
 
     public function setIcon($icon)
@@ -62,7 +62,7 @@ class Item implements ItemInterface
 
     public function getIcon()
     {
-        return $this->icon;
+        return isset($this->icon) ? $this->icon : null;
     }
 
     public function setPosition($position)
@@ -72,12 +72,12 @@ class Item implements ItemInterface
 
     public function getPackageHandle()
     {
-        return $this->pkgHandle;
+        return isset($this->pkgHandle) ? $this->pkgHandle : null;
     }
 
     public function getPackageObject()
     {
-        return Package::getByHandle($this->pkgHandle);
+        return Package::getByHandle($this->getPackageHandle());
     }
 
     public function getController()

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -8,19 +8,17 @@ class Item implements ItemInterface
     protected $controller = null;
 
     protected $linkAttributes = [];
-    
+
     protected $handle = null;
 
     protected $label = null;
-    
+
     protected $position = null;
-    
-    protected $linkAttributes = null;
-    
+
     protected $href = null;
-    
+
     protected $icon = null;
-    
+
     protected $pkgHandle = null;
 
     public function __construct($handle, $pkgHandle = false)

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -5,9 +5,23 @@ use Concrete\Core\Package\Package;
 
 class Item implements ItemInterface
 {
-    protected $controller;
+    protected $controller = null;
 
     protected $linkAttributes = [];
+    
+    protected $handle = null;
+
+    protected $label = null;
+    
+    protected $position = null;
+    
+    protected $linkAttributes = null;
+    
+    protected $href = null;
+    
+    protected $icon = null;
+    
+    protected $pkgHandle = null;
 
     public function __construct($handle, $pkgHandle = false)
     {
@@ -17,12 +31,12 @@ class Item implements ItemInterface
 
     public function getHandle()
     {
-        return isset($this->handle) ? $this->handle : null;
+        return $this->handle;
     }
 
     public function getLabel()
     {
-        return isset($this->label) ? $this->label : null;
+        return $this->label;
     }
 
     public function setLabel($label)
@@ -32,12 +46,12 @@ class Item implements ItemInterface
 
     public function getPosition()
     {
-        return isset($this->position) ? $this->position : null;
+        return $this->position;
     }
 
     public function getLinkAttributes()
     {
-        return isset($this->linkAttributes) ? $this->linkAttributes : null;
+        return $this->linkAttributes;
     }
 
     public function setLinkAttributes($linkAttributes)
@@ -52,7 +66,7 @@ class Item implements ItemInterface
 
     public function getLink()
     {
-        return isset($this->href) ? $this->href : null;
+        return $this->href;
     }
 
     public function setIcon($icon)
@@ -62,7 +76,7 @@ class Item implements ItemInterface
 
     public function getIcon()
     {
-        return isset($this->icon) ? $this->icon : null;
+        return $this->icon;
     }
 
     public function setPosition($position)
@@ -72,7 +86,7 @@ class Item implements ItemInterface
 
     public function getPackageHandle()
     {
-        return isset($this->pkgHandle) ? $this->pkgHandle : null;
+        return $this->pkgHandle;
     }
 
     public function getPackageObject()

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -82,18 +82,17 @@ class Item implements ItemInterface
 
     public function getController()
     {
-        if (isset($this->controller)) {
-            return $this->controller;
-        } else {
+        if (!isset($this->controller)) {
+            $handle = $this->getHandle();
             $class = overrideable_core_class(
-                'MenuItem\\' . camelcase($this->handle) . '\\Controller',
-                DIRNAME_MENU_ITEMS . '/' . $this->handle . '/' . FILENAME_CONTROLLER,
+                'MenuItem\\' . camelcase($handle) . '\\Controller',
+                DIRNAME_MENU_ITEMS . '/' . $handle . '/' . FILENAME_CONTROLLER,
                 $this->pkgHandle
             );
             $this->setController(\Core::make($class, [$this]));
-
-            return $this->controller;
         }
+
+        return $this->controller;
     }
 
     public function setController(ControllerInterface $controller)

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -7,7 +7,7 @@ class Item implements ItemInterface
 {
     protected $controller;
 
-    protected $linkAttributes = array();
+    protected $linkAttributes = [];
 
     public function __construct($handle, $pkgHandle = false)
     {
@@ -90,7 +90,7 @@ class Item implements ItemInterface
                 DIRNAME_MENU_ITEMS . '/' . $this->handle . '/' . FILENAME_CONTROLLER,
                 $this->pkgHandle
             );
-            $this->setController(\Core::make($class, array($this)));
+            $this->setController(\Core::make($class, [$this]));
 
             return $this->controller;
         }


### PR DESCRIPTION
Ref: #4723

I guess it's too late to add protected properties, so we need to check them with `isset`...
