### PR TITLE
Make it so that we can delete Entities and stuff related to entities

### DIFF
--- a/concrete/src/Entity/Attribute/Value/Value/AbstractValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/AbstractValue.php
@@ -17,7 +17,7 @@ abstract class AbstractValue
     /**
      * @ORM\Id
      * @ORM\OneToOne(targetEntity="\Concrete\Core\Entity\Attribute\Value\Value\Value")
-     * @ORM\JoinColumn(name="avID", referencedColumnName="avID")
+     * @ORM\JoinColumn(name="avID", referencedColumnName="avID", onDelete="CASCADE")
      */
     protected $generic_value;
 

--- a/concrete/src/Entity/Attribute/Value/Value/ImageFileValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/ImageFileValue.php
@@ -12,7 +12,7 @@ class ImageFileValue extends AbstractValue implements FileProviderInterface
 {
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\File\File")
-     * @ORM\JoinColumn(name="fID", referencedColumnName="fID")
+     * @ORM\JoinColumn(name="fID", referencedColumnName="fID", onDelete="CASCADE")
      */
     protected $file;
 

--- a/concrete/src/Entity/Attribute/Value/Value/Value.php
+++ b/concrete/src/Entity/Attribute/Value/Value/Value.php
@@ -21,7 +21,7 @@ class Value
      * This is needed for backward compatibility –but it also might be handy if you need to figure out what kind of
      * attribute something is but we don't want a direct association due to performance concerns
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Attribute\Key\Key")
-     * @ORM\JoinColumn(name="akID", referencedColumnName="akID")
+     * @ORM\JoinColumn(name="akID", referencedColumnName="akID", onDelete="CASCADE")
      **/
     protected $attribute_key;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
@@ -1,0 +1,21 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Database\DatabaseStructureManager;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use ORM;
+
+class Version20170407000001 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $em = ORM::entityManager();
+        $manager = new DatabaseStructureManager($em);
+        $manager->refreshEntities();
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
This fixes a bunch of issues where people can't delete things because of foreign key constraints.

Basically (if you don't know what the cascade does) we tell the DB to delete any associated data.

This Fixes #5275

@KorvinSzanto This allows the deletion of attributes on entities that had values (the ID attribute)