### PR TITLE
Use Trusty (Ubuntu) to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: trusty
 
 php:
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
     - php: hhvm
     - php: nightly
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y mysql-server
+
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then cat tests/travis.hhvm.ini >> /etc/hhvm/php.ini; else phpenv config-add tests/travis.php.ini; fi
   - travis_retry composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+sudo: required
 dist: trusty
 
 php:


### PR DESCRIPTION
This allows for current versions of hhvm to be used in test runs.

See https://docs.travis-ci.com/user/languages/php/#HHVM-versions-on-Trusty for more info