### PR TITLE
Image block - fix image hover and add image cropping

### DIFF
--- a/concrete/blocks/image/add.php
+++ b/concrete/blocks/image/add.php
@@ -1,4 +1,2 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
-
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/image/composer.php
+++ b/concrete/blocks/image/composer.php
@@ -1,6 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
-$al = Core::make('helper/concrete/asset_library');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$al = $app->make('helper/concrete/asset_library');
 $bf = null;
 
 if ($controller->getFileID() > 0) {
@@ -15,9 +16,9 @@ $fieldName = 'ccm-b-image-'.$setcontrol->getPageTypeComposerFormLayoutSetControl
     <?php
     echo $form->label($fieldName, $label);
 
-    if ($description): ?>
+    if ($description) { ?>
         <i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo $description ?>"></i>
-    <?php endif; ?>
+    <?php } ?>
 
     <div class="controls">
         <?php echo $al->image($fieldName, $view->field('fID'), t('Choose Image'), $bf); ?>

--- a/concrete/blocks/image/db.xml
+++ b/concrete/blocks/image/db.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema
-  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
-
-  <table name="btContentImage">
-    <field name="bID" type="integer">
-      <unsigned/>
-      <key/>
-    </field>
-    <field name="fID" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="fOnstateID" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="maxWidth" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="maxHeight" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="externalLink" type="string" size="255"/>
-    <field name="internalLinkCID" type="integer">
-      <unsigned/>
-      <default value="0"/>
-    </field>
-    <field name="altText" type="string" size="255"/>
-    <field name="title" type="string" size="255"/>
-    <index name="fID">
-      <col>fID</col>
-    </index>
-  </table>
-
+<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+    <table name="btContentImage">
+        <field name="bID" type="integer">
+            <unsigned/>
+            <key/>
+        </field>
+        <field name="fID" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="fOnstateID" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="cropImage" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="maxWidth" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="maxHeight" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="externalLink" type="string" size="255" />
+        <field name="internalLinkCID" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
+        <field name="altText" type="string" size="255" />
+        <field name="title" type="string" size="255" />
+        <index name="fID">
+            <col>fID</col>
+        </index>
+    </table>
 </schema>

--- a/concrete/blocks/image/edit.php
+++ b/concrete/blocks/image/edit.php
@@ -1,4 +1,2 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
-
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -1,8 +1,8 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
-$ps = Core::make('helper/form/page_selector');
-$al = Core::make('helper/concrete/asset_library');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$ps = $app->make('helper/form/page_selector');
+$al = $app->make('helper/concrete/asset_library');
 ?>
 
 <fieldset>
@@ -17,6 +17,7 @@ $al = Core::make('helper/concrete/asset_library');
 
     <div class="form-group">
         <label class="control-label"><?php echo t('Image Hover')?> <small style="color: #999999; font-weight: 200;"><?php echo t('(Optional)'); ?></small></label>
+        <i class="fa fa-question-circle launch-tooltip" title="" data-original-title="<?php echo t('The image hover effect requires constraining the image size.'); ?>"></i>
         <?php
         echo $al->image('ccm-b-image-onstate', 'fOnstateID', t('Choose Image On-State'), $bfo);
         ?>
@@ -55,7 +56,7 @@ $al = Core::make('helper/concrete/asset_library');
 
     <div class="form-group">
         <?php
-        echo $form->label('altText', t('Alt. Text'));
+        echo $form->label('altText', t('Alt Text'));
         echo $form->text('altText', $altText, ['maxlength' => 255]);
         ?>
     </div>
@@ -73,7 +74,7 @@ $al = Core::make('helper/concrete/asset_library');
 
     <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">
-            <label>
+            <label class="control-label">
                 <?php
                 echo $form->checkbox('constrainImage', 1, $constrainImage);
                 echo t('Constrain Image Size');
@@ -83,23 +84,38 @@ $al = Core::make('helper/concrete/asset_library');
     </div>
 
     <div data-fields="constrain-image" style="display: none">
-        <div class="form-group">
-            <?php
-            echo $form->label('maxWidth', t('Max Width'));
-            echo $form->number('maxWidth', $maxWidth, ['min' => 0]);
-            ?>
-        </div>
+        <div class="well">
+            <div class="checkbox">
+                <div class="form-group">
+                    <label class="control-label">
+                        <?php
+                        echo $form->checkbox('cropImage', 1, $cropImage);
+                        echo t('Crop Image');
+                        ?>
+                    </label>
+                </div>
+            </div>
 
-        <div class="form-group">
-            <?php
-            echo $form->label('maxHeight', t('Max Height'));
-            echo $form->number('maxHeight', $maxHeight, ['min' => 0]);
-            ?>
+            <div class="form-group">
+                <?php echo $form->label('maxWidth', t('Max Width')); ?>
+                <div class="input-group">
+                    <?php echo $form->number('maxWidth', $maxWidth, ['min' => 0]); ?>
+                    <span class="input-group-addon"><?php echo t('px'); ?></span>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <?php echo $form->label('maxHeight', t('Max Height')); ?>
+                <div class="input-group">
+                    <?php echo $form->number('maxHeight', $maxHeight, ['min' => 0]); ?>
+                    <span class="input-group-addon"><?php echo t('px'); ?></span>
+                </div>
+            </div>
         </div>
     </div>
 </fieldset>
 
-<script type="text/javascript">
+<script>
 refreshImageLinkTypeControls = function() {
     var linkType = $('#linkType').val();
     $('#imageLinkTypePage').toggle(linkType == 1);
@@ -111,6 +127,12 @@ $(document).ready(function() {
 
     $('#constrainImage').on('change', function() {
         $('div[data-fields=constrain-image]').toggle($(this).is(':checked'));
+
+        if (!$(this).is(':checked')) {
+            $('#cropImage').prop('checked', false);
+            $('#maxWidth').val('');
+            $('#maxHeight').val('');
+        }
     }).trigger('change');
 
     refreshImageLinkTypeControls();

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -1,20 +1,20 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 if (is_object($f) && $f->getFileID()) {
     if ($maxWidth > 0 || $maxHeight > 0) {
-        $crop = false;
-
-        $im = Core::make('helper/image');
-        $thumb = $im->getThumbnail($f, $maxWidth, $maxHeight, $crop);
+        $im = $app->make('helper/image');
+        $thumb = $im->getThumbnail($f, $maxWidth, $maxHeight, $cropImage);
 
         $tag = new \HtmlObject\Image();
         $tag->src($thumb->src)->width($thumb->width)->height($thumb->height);
     } else {
-        $image = Core::make('html/image', [$f]);
+        $image = $app->make('html/image', [$f]);
         $tag = $image->getTag();
     }
 
     $tag->addClass('ccm-image-block img-responsive bID-'.$bID);
+
     if ($altText) {
         $tag->alt(h($altText));
     } else {
@@ -34,13 +34,12 @@ if (is_object($f) && $f->getFileID()) {
     if ($linkURL) {
         echo '</a>';
     }
-} elseif ($c->isEditMode()) {
-    ?>
-    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Image Block.') ?></div>
-    <?php
+} elseif ($c->isEditMode()) { ?>
+    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Image Block.'); ?></div>
+<?php
 }
 
-if (is_object($foS)): ?>
+if (is_object($foS) && ($maxWidth > 0 || $maxHeight > 0)) { ?>
 <script>
 $(function() {
     $('.bID-<?php echo $bID; ?>')
@@ -49,4 +48,4 @@ $(function() {
 });
 </script>
 <?php
-endif;
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170408000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170408000000.php
@@ -1,0 +1,21 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Block\BlockType\BlockType;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170408000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $bt = BlockType::getByHandle('image');
+        if (is_object($bt)) {
+            $bt->refresh();
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170408000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170408000000.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
@@ -9,10 +8,7 @@ class Version20170408000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        $bt = BlockType::getByHandle('image');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('image');
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
This pull request:
- limits the image hover effect to size constrained images
- adds optional image cropping to constrained images

### Image Hover

When adding an image using the Image block, it will display as an `img` or `picture` depending on whether the image size has been constrained. Size constrained images display as img and unconstrained images display as picture. 

The type of image element displayed plays a role when selecting a second image to use for the image hover effect. The image hover effect only works with img elements and does not work with picture elements. This is due to picture elements having a fallback src attribute and multiple srcset attributes that are more involved to modify than img elements. To address this, image hover only works when an image has been size constrained.

### Image Cropping

To prevent any potential errors when dealing with the image helper, I added multiple checks to limit input. To add the image cropping a table column and migration was added.

I believe the changes I made should not affect existing users who upgrade concrete5. With any changes to an important core block like this, I welcome others to review and test my changes.

**Current:**

![image_hover-form_before1](https://cloud.githubusercontent.com/assets/10898145/24834928/84ff8bf2-1cc0-11e7-9132-971868511913.png)

![image_hover-form_before2](https://cloud.githubusercontent.com/assets/10898145/24834930/885628c4-1cc0-11e7-8417-386799dcc42a.png)

**Changes:**

![image_hover-form_after1](https://cloud.githubusercontent.com/assets/10898145/24834931/8ea566fe-1cc0-11e7-981d-07db449471f8.png)

![image_hover-form_after2](https://cloud.githubusercontent.com/assets/10898145/24834932/920f5fb6-1cc0-11e7-920e-e9574334c1f2.png)
