### PR TITLE
Page Search: include system pages when parent id is also a system page

### DIFF
--- a/concrete/src/Page/Search/Field/Field/ParentPageField.php
+++ b/concrete/src/Page/Search/Field/Field/ParentPageField.php
@@ -33,8 +33,12 @@ class ParentPageField extends AbstractField
     public function filterList(ItemList $list)
     {
         if ($this->data['cParentIDSearchField'] > 0) {
+            $pc = \Page::getByID($this->data['cParentIDSearchField']);
+            if ($pc->isSystemPage()) {
+                $list->includeSystemPages();
+                $list->includeInactivePages();
+            }
             if ($this->data['cParentAll'] == 1) {
-                $pc = \Page::getByID($this->data['cParentIDSearchField']);
                 $cPath = $pc->getCollectionPath();
                 $list->filterByPath($cPath);
             } else {


### PR DESCRIPTION
Let's include system pages on page search when the parent id is in system page area.