### PR TITLE
Refactoring of the IP blacklist

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -1,22 +1,21 @@
 <?php
-
 namespace Concrete\Authentication\Concrete;
 
 use Concrete\Core\Authentication\AuthenticationTypeController;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
 use Concrete\Core\Validation\CSRF\Token;
 use Config;
-use Exception;
-use Database;
 use Core;
-use Concrete\Core\User\User;
+use Database;
+use Exception;
+use Session;
 use UserInfo;
 use View;
-use Session;
 
 class Controller extends AuthenticationTypeController
 {
-    public $apiMethods = array('forgot_password', 'v', 'change_password', 'password_changed', 'email_validated', 'invalid_token', 'required_password_upgrade');
+    public $apiMethods = ['forgot_password', 'v', 'change_password', 'password_changed', 'email_validated', 'invalid_token', 'required_password_upgrade'];
 
     public function getHandle()
     {
@@ -30,7 +29,7 @@ class Controller extends AuthenticationTypeController
             list($uID, $authType, $hash) = explode(':', $cookie);
             if ($authType == 'concrete') {
                 $db = Database::connection();
-                $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', array($uID, $hash));
+                $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', [$uID, $hash]);
             }
         }
     }
@@ -46,14 +45,14 @@ class Controller extends AuthenticationTypeController
         $db = Database::connection();
         $q = $db->fetchColumn(
             'SELECT validThrough FROM authTypeConcreteCookieMap WHERE uID=? AND token=?',
-            array($uID, $hash)
+            [$uID, $hash]
         );
         $bool = time() < $q;
         if (!$bool) {
-            $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', array($uID, $hash));
+            $db->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID=? AND token=?', [$uID, $hash]);
         } else {
             $newTime = strtotime('+2 weeks');
-            $db->executeQuery('UPDATE authTypeConcreteCookieMap SET validThrough=?', array($newTime));
+            $db->executeQuery('UPDATE authTypeConcreteCookieMap SET validThrough=?', [$newTime]);
         }
 
         return $bool;
@@ -77,7 +76,7 @@ class Controller extends AuthenticationTypeController
         try {
             $db->executeQuery(
                 'INSERT INTO authTypeConcreteCookieMap (token, uID, validThrough) VALUES (?,?,?)',
-                array($token, $u->getUserID(), $validThrough)
+                [$token, $u->getUserID(), $validThrough]
             );
         } catch (\Exception $e) {
             // HOLY CRAP.. SERIOUSLY?
@@ -144,8 +143,8 @@ class Controller extends AuthenticationTypeController
     public function required_password_upgrade()
     {
         $email = $this->post('uEmail');
-	    $token = $this->app->make(Token::class);
-	    $this->set('token', $token);
+        $token = $this->app->make(Token::class);
+        $this->set('token', $token);
 
         if ($email) {
             $errorValidator = Core::make('helper/validation/error');
@@ -253,7 +252,7 @@ class Controller extends AuthenticationTypeController
         $e = Core::make('helper/validation/error');
         $ui = UserInfo::getByValidationHash($uHash);
         if (is_object($ui)) {
-            $hashCreated = $db->fetchColumn('SELECT uDateGenerated FROM UserValidationHashes WHERE uHash=?', array($uHash));
+            $hashCreated = $db->fetchColumn('SELECT uDateGenerated FROM UserValidationHashes WHERE uHash=?', [$uHash]);
             if ($hashCreated < (time() - (USER_CHANGE_PASSWORD_URL_LIFETIME))) {
                 $h->deleteKey('UserValidationHashes', 'uHash', $uHash);
                 throw new \Exception(
@@ -377,7 +376,7 @@ class Controller extends AuthenticationTypeController
         $app = Application::getFacadeApplication();
         $db = $app['database']->connection();
 
-        return $db->GetOne('select uIsPasswordReset from Users where uName = ?', array($this->post('uName')));
+        return $db->GetOne('select uIsPasswordReset from Users where uName = ?', [$this->post('uName')]);
     }
 
     public function v($hash = '')

--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -326,7 +326,7 @@ class Controller extends AuthenticationTypeController
 
         /** @var \Concrete\Core\Permission\IPService $ip_service */
         $ip_service = Core::make('ip');
-        if ($ip_service->isBanned()) {
+        if ($ip_service->isBlacklisted()) {
             throw new \Exception($ip_service->getErrorMessage());
         }
 
@@ -343,9 +343,9 @@ class Controller extends AuthenticationTypeController
                     break;
                 case USER_INVALID:
                     // Log failed auth
-                    $ip_service->logSignupRequest();
-                    if ($ip_service->signupRequestThresholdReached()) {
-                        $ip_service->createIPBan();
+                    $ip_service->logFailedLogin();
+                    if ($ip_service->failedLoginsThresholdReached()) {
+                        $ip_service->addToBlacklistForThresholdReached();
                         throw new \Exception($ip_service->getErrorMessage());
                     }
 

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -2,18 +2,18 @@
 namespace Concrete\Block\Form;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Entity\File\Version;
+use Config;
 use Core;
 use Database;
-use User;
-use Page;
-use UserInfo;
+use Events;
 use Exception;
+use File;
 use FileImporter;
 use FileSet;
-use File;
-use Config;
-use Concrete\Core\Entity\File\Version;
-use Events;
+use Page;
+use User;
+use UserInfo;
 
 class Controller extends BlockController
 {
@@ -39,12 +39,12 @@ class Controller extends BlockController
      */
     public function getBlockTypeDescription()
     {
-        return t("Build simple forms and surveys.");
+        return t('Build simple forms and surveys.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Legacy Form");
+        return t('Legacy Form');
     }
 
     public function getJavaScriptStrings()
@@ -121,9 +121,10 @@ class Controller extends BlockController
             $this->requireAsset('css', 'core/frontend/captcha');
         }
     }
+
     public function getDefaultThankYouMsg()
     {
-        return t("Thanks!");
+        return t('Thanks!');
     }
 
     public function getDefaultSubmitText()
@@ -151,7 +152,7 @@ class Controller extends BlockController
 
         $db = Database::connection();
         if (intval($this->bID) > 0) {
-            $q = "select count(*) as total from {$this->btTable} where bID = ".intval($this->bID);
+            $q = "select count(*) as total from {$this->btTable} where bID = " . intval($this->bID);
             $total = $db->getOne($q);
         } else {
             $total = 0;
@@ -275,7 +276,7 @@ class Controller extends BlockController
         }
         $vals = [$this->bID, intval($data['qsID'])];
         $pendingDeleteQIDs = implode(',', $pendingDeleteQIDs);
-        $unchangedQuestions = $db->query('DELETE FROM btFormQuestions WHERE bID=? AND questionSetId=? AND msqID IN ('.$pendingDeleteQIDs.')', $vals);
+        $unchangedQuestions = $db->query('DELETE FROM btFormQuestions WHERE bID=? AND questionSetId=? AND msqID IN (' . $pendingDeleteQIDs . ')', $vals);
     }
 
     /**
@@ -298,8 +299,8 @@ class Controller extends BlockController
 
             //It should only generate a new question set id if the block is copied to a new page,
             //otherwise it will loose all of its answer sets (from all the people who've used the form on this page)
-            $questionSetCIDs = $db->getCol("SELECT distinct cID FROM {$this->btTable} AS f, CollectionVersionBlocks AS cvb ".
-                        "WHERE f.bID=cvb.bID AND questionSetId=".intval($row['questionSetId']));
+            $questionSetCIDs = $db->getCol("SELECT distinct cID FROM {$this->btTable} AS f, CollectionVersionBlocks AS cvb " .
+                        'WHERE f.bID=cvb.bID AND questionSetId=' . intval($row['questionSetId']));
 
             //this question set id is used on other pages, so make a new one for this page block
             if (count($questionSetCIDs) > 1 || !in_array($c->cID, $questionSetCIDs)) {
@@ -316,7 +317,7 @@ class Controller extends BlockController
             $q = "insert into {$this->btTable} ( questionSetId, surveyName, submitText, bID,thankyouMsg,notifyMeOnSubmission,recipientEmail,displayCaptcha,addFilesToSet) values (?, ?, ?, ?, ?, ?, ?, ?,?)";
             $result = $db->Execute($q, $v);
 
-            $rs = $db->query("SELECT * FROM {$this->btQuestionsTablename} WHERE questionSetId=$oldQuestionSetId AND bID=".intval($this->bID));
+            $rs = $db->query("SELECT * FROM {$this->btQuestionsTablename} WHERE questionSetId=$oldQuestionSetId AND bID=" . intval($this->bID));
             while ($row = $rs->fetchRow()) {
                 $v = [$newQuestionSetId, intval($row['msqID']), intval($newBID), $row['question'], $row['inputType'], $row['options'], $row['position'], $row['width'], $row['height'], $row['required'], $row['defaultDate']];
                 $sql = "INSERT INTO {$this->btQuestionsTablename} (questionSetId,msqID,bID,question,inputType,options,position,width,height,required,defaultDate) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
@@ -359,8 +360,8 @@ class Controller extends BlockController
         }
 
         $token = Core::make('token');
-        if (!$token->validate('form_block_submit_qs_'.$qsID)) {
-            throw new Exception(t("Invalid Request"));
+        if (!$token->validate('form_block_submit_qs_' . $qsID)) {
+            throw new Exception(t('Invalid Request'));
         }
 
         //get all questions for this question set
@@ -376,7 +377,7 @@ class Controller extends BlockController
         if ($this->displayCaptcha) {
             $captcha = Core::make('helper/validation/captcha');
             if (!$captcha->check()) {
-                $errors['captcha'] = t("Incorrect captcha code");
+                $errors['captcha'] = t('Incorrect captcha code');
                 $_REQUEST['ccmCaptchaCode'] = '';
             }
         }
@@ -387,9 +388,9 @@ class Controller extends BlockController
                 if (!isset($datetime)) {
                     $datetime = Core::make('helper/form/date_time');
                 }
-                $translated = $datetime->translate('Question'.$row['msqID']);
+                $translated = $datetime->translate('Question' . $row['msqID']);
                 if ($translated) {
-                    $_POST['Question'.$row['msqID']] = $translated;
+                    $_POST['Question' . $row['msqID']] = $translated;
                 }
             }
             if (intval($row['required']) == 1) {
@@ -403,7 +404,7 @@ class Controller extends BlockController
                 if ($row['inputType'] == 'checkboxlist') {
                     $answerFound = 0;
                     foreach ($_POST as $key => $val) {
-                        if (strstr($key, 'Question'.$row['msqID'].'_') && strlen($val)) {
+                        if (strstr($key, 'Question' . $row['msqID'] . '_') && strlen($val)) {
                             $answerFound = 1;
                         }
                     }
@@ -411,14 +412,14 @@ class Controller extends BlockController
                         $notCompleted = 1;
                     }
                 } elseif ($row['inputType'] == 'fileupload') {
-                    if (!isset($_FILES['Question'.$row['msqID']]) || !is_uploaded_file($_FILES['Question'.$row['msqID']]['tmp_name'])) {
+                    if (!isset($_FILES['Question' . $row['msqID']]) || !is_uploaded_file($_FILES['Question' . $row['msqID']]['tmp_name'])) {
                         $notCompleted = 1;
                     }
-                } elseif (!strlen(trim($_POST['Question'.$row['msqID']]))) {
+                } elseif (!strlen(trim($_POST['Question' . $row['msqID']]))) {
                     $notCompleted = 1;
                 }
                 if ($notCompleted) {
-                    $errors['CompleteRequired'] = t("Complete required fields *");
+                    $errors['CompleteRequired'] = t('Complete required fields *');
                     $errorDetails[$row['msqID']]['CompleteRequired'] = $errors['CompleteRequired'];
                 }
             }
@@ -431,7 +432,7 @@ class Controller extends BlockController
                 if ($row['inputType'] != 'fileupload') {
                     continue;
                 }
-                $questionName = 'Question'.$row['msqID'];
+                $questionName = 'Question' . $row['msqID'];
                 if (!intval($row['required']) &&
                     (
                     !isset($_FILES[$questionName]['tmp_name']) || !is_uploaded_file($_FILES[$questionName]['tmp_name'])
@@ -451,7 +452,6 @@ class Controller extends BlockController
                         $errors['fileupload'] = t('Invalid file.');
                         $errorDetails[$row['msqID']]['fileupload'] = $errors['fileupload'];
                         break;
-
                 }
                 } else {
                     $tmpFileIds[intval($row['msqID'])] = $resp->getFileID();
@@ -497,18 +497,18 @@ class Controller extends BlockController
                 $answerDisplay = '';
                 if ($row['inputType'] == 'checkboxlist') {
                     $answer = [];
-                    $answerLong = "";
+                    $answerLong = '';
                     $keys = array_keys($_POST);
                     foreach ($keys as $key) {
-                        if (strpos($key, 'Question'.$row['msqID'].'_') === 0) {
+                        if (strpos($key, 'Question' . $row['msqID'] . '_') === 0) {
                             $answer[] = $txt->sanitize($_POST[$key]);
                         }
                     }
                 } elseif ($row['inputType'] == 'text') {
-                    $answerLong = $txt->sanitize($_POST['Question'.$row['msqID']]);
+                    $answerLong = $txt->sanitize($_POST['Question' . $row['msqID']]);
                     $answer = '';
                 } elseif ($row['inputType'] == 'fileupload') {
-                    $answerLong = "";
+                    $answerLong = '';
                     $answer = intval($tmpFileIds[intval($row['msqID'])]);
                     if ($answer > 0) {
                         $answerDisplay = File::getByID($answer)->getVersion()->getDownloadURL();
@@ -516,11 +516,11 @@ class Controller extends BlockController
                         $answerDisplay = t('No file specified');
                     }
                 } elseif ($row['inputType'] == 'url') {
-                    $answerLong = "";
-                    $answer = $txt->sanitize($_POST['Question'.$row['msqID']]);
+                    $answerLong = '';
+                    $answer = $txt->sanitize($_POST['Question' . $row['msqID']]);
                 } elseif ($row['inputType'] == 'email') {
-                    $answerLong = "";
-                    $answer = $txt->sanitize($_POST['Question'.$row['msqID']]);
+                    $answerLong = '';
+                    $answer = $txt->sanitize($_POST['Question' . $row['msqID']]);
                     if (!empty($row['options'])) {
                         $settings = unserialize($row['options']);
                         if (is_array($settings) && array_key_exists('send_notification_from', $settings) && $settings['send_notification_from'] == 1) {
@@ -531,11 +531,11 @@ class Controller extends BlockController
                         }
                     }
                 } elseif ($row['inputType'] == 'telephone') {
-                    $answerLong = "";
-                    $answer = $txt->sanitize($_POST['Question'.$row['msqID']]);
+                    $answerLong = '';
+                    $answer = $txt->sanitize($_POST['Question' . $row['msqID']]);
                 } else {
-                    $answerLong = "";
-                    $answer = $txt->sanitize($_POST['Question'.$row['msqID']]);
+                    $answerLong = '';
+                    $answer = $txt->sanitize($_POST['Question' . $row['msqID']]);
                 }
 
                 if (is_array($answer)) {
@@ -543,7 +543,7 @@ class Controller extends BlockController
                 }
 
                 $questionAnswerPairs[$row['msqID']]['question'] = $row['question'];
-                $questionAnswerPairs[$row['msqID']]['answer'] = $txt->sanitize($answer.$answerLong);
+                $questionAnswerPairs[$row['msqID']]['answer'] = $txt->sanitize($answer . $answerLong);
                 $questionAnswerPairs[$row['msqID']]['answerDisplay'] = strlen($answerDisplay) ? $answerDisplay : $questionAnswerPairs[$row['msqID']]['answer'];
 
                 $v = [$row['msqID'], $answerSetID, $answer, $answerLong];
@@ -554,7 +554,7 @@ class Controller extends BlockController
 
             $submittedData = '';
             foreach ($questionAnswerPairs as $questionAnswerPair) {
-                $submittedData .= $questionAnswerPair['question']."\r\n".$questionAnswerPair['answer']."\r\n"."\r\n";
+                $submittedData .= $questionAnswerPair['question'] . "\r\n" . $questionAnswerPair['answer'] . "\r\n" . "\r\n";
             }
             $antispam = Core::make('helper/validation/antispam');
             if (!$antispam->check($submittedData, 'form_block')) {
@@ -612,7 +612,7 @@ class Controller extends BlockController
                     $response = \Redirect::page($targetPage);
                 } else {
                     $response = \Redirect::page(Page::getCurrentPage());
-                    $url = $response->getTargetUrl() . "?surveySuccess=1&qsid=".$this->questionSetId."#formblock".$this->bID;
+                    $url = $response->getTargetUrl() . '?surveySuccess=1&qsid=' . $this->questionSetId . '#formblock' . $this->bID;
                     $response->setTargetUrl($url);
                 }
                 $response->send();
@@ -632,25 +632,25 @@ class Controller extends BlockController
         $info = $miniSurvey->getMiniSurveyBlockInfo($this->bID);
 
         //get all answer sets
-        $q = "SELECT asID FROM {$this->btAnswerSetTablename} WHERE questionSetId = ".intval($info['questionSetId']);
+        $q = "SELECT asID FROM {$this->btAnswerSetTablename} WHERE questionSetId = " . intval($info['questionSetId']);
         $answerSetsRS = $db->query($q);
 
         //delete the questions
-        $deleteData['questionsIDs'] = $db->getAll("SELECT qID FROM {$this->btQuestionsTablename} WHERE questionSetId = ".intval($info['questionSetId']).' AND bID='.intval($this->bID));
+        $deleteData['questionsIDs'] = $db->getAll("SELECT qID FROM {$this->btQuestionsTablename} WHERE questionSetId = " . intval($info['questionSetId']) . ' AND bID=' . intval($this->bID));
         foreach ($deleteData['questionsIDs'] as $questionData) {
-            $db->query("DELETE FROM {$this->btQuestionsTablename} WHERE qID=".intval($questionData['qID']));
+            $db->query("DELETE FROM {$this->btQuestionsTablename} WHERE qID=" . intval($questionData['qID']));
         }
 
         //delete left over answers
         $strandedAnswerIDs = $db->getAll('SELECT fa.aID FROM `btFormAnswers` AS fa LEFT JOIN btFormQuestions as fq ON fq.msqID=fa.msqID WHERE fq.msqID IS NULL');
         foreach ($strandedAnswerIDs as $strandedAnswer) {
-            $db->query('DELETE FROM `btFormAnswers` WHERE aID='.intval($strandedAnswer['aID']));
+            $db->query('DELETE FROM `btFormAnswers` WHERE aID=' . intval($strandedAnswer['aID']));
         }
 
         //delete the left over answer sets
         $deleteData['strandedAnswerSetIDs'] = $db->getAll('SELECT aset.asID FROM btFormAnswerSet AS aset LEFT JOIN btFormAnswers AS fa ON aset.asID=fa.asID WHERE fa.asID IS NULL');
         foreach ($deleteData['strandedAnswerSetIDs'] as $strandedAnswerSetIDs) {
-            $db->query('DELETE FROM btFormAnswerSet WHERE asID='.intval($strandedAnswerSetIDs['asID']));
+            $db->query('DELETE FROM btFormAnswerSet WHERE asID=' . intval($strandedAnswerSetIDs['asID']));
         }
 
         //delete the form block

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -343,7 +343,7 @@ class Controller extends BlockController
         $ip = Core::make('helper/validation/ip');
         $this->view();
 
-        if ($ip->isBanned()) {
+        if ($ip->isBlacklisted()) {
             $this->set('invalidIP', $ip->getErrorMessage());
 
             return;

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.2.0a2',
     'version_installed' => '8.2.0a2',
-    'version_db' => '20170404000000', // the key of the latest database migration
+    'version_db' => '20170412000000', // the key of the latest database migration
 
     /*
      * Installation status
@@ -774,21 +774,13 @@ return [
         ],
         'ban' => [
             'ip' => [
+                // Is the automatic ban system enabled?
                 'enabled' => true,
-
-                /*
-                 * Maximum attempts
-                 */
+                // Maximum number of login attempts before banning the IP address
                 'attempts' => 5,
-
-                /*
-                 * Threshold time
-                 */
+                // Time window (in seconds) for past failed login attempts
                 'time' => 300,
-
-                /*
-                 * Ban length in minutes
-                 */
+                // Ban duration (in minutes) when <attempts> failed logins occurred in the past <time> seconds
                 'length' => 10,
             ],
         ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -573,7 +573,7 @@ return [
             'api_token' => '',
             // Languages below this translation progress won't be considered
             'progress_limit' => 60,
-            // Lifetime (in seconds) of the cache items associated to downloaded data 
+            // Lifetime (in seconds) of the cache items associated to downloaded data
             'cache_lifetime' => 3600, // 1 hour
         ],
     ],

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -3476,28 +3476,29 @@
     </index>
   </table>
 
-  <table name="UserBannedIPs">
-    <field name="id" type="integer" size="11">
+  <table name="LoginControlIpRanges" comment="IP ranges used to control login attempts">
+    <field name="lcirID" type="integer" comment="Record identifier">
       <unsigned/>
       <autoincrement/>
       <key/>
     </field>
-    <field name="ipFrom" type="blob" size="32">
-    </field>
-    <field name="ipTo" type="blob" size="32">
-    </field>
-    <field name="banCode" type="boolean">
-      <default value="1"/>
+    <field name="lcirIpFrom" type="string" size="40" comment="Start of the range">
       <notnull/>
     </field>
-    <field name="expires" type="datetime">
-      <default value="1000-01-01 00:00:00"/>
+    <field name="lcirIpTo" type="string" size="40" comment="End of the range">
       <notnull/>
     </field>
-    <field name="isManual" type="boolean">
-      <default value="0"/>
+    <field name="lcirType" type="smallint" comment="Type of the record">
+      <unsigned/>
       <notnull/>
     </field>
+    <field name="lcirExpires" type="datetime" comment="Record end-of-life timestamp">
+    </field>
+    <index name="IX_LoginControlIpRanges_Search">
+      <col>lcirIpFrom</col>
+      <col>lcirIpTo</col>
+      <col>lcirExpires</col>
+    </index>
   </table>
 
   <table name="UserGroups">
@@ -3666,14 +3667,16 @@
     </index>
   </table>
 
-  <table name="SignupRequests">
-    <field name="id" type="integer" size="11">
+  <table name="FailedLoginAttempts" comment="Records failed login attempts">
+    <field name="lcirID" type="integer" comment="Record identifier">
+      <unsigned/>
       <autoincrement/>
       <key/>
     </field>
-    <field name="ipFrom" type="blob" size="32"/>
-    <field name="date_access" type="timestamp">
-      <deftimestamp/>
+    <field name="flaIp" type="string" size="40" comment="IP address of the failed login attempt">
+      <notnull/>
+    </field>
+    <field name="flaTimestamp" type="timestamp" comment="Timestamp of the failed login attempt">
       <notnull/>
     </field>
   </table>

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -802,6 +802,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="IP Range" path="/dashboard/system/permissions/blacklist/range"
+              filename="/dashboard/system/permissions/blacklist/range.php" pagetype="" description="" package="">
+            <attributes>
+				<attributekey handle="exclude_nav">
+                    <value>0</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="Captcha Setup" path="/dashboard/system/permissions/captcha"
               filename="/dashboard/system/permissions/captcha.php" pagetype="" description="" package="">
             <attributes>

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist.php
@@ -2,198 +2,57 @@
 namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Config;
-use Loader;
-use Concrete\Core\User\UserBannedIp;
-use Exception;
 
 class Blacklist extends DashboardPageController
 {
-    public function formatTimestampAsMinutesSeconds($seconds)
+    public function view()
     {
-        if ($seconds == 0) {
-            return t('Never');
-        } else {
-            $seconds = $seconds - time();
-
-            return floor($seconds / 60) . 'm' . $seconds % 60 . 's';
-        }
+        $config = $this->app->make('config');
+        $this->set('banEnabled', $config->get('concrete.security.ban.ip.enabled') ? true : false);
+        $this->set('allowedAttempts', (int) $config->get('concrete.security.ban.ip.attempts'));
+        $this->set('attemptsTimeWindow', (int) $config->get('concrete.security.ban.ip.time'));
+        $this->set('banDuration', (int) $config->get('concrete.security.ban.ip.length'));
     }
-
-    // assumes ipv4
-    private function parseIPBlacklistIntoRanges()
-    {
-        $ips = preg_split('{[\r\n]+}', $this->post('ip_ban_manual'), null, PREG_SPLIT_NO_EMPTY);
-        $ip_ranges = array();
-        foreach ($ips as $ip) {
-            if (strpos($ip, '*') === false) {
-                $ip = long2ip(ip2long($ip)); // ensures a valid ip
-                $ip_ranges[] = array(
-                    'ipFrom' => $ip,
-                    'ipTo' => 0,
-                );
-            } else {
-                $aOctets = preg_split('{\.}', $ip);
-                $ipFrom = '';
-                $ipTo = '';
-                for ($i = 0; $i < 4; ++$i) {
-                    if (is_numeric($aOctets[$i])) {
-                        $ipFrom .= $aOctets[$i] . '.';
-                        $ipTo .= $aOctets[$i] . '.';
-                    } else {
-                        $ipFrom .= '0' . '.';
-                        $ipTo .= '255' . '.';
-                    }
-                }
-                $ipFrom = substr($ipFrom, 0, strlen($ipFrom) - 1);
-                $ipTo = substr($ipTo, 0, strlen($ipTo) - 1);
-
-                $ipFrom = long2ip(ip2long($ipFrom)); // ensures a valid ip
-                $ipTo = long2ip(ip2long($ipTo)); // ensures a valid ip
-
-                $ip_ranges[] = array(
-                    'ipFrom' => $ipFrom,
-                    'ipTo' => $ipTo,
-                );
-            }
-        }
-
-        return $ip_ranges;
-    }
-
-    const IP_BLACKLIST_CHANGE_MAKEPERM = 1;
-
-    const IP_BLACKLIST_CHANGE_REMOVE = 2;
-
-    const IP_BAN_LOCK_IP_HOW_LONG_TYPE_TIMED = 'timed';
-
-    const IP_BAN_LOCK_IP_HOW_LONG_TYPE_FOREVER = 'forever';
 
     public function update_ipblacklist()
     {
-        $db = Loader::db();
-        if ($this->token->validate("update_ipblacklist")) {
+        if ($this->token->validate('update_ipblacklist')) {
+            $post = $this->request->request;
+            $valn = $this->app->make('helper/validation/numbers');
+            /* @var \Concrete\Core\Utility\Service\Validation\Numbers $valn */
 
-            // configs from top part form
-            $ip_ban_lock_ip_enable = (1 == $this->post('ip_ban_lock_ip_enable')) ? 1 : 0;
-            Config::save('concrete.security.ban.ip.enabled', $ip_ban_lock_ip_enable);
-            Config::save('concrete.security.ban.ip.attempts', $this->post('ip_ban_lock_ip_attempts'));
-            Config::Save('concrete.security.ban.ip.time', $this->post('ip_ban_lock_ip_time'));
+            $enabled = $post->get('banEnabled') ? true : false;
 
-            if (self::IP_BAN_LOCK_IP_HOW_LONG_TYPE_FOREVER != $this->post('ip_ban_lock_ip_how_long_type')) {
-                Config::Save('concrete.security.ban.ip.length', $this->post('ip_ban_lock_ip_how_long_min'));
+            $allowedAttempts = $post->get('allowedAttempts');
+            if (!$valn->integer($allowedAttempts) || ($allowedAttempts = (int) $allowedAttempts) < 1) {
+                $this->error->add(t('Please specify a number greater than zero for the maximum number of failed login attempts'));
+            }
+
+            $attemptsTimeWindow = $post->get('attemptsTimeWindow');
+            if (!$valn->integer($attemptsTimeWindow) || ($attemptsTimeWindow = (int) $attemptsTimeWindow) < 1) {
+                $this->error->add(t('Please specify a number greater than zero for the failed login attempts time window'));
+            }
+
+            if ($post->get('banDurationUnlimited')) {
+                $banDuration = 0;
             } else {
-                Config::Save('concrete.security.ban.ip.length', 0);
-            }
-
-            // ip table actions
-            // use a single sql query, more efficient than active record
-            $ip_ban_changes = $this->post('ip_ban_changes');
-            if (count($ip_ban_changes) > 0) {
-                $ip_ban_change_to = $this->post('ip_ban_change_to');
-                $q = 'UPDATE UserBannedIPs SET expires = ? WHERE ';
-                $v = array();
-                switch ($ip_ban_change_to) {
-                    case self::IP_BLACKLIST_CHANGE_MAKEPERM:
-                        $v[] = 0; // expires 0 is a perma-ban
-                        break;
-                    case self::IP_BLACKLIST_CHANGE_REMOVE:
-                        $v[] = 1; // expires 1 is really far in past, defacto expire
-                        break;
-                }
-
-                $utility = new UserBannedIp();
-                foreach ($ip_ban_changes as $key) {
-                    $q .= '(ipFrom = ? AND ipTo = ?) OR';
-                    $ids = $utility->parseUniqueID($key);
-                    $v[] = $ids['ipFrom'];
-                    $v[] = $ids['ipTo'];
-                }
-                $q = substr($q, 0, strlen($q) - 3);
-                $db->execute($q, $v);
-            }
-
-            // textarea actions
-            $ip_ranges = $this->parseIPBlacklistIntoRanges();
-            $db = Loader::db();
-            $q = 'DELETE FROM UserBannedIPs WHERE isManual = 1';
-            $db->execute($q);
-            // no batch insert in adodb? :(
-
-            foreach ($ip_ranges as $ip_range) {
-                $ip = new UserBannedIp();
-
-                $ip->ipFrom = ip2long($ip_range['ipFrom']);
-                $ip->ipTo = $ip_range['ipTo'];
-                if ($ip->ipTo != 0) {
-                    $ip->ipTo = ip2long($ip_range['ipTo']);
-                }
-                $ip->banCode = UserBannedIp::IP_BAN_CODE_REGISTRATION_THROTTLE;
-                $ip->expires = 0;
-                $ip->isManual = 1;
-                try {
-                    $ip->save();
-                } catch (Exception $e) {
-                    // silently discard duplicates
+                $banDuration = $post->get('banDuration');
+                if (!$valn->integer($banDuration) || ($banDuration = (int) $banDuration) < 1) {
+                    $this->error->add(t('Please specify a number greater than zero for the ban duration'));
                 }
             }
 
-            $this->redirect('/dashboard/system/permissions/blacklist', 'saved');
+            if (!$this->error->has()) {
+                $config = $this->app->make('config');
+                $config->save('concrete.security.ban.ip.enabled', $enabled);
+                $config->save('concrete.security.ban.ip.attempts', $allowedAttempts);
+                $config->save('concrete.security.ban.ip.time', $attemptsTimeWindow);
+                $config->save('concrete.security.ban.ip.length', $banDuration);
+                $this->flash('success', t('IP Blacklist settings saved.'));
+                $this->redirect($this->action(''));
+            }
         } else {
-            $this->set('error', array(
-                $this->token->getErrorMessage(),
-            ));
+            $this->error->add($this->token->getErrorMessage());
         }
-    }
-
-    public function saved()
-    {
-        $this->set("message", t("IP Blacklist settings saved."));
-        $this->view();
-    }
-
-    public function view()
-    {
-        // IP Address Blacklist
-        $ip_ban_enable_lock_ip_after = Config::get('concrete.security.ban.ip.enabled');
-        $ip_ban_enable_lock_ip_after = ($ip_ban_enable_lock_ip_after == 1) ? 1 : 0;
-        $ip_ban_lock_ip_after_attempts = Config::get('concrete.security.ban.ip.attempts');
-        $ip_ban_lock_ip_after_time = Config::get('concrete.security.ban.ip.time');
-        $ip_ban_lock_ip_how_long_min = Config::get('concrete.security.ban.ip.length', '');
-        if (!$ip_ban_lock_ip_how_long_min) {
-            $ip_ban_lock_ip_how_long_type = self::IP_BAN_LOCK_IP_HOW_LONG_TYPE_FOREVER;
-        } else {
-            $ip_ban_lock_ip_how_long_type = self::IP_BAN_LOCK_IP_HOW_LONG_TYPE_TIMED;
-        }
-
-        $user_banned_ip = new UserBannedIp();
-        // pull all once filter various lists using code
-        $user_banned_ips = $user_banned_ip->Find('1=1');
-        $user_banned_manual_ips = array();
-        $user_banned_limited_ips = array();
-
-        foreach ($user_banned_ips as $user_banned_ip) {
-            if ($user_banned_ip->isManual == 1) {
-                $user_banned_manual_ips[] = $user_banned_ip->getIPRangeForDisplay();
-            } elseif ($user_banned_ip->expires - time() > 0 || $user_banned_ip->expires == 0) {
-                $user_banned_limited_ips[] = $user_banned_ip;
-            }
-        }
-        $user_banned_manual_ips = implode($user_banned_manual_ips, "\n");
-        $this->set('user_banned_manual_ips', $user_banned_manual_ips);
-        $this->set('user_banned_limited_ips', $user_banned_limited_ips);
-        $this->set('ip_ban_enable_lock_ip_after', $ip_ban_enable_lock_ip_after);
-        $this->set('ip_ban_lock_ip_after_attempts', $ip_ban_lock_ip_after_attempts);
-        $this->set('ip_ban_lock_ip_after_time', $ip_ban_lock_ip_after_time);
-        $this->set('ip_ban_change_makeperm', self::IP_BLACKLIST_CHANGE_MAKEPERM);
-        $this->set('ip_ban_change_remove', self::IP_BLACKLIST_CHANGE_REMOVE);
-
-        $this->set('ip_ban_lock_ip_how_long_type', $ip_ban_lock_ip_how_long_type);
-        $this->set('ip_ban_lock_ip_how_long_type', $ip_ban_lock_ip_how_long_type);
-        $this->set('ip_ban_lock_ip_how_long_type_forever', self::IP_BAN_LOCK_IP_HOW_LONG_TYPE_FOREVER);
-        $this->set('ip_ban_lock_ip_how_long_type_timed', self::IP_BAN_LOCK_IP_HOW_LONG_TYPE_TIMED);
-        $this->set('ip_ban_lock_ip_how_long_min', $ip_ban_lock_ip_how_long_min);
-
-        $this->set('user_banned_ips', $user_banned_ips);
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
@@ -1,0 +1,150 @@
+<?php
+namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist;
+
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Permission\IPRange;
+use Concrete\Core\Permission\IPRangesCsvWriter;
+use Concrete\Core\Permission\IPService;
+use Exception;
+use IPLib\Factory as IPFactory;
+use League\Csv\Writer;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class Range extends DashboardPageController
+{
+    public function view($type = null)
+    {
+        $type = (int) $type;
+        switch ($type) {
+            case IPService::IPRANGETYPE_BLACKLIST_MANUAL:
+                $this->set('pageTitle', t('Blacklisted IP addresses (manual)'));
+                break;
+            case IPService::IPRANGETYPE_WHITELIST_MANUAL:
+                $this->set('pageTitle', t('Whitelisted IP addresses'));
+                break;
+            case IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC:
+            default:
+                $this->set('pageTitle', t('Blacklisted IP addresses (automatic)'));
+                $type = IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC;
+                break;
+        }
+        $this->set('type', $type);
+        $this->set('ranges', $this->app->make('ip')->getRanges($type));
+    }
+
+    public function formatRangeRow(IPRange $range)
+    {
+        $html = '';
+        $html .= '<tr data-range-id="' . $range->getID() . '">';
+        $html .= '<td><a class="btn btn-xs btn-danger ccm-iprange-delete" href="#"><i class="fa fa-times"></i></a></td>';
+        $html .= '<td><code>' . $range->getIpRange() . '</code></td>';
+        if ($range->getType() === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+            $html .= '<td>';
+            if ($range->getExpires() !== null) {
+                $html .= $this->app->make('date')->formatPrettyDateTime($range->getExpires(), true);
+            }
+            $html .= '</td>';
+            $html .= '<td class="pull-right"><a href="#" class="btn btn-xs btn-info ccm-iprange-makepermanent">' . t('Make permament') . '</a></td>';
+        }
+        $html .= '</tr>';
+
+        return $html;
+    }
+
+    public function add_range($type)
+    {
+        if (!$this->token->validate('add_range/' . $type)) {
+            throw new Exception($this->token->getErrorMessage());
+        }
+        $range = IPFactory::rangeFromString($this->request->request->get('range'));
+        if ($range === null) {
+            throw new Exception(t('The specified IP range is invalid'));
+        }
+        $ipService = $this->app->make('ip');
+        /* @var IPService $ipService */
+        $record = $ipService->createRange($range, $type);
+
+        return $this->app->make(ResponseFactoryInterface::class)->json(['row' => $this->formatRangeRow($record)]);
+    }
+
+    public function delete_range($type)
+    {
+        if (!$this->token->validate('delete_range/' . $type)) {
+            throw new Exception($this->token->getErrorMessage());
+        }
+        $ipService = $this->app->make('ip');
+        /* @var IPService $ipService */
+        $record = $ipService->getRangeByID($this->request->request->get('id'));
+        if ($record !== null) {
+            if ($record->getType() !== (int) $type) {
+                throw new Exception(t('The specified IP range is invalid'));
+            }
+            $ipService->deleteRange($record);
+        }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json(true);
+    }
+
+    public function make_range_permanent($type)
+    {
+        if (!$this->token->validate('make_range_permanent/' . $type)) {
+            throw new Exception($this->token->getErrorMessage());
+        }
+        $ipService = $this->app->make('ip');
+        /* @var IPService $ipService */
+        $record = $ipService->getRangeByID($this->request->request->get('id'));
+        if ($record === null) {
+            throw new Exception(t('Unable to find the IP range specified'));
+        }
+        if ($record->getType() !== (int) $type) {
+            throw new Exception(t('The specified IP range is invalid'));
+        }
+        $ipService->createRange($record->getIpRange(), IPService::IPRANGETYPE_BLACKLIST_MANUAL);
+        $ipService->deleteRange($record);
+
+        return $this->app->make(ResponseFactoryInterface::class)->json(true);
+    }
+
+    public function export($type, $includeExpired, $token)
+    {
+        if (!$this->token->validate("iprange/export/range/{$type}/$includeExpired", $token)) {
+            throw new Exception($this->token->getErrorMessage());
+        }
+        $type = (int) $type;
+        switch ($type) {
+            case IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC:
+                $filename = 'blacklist-automatic';
+                break;
+            case IPService::IPRANGETYPE_BLACKLIST_MANUAL:
+                $filename = 'blacklist-manual';
+                break;
+            case IPService::IPRANGETYPE_WHITELIST_MANUAL:
+                $filename = 'whitelist';
+                break;
+            default:
+                $filename = 'ip-ranges';
+                break;
+        }
+        $filename .= '-' . $this->app->make('date')->formatCustom('Y-m-d-H-i-s') . '.csv';
+        $includeExpired = (bool) $includeExpired;
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename=' . $filename,
+        ];
+        $ipService = $this->app->make('ip');
+        /* @var IPService $ipService */
+        $ranges = $ipService->getRanges($type, $includeExpired);
+        $app = $this->app;
+
+        return StreamedResponse::create(
+            function () use ($app, $type, $ranges) {
+                $writer = $app->build(IPRangesCsvWriter::class, ['writer' => Writer::createFromPath('php://output', 'w'), 'type' => $type]);
+                $writer->insertHeaders();
+                $writer->insertRanges($ranges);
+            },
+            StreamedResponse::HTTP_OK,
+            $headers
+        );
+    }
+}

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -57,7 +57,7 @@ class Register extends PageController
             $username = trim($username);
             $username = preg_replace("/ +/", " ", $username);
 
-            if ($ip->isBanned()) {
+            if ($ip->isBlacklisted()) {
                 $e->add($ip->getErrorMessage());
             }
 

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -9,12 +9,12 @@ use Concrete\Core\Validation\ResponseInterface;
 use Config;
 use Loader;
 use User;
-use UserInfo;
 use UserAttributeKey;
+use UserInfo;
 
 class Register extends PageController
 {
-    public $helpers = array('form', 'html');
+    public $helpers = ['form', 'html'];
 
     protected $displayUserName = true;
 
@@ -55,7 +55,7 @@ class Register extends PageController
 
             // clean the username
             $username = trim($username);
-            $username = preg_replace("/ +/", " ", $username);
+            $username = preg_replace('/ +/', ' ', $username);
 
             if ($ip->isBlacklisted()) {
                 $e->add($ip->getErrorMessage());
@@ -64,14 +64,14 @@ class Register extends PageController
             if ($config->get('concrete.user.registration.captcha')) {
                 $captcha = $this->app->make('helper/validation/captcha');
                 if (!$captcha->check()) {
-                    $e->add(t("Incorrect image validation code. Please check the image and re-enter the letters or numbers as necessary."));
+                    $e->add(t('Incorrect image validation code. Please check the image and re-enter the letters or numbers as necessary.'));
                 }
             }
 
             if (!$vals->email($_POST['uEmail'])) {
                 $e->add(t('Invalid email address provided.'));
             } elseif (!$valc->isUniqueEmail($_POST['uEmail'])) {
-                $e->add(t("The email address %s is already in use. Please choose another.", $_POST['uEmail']));
+                $e->add(t('The email address %s is already in use. Please choose another.', $_POST['uEmail']));
             }
 
             if ($this->displayUserName) {
@@ -97,7 +97,7 @@ class Register extends PageController
                     }
                 }
                 if (!$valc->isUniqueUsername($username)) {
-                    $e->add(t("The username %s already exists. Please choose another", $username));
+                    $e->add(t('The username %s already exists. Please choose another', $username));
                 }
             }
 
@@ -124,7 +124,7 @@ class Register extends PageController
                     $uak->isAttributeKeyRequiredOnRegister()
                 );
                 /**
-                 * @var $response ResponseInterface
+                 * @var ResponseInterface
                  */
                 if (!$response->isValid()) {
                     $error = $response->getErrorObject();
@@ -162,7 +162,7 @@ class Register extends PageController
                     $mh->addParameter('uName', $process->getUserName());
                     $mh->addParameter('uEmail', $process->getUserEmail());
                     $attribs = UserAttributeKey::getRegistrationList();
-                    $attribValues = array();
+                    $attribValues = [];
                     foreach ($attribs as $ak) {
                         $attribValues[] = $ak->getAttributeKeyDisplayName('text') . ': ' . $process->getAttribute($ak->getAttributeKeyHandle(),
                                 'display');
@@ -264,7 +264,7 @@ class Register extends PageController
 
     public function getRegisterSuccessValidateMsgs()
     {
-        $msgs = array();
+        $msgs = [];
         $msgs[] = t('You are registered but you need to validate your email address. Some or all functionality on this site will be limited until you do so.');
         $msgs[] = t('An email has been sent to your email address. Click on the URL contained in the email to validate your email address.');
 

--- a/concrete/elements/dashboard/system/permissions/blacklist/menu.php
+++ b/concrete/elements/dashboard/system/permissions/blacklist/menu.php
@@ -1,0 +1,38 @@
+<?php
+use Concrete\Core\Permission\IPService;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+// Arguments
+/* @var int|null $type */
+?>
+<div class="ccm-dashboard-header-buttons">
+    <div class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <?= t('View') ?>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+            <li<?= ($type === null) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist')?>"><?= t('Options') ?></a></li>
+            <li class="divider"></li>
+            <li<?= ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) ?>"><?= t('Blackisted IP addresses (automatic)') ?></a></li>
+            <li<?= ($type === IPService::IPRANGETYPE_BLACKLIST_MANUAL) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_BLACKLIST_MANUAL) ?>"><?= t('Blackisted IP addresses (manual)') ?></a></li>
+            <li<?= ($type === IPService::IPRANGETYPE_WHITELIST_MANUAL) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_WHITELIST_MANUAL) ?>"><?= t('Whitelisted IP addresses') ?></a></li>
+            <?php
+            if ($type !== null) {
+                $token = Core::make('token');
+                /* @var Concrete\Core\Validation\CSRF\Token $token */
+                ?>
+                <li class="divider"></li>
+                <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, 0, $token->generate("iprange/export/range/{$type}/0")) ?>"><?= t('Export as CSV') ?></a></li>
+                <?php
+                if ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+                    ?>
+                    <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, 1, $token->generate("iprange/export/range/{$type}/1")) ?>"><?= t('Export as CSV (including expired)') ?></a></li>
+                    <?php
+                }
+            }
+            ?>
+        </ul>
+    </div>
+</div>

--- a/concrete/single_pages/dashboard/system/permissions/blacklist.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist.php
@@ -16,31 +16,27 @@ $view->element('dashboard/system/permissions/blacklist/menu', ['type' => null]);
 <form method="post" id="ipblacklist-form" action="<?= $view->action('update_ipblacklist') ?>">
     <?php $token->output('update_ipblacklist') ?>
     <div class="ccm-pane-body">
-        <fieldset>
-            <legend><?= t('Smart IP Banning')?></legend>
+        <div class="form-group form-inline">
+            <?= $form->checkbox('banEnabled', 1, $banEnabled) ?> <?= t('Lock IP after') ?>
+            <?= $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]) ?>
+            <?= t(/*i18n: before we have the number of failed logins, after we have a time duration */'failed login attempts in') ?>
+            <?= $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1]) ?>
+            <?= t('seconds') ?>
+        </div>
 
-            <div class="form-group form-inline">
-                <?= $form->checkbox('banEnabled', 1, $banEnabled) ?> <?= t('Lock IP after') ?>
-                <?= $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]) ?>
-                <?= t(/*i18n: before we have the number of failed logins, after we have a time duration */'failed login attempts in') ?>
-                <?= $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1]) ?>
-                <?= t('seconds') ?>
-            </div>
-
-            <div class="form-inline form-group radio">
-                <?= t('Ban IP For') ?>
-                <br />
-                <label class="radio">
-                    <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
-                    <?= $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px', 'min' => 1]) ?>
-                    <?= t('minutes') ?>
-                </label>
-                <br />
-                <label class="radio">
-                    <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?> <?= t('Forever') ?>
-                </label>
-            </div>
-        </fieldset>
+        <div class="form-inline form-group radio">
+            <?= t('Ban IP For') ?>
+            <br />
+            <label class="radio">
+                <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
+                <?= $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px', 'min' => 1]) ?>
+                <?= t('minutes') ?>
+            </label>
+            <br />
+            <label class="radio">
+                <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?> <?= t('Forever') ?>
+            </label>
+        </div>
     </div>
 
     <div class="ccm-dashboard-form-actions-wrapper">

--- a/concrete/single_pages/dashboard/system/permissions/blacklist.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist.php
@@ -1,116 +1,51 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-/* @var $h ConcreteDashboardHelper */
-$h = Loader::helper('concrete/dashboard');?>
-<form method="post" id="ipblacklist-form" action="<?php echo $view->action('update_ipblacklist')?>">
-	<?php echo $this->controller->token->output('update_ipblacklist')?>
-	<div class="ccm-pane-body">
-			
-			<legend><?php echo t('Smart IP Banning')?></legend>
-			<div class="form-group form-inline">
-				<?php echo $form->checkbox('ip_ban_lock_ip_enable', 1, $ip_ban_enable_lock_ip_after)?> <?php echo t('Lock IP after')?>
-				
-				<?php echo $form->text('ip_ban_lock_ip_attempts', $ip_ban_lock_ip_after_attempts, array('style' => 'width:60px'))?>
-				<?php echo t('failed login attempts');?>		
-				<?php echo t('in');?>		
-				<?php echo $form->text('ip_ban_lock_ip_time', $ip_ban_lock_ip_after_time, array('style' => 'width:60px'))?>
-				<?php echo t('seconds');?>				
-			</div>	
-			<div class="form-inline form-group">
-				<?php echo $form->radio('ip_ban_lock_ip_how_long_type', $ip_ban_lock_ip_how_long_type_timed, $ip_ban_lock_ip_how_long_type)?> <?php echo t('Ban IP For')?>	
-				<?php echo $form->text('ip_ban_lock_ip_how_long_min', $ip_ban_lock_ip_how_long_min, array('style' => 'width:60px'))?>
-				<?php echo t('minutes');?>
-				<?php echo $form->radio('ip_ban_lock_ip_how_long_type', $ip_ban_lock_ip_how_long_type_forever, $ip_ban_lock_ip_how_long_type)?> <?php echo t('Forever')?>					
-			</div>
-			<h4><?php echo t('Automatically Banned IP Addresses')?></h4>
-			<table id="ip-blacklist" class="ccm-results-list table table-condensed table-striped" width="100%" cellspacing="1" cellpadding="0" border="0">
-				<thead>
-				<tr>
-					<th><?php echo $form->checkbox('ip_ban_select_all', 1, false)?> <?php echo t('IP')?></th>
-					<th><?php echo t('Reason For Ban')?></th>
-					<th><?php echo t('Expires In')?></th>
-					<th> 
-						<select name="ip_ban_change_to" id="ip_ban_change_to" class="form-control" style="display: inline-block; width: 50%;">
-							<option value="<?php echo $ip_ban_change_makeperm?>"><?php echo t('Make Ban Permanent')?></option>
-							<option value="<?php echo $ip_ban_change_remove?>"><?php echo t('Remove Ban')?></option>
-						</select>
-						<input type="button" value="<?php echo t('Go')?>" name="submit-ipblacklist" id="submit-ipblacklist" class="btn btn-default" />
-					</th>
-				</tr>
-				</thead>
-				<tbody>
-				<?php  if (count($user_banned_limited_ips) == 0) {
-     ?>
-				<tr>
-					<td colspan="4"><?php  echo t('None')?></td>
-				</tr>
-				<?php 
- } else {
-     ?>
-					<?php  foreach ($user_banned_limited_ips as $user_banned_ip) {
-     ?>
-						<tr>
-							<td><label><?php echo $form->checkbox('ip_ban_changes[]', $user_banned_ip->getUniqueID(), false)?> <?php echo $user_banned_ip->getIPRangeForDisplay()?></label></td>
-							<td><?php echo $user_banned_ip->getReason()?></td>
-							<td><?php echo $this->controller->formatTimestampAsMinutesSeconds($user_banned_ip->expires)?></td>			
-							<td>&nbsp;</td>
-						</tr>		
-					<?php 
- }
-     ?>
-				<?php 
- } ?>
-				</tbody>
-			</table>	
-			<legend><?php echo t('Permanent IP Ban')?></legend>
-			<p class="notes">
-			<?php echo t('Enter IP addresses, one per line, in the form below to manually ban an IP address. To indicate a range, use a wildcard character (e.g. 192.168.15.* will block 192.168.15.1, 192.168.15.2, etc...)')?>			
-			</p>					
-			<textarea id="ip_ban_manual" name="ip_ban_manual" rows="10" style="width: 350px; margin-bottom: 10px;"><?php echo $user_banned_manual_ips?></textarea>
-	</div>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Form\Service\Form $form */
+
+/* @var bool $banEnabled */
+/* @var int $allowedAttempts */
+/* @var int $attemptsTimeWindow */
+/* @var int $banDuration */
+
+$view->element('dashboard/system/permissions/blacklist/menu', ['type' => null]);
+?>
+
+<form method="post" id="ipblacklist-form" action="<?= $view->action('update_ipblacklist') ?>">
+    <?php $token->output('update_ipblacklist') ?>
+    <div class="ccm-pane-body">
+        <fieldset>
+            <legend><?= t('Smart IP Banning')?></legend>
+
+            <div class="form-group form-inline">
+                <?= $form->checkbox('banEnabled', 1, $banEnabled) ?> <?= t('Lock IP after') ?>
+                <?= $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]) ?>
+                <?= t(/*i18n: before we have the number of failed logins, after we have a time duration */'failed login attempts in') ?>
+                <?= $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1]) ?>
+                <?= t('seconds') ?>
+            </div>
+
+            <div class="form-inline form-group radio">
+                <?= t('Ban IP For') ?>
+                <br />
+                <label class="radio">
+                    <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
+                    <?= $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px', 'min' => 1]) ?>
+                    <?= t('minutes') ?>
+                </label>
+                <br />
+                <label class="radio">
+                    <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?> <?= t('Forever') ?>
+                </label>
+            </div>
+        </fieldset>
+    </div>
+
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-
-		<?php 
-        echo $interface->button_js(t('Save'), 'saveIpBlacklist()', 'right', 'btn-primary');
-        ?>
-	    </div>
-	</div>
+            <input type="submit" class="btn btn-primary pull-right" value="<?= t('Save') ?>" />
+        </div>
+    </div>
 </form>
-
-<script type="text/javascript">
-
-var saveIpBlacklist = function(){
-	$("form#ipblacklist-form").get(0).submit();	
-}
-
-//jQuery block for non-submit form logic
-$(document).ready(function(){
-	var sParentSelector;
-	sParentSelector = 'form#ipblacklist-form';	
-	//delegate for any clicks to this form
-	$(sParentSelector).bind('click', function(e){
-		//clicks the parent IP checkbox
-		if ( $(e.target).is('input#ip_ban_select_all') ) {
-			allIPs(e.target);
-		}
-		else if( $(e.target).is('input#submit-ipblacklist') ) {
-			saveIpBlacklist();
-		}
-	});	
-	
-	$(sParentSelector).bind('change', function(e){
-		if ($(e.target).is('select')) {			
-			//$('input[name=submit-ipblacklist]').attr('value',$(':selected',e.target).text());
-		}
-	});
-	
-	function allIPs(t){
-		if(t.checked){
-			$('form#ipblacklist-form table input').attr('checked',true);
-		}
-		else{
-			$('form#ipblacklist-form table input').attr('checked',false);
-		}	
-	}
-});
-</script>

--- a/concrete/single_pages/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist/range.php
@@ -1,0 +1,123 @@
+<?php
+use Concrete\Core\Permission\IPService;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist\Range $controller */
+
+/* @var int $type */
+/* @var Concrete\Core\Permission\IPRange[]|Generator $ranges */
+
+$view->element('dashboard/system/permissions/blacklist/menu', ['type' => $type]);
+
+if (($type & IPService::IPRANGEFLAG_MANUAL) === IPService::IPRANGEFLAG_MANUAL) {
+    ?>
+    <form class="form-inline" id="ccm-form-new-range">
+        <fieldset>
+            <legend><?= t('Add IP Range') ?></legend>
+            <div class="form-group">
+                <label for="new-range" class="launch-tooltip control-label" data-html="true" title="<?= h(t(
+                    'Enter a single address<br />(example: %s) or a range<br />(example: %s or %s).<br />Accept both IPv4 and IPv6 ranges.',
+                    '<code>1.2.3.4</code>',
+                    '<code>1.2.3.*</code>',
+                    '<code>1.2.3.0/8</code>'
+                )) ?>"><?= t('IP Range') ?></label>
+                <input type="text" class="form-control" id="ccm-new-range" required="required" />
+            </div>
+             <button type="submit" class="btn btn-default"><?= t('Add') ?></button>
+        </fieldset>
+    </form>
+    <script>
+    $(document).ready(function() {
+        $('#ccm-form-new-range').on('submit', function(e) {
+            e.preventDefault();
+            var $range = $('#ccm-new-range'), range = $.trim($range.val());
+            if (range === '') {
+                $range.focus();
+                return;
+            }
+            new ConcreteAjaxRequest({
+                url: <?= json_encode($view->action('add_range', $type)) ?>,
+                data: {
+                    ccm_token:<?= json_encode($token->generate('add_range/' . $type)) ?>,
+                    range: range
+                },
+                success: function(data) {
+                    $('#ccm-ranges-table>tbody').append(data.row);
+                    $range.val('');
+                }
+            });
+        });
+    });
+    </script>
+    <?php
+}
+?>
+<table class="table table-hover" id="ccm-ranges-table">
+    <colgroup>
+        <col width="45" />
+    </colgroup>
+    <thead>
+        <tr>
+            <th></th>
+            <th><?= t('Range') ?></th>
+            <?php
+            if ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+                ?>
+                <th><?= t('Expires') ?></th>
+                <th></th>
+                <?php
+            }
+            ?>
+        </tr>
+    </thead>
+    <tbody>
+        <?php
+        foreach ($ranges as $range) {
+            echo $controller->formatRangeRow($range);
+        }
+        ?>
+    </tbody>
+</table>
+<script>
+$(document).ready(function() {
+    $('#ccm-ranges-table>tbody')
+        .on('click', 'a.ccm-iprange-delete', function(e) {
+            e.preventDefault();
+            var $tr = $(this).closest('tr'), id = $tr.data('range-id');
+            new ConcreteAjaxRequest({
+                url: <?= json_encode($view->action('delete_range', $type)) ?>,
+                data: {
+                    ccm_token:<?= json_encode($token->generate('delete_range/' . $type)) ?>,
+                    id: id
+                },
+                success: function(data) {
+                    $tr.hide('fast', function() {
+                        $tr.remove();
+                    });
+                }
+            });
+        })
+        .on('click', 'a.ccm-iprange-makepermanent', function(e) {
+            e.preventDefault();
+            var $tr = $(this).closest('tr'), id = $tr.data('range-id');
+            new ConcreteAjaxRequest({
+                url: <?= json_encode($view->action('make_range_permanent', $type)) ?>,
+                data: {
+                    ccm_token:<?= json_encode($token->generate('make_range_permanent/' . $type)) ?>,
+                    id: id
+                },
+                success: function(data) {
+                    $tr.hide('fast', function() {
+                        $tr.remove();
+                    });
+                }
+            });
+
+        })
+    ;
+});
+</script>

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -2,14 +2,17 @@
 namespace Concrete\Core\Package;
 
 use AuthenticationType;
+use Concrete\Block\ExpressForm\Controller as ExpressFormBlockController;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Config\Renderer;
 use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Entity\Site\Locale;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\File\Service\File;
+use Concrete\Core\Localization\Localization;
 use Concrete\Core\Mail\Importer\MailImporter;
 use Concrete\Core\Package\Routine\AttachModeInstallRoutine;
+use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use Concrete\Core\Permission\Access\Entity\ConversationMessageAuthorEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\UserEntity;
@@ -18,24 +21,21 @@ use Concrete\Core\Tree\Node\Type\ExpressEntryCategory;
 use Concrete\Core\Tree\Type\ExpressEntryResults;
 use Concrete\Core\Updater\Migrations\Configuration;
 use Concrete\Core\User\Point\Action\Action as UserPointAction;
-use Concrete\Block\ExpressForm\Controller as ExpressFormBlockController;
 use Config;
 use Core;
 use Database;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
+use Exception;
 use Group;
 use GroupTree;
 use Hautelook\Phpass\PasswordHash;
 use Package as BasePackage;
 use Page;
-use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use PermissionKey;
+use Throwable;
 use User;
 use UserInfo;
-use Concrete\Core\Localization\Localization;
-use Exception;
-use Throwable;
 
 class StartingPointPackage extends BasePackage
 {
@@ -320,7 +320,7 @@ class StartingPointPackage extends BasePackage
     protected function install_database()
     {
         $db = Database::get();
-        $num = $db->GetCol("show tables");
+        $num = $db->GetCol('show tables');
 
         if (count($num) > 0) {
             throw new \Exception(
@@ -391,18 +391,18 @@ class StartingPointPackage extends BasePackage
         // create the groups our site users
         // specify the ID's since auto increment may not always be +1
         $g1 = Group::add(
-            tc("GroupName", "Guest"),
-            tc("GroupDescription", "The guest group represents unregistered visitors to your site."),
+            tc('GroupName', 'Guest'),
+            tc('GroupDescription', 'The guest group represents unregistered visitors to your site.'),
             false,
             false,
             GUEST_GROUP_ID);
         $g2 = Group::add(
-            tc("GroupName", "Registered Users"),
-            tc("GroupDescription", "The registered users group represents all user accounts."),
+            tc('GroupName', 'Registered Users'),
+            tc('GroupDescription', 'The registered users group represents all user accounts.'),
             false,
             false,
             REGISTERED_GROUP_ID);
-        $g3 = Group::add(tc("GroupName", "Administrators"), "", false, false, ADMIN_GROUP_ID);
+        $g3 = Group::add(tc('GroupName', 'Administrators'), '', false, false, ADMIN_GROUP_ID);
 
         // insert admin user into the user table
         if (defined('INSTALL_USER_PASSWORD')) {
@@ -544,19 +544,19 @@ class StartingPointPackage extends BasePackage
         $u->saveConfig('NEWSFLOW_LAST_VIEWED', 'FIRSTRUN');
 
         // login
-        $login = Page::getByPath('/login', "RECENT");
+        $login = Page::getByPath('/login', 'RECENT');
         $login->assignPermissions($g1, ['view_page']);
 
         // register
-        $register = Page::getByPath('/register', "RECENT");
+        $register = Page::getByPath('/register', 'RECENT');
         $register->assignPermissions($g1, ['view_page']);
 
         // dashboard
-        $dashboard = Page::getByPath('/dashboard', "RECENT");
+        $dashboard = Page::getByPath('/dashboard', 'RECENT');
         $dashboard->assignPermissions($g3, ['view_page']);
 
         // drafts
-        $drafts = Page::getByPath('/!drafts', "RECENT");
+        $drafts = Page::getByPath('/!drafts', 'RECENT');
         $drafts->assignPermissions(
             $g3,
             [
@@ -581,7 +581,7 @@ class StartingPointPackage extends BasePackage
             ]
         );
 
-        $home = Page::getByID(1, "RECENT");
+        $home = Page::getByID(1, 'RECENT');
         $home->assignPermissions($g1, ['view_page']);
         $home->assignPermissions(
             $g3,

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -366,8 +366,6 @@ class StartingPointPackage extends BasePackage
 
         $db->Execute('ALTER TABLE PagePaths ADD INDEX (`cPath` (255))');
         $db->Execute('ALTER TABLE Groups ADD INDEX (`gPath` (255))');
-        $db->Execute('ALTER TABLE SignupRequests ADD INDEX (`ipFrom` (32))');
-        $db->Execute('ALTER TABLE UserBannedIPs ADD UNIQUE INDEX (ipFrom (32), ipTo(32))');
     }
 
     protected function add_users()

--- a/concrete/src/Permission/IPRange.php
+++ b/concrete/src/Permission/IPRange.php
@@ -1,0 +1,89 @@
+<?php
+namespace Concrete\Core\Permission;
+
+use DateTime;
+use IPLib\Factory as IPFactory;
+use IPLib\Range\RangeInterface;
+
+class IPRange
+{
+    /**
+     * Record identifier.
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * IP address range.
+     *
+     * @var RangeInterface
+     */
+    protected $ipRange;
+
+    /**
+     * Range type.
+     *
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * @var DateTime|null
+     */
+    protected $expires;
+
+    /**
+     * Get the record identifier.
+     *
+     * @return int
+     */
+    public function getID()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the IP address range.
+     *
+     * @return \IPLib\Range\RangeInterface
+     */
+    public function getIpRange()
+    {
+        return $this->ipRange;
+    }
+
+    /**
+     * Get the range type.
+     *
+     * @return int
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getExpires()
+    {
+        return $this->expires;
+    }
+
+    /**
+     * @param array $row
+     *
+     * @return static
+     */
+    public static function createFromRow(array $row, $dateTimeFormat)
+    {
+        $result = new static();
+        $result->id = empty($row['lcirID']) ? null : (int) $row['lcirID'];
+        $result->ipRange = IPFactory::rangeFromBoundaries($row['lcirIpFrom'], $row['lcirIpTo']);
+        $result->type = (int) $row['lcirType'];
+        $result->expires = empty($row['lcirExpires']) ? null : DateTime::createFromFormat($dateTimeFormat, $row['lcirExpires']);
+
+        return $result;
+    }
+}

--- a/concrete/src/Permission/IPRangesCsvWriter.php
+++ b/concrete/src/Permission/IPRangesCsvWriter.php
@@ -1,0 +1,124 @@
+<?php
+namespace Concrete\Core\Permission;
+
+use Concrete\Core\Localization\Service\Date;
+use League\Csv\Writer;
+
+class IPRangesCsvWriter
+{
+    /**
+     * The writer we use to output.
+     *
+     * @var Writer
+     */
+    protected $writer;
+
+    /**
+     * One of the IPService::IPRANGETYPE_... constants.
+     *
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * The date localization service.
+     *
+     * @var Date
+     */
+    protected $dateHelper;
+
+    /**
+     * @param Writer $writer the writer we use to output
+     * @param int $type One of the IPService::IPRANGETYPE_... constants
+     * @param Date $dateHelper the Date localization service
+     */
+    public function __construct(Writer $writer, $type, Date $dateHelper)
+    {
+        $this->writer = $writer;
+        $this->type = $type;
+        $this->dateHelper = $dateHelper;
+    }
+
+    /**
+     * Insert a header row for this result set.
+     */
+    public function insertHeaders()
+    {
+        $this->writer->insertOne($this->getHeaders());
+    }
+
+    /**
+     * Insert a list of IPRange instances.
+     *
+     * @param IPRange[]|Generator $ranges
+     */
+    public function insertRanges($ranges)
+    {
+        $this->writer->insertAll($this->projectRanges($ranges));
+    }
+
+    /**
+     * Insert an IPRange instance.
+     *
+     * @param IPRange $range
+     */
+    public function insertRange(IPRange $range)
+    {
+        $this->writer->insertOne($this->projectRange($range));
+    }
+
+    /**
+     * A generator that takes a collection of IPRange ranges and converts it to CSV rows.
+     *
+     * @param IPRange[]|Generator $list
+     *
+     * @return array[]|Generator
+     */
+    private function projectRanges($ranges)
+    {
+        foreach ($ranges as $range) {
+            yield $this->projectRange($range);
+        }
+    }
+
+    /**
+     * Turn an IPRange instance into an array.
+     *
+     * @param IPRange $range
+     *
+     * @return string[]
+     */
+    private function projectRange(IPRange $range)
+    {
+        $result = [
+            $range->getIpRange()->toString(),
+            $range->getIpRange()->getComparableStartString(),
+            $range->getIpRange()->getComparableEndString(),
+        ];
+        if ($this->type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+            $dt = $range->getExpires();
+            if ($dt === null) {
+                $result[] = '';
+            } else {
+                $result[] = $this->dateHelper->formatCustom('c', $dt);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the headers of the CSV.
+     *
+     * @return string[]
+     */
+    private function getHeaders()
+    {
+        $headers = [t('IP Range'), t('Start address'), t('End address')];
+        if ($this->type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+            $headers[] = t('Expiration');
+        }
+
+        return $headers;
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
@@ -1,0 +1,32 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170412000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshDatabaseTables([
+            'FailedLoginAttempts',
+            'LoginControlIpRanges',
+        ]);
+        $this->connection->executeQuery('DROP TABLE IF EXISTS SignupRequests');
+        $this->connection->executeQuery('DROP TABLE IF EXISTS UserBannedIPs');
+
+        // Add the new dashboard page to show IP ranges
+        $sp = Page::getByPath('/dashboard/system/permissions/blacklist/range');
+        if (!is_object($sp) || $sp->isError()) {
+            $sp = SinglePage::add('/dashboard/system/permissions/blacklist/range');
+            $sp->update(['cName' => 'IP Range']);
+            $sp->setAttribute('exclude_nav', true);
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/concrete/src/User/UserBannedIp.php
+++ b/concrete/src/User/UserBannedIp.php
@@ -7,10 +7,11 @@ namespace Concrete\Core\User;
 class UserBannedIp
 {
     protected $unique_keys;
+
     public function __construct($db_name = false, $keys = false)
     {
         if (!$keys) {
-            $keys = array('ipFrom', 'ipTo');
+            $keys = ['ipFrom', 'ipTo'];
         }
         $this->unique_keys = $keys;
     }
@@ -29,8 +30,8 @@ class UserBannedIp
     public function parseUniqueID($id)
     {
         $ids = preg_split('{-}', $id, null, PREG_SPLIT_NO_EMPTY);
-        $info = array();
-        for ($i = 0;$i < count($ids);++$i) {
+        $info = [];
+        for ($i = 0; $i < count($ids); ++$i) {
             $info[$this->unique_keys[$i]] = $ids[$i];
         }
 
@@ -45,7 +46,7 @@ class UserBannedIp
             $to = preg_split('{\.}', long2ip($this->ipTo));
             $from = preg_split('{\.}', long2ip($this->ipFrom));
             $ip = '';
-            for ($i = 0;$i < 4;++$i) {
+            for ($i = 0; $i < 4; ++$i) {
                 $ip = $ip . (($to[$i] == $from[$i]) ? $to[$i] : '*');
                 $ip .= '.';
             }
@@ -65,6 +66,7 @@ class UserBannedIp
     }
 
     const IP_BAN_CODE_REGISTRATION_THROTTLE = 1;
+
     public function getCodeText($code)
     {
         switch ($code) {

--- a/concrete/src/User/UserBannedIp.php
+++ b/concrete/src/User/UserBannedIp.php
@@ -1,8 +1,9 @@
 <?php
 namespace Concrete\Core\User;
 
-use Loader;
-
+/**
+ * @deprecated
+ */
 class UserBannedIp
 {
     protected $unique_keys;
@@ -56,28 +57,11 @@ class UserBannedIp
 
     public function Find($where)
     {
-        $db = Loader::db();
-        $r = $db->Execute('select * from UserBannedIPs where ' . $where);
-        $ips = array();
-        while ($row = $r->FetchRow()) {
-            $ip = new self();
-            $ip = array_to_object(new self(), $row);
-            $ips[] = $ip;
-        }
-
-        return $ips;
+        return [];
     }
 
     public function save()
     {
-        $db = Loader::db();
-        $db->Replace('UserBannedIPs', array(
-            'ipFrom' => $this->ipFrom,
-            'ipTo' => $this->ipTo,
-            'banCode' => $this->banCode,
-            'expires' => $this->expires,
-            'isManual' => $this->isManual,
-        ), array('ipFrom', 'ipTo'));
     }
 
     const IP_BAN_CODE_REGISTRATION_THROTTLE = 1;

--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -1,16 +1,15 @@
 <?php
 use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Database\Schema\Schema;
+use Concrete\Core\Support\Facade\Application;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\PDOConnection;
-use Concrete\Core\Support\Facade\Application;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Imagine\Exception\RuntimeException;
 
 class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 {
-
     /** @var Connection The cached database connection */
     public static $connection = null;
 
@@ -33,7 +32,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     protected $metadatas = [];
 
     /**
-     * Get the connection to use
+     * Get the connection to use.
      *
      * @return \Concrete\Core\Database\Connection\Connection
      */
@@ -50,6 +49,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
      * Returns the test database connection.
      *
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+     *
      * @throws \Imagine\Exception\RuntimeException
      */
     protected function getConnection()
@@ -76,12 +76,12 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Set up before any tests run
+     * Set up before any tests run.
      */
     public static function setUpBeforeClass()
     {
         // Make sure tables are imported
-        $testCase = new Static();
+        $testCase = new static();
         $testCase->importTables();
         $testCase->importMetadatas();
 
@@ -90,12 +90,12 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Tear down after class has completed
+     * Tear down after class has completed.
      */
     public static function tearDownAfterClass()
     {
         // Make sure tables are removed
-        $testCase = new Static();
+        $testCase = new static();
         $testCase->removeTables();
 
         // Call parent teardown
@@ -103,14 +103,14 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Import tables from $this->tables
+     * Import tables from $this->tables.
      */
     protected function importTables()
     {
         $connection = $this->connection();
 
         // Filter out any tables that have already been imported
-        $tables = array_filter($this->tables, function($table) {
+        $tables = array_filter($this->tables, function ($table) {
             return !isset(static::$existingTables[$table]);
         });
 
@@ -132,7 +132,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Remove all existing tables
+     * Remove all existing tables.
      */
     protected function removeTables()
     {
@@ -159,9 +159,10 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Extract the table data from the db.xml
+     * Extract the table data from the db.xml.
      *
      * @param array $tables
+     *
      * @return array|null
      */
     protected function extractTableData(array $tables)
@@ -180,14 +181,14 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 
         // Loop through tables that exist in the document
         foreach ($xml1->table as $table) {
-            $name = (string)$table['name'];
+            $name = (string) $table['name'];
 
             // If this table is being requested
             if (in_array($name, $tables, false)) {
                 $this->appendXML($partial, $table);
 
                 // Remove the table from our list of tables
-                $tables = array_filter($tables, function($name) use ($table) {
+                $tables = array_filter($tables, function ($name) use ($table) {
                     return $name !== $table;
                 });
 
@@ -207,10 +208,11 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Import needed tables
+     * Import needed tables.
      *
      * @param SimpleXMLElement $xml
      * @param Connection $connection
+     *
      * @internal param $partial
      */
     protected function importTableXML(SimpleXMLElement $xml, Connection $connection)
@@ -243,7 +245,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Import requested metadatas
+     * Import requested metadatas.
      */
     protected function importMetadatas()
     {
@@ -255,7 +257,8 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Gets the metadatas to import
+     * Gets the metadatas to import.
+     *
      * @return array
      */
     protected function getMetadatas()
@@ -275,7 +278,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
                     $metadatas[] = $meta;
 
                     // Remove this from the list of entities to install
-                    $install = array_filter($install, function($name) use ($meta) {
+                    $install = array_filter($install, function ($name) use ($meta) {
                         return $name !== $meta->getName();
                     });
 
@@ -301,7 +304,8 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Append an xml onto another xml
+     * Append an xml onto another xml.
+     *
      * @param \SimpleXMLElement $root
      * @param \SimpleXMLElement $new
      */
@@ -324,7 +328,8 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Truncate all known databases
+     * Truncate all known databases.
+     *
      * @param null|array $tables The tables to truncate
      */
     protected function truncateTables($tables = null)
@@ -350,5 +355,4 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
         // Reset foreign key checks on
         $connection->exec('SET FOREIGN_KEY_CHECKS = 1');
     }
-
 }

--- a/tests/tests/ConcreteDatabaseTestCase.php
+++ b/tests/tests/ConcreteDatabaseTestCase.php
@@ -35,7 +35,7 @@ class ConcreteDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
     /**
      * Get the connection to use
      *
-     * @return \Doctrine\DBAL\Driver\Connection
+     * @return \Concrete\Core\Database\Connection\Connection
      */
     protected function connection()
     {

--- a/tests/tests/Core/Permission/IPServiceTest.php
+++ b/tests/tests/Core/Permission/IPServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+namespace Concrete\Tests\Core\Permission;
+
+use Concrete\Core\Permission\IPService;
+use Concrete\Core\Support\Facade\Application;
+use ConcreteDatabaseTestCase;
+use DateTime;
+use IPLib\Factory as IPFactory;
+
+class IPServiceTest extends ConcreteDatabaseTestCase
+{
+    protected $tables = [
+        'FailedLoginAttempts',
+        'LoginControlIpRanges',
+    ];
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    private $config;
+
+    /**
+     * @var array
+     */
+    private $originalConfig;
+
+    /**
+     * @var IPService
+     */
+    private $ipService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->connection()->executeQuery('DELETE FROM FailedLoginAttempts');
+        $this->connection()->executeQuery('DELETE FROM LoginControlIpRanges');
+        $app = Application::getFacadeApplication();
+        $this->config = $app->make('config');
+        $this->originalConfig = $this->config->get('concrete.security.ban.ip');
+        $this->ipService = $app->build(
+            IPService::class,
+            [
+                'config' => $this->config,
+                'connection' => $this->connection(),
+            ]
+        );
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->config->set('concrete.security.ban.ip', $this->originalConfig);
+    }
+
+    public function automaticBanEnabledProvider()
+    {
+        return [
+            [1],
+            [2],
+            [5],
+        ];
+    }
+
+    /**
+     * @dataProvider automaticBanEnabledProvider
+     */
+    public function testAutomaticBanEnabled($allowedAttempts)
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', true);
+        $this->config->set('concrete.security.ban.ip.attempts', $allowedAttempts);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        for ($attempt = 1; $attempt <= $allowedAttempts; ++$attempt) {
+            $this->assertFalse($this->ipService->isWhitelisted($ip));
+            $this->assertFalse($this->ipService->isBlacklisted($ip));
+            $this->assertFalse($this->ipService->failedLoginsThresholdReached($ip));
+            $this->ipService->logFailedLogin($ip);
+            if ($attempt < $allowedAttempts) {
+                $this->assertFalse($this->ipService->failedLoginsThresholdReached($ip));
+            } else {
+                $this->assertTrue($this->ipService->failedLoginsThresholdReached($ip));
+            }
+        }
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->addToBlacklistForThresholdReached($ip);
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertTrue($this->ipService->isBlacklisted($ip));
+        $ip2 = IPFactory::addressFromString('::');
+        $this->assertFalse($this->ipService->isWhitelisted($ip2));
+        $this->assertFalse($this->ipService->isBlacklisted($ip2));
+    }
+
+    public function testAutomaticBanDisabled()
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', false);
+        $this->config->set('concrete.security.ban.ip.attempts', 3);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        for ($attempt = 1; $attempt <= 10; ++$attempt) {
+            $this->ipService->logFailedLogin($ip);
+        }
+        $this->assertFalse($this->ipService->failedLoginsThresholdReached($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+    }
+
+    public function testWhitelisted()
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', true);
+        $this->config->set('concrete.security.ban.ip.attempts', 3);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL);
+        $this->assertTrue($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        for ($attempt = 1; $attempt <= 10; ++$attempt) {
+            $this->ipService->logFailedLogin($ip);
+        }
+        $this->assertFalse($this->ipService->failedLoginsThresholdReached($ip));
+        $this->assertTrue($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+    }
+
+    public function testBlacklistedPermament()
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', true);
+        $this->config->set('concrete.security.ban.ip.attempts', 3);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_MANUAL);
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertTrue($this->ipService->isBlacklisted($ip));
+    }
+
+    public function testBlacklistedExpiration()
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', true);
+        $this->config->set('concrete.security.ban.ip.attempts', 3);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('-1 seconds'));
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 seconds'));
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertTrue($this->ipService->isBlacklisted($ip));
+    }
+
+    public function testBlacklistedVsWhitelisted()
+    {
+        $this->config->set('concrete.security.ban.ip.enabled', true);
+        $this->config->set('concrete.security.ban.ip.attempts', 3);
+        $this->config->set('concrete.security.ban.ip.time', 300);
+        $this->config->set('concrete.security.ban.ip.length', 10);
+        $ip = IPFactory::addressFromString('1.2.3.4');
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 hours'));
+        $this->assertFalse($this->ipService->isWhitelisted($ip));
+        $this->assertTrue($this->ipService->isBlacklisted($ip));
+        $this->ipService->createRange(IPFactory::rangeFromString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL, new DateTime('+10 hours'));
+        $this->assertTrue($this->ipService->isWhitelisted($ip));
+        $this->assertFalse($this->ipService->isBlacklisted($ip));
+    }
+}


### PR DESCRIPTION
Fix #3149
Fix #4100
Fix #5029

I also added support for whitelisted IP address ranges.

For instance, you can permanently ban (blacklist) all ip addresses, both IPv6 and IPv4 (`::/0` and `*.*.*.*`), and whitelist only selected IP addresses: that way, the login is only allowed from those selected addresses.

### Before

![image](https://cloud.githubusercontent.com/assets/928116/24948981/63d32688-1f6c-11e7-8ae4-0b164b6fe0ad.png)

### After

![image](https://cloud.githubusercontent.com/assets/928116/24949034/8d5b5e9e-1f6c-11e7-8986-e0c53cc12956.png)

-----

![image](https://cloud.githubusercontent.com/assets/928116/24949154/eeab8a52-1f6c-11e7-9df3-a717e171f03e.png)

-----

![image](https://cloud.githubusercontent.com/assets/928116/24949211/184a4358-1f6d-11e7-93b2-aa3ac6831778.png)

-----

![image](https://cloud.githubusercontent.com/assets/928116/24949253/355dbc9a-1f6d-11e7-89b4-78b65425b9d0.png)
