### PR TITLE
add GIF to supportsThumbnails()

### DIFF
--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -421,7 +421,7 @@ class Type
      */
     public function supportsThumbnails()
     {
-        if ($this->getName() == 'PNG' || $this->getName() == 'JPEG') {
+        if ($this->getName() == 'PNG' || $this->getName() == 'JPEG'|| $this->getName() == 'GIF') {
             return true;
         }
     }


### PR DESCRIPTION
I mistakenly left out GIF when creating the supportsThumbnails() method.