### PR TITLE
Prevent errors when SVG images are used with the Image block

### DIFF
--- a/concrete/src/Http/Middleware/ThumbnailMiddleware.php
+++ b/concrete/src/Http/Middleware/ThumbnailMiddleware.php
@@ -130,7 +130,11 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
                 $this->getThumbnailer()->getThumbnail($file, $width, $height, (bool) $crop);
             } elseif ($type = Version::getByHandle($thumbnail['thumbnailTypeHandle'])) {
                 // This is a predefined thumbnail type, lets just call the version->rescan
-                $file->getVersion($thumbnail['fileVersionID'])->generateThumbnail($type);
+                $fv = $file->getVersion($thumbnail['fileVersionID']);
+
+                if ($fv->getTypeObject()->supportsThumbnails()) {
+                    $fv->generateThumbnail($type);
+                }
             }
         } catch (\Exception $e) {
             // Catch any exceptions so we don't break the page and return false


### PR DESCRIPTION
In concrete5 5.7, there was a bug that allowed for SVG images to be displayed using the Image block. The image would be displayed as a picture element with multiple duplicate srcset attributes. In concrete5 v8, using SVG images in the Image block triggers an error.

https://www.concrete5.org/community/forums/submitting-to-the-marketplace/svg-issue-notify-existing-stucco-users-or-hurry-up-to-fix-and-re/

**Errors:**

![supports_thumbnails_check-error1](https://cloud.githubusercontent.com/assets/10898145/25060910/e88a3108-2176-11e7-805d-d653cdad35d8.png)

![supports_thumbnails_check-error2](https://cloud.githubusercontent.com/assets/10898145/25060911/ec231456-2176-11e7-9d76-ecb0f918ab00.png)