### PR TITLE
Make thumbnail cache clearing optional

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -254,7 +254,7 @@ return [
         ],
 
         'clear' => [
-            'thumbnails' => true
+            'thumbnails' => false
         ],
     ],
 

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -252,6 +252,10 @@ return [
                 ],
             ],
         ],
+
+        'clear' => [
+            'thumbnails' => true
+        ],
     ],
 
     'multilingual' => [
@@ -573,7 +577,7 @@ return [
             'api_token' => '',
             // Languages below this translation progress won't be considered
             'progress_limit' => 60,
-            // Lifetime (in seconds) of the cache items associated to downloaded data 
+            // Lifetime (in seconds) of the cache items associated to downloaded data
             'cache_lifetime' => 3600, // 1 hour
         ],
     ],

--- a/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
+++ b/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
@@ -1,8 +1,10 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Optimization;
 
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Core;
+use Symfony\Component\HttpFoundation\Request;
 
 class Clearcache extends DashboardPageController
 {
@@ -16,8 +18,10 @@ class Clearcache extends DashboardPageController
     {
         if ($this->token->validate("clear_cache")) {
             if ($this->isPost()) {
-                $cms = Core::make('app');
-                $cms->clearCaches();
+                $thumbnails = $this->request('thumbnails') === '1';
+                $this->app->make(Repository::class)->save('concrete.cache.clear.thumbnails', $thumbnails);
+
+                $this->app->clearCaches();
                 $this->redirect('/dashboard/system/optimization/clearcache', 'cache_cleared');
             }
         } else {

--- a/concrete/single_pages/dashboard/system/optimization/clearcache.php
+++ b/concrete/single_pages/dashboard/system/optimization/clearcache.php
@@ -3,8 +3,13 @@
 <form method="post" id="clear-cache-form" action="<?php echo $view->url('/dashboard/system/optimization/clearcache', 'do_clear')?>">
 	<?php echo $this->controller->token->output('clear_cache')?>
     <p><?php echo t('If your site is displaying out-dated information, or behaving unexpectedly, it may help to clear your cache.')?></p>
-    <br/>
-    <?php echo $interface->submit(t('Clear Cache'), 'clear-cache-form', '', 'btn-primary'); ?>
+    <label>
+        <input type="checkbox" name="thumbnails" value="1" <?= \Config::get('concrete.cache.clear.thumbnails', true) ? 'checked' : '' ?> />
+        <?= t('Clear thumbnail cache') ?>
+    </label>
+    <div>
+        <?= $interface->submit(t('Clear Cache'), 'clear-cache-form', '', 'btn-primary'); ?>
+    </div>
 </form>
 
 

--- a/concrete/single_pages/dashboard/system/optimization/clearcache.php
+++ b/concrete/single_pages/dashboard/system/optimization/clearcache.php
@@ -2,12 +2,16 @@
 
 <form method="post" id="clear-cache-form" action="<?php echo $view->url('/dashboard/system/optimization/clearcache', 'do_clear')?>">
 	<?php echo $this->controller->token->output('clear_cache')?>
-    <p><?php echo t('If your site is displaying out-dated information, or behaving unexpectedly, it may help to clear your cache.')?></p>
-    <label>
-        <input type="checkbox" name="thumbnails" value="1" <?= \Config::get('concrete.cache.clear.thumbnails', true) ? 'checked' : '' ?> />
-        <?= t('Clear thumbnail cache') ?>
-    </label>
-    <div>
+    <div class="form-group">
+        <p><?php echo t('If your site is displaying out-dated information, or behaving unexpectedly, it may help to clear your cache.')?></p>
+    </div>
+    <div class="checkbox">
+        <label>
+            <input type="checkbox" name="thumbnails" value="1" <?= \Config::get('concrete.cache.clear.thumbnails', true) ? 'checked' : '' ?> />
+            <?= t('Clear cached thumbnails') ?>
+        </label>
+    </div>
+    <div class="form-group">
         <?= $interface->submit(t('Clear Cache'), 'clear-cache-form', '', 'btn-primary'); ?>
     </div>
 </form>

--- a/concrete/src/Cache/Cache.php
+++ b/concrete/src/Cache/Cache.php
@@ -20,7 +20,7 @@ use Stash\Pool;
  * This class imports the various caching settings from Config class, sets
  * up the Stash pools and provides a basic caching API for all of Concrete5.
  */
-abstract class Cache
+abstract class Cache implements FlushableInterface
 {
     /** @var Pool */
     public $pool = null;

--- a/concrete/src/Cache/CacheClearer.php
+++ b/concrete/src/Cache/CacheClearer.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Concrete\Core\Cache;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Block\BlockType\BlockType;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Database\DatabaseManager;
+use Concrete\Core\Foundation\Environment;
+use Concrete\Core\Localization\Localization;
+use FilesystemIterator;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class CacheClearer
+{
+
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher */
+    private $dispatcher;
+
+    /** @var \Concrete\Core\Application\Application */
+    private $application;
+
+    /** @var \Concrete\Core\Database\DatabaseManager */
+    private $manager;
+
+    /** @var \Concrete\Core\Config\Repository\Repository */
+    private $repository;
+
+    /** @var \Illuminate\Filesystem\Filesystem */
+    private $filesystem;
+
+    /** @var \Concrete\Core\Cache\Level\ObjectCache */
+    private $caches = [
+        'cache' => 'cache',
+        'expensive' => 'cache/expensive',
+        'overrides' => 'cache/overrides',
+        'request' => 'cache/request',
+        'page' => 'cache/page'
+    ];
+
+    public function __construct(
+        EventDispatcher $dispatcher,
+        DatabaseManager $manager,
+        Repository $repository,
+        Application $application,
+        Filesystem $filesystem
+    ) {
+        $this->dispatcher = $dispatcher;
+        $this->application = $application;
+        $this->manager = $manager;
+        $this->repository = $repository;
+        $this->filesystem = $filesystem;
+    }
+
+    public function flush()
+    {
+        $this->dispatcher->dispatch('on_cache_flush');
+
+        // Flush the cache objects
+        $this->flushCaches();
+
+        // Clear the /files/cache directory
+        $directory = $this->repository->get('concrete.cache.directory');
+        $this->clearCacheDirectory($directory);
+
+        // Clear the file thumbnail path cache
+        $this->clearDatabaseCache();
+
+        // clear the environment overrides cache (This is probably already cleared)
+        $this->application->make(Environment::class)->clearOverrideCache();
+
+        // Clear localization cache
+        $this->clearLocalizationCache();
+
+        // clear block type cache
+        $this->clearBlockTypeCache();
+
+        // Clear precompiled script bytecode caches
+        $this->clearOpcodeCache();
+
+        // Setup the filesystem
+        $this->setupFilesystem();
+
+        $this->dispatcher->dispatch('on_cache_flush_end');
+    }
+
+    /**
+     * Set a cache object to be cleared
+     *
+     * @param $handle
+     * @param $cache
+     */
+    public function setCache($handle, $cache)
+    {
+        $this->caches[$handle] = $cache;
+    }
+
+    /**
+     * A generator that populates the cache objects from the container
+     * @return \Generator|FlushableInterface[]
+     */
+    protected function getCaches()
+    {
+        foreach ($this->caches as $key => $cache) {
+            if (!$cache instanceof FlushableInterface) {
+                $cache = $this->application->make($cache);
+            }
+
+            if ($cache instanceof FlushableInterface) {
+                yield $key => $cache;
+            }
+        }
+    }
+
+    /**
+     * Flush all the caches
+     */
+    protected function flushCaches()
+    {
+        foreach ($this->getCaches() as $key => $cache) {
+            $cache->flush();
+        }
+    }
+
+    /**
+     * Clear out items from the cache directory
+     * @param $directory
+     */
+    protected function clearCacheDirectory($directory)
+    {
+        foreach ($this->filesToClear($directory) as $file) {
+            if ($file->isDir()) {
+                $this->filesystem->deleteDirectory($file->getPathname());
+            } else {
+                $this->filesystem->delete($file->getPathname());
+            }
+        }
+    }
+
+    /**
+     * @param $directory
+     * @return \Generator|\SplFileInfo[]
+     */
+    protected function filesToClear($directory)
+    {
+        $iterator = new FilesystemIterator($directory);
+        $exclude = [];
+
+        if (!$this->repository->get('concrete.cache.clear.thumbnails', true)) {
+            $exclude[] = $directory . '/thumbnails';
+        }
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            if (!in_array($item->getPathname(), $exclude, true)) {
+                yield $item;
+            }
+        }
+    }
+
+    private function setupFilesystem()
+    {
+        $directory = $this->repository->get('concrete.cache.directory');
+        $perms = $this->repository->get('concrete.filesystem.permissions');
+        $directoryPermissions = array_get($perms, 'directory');
+        $filePermissions = array_get($perms, 'file');
+
+        $create = [
+            $directory,
+            $directory . '/thumbnails'
+        ];
+
+        foreach ($create as $dir) {
+            if (is_dir($dir) || $this->filesystem->makeDirectory($dir, $directoryPermissions)) {
+                if (!$this->filesystem->exists($dir . '/index.html')) {
+                    @touch($dir . '/index.html', $filePermissions);
+                }
+            }
+        }
+    }
+
+    private function clearDatabaseCache()
+    {
+        $connection = $this->manager->connection();
+        $sql = $connection->getDatabasePlatform()->getTruncateTableSQL('FileImageThumbnailPaths');
+        try {
+            $connection->executeUpdate($sql);
+        } catch (Exception $e) {
+        }
+    }
+
+    protected function clearLocalizationCache()
+    {
+        Localization::clearCache();
+    }
+
+    protected function clearBlockTypeCache()
+    {
+        BlockType::clearCache();
+    }
+
+    protected function clearOpcodeCache()
+    {
+        OpCache::clear();
+    }
+}

--- a/concrete/src/Cache/CacheClearer.php
+++ b/concrete/src/Cache/CacheClearer.php
@@ -8,6 +8,7 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Database\DatabaseManager;
 use Concrete\Core\Foundation\Environment;
 use Concrete\Core\Localization\Localization;
+use Exception;
 use FilesystemIterator;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/concrete/src/Cache/CacheServiceProvider.php
+++ b/concrete/src/Cache/CacheServiceProvider.php
@@ -1,21 +1,20 @@
 <?php
-/**
- * Created by IntelliJ IDEA.
- * User: christopher
- * Date: 9/4/14
- * Time: 12:42 AM.
- */
+
 namespace Concrete\Core\Cache;
 
+use Concrete\Core\Cache\Page\PageCache;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
 class CacheServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('cache', '\Concrete\Core\Cache\Level\ObjectCache');
-        $this->app->singleton('cache/request', '\Concrete\Core\Cache\Level\RequestCache');
-        $this->app->singleton('cache/expensive', '\Concrete\Core\Cache\Level\ExpensiveCache');
-        $this->app->singleton('cache/overrides', '\Concrete\Core\Cache\Level\OverridesCache');
+        $this->app->singleton('cache', Level\ObjectCache::class);
+        $this->app->singleton('cache/request', Level\RequestCache::class);
+        $this->app->singleton('cache/expensive', Level\ExpensiveCache::class);
+        $this->app->singleton('cache/overrides', Level\OverridesCache::class);
+        $this->app->singleton('cache/page', function() {
+            return PageCache::getLibrary();
+        });
     }
 }

--- a/concrete/src/Cache/FlushableInterface.php
+++ b/concrete/src/Cache/FlushableInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Concrete\Core\Cache;
+
+/**
+ * A cache store that has the ability to be flushed
+ */
+interface FlushableInterface
+{
+
+    /**
+     * Removes all values from the cache.
+     */
+    public function flush();
+}

--- a/concrete/src/Cache/Page/PageCache.php
+++ b/concrete/src/Cache/Page/PageCache.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Cache\Page;
 
+use Concrete\Core\Cache\FlushableInterface;
 use Concrete\Core\Http\Response;
 use Config;
 use Request;
@@ -11,7 +12,7 @@ use Permissions;
 use User;
 use Session;
 
-abstract class PageCache
+abstract class PageCache implements FlushableInterface
 {
 
     static $library;

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -273,7 +273,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
             $filename = $baseFilename . '.' . $extension;
         }
 
-        $abspath = '/cache/' . $filename;
+        $abspath = '/cache/thumbnails/' . $filename;
 
         $src = $configuration->getPublicURLToFile($abspath);
 


### PR DESCRIPTION
This moves cache flushing into its own service in a backwards compatible way and makes it possible to exclude thumbnails from being cleared when cache gets cleared.