### PR TITLE
Fix display of date/time attributes

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -6,6 +6,7 @@ use Concrete\Core\Attribute\Key\CollectionKey as CollectionAttributeKey;
 use Concrete\Core\Entity\Attribute\Value\Value\SelectValue;
 use Database;
 use Core;
+use Concrete\Core\Localization\Service\Date;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
@@ -72,27 +73,34 @@ class Controller extends BlockController
                 break;
             default:
                 $content = $c->getAttribute($this->attributeHandle);
-                $content_alt = $c->getAttributeValue($this->attributeHandle);
-                if (is_object($content) && $content instanceof \Concrete\Core\Entity\File\File) {
-                    if ($this->thumbnailWidth > 0 || $this->thumbnailHeight > 0) {
-                        $im = Core::make('helper/image');
-                        $thumb = $im->getThumbnail(
-                            $content,
-                            $this->thumbnailWidth,
-                            $this->thumbnailHeight
-                        ); //<-- set these 2 numbers to max width and height of thumbnails
-                        $content = "<img src=\"{$thumb->src}\" width=\"{$thumb->width}\" height=\"{$thumb->height}\" alt=\"\" />";
-                    } else {
-                        $image = Core::make('html/image', [$content]);
-                        $content = (string) $image->getTag();
-                    }
-                } elseif (is_object($content_alt)) {
-                    if (is_array($content) && $content[0] instanceof \Concrete\Core\Tree\Node\Type\Topic) {
-                        $content = str_replace(', ', "\n", $content_alt->getDisplayValue());
-                    } elseif ($content instanceof SelectValue) {
-                        $content = (string) $content;
-                    } else {
-                        $content = $content_alt->getDisplayValue();
+                if ($content instanceof \DateTime) {
+                    $content = $content->format(Date::DB_FORMAT);
+                } else {
+                    $content_alt = $c->getAttributeValue($this->attributeHandle);
+                    if (is_object($content) && $content instanceof \Concrete\Core\Entity\File\File) {
+                        if ($this->thumbnailWidth > 0 || $this->thumbnailHeight > 0) {
+                            $im = Core::make('helper/image');
+                            $thumb = $im->getThumbnail(
+                                $content,
+                                $this->thumbnailWidth,
+                                $this->thumbnailHeight
+                            ); //<-- set these 2 numbers to max width and height of thumbnails
+                            $content = "<img src=\"{$thumb->src}\" width=\"{$thumb->width}\" height=\"{$thumb->height}\" alt=\"\" />";
+                        } else {
+                            $image = Core::make('html/image', [$content]);
+                            $content = (string) $image->getTag();
+                        }
+                    } elseif (is_object($content_alt)) {
+                        if (is_array($content) && $content[0] instanceof \Concrete\Core\Tree\Node\Type\Topic) {
+                            $content = str_replace(', ', "\n", $content_alt->getDisplayValue());
+                        } elseif ($content instanceof SelectValue) {
+                            $content = (string) $content;
+                        } else {
+                            var_dump_safe($content);
+                            var_dump_safe($content_alt);
+                            dd(0);
+                            $content = $content_alt->getDisplayValue();
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
In the page_attribute_display block type, when we handle date/time attributes, we [currently get the display value](https://github.com/concrete5/concrete5/blob/c72a0fe3ae4d1839487606d81c47cdb07ea8d2f2/concrete/blocks/page_attribute_display/controller.php#L95), but we need the full representation of the DateTime value in order to correctly format it.