### PR TITLE
Increase regex performance in in HTML block controller method xml_highlight()

### DIFF
--- a/concrete/blocks/html/controller.php
+++ b/concrete/blocks/html/controller.php
@@ -82,7 +82,7 @@ class Controller extends BlockController
             $s
         );
         $s = preg_replace(
-            "#&lt;(.*)(\[)(.*)(\])&gt;#isU",
+            "#&lt;([^[]*+)(\[)([^]]*+)(\])&gt;#i",
             "&lt;\\1<font color=\"#800080\">\\2\\3\\4</font>&gt;",
             $s
         );


### PR DESCRIPTION
Changing the needle regex as shown has decreased Stack loading time when editing pages by an order of magnitude: it was **~47 seconds** before (above the `max_execution_time` set in `php.ini`, causing server errors, HTTP code 500); after applying this fix the XHR completes in **~3 seconds**.

### Context

A web designer working on a site I support emailed me panicked that Stacks were not loading; after doing some investigation, I found that the server had started throwing server errors (`PHP Fatal error:  Maximum execution time of 30 seconds exceeded in /example/path/to/website/concrete/blocks/html/controller.php on line 89`) when editing pages, specifically when GET-ting `/ccm/system/panels/add?cID=2468&tab=stacks` via XHR.

To give credit where credit is due, [Alan Moore](http://stackoverflow.com/users/20938/alan-moore), answering [my Stack Overflow question](http://stackoverflow.com/questions/43477969/concrete5-7-stacks-php-maximum-execution-time-exceeded), was the one who suggested the change to possessive quantifiers to increase performance.