### PR TITLE
Hide the usage button on global areas (for now)

### DIFF
--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -89,11 +89,13 @@ if (isset($neutralStack)) {
                     <?php if (!$isGlobalArea && $cpc->canMoveOrCopyPage()) { ?>
                         <li><a href="<?=$view->action('duplicate', $neutralStack->getCollectionID())?>" style="margin-right: 4px;"><?=t('Duplicate')?></a></li>
                     <?php } ?>
+                    <?php if (!$isGlobalArea) { ?>
                     <li>
                         <a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackUsage" dialog-title="<?=t('Usage')?>" href="<?= $view->action('usage', $stackToEdit->getCollectionID()) ?>">
                    <?=t('Stack Usage')?>
                     </a>
                     </li>
+                    <?php } ?>
                     <?php
                     if ($cpc->canDeletePage()) {
                         if ($isGlobalArea) {


### PR DESCRIPTION
Fixes #5196 by hiding the usage button on global areas (for now)