### PR TITLE
Allow to choose single select mode for topic type attribute

### DIFF
--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -88,7 +88,7 @@ class Controller extends AttributeTypeController
         if ($akTopicTreeID) {
             $type->setTopicTreeID($akTopicTreeID);
         }
-        $type->setAllowMultipleValues((bool) $data['akTopicAllowMultipleValues']);
+        $type->setAllowMultipleValues((bool) $akTopicAllowMultipleValues);
 
         return $type;
     }

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -23,9 +23,9 @@ class Controller extends AttributeTypeController
     private $akTopicTreeID;
     private $akTopicAllowMultipleValues = true;
 
-    protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('default' => null, 'notnull' => false));
+    protected $searchIndexFieldDefinition = ['type' => 'text', 'options' => ['default' => null, 'notnull' => false]];
 
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     public function getIconFormatter()
     {
@@ -42,13 +42,13 @@ class Controller extends AttributeTypeController
         if (is_array($value)) {
             $topics = $value;
         } else {
-            $topics = array($value);
+            $topics = [$value];
         }
 
         $i = 1;
-        $expressions = array();
+        $expressions = [];
         $qb = $list->getQueryObject();
-        foreach($topics as $value) {
+        foreach ($topics as $value) {
             if ($value instanceof TreeNode) {
                 $topic = $value;
             } else {
@@ -61,20 +61,20 @@ class Controller extends AttributeTypeController
                 $expressions[] = $qb->expr()->like($column, ':topicPath' . $i);
                 $qb->setParameter('topicPath' . $i, "%||" . $topic->getTreeNodeDisplayPath() . '%||');
             }
-            $i++;
+            ++$i;
         }
 
         $expr = $qb->expr();
-        $qb->andWhere(call_user_func_array(array($expr, 'orX'), $expressions));
+        $qb->andWhere(call_user_func_array([$expr, 'orX'], $expressions));
     }
 
     public function saveKey($data)
     {
         $type = $this->getAttributeKeySettings();
-        $data += array(
+        $data += [
             'akTopicParentNodeID' => null,
             'akTopicTreeID' => null,
-        );
+        ];
         $akTopicParentNodeID = $data['akTopicParentNodeID'];
         $akTopicTreeID = $data['akTopicTreeID'];
         if (isset($data['akTopicAllowMultipleValues']) && $data['akTopicAllowMultipleValues'] == 1) {
@@ -104,7 +104,7 @@ class Controller extends AttributeTypeController
     public function exportValue(\SimpleXMLElement $akn)
     {
         /**
-         * @var $xml Xml
+         * @var Xml
          */
         $xml = \Core::make('helper/xml');
         $avn = $akn->addChild('topics');
@@ -116,7 +116,7 @@ class Controller extends AttributeTypeController
 
     public function importValue(\SimpleXMLElement $akn)
     {
-        $selected = array();
+        $selected = [];
         if (isset($akn->topics)) {
             foreach ($akn->topics->topic as $topicPath) {
                 $selected[] = (string) $topicPath;
@@ -126,14 +126,13 @@ class Controller extends AttributeTypeController
         }
     }
 
-
     /**
      * @deprecated
      */
     public function setNodes($akTopicParentNodeID, $akTopicTreeID)
     {
         /**
-         * @var $type TopicsSettings
+         * @var TopicsSettings
          */
         $type = $this->getAttributeKey()->getAttributeKeySettings();
         $type->setParentNodeID($akTopicParentNodeID);
@@ -144,7 +143,7 @@ class Controller extends AttributeTypeController
 
     public function createAttributeValue($nodes)
     {
-        $selected = array();
+        $selected = [];
         $this->load();
         $tree = Tree::getByID($this->akTopicTreeID);
         if (is_array($nodes) && $this->akTopicAllowMultipleValues == false) {
@@ -210,7 +209,7 @@ class Controller extends AttributeTypeController
         $this->requireAsset('core/topics');
         $this->requireAsset('javascript', 'jquery/form');
         if (is_object($this->attributeValue)) {
-            $valueIDs = array();
+            $valueIDs = [];
             foreach ($this->attributeValue->getValueObject()->getSelectedTopics() as $value) {
                 $valueID = $value->getTreeNodeID();
                 $withinParentScope = false;
@@ -242,6 +241,7 @@ class Controller extends AttributeTypeController
     public function searchForm($list)
     {
         $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $this->request('treeNodeID'));
+
         return $list;
     }
 
@@ -279,7 +279,7 @@ class Controller extends AttributeTypeController
     {
         $sh = Core::make('helper/security');
         $av = new TopicsValue();
-        $cleanIDs = array();
+        $cleanIDs = [];
         $topicsArray = $_POST['topics_' . $this->attributeKey->getAttributeKeyID()];
         if (is_array($topicsArray) && count($topicsArray) > 0) {
             foreach ($topicsArray as $topicID) {
@@ -309,7 +309,7 @@ class Controller extends AttributeTypeController
             $tree = $defaultTree;
         }
         $this->set('tree', $tree);
-        $trees = array();
+        $trees = [];
         if (is_object($defaultTree)) {
             $trees[] = $defaultTree;
             foreach ($topicTreeList as $ctree) {
@@ -341,6 +341,7 @@ class Controller extends AttributeTypeController
     public function validateValue()
     {
         $val = $this->getAttributeValue()->getValue();
+
         return is_array($val) && count($val) > 0;
     }
 
@@ -394,13 +395,13 @@ class Controller extends AttributeTypeController
         $db = Database::get();
         $db->Replace(
             'atTopicSettings',
-            array(
+            [
                 'akID' => $newAK->getAttributeKeyID(),
                 'akTopicParentNodeID' => $this->akTopicParentNodeID,
                 'akTopicTreeID' => $this->akTopicTreeID,
                 'akTopicAllowMultipleValues' => $this->akTopicAllowMultipleValues,
-            ),
-            array('akID'),
+            ],
+            ['akID'],
             true
         );
     }
@@ -409,5 +410,4 @@ class Controller extends AttributeTypeController
     {
         return TopicsSettings::class;
     }
-
 }

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -19,6 +19,10 @@ use Database;
 
 class Controller extends AttributeTypeController
 {
+    private $akTopicParentNodeID;
+    private $akTopicTreeID;
+    private $akTopicAllowMultipleValues = true;
+
     protected $searchIndexFieldDefinition = array('type' => 'text', 'options' => array('default' => null, 'notnull' => false));
 
     public $helpers = array('form');
@@ -73,12 +77,18 @@ class Controller extends AttributeTypeController
         );
         $akTopicParentNodeID = $data['akTopicParentNodeID'];
         $akTopicTreeID = $data['akTopicTreeID'];
+        if (isset($data['akTopicAllowMultipleValues']) && $data['akTopicAllowMultipleValues'] == 1) {
+            $akTopicAllowMultipleValues = 1;
+        } else {
+            $akTopicAllowMultipleValues = 0;
+        }
         if ($akTopicParentNodeID) {
             $type->setParentNodeID($akTopicParentNodeID);
         }
         if ($akTopicTreeID) {
             $type->setTopicTreeID($akTopicTreeID);
         }
+        $type->setAllowMultipleValues((bool) $data['akTopicAllowMultipleValues']);
 
         return $type;
     }
@@ -137,6 +147,9 @@ class Controller extends AttributeTypeController
         $selected = array();
         $this->load();
         $tree = Tree::getByID($this->akTopicTreeID);
+        if (is_array($nodes) && $this->akTopicAllowMultipleValues == false) {
+            $nodes = $nodes[0];
+        }
         if ($nodes instanceof Topic) {
             $selected[] = $nodes->getTreeNodeID();
         } else {
@@ -172,6 +185,7 @@ class Controller extends AttributeTypeController
         $treeNode = $key->addChild('tree');
         $treeNode->addAttribute('name', $tree->getTreeName());
         $treeNode->addAttribute('path', $path);
+        $treeNode->addAttribute('allow-multiple-values', $this->akTopicAllowMultipleValues);
 
         return $key;
     }
@@ -182,8 +196,10 @@ class Controller extends AttributeTypeController
         $name = (string) $key->tree['name'];
         $tree = \Concrete\Core\Tree\Type\Topic::getByName($name);
         $node = $tree->getNodeByDisplayPath((string) $key->tree['path']);
+        $allowMultipleValues = $key->tree['allow-multiple-values'];
         $type->setTopicTreeID($tree->getTreeID());
         $type->setParentNodeID($node->getTreeNodeID());
+        $type->setAllowMultipleValues(((string) $allowMultipleValues) == '1' ? true : false);
 
         return $type;
     }
@@ -220,6 +236,7 @@ class Controller extends AttributeTypeController
         $this->set('akID', $ak->getAttributeKeyID());
         $this->set('parentNode', $this->akTopicParentNodeID);
         $this->set('treeID', $this->akTopicTreeID);
+        $this->set('allowMultipleValues', $this->akTopicAllowMultipleValues);
     }
 
     public function searchForm($list)
@@ -303,6 +320,7 @@ class Controller extends AttributeTypeController
         }
         $this->set('trees', $trees);
         $this->set('parentNode', $this->akTopicParentNodeID);
+        $this->set('allowMultipleValues', $this->akTopicAllowMultipleValues);
     }
 
     public function validateKey($data = false)
@@ -347,14 +365,27 @@ class Controller extends AttributeTypeController
         return $this->akTopicTreeID;
     }
 
+    public function getAllowMultipleValues()
+    {
+        $this->load();
+
+        return $this->akTopicAllowMultipleValues;
+    }
+
     protected function load()
     {
         $ak = $this->getAttributeKey();
         if (!is_object($ak)) {
             return false;
         }
-        $this->akTopicParentNodeID = $ak->getAttributeKeySettings()->getParentNodeID();
-        $this->akTopicTreeID = $ak->getAttributeKeySettings()->getTopicTreeID();
+
+        /** @var TopicsSettings $type */
+        $type = $ak->getAttributeKeySettings();
+        if (is_object($type)) {
+            $this->akTopicParentNodeID = $type->getParentNodeID();
+            $this->akTopicTreeID = $type->getTopicTreeID();
+            $this->akTopicAllowMultipleValues = $type->getAllowMultipleValues();
+        }
     }
 
     public function duplicateKey($newAK)
@@ -367,6 +398,7 @@ class Controller extends AttributeTypeController
                 'akID' => $newAK->getAttributeKeyID(),
                 'akTopicParentNodeID' => $this->akTopicParentNodeID,
                 'akTopicTreeID' => $this->akTopicTreeID,
+                'akTopicAllowMultipleValues' => $this->akTopicAllowMultipleValues,
             ),
             array('akID'),
             true

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -224,6 +224,9 @@ class Controller extends AttributeTypeController
                 }
             }
             $this->set('valueIDs', implode(',', $valueIDs));
+        } else {
+            $valueIDs = null;
+            $this->set('valueIDs', null);
         }
         $this->set('valueIDArray', $valueIDs);
         $ak = $this->getAttributeKey();
@@ -275,7 +278,7 @@ class Controller extends AttributeTypeController
         $sh = Core::make('helper/security');
         $av = new TopicsValue();
         $cleanIDs = [];
-        $topicsArray = $_POST['topics_' . $this->attributeKey->getAttributeKeyID()];
+        $topicsArray = $this->request->request->get('topics_' . $this->attributeKey->getAttributeKeyID());
         if (is_array($topicsArray) && count($topicsArray) > 0) {
             foreach ($topicsArray as $topicID) {
                 $cleanIDs[] = $sh->sanitizeInt($topicID);

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -19,8 +19,8 @@ use Database;
 
 class Controller extends AttributeTypeController
 {
-    private $akTopicParentNodeID;
-    private $akTopicTreeID;
+    public $akTopicParentNodeID;
+    public $akTopicTreeID;
     private $akTopicAllowMultipleValues = true;
 
     protected $searchIndexFieldDefinition = ['type' => 'text', 'options' => ['default' => null, 'notnull' => false]];
@@ -88,7 +88,7 @@ class Controller extends AttributeTypeController
         if ($akTopicTreeID) {
             $type->setTopicTreeID($akTopicTreeID);
         }
-        $type->setAllowMultipleValues((bool) $akTopicAllowMultipleValues);
+        $type->allowMultipleValues((bool) $akTopicAllowMultipleValues);
 
         return $type;
     }
@@ -103,9 +103,7 @@ class Controller extends AttributeTypeController
 
     public function exportValue(\SimpleXMLElement $akn)
     {
-        /**
-         * @var Xml
-         */
+        /** @var Xml $xml */
         $xml = \Core::make('helper/xml');
         $avn = $akn->addChild('topics');
         $nodes = $this->attributeValue->getValue();
@@ -132,7 +130,7 @@ class Controller extends AttributeTypeController
     public function setNodes($akTopicParentNodeID, $akTopicTreeID)
     {
         /**
-         * @var TopicsSettings
+         * @var TopicsSettings $type
          */
         $type = $this->getAttributeKey()->getAttributeKeySettings();
         $type->setParentNodeID($akTopicParentNodeID);
@@ -146,9 +144,6 @@ class Controller extends AttributeTypeController
         $selected = [];
         $this->load();
         $tree = Tree::getByID($this->akTopicTreeID);
-        if (is_array($nodes) && $this->akTopicAllowMultipleValues == false) {
-            $nodes = $nodes[0];
-        }
         if ($nodes instanceof Topic) {
             $selected[] = $nodes->getTreeNodeID();
         } else {
@@ -198,7 +193,7 @@ class Controller extends AttributeTypeController
         $allowMultipleValues = $key->tree['allow-multiple-values'];
         $type->setTopicTreeID($tree->getTreeID());
         $type->setParentNodeID($node->getTreeNodeID());
-        $type->setAllowMultipleValues(((string) $allowMultipleValues) == '1' ? true : false);
+        $type->allowMultipleValues(((string) $allowMultipleValues) == '1' ? true : false);
 
         return $type;
     }
@@ -366,7 +361,7 @@ class Controller extends AttributeTypeController
         return $this->akTopicTreeID;
     }
 
-    public function getAllowMultipleValues()
+    public function allowMultipleValues()
     {
         $this->load();
 
@@ -385,7 +380,7 @@ class Controller extends AttributeTypeController
         if (is_object($type)) {
             $this->akTopicParentNodeID = $type->getParentNodeID();
             $this->akTopicTreeID = $type->getTopicTreeID();
-            $this->akTopicAllowMultipleValues = $type->getAllowMultipleValues();
+            $this->akTopicAllowMultipleValues = $type->allowMultipleValues();
         }
     }
 

--- a/concrete/attributes/topics/form.php
+++ b/concrete/attributes/topics/form.php
@@ -1,4 +1,11 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+$chooseNodeInForm = 'multiple';
+$selectMode = 2;
+if (isset($allowMultipleValues) && $allowMultipleValues === false) {
+    $chooseNodeInForm = 'single';
+    $selectMode = 1;
+}
+?>
 <div class="ccm-topic-attribute-wrapper">
 	<script type="text/javascript">
 	$(function() {
@@ -6,10 +13,10 @@
 		treeObj.concreteTree({
 			'treeID': '<?php echo $treeID ?>',
 			'treeNodeParentID': '<?php echo $parentNode ?>',
-			'chooseNodeInForm': 'multiple',
+			'chooseNodeInForm': '<?php echo $chooseNodeInForm ?>',
 			'allowFolderSelection': false,
 			'selectNodesByKey': [<?php echo $valueIDs ?>],
-			'selectMode': '2',
+			'selectMode': <?php echo $selectMode ?>,
 			'minExpandLevel': '1',
 			'checkbox': true,
 			'onSelect' : function(nodes) {

--- a/concrete/attributes/topics/type_form.php
+++ b/concrete/attributes/topics/type_form.php
@@ -66,6 +66,14 @@
             <legend><?=t('Topic Default Parent Node')?></legend>
         </div>
     </div>
+        <legend><?= t('Select Mode'); ?></legend>
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('allowMultipleValues', 1, $allowMultipleValues)?> <span><?=t('Allow multiple nodes to be chosen.') ?></span>
+                </label>
+            </div>
+        </div>
     <input type="hidden" name="akTopicParentNodeID" value="<?php echo $parentNode ?>">
     <input type="hidden" name="akTopicTreeID" value="<?php echo $tree->getTreeID();
     ?>">

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.2.0b1',
     'version_installed' => '8.2.0b1',
-    'version_db' => '20170421000000', // the key of the latest database migration
+    'version_db' => '20170425000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.2.0b1',
     'version_installed' => '8.2.0b1',
-    'version_db' => '20170425000000', // the key of the latest database migration
+    'version_db' => '20170505000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -3797,10 +3797,6 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="siteTreeID" type="integer" size="10">
-      <unsigned/>
-      <default value="0"/>
-    </field>
     <index name="stType">
       <col>stType</col>
     </index>

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -12,7 +12,7 @@ use Concrete\Core\View\AbstractView;
 use Config;
 use Concrete\Core\Page\Stack\StackList;
 use Doctrine\ORM\EntityManagerInterface;
-use Stack;
+use Concrete\Core\Page\Stack\Stack;
 use Page;
 use Permissions;
 use User;
@@ -239,15 +239,16 @@ class Stacks extends DashboardPageController
             'name' => t('Stacks & Global Areas'),
             'url' => \URL::to('/dashboard/blocks/stacks'),
         ]];
-        $nav = $this->app->make('helper/navigation');
-        if ($page === null) {
+        if ($this->getTask() == 'view_global_areas' || ($page instanceof Stack && $page->getStackType() == Stack::ST_TYPE_GLOBAL_AREA)) {
             $breadcrumb[] = [
                 'id' => '',
-                'active' => true,
+                'active' => $this->getTask() == 'view_global_areas',
                 'name' => t('Global Areas'),
                 'url' => \URL::to('/dashboard/blocks/stacks', 'view_global_areas'),
             ];
-        } else {
+        }
+        if ($page !== null) {
+            $nav = $this->app->make('helper/navigation');
             $pages = array_reverse($nav->getTrailToCollection($page));
             $pages[] = $page;
             for ($i = 1; $i < count($pages); ++$i) {
@@ -260,7 +261,6 @@ class Stacks extends DashboardPageController
                 ];
             }
         }
-
         return $breadcrumb;
     }
 

--- a/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
@@ -22,6 +22,11 @@ class TopicsSettings extends Settings
     protected $akTopicTreeID = 0;
 
     /**
+     * @ORM\Column(type="boolean", options={"default":true})
+     */
+    protected $akTopicAllowMultipleValues = true;
+
+    /**
      * @return mixed
      */
     public function getTopicTreeID()
@@ -57,4 +62,21 @@ class TopicsSettings extends Settings
     {
         return Tree::getByID($this->akTopicTreeID);
     }
+
+    /**
+     * @return mixed
+     */
+    public function getAllowMultipleValues()
+    {
+        return $this->akTopicAllowMultipleValues;
+    }
+
+    /**
+     * @param mixed $allowMultipleValues
+     */
+    public function setAllowMultipleValues($allowMultipleValues)
+    {
+        $this->akTopicAllowMultipleValues = $allowMultipleValues;
+    }
+
 }

--- a/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Core\Entity\Attribute\Key\Settings;
 
-use Concrete\Core\Entity\Attribute\Value\Value\TopicsValue;
 use Concrete\Core\Tree\Tree;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -78,5 +77,4 @@ class TopicsSettings extends Settings
     {
         $this->akTopicAllowMultipleValues = $allowMultipleValues;
     }
-
 }

--- a/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/TopicsSettings.php
@@ -63,17 +63,17 @@ class TopicsSettings extends Settings
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
-    public function getAllowMultipleValues()
+    public function allowMultipleValues()
     {
         return $this->akTopicAllowMultipleValues;
     }
 
     /**
-     * @param mixed $allowMultipleValues
+     * @param bool $allowMultipleValues
      */
-    public function setAllowMultipleValues($allowMultipleValues)
+    public function allowMultipleValues($allowMultipleValues)
     {
         $this->akTopicAllowMultipleValues = $allowMultipleValues;
     }

--- a/concrete/src/Localization/Locale/Service.php
+++ b/concrete/src/Localization/Locale/Service.php
@@ -99,6 +99,9 @@ class Service
         ]);
         $home->rescanCollectionPath();
 
+        // Copy the permissions from the canonical home page to this home page.
+        $home->acquirePagePermissions(1);
+
         return $home;
     }
 

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -506,13 +506,12 @@ class Stack extends Page implements ExportableInterface
         $localizedStackCID = $localizedStackPage->getCollectionID();
         $db = Database::connection();
         $db->executeQuery('
-            insert into Stacks (stName, cID, stType, stMultilingualSection, siteTreeID) values (?, ?, ?, ?, ?)',
+            insert into Stacks (stName, cID, stType, stMultilingualSection) values (?, ?, ?, ?)',
             [
                 $name,
                 $localizedStackCID,
                 $this->getStackType(),
-                $section->getCollectionID(),
-                //$siteTreeID
+                $section->getCollectionID()
             ]
         );
         $localizedStack = static::getByID($localizedStackCID);

--- a/concrete/src/Updater/Migrations/Migrations/Version20170425000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170425000000.php
@@ -1,0 +1,19 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170425000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshEntities([
+            'Concrete\Core\Entity\Attribute\Key\Settings\TopicsSettings',
+        ]);
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170505000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshDatabaseTables(['Stacks']);
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
Fancytree has single select mode, and core uses this option sometimes, but users can not select this mode for topic tree attributes. Let's add a new option to enable to choose select mode!

Ref https://github.com/mar10/fancytree/wiki/SpecSelect