### PR TITLE
Make it enable to override session handler

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -8,11 +8,9 @@ use Concrete\Core\File\Type\TypeList;
 use Concrete\Core\Foundation\ClassAliasList;
 use Concrete\Core\Foundation\Service\ProviderList;
 use Concrete\Core\Http\Request;
-use Concrete\Core\Localization\Localization;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Support\Facade\Route;
 use Concrete\Core\Support\Facade\Facade;
-use Concrete\Core\User\User;
 use Illuminate\Config\Repository;
 use Symfony\Component\HttpFoundation\Response;
 use Concrete\Core\Application\ApplicationAwareTrait;
@@ -168,15 +166,6 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
              * ----------------------------------------------------------------------------.
              */
             require DIR_BASE_CORE . '/bootstrap/preprocess.php';
-
-            /*
-             * ----------------------------------------------------------------------------
-             * Set the active language for the site, based either on the site locale, or the
-             * current user record. This can be changed later as well, during runtime.
-             * Start localization library.
-             * ----------------------------------------------------------------------------
-             */
-            $this->setSystemLocale();
         }
     }
 
@@ -389,16 +378,5 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
     private function initializePackages(Application $app)
     {
         $app->setupPackageAutoloaders();
-    }
-
-    /**
-     * Initialize localization.
-     */
-    private function setSystemLocale()
-    {
-        $u = new User();
-        $lan = $u->getUserLanguageToDisplay();
-        $loc = Localization::getInstance();
-        $loc->setContextLocale(Localization::CONTEXT_UI, $lan);
     }
 }

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -70,6 +70,11 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
             // Call each step in the line
             // @todo Move these to individual middleware, this is basically a duplicated middleware pipeline
             $response = $this->trySteps([
+                // Set the active language for the site, based either on the site locale, or the
+                // current user record. This can be changed later as well, during runtime.
+                // Start localization library.
+                'setSystemLocale',
+
                 // Set up packages first.
                 // We do this because we don't want the entity manager to be loaded and we
                 // want to give packages an opportunity to replace classes and load new classes
@@ -78,11 +83,6 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
                 // Load site specific timezones. Has to come after packages because it
                 // instantiates the site service, which sometimes packages need to override.
                 'initializeTimezone',
-
-                // Set the active language for the site, based either on the site locale, or the
-                // current user record. This can be changed later as well, during runtime.
-                // Start localization library.
-                'setSystemLocale',
 
                 // Define legacy urls, this may be the first thing that loads the entity manager
                 'initializeLegacyUrlDefinitions',

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -7,11 +7,13 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Http\ServerInterface;
+use Concrete\Core\Localization\Localization;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Routing\RouterInterface;
 use Concrete\Core\Site\Service as SiteService;
 use Concrete\Core\Url\Resolver\CanonicalUrlResolver;
 use Concrete\Core\Url\Resolver\UrlResolverInterface;
+use Concrete\Core\User\User;
 use Exception;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -76,6 +78,11 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
                 // Load site specific timezones. Has to come after packages because it
                 // instantiates the site service, which sometimes packages need to override.
                 'initializeTimezone',
+
+                // Set the active language for the site, based either on the site locale, or the
+                // current user record. This can be changed later as well, during runtime.
+                // Start localization library.
+                'setSystemLocale',
 
                 // Define legacy urls, this may be the first thing that loads the entity manager
                 'initializeLegacyUrlDefinitions',
@@ -151,6 +158,16 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
         @date_default_timezone_set($config->get('app.server_timezone'));
     }
 
+    /**
+     * Initialize localization.
+     */
+    protected function setSystemLocale()
+    {
+        $u = new User();
+        $lan = $u->getUserLanguageToDisplay();
+        $loc = Localization::getInstance();
+        $loc->setContextLocale(Localization::CONTEXT_UI, $lan);
+    }
 
     /**
      * Set legacy config values

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -160,6 +160,8 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
 
     /**
      * Initialize localization.
+     *
+     * @deprecated In a future major version this will be part of HTTP middleware
      */
     protected function setSystemLocale()
     {


### PR DESCRIPTION
In version 7, we could override session handler like this:
https://github.com/hissy/scaling-concrete5/tree/master

However, we couldn't because core creates `User` instance before loading `bootstrap/app.php`.

If we move `setSystemLocale()` method from Booter to Runner, we can do it even in v8.

https://github.com/hissy/scaling-concrete5/tree/v8

However, I'm not sure the place of running `setSystemLocale` in Runner.