### PR TITLE
Do not block deleting cookies on logout

### DIFF
--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -384,7 +384,8 @@ class Login extends PageController
         if ($this->app->make('token')->validate('logout', $token)) {
             $u = new User();
             $u->logout();
-            $this->redirect('/');
+            $r = Redirect::to('/');
+            return $r;
         }
     }
 


### PR DESCRIPTION
Problem: `\Concrete\Core\Controller\AbstractController::redirect` has `exit()` function call, so it blocks clearing `CONCRETE5_LOGIN' cookie on Cookie Middleware. So, this cookie is remains after the user logout.