### PR TITLE
Add a queue batch size to the index_search_all job

### DIFF
--- a/concrete/jobs/index_search_all.php
+++ b/concrete/jobs/index_search_all.php
@@ -17,6 +17,7 @@ class IndexSearchAll extends QueueableJob
     // A flag for clearing the index
     const CLEAR = '-1';
 
+    public $jQueueBatchSize = 50;
     public $jNotUninstallable = 1;
     public $jSupportsQueue = true;
 


### PR DESCRIPTION
I think 50 is a good size for this, any input?

This resolves #5272 
> We index 1 item in the queue at a time, we should probably increase this as the time to make the ajax call is significantly longer than it takes to process 1 item.