### PR TITLE
Improve queueable job functionality

### DIFF
--- a/concrete/src/Job/QueueableJob.php
+++ b/concrete/src/Job/QueueableJob.php
@@ -1,57 +1,119 @@
 <?php
+
 namespace Concrete\Core\Job;
 
 use Config;
 use Job as AbstractJob;
 use Queue;
-use ZendQueue\Queue as ZendQueue;
 use ZendQueue\Message as ZendQueueMessage;
+use ZendQueue\Queue as ZendQueue;
 
 abstract class QueueableJob extends AbstractJob
 {
-    // optional queue functions
+    /** @var int The size of the batch */
     protected $jQueueBatchSize;
-    public function getJobQueueBatchSize()
-    {
-        return $this->jQueueBatchSize;
-    }
+
+    /** @var ZendQueue */
+    protected $jQueueObject;
+
+    /**
+     * Start processing a queue
+     * Typically this is where you would inject new messages into the queue
+     *
+     * @param \ZendQueue\Queue $q
+     * @return mixed
+     */
     abstract public function start(ZendQueue $q);
+
+    /**
+     * Finish processing a queue
+     *
+     * @param \ZendQueue\Queue $q
+     * @return mixed
+     */
     abstract public function finish(ZendQueue $q);
+
+    /**
+     * Process a QueueMessage
+     *
+     * @param \ZendQueue\Message $msg
+     * @return void
+     */
     abstract public function processQueueItem(ZendQueueMessage $msg);
+
+    /**
+     * QueueableJob constructor.
+     * This is here and empty since it'd be a BC break to remove it.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * This is disabled since we don't want users to accidentally run a queable job without knowing it
+     */
     public function run()
     {
     }
 
-    public function __construct()
+    /**
+     * Get the size of the queue batches
+     * @return int
+     */
+    public function getJobQueueBatchSize()
     {
-        $this->jQueueBatchSize = Config::get('concrete.limits.job_queue_batch');
+        // If there's no batch size set, let's pull the batch size from the config
+        if ($this->jQueueBatchSize === null) {
+            $this->jQueueBatchSize = Config::get('concrete.limits.job_queue_batch');
+        }
+
+        return $this->jQueueBatchSize;
     }
 
+    /**
+     * Get the queue object we're going to use to queue
+     * @return \ZendQueue\Queue
+     */
     public function getQueueObject()
     {
-        return Queue::get('job_' . $this->getJobHandle(), array('timeout' => 1));
+        if ($this->jQueueObject === null) {
+            $this->jQueueObject = Queue::get('job_' . $this->getJobHandle(), array('timeout' => 1));
+        }
+
+        return $this->jQueueObject;
     }
 
+    /**
+     * Delete the queue
+     */
     public function reset()
     {
         parent::reset();
-        $q = $this->getQueueObject();
-        $q->deleteQueue();
+        $this->getQueueObject()->deleteQueue();
     }
 
+    /**
+     * Mark the queue as started
+     */
     public function markStarted()
     {
         parent::markStarted();
-
         return $this->getQueueObject();
     }
 
+    /**
+     * Mark the queue as having completed
+     *
+     * @param int $code 0 for success, otherwise the exception error code
+     * @param bool $message The message to show
+     * @return \Concrete\Core\Job\JobResult
+     */
     public function markCompleted($code = 0, $message = false)
     {
         $obj = parent::markCompleted($code, $message);
-        $q = $this->getQueueObject();
+        $queue = $this->getQueueObject();
         if (!$this->didFail()) {
-            $q->deleteQueue();
+            $queue->deleteQueue();
         }
 
         return $obj;
@@ -62,21 +124,49 @@ abstract class QueueableJob extends AbstractJob
      */
     public function executeJob()
     {
-        $q = $this->markStarted();
-        $this->start($q);
-        try {
-            $messages = $q->receive(PHP_INT_MAX);
-            foreach ($messages as $p) {
-                $this->processQueueItem($p);
-                $q->deleteMessage($p);
-            }
-            $result = $this->finish($q);
-            $obj = $this->markCompleted(0, $result);
-        } catch (\Exception $e) {
-            $obj = $this->markCompleted(Job::JOB_ERROR_EXCEPTION_GENERAL, $e->getMessage());
-            $obj->message = $obj->result; // needed for progressive library.
+        // If the job's already running, don't try to restart it
+        if ($this->getJobStatus() !== 'RUNNING') {
+            $queue = $this->markStarted();
+
+            // Prepare the queue for processing
+            $this->start($queue);
+        } else {
+            $queue = $this->getQueueObject();
         }
 
-        return $obj;
+        try {
+            $batchSize = $this->getJobQueueBatchSize() ?: PHP_INT_MAX;
+
+            // Loop over queue batches
+            while (($messages = $queue->receive($batchSize)) && $messages->count() > 0) {
+                // Run the batch
+                $this->executeBatch($messages, $queue);
+            }
+
+            // Mark the queue as finished
+            $output = $this->finish($queue);
+
+            // Mark the job as completed
+            $result = $this->markCompleted(0, $output);
+        } catch (\Exception $e) {
+            $result = $this->markCompleted(Job::JOB_ERROR_EXCEPTION_GENERAL, $e->getMessage());
+            $result->message = $result->result; // needed for progressive library.
+        }
+
+        return $result;
+    }
+
+    /**
+     * Process a queue batch
+     *
+     * @param array|iterator $batch
+     * @param \ZendQueue\Queue $queue
+     */
+    public function executeBatch($batch, ZendQueue $queue)
+    {
+        foreach ($batch as $item) {
+            $this->processQueueItem($item);
+            $queue->deleteMessage($item);
+        }
     }
 }


### PR DESCRIPTION
This makes it possible to track your jobs a little more closely, and makes it so that jobs running from the command line are able to resume.

This resolves #5272 
> output from a mostly fixed search_index job is always Indexed 0 Pages, 0 Users, 0 Files, and 1 Sites. (only when run via queue)
