### PR TITLE
Micro-fixes

### DIFF
--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -51,6 +51,8 @@ if (isset($modestbranding) && $modestbranding) {
 
 if (isset($rel) && $rel) {
     $params[] = 'rel=1';
+} else {
+    $params[] = 'rel=0';
 }
 
 if (isset($showinfo) && $showinfo) {

--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -257,6 +257,7 @@ class Install extends Controller
             }
             $recommendedCountries[$country] = $cl->getCountryName($country);
         }
+        asort($recommendedCountries);
         $languages = $ll->getLanguageList();
         $this->set('languages', $languages);
         $this->set('countries', $countries);


### PR DESCRIPTION
## First fix is for the Youtube block

If the related videos option is not checked the rel argument is not added at all and Youtube assumes its value is 1 and show the related videos... It's a bit backward.

This micro fix is to ensure the rel argument is always added

## Second Fix is to order recommended countries alphabetically during install

During install, in advanced options, the list of countries is divided in 2: recommended countries and other countries.

The list of recommended countries is organized by Punic in order of the number of people speaking that language which doesn't make much sense in the context of a dropdown during install.

This micro-fix ensures the list is ordered alphabetically by country name