### PR TITLE
Show details of installed/available languages

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -449,8 +449,8 @@ return [
             'attribute_action',
             ['action' => '.+'],
         ],
-        "/ccm/system/attribute/attribute_sort/set" => ['\Concrete\Controller\Backend\Attributes::sortInSet'],
-        "/ccm/system/attribute/attribute_sort/user" => ['\Concrete\Controller\Backend\Attributes::sortUser'],
+        '/ccm/system/attribute/attribute_sort/set' => ['\Concrete\Controller\Backend\Attributes::sortInSet'],
+        '/ccm/system/attribute/attribute_sort/user' => ['\Concrete\Controller\Backend\Attributes::sortUser'],
 
         /*
          * Trees
@@ -597,6 +597,11 @@ return [
         '/ccm/assets/localization/translator/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getTranslatorJavascript'],
         '/ccm/assets/localization/dropzone/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getDropzoneJavascript'],
         '/ccm/assets/localization/conversations/js' => ['\Concrete\Controller\Frontend\AssetsLocalization::getConversationsJavascript'],
+
+        /*
+         * Languages
+         */
+        '/ccm/system/dialogs/language/update/details' => ['\Concrete\Controller\Dialog\Language\Update\Details::view'],
     ],
 
     /*

--- a/concrete/controllers/dialog/language/update/details.php
+++ b/concrete/controllers/dialog/language/update/details.php
@@ -1,0 +1,52 @@
+<?php
+namespace Concrete\Controller\Dialog\Language\Update;
+
+use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
+use Concrete\Core\Localization\Translation\Local\FactoryInterface as LocalFactory;
+use Concrete\Core\Localization\Translation\Remote\ProviderInterface as RemoteProvider;
+use Concrete\Core\Package\BrokenPackage;
+use Concrete\Core\Package\PackageService;
+use Exception;
+
+class Details extends BackendInterfacePageController
+{
+    protected $viewPath = '/dialogs/language/update/details';
+
+    protected function canAccess()
+    {
+        return $this->permissions->canViewPage();
+    }
+
+    public function view()
+    {
+        $localeID = (string) $this->request->query->get('locale');
+        if ($localeID === '') {
+            throw new Exception(t('Missing locale identifier'));
+        }
+        $package = null;
+        if ($this->request->query->has('pkgHandle')) {
+            $packageHandle = (string) $this->request->query->get('pkgHandle');
+            if ($packageHandle !== '') {
+                $packageService = $this->app->make(PackageService::class);
+                /* @var PackageService $packageService */
+                $package = $packageService->getClass($packageHandle);
+                if ($package instanceof BrokenPackage) {
+                    throw new Exception(t('Unable to find the specified package'));
+                }
+            }
+        }
+        $localFactory = $this->app->make(LocalFactory::class);
+        /* @var LocalFactory $localFactory */
+        $remoteProvider = $this->app->make(RemoteProvider::class);
+        /* @var RemoteProvider $remoteProvider */
+        if ($package === null) {
+            $coreVersion = $this->app->make('config')->get('concrete.version_installed');
+            $this->set('local', $localFactory->getCoreStats($localeID));
+            $this->set('remote', $remoteProvider->getCoreStats($coreVersion, $localeID));
+        } else {
+            $this->set('local', $localFactory->getPackageStats($package, $localeID));
+            $this->set('remote', $remoteProvider->getPackageStats($package->getPackageHandle(), $package->getPackageVersion(), $localeID));
+        }
+        $this->set('dateHelper', $this->app->make('date'));
+    }
+}

--- a/concrete/controllers/single_page/dashboard/system/basics/multilingual/update.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/multilingual/update.php
@@ -144,7 +144,7 @@ EOT
         }
         $result .= <<<EOT
     <td><code>{$hLocaleID}</code></td>
-    <td><a class="dialog-launch" dialog-width="550" dialog-height="490" dialog-modal="true" dialog-title="{$dialogTitle}" href="{$dialogUrl}">{$hLocaleName}</a></td>
+    <td><a class="dialog-launch" dialog-width="580" dialog-height="490" dialog-modal="true" dialog-title="{$dialogTitle}" href="{$dialogUrl}">{$hLocaleName}</a></td>
     <td class="hidden-xs">{$hUpdatedOn}</td>
     <td>{$button}</td>
 </tr>

--- a/concrete/single_pages/dashboard/system/basics/multilingual/update.php
+++ b/concrete/single_pages/dashboard/system/basics/multilingual/update.php
@@ -71,6 +71,14 @@ $someUpdateAvailable = false;
                                     echo $controller->getLocaleRowHtml($localeID, $handle, $rl->getRemoteStats(), $rl->getLocalStats(), '');
                                 }
                             }
+                            if (!empty($details->getOnlyLocal())) {
+                                ?>
+                                <tr><th colspan="5"><?= t('Only local languages') ?></th></tr>
+                                <?php
+                                foreach ($details->getOnlyLocal() as $localeID => $l) {
+                                    echo $controller->getLocaleRowHtml($localeID, $handle, null, $l, '');
+                                }
+                            }
                             ?>
                         </tbody>
                     </table>

--- a/concrete/src/Localization/Translation/Local/Stats.php
+++ b/concrete/src/Localization/Translation/Local/Stats.php
@@ -68,6 +68,23 @@ class Stats
     }
 
     /**
+     * Get the display name of the translation file.
+     *
+     * @return string
+     */
+    public function getFileDisplayName()
+    {
+        $base = str_replace(DIRECTORY_SEPARATOR, '/', DIR_BASE);
+        if (strpos($this->filename, $base) === 0) {
+            $path = substr($this->filename, strlen($base) + 1);
+        } else {
+            $path = $this->filename;
+        }
+
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    /**
      * Get the version of the translations.
      *
      * @return string

--- a/concrete/src/Localization/Translation/Remote/CommunityStoreTranslationProvider.php
+++ b/concrete/src/Localization/Translation/Remote/CommunityStoreTranslationProvider.php
@@ -274,11 +274,14 @@ class CommunityStoreTranslationProvider implements ProviderInterface
             $result = $allStats[$localeID];
         } else {
             if (empty($allStats)) {
+                $version = '';
                 $total = 0;
             } else {
-                $total = array_pop($allStats)->getTotal();
+                $sampleStats = array_pop($allStats);
+                $version = $sampleStats->getVersion();
+                $total = $sampleStats->getTotal();
             }
-            $result = new Stats(0, 0);
+            $result = new Stats($version, 0, 0);
         }
 
         return $result;

--- a/concrete/src/Localization/Translation/Remote/Stats.php
+++ b/concrete/src/Localization/Translation/Remote/Stats.php
@@ -96,10 +96,10 @@ class Stats
      */
     public function getProgress($decimals = 0)
     {
-        if ($this->translated === $this->total) {
-            $result = 100;
-        } elseif ($this->translated === 0) {
+        if ($this->translated === 0) {
             $result = 0;
+        } elseif ($this->translated === $this->total) {
+            $result = 100;
         } else {
             $result = ($this->translated * 100.0) / $this->total;
             $decimals = (int) $decimals;

--- a/concrete/views/dialogs/language/update/details.php
+++ b/concrete/views/dialogs/language/update/details.php
@@ -1,0 +1,53 @@
+<?php
+// Arguments
+/* @var Concrete\Core\Localization\Service\Date $dateHelper */
+/* @var Concrete\Core\Localization\Translation\Local\Stats $local */
+/* @var Concrete\Core\Localization\Translation\Remote\Stats $remote */
+
+?>
+<table class="table">
+    <caption><h4><?= t('Local translations file') ?></h4></caption>
+    <tbody>
+        <tr>
+            <th><?= t('File path') ?></th>
+            <td><code><?= h($local->getFileDisplayName()) ?></code></td>
+        </tr>
+        <tr>
+            <th><?= t('Version') ?></th>
+            <td><?= ($local->getVersion() === '') ? '' : ('<code>' . h($local->getVersion()) . '</code>') ?></code></td>
+        </tr>
+        <tr>
+            <th><?= t('Updated on') ?></th>
+            <td><?= ($local->getUpdatedOn() === null) ? '' : $dateHelper->formatPrettyDateTime($local->getUpdatedOn(), true, true) ?></td>
+        </tr>
+    </tbody>
+</table>
+<table class="table">
+    <caption><h4><?= t('Remote translations file') ?></h4></caption>
+    <tbody>
+        <tr>
+            <th><?= t('Version') ?></th>
+            <td><?= ($remote->getVersion() === '') ? '' : ('<code>' . h($remote->getVersion()) . '</code>') ?></td>
+        </tr>
+        <tr>
+            <th><?= t('Updated on') ?></th>
+            <td><?= ($remote->getUpdatedOn() === null) ? '' : $dateHelper->formatPrettyDateTime($remote->getUpdatedOn(), true, true) ?></td>
+        </tr>
+        <tr>
+            <th><?= t('Total strings') ?></th>
+            <td><?= $remote->getTotal() ?></td>
+        </tr>
+        <tr>
+            <th><?= t('Translated strings') ?></th>
+            <td><?= $remote->getTranslated() ?></td>
+        </tr>
+        <tr>
+            <th><?= t('Untranslated strings') ?></th>
+            <td><?= $remote->getTotal() - $remote->getTranslated() ?></td>
+        </tr>
+        <tr>
+            <th><?= t('Translation progress') ?></th>
+            <td><?= $remote->getProgress() ?>%</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
What about showing details of installed/available languages?

This PR adds a link to the language names:

![image](https://cloud.githubusercontent.com/assets/928116/25425694/0230c1cc-2a6d-11e7-8a46-7e269b3b470e.png)

If clicked, this dialog is shown:

![image](https://cloud.githubusercontent.com/assets/928116/25425702/0f0d0450-2a6d-11e7-9bc3-667db5b8da37.png)

This is useful to:
1. see the location of the language file
2. debug potential issues when determining the correct version of the language files
3. show the power of the new translation system :wink:
