### PR TITLE
Do not use $view in block template to avoid conflict with elements

### DIFF
--- a/concrete/blocks/desktop_waiting_for_me/view.php
+++ b/concrete/blocks/desktop_waiting_for_me/view.php
@@ -9,10 +9,10 @@
         foreach($items as $item) {
             $notification = $item->getNotification();
             /**
-             * @var $view \Concrete\Core\Notification\View\ListViewInterface
+             * @var $listView \Concrete\Core\Notification\View\ListViewInterface
              */
-            $view = $notification->getListView();
-            $action = $view->getFormAction();
+            $listView = $notification->getListView();
+            $action = $listView->getFormAction();
 
             ?>
 
@@ -23,15 +23,15 @@
             <?php }  ?>
 
                 <div class="ccm-block-desktop-waiting-for-me-icon">
-                    <?php print $view->renderIcon() ?>
+                    <?php print $listView->renderIcon() ?>
                 </div>
 
                 <div class="ccm-block-desktop-waiting-for-me-details">
-                    <?php print $view->renderDetails() ?>
+                    <?php print $listView->renderDetails() ?>
                 </div>
 
                 <div class="ccm-block-desktop-waiting-for-me-menu">
-                    <?php print $view->renderMenu() ?>
+                    <?php print $listView->renderMenu() ?>
                 </div>
 
 


### PR DESCRIPTION
Now we can't edit /account/welcome page with an error. This PR will fix it.

```
Error thrown with message "Call to undefined method Concrete\Core\Notification\View\UserSignupListView::showControls()"

Stacktrace:
#28 Error in /Users/hissy/Repositories/concrete5/concrete/elements/block_header_view.php:14
#27 include in /Users/hissy/Repositories/concrete5/concrete/src/Block/View/BlockView.php:268
#26 Concrete\Core\Block\View\BlockView:renderViewContents in /Users/hissy/Repositories/concrete5/concrete/src/View/AbstractView.php:151
#25 Concrete\Core\View\AbstractView:render in /Users/hissy/Repositories/concrete5/concrete/src/Area/Area.php:873
#24 Concrete\Core\Area\Area:display in /Users/hissy/Repositories/concrete5/concrete/single_pages/desktop.php:7
#23 include in /Users/hissy/Repositories/concrete5/concrete/src/View/View.php:210
#22 Concrete\Core\View\View:renderViewContents in /Users/hissy/Repositories/concrete5/concrete/src/View/AbstractView.php:151
#21 Concrete\Core\View\AbstractView:render in /Users/hissy/Repositories/concrete5/concrete/src/Http/ResponseFactory.php:147
#20 Concrete\Core\Http\ResponseFactory:view in /Users/hissy/Repositories/concrete5/concrete/src/Http/ResponseFactory.php:209
#19 Concrete\Core\Http\ResponseFactory:controller in /Users/hissy/Repositories/concrete5/concrete/src/Http/ResponseFactory.php:369
#18 Concrete\Core\Http\ResponseFactory:collection in /Users/hissy/Repositories/concrete5/concrete/src/Routing/DispatcherRouteCallback.php:34
#17 Concrete\Core\Routing\DispatcherRouteCallback:execute in /Users/hissy/Repositories/concrete5/concrete/src/Http/DefaultDispatcher.php:115
#16 Concrete\Core\Http\DefaultDispatcher:handleDispatch in /Users/hissy/Repositories/concrete5/concrete/src/Http/DefaultDispatcher.php:53
#15 Concrete\Core\Http\DefaultDispatcher:dispatch in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/DispatcherDelegate.php:39
#14 Concrete\Core\Http\Middleware\DispatcherDelegate:next in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/ThumbnailMiddleware.php:60
#13 Concrete\Core\Http\Middleware\ThumbnailMiddleware:process in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#12 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/FrameOptionsMiddleware.php:39
#11 Concrete\Core\Http\Middleware\FrameOptionsMiddleware:process in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#10 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/CookieMiddleware.php:37
#9 Concrete\Core\Http\Middleware\CookieMiddleware:process in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#8 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/ApplicationMiddleware.php:29
#7 Concrete\Core\Http\Middleware\ApplicationMiddleware:process in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#6 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /Users/hissy/Repositories/concrete5/concrete/src/Http/Middleware/MiddlewareStack.php:86
#5 Concrete\Core\Http\Middleware\MiddlewareStack:process in /Users/hissy/Repositories/concrete5/concrete/src/Http/DefaultServer.php:85
#4 Concrete\Core\Http\DefaultServer:handleRequest in /Users/hissy/Repositories/concrete5/concrete/src/Foundation/Runtime/Run/DefaultRunner.php:104
#3 Concrete\Core\Foundation\Runtime\Run\DefaultRunner:run in /Users/hissy/Repositories/concrete5/concrete/src/Foundation/Runtime/DefaultRuntime.php:102
#2 Concrete\Core\Foundation\Runtime\DefaultRuntime:run in /Users/hissy/Repositories/concrete5/concrete/dispatcher.php:39
#1 require in /Users/hissy/Repositories/concrete5/index.php:3
#0 require in /Users/hissy/.composer/vendor/laravel/valet/server.php:106
```