### PR TITLE
Youtube block not respecting the related video setting

### DIFF
--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -51,6 +51,8 @@ if (isset($modestbranding) && $modestbranding) {
 
 if (isset($rel) && $rel) {
     $params[] = 'rel=1';
+} else {
+    $params[] = 'rel=0';
 }
 
 if (isset($showinfo) && $showinfo) {


### PR DESCRIPTION
If the related videos checkbox is left unchecked, the REL argument is not used and Youtube assumes it to be set at 1 which defies the purpose.

This fixes that and ensures rel always got a value.