### PR TITLE
Make it possible for the search indexer to remove pages from the index

### DIFF
--- a/concrete/jobs/index_search.php
+++ b/concrete/jobs/index_search.php
@@ -53,9 +53,10 @@ class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
 
         parent::processQueueItem($msg);
 
-        $message = substr($msg->body, 2);
-        $remove = substr($msg->body, 0, 1);
-        $type = substr($msg->body, 1, 1);
+        $body = $msg->body;
+        $message = substr($body, 2);
+        $remove = $body[0];
+        $type = $body[1];
 
         // Make sure that we were meant to remove this item
         if ($remove !== 'R') {

--- a/concrete/jobs/index_search.php
+++ b/concrete/jobs/index_search.php
@@ -3,6 +3,7 @@ namespace Concrete\Job;
 
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
+use ZendQueue\Message;
 
 class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
 {
@@ -21,6 +22,60 @@ class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
         return t(
             "Index the site to allow searching to work quickly and accurately"
         );
+    }
+
+    protected function queueMessages()
+    {
+        $generator = parent::queueMessages();
+
+        foreach ($generator as $item) {
+            yield $item;
+        }
+
+        foreach ($this->pagesToRemove() as $id) {
+            yield "RP{$id}";
+        }
+        foreach ($this->usersToRemove() as $id) {
+            yield "RU{$id}";
+        }
+        foreach ($this->filesToRemove() as $id) {
+            yield "RF{$id}";
+        }
+        foreach ($this->sitesToRemove() as $id) {
+            yield "RS{$id}";
+        }
+    }
+
+
+    public function processQueueItem(Message $msg)
+    {
+        $index = $this->indexManager;
+
+        parent::processQueueItem($msg);
+
+        $message = substr($msg->body, 2);
+        $remove = substr($msg->body, 0, 1);
+        $type = substr($msg->body, 1, 1);
+
+        // Make sure that we were meant to remove this item
+        if ($remove !== 'R') {
+            return;
+        }
+
+        switch ($type) {
+            case 'P':
+                $index->forget(Page::class, $message);
+                break;
+            case 'U':
+                $index->forget(User::class, $message);
+                break;
+            case 'F':
+                $index->forget(File::class, $message);
+                break;
+            case 'S':
+                $index->forget(Site::class, $message);
+                break;
+        }
     }
 
     /**
@@ -43,6 +98,64 @@ class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
             ->orWhere('s.cDateLastIndexed is null')->execute();
 
         while ($id = $statement->fetchColumn()) {
+            yield $id;
+        }
+    }
+
+    /**
+     * Get a list of sites to remove from the search index
+     *
+     * @return int[]
+     */
+    protected function sitesToRemove()
+    {
+        return [];
+    }
+
+    /**
+     * Get a list of files to remove from the search index
+     * @return int[]
+     */
+    protected function filesToRemove()
+    {
+        return [];
+    }
+
+    /**
+     * Get a list of users to remove from the search index
+     *
+     * @return int[]
+     */
+    protected function usersToRemove()
+    {
+        return [];
+    }
+
+    /**
+     * Get a list of pages to be removed from the search index
+     *
+     * @return int[];
+     */
+    protected function pagesToRemove()
+    {
+        $qb = $this->connection->createQueryBuilder();
+
+        // Find all pages that need to be removed from the index
+        $query = $qb
+            ->select('p.cID')
+            ->from('Pages', 'p')
+            ->leftJoin('p', 'CollectionSearchIndexAttributes', 'a', 'p.cID = a.cID')
+            ->leftJoin('p', 'PageSearchIndex', 's', 'p.cID = s.cID')
+            ->where('s.cDateLastIndexed IS NOT NULL')
+            ->andWhere($qb->expr()->orX(
+                'p.cIsActive != 1',
+                $qb->expr()->andX(
+                    'a.ak_exclude_search_index IS NOT NULL',
+                    'a.ak_exclude_search_index != 0'
+                )
+            ))->execute();
+
+        while ($id = $query->fetchColumn()) {
             yield $id;
         }
     }

--- a/concrete/jobs/index_search_all.php
+++ b/concrete/jobs/index_search_all.php
@@ -102,8 +102,10 @@ class IndexSearchAll extends QueueableJob
         if ($msg->body == self::CLEAR) {
             $this->clearIndex($index);
         } else {
-            $message = substr($msg->body, 1);
-            $type = substr($msg->body, 0, 1);
+            $body = $msg->body;
+
+            $message = substr($body, 1);
+            $type = $body[0];
 
             $map = [
                 'P' => Page::class,


### PR DESCRIPTION
This resolves #5272 
>  if we fix the above, search_index does not remove items from the search index once they have the attribute applied

This deleted any indexed page where the following is true:
* The page is indexed
* The page is one of:
    * The page is inactive (`cIsActive = 0`)
    * The page has exclude from search set to true