### PR TITLE
Catch exception when cache directory doesn't exist

### DIFF
--- a/concrete/src/Cache/CacheClearer.php
+++ b/concrete/src/Cache/CacheClearer.php
@@ -145,7 +145,13 @@ class CacheClearer
      */
     protected function filesToClear($directory)
     {
-        $iterator = new FilesystemIterator($directory);
+        try {
+            $iterator = new FilesystemIterator($directory);
+        } catch (\UnexpectedValueException $e) {
+            // The directory doesn't exist
+            return;
+        }
+
         $exclude = [];
 
         if (!$this->repository->get('concrete.cache.clear.thumbnails', true)) {


### PR DESCRIPTION
This resolves the exception some get:
```php
FilesystemIterator::__construct(/Users/andrewembler/git/armymwr/web/application/files/cache): failed to open dir: No such file or directory
```