### PR TITLE
Fix wrong message when the session invalidated

### DIFF
--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -39,6 +39,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
 
     /**
      * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     * @return bool True if the session invalidated, false otherwise.
      */
     public function handleSessionValidation(SymfonySession $session)
     {
@@ -86,6 +87,8 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
                 $session->set('CLIENT_HTTP_USER_AGENT', $request_agent);
             }
         }
+
+        return $invalidate;
     }
 
     /**

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -94,7 +94,10 @@ class User extends Object
             self::refreshUserGroups();
         }
 
-        $app->make('Concrete\Core\Session\SessionValidatorInterface')->handleSessionValidation($session);
+        $invalidate = $app->make('Concrete\Core\Session\SessionValidatorInterface')->handleSessionValidation($session);
+        if ($invalidate) {
+            $this->loadError(USER_SESSION_EXPIRED);
+        }
 
         if ($session->get('uID') > 0) {
             $db = $app['database']->connection();


### PR DESCRIPTION
When user agent or ip address of the user changed, session validator clears session storage. This is nice feature for prevent session fixation attack, but the message "This user is inactive." is wrong. The user is not changed to inactive. I think "Your session has expired." message is correct for this situation.