### PR TITLE
Required comments fixes

### DIFF
--- a/concrete/controllers/panel/page/check_in.php
+++ b/concrete/controllers/panel/page/check_in.php
@@ -11,6 +11,7 @@ use Loader;
 use Page;
 use Concrete\Core\Workflow\Request\ApprovePageRequest as ApprovePagePageWorkflowRequest;
 use PageEditResponse;
+use Concrete\Core\Http\ResponseFactoryInterface;
 
 class CheckIn extends BackendInterfacePageController
 {
@@ -79,12 +80,13 @@ class CheckIn extends BackendInterfacePageController
             $comments = $this->request->request('comments');
             $comments = is_string($comments) ? trim($comments) : '';
             if ($comments === '' && $this->app->make('config')->get('concrete.misc.require_version_comments')) {
-                return Response::create(t('Please specify the version comments'), 400);
+                $rf = $this->app->make(ResponseFactoryInterface::class);
+                return $rf->create(t('Please specify the version comments'), 400);
             }
             $c = $this->page;
             $u = new User();
             $v = CollectionVersion::get($c, "RECENT");
-            $v->setComment($_REQUEST['comments']);
+            $v->setComment($comments);
             $pr = new PageEditResponse();
             if (($this->request->request->get('action') == 'publish'
                     || $this->request->request->get('action') == 'schedule')

--- a/concrete/elements/dashboard/welcome.php
+++ b/concrete/elements/dashboard/welcome.php
@@ -43,6 +43,7 @@ if (Config::get('concrete.white_label.background_image') !== 'none' && !Config::
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <form method="post" data-form="check-in" action="<?=$approveAction?>">
+            <input type="hidden" name="comments" value="<?= h(t('Welcome page updated')) ?>" />
             <ul class="nav navbar-nav">
                 <li><p class="navbar-text"><?=Core::make('date')->formatDateTime('now', true, true)?></p></li>
                 <li>


### PR DESCRIPTION
If the `concrete.misc.require_version_comments` is set to `true`, we require that page versions have comments.

If the user specifies an empty comment (or a comment with spaces only), we have a `Concrete\Controller\Panel\Page\Response` class does not exist exception. Let's fix this.

We also need to specify comments when saving the dashboard welcome page: let's add them.