### PR TITLE
Filemanager fileset dialog fix

### DIFF
--- a/concrete/elements/files/add_to_sets.php
+++ b/concrete/elements/files/add_to_sets.php
@@ -55,7 +55,7 @@ $sets = FileSet::getMySets();
 		});
 		$('#ccm-file-set-list').on('click', 'a', function(e) {
 			e.preventDefault();
-			var $row = $(this).parent();
+			var $row = $(this).parents('.input-group');
 			$row.remove();
 		});
 		$('input[data-field=file-set-search]').liveUpdate('ccm-file-set-list', 'fileset').closest('form').unbind('submit.liveupdate');


### PR DESCRIPTION
When the fileset dialog is open in the file manager and we add a new fileset, clicking on the "-" button to remove it only removed the add-on that says "Public set".

This tiny fix removes the whole row as it should be