### PR TITLE
add SVG support to the Image block

### DIFF
--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -2,7 +2,11 @@
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 if (is_object($f) && $f->getFileID()) {
-    if ($maxWidth > 0 || $maxHeight > 0) {
+    if ($f->getTypeObject()->isSVG()) {
+        $tag = new \HtmlObject\Image();
+        $tag->src($f->getRelativePath());
+        $tag->addClass('ccm-svg');
+    } elseif ($maxWidth > 0 || $maxHeight > 0) {
         $im = $app->make('helper/image');
         $thumb = $im->getThumbnail($f, $maxWidth, $maxHeight, $cropImage);
 
@@ -13,7 +17,7 @@ if (is_object($f) && $f->getFileID()) {
         $tag = $image->getTag();
     }
 
-    $tag->addClass('ccm-image-block img-responsive bID-'.$bID);
+    $tag->addClass('ccm-image-block img-responsive bID-' . $bID);
 
     if ($altText) {
         $tag->alt(h($altText));
@@ -26,7 +30,7 @@ if (is_object($f) && $f->getFileID()) {
     }
 
     if ($linkURL) {
-        echo '<a href="'.$linkURL.'">';
+        echo '<a href="' . $linkURL . '">';
     }
 
     echo $tag;
@@ -39,13 +43,15 @@ if (is_object($f) && $f->getFileID()) {
 <?php
 }
 
-if (is_object($foS) && ($maxWidth > 0 || $maxHeight > 0)) { ?>
-<script>
-$(function() {
-    $('.bID-<?php echo $bID; ?>')
-        .mouseover(function(){$(this).attr("src", '<?php echo $imgPaths["hover"]; ?>');})
-        .mouseout(function(){$(this).attr("src", '<?php echo $imgPaths["default"]; ?>');});
-});
-</script>
-<?php
+if (is_object($f) && is_object($foS)) {
+    if (($maxWidth > 0 || $maxHeight > 0) && !$f->getTypeObject()->isSVG() && !$foS->getTypeObject()->isSVG()) { ?>
+    <script>
+    $(function() {
+        $('.bID-<?php echo $bID; ?>')
+            .mouseover(function(){$(this).attr("src", '<?php echo $imgPaths["hover"]; ?>');})
+            .mouseout(function(){$(this).attr("src", '<?php echo $imgPaths["default"]; ?>');});
+    });
+    </script>
+    <?php
+    }
 }

--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -428,6 +428,19 @@ class Type
     }
 
     /**
+     * Is the file type an SVG.
+     *
+     * @return bool|null Return true if the type is an SVG, null otherwise
+     */
+    public function isSVG()
+    {
+        $typeName = strtoupper($this->getName());
+        if ($typeName == 'SVG') {
+            return true;
+        }
+    }
+
+    /**
      * Get the name of a generic file type.
      *
      * @param int $type Generic category type (one of the \Concrete\Core\File\Type\Type::T_... constants)


### PR DESCRIPTION
This pull request adds basic SVG support to the Image block.
- The SVG is displayed in an img element with the additional class of "ccm-svg".
- Size constraining and image hover are not supported.

Because of the variability in how SVG images are displayed in different browsers (and if the SVG has width/height attributes), custom sizing of the SVG should be handled using CSS. This would ideally be done by adding a custom class to the Image block (using Custom Class in Design & Custom Template) and then selecting the child img element. I will explain this and include an example in the Editors documentation.

Also, a minor change to the alt attribute was made. If an alt attribute is not set, then the file title is used.
