### PR TITLE
Add addRawAttachment method to mail service

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -84,34 +84,36 @@ class Service
     }
 
     /**
-     * Add attachment to send with an email.
-     *
-     * Sample Code:
-     * $attachment = $mailHelper->addAttachment($fileObject);
-     * $attachment->filename = "CustomFilename";
-     * $mailHelper->send();
+     * Add a File entity as a mail attachment.
      *
      * @param File $fob File to attach
      */
-    public function addAttachment(File $fob)
+    public function addAttachment(File $file)
     {
-        // Get file version.
-        $fv = $fob->getVersion();
+        $fileVersion = $file->getVersion();
+        $resource = $fileVersion->getFileResource();
+        $this->addRawAttachment(
+            $resource->read(),
+            $fileVersion->getFilename(),
+            $fileVersion->getMimeType()
+        );
+    }
 
-        // Get file data.
-        $mimetype = $fv->getMimeType();
-        $filename = $fv->getFilename();
-        $resource = $fob->getFileResource();
-        $content = $resource->read();
-
-        // Create attachment.
+    /**
+     * Add a mail attachment by specifying its raw binary data.
+     *
+     * @param string $content The binary data of the attachemt
+     * @param string $filename The name to give to the attachment
+     * @param string $mimetype The MIME type of the attachment
+     */
+    public function addRawAttachment($content, $filename, $mimetype = 'application/octet-stream')
+    {
         $mp = new MimePart($content);
-        $mp->type = $mimetype;
-        $mp->disposition = Mime::DISPOSITION_ATTACHMENT;
-        $mp->encoding = Mime::ENCODING_BASE64;
-        $mp->filename = $filename;
-
-        // Add mimepart to attachments.
+        $mp
+            ->setType($mimetype)
+            ->setDisposition(Mime::DISPOSITION_ATTACHMENT)
+            ->setEncoding(Mime::ENCODING_BASE64)
+            ->setFileName($filename);
         $this->attachments[] = $mp;
     }
 

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Mail;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Logging\GroupLogger;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
-use Config;
 use Exception;
 use Monolog\Logger;
 use Zend\Mail\Message;
@@ -501,9 +500,9 @@ class Service
             $l = new GroupLogger(LOG_TYPE_EMAILS, Logger::INFO);
             if ($config->get('concrete.email.enabled')) {
                 if ($sent) {
-                    $l->write('**'.t('EMAILS ARE ENABLED. THIS EMAIL HAS BEEN SENT').'**');
+                    $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS BEEN SENT') . '**');
                 } else {
-                    $l->write('**'.t('EMAILS ARE ENABLED. THIS EMAIL HAS NOT BEEN SENT').'**');
+                    $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS NOT BEEN SENT') . '**');
                 }
             } else {
                 $l->write('**' . t('EMAILS ARE DISABLED. THIS EMAIL WAS LOGGED BUT NOT SENT') . '**');

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -2,10 +2,12 @@
 namespace Concrete\Core\Mail;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Entity\File\File;
 use Concrete\Core\Logging\GroupLogger;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Exception;
 use Monolog\Logger;
+use Zend\Mail\Header\MessageId as MessageIdHeader;
 use Zend\Mail\Message;
 use Zend\Mail\Transport\TransportInterface;
 use Zend\Mime\Message as MimeMessage;
@@ -89,13 +91,9 @@ class Service
      * $attachment->filename = "CustomFilename";
      * $mailHelper->send();
      *
-     * @param \Concrete\Core\Entity\File\File $fob File to attach
-     *
-     * @return \StdClass Pointer to the attachment
-     *
-     * @throws \Exception
+     * @param File $fob File to attach
      */
-    public function addAttachment(\Concrete\Core\Entity\File\File $fob)
+    public function addAttachment(File $fob)
     {
         // Get file version.
         $fv = $fob->getVersion();
@@ -368,7 +366,7 @@ class Service
      *
      * @param bool $resetData Whether or not to reset the service to its default values
      *
-     * @throws \Exception
+     * @throws Exception
      *
      * @return bool
      */
@@ -423,7 +421,7 @@ class Service
         if ($headers->has('messageid')) {
             $messageIdHeader = $headers->get('messageid');
         } else {
-            $messageIdHeader = new \Zend\Mail\Header\MessageId();
+            $messageIdHeader = new MessageIdHeader();
             $headers->addHeader($messageIdHeader);
         }
 


### PR DESCRIPTION
Currently we can only add `File` entities to the emails sent from concrete5.

What about implementing a way to add other kinds of attachments?