### PR TITLE
Multilingual stack/setup fixes

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.2.0b1',
     'version_installed' => '8.2.0b1',
-    'version_db' => '20170424000000', // the key of the latest database migration
+    'version_db' => '20170505000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -3797,10 +3797,6 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="siteTreeID" type="integer" size="10">
-      <unsigned/>
-      <default value="0"/>
-    </field>
     <index name="stType">
       <col>stType</col>
     </index>

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -12,7 +12,7 @@ use Concrete\Core\View\AbstractView;
 use Config;
 use Concrete\Core\Page\Stack\StackList;
 use Doctrine\ORM\EntityManagerInterface;
-use Stack;
+use Concrete\Core\Page\Stack\Stack;
 use Page;
 use Permissions;
 use User;
@@ -239,15 +239,16 @@ class Stacks extends DashboardPageController
             'name' => t('Stacks & Global Areas'),
             'url' => \URL::to('/dashboard/blocks/stacks'),
         ]];
-        $nav = $this->app->make('helper/navigation');
-        if ($page === null) {
+        if ($this->getTask() == 'view_global_areas' || ($page instanceof Stack && $page->getStackType() == Stack::ST_TYPE_GLOBAL_AREA)) {
             $breadcrumb[] = [
                 'id' => '',
-                'active' => true,
+                'active' => $this->getTask() == 'view_global_areas',
                 'name' => t('Global Areas'),
                 'url' => \URL::to('/dashboard/blocks/stacks', 'view_global_areas'),
             ];
-        } else {
+        }
+        if ($page !== null) {
+            $nav = $this->app->make('helper/navigation');
             $pages = array_reverse($nav->getTrailToCollection($page));
             $pages[] = $page;
             for ($i = 1; $i < count($pages); ++$i) {
@@ -260,7 +261,6 @@ class Stacks extends DashboardPageController
                 ];
             }
         }
-
         return $breadcrumb;
     }
 

--- a/concrete/src/Localization/Locale/Service.php
+++ b/concrete/src/Localization/Locale/Service.php
@@ -99,6 +99,9 @@ class Service
         ]);
         $home->rescanCollectionPath();
 
+        // Copy the permissions from the canonical home page to this home page.
+        $home->acquirePagePermissions(1);
+
         return $home;
     }
 

--- a/concrete/src/Localization/Locale/Service.php
+++ b/concrete/src/Localization/Locale/Service.php
@@ -100,7 +100,7 @@ class Service
         $home->rescanCollectionPath();
 
         // Copy the permissions from the canonical home page to this home page.
-        $home->acquirePagePermissions(1);
+        $home->acquirePagePermissions(HOME_CID);
 
         return $home;
     }

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -506,13 +506,12 @@ class Stack extends Page implements ExportableInterface
         $localizedStackCID = $localizedStackPage->getCollectionID();
         $db = Database::connection();
         $db->executeQuery('
-            insert into Stacks (stName, cID, stType, stMultilingualSection, siteTreeID) values (?, ?, ?, ?, ?)',
+            insert into Stacks (stName, cID, stType, stMultilingualSection) values (?, ?, ?, ?)',
             [
                 $name,
                 $localizedStackCID,
                 $this->getStackType(),
-                $section->getCollectionID(),
-                //$siteTreeID
+                $section->getCollectionID()
             ]
         );
         $localizedStack = static::getByID($localizedStackCID);

--- a/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170505000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshDatabaseTables(['Stacks']);
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
@@ -8,7 +8,10 @@ class Version20170505000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        $this->refreshDatabaseTables(['Stacks']);
+        $stacks = $schema->getTable('Stacks');
+        if ($stacks->hasColumn('siteTreeID')) {
+            $stacks->dropColumn('siteTreeID');
+        }
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
- Fixes breadcrumb in dashboard when viewing global areas
- Fixes error when trying to add a localized stack
- Removes unused siteTreeID column from Stacks table in db.xml, adds migration.
- Fixes bug where no permissions were applied to new multilingual home page when creating new multilingual section.

This is orthogonal to #5075 but and #5035 but they are related and both are now resolved (though not specifically with this.)