### PR TITLE
Fix search users by group set

### DIFF
--- a/concrete/src/User/Search/Field/Field/GroupSetField.php
+++ b/concrete/src/User/Search/Field/Field/GroupSetField.php
@@ -1,10 +1,7 @@
 <?php
 namespace Concrete\Core\User\Search\Field\Field;
 
-use Concrete\Core\File\FileList;
-use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Search\Field\AbstractField;
-use Concrete\Core\Search\Field\FieldInterface;
 use Concrete\Core\Search\ItemList\ItemList;
 use Concrete\Core\User\Group\GroupSet;
 use Concrete\Core\User\Group\GroupSetList;
@@ -13,7 +10,6 @@ use Permissions;
 
 class GroupSetField extends AbstractField
 {
-
     protected $requestVariables = [
         'gsID',
     ];
@@ -32,11 +28,12 @@ class GroupSetField extends AbstractField
     {
         $form = \Core::make('helper/form');
         $gsl = new GroupSetList();
-        $groupsets = array();
+        $groupsets = [];
         foreach ($gsl->get() as $gs) {
             $groupsets[$gs->getGroupSetID()] = $gs->getGroupSetDisplayName();
         }
         $html = $form->select('gsID', $groupsets);
+
         return $html;
     }
 

--- a/concrete/src/User/UserList.php
+++ b/concrete/src/User/UserList.php
@@ -277,7 +277,7 @@ class UserList extends DatabaseItemList
         $where = null;
         foreach ($groups as $group) {
             if ($group instanceof \Concrete\Core\User\Group\Group) {
-                $uniqueID = $group->getGroupID() . '_' . mt_rand();
+                $uniqueID = str_replace('.', '_', uniqid($group->getGroupID() . '_', true));
                 $joinTable = 'ug' . $uniqueID;
                 $groupTable = 'g' . $uniqueID;
                 $path = $group->getGroupPath();

--- a/concrete/src/User/UserList.php
+++ b/concrete/src/User/UserList.php
@@ -265,7 +265,7 @@ class UserList extends DatabaseItemList
         }
         $this->filterByInAnyGroup([group], $inGroup);
     }
-        
+
     /**
      * Filters the user list for only users within at least one of the provided groups.
      *

--- a/concrete/src/User/UserList.php
+++ b/concrete/src/User/UserList.php
@@ -263,7 +263,7 @@ class UserList extends DatabaseItemList
         if (!($group instanceof \Concrete\Core\User\Group\Group)) {
             $group = \Concrete\Core\User\Group\Group::getByName($group);
         }
-        $this->filterByInAnyGroup([group], $inGroup);
+        $this->filterByInAnyGroup([$group], $inGroup);
     }
 
     /**

--- a/concrete/src/User/UserList.php
+++ b/concrete/src/User/UserList.php
@@ -277,7 +277,7 @@ class UserList extends DatabaseItemList
         $where = null;
         foreach ($groups as $group) {
             if ($group instanceof \Concrete\Core\User\Group\Group) {
-                $uniqueID = $group->getGroupID() . '_' . bin2hex(random_bytes(10));
+                $uniqueID = $group->getGroupID() . '_' . mt_rand();
                 $joinTable = 'ug' . $uniqueID;
                 $groupTable = 'g' . $uniqueID;
                 $path = $group->getGroupPath();


### PR DESCRIPTION
Fix #5427

I had to add a way to look for users that belong to **at least one** of the groups in the set (calling the existing `filterByGroup` method would have required that users must belong to **all** the groups in the set).
For that reason, I added the new `filterByInAnyGroup` method.