### PR TITLE
Avoid accessing an undefined array index in NotifyInNotificationCenterNotificationAccess::getAccessListItems

### DIFF
--- a/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
+++ b/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
@@ -1,10 +1,9 @@
 <?php
 namespace Concrete\Core\Permission\Access;
 
-use Concrete\Core\Permission\Access\ListItem\NotifyInNotificationCenterNotificationListItem;
 use Concrete\Core\Permission\Duration as PermissionDuration;
-use Database;
 use Concrete\Core\Permission\Key\PageKey as PagePermissionKey;
+use Database;
 
 class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
 {
@@ -12,36 +11,36 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
     {
         $newPA = parent::duplicate($newPA);
         $db = Database::connection();
-        $r = $db->executeQuery('select * from NotificationPermissionSubscriptionList where paID = ?', array($this->getPermissionAccessID()));
+        $r = $db->executeQuery('select * from NotificationPermissionSubscriptionList where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->FetchRow()) {
-            $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission']);
+            $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['permission']];
             $db->executeQuery('insert into NotificationPermissionSubscriptionList (peID, paID, permission) values (?, ?, ?)', $v);
         }
-        $r = $db->executeQuery('select * from NotificationPermissionSubscriptionListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $r = $db->executeQuery('select * from NotificationPermissionSubscriptionListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->FetchRow()) {
-            $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['nSubscriptionIdentifier']);
+            $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['nSubscriptionIdentifier']];
             $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom  (peID, paID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
         }
 
         return $newPA;
     }
 
-    public function save($args = array())
+    public function save($args = [])
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from NotificationPermissionSubscriptionList where paID = ?', array($this->getPermissionAccessID()));
-        $db->executeQuery('delete from NotificationPermissionSubscriptionListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeQuery('delete from NotificationPermissionSubscriptionList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeQuery('delete from NotificationPermissionSubscriptionListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (is_array($args['subscriptionsIncluded'])) {
             foreach ($args['subscriptionsIncluded'] as $peID => $permission) {
-                $v = array($this->getPermissionAccessID(), $peID, $permission);
+                $v = [$this->getPermissionAccessID(), $peID, $permission];
                 $db->executeQuery('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (is_array($args['subscriptionsExcluded'])) {
             foreach ($args['subscriptionsExcluded'] as $peID => $permission) {
-                $v = array($this->getPermissionAccessID(), $peID, $permission);
+                $v = [$this->getPermissionAccessID(), $peID, $permission];
                 $db->executeQuery('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
@@ -49,7 +48,7 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
         if (is_array($args['subscriptionIdentifierInclude'])) {
             foreach ($args['subscriptionIdentifierInclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
-                    $v = array($this->getPermissionAccessID(), $peID, $pThemeID);
+                    $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
                     $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
                 }
             }
@@ -58,29 +57,29 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
         if (is_array($args['subscriptionIdentifierExclude'])) {
             foreach ($args['subscriptionIdentifierExclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
-                    $v = array($this->getPermissionAccessID(), $peID, $pThemeID);
+                    $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
                     $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
                 }
             }
         }
     }
 
-    public function getAccessListItems($accessType = PagePermissionKey::ACCESS_TYPE_INCLUDE, $filterEntities = array(), $checkCache = true)
+    public function getAccessListItems($accessType = PagePermissionKey::ACCESS_TYPE_INCLUDE, $filterEntities = [], $checkCache = true)
     {
         $db = Database::connection();
         $list = parent::getAccessListItems($accessType, $filterEntities);
         $list = PermissionDuration::filterByActive($list);
         foreach ($list as $l) {
             /**
-             * @var $l NotifyInNotificationCenterNotificationListItem
+             * @var \Concrete\Core\Permission\Access\ListItem\NotifyInNotificationCenterNotificationListItem
              */
             $pe = $l->getAccessEntityObject();
-            $prow = $db->fetchAssoc('select permission from NotificationPermissionSubscriptionList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
+            $prow = $db->fetchAssoc('select permission from NotificationPermissionSubscriptionList where peID = ? and paID = ?', [$pe->getAccessEntityID(), $l->getPermissionAccessID()]);
             if (is_array($prow) && $prow['permission']) {
                 $l->setSubscriptionsAllowedPermission($prow['permission']);
                 $permission = $prow['permission'];
                 if ($permission == 'C') {
-                    $subscriptions = $db->GetCol('select nSubscriptionIdentifier from NotificationPermissionSubscriptionListCustom where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
+                    $subscriptions = $db->GetCol('select nSubscriptionIdentifier from NotificationPermissionSubscriptionListCustom where peID = ? and paID = ?', [$pe->getAccessEntityID(), $l->getPermissionAccessID()]);
                     $l->setSubscriptionsAllowedArray($subscriptions);
                 }
             } elseif ($l->getAccessType() == PagePermissionKey::ACCESS_TYPE_INCLUDE) {

--- a/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
+++ b/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
@@ -75,7 +75,7 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
              * @var $l NotifyInNotificationCenterNotificationListItem
              */
             $pe = $l->getAccessEntityObject();
-            $prow = $db->GetRow('select permission from NotificationPermissionSubscriptionList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
+            $prow = $db->fetchAssoc('select permission from NotificationPermissionSubscriptionList where peID = ? and paID = ?', array($pe->getAccessEntityID(), $l->getPermissionAccessID()));
             if (is_array($prow) && $prow['permission']) {
                 $l->setSubscriptionsAllowedPermission($prow['permission']);
                 $permission = $prow['permission'];


### PR DESCRIPTION
Ref: #4723

`$db->GetRow` always returns an array (if no record found, it's an empty array): let's switch to `$db->fetchAssoc` (that returns false if no record is found)