### PR TITLE
Set the canonical URL by default

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -223,7 +223,7 @@ class Install extends Controller
         }
         $this->set('passwordAttributes', $passwordAttributes);
         $canonicalUrl = '';
-        $canonicalUrlChecked = false;
+        $canonicalUrlChecked = true;
         $canonicalSSLUrl = '';
         $canonicalSSLUrlChecked = false;
         $uri = $this->request->getUri();


### PR DESCRIPTION
This improves overall default security for sites.
Discussed with @KorvinSzanto 