### PR TITLE
Feature/repetition time zone

### DIFF
--- a/concrete/elements/date_time/duration.php
+++ b/concrete/elements/date_time/duration.php
@@ -68,11 +68,14 @@ if (is_object($pd)) {
     $pdStartDate = $pd->getStartDate();
     $pdEndDate = $pd->getEndDate();
 
-    $selectedStartTime = $service->toDateTime($pdStartDate, $timezone)->format('g:ia');
-    $selectedEndTime = $service->toDateTime($pdEndDate, $timezone)->format('g:ia');
+    $pdStartDateDateTime = new DateTime($pdStartDate, new DateTimeZone($timezone));
+    $pdEndDateDateTime = new DateTime($pdEndDate, new DateTimeZone($timezone));
 
-    $pdStartDate = $service->toDateTime($pdStartDate, $timezone)->format('Y-m-d');
-    $pdEndDate = $service->toDateTime($pdEndDate, $timezone)->format('Y-m-d');
+    $selectedStartTime = $pdStartDateDateTime->format('g:ia');
+    $selectedEndTime = $pdEndDateDateTime->format('g:ia');
+
+    $pdStartDate = $pdStartDateDateTime->format('Y-m-d');
+    $pdEndDate = $pdEndDateDateTime->format('Y-m-d');
 
     $pdRepeats = $pd->repeats();
     $pdStartDateAllDay = $pd->isStartDateAllDay();

--- a/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -779,32 +779,6 @@ abstract class AbstractRepetition implements RepetitionInterface
                                     }
                                 }
 
-
-                                /*
-                                $occurrence_start_date_time = new \DateTime();
-                                $occurrence_start_date_time->setTimestamp($occurrence_start);
-                                $occurrence_start_date_time->setTimezone($this->getTimezone());
-                                $occurrence_start_date_time->modify("+{$wotm} weeks");
-
-
-                                $occurrence_start = strtotime(
-                                    $occurrence_start_date_time->format('Y-m-d ') .
-                                    $repetition_start_datetime->format("H:i:s")
-                                );
-
-                                $occurrence_start_modified = new \DateTime();
-                                $occurrence_start_modified->setTimezone($this->getTimezone());
-                                $occurrence_start_modified->setTimestamp($occurrence_start);
-
-                                if ($occurrence_start >= $start && $occurrence_start <= $end) {
-                                    if ($occurrence_start_modified->format('m') === $current_datetime->format('m')) {
-                                        $occurrences[] = array(
-                                            $occurrence_start,
-                                            $occurrence_start + $repetition_end - $repetition_start,
-                                        );
-                                    }
-                                }*/
-
                                 $last_datetime = clone $current_datetime;
                                 $current_datetime->add($interval);
                             }
@@ -851,22 +825,19 @@ abstract class AbstractRepetition implements RepetitionInterface
                                 $occurrence_start_date_time2 = new \DateTime();
                                 $occurrence_start_date_time2->setTimestamp($occurrence_start);
                                 $occurrence_start_date_time2->setTimezone($this->getTimezone());
-                                $date2 = $occurrence_start_date_time2->format('Last ' . $weekday . ' of ' . $date1);
+                                $occurrence_start_date_time2->modify('Last ' . $weekday . ' of ' . $date1);
 
-                                $occurrence_start_date_time3 = new \DateTime($date2, $this->getTimezone());
+                                $occurrence_start = $occurrence_start_date_time2->format('Y-m-d ') .
+                                    $repetition_start_datetime->format('H:i:s');
 
-                                $occurrence_start = strtotime(
-                                    $occurrence_start_date_time3->format('Y-m-d ') .
-                                    $repetition_start_datetime->format('H:i:s')
-                                );
+                                $occurrence_start = new \DateTime($occurrence_start, $this->getTimezone());
+                                $occurrence_start = $occurrence_start->getTimestamp();
 
                                 if ($occurrence_start >= $start && $occurrence_start <= $end) {
-                                    if ($repetition_start_datetime->format('m') === $current_datetime->format('m')) {
-                                        $occurrences[] = array(
-                                            $occurrence_start,
-                                            $occurrence_start + $repetition_end - $repetition_start,
-                                        );
-                                    }
+                                    $occurrences[] = array(
+                                        $occurrence_start,
+                                        $occurrence_start + $repetition_end - $repetition_start,
+                                    );
                                 }
 
                                 $last_datetime = clone $current_datetime;

--- a/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -82,6 +82,11 @@ abstract class AbstractRepetition implements RepetitionInterface
                 $timezone = new \DateTimeZone(date_default_timezone_get());
             }
         }
+        $this->setTimezone($timezone);
+    }
+
+    public function setTimezone(\DateTimeZone $timezone)
+    {
         $this->timezone = $timezone;
     }
 

--- a/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -145,7 +145,7 @@ abstract class AbstractRepetition implements RepetitionInterface
     public function getTimezone()
     {
         if (!$this->timezone) {
-            $this->timezone = new \DateTimemZone(date_default_timezone_get());
+            $this->timezone = new \DateTimeZone(date_default_timezone_get());
         }
         return $this->timezone;
     }

--- a/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -87,10 +87,8 @@ abstract class AbstractRepetition implements RepetitionInterface
 
     public function getStartDateTimestamp()
     {
-        $date = new Date();
-        return $date->toDateTime(
-            $this->getStartDate(), 'system', $this->getTimezone()->getName()
-        )->getTimestamp();
+        $datetime = new \DateTime($this->getStartDate(), $this->getTimezone());
+        return $datetime->getTimestamp();
     }
 
     /**
@@ -146,6 +144,9 @@ abstract class AbstractRepetition implements RepetitionInterface
      */
     public function getTimezone()
     {
+        if (!$this->timezone) {
+            $this->timezone = new \DateTimemZone(date_default_timezone_get());
+        }
         return $this->timezone;
     }
 

--- a/concrete/src/Foundation/Repetition/RepetitionInterface.php
+++ b/concrete/src/Foundation/Repetition/RepetitionInterface.php
@@ -28,6 +28,11 @@ interface RepetitionInterface
     public function getID();
 
     /**
+     * Returns the start date/time as a timestamp
+     */
+    public function getStartDateTimestamp();
+
+    /**
      * Set the start date.
      *
      * @param $start_date

--- a/concrete/src/Foundation/Repetition/RepetitionInterface.php
+++ b/concrete/src/Foundation/Repetition/RepetitionInterface.php
@@ -18,6 +18,8 @@ interface RepetitionInterface
     const MONTHLY_REPEAT_MONTHLY = 2;
     const MONTHLY_REPEAT_LAST_WEEKDAY = 3;
 
+    public function getTimezone();
+
     /**
      * The ID of this repetition, null for unsaved.
      *

--- a/concrete/src/Foundation/Repetition/RepetitionInterface.php
+++ b/concrete/src/Foundation/Repetition/RepetitionInterface.php
@@ -20,6 +20,8 @@ interface RepetitionInterface
 
     public function getTimezone();
 
+    public function setTimezone(\DateTimeZone $timezone);
+
     /**
      * The ID of this repetition, null for unsaved.
      *

--- a/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
+++ b/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
@@ -65,7 +65,10 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
 
         $repetition->setStartDate('2017-08-01 09:00:00'); // Since we're defaulting to the site time of America/Los Angeles it's 9am
         $start_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
-        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
+
+        $end_date_time = new \DateTime('2022-04-25', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
+
         $this->assertEquals(1501603200, $start_time);
 
         $initial_occurrence_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
@@ -109,7 +112,9 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(1);
         $repetition->setRepeatPeriodEnd('2017-04-05');
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
+
+        $end_date_time = new \DateTime('2022-04-25', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
 
         $this->assertEquals(1490670000, $repetition->getStartDateTimestamp());
 
@@ -137,7 +142,8 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatPeriodEnd('2017-07-07');
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
+        $end_date_time = new \DateTime('2022-04-25', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
 
         $this->assertEquals(1488603600, $repetition->getStartDateTimestamp());
 
@@ -165,7 +171,8 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(2);
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('2019-05-07')->getTimestamp();
+        $end_date_time = new \DateTime('2019-05-07', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
 
         $this->assertEquals(1493618400, $repetition->getStartDateTimestamp());
 
@@ -196,7 +203,8 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(1);
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('2018-05-07')->getTimestamp();
+        $end_date_time = new \DateTime('2018-05-07', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
 
         $this->assertEquals(1496878200, $repetition->getStartDateTimestamp());
 
@@ -227,7 +235,9 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1480035600, $repetition->getStartDateTimestamp());
 
-        $end_time = $this->dateService->toDateTime('2030-05-07')->getTimestamp();
+        $end_date_time = new \DateTime('2030-05-07', $repetition->getTimezone());
+        $end_time = $end_date_time->getTimestamp();
+
         $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
 
 

--- a/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
+++ b/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
@@ -65,7 +65,7 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
 
         $repetition->setStartDate('2017-08-01 09:00:00'); // Since we're defaulting to the site time of America/Los Angeles it's 9am
         $start_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
-        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
         $this->assertEquals(1501603200, $start_time);
 
         $initial_occurrence_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
@@ -109,7 +109,7 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(1);
         $repetition->setRepeatPeriodEnd('2017-04-05');
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
 
         $this->assertEquals(1490670000, $repetition->getStartDateTimestamp());
 
@@ -137,7 +137,7 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatPeriodEnd('2017-07-07');
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+        $end_time = $this->dateService->toDateTime('2022-04-25')->getTimestamp();
 
         $this->assertEquals(1488603600, $repetition->getStartDateTimestamp());
 
@@ -165,7 +165,7 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(2);
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('+2 years')->getTimestamp();
+        $end_time = $this->dateService->toDateTime('2019-05-07')->getTimestamp();
 
         $this->assertEquals(1493618400, $repetition->getStartDateTimestamp());
 
@@ -181,8 +181,6 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(13, count($occurrences));
 
         $this->resetTimezone($old);
-
-
     }
 
     public function testMonthlyFirstByWeek()
@@ -198,7 +196,7 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $repetition->setRepeatEveryNum(1);
 
         $start_time = $repetition->getStartDateTimestamp();
-        $end_time = $this->dateService->toDateTime('+1 years')->getTimestamp();
+        $end_time = $this->dateService->toDateTime('2018-05-07')->getTimestamp();
 
         $this->assertEquals(1496878200, $repetition->getStartDateTimestamp());
 
@@ -210,7 +208,41 @@ class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(12, count($occurrences));
 
         $this->resetTimezone($old);
+    }
 
+    public function testLastThursday()
+    {
+        $old = $this->setTimezone('GMT');
+
+        $repetition = new TestRepetition('America/Los_Angeles');
+        $repetition->setStartDate('2016-11-24 17:00:00');
+        $repetition->setEndDate('2016-11-24 20:00:00');
+        $repetition->setRepeatMonthLastWeekday(4);
+        $repetition->setRepeatPeriod(TestRepetition::REPEAT_MONTHLY);
+        $repetition->setRepeatMonthBy(TestRepetition::MONTHLY_REPEAT_LAST_WEEKDAY);
+        $repetition->setRepeatEveryNum(1);
+        $repetition->setRepeatPeriodEnd('2018-01-01');
+
+        $start_time = $repetition->getStartDateTimestamp();
+
+        $this->assertEquals(1480035600, $repetition->getStartDateTimestamp());
+
+        $end_time = $this->dateService->toDateTime('2030-05-07')->getTimestamp();
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+
+
+        $this->assertEquals(1480035600, $occurrences[0][0]);
+        $this->assertEquals(1480046400, $occurrences[0][1]);
+
+        $this->assertEquals(1490918400, $occurrences[4][0]);
+        $this->assertEquals(1490929200, $occurrences[4][1]);
+
+        $this->assertEquals(1514509200, $occurrences[13][0]);
+        $this->assertEquals(1514520000, $occurrences[13][1]);
+
+        $this->assertEquals(14, count($occurrences));
+
+        $this->resetTimezone($old);
 
     }
 

--- a/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
+++ b/tests/tests/Core/Foundation/RepetitionTimezoneTest.php
@@ -1,0 +1,218 @@
+<?php
+namespace Concrete\Tests\Core\Foundation;
+
+use Concrete\Core\Application\Application as ServiceLocator;
+use Concrete\Core\Foundation\Repetition\AbstractRepetition;
+use Concrete\Core\Foundation\Service\ProviderList;
+use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Support\Facade\Facade;
+
+class TestRepetition extends AbstractRepetition
+{
+
+    public function save()
+    {
+        return false;
+    }
+
+    public function getID()
+    {
+        return false;
+    }
+
+}
+
+class RepetitionTimezoneTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var $dateService Date
+     */
+    protected $dateService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->dateService = new Date();
+    }
+
+    protected function setTimezone($timezone)
+    {
+        $old = date_default_timezone_get();
+        $app = Facade::getFacadeApplication();
+        $config = $app->make('config');
+        $config->set('app.server_timezone', $timezone);
+        date_default_timezone_set($timezone);
+        return $old;
+    }
+
+    protected function resetTimezone($old)
+    {
+        date_default_timezone_set($old);
+        $app = Facade::getFacadeApplication();
+        $config = $app->make('config');
+        $config->set('app.server_timezone', null);
+    }
+
+
+    public function testSingleOccurrence()
+    {
+        $old = $this->setTimezone('America/Los_Angeles');
+
+        $repetition = new TestRepetition();
+
+        $this->assertEquals('America/Los_Angeles', $repetition->getTimezone()->getName());
+
+        $repetition->setStartDate('2017-08-01 09:00:00'); // Since we're defaulting to the site time of America/Los Angeles it's 9am
+        $start_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
+        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+        $this->assertEquals(1501603200, $start_time);
+
+        $initial_occurrence_time = $this->dateService->toDateTime($repetition->getStartDate())->getTimestamp();
+        if ($repetition->getEndDate()) {
+            $initial_occurrence_time_end = $this->dateService->toDateTime($repetition->getEndDate())->getTimestamp();
+        } else {
+            $initial_occurrence_time_end = $initial_occurrence_time;
+        }
+
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+
+        $this->assertEquals(1, count($occurrences));
+        $this->assertEquals($occurrences[0][0], $initial_occurrence_time);
+        $this->assertEquals($occurrences[0][1], $initial_occurrence_time_end);
+
+        $this->resetTimezone($old);
+    }
+
+    public function testSingleOccurrenceDifferentZone()
+    {
+        $old = $this->setTimezone('GMT');
+
+        $repetition = new TestRepetition('America/Los_Angeles');
+
+        $repetition->setStartDate('2017-08-01 16:00:00'); // 8/1/17 4PM Pacific, should be 8/1/17 23:00
+        $start_time = $this->dateService->toDateTime($repetition->getStartDate(), 'system', $repetition->getTimezone()->getName())->getTimestamp();
+        $this->assertEquals(1501628400, $start_time);
+        $this->assertEquals(1501628400, $repetition->getStartDateTimestamp());
+
+        $this->resetTimezone($old);
+    }
+
+    public function testDaily()
+    {
+        $old = $this->setTimezone('GMT');
+
+        $repetition = new TestRepetition('America/Los_Angeles');
+        $repetition->setStartDate('2017-03-27 20:00:00'); // 8 PM PST
+        $repetition->setEndDate('2017-03-27 22:00:00'); // 8 PM - 10 PM
+        $repetition->setRepeatPeriod(TestRepetition::REPEAT_DAILY);
+        $repetition->setRepeatEveryNum(1);
+        $repetition->setRepeatPeriodEnd('2017-04-05');
+        $start_time = $repetition->getStartDateTimestamp();
+        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+
+        $this->assertEquals(1490670000, $repetition->getStartDateTimestamp());
+
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+        $this->assertEquals(10, count($occurrences));
+
+        $this->assertEquals(1490670000, $occurrences[0][0]); // 3/28/17 3:00 am GMT
+        $this->assertEquals(1490677200, $occurrences[0][1]); // 3/28/17 5:00 am GMT
+        $this->assertEquals(1491447600, $occurrences[9][0]); // 3/28/17 3:00 am GMT
+        $this->assertEquals(1491454800, $occurrences[9][1]); // 3/28/17 5:00 am GMT
+
+        $this->resetTimezone($old);
+    }
+
+    public function testWeekly()
+    {
+        $old = $this->setTimezone('Europe/Paris');
+
+        $repetition = new TestRepetition('America/Los_Angeles');
+        $repetition->setStartDate('2017-03-03 21:00'); // 9 PM PST
+        $repetition->setEndDate('2017-03-04 02:00:00'); // 9-2AM
+        $repetition->setRepeatPeriod(TestRepetition::REPEAT_WEEKLY);
+        $repetition->setRepeatEveryNum(1);
+        $repetition->setRepeatPeriodWeekDays([5]); // every Friday
+        $repetition->setRepeatPeriodEnd('2017-07-07');
+
+        $start_time = $repetition->getStartDateTimestamp();
+        $end_time = $this->dateService->toDateTime('+5 years')->getTimestamp();
+
+        $this->assertEquals(1488603600, $repetition->getStartDateTimestamp());
+
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+        $this->assertEquals(19, count($occurrences));
+        $this->resetTimezone($old);
+
+        $this->assertEquals(1488603600, $occurrences[0][0]);
+        $this->assertEquals(1488621600, $occurrences[0][1]);
+        $this->assertEquals(1491019200, $occurrences[4][0]);
+        $this->assertEquals(1491037200, $occurrences[4][1]);
+        $this->assertEquals(1499486400, $occurrences[18][0]);
+        $this->assertEquals(1499504400, $occurrences[18][1]);
+    }
+
+    public function testMonthlyFirstByDate()
+    {
+        $old = $this->setTimezone('Pacific/Honolulu');
+
+        $repetition = new TestRepetition('Europe/Paris');
+        $repetition->setStartDate('2017-05-01 8:00:00');
+        $repetition->setEndDate('2017-05-01 11:00:00');
+        $repetition->setRepeatPeriod(TestRepetition::REPEAT_MONTHLY);
+        $repetition->setRepeatMonthBy(TestRepetition::MONTHLY_REPEAT_MONTHLY);
+        $repetition->setRepeatEveryNum(2);
+
+        $start_time = $repetition->getStartDateTimestamp();
+        $end_time = $this->dateService->toDateTime('+2 years')->getTimestamp();
+
+        $this->assertEquals(1493618400, $repetition->getStartDateTimestamp());
+
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+
+        $this->assertEquals(1493618400, $occurrences[0][0]);
+        $this->assertEquals(1493629200, $occurrences[0][1]);
+        $this->assertEquals(1504245600, $occurrences[2][0]);
+        $this->assertEquals(1504256400, $occurrences[2][1]);
+        $this->assertEquals(1556690400, $occurrences[12][0]);
+        $this->assertEquals(1556701200, $occurrences[12][1]);
+
+        $this->assertEquals(13, count($occurrences));
+
+        $this->resetTimezone($old);
+
+
+    }
+
+    public function testMonthlyFirstByWeek()
+    {
+        $old = $this->setTimezone('GMT');
+
+        $repetition = new TestRepetition('America/Chicago');
+        $repetition->setStartDate('2017-06-07 18:30:00'); // every first wednesday
+        $repetition->setEndDate('2017-06-07 20:00:00');
+        $repetition->setRepeatPeriodWeekDays([3]); // every wednesday
+        $repetition->setRepeatPeriod(TestRepetition::REPEAT_MONTHLY);
+        $repetition->setRepeatMonthBy(TestRepetition::MONTHLY_REPEAT_WEEKLY); // Boxing every Wednesday
+        $repetition->setRepeatEveryNum(1);
+
+        $start_time = $repetition->getStartDateTimestamp();
+        $end_time = $this->dateService->toDateTime('+1 years')->getTimestamp();
+
+        $this->assertEquals(1496878200, $repetition->getStartDateTimestamp());
+
+        $occurrences = $repetition->activeRangesBetween($start_time, $end_time);
+
+        $this->assertEquals(1496878200, $occurrences[0][0]);
+        $this->assertEquals(1496883600, $occurrences[0][1]);
+
+        $this->assertEquals(12, count($occurrences));
+
+        $this->resetTimezone($old);
+
+
+    }
+
+
+}


### PR DESCRIPTION
Currently our internal repetition object doesn't track time zones. This is a problem in environments where time zones are used across multiple sites, specifically in the calendar add-on.