### PR TITLE
Catch the duplicate exception when generating thumbnail cache

### DIFF
--- a/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -10,6 +10,7 @@ use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailVersion;
 use Concrete\Core\File\StorageLocation\Configuration\ConfigurationInterface;
 use Concrete\Core\File\StorageLocation\Configuration\DeferredConfigurationInterface;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 class Resolver
 {
@@ -131,6 +132,8 @@ class Resolver
             ));
         } catch (InvalidFieldNameException $e) {
             // User needs to run the database upgrade routine
+        } catch (UniqueConstraintViolationException $e) {
+            // We tried to generate a thumbnail for something we already generated (race condition)
         }
     }
 


### PR DESCRIPTION
There is a race condition when saving after generating a thumbnail the race is as follows:

Cache is cleared/page has never been visited
User 1 Visits site
User 2 Visits site
Resolver for user 1 sees no thumbnail in cache table
Resolver for user 2 sees no thumbnail in cache table
Generate thumbnail for user 1
Generate thumbnail for user 2
Insert into DB info for thumbnail generated by user 1
Insert into DB info for thumbnail generated by user 2
User 2 gets a duplicate key exception.

This fixes it by hiding the exception under the rug.