### PR TITLE
Conversation block form - display the Custom Date Format input conditionally

### DIFF
--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -1,6 +1,8 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
-$helperFile = Loader::helper('concrete/file');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$helperFile = $app->make('helper/concrete/file');
+
 if ($controller->getTask() == 'add') {
     $enablePosting = 1;
     $paginate = 1;
@@ -54,14 +56,12 @@ if (!$dateFormat) {
     <div class="form-group">
         <label class="control-label"><?=t('Ordering')?></label>
         <?=$form->select('orderBy', array('date_asc' => t('Earliest First'), 'date_desc' => t('Most Recent First'), 'rating' => t('Highest Rated')), $orderBy)?>
-
         <div class="checkbox">
             <label>
                 <?=$form->checkbox('enableOrdering', 1, $enableOrdering)?>
                 <?=t('Display Ordering Option in Page')?>
             </label>
         </div>
-
     </div>
     <div class="form-group">
         <label class="control-label"><?=t('Rating')?></label>
@@ -160,6 +160,7 @@ if (!$dateFormat) {
         </div>
     </div>
 </fieldset>
+
 <fieldset>
     <div class="form-group">
         <label class="control-label"><?=t('Date Format')?></label>
@@ -187,6 +188,7 @@ if (!$dateFormat) {
         </div>
     </div>
 </fieldset>
+
 <fieldset>
     <legend><?=t('File Attachment Management')?></legend>
     <p class="text-muted"><?php echo t('Note: Entering values here will override global conversations file attachment settings for this block if you enable Attachment Overrides for this Conversation.') ?></p>
@@ -234,8 +236,6 @@ if (!$dateFormat) {
             <?=$form->textarea('fileExtensions', $fileExtensions)?>
         </div>
     </div>
-
-
 </fieldset>
 
 <fieldset>
@@ -249,7 +249,7 @@ if (!$dateFormat) {
     </div>
     <div class="form-group notification-overrides">
         <label class="control-label"><?=t('Users To Receive Conversation Notifications')?></label>
-        <?=Core::make("helper/form/user_selector")->selectMultipleUsers('notificationUsers', $notificationUsers)?>
+        <?=$app->make("helper/form/user_selector")->selectMultipleUsers('notificationUsers', $notificationUsers)?>
     </div>
     <div class="form-group notification-overrides">
         <label class="control-label"><?=t('Subscribe Option')?></label>
@@ -276,6 +276,7 @@ $(function() {
             }
         }).trigger('change');
     });
+
     $('input[name=paginate]').on('change', function() {
         var pg = $('input[name=paginate]:checked');
         if (pg.val() == 1) {
@@ -284,6 +285,7 @@ $(function() {
             $('div[data-row=itemsPerPage]').hide();
         }
     }).trigger('change');
+
     $('input[name=dateFormat]').on('change', function() {
         var dateFormat = $('input[name=dateFormat]:checked');
         if (dateFormat.val() == 'custom') {
@@ -292,6 +294,7 @@ $(function() {
             $('div[data-row=customDateFormat]').hide();
         }
     }).trigger('change');
+
     $('input[name=attachmentOverridesEnabled]').on('change', function() {
         var ao = $('input[name=attachmentOverridesEnabled]:checked');
         if (ao.val() == 1) {
@@ -302,6 +305,7 @@ $(function() {
             $('.attachment-overrides label').addClass('text-muted');
         }
     }).trigger('change');
+
     $('input[name=notificationOverridesEnabled]').on('change', function() {
         var ao = $('input[name=notificationOverridesEnabled]:checked');
         if (ao.val() == 1) {

--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -1,5 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-<?php
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
 $helperFile = Loader::helper('concrete/file');
 if ($controller->getTask() == 'add') {
@@ -36,49 +35,49 @@ if (!$dateFormat) {
 ?>
 
 <fieldset>
-	<legend><?=t('Message List')?></legend>
-	<div class="form-group">
-		<label class="control-label"><?=t('Display Mode')?></label>
-		<div class="radio">
-			<label>
-			<?=$form->radio('displayMode', 'threaded', $displayMode)?>
-			<?=t('Threaded')?>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('displayMode', 'flat', $displayMode)?>
-			<?=t('Flat')?>
-			</label>
-		</div>
-	</div>
-	<div class="form-group">
-		<label class="control-label"><?=t('Ordering')?></label>
-		<?=$form->select('orderBy', array('date_asc' => t('Earliest First'), 'date_desc' => t('Most Recent First'), 'rating' => t('Highest Rated')), $orderBy)?>
+    <legend><?=t('Message List')?></legend>
+    <div class="form-group">
+        <label class="control-label"><?=t('Display Mode')?></label>
+        <div class="radio">
+            <label>
+            <?=$form->radio('displayMode', 'threaded', $displayMode)?>
+            <?=t('Threaded')?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('displayMode', 'flat', $displayMode)?>
+            <?=t('Flat')?>
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Ordering')?></label>
+        <?=$form->select('orderBy', array('date_asc' => t('Earliest First'), 'date_desc' => t('Most Recent First'), 'rating' => t('Highest Rated')), $orderBy)?>
 
-		<div class="checkbox">
-			<label>
-				<?=$form->checkbox('enableOrdering', 1, $enableOrdering)?>
-				<?=t('Display Ordering Option in Page')?>
-			</label>
-		</div>
+        <div class="checkbox">
+            <label>
+                <?=$form->checkbox('enableOrdering', 1, $enableOrdering)?>
+                <?=t('Display Ordering Option in Page')?>
+            </label>
+        </div>
 
-	</div>
-	<div class="form-group">
-		<label class="control-label"><?=t('Rating')?></label>
-		<div class="checkbox">
-			<label>
-			<?=$form->checkbox('enableCommentRating', 1, $enableCommentRating)?>
-			<?=t('Enable Comment Rating')?>
-			</label>
-		</div>
+    </div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Rating')?></label>
+        <div class="checkbox">
+            <label>
+            <?=$form->checkbox('enableCommentRating', 1, $enableCommentRating)?>
+            <?=t('Enable Comment Rating')?>
+            </label>
+        </div>
         <div class="checkbox">
             <label>
                 <?=$form->checkbox('enableTopCommentReviews', 1, $enableTopCommentReviews)?>
                 <?=t('Turn Top-Level Posts into Reviews')?>
             </label>
         </div>
-	</div>
+    </div>
     <?php
     if (isset($reviewAttributeKeys)) {
         ?>
@@ -103,163 +102,166 @@ if (!$dateFormat) {
         <?php
     }
     ?>
-	<div class="form-group">
-		<label class="control-label"><?=t('Paginate Message List')?></label>
-		<div class="radio">
-			<label>
-			<?=$form->radio('paginate', 0, $paginate)?>
-			<?=t('No, display all messages.')?>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('paginate', 1, $paginate)?>
-			<?=t('Yes, display only a sub-set of messages at a time.')?>
-			</label>
-		</div>
-	</div>
-	<div class="form-group" data-row="itemsPerPage">
-		<label class="control-label"><?=t('Messages Per Page')?></label>
-		<?=$form->text('itemsPerPage', $itemsPerPage, array('class' => 'span1'))?>
-	</div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Paginate Message List')?></label>
+        <div class="radio">
+            <label>
+            <?=$form->radio('paginate', 0, $paginate)?>
+            <?=t('No, display all messages.')?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('paginate', 1, $paginate)?>
+            <?=t('Yes, display only a sub-set of messages at a time.')?>
+            </label>
+        </div>
+    </div>
+    <div class="form-group" data-row="itemsPerPage">
+        <label class="control-label"><?=t('Messages Per Page')?></label>
+        <?=$form->text('itemsPerPage', $itemsPerPage, array('class' => 'span1'))?>
+    </div>
 </fieldset>
 
 <fieldset>
-	<legend><?=t('Posting')?></legend>
-	<div class="form-group">
-		<?=$form->label('addMessageLabel', t('Add Message Label'))?>
-		<?=$form->text('addMessageLabel', $addMessageLabel)?>
-	</div>
-	<div class="form-group">
-		<label class="control-label"><?=t('Enable Posting')?></label>
-		<div class="radio">
-			<label>
-			<?=$form->radio('enablePosting', 1, $enablePosting)?>
-			<span><?=t('Yes, this conversation accepts messages and replies.')?></span>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('enablePosting', 0, $enablePosting)?>
-			<span><?=t('No, posting is disabled.')?></span>
-			</label>
-		</div>
-	</div>
-	<div class="form-group">
-		<label class="control-label"><?=t('Display Posting Form')?></label>
-		<div class="radio">
-			<label>
-			<?=$form->radio('displayPostingForm', 'top', $displayPostingForm)?>
-			<span><?=t('Top')?></span>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('displayPostingForm', 'bottom', $displayPostingForm)?>
-			<span><?=t('Bottom')?></span>
-			</label>
-		</div>
-	</div>
+    <legend><?=t('Posting')?></legend>
+    <div class="form-group">
+        <?=$form->label('addMessageLabel', t('Add Message Label'))?>
+        <?=$form->text('addMessageLabel', $addMessageLabel)?>
+    </div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Enable Posting')?></label>
+        <div class="radio">
+            <label>
+            <?=$form->radio('enablePosting', 1, $enablePosting)?>
+            <span><?=t('Yes, this conversation accepts messages and replies.')?></span>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('enablePosting', 0, $enablePosting)?>
+            <span><?=t('No, posting is disabled.')?></span>
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Display Posting Form')?></label>
+        <div class="radio">
+            <label>
+            <?=$form->radio('displayPostingForm', 'top', $displayPostingForm)?>
+            <span><?=t('Top')?></span>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('displayPostingForm', 'bottom', $displayPostingForm)?>
+            <span><?=t('Bottom')?></span>
+            </label>
+        </div>
+    </div>
 </fieldset>
 <fieldset>
-	<div class="form-group">
-		<label class="control-label"><?=t('Date Format')?></label>
-		<div class="radio">
-			<label>
-			<?=$form->radio('dateFormat', 'default', $dateFormat)?>
-			<span><?=t('Use Site Default.')?></span>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('dateFormat', 'elapsed', $dateFormat)?>
-			<span><?=t('Time elapsed since post.')?></span>
-			</label>
-		</div>
-		<div class="radio">
-			<label>
-			<?=$form->radio('dateFormat', 'custom', $dateFormat)?>
-			<span><?=t('Custom')?></span>
-			</label>
-		</div>
-		<?=$form->text('customDateFormat', $customDateFormat)?>
-	</div>
+    <div class="form-group">
+        <label class="control-label"><?=t('Date Format')?></label>
+        <div class="radio">
+            <label>
+            <?=$form->radio('dateFormat', 'default', $dateFormat)?>
+            <span><?=t('Use Site Default.')?></span>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('dateFormat', 'elapsed', $dateFormat)?>
+            <span><?=t('Time elapsed since post.')?></span>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+            <?=$form->radio('dateFormat', 'custom', $dateFormat)?>
+            <span><?=t('Custom Date Format')?></span>
+            </label>
+        </div>
+        <div class="form-group" data-row="customDateFormat">
+            <?=$form->text('customDateFormat', $customDateFormat)?>
+            <div class="help-block"><?php echo sprintf(t('See the formatting options for date at %s.'), '<a href="http://www.php.net/date" target="_blank">php.net/date</a>'); ?></div>
+        </div>
+    </div>
 </fieldset>
 <fieldset>
-	<legend><?=t('File Attachment Management')?></legend>
-	<p class="text-muted"><?php echo t('Note: Entering values here will override global conversations file attachment settings for this block if you enable Attachment Overrides for this Conversation.') ?></p>
+    <legend><?=t('File Attachment Management')?></legend>
+    <p class="text-muted"><?php echo t('Note: Entering values here will override global conversations file attachment settings for this block if you enable Attachment Overrides for this Conversation.') ?></p>
     <div class="form-group">
         <div class="checkbox">
             <label class="">
             <?=$form->checkbox('attachmentOverridesEnabled', 1, $attachmentOverridesEnabled)?><?=t('Enable Attachment Overrides')?>
             </label>
         </div>
-		<div class="attachment-overrides">
-			<div class="checkbox">
-				<label class="">
-				<?=$form->checkbox('attachmentsEnabled', 1, $attachmentsEnabled)?><?=t('Enable Attachments')?>
-				</label>
-			</div>
-		</div>
-	</div>
+        <div class="attachment-overrides">
+            <div class="checkbox">
+                <label class="">
+                <?=$form->checkbox('attachmentsEnabled', 1, $attachmentsEnabled)?><?=t('Enable Attachments')?>
+                </label>
+            </div>
+        </div>
+    </div>
     <div class="form-group attachment-overrides">
-		<label class="control-label"><?=t('Max Attachment Size for Guest Users. (MB)')?></label>
-		<div class="controls">
-			<?=$form->text('maxFileSizeGuest', $maxFileSizeGuest > 0 ? $maxFileSizeGuest : '')?>
-		</div>
-	</div>
-	<div class="form-group attachment-overrides">
-		<label class="control-label"><?=t('Max Attachment Size for Registered Users. (MB)')?></label>
-		<div class="controls">
-			<?=$form->text('maxFileSizeRegistered', $maxFileSizeRegistered > 0 ? $maxFileSizeRegistered : '')?>
-		</div>
-	</div>
-	<div class="form-group attachment-overrides">
-		<label class="control-label"><?=t('Max Attachments Per Message for Guest Users.')?></label>
-		<div class="controls">
-			<?=$form->text('maxFilesGuest', $maxFilesGuest > 0 ? $maxFilesGuest : '')?>
-		</div>
-	</div>
-	<div class="form-group attachment-overrides">
-		<label class="control-label"><?=t('Max Attachments Per Message for Registered Users')?></label>
-		<div class="controls">
-			<?=$form->text('maxFilesRegistered', $maxFilesRegistered > 0 ?  $maxFilesRegistered : '')?>
-		</div>
-	</div>
-	<div class="form-group attachment-overrides">
-		<label class="control-label"><?=t('Allowed File Extensions (Comma separated, no periods).')?></label>
-		<div class="controls">
-			<?=$form->textarea('fileExtensions', $fileExtensions)?>
-		</div>
-	</div>
+        <label class="control-label"><?=t('Max Attachment Size for Guest Users. (MB)')?></label>
+        <div class="controls">
+            <?=$form->text('maxFileSizeGuest', $maxFileSizeGuest > 0 ? $maxFileSizeGuest : '')?>
+        </div>
+    </div>
+    <div class="form-group attachment-overrides">
+        <label class="control-label"><?=t('Max Attachment Size for Registered Users. (MB)')?></label>
+        <div class="controls">
+            <?=$form->text('maxFileSizeRegistered', $maxFileSizeRegistered > 0 ? $maxFileSizeRegistered : '')?>
+        </div>
+    </div>
+    <div class="form-group attachment-overrides">
+        <label class="control-label"><?=t('Max Attachments Per Message for Guest Users.')?></label>
+        <div class="controls">
+            <?=$form->text('maxFilesGuest', $maxFilesGuest > 0 ? $maxFilesGuest : '')?>
+        </div>
+    </div>
+    <div class="form-group attachment-overrides">
+        <label class="control-label"><?=t('Max Attachments Per Message for Registered Users')?></label>
+        <div class="controls">
+            <?=$form->text('maxFilesRegistered', $maxFilesRegistered > 0 ?  $maxFilesRegistered : '')?>
+        </div>
+    </div>
+    <div class="form-group attachment-overrides">
+        <label class="control-label"><?=t('Allowed File Extensions (Comma separated, no periods).')?></label>
+        <div class="controls">
+            <?=$form->textarea('fileExtensions', $fileExtensions)?>
+        </div>
+    </div>
 
 
 </fieldset>
 
 <fieldset>
-	<legend><?=t('Notification')?></legend>
-	<div class="form-group">
-		<div class="checkbox">
-			<label>
-				<?=$form->checkbox('notificationOverridesEnabled', 1, $notificationOverridesEnabled)?><?=t('Override Global Settings')?>
-			</label>
-		</div>
-	</div>
-	<div class="form-group notification-overrides">
-		<label class="control-label"><?=t('Users To Receive Conversation Notifications')?></label>
-		<?=Core::make("helper/form/user_selector")->selectMultipleUsers('notificationUsers', $notificationUsers)?>
-	</div>
-	<div class="form-group notification-overrides">
-		<label class="control-label"><?=t('Subscribe Option')?></label>
-		<div class="checkbox">
-			<label><?=$form->checkbox('subscriptionEnabled', 1, $subscriptionEnabled)?>
-				<?=t('Yes, allow registered users to choose to subscribe to conversations.')?>
-			</label>
-		</div>
-	</div>
+    <legend><?=t('Notification')?></legend>
+    <div class="form-group">
+        <div class="checkbox">
+            <label>
+                <?=$form->checkbox('notificationOverridesEnabled', 1, $notificationOverridesEnabled)?><?=t('Override Global Settings')?>
+            </label>
+        </div>
+    </div>
+    <div class="form-group notification-overrides">
+        <label class="control-label"><?=t('Users To Receive Conversation Notifications')?></label>
+        <?=Core::make("helper/form/user_selector")->selectMultipleUsers('notificationUsers', $notificationUsers)?>
+    </div>
+    <div class="form-group notification-overrides">
+        <label class="control-label"><?=t('Subscribe Option')?></label>
+        <div class="checkbox">
+            <label><?=$form->checkbox('subscriptionEnabled', 1, $subscriptionEnabled)?>
+                <?=t('Yes, allow registered users to choose to subscribe to conversations.')?>
+            </label>
+        </div>
+    </div>
 </fieldset>
 
-<script type="text/javascript">
+<script>
 $(function() {
     $('[data-unhide]').each(function() {
         var me = $(this),
@@ -274,14 +276,22 @@ $(function() {
             }
         }).trigger('change');
     });
-	$('input[name=paginate]').on('change', function() {
-		var pg = $('input[name=paginate]:checked');
-		if (pg.val() == 1) {
-			$('div[data-row=itemsPerPage]').show();
-		} else {
-			$('div[data-row=itemsPerPage]').hide();
-		}
-	}).trigger('change');
+    $('input[name=paginate]').on('change', function() {
+        var pg = $('input[name=paginate]:checked');
+        if (pg.val() == 1) {
+            $('div[data-row=itemsPerPage]').show();
+        } else {
+            $('div[data-row=itemsPerPage]').hide();
+        }
+    }).trigger('change');
+    $('input[name=dateFormat]').on('change', function() {
+        var dateFormat = $('input[name=dateFormat]:checked');
+        if (dateFormat.val() == 'custom') {
+            $('div[data-row=customDateFormat]').show();
+        } else {
+            $('div[data-row=customDateFormat]').hide();
+        }
+    }).trigger('change');
     $('input[name=attachmentOverridesEnabled]').on('change', function() {
         var ao = $('input[name=attachmentOverridesEnabled]:checked');
         if (ao.val() == 1) {
@@ -292,13 +302,13 @@ $(function() {
             $('.attachment-overrides label').addClass('text-muted');
         }
     }).trigger('change');
-	$('input[name=notificationOverridesEnabled]').on('change', function() {
-		var ao = $('input[name=notificationOverridesEnabled]:checked');
-		if (ao.val() == 1) {
-			$('.notification-overrides').show();
-		} else {
-			$('.notification-overrides').hide();
-		}
-	}).trigger('change');
+    $('input[name=notificationOverridesEnabled]').on('change', function() {
+        var ao = $('input[name=notificationOverridesEnabled]:checked');
+        if (ao.val() == 1) {
+            $('.notification-overrides').show();
+        } else {
+            $('.notification-overrides').hide();
+        }
+    }).trigger('change');
 });
 </script>


### PR DESCRIPTION
This pull request:
- Displays the Custom Date Format input field conditionally. It currently displays at all times.
- Adds formatting help text.
- Makes the input label more specific.

**Current:**

![conversation_custom_input-current](https://cloud.githubusercontent.com/assets/10898145/25876144/557ff1be-34e9-11e7-9afc-fc25ae096c78.png)

**Changes:**

![conversation_custom_input-changes1](https://cloud.githubusercontent.com/assets/10898145/25876132/4702eb64-34e9-11e7-9757-1208cbe1d9b1.png)

![conversation_custom_input-changes2](https://cloud.githubusercontent.com/assets/10898145/25876136/4a0239e6-34e9-11e7-8718-2809321f3fd3.png)
