### PR TITLE
Conversation block - save enableTopCommentReviews checkbox value

### DIFF
--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -218,6 +218,7 @@ class Controller extends BlockController implements ConversationFeatureInterface
             'maxFileSizeRegistered' => null,
             'enableOrdering' => null,
             'enableCommentRating' => null,
+            'enableTopCommentReviews' => null,
             'notificationOverridesEnabled' => null,
             'subscriptionEnabled' => null,
             'fileExtensions' => null,
@@ -252,6 +253,9 @@ class Controller extends BlockController implements ConversationFeatureInterface
         }
         if (!$values['enableCommentRating']) {
             $values['enableCommentRating'] = 0;
+        }
+        if (!$values['enableTopCommentReviews']) {
+            $values['enableTopCommentReviews'] = 0;
         }
 
         if ($values['notificationOverridesEnabled']) {

--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -9,6 +9,7 @@ if ($controller->getTask() == 'add') {
     $displayMode = 'threaded';
     $enableOrdering = 1;
     $enableCommentRating = 1;
+    $enableTopCommentReviews = 0;
     $displayPostingForm = 'top';
     $addMessageLabel = t('Add Message');
     $attachmentOverridesEnabled = 0;
@@ -83,7 +84,7 @@ if (!$dateFormat) {
     if (isset($reviewAttributeKeys)) {
         ?>
         <div class="form-group" data-unhide="[name=enableTopCommentReviews]">
-            <label class="control-label"><?= t('Aggregate ratings by attribute') ?></label>
+            <label class="control-label"><?= t('Aggregate Ratings by Attribute') ?></label>
             <div class="checkbox">
                 <label>
                     <?php


### PR DESCRIPTION
This pull request:
- Saves the enableTopCommentReviews checkbox value. Currently the value is not saved.
- Capitalizes the "Aggregate Ratings by Attribute" label.