### PR TITLE
Image Slider sortable fix

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -176,6 +176,7 @@ echo Core::make('helper/concrete/ui')->tabs($tabs);
     }
     .ccm-image-slider-entries {
         padding-bottom: 30px;
+        position: relative;
     }
     .ccm-image-slider-block-container .slide-well {
         min-height: 20px;


### PR DESCRIPTION
When a slide has been reordered multiple times, it will pull to the left edge of the form modal. Adding position relative to the slide's parent fixes this.

**Current:**

![sliderfix 001](https://cloud.githubusercontent.com/assets/10898145/26021637/e3074528-375f-11e7-94ae-dafcfc5e8c43.png)

**Changes:**

![sliderfix 002](https://cloud.githubusercontent.com/assets/10898145/26021638/e5fa68dc-375f-11e7-9185-5d3456d6e64f.png)
