### PR TITLE
FAQ block update

### DIFF
--- a/concrete/blocks/faq/LICENSE.TXT
+++ b/concrete/blocks/faq/LICENSE.TXT
@@ -1,8 +1,0 @@
-The MIT License
-Copyright © 2008, Concrete CMS Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/concrete/blocks/faq/add.php
+++ b/concrete/blocks/faq/add.php
@@ -1,5 +1,2 @@
-<?php
-
-defined('C5_EXECUTE') or die("Access Denied.");
-
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form_setup_html.php');

--- a/concrete/blocks/faq/controller.php
+++ b/concrete/blocks/faq/controller.php
@@ -2,36 +2,34 @@
 namespace Concrete\Block\Faq;
 
 use Concrete\Core\Block\BlockController;
-use Database;
 
 class Controller extends BlockController
 {
+    protected $btInterfaceWidth = 600;
+    protected $btInterfaceHeight = 465;
     protected $btTable = 'btFaq';
-    protected $btExportTables = array('btFaq', 'btFaqEntries');
-    protected $btInterfaceWidth = "600";
+    protected $btExportTables = ['btFaq', 'btFaqEntries'];
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "465";
-    protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
 
-    public function getBlockTypeDescription()
-    {
-        return t("Frequently Asked Questions Block");
-    }
-
     public function getBlockTypeName()
     {
-        return t("FAQ");
+        return t('FAQ');
+    }
+
+    public function getBlockTypeDescription()
+    {
+        return t('Frequently Asked Questions Block');
     }
 
     public function getSearchableContent()
     {
         $content = '';
-        $db = Database::connection();
-        $v = array($this->bID);
-        $q = 'select * from btFaqEntries where bID = ?';
+        $db = $this->app->make('database')->connection();
+        $v = [$this->bID];
+        $q = 'SELECT * FROM btFaqEntries WHERE bID = ?';
         $r = $db->query($q, $v);
         foreach ($r as $row) {
             $content .= $row['title'] . ' ' . $row['linkTitle'] . ' ' . $row['description'];
@@ -40,72 +38,65 @@ class Controller extends BlockController
         return $content;
     }
 
-    public function add()
-    {
-        $this->requireAsset('core/file-manager');
-        $this->requireAsset('core/sitemap');
-    }
-
     public function edit()
     {
-        $this->add();
-
-        $db = Database::connection();
-        $query = $db->GetAll('SELECT * from btFaqEntries WHERE bID = ? ORDER BY sortOrder', array($this->bID));
+        $db = $this->app->make('database')->connection();
+        $query = $db->GetAll('SELECT * FROM btFaqEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
         $this->set('rows', $query);
     }
 
     public function view()
     {
-        $db = Database::connection();
-        $query = $db->GetAll('SELECT * from btFaqEntries WHERE bID = ? ORDER BY sortOrder', array($this->bID));
+        $db = $this->app->make('database')->connection();
+        $query = $db->GetAll('SELECT * FROM btFaqEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
         $this->set('rows', $query);
     }
 
     public function duplicate($newBID)
     {
-        $db = Database::connection();
-        $v = array($this->bID);
-        $q = 'select * from btFaqEntries where bID = ?';
+        $db = $this->app->make('database')->connection();
+        $v = [$this->bID];
+        $q = 'SELECT * FROM btFaqEntries WHERE bID = ?';
         $r = $db->query($q, $v);
         foreach ($r as $row) {
             $db->execute(
-                'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) values(?,?,?,?,?)',
-                array(
+                'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) VALUES(?,?,?,?,?)',
+                [
                     $newBID,
                     $row['title'],
                     $row['linkTitle'],
                     $row['description'],
                     $row['sortOrder'],
-                )
+                ]
             );
         }
     }
 
     public function delete()
     {
-        $db = Database::connection();
-        $db->execute('DELETE from btFaqEntries WHERE bID = ?', array($this->bID));
+        $db = $this->app->make('database')->connection();
+        $db->execute('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
         parent::delete();
     }
 
     public function save($args)
     {
-        $db = Database::connection();
-        $db->execute('DELETE from btFaqEntries WHERE bID = ?', array($this->bID));
+        $db = $this->app->make('database')->connection();
+        $db->execute('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
         $count = isset($args['sortOrder']) ? count($args['sortOrder']) : 0;
+
         $i = 0;
         parent::save($args);
         while ($i < $count) {
             $db->execute(
-                'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) values(?,?,?,?,?)',
-                array(
+                'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) VALUES(?,?,?,?,?)',
+                [
                     $this->bID,
                     $args['title'][$i],
                     $args['linkTitle'][$i],
                     $args['description'][$i],
                     $args['sortOrder'][$i],
-                )
+                ]
             );
             ++$i;
         }

--- a/concrete/blocks/faq/db.xml
+++ b/concrete/blocks/faq/db.xml
@@ -1,33 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema
-  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
-
-  <table name="btFaq">
-    <field name="bID" type="integer">
-      <unsigned/>
-      <key/>
-    </field>
-    <field name="blockTitle" type="string" size="255"/>
-  </table>
-
-  <table name="btFaqEntries">
-    <field name="id" type="integer">
-      <unsigned/>
-      <autoincrement/>
-      <key/>
-    </field>
-    <field name="bID" type="integer">
-      <unsigned/>
-    </field>
-    <field name="linkTitle" type="string" size="255"/>
-    <field name="title" type="string" size="255"/>
-    <field name="sortOrder" type="integer"/>
-    <field name="description" type="text"/>
-    <index name="bID">
-      <col>bID</col>
-      <col>sortOrder</col>
-    </index>
-  </table>
-
+<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+    <table name="btFaq">
+        <field name="bID" type="integer">
+            <unsigned/>
+            <key/>
+        </field>
+        <field name="blockTitle" type="string" size="255" />
+    </table>
+    <table name="btFaqEntries">
+        <field name="id" type="integer">
+            <unsigned/>
+            <autoincrement/>
+            <key/>
+        </field>
+        <field name="bID" type="integer">
+            <unsigned/>
+        </field>
+        <field name="linkTitle" type="string" size="255" />
+        <field name="title" type="string" size="255" />
+        <field name="sortOrder" type="integer" />
+        <field name="description" type="text" />
+        <index name="bID">
+            <col>bID</col>
+            <col>sortOrder</col>
+        </index>
+    </table>
 </schema>

--- a/concrete/blocks/faq/edit.php
+++ b/concrete/blocks/faq/edit.php
@@ -1,4 +1,2 @@
-<?php
-
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form_setup_html.php');

--- a/concrete/blocks/faq/form_setup_html.php
+++ b/concrete/blocks/faq/form_setup_html.php
@@ -1,8 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-
-$fp = FilePermissions::getGlobal();
-$tp = new TaskPermission();
-?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <style>
     .ccm-faq-block-container input,
@@ -37,62 +33,69 @@ $tp = new TaskPermission();
         right: 10px;
     }
 </style>
+
 <div class="ccm-faq-block-container">
-    <span class="btn btn-success ccm-add-faq-entry"><?php echo t('Add Entry') ?></span>
-    <?php if ($rows) {
-    foreach ($rows as $row) {
-        ?>
-        <div class="ccm-faq-entry well">
-            <i class="fa-sort-asc fa"></i>
-            <i class="fa-sort-desc fa"></i>
-
-            <div class="form-group">
-                <label><?php echo t('Navigation Link Text') ?></label>
-                <input type="text" name="linkTitle[]" value="<?php echo $row['linkTitle'] ?>"/>
-            </div>
-            <div class="form-group">
-                <label><?php echo t('Title Text') ?></label>
-                <input type="text" name="title[]" value="<?php echo $row['title'] ?>"/>
-            </div>
-            <div class="form-group">
-                <label><?php echo t('Description') ?></label>
-                <textarea class='editor-content' name="description[]"><?php echo $row['description'] ?></textarea>
-            </div>
-            <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="<?php echo $row['sortOrder'] ?>"/>
-
-            <div class="form-group">
-                <span class="btn btn-danger ccm-delete-faq-entry"><?php echo t('Delete Entry');
-        ?></span>
-            </div>
-        </div>
+    <span class="btn btn-success ccm-add-faq-entry"><?php echo t('Add Entry'); ?></span>
     <?php
-    }
-} else {
+    if ($rows) {
+        foreach ($rows as $row) { ?>
+            <div class="ccm-faq-entry well">
+                <i class="fa-sort-asc fa"></i>
+                <i class="fa-sort-desc fa"></i>
+
+                <div class="form-group">
+                    <label class="control-label"><?php echo t('Navigation Link Text'); ?></label>
+                    <input class="form-control ccm-input-text" type="text" name="linkTitle[]" value="<?php echo $row['linkTitle']; ?>">
+                </div>
+
+                <div class="form-group">
+                    <label class="control-label"><?php echo t('Title Text'); ?></label>
+                    <input class="form-control ccm-input-text" type="text" name="title[]" value="<?php echo $row['title']; ?>">
+                </div>
+
+                <div class="form-group">
+                    <label class="control-label"><?php echo t('Description'); ?></label>
+                    <textarea class='editor-content' name="description[]"><?php echo $row['description']; ?></textarea>
+                </div>
+
+                <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="<?php echo $row['sortOrder']; ?>">
+
+                <div class="form-group">
+                    <span class="btn btn-danger ccm-delete-faq-entry"><?php echo t('Delete Entry'); ?></span>
+                </div>
+            </div>
+        <?php
+        }
+    } else {
     ?>
         <script>
-            _.defer(function () {
-                $('.ccm-add-faq-entry').click();
-            });
+        _.defer(function () {
+            $('.ccm-add-faq-entry').click();
+        });
         </script>
     <?php
-} ?>
+    }
+    ?>
+
     <div class="ccm-faq-entry well ccm-faq-entry-template" style="display: none;">
         <i class="fa-sort-asc fa"></i>
         <i class="fa-sort-desc fa"></i>
 
         <div class="form-group">
-            <label><?php echo t('Navigation Link Text') ?></label>
-            <input type="text" name="linkTitle[]" value=""/>
+            <label class="control-label"><?php echo t('Navigation Link Text'); ?></label>
+            <input class="form-control ccm-input-text" type="text" name="linkTitle[]" value="">
         </div>
+
         <div class="form-group">
-            <label><?php echo t('Title Text') ?></label>
-            <input type="text" name="title[]" value=""/>
+            <label class="control-label"><?php echo t('Title Text'); ?></label>
+            <input class="form-control ccm-input-text" type="text" name="title[]" value="">
         </div>
+
         <div class="form-group">
-            <label><?php echo t('Description') ?></label>
+            <label class="control-label"><?php echo t('Description'); ?></label>
             <textarea class='editor-content' name="description[]"></textarea>
         </div>
-        <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value=""/>
+        <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="">
 
         <div class="form-group">
             <span class="btn btn-danger ccm-delete-faq-entry"><?php echo t('Delete Entry'); ?></span>
@@ -101,81 +104,82 @@ $tp = new TaskPermission();
 </div>
 
 <script>
-    <?php
-    $editorJavascript = Core::make('editor')->outputStandardEditorInitJSFunction();
-    ?>
-    var launchEditor = <?=$editorJavascript?>;
+<?php
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$editorJavascript = $app->make('editor')->outputStandardEditorInitJSFunction();
+?>
+var launchEditor = <?=$editorJavascript?>;
 
-    (function() {
-        var container = $('.ccm-faq-block-container');
+(function() {
+    var container = $('.ccm-faq-block-container');
 
-        var doSortCount = function () {
-            $('.ccm-faq-entry', container).each(function (index) {
-                $(this).find('.ccm-faq-entry-sort').val(index);
-            });
-        };
-        doSortCount();
+    var doSortCount = function () {
+        $('.ccm-faq-entry', container).each(function (index) {
+            $(this).find('.ccm-faq-entry-sort').val(index);
+        });
+    };
+    doSortCount();
 
-        var uniqueEntryID = function () {
-            $('.ccm-faq-entry', container).each(function () {
-                $(this).find('.editor-content').not('.ccm-faq-entry-template').attr('id', _.uniqueId());
-            });
-        };
-        uniqueEntryID();
+    var uniqueEntryID = function () {
+        $('.ccm-faq-entry', container).each(function () {
+            $(this).find('.editor-content').not('.ccm-faq-entry-template').attr('id', _.uniqueId());
+        });
+    };
+    uniqueEntryID();
 
-        var cloneTemplate = $('.ccm-faq-entry-template', container).clone(true);
-        cloneTemplate.removeClass('.ccm-faq-entry-template');
-        $('.ccm-faq-entry-template').remove();
+    var cloneTemplate = $('.ccm-faq-entry-template', container).clone(true);
+    cloneTemplate.removeClass('.ccm-faq-entry-template');
+    $('.ccm-faq-entry-template').remove();
 
-        $(cloneTemplate).add($('.ccm-faq-entry', container)).find('.ccm-delete-faq-entry').click(function () {
-            var deleteIt = confirm('<?php echo t('Are you sure?') ?>');
-            if (deleteIt == true) {
-                entryID = $(this).closest('.ccm-faq-entry').find('.editor-content').attr('id');
-                if (typeof CKEDITOR === 'object') {
-                    CKEDITOR.instances[entryID].destroy();
-                }
-
-                $(this).closest('.ccm-faq-entry').remove();
-                doSortCount();
+    $(cloneTemplate).add($('.ccm-faq-entry', container)).find('.ccm-delete-faq-entry').click(function () {
+        var deleteIt = confirm('<?php echo t('Are you sure?'); ?>');
+        if (deleteIt == true) {
+            entryID = $(this).closest('.ccm-faq-entry').find('.editor-content').attr('id');
+            if (typeof CKEDITOR === 'object') {
+                CKEDITOR.instances[entryID].destroy();
             }
-        });
 
-        if (container.find('.editor-content').length) {
-            launchEditor(container.find('.editor-content'));
+            $(this).closest('.ccm-faq-entry').remove();
+            doSortCount();
         }
+    });
 
-        var attachSortDesc = function ($obj) {
-            $obj.click(function () {
-                var myContainer = $(this).closest('.ccm-faq-entry');
-                myContainer.insertAfter(myContainer.next('.ccm-faq-entry'));
-                doSortCount();
-            });
-        };
+    if (container.find('.editor-content').length) {
+        launchEditor(container.find('.editor-content'));
+    }
 
-        var attachSortAsc = function ($obj) {
-            $obj.click(function () {
-                var myContainer = $(this).closest('.ccm-faq-entry');
-                myContainer.insertBefore(myContainer.prev('.ccm-faq-entry'));
-                doSortCount();
-            });
-        };
-        $('i.fa-sort-desc', container).each(function () {
-            attachSortDesc($(this));
-        });
-        $('i.fa-sort-asc', container).each(function () {
-            attachSortAsc($(this));
-        });
-        $('.ccm-add-faq-entry', container).click(function () {
-            var newClone = cloneTemplate.clone(true);
-            newClone.find('.editor-content').attr('id', _.uniqueId());
-            launchEditor(newClone.show().find('.editor-content'));
-            container.append(newClone);
-            attachSortAsc(newClone.find('i.fa-sort-asc'));
-            attachSortDesc(newClone.find('i.fa-sort-desc'));
-            var thisModal = $(this).closest('.ui-dialog-content');
-            var newSlide = $('.ccm-faq-entry').last();
-            thisModal.scrollTop(newSlide.offset().top);
+    var attachSortDesc = function ($obj) {
+        $obj.click(function () {
+            var myContainer = $(this).closest('.ccm-faq-entry');
+            myContainer.insertAfter(myContainer.next('.ccm-faq-entry'));
             doSortCount();
         });
-    }());
+    };
+
+    var attachSortAsc = function ($obj) {
+        $obj.click(function () {
+            var myContainer = $(this).closest('.ccm-faq-entry');
+            myContainer.insertBefore(myContainer.prev('.ccm-faq-entry'));
+            doSortCount();
+        });
+    };
+    $('i.fa-sort-desc', container).each(function () {
+        attachSortDesc($(this));
+    });
+    $('i.fa-sort-asc', container).each(function () {
+        attachSortAsc($(this));
+    });
+    $('.ccm-add-faq-entry', container).click(function () {
+        var newClone = cloneTemplate.clone(true);
+        newClone.find('.editor-content').attr('id', _.uniqueId());
+        launchEditor(newClone.show().find('.editor-content'));
+        container.append(newClone);
+        attachSortAsc(newClone.find('i.fa-sort-asc'));
+        attachSortDesc(newClone.find('i.fa-sort-desc'));
+        var thisModal = $(this).closest('.ui-dialog-content');
+        var newSlide = $('.ccm-faq-entry').last();
+        thisModal.scrollTop(newSlide.offset().top);
+        doSortCount();
+    });
+}());
 </script>

--- a/concrete/blocks/faq/form_setup_html.php
+++ b/concrete/blocks/faq/form_setup_html.php
@@ -1,75 +1,102 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <style>
-    .ccm-faq-block-container input,
-    .ccm-faq-block-container textarea {
-        display: block;
-        width: 100%;
+    .ccm-faq-block-container {
+        position: relative;
     }
-
     .ccm-faq-block-container .btn-success {
         margin-bottom: 20px;
     }
-
     .ccm-faq-entry {
         position: relative;
     }
-
-    .ccm-faq-block-container i.fa-sort-asc {
+    .ccm-faq-entry.well {
+        margin-bottom: 10px;
+        padding: 28px 10px 10px;
+    }
+    .ccm-faq-entry.well.entry-closed {
+        height: 57px;
+        padding: 0 0 0 15px;
+    }
+    .ccm-faq-entry .entry-collapse-text {
+        display: none;
+    }
+    .ccm-faq-entry.entry-closed .entry-collapse-text {
+        display: block;
+        line-height: 57px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 335px;
+    }
+    .ccm-faq-entry.entry-closed .form-group {
+        display: none;
+    }
+    .ccm-faq-entry .form-group:last-of-type {
+        margin-bottom: 0;
+    }
+    .ccm-edit-entry {
         position: absolute;
+        right: 127px;
         top: 10px;
-        right: 10px;
-        cursor: pointer;
     }
-
-    .ccm-faq-block-container i:hover {
-        color: #5cb85c;
-    }
-
-    .ccm-faq-block-container i.fa-sort-desc {
+    .ccm-delete-faq-entry {
         position: absolute;
-        top: 15px;
-        cursor: pointer;
-        right: 10px;
+        right: 41px;
+        top: 10px;
+    }
+    .ccm-faq-block-container i:hover {
+        color: #428bca;
+    }
+    .ccm-faq-block-container i.fa-arrows {
+        cursor: move;
+        font-size: 20px;
+        padding: 5px;
+        position: absolute;
+        right: 5px;
+        top: 6px;
+    }
+    .ccm-faq-block-container .ui-state-highlight {
+        height: 57px;
+        margin-bottom: 10px;
+    }
+    .ccm-faq-block-container .ui-sortable-helper {
+        box-shadow: 0 10px 18px 2px rgba(54,55,66,0.27);
     }
 </style>
 
 <div class="ccm-faq-block-container">
-    <span class="btn btn-success ccm-add-faq-entry"><?php echo t('Add Entry'); ?></span>
+    <button type="button" class="btn btn-success ccm-add-faq-entry"><?php echo t('Add Entry'); ?></button>
     <?php
     if ($rows) {
         foreach ($rows as $row) { ?>
-            <div class="ccm-faq-entry well">
-                <i class="fa-sort-asc fa"></i>
-                <i class="fa-sort-desc fa"></i>
+            <div class="ccm-faq-entry well entry-closed">
+                <p class="entry-collapse-text"><?php echo $row['linkTitle'] ? $row['linkTitle'] : ''; ?></p>
 
                 <div class="form-group">
                     <label class="control-label"><?php echo t('Navigation Link Text'); ?></label>
                     <input class="form-control ccm-input-text" type="text" name="linkTitle[]" value="<?php echo $row['linkTitle']; ?>">
                 </div>
-
                 <div class="form-group">
                     <label class="control-label"><?php echo t('Title Text'); ?></label>
                     <input class="form-control ccm-input-text" type="text" name="title[]" value="<?php echo $row['title']; ?>">
                 </div>
-
                 <div class="form-group">
                     <label class="control-label"><?php echo t('Description'); ?></label>
                     <textarea class='editor-content' name="description[]"><?php echo $row['description']; ?></textarea>
                 </div>
+                <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?php echo t('Collapse Entry'); ?>" data-entry-edit-text="<?php echo t('Edit Entry'); ?>"><?php echo t('Edit Entry'); ?></button>
+                <button type="button" class="btn btn-sm btn-danger ccm-delete-faq-entry"><?php echo t('Remove'); ?></button>
+                <i class="fa fa-arrows"></i>
 
                 <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="<?php echo $row['sortOrder']; ?>">
-
-                <div class="form-group">
-                    <span class="btn btn-danger ccm-delete-faq-entry"><?php echo t('Delete Entry'); ?></span>
-                </div>
             </div>
         <?php
         }
     } else {
     ?>
         <script>
-        _.defer(function () {
+        _.defer(function() {
             $('.ccm-add-faq-entry').click();
         });
         </script>
@@ -78,28 +105,25 @@
     ?>
 
     <div class="ccm-faq-entry well ccm-faq-entry-template" style="display: none;">
-        <i class="fa-sort-asc fa"></i>
-        <i class="fa-sort-desc fa"></i>
+        <p class="entry-collapse-text"></p>
 
         <div class="form-group">
             <label class="control-label"><?php echo t('Navigation Link Text'); ?></label>
             <input class="form-control ccm-input-text" type="text" name="linkTitle[]" value="">
         </div>
-
         <div class="form-group">
             <label class="control-label"><?php echo t('Title Text'); ?></label>
             <input class="form-control ccm-input-text" type="text" name="title[]" value="">
         </div>
-
         <div class="form-group">
             <label class="control-label"><?php echo t('Description'); ?></label>
             <textarea class='editor-content' name="description[]"></textarea>
         </div>
-        <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="">
+        <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?php echo t('Collapse Entry'); ?>" data-entry-edit-text="<?php echo t('Edit Entry'); ?>"><?php echo t('Edit Entry'); ?></button>
+        <button type="button" class="btn btn-sm btn-danger ccm-delete-faq-entry"><?php echo t('Remove'); ?></button>
+        <i class="fa fa-arrows"></i>
 
-        <div class="form-group">
-            <span class="btn btn-danger ccm-delete-faq-entry"><?php echo t('Delete Entry'); ?></span>
-        </div>
+        <input class="ccm-faq-entry-sort" type="hidden" name="sortOrder[]" value="">
     </div>
 </div>
 
@@ -110,18 +134,18 @@ $editorJavascript = $app->make('editor')->outputStandardEditorInitJSFunction();
 ?>
 var launchEditor = <?=$editorJavascript?>;
 
-(function() {
+$(document).ready(function() {
     var container = $('.ccm-faq-block-container');
 
-    var doSortCount = function () {
-        $('.ccm-faq-entry', container).each(function (index) {
+    var doSortCount = function() {
+        $('.ccm-faq-entry', container).each(function(index) {
             $(this).find('.ccm-faq-entry-sort').val(index);
         });
     };
     doSortCount();
 
-    var uniqueEntryID = function () {
-        $('.ccm-faq-entry', container).each(function () {
+    var uniqueEntryID = function() {
+        $('.ccm-faq-entry', container).each(function() {
             $(this).find('.editor-content').not('.ccm-faq-entry-template').attr('id', _.uniqueId());
         });
     };
@@ -131,9 +155,9 @@ var launchEditor = <?=$editorJavascript?>;
     cloneTemplate.removeClass('.ccm-faq-entry-template');
     $('.ccm-faq-entry-template').remove();
 
-    $(cloneTemplate).add($('.ccm-faq-entry', container)).find('.ccm-delete-faq-entry').click(function () {
+    $(cloneTemplate).add($('.ccm-faq-entry', container)).find('.ccm-delete-faq-entry').click(function() {
         var deleteIt = confirm('<?php echo t('Are you sure?'); ?>');
-        if (deleteIt == true) {
+        if (deleteIt === true) {
             entryID = $(this).closest('.ccm-faq-entry').find('.editor-content').attr('id');
             if (typeof CKEDITOR === 'object') {
                 CKEDITOR.instances[entryID].destroy();
@@ -148,38 +172,58 @@ var launchEditor = <?=$editorJavascript?>;
         launchEditor(container.find('.editor-content'));
     }
 
-    var attachSortDesc = function ($obj) {
-        $obj.click(function () {
-            var myContainer = $(this).closest('.ccm-faq-entry');
-            myContainer.insertAfter(myContainer.next('.ccm-faq-entry'));
-            doSortCount();
-        });
-    };
-
-    var attachSortAsc = function ($obj) {
-        $obj.click(function () {
-            var myContainer = $(this).closest('.ccm-faq-entry');
-            myContainer.insertBefore(myContainer.prev('.ccm-faq-entry'));
-            doSortCount();
-        });
-    };
-    $('i.fa-sort-desc', container).each(function () {
-        attachSortDesc($(this));
-    });
-    $('i.fa-sort-asc', container).each(function () {
-        attachSortAsc($(this));
-    });
-    $('.ccm-add-faq-entry', container).click(function () {
+    $('.ccm-add-faq-entry', container).click(function() {
         var newClone = cloneTemplate.clone(true);
         newClone.find('.editor-content').attr('id', _.uniqueId());
         launchEditor(newClone.show().find('.editor-content'));
         container.append(newClone);
-        attachSortAsc(newClone.find('i.fa-sort-asc'));
-        attachSortDesc(newClone.find('i.fa-sort-desc'));
+
+        $('.ccm-faq-entry').not('.entry-closed').each(function() {
+            $(this).addClass('entry-closed');
+            var thisEditButton = $(this).find('.ccm-edit-entry');
+            thisEditButton.text(thisEditButton.data('entryEditText'));
+
+            var linkTitleText = $(this).find('input[name="linkTitle[]"]').val();
+            if (linkTitleText) {
+                $(this).find('.entry-collapse-text').text(linkTitleText);
+            }
+        });
+
+        var newEntry = $('.ccm-faq-entry').last();
+        var closeText = newEntry.find('.ccm-edit-entry').data('entryCloseText');
+        newEntry.removeClass('entry-closed').find('.ccm-edit-entry').text(closeText);
+
         var thisModal = $(this).closest('.ui-dialog-content');
-        var newSlide = $('.ccm-faq-entry').last();
-        thisModal.scrollTop(newSlide.offset().top);
+        thisModal.scrollTop(newEntry.offset().top);
         doSortCount();
     });
-}());
+
+    $(container).on('click','.ccm-edit-entry', function() {
+        var closestEntry = $(this).closest('.ccm-faq-entry');
+        closestEntry.toggleClass('entry-closed');
+
+        var thisEditButton = $(this);
+        if (thisEditButton.data('entryEditText') === thisEditButton.text()) {
+            thisEditButton.text(thisEditButton.data('entryCloseText'));
+        } else if (thisEditButton.data('entryCloseText') === thisEditButton.text()) {
+            thisEditButton.text(thisEditButton.data('entryEditText'));
+
+            var linkTitleText = closestEntry.find('input[name="linkTitle[]"]').val();
+            if (linkTitleText) {
+                closestEntry.find('.entry-collapse-text').text(linkTitleText);
+            }
+        }
+    });
+
+    $(container).sortable({
+        placeholder: 'ui-state-highlight',
+        axis: 'y',
+        items: '.ccm-faq-entry',
+        handle: 'i.fa-arrows',
+        cursor: 'move',
+        update: function() {
+            doSortCount();
+        }
+    });
+});
 </script>

--- a/concrete/blocks/faq/view.php
+++ b/concrete/blocks/faq/view.php
@@ -1,38 +1,36 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $linkCount = 1;
-$faqEntryCount = 1; ?>
+$faqEntryCount = 1;
+?>
+
 <div class="ccm-faq-container">
-    <?php if (count($rows) > 0) {
-    ?>
+    <?php if (count($rows) > 0) { ?>
         <div class="ccm-faq-block-links">
-            <?php foreach ($rows as $row) {
-    ?>
-                <a href="#<?php echo $bID . $linkCount ?>"><?php echo $row['linkTitle'] ?></a>
-                <?php ++$linkCount;
-}
-    ?>
+            <?php foreach ($rows as $row) { ?>
+                <a href="#<?php echo $bID . $linkCount; ?>"><?php echo $row['linkTitle']; ?></a>
+                <?php
+                ++$linkCount;
+            } ?>
         </div>
         <div class="ccm-faq-block-entries">
-            <?php foreach ($rows as $row) {
-    ?>
+            <?php foreach ($rows as $row) { ?>
                 <div class="faq-entry-content">
-                    <a name="<?php echo $bID . $faqEntryCount ?>"></a>
-
-                    <h3><?php echo $row['title'] ?></h3>
-
-                    <p><?php echo $row['description'] ?></p>
+                    <a name="<?php echo $bID . $faqEntryCount; ?>"></a>
+                    <h3><?php echo $row['title']; ?></h3>
+                    <p><?php echo $row['description']; ?></p>
                 </div>
-                <?php ++$faqEntryCount;
-}
-    ?>
+                <?php
+                ++$faqEntryCount;
+            } ?>
         </div>
-    <?php 
-} else {
+    <?php
+    } else {
     ?>
         <div class="ccm-faq-block-links">
-            <p><?php echo t('No Faq Entries Entered.');
-    ?></p>
+            <p><?php echo t('No Faq Entries Entered.'); ?></p>
         </div>
-    <?php 
-} ?>
+    <?php
+    }
+    ?>
 </div>


### PR DESCRIPTION
This pull request updates the FAQ block:
- entries can be collapsed and dragged to reorder
- when an entry is collapsed, the Navigation Link Text becomes the entry label
- the missing LinkAbstractor translate methods were added
- Core:make() and Database::connection() were replaced with $app->make()
- the database methods were updated
- existing code was formatted and indented

In an attempt to keep a concise commit history, I mistakenly condensed too many changes into too few commits.

**Current:**

![faq_update-current](https://cloud.githubusercontent.com/assets/10898145/26034094/2a4b7a1e-3885-11e7-9e5e-5d6751ca90cf.png)

**Changes:**

![faq_update-changes1](https://cloud.githubusercontent.com/assets/10898145/26034095/2e8e47f0-3885-11e7-9650-1f975b565dd6.png)

![faq_update-changes2](https://cloud.githubusercontent.com/assets/10898145/26034099/30f87eac-3885-11e7-8c66-656a99e8ff03.png)

![faq_update-changes3](https://cloud.githubusercontent.com/assets/10898145/26034101/32d2ac20-3885-11e7-90c5-f1474a2dc2e0.png)

![faq_update-changes4](https://cloud.githubusercontent.com/assets/10898145/26034102/34d8d990-3885-11e7-9fc1-01cf164c2289.png)

![faq_update-changes5](https://cloud.githubusercontent.com/assets/10898145/26034104/387ca7d4-3885-11e7-8100-6d29768dddc5.png)
