### PR TITLE
Redirected to /favicon.ico after sign in on private website

### DIFF
--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -553,6 +553,14 @@ class StartingPointPackage extends BasePackage
         $register = Page::getByPath('/register', "RECENT");
         $register->assignPermissions($g1, ['view_page']);
 
+        // Page Forbidden
+        $page_forbidden = Page::getByPath('/page_forbidden', "RECENT");
+        $page_forbidden->assignPermissions($g1, ['view_page']);
+
+        // Page Not Found
+        $page_not_found = Page::getByPath('/page_not_found', "RECENT");
+        $page_not_found->assignPermissions($g1, ['view_page']);
+
         // dashboard
         $dashboard = Page::getByPath('/dashboard', "RECENT");
         $dashboard->assignPermissions($g3, ['view_page']);


### PR DESCRIPTION
## Steps to reproduce

1. Set Viewing Permissions to Members on Site Access page
2. Sign out
3. Access to some 404 page (e.g. `https://YOUR_SITE/favicon.ico`)
4. Sign In
5. Redirected to previous 404 page

## Behind the issue

1. `ResponseFactory::notFound` will pass `Page::getByPath('/page_not_found')` to `ResponseFactory::collection`
2. If the user is not able to access to `Page::getByPath('/page_not_found')`, `ResponseFactory::collection` will pass request uri (e.g. /favicon.ico or anything 404 uri) to `ResponseFactory::forbidden`
3. `ResponseFactory::forbidden` will save given request uri to session storage