### PR TITLE
Reduce memory usage on rescan file version

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -19,6 +19,7 @@ use Concrete\Core\File\Type\TypeList as FileTypeList;
 use Concrete\Core\Http\FlysystemFileResponse;
 use Concrete\Core\Support\Facade\Application;
 use Imagine\Gd\Image;
+use Imagine\Image\Metadata\ExifMetadataReader;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FileNotFoundException;
 use Core;
@@ -137,6 +138,8 @@ class Version implements ObjectInterface
      * @ORM\Column(type="boolean")
      */
     protected $fvHasDetailThumbnail = false;
+
+    private $imagineImage = null;
 
     /**
      * Add a new file version.
@@ -984,24 +987,39 @@ class Version implements ObjectInterface
      */
     public function getImagineImage()
     {
-        $resource = $this->getFileResource();
-        $mimetype = $resource->getMimeType();
-        $imageLibrary = \Image::getFacadeRoot();
+        if (null === $this->imagineImage) {
+            $resource = $this->getFileResource();
+            $mimetype = $resource->getMimeType();
+            $imageLibrary = \Image::getFacadeRoot();
 
-        switch ($mimetype) {
-            case 'image/svg+xml':
-            case 'image/svg-xml':
-                if ($imageLibrary instanceof \Imagine\Gd\Imagine) {
+            switch ($mimetype) {
+                case 'image/svg+xml':
+                case 'image/svg-xml':
+                    if ($imageLibrary instanceof \Imagine\Gd\Imagine) {
+                        try {
+                            $app = Facade::getFacadeApplication();
+                            $imageLibrary = $app->make('image/imagick');
+                        } catch (\Exception $x) {
+                            $this->imagineImage = false;
+                        }
+                    }
+                    break;
+            }
+
+            $metadataReader = $imageLibrary->getMetadataReader();
+            if (!$metadataReader instanceof ExifMetadataReader) {
+                if (\Config::get('concrete.file_manager.images.use_exif_data_to_rotate_images')) {
                     try {
-                        $app = Facade::getFacadeApplication();
-                        $imageLibrary = $app->make('image/imagick');
-                    } catch (\Exception $x) {
-                        return false;
+                        $imageLibrary->setMetadataReader(new ExifMetadataReader());
+                    } catch (NotSupportedException $e) {
                     }
                 }
-                break;
+            }
+
+            $this->imagineImage = $imageLibrary->load($resource->read());
         }
-        return  $imageLibrary->load($resource->read());
+
+        return $this->imagineImage;
     }
 
     /**

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -18,6 +18,7 @@ use Concrete\Core\File\Menu;
 use Concrete\Core\File\Type\TypeList as FileTypeList;
 use Concrete\Core\Http\FlysystemFileResponse;
 use Concrete\Core\Support\Facade\Application;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Gd\Image;
 use Imagine\Image\Metadata\ExifMetadataReader;
 use League\Flysystem\AdapterInterface;

--- a/concrete/src/File/Type/Inspector/ImageInspector.php
+++ b/concrete/src/File/Type/Inspector/ImageInspector.php
@@ -12,16 +12,7 @@ class ImageInspector extends Inspector
 {
     public function inspect(Version $fv)
     {
-        $fr = $fv->getFileResource();
-        $imagine = Core::make(Image::getFacadeAccessor());
-        if (\Config::get('concrete.file_manager.images.use_exif_data_to_rotate_images')) {
-            try {
-                $imagine->setMetadataReader(new ExifMetadataReader());
-            } catch (NotSupportedException $e) {
-            }
-        }
-
-        $image = $imagine->load($fr->read());
+        $image = $fv->getImagineImage();
         $data = $image->getSize();
 
         // sets an attribute - these file attribute keys should be added

--- a/concrete/src/File/Type/Inspector/ImageInspector.php
+++ b/concrete/src/File/Type/Inspector/ImageInspector.php
@@ -5,8 +5,6 @@ use Concrete\Core\Entity\File\Version;
 use Image;
 use FileAttributeKey;
 use Core;
-use Imagine\Exception\NotSupportedException;
-use Imagine\Image\Metadata\ExifMetadataReader;
 
 class ImageInspector extends Inspector
 {


### PR DESCRIPTION
I tried to rescan a file with this simple script.

```php
Route::register('/test', function() {
    $f = Concrete\Core\File\File::getByID(16); // sunset.jpg
    $fv = $f->getApprovedVersion();
    $resp = $fv->refreshAttributes();
});
```

This refreshed file is sunset.jpg in elemental_full starting point package. The size of this image is only 447.31 KB. Amazingly, this scripts will allocate 49.1MB memory!

This change will avoid loading same image on memory repeatedly, and reduce 19% memory usage on refreshing file versions.

https://blackfire.io/profiles/compare/6ff77e4a-d709-4687-8ac3-a1bb698e0094/graph