### PR TITLE
add Link to File option to the Image Block

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -34,14 +34,14 @@ class Controller extends BlockController implements FileTrackableInterface
         $this->tracker = $tracker;
     }
 
-    public function getBlockTypeDescription()
-    {
-        return t("Adds images and onstates from the library to pages.");
-    }
-
     public function getBlockTypeName()
     {
-        return t("Image");
+        return t('Image');
+    }
+
+    public function getBlockTypeDescription()
+    {
+        return t('Adds images and onstates from the library to pages.');
     }
 
     /**
@@ -184,7 +184,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $db = $this->app->make('database')->connection();
 
         $file = null;
-        $fID = $db->fetchColumn('select fID from btContentImage where bID = ?', [$this->bID], 0);
+        $fID = $db->fetchColumn('SELECT fID FROM btContentImage WHERE bID = ?', [$this->bID], 0);
         if ($fID) {
             $f = File::getByID($fID);
             if (is_object($f) && $f->getFileID()) {
@@ -371,12 +371,12 @@ class Controller extends BlockController implements FileTrackableInterface
             'fileLinkID' => 0,
         ];
 
-        $args['fID'] = ($args['fID'] != '') ? $args['fID'] : 0;
-        $args['fOnstateID'] = ($args['fOnstateID'] != '') ? $args['fOnstateID'] : 0;
+        $args['fID'] = $args['fID'] != '' ? $args['fID'] : 0;
+        $args['fOnstateID'] = $args['fOnstateID'] != '' ? $args['fOnstateID'] : 0;
         $args['fileLinkID'] = $args['fileLinkID'] != '' ? $args['fileLinkID'] : 0;
         $args['cropImage'] = isset($args['cropImage']) ? 1 : 0;
-        $args['maxWidth'] = (intval($args['maxWidth']) > 0) ? intval($args['maxWidth']) : 0;
-        $args['maxHeight'] = (intval($args['maxHeight']) > 0) ? intval($args['maxHeight']) : 0;
+        $args['maxWidth'] = intval($args['maxWidth']) > 0 ? intval($args['maxWidth']) : 0;
+        $args['maxHeight'] = intval($args['maxHeight']) > 0 ? intval($args['maxHeight']) : 0;
 
         if (!$args['constrainImage']) {
             $args['cropImage'] = 0;

--- a/concrete/blocks/image/db.xml
+++ b/concrete/blocks/image/db.xml
@@ -30,6 +30,10 @@
             <unsigned/>
             <default value="0" />
         </field>
+        <field name="fileLinkID" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
         <field name="altText" type="string" size="255" />
         <field name="title" type="string" size="255" />
         <index name="fID">

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -31,8 +31,9 @@ $al = $app->make('helper/concrete/asset_library');
         <?php
         $options = [
             0 => t('None'),
-            1 => t('Another Page'),
+            1 => t('Page'),
             2 => t('External URL'),
+            3 => t('File')
         ];
 
         echo $form->label('imageLinkType', t('Image Link'));
@@ -42,15 +43,22 @@ $al = $app->make('helper/concrete/asset_library');
 
     <div id="imageLinkTypePage" style="display: none;" class="form-group">
         <?php
-        echo $form->label('internalLinkCID', t('Choose Page:'));
+        echo $form->label('internalLinkCID', t('Page'));
         echo $ps->selectPage('internalLinkCID', $internalLinkCID);
         ?>
     </div>
 
     <div id="imageLinkTypeExternal" style="display: none;" class="form-group">
         <?php
-        echo $form->label('externalLink', t('URL'));
+        echo $form->label('externalLink', t('External URL'));
         echo $form->text('externalLink', $externalLink);
+        ?>
+    </div>
+
+    <div id="imageLinkTypeFile" style="display: none;" class="form-group">
+        <?php
+        echo $form->label('fileLinkID', t('File'));
+        echo $al->file('ccm-b-file', 'fileLinkID', t('Choose File'), $linkFile);
         ?>
     </div>
 
@@ -120,6 +128,7 @@ refreshImageLinkTypeControls = function() {
     var linkType = $('#linkType').val();
     $('#imageLinkTypePage').toggle(linkType == 1);
     $('#imageLinkTypeExternal').toggle(linkType == 2);
+    $('#imageLinkTypeFile').toggle(linkType == 3);
 };
 
 $(document).ready(function() {

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -6,7 +6,7 @@ $al = $app->make('helper/concrete/asset_library');
 ?>
 
 <fieldset>
-    <legend><?php echo t('Files') ?></legend>
+    <legend><?php echo t('Files'); ?></legend>
 
     <div class="form-group">
         <?php
@@ -25,7 +25,7 @@ $al = $app->make('helper/concrete/asset_library');
 </fieldset>
 
 <fieldset>
-    <legend><?php echo t('HTML') ?></legend>
+    <legend><?php echo t('HTML'); ?></legend>
 
     <div class="form-group">
         <?php
@@ -78,7 +78,7 @@ $al = $app->make('helper/concrete/asset_library');
 </fieldset>
 
 <fieldset>
-    <legend><?php echo t('Resize Image') ?></legend>
+    <legend><?php echo t('Resize Image'); ?></legend>
 
     <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">


### PR DESCRIPTION
https://github.com/concrete5/concrete5/issues/5450

I believe this existing migration should handle the changes to the Image block table: https://github.com/concrete5/concrete5/blob/develop/concrete/src/Updater/Migrations/Migrations/Version20170421000000.php#L18

**Current:**

![image_link_file-current](https://cloud.githubusercontent.com/assets/10898145/26281901/bd83ce42-3dd2-11e7-9cb1-49f01ba2249f.png)

**Changes:**

![image-changes1](https://cloud.githubusercontent.com/assets/10898145/26289695/188d566c-3e70-11e7-8586-8d462489ae13.png)

![image-changes2](https://cloud.githubusercontent.com/assets/10898145/26289699/1b68cdd0-3e70-11e7-8d0e-b65aaa301903.png)

I have tested the code changes, but would appreciate additional eyes to make sure I haven't overlooked something.