### PR TITLE
File Manager Replace modal - make inputs and buttons use the full width available

### DIFF
--- a/concrete/tools/files/replace.php
+++ b/concrete/tools/files/replace.php
@@ -2,9 +2,10 @@
 
 use Concrete\Core\File\StorageLocation\StorageLocation;
 $u = new User();
-$ch = Loader::helper('concrete/file');
-$valt = Loader::helper('validation/token');
-$form = Loader::helper('form');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$ch = $app->make('helper/concrete/file');
+$valt = $app->make('helper/validation/token');
+$form = $app->make('helper/form');
 
 $f = File::getByID($_REQUEST['fID']);
 $fp = new Permissions($f);
@@ -12,7 +13,7 @@ if (!$fp->canEditFileContents()) {
     die(t('Access Denied.'));
 }
 
-$searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
+$searchInstance = $app->make('helper/text')->entities($_REQUEST['searchInstance']);
 ?>
 
 <div class="ccm-ui">

--- a/concrete/tools/files/replace.php
+++ b/concrete/tools/files/replace.php
@@ -1,10 +1,10 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+use Concrete\Core\File\StorageLocation\StorageLocation;
 $u = new User();
 $ch = Loader::helper('concrete/file');
 $valt = Loader::helper('validation/token');
 $form = Loader::helper('form');
-use Concrete\Core\File\StorageLocation\StorageLocation;
 
 $f = File::getByID($_REQUEST['fID']);
 $fp = new Permissions($f);
@@ -16,27 +16,26 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
 ?>
 
 <div class="ccm-ui">
-
     <ul class="nav nav-tabs" id="ccm-file-import-tabs">
         <li class="active"><a href="javascript:void(0)" id="ccm-file-add-computer"><?=t('Add From Computer')?></a></li>
         <li><a href="javascript:void(0)" id="ccm-file-add-incoming"><?=t('Add From Incoming')?></a></li>
         <li><a href="javascript:void(0)" id="ccm-file-add-remote"><?=t('Add Remote Files')?></a></li>
     </ul>
-    <script type="text/javascript">
-        var ccm_fiActiveTab = "ccm-file-add-computer";
-        $("#ccm-file-import-tabs a").click(function() {
 
-            $("li.active").removeClass('active');
-            var activesection = ccm_fiActiveTab.substring(13);
+    <script>
+    var ccm_fiActiveTab = "ccm-file-add-computer";
+    $("#ccm-file-import-tabs a").click(function() {
+        $("li.active").removeClass('active');
+        var activesection = ccm_fiActiveTab.substring(13);
 
-            $("#" + ccm_fiActiveTab + "-tab").hide();
-            ccm_fiActiveTab = $(this).attr('id');
+        $("#" + ccm_fiActiveTab + "-tab").hide();
+        ccm_fiActiveTab = $(this).attr('id');
 
-            $(this).parent().addClass("active");
-            $("#" + ccm_fiActiveTab + "-tab").show();
-        });
-
+        $(this).parent().addClass("active");
+        $("#" + ccm_fiActiveTab + "-tab").show();
+    });
     </script>
+
     <div id="ccm-file-add-computer-tab">
         <form method="post" class="form-inline" id="ccm-file-manager-replace-upload" data-dialog-form="replace-file" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/importers/single">
             <h4><?=t('Add From Computer')?></h4>
@@ -54,7 +53,6 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
             </table>
         </form>
     </div>
-
 
     <div id="ccm-file-add-incoming-tab" style="display: none">
         <h4><?=t('Add from Incoming Directory')?></h4>
@@ -90,19 +88,19 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
                 </form>
             <?php
             } else {
-                if ($error) {
-                    ?>
+                if ($error) { ?>
                     <div class="alert alert-danger">
-                        <?php echo $error;
-                    ?>
+                        <?php echo $error; ?>
                     </div>
                 <?php
                 } else {
                     echo t('No files found in %s for the storage location "%s".', REL_DIR_FILES_INCOMING, StorageLocation::getDefault()->getName());
                 }
-            } ?>
+            }
+            ?>
         </div>
     </div>
+
     <div id="ccm-file-add-remote-tab" style="display: none">
         <h4><?=t("Add from Remote URL")?></h4>
         <form method="post" id="ccm-file-manager-replace-remote" class="form-inline" data-dialog-form="replace-file" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/importers/remote">
@@ -123,13 +121,13 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
     </div>
 </div>
 
-<script type="text/javascript">
-    $(function() {
-        $('#ccm-file-manager-replace-incoming,#ccm-file-manager-replace-remote,#ccm-file-manager-replace-upload').concreteAjaxForm();
-        ConcreteEvent.subscribe('AjaxFormSubmitSuccess', function(e, data) {
-            if (data.form == 'replace-file') {
-                ConcreteEvent.publish('FileManagerReplaceFileComplete', {files: data.response.files});
-            }
-        });
+<script>
+$(function() {
+    $('#ccm-file-manager-replace-incoming,#ccm-file-manager-replace-remote,#ccm-file-manager-replace-upload').concreteAjaxForm();
+    ConcreteEvent.subscribe('AjaxFormSubmitSuccess', function(e, data) {
+        if (data.form == 'replace-file') {
+            ConcreteEvent.publish('FileManagerReplaceFileComplete', {files: data.response.files});
+        }
     });
+});
 </script>

--- a/concrete/tools/files/replace.php
+++ b/concrete/tools/files/replace.php
@@ -40,10 +40,18 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
     <div id="ccm-file-add-computer-tab">
         <form method="post" class="form-inline" id="ccm-file-manager-replace-upload" data-dialog-form="replace-file" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/importers/single">
             <h4><?=t('Add From Computer')?></h4>
-            <input type="file" name="Filedata" class="form-control" style="width: 195px" />
-            <?=$valt->output('upload');?>
-            <?= $form->hidden('fID', $f->getFileID()); ?>
-            <button type="submit" class="btn btn-warning btn-sm"><?=t('Upload')?></button>
+            <table style="width: 100%;">
+                <tr>
+                    <td style="width: 100%;">
+                        <input type="file" name="Filedata" class="form-control" style="width: 100%; height: auto;">
+                        <?=$valt->output('upload');?>
+                        <?= $form->hidden('fID', $f->getFileID()); ?>
+                    </td>
+                    <td>
+                        <button type="submit" class="btn btn-warning" style="margin-left: 4px;"><?=t('Upload')?></button>
+                    </td>
+                </tr>
+            </table>
         </form>
     </div>
 
@@ -65,19 +73,22 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
             foreach ($con1 as $con) {
                 $contents[$con['basename']] = $con['basename'];
             }
-            if (count($contents) > 0) {
-                ?>
+            if (count($contents) > 0) { ?>
                 <form method="post" id="ccm-file-manager-replace-incoming" class="form-inline" data-dialog-form="replace-file" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/importers/incoming">
-                    <?= $form->select('send_file', $contents, array('style' => 'width:195px'));
-                ?>
-                    &nbsp;&nbsp;
-                    <button type="submit" class="btn btn-default btn-sm"><?=t('Replace')?></button>
-                    <?= $form->hidden('fID', $f->getFileID());
-                ?>
-                    <?=$valt->output('import_incoming');
-                ?>
+                    <table style="width: 100%;">
+                        <tr>
+                            <td style="width: 100%;">
+                                <?= $form->select('send_file', $contents, array('style' => 'width: 100%;'));?>
+                            </td>
+                            <td>
+                                <button type="submit" class="btn btn-warning" style="margin-left: 4px;"><?=t('Replace')?></button>
+                                <?= $form->hidden('fID', $f->getFileID()); ?>
+                                <?=$valt->output('import_incoming'); ?>
+                            </td>
+                        </tr>
+                    </table>
                 </form>
-            <?php 
+            <?php
             } else {
                 if ($error) {
                     ?>
@@ -85,7 +96,7 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
                         <?php echo $error;
                     ?>
                     </div>
-                <?php 
+                <?php
                 } else {
                     echo t('No files found in %s for the storage location "%s".', REL_DIR_FILES_INCOMING, StorageLocation::getDefault()->getName());
                 }
@@ -94,18 +105,20 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
     </div>
     <div id="ccm-file-add-remote-tab" style="display: none">
         <h4><?=t("Add from Remote URL")?></h4>
-
-
         <form method="post" id="ccm-file-manager-replace-remote" class="form-inline" data-dialog-form="replace-file" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/importers/remote">
-            <?=$valt->output('import_remote');?>
-            <input type="hidden" name="searchInstance" value="<?=$searchInstance?>" />
-            <?= $form->hidden('fID', $f->getFileID()); ?>
-
-            <?=$form->text('url_upload_1', array('style' => 'width:195px'))?>
-
-            <button type="submit" class="btn btn-warning btn-sm"><?=t('Replace')?></button>
-
-
+            <table style="width: 100%;">
+                <tr>
+                    <td style="width: 100%;">
+                        <?=$valt->output('import_remote');?>
+                        <input type="hidden" name="searchInstance" value="<?=$searchInstance?>" />
+                        <?= $form->hidden('fID', $f->getFileID()); ?>
+                        <?=$form->text('url_upload_1', array('style' => 'width: 100%;'))?>
+                    </td>
+                    <td>
+                        <button type="submit" class="btn btn-warning" style="margin-left: 4px;"><?=t('Replace')?></button>
+                    </td>
+                </tr>
+            </table>
         </form>
     </div>
 </div>


### PR DESCRIPTION
**Current:**

![replace_modal-current1](https://cloud.githubusercontent.com/assets/10898145/26435594/60100b36-40de-11e7-85ee-31102cee78a5.png)

![replace_modal-current2](https://cloud.githubusercontent.com/assets/10898145/26435596/61c411e8-40de-11e7-88e7-68d89f50c0f7.png)

![replace_modal-current3](https://cloud.githubusercontent.com/assets/10898145/26435599/6350a30a-40de-11e7-95db-374689893799.png)

**Changes:**

![replace_modal-changes1](https://cloud.githubusercontent.com/assets/10898145/26435601/66a1f2fc-40de-11e7-995e-fed5ba2df109.png)

![replace_modal-changes2](https://cloud.githubusercontent.com/assets/10898145/26435602/6865032c-40de-11e7-83bb-d95f5da81949.png)

![replace_modal-changes3](https://cloud.githubusercontent.com/assets/10898145/26435604/6a360c00-40de-11e7-9bb4-5dea8049ef06.png)

The approach used for spacing the input and buttons should allow for the button to accomodate more or less text and stay on one line.

**Example:**
![replace_modal-changes4](https://cloud.githubusercontent.com/assets/10898145/26435606/6c7c5dde-40de-11e7-8b3d-2ce807018c77.png)

