### PR TITLE
URLs and Redirection - warning and placeholder

### DIFF
--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -33,7 +33,7 @@
 
         <div class="form-group">
             <label class="control-label" for="canonical_ssl_url"><?= t('Separate SSL URL') ?></label>
-            <?=$form->text('canonical_ssl_url', $canonical_ssl_url, ['placeholder' => 'http://domain.com'])?>
+            <?=$form->text('canonical_ssl_url', $canonical_ssl_url, ['placeholder' => 'https://domain.com'])?>
         </div>
 
         <div class="alert alert-warning">

--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -1,11 +1,11 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
-?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+
 <form method="post" action="<?php echo $view->action('save_urls'); ?>">
     <?php echo $this->controller->token->output('save_urls'); ?>
 
     <fieldset>
         <legend><?= t('Pretty URLs') ?></legend>
+
         <div class="form-group">
             <div class="checkbox">
                 <label>
@@ -25,6 +25,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
     <fieldset>
         <legend><?= t('Canonical URLs') ?></legend>
+
         <div class="form-group">
             <label class="control-label" for="canonical_url"><?= t('Canonical URL') ?></label>
             <?=$form->text('canonical_url', $canonical_url, ['placeholder' => 'http://domain.com'])?>
@@ -33,7 +34,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <div class="form-group">
             <label class="control-label" for="canonical_ssl_url"><?= t('Separate SSL URL') ?></label>
             <?=$form->text('canonical_ssl_url', $canonical_ssl_url, ['placeholder' => 'http://domain.com'])?>
-
         </div>
 
         <div class="alert alert-warning">
@@ -43,7 +43,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
         <div class="form-group">
             <label class="control-label launch-tooltip" title="<?= t('If checked, this site will only be available at the host, port and SSL combination chosen above.') ?>" for="redirect_to_canonical_url"><?= t('URL Redirection') ?></label>
-
             <div class="checkbox">
                 <label>
                     <?php echo $fh->checkbox('redirect_to_canonical_url', 1, $redirect_to_canonical_url) ?>
@@ -53,11 +52,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
         </div>
     </fieldset>
 
-
-
-
-
-
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <?php echo $interface->submit(t('Save'), 'url-form', 'right', 'btn-primary'); ?>
@@ -65,59 +59,55 @@ defined('C5_EXECUTE') or die("Access Denied.");
     </div>
 </form>
 
-<script type="text/javascript">
-    $(function () {
+<script>
+$(function () {
+    var steps = [{
+        content: <?= json_encode('<p><span class="h5">' . t('Pretty URLs') . '</span><br/>' . t('Check this checkbox to remove index.php from your URLs. You will be given code to place in a file named .htaccess in your web root. concrete5 will try and place this code in the file for you.') . '</p>') ?>,
+        highlightTarget: false,
+        nextButton: true,
+        target: $('input[name=URL_REWRITING]'),
+        my: 'bottom left',
+        at: 'top left'
+    },{
+        content: <?= json_encode('<p><span class="h5">' . t('Canonical URL') . '</span><br/>' . t('If you are running a site at multiple domains, enter the canonical domain here. This will be used for sitemap generation, any other purposes that require a specific domain. You can usually leave this blank.') . '</p>') ?>,
+        highlightTarget: false,
+        nextButton: true,
+        target: $('input[name=canonical_url]'),
+        my: 'bottom center',
+        at: 'top center',
+        setup: function() {
+            var $url = $('input[name=canonical_url]');
+            $(document).scrollTop($url.offset().top);
+        }
+    },{
+        content: <?= json_encode('<p><span class="h5">' . t('SSL URL') . '</span><br/>' . t('Certain add-ons require a secure SSL URL. Enter that URL here.') . '</p>') ?>,
+        highlightTarget: false,
+        nextButton: true,
+        target: $('input[name=canonical_ssl_url]'),
+        my: 'bottom center',
+        at: 'top center'
+    },{
+        content: <?= json_encode('<p><span class="h5">' . t('SSL URL') . '</span><br/>' . t('Ensure that your site ONLY renders at the canonical URL or the canonical SSL URL.') . '</p>') ?>,
+        highlightTarget: false,
+        nextButton: true,
+        target: $('input[name=redirect_to_canonical_url]'),
+        my: 'bottom left',
+        at: 'top left'
+    }];
 
-        var steps = [{
-            content: <?= json_encode('<p><span class="h5">' . t('Pretty URLs') . '</span><br/>' . t('Check this checkbox to remove index.php from your URLs. You will be given code to place in a file named .htaccess in your web root. concrete5 will try and place this code in the file for you.') . '</p>') ?>,
-            highlightTarget: false,
-            nextButton: true,
-            target: $('input[name=URL_REWRITING]'),
-            my: 'bottom left',
-            at: 'top left'
-        },{
-            content: <?= json_encode('<p><span class="h5">' . t('Canonical URL') . '</span><br/>' . t('If you are running a site at multiple domains, enter the canonical domain here. This will be used for sitemap generation, any other purposes that require a specific domain. You can usually leave this blank.') . '</p>') ?>,
-            highlightTarget: false,
-            nextButton: true,
-            target: $('input[name=canonical_url]'),
-            my: 'bottom center',
-            at: 'top center',
-            setup: function() {
-                var $url = $('input[name=canonical_url]');
-                $(document).scrollTop($url.offset().top);
-            }
-        },{
-            content: <?= json_encode('<p><span class="h5">' . t('SSL URL') . '</span><br/>' . t('Certain add-ons require a secure SSL URL. Enter that URL here.') . '</p>') ?>,
-            highlightTarget: false,
-            nextButton: true,
-            target: $('input[name=canonical_ssl_url]'),
-            my: 'bottom center',
-            at: 'top center'
-        },{
-            content: <?= json_encode('<p><span class="h5">' . t('SSL URL') . '</span><br/>' . t('Ensure that your site ONLY renders at the canonical URL or the canonical SSL URL.') . '</p>') ?>,
-            highlightTarget: false,
-            nextButton: true,
-            target: $('input[name=redirect_to_canonical_url]'),
-            my: 'bottom left',
-            at: 'top left'
-        }];
-
-        var tour = new Tourist.Tour({
-            steps: steps,
-            tipClass: 'Bootstrap',
-            tipOptions:{
-                showEffect: 'slidein'
-            }
-        });
-        tour.on('start', function() {
-            ConcreteHelpLauncher.close();
-        });
-        tour.on('stop', function() {
-            $(document).scrollTop(0);
-        });
-        ConcreteHelpGuideManager.register('dashboard-system-urls', tour);
-
+    var tour = new Tourist.Tour({
+        steps: steps,
+        tipClass: 'Bootstrap',
+        tipOptions:{
+            showEffect: 'slidein'
+        }
     });
-
-
+    tour.on('start', function() {
+        ConcreteHelpLauncher.close();
+    });
+    tour.on('stop', function() {
+        $(document).scrollTop(0);
+    });
+    ConcreteHelpGuideManager.register('dashboard-system-urls', tour);
+});
 </script>

--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -35,6 +35,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
             <?=$form->text('canonical_ssl_url', $canonical_ssl_url, ['placeholder' => 'http://domain.com'])?>
 
         </div>
+
+        <div class="alert alert-warning">
+            <?= t('Ensure that your site is viewable at the URL(s) above before you check the checkbox below.
+            If not, doing so may render your site unviewable until you can manually undo this change.') ?>
+        </div>
+
         <div class="form-group">
             <label class="control-label launch-tooltip" title="<?= t('If checked, this site will only be available at the host, port and SSL combination chosen above.') ?>" for="redirect_to_canonical_url"><?= t('URL Redirection') ?></label>
 
@@ -49,10 +55,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 
 
-    <div class="alert alert-warning">
-        <?= t('Ensure that your site is viewable at the URL(s) above before you check the checkbox below.
-        If not, doing so may render your site unviewable until you can manually undo this change.') ?>
-    </div>
+
 
 
     <div class="ccm-dashboard-form-actions-wrapper">


### PR DESCRIPTION
https://github.com/concrete5/concrete5/issues/5499

This pull request:
- places the URL Redirection warning above the URL Redirection checkbox
- changes the Separate SSL URL text input placeholder text to "https://domain.com" from "http://domain.com"

**Current:**

![url_redirection_warning-current](https://cloud.githubusercontent.com/assets/10898145/26517564/0ad1af6c-4269-11e7-96b9-5096f397d006.png)

**Changes:**

![url_redirection_warning-changes](https://cloud.githubusercontent.com/assets/10898145/26517565/0d4fa050-4269-11e7-9415-bd0428cb091e.png)
