### PR TITLE
Logs - add icon to critical and alert levels

### DIFF
--- a/concrete/src/Logging/LogEntry.php
+++ b/concrete/src/Logging/LogEntry.php
@@ -49,7 +49,7 @@ class LogEntry
                 return '<i class="text-danger fa fa-fire launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Logger::CRITICAL:
             case Logger::ALERT:
-                return '<i class="text-danger fa fa-exclamation-sign launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
+                return '<i class="text-danger fa fa-exclamation-circle launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Logger::ERROR:
             case Logger::WARNING:
                 return '<i class="text-warning fa fa-warning launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';


### PR DESCRIPTION
There was a typo in the Font Awesome class used for critical and alert level icons.

**Current:**

![icon-current](https://cloud.githubusercontent.com/assets/10898145/26519175/2fc422a6-428b-11e7-9b22-35d8796a6f88.png)

**Changes:**

![icon-changes](https://cloud.githubusercontent.com/assets/10898145/26519176/325fdca8-428b-11e7-99aa-cb3e2dd1d59d.png)
