### PR TITLE
Add ItemList::splitKeywords

### DIFF
--- a/concrete/src/Search/ItemList/ItemList.php
+++ b/concrete/src/Search/ItemList/ItemList.php
@@ -224,4 +224,30 @@ abstract class ItemList
     {
         return $this->getResults();
     }
+
+    /**
+     * Split a string into words and format them to be used in LIKE queries.
+     *
+     * @param string|mixed $keywords The string to be splitted
+     * @param string $wordSeparators The regular expression pattern that represents potential word delimiters (eg '\s' for any whitespace character)
+     *
+     * @return string[]|null returns null if no word has been found, or an array of words enclosed by '%'
+     *
+     * @example for instance, with 'Hello world!', you'll get ['%Hello$', '%world!$']
+     */
+    protected function splitKeywords($keywords, $wordSeparators = '\s')
+    {
+        $result = null;
+        if (is_string($keywords)) {
+            $keywords = trim(preg_replace('/[' . $wordSeparators . ']+/', ' ', $keywords));
+            if ($keywords !== '') {
+                $result = [];
+                foreach (explode(' ', $keywords) as $keyword) {
+                    $result[] = '%' . addcslashes($keyword, '%_') . '%';
+                }
+            }
+        }
+
+        return $result;
+    }
 }

--- a/concrete/src/Search/ItemList/ItemList.php
+++ b/concrete/src/Search/ItemList/ItemList.php
@@ -17,19 +17,24 @@ abstract class ItemList
     // we just turn it off to save processing in the attributed item list (so it doesn't have to instantiate
     // all those objects if it's not necessary)
     protected $enableAutomaticSorting = true;
-    protected $autoSortColumns = array();
+    protected $autoSortColumns = [];
 
     protected $itemsPerPage = -1; // determined by the pagination object.
     protected $debug = false;
 
     abstract protected function executeSortBy($field, $direction = 'asc');
+
     protected function executeSanitizedSortBy($field, $direction)
     {
         $this->executeSortBy($field, $direction);
     }
+
     abstract public function executeGetResults();
+
     abstract public function getResult($mixed);
+
     abstract public function debugStart();
+
     abstract public function debugStop();
 
     /**
@@ -64,7 +69,7 @@ abstract class ItemList
     /** Returns a full array of results. */
     public function getResults()
     {
-        $results = array();
+        $results = [];
 
         $this->debugStart();
 
@@ -119,17 +124,17 @@ abstract class ItemList
             $dir = ($dir == 'asc') ? 'desc' : 'asc';
         }
 
-        $args = array(
+        $args = [
             $this->getQuerySortColumnParameter() => $column,
             $this->getQuerySortDirectionParameter() => $dir,
-        );
+        ];
 
         $url = $uh->setVariable($args, false, $url);
 
         return strip_tags($url);
     }
 
-    /** @var \Concrete\Core\Search\Pagination\Pagination  */
+    /** @var \Concrete\Core\Search\Pagination\Pagination */
     protected $pagination;
 
     public function getActiveSortDirection()

--- a/tests/tests/Core/Search/Fixtures/UserListFixture.php
+++ b/tests/tests/Core/Search/Fixtures/UserListFixture.php
@@ -1,0 +1,12 @@
+<?php
+namespace Concrete\Tests\Core\Search\Fixtures;
+
+use Concrete\Core\User\UserList;
+
+class UserListFixture extends UserList
+{
+    public function splitKeywordsWrapper()
+    {
+        return call_user_func_array([$this, 'splitKeywords'], func_get_args());
+    }
+}

--- a/tests/tests/Core/Search/ItemListTest.php
+++ b/tests/tests/Core/Search/ItemListTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Concrete\Tests\Core\Search;
+
+use PHPUnit_Framework_TestCase;
+
+class ItemListTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Fixtures\UserListFixture
+     */
+    private static $userListFixture;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$userListFixture = new Fixtures\UserListFixture();
+    }
+
+    public function splitKeywordsProvider()
+    {
+        return [
+            ['', null],
+            [$this, null],
+            [false, null],
+            ['   word  ', ['%word%']],
+            ['This is a sentence', ['%This%', '%is%', '%a%', '%sentence%']],
+            ['%Special_chars', ['%\%Special\_chars%']],
+            ['Hello, world!', ['%Hello,%', '%world!%']],
+            ['Hello, world!', ['%Hello%', '%world%'], '\s,!'],
+        ];
+    }
+
+    /**
+     * @dataProvider splitKeywordsProvider
+     */
+    public function testSplitKeywords($text, $expectedKeywords, $wordSeparators = null)
+    {
+        if ($wordSeparators === null) {
+            $calculatedKeywords = self::$userListFixture->splitKeywordsWrapper($text);
+        } else {
+            $calculatedKeywords = self::$userListFixture->splitKeywordsWrapper($text, $wordSeparators);
+        }
+        $this->assertSame($expectedKeywords, $calculatedKeywords);
+    }
+}


### PR DESCRIPTION
We often need to search for keywords, that means that we have to split the search text into words, escape the `%` and the `_` characters in them,  and wrap the final words within `%` characters to use them with `LIKE` queries.

Let's add the `ItemList::splitKeywords` method for this.

Sample usage:
```php
public function filterByKeywords($keywords)
{
    $words = $this->splitKeywords($keywords);
    if ($words !== null) {
        $expr = $this->query->expr();
        $and = $expr->andX();
        foreach ($words as $word) {
            $and->add($expr->like('table.field', $this->query->createNamedParameter($word)));
        }
        $this->query->andWhere($and);
    }
}
```