### PR TITLE
WorkflowKey::getCurrentlyActiveUsers() doesn't pass all args to getAc…

### DIFF
--- a/concrete/src/Permission/Key/WorkflowKey.php
+++ b/concrete/src/Permission/Key/WorkflowKey.php
@@ -27,7 +27,7 @@ abstract class WorkflowKey extends Key
 
         foreach ($excluded as $inc) {
             $pae = $inc->getAccessEntityObject();
-            $usersExcluded = array_merge($usersExcluded, $pae->getAccessEntityUsers());
+            $usersExcluded = array_merge($usersExcluded, $pae->getAccessEntityUsers($paa));
         }
         $users = array_diff($users, $usersExcluded);
 


### PR DESCRIPTION
WorkflowKey::getCurrentlyActiveUsers() doesn't pass all args to getAccessEntityUsers(), when constructing a list of users to exclude

Came about this bug when using the MSW extension.
