### PR TITLE
Add VolatileDirectory

### DIFF
--- a/concrete/src/File/FileServiceProvider.php
+++ b/concrete/src/File/FileServiceProvider.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\File;
 use Concrete\Core\File\StorageLocation\StorageLocation;
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
+use Concrete\Core\Application\Application;
 
 class FileServiceProvider extends ServiceProvider
 {
@@ -27,6 +28,15 @@ class FileServiceProvider extends ServiceProvider
 
         $this->app->bind(StorageLocationInterface::class, function($app) {
             return StorageLocation::getDefault();
+        });
+
+        $this->app->bindIf(Service\VolatileDirectory::class, function (Application $app) {
+            return $app->build(
+                Service\VolatileDirectory::class,
+                [
+                    'parentDirectory' => $app->make('helper/file')->getTemporaryDirectory(),
+                ]
+            );
         });
     }
 }

--- a/concrete/src/File/Service/VolatileDirectory.php
+++ b/concrete/src/File/Service/VolatileDirectory.php
@@ -1,0 +1,85 @@
+<?php
+namespace Concrete\Core\File\Service;
+
+use Exception;
+use Illuminate\Filesystem\Filesystem;
+
+class VolatileDirectory
+{
+    /**
+     * The used Filesystem instance.
+     *
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * The path of this volatile directory.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Initializes the instance.
+     *
+     * @param Filesystem $filesystem the Filesystem instance to use
+     * @param string $parentDirectory the parent directory that will contain this volatile directory
+     *
+     * @throws Exception
+     */
+    public function __construct(Filesystem $filesystem, $parentDirectory)
+    {
+        $this->filesystem = $filesystem;
+        $parentDirectory = is_string($parentDirectory) ? rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $parentDirectory), '/') : '';
+        if ($parentDirectory === '') {
+            throw new Exception(t('Unable to retrieve the temporary directory.'));
+        }
+        if (!$this->filesystem->isWritable($parentDirectory)) {
+            throw new Exception(t('The temporary directory is not writable.'));
+        }
+        for ($i = 0; ; ++$i) {
+            $path = $parentDirectory . '/volatile-' . $i . '-' . uniqid();
+            if (!$this->filesystem->exists($path)) {
+                if (@$this->filesystem->makeDirectory($path, DIRECTORY_PERMISSIONS_MODE_COMPUTED)) {
+                    break;
+                }
+            }
+        }
+        $this->path = $path;
+    }
+
+    /**
+     * Get the used Filesystem instance.
+     *
+     * @return Filesystem
+     */
+    public function getFilesystem()
+    {
+        return $this->filesystem;
+    }
+
+    /**
+     * Get the absolute path of this volatile directory (always with '/' as directory separator, without the trailing '/').
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Clear and delete this volatile directory.
+     */
+    public function __destruct()
+    {
+        if ($this->path !== null) {
+            try {
+                $this->filesystem->deleteDirectory($this->path);
+            } catch (Exception $foo) {
+            }
+            $this->path = null;
+        }
+    }
+}

--- a/tests/tests/Core/File/Service/VolatileDirectoryTest.php
+++ b/tests/tests/Core/File/Service/VolatileDirectoryTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Concrete\Tests\Core\File\Service;
+
+use Concrete\Core\File\Service\VolatileDirectory;
+use Concrete\Core\Support\Facade\Application;
+use PHPUnit_Framework_TestCase;
+
+class VolatileDirectoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private static $app;
+
+    public static function setupBeforeClass()
+    {
+        self::$app = Application::getFacadeApplication();
+    }
+
+    public function testVolatileDirectoryExplicitUnset()
+    {
+        $vd = self::$app->make(VolatileDirectory::class);
+        $fs = $vd->getFilesystem();
+        $path = $vd->getPath();
+        $this->assertTrue($fs->isDirectory($path));
+        unset($vd);
+        $this->assertFalse($fs->isDirectory($path));
+    }
+
+    public function testVolatileDirectoryImplicitUnset()
+    {
+        list($fs, $path) = $this->createVolatileDirectory();
+        $this->assertFalse($fs->isDirectory($path));
+    }
+
+    private function createVolatileDirectory()
+    {
+        $vd = self::$app->make(VolatileDirectory::class);
+        /* @var VolatileDirectory $vd */
+        $fs = $vd->getFilesystem();
+        $path = $vd->getPath();
+        $this->assertTrue($fs->isDirectory($path));
+        $this->assertTrue($fs->makeDirectory($path . '/subfolder'));
+        $this->assertTrue($fs->put($path . '/subfolder/file.txt', 'contents') !== false);
+
+        return [$fs, $path];
+    }
+}


### PR DESCRIPTION
What about a new helper class that automatically creates a new (empty) temporary directory and self-destroys it when it's no more used?

Example:
```php
// Create a new temp directory
$virtualDirectory = \Core::make(\Concrete\Core\File\Service\VolatileDirectory::class);

// Work on that directory
file_put_contents($virtualDirectory->getPath() . '/test.file', 'sample');

// Delete the temp directory
unset($virtualDirectory); // or simply exist the current function
```
