### PR TITLE
Allow clearing blacklist-related data

### DIFF
--- a/concrete/single_pages/dashboard/system/permissions/blacklist.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist.php
@@ -17,25 +17,28 @@ $view->element('dashboard/system/permissions/blacklist/menu', ['type' => null]);
     <?php $token->output('update_ipblacklist') ?>
     <div class="ccm-pane-body">
         <div class="form-group form-inline">
-            <?= $form->checkbox('banEnabled', 1, $banEnabled) ?> <?= t('Lock IP after') ?>
-            <?= $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]) ?>
-            <?= t(/*i18n: before we have the number of failed logins, after we have a time duration */'failed login attempts in') ?>
-            <?= $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1]) ?>
-            <?= t('seconds') ?>
+            <?= $form->checkbox('banEnabled', 1, $banEnabled) ?>
+            <?= t(
+                'Lock IP after %1$s failed login attempts in %2$s seconds',
+                $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]),
+                $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1])
+            ) ?>
         </div>
 
-        <div class="form-inline form-group radio">
-            <?= t('Ban IP For') ?>
-            <br />
-            <label class="radio">
-                <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
-                <?= $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px', 'min' => 1]) ?>
-                <?= t('minutes') ?>
-            </label>
-            <br />
-            <label class="radio">
-                <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?> <?= t('Forever') ?>
-            </label>
+        <div class="form-group">
+            <?= $form->label('banDurationUnlimited', 'Ban Duration')?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
+                    <?= t('Ban IP for %s minutes', $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px; display: inline-block', 'min' => 1])) ?>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?>
+                    <?= t('Ban Forever') ?>
+                </label>
+            </div>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist/range.php
@@ -82,6 +82,47 @@ if (($type & IPService::IPRANGEFLAG_MANUAL) === IPService::IPRANGEFLAG_MANUAL) {
         ?>
     </tbody>
 </table>
+
+<?php
+if ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+    ?>
+    <div style="display: none" data-dialog="ccm-blacklist-clear-data-dialog" class="ccm-ui">
+        <form data-dialog-form="ccm-blacklist-clear-data-form" method="POST" action="<?= $view->action('clear_data') ?>">
+            <?php $token->output('blacklist-clear-data') ?>
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('delete-failed-login-attempts', 'yes', false) ?>
+                    <?= t('Delete failed login attempts older than %s days',  $form->number('delete-failed-login-attempts-min-age', 1, ['style' => 'width: 90px; display: inline-block', 'min' => '0'])) ?>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('delete-automatic-blacklist', 'yes-keep-current', true) ?>
+                    <?= t('Delete expired automatic bans') ?>
+                </label>
+                <label>
+                    <?= $form->radio('delete-automatic-blacklist', 'yes-all', false) ?>
+                    <?= t('Delete every automatic ban (including the current ones)') ?>
+                </label>
+                <label>
+                    <?= $form->radio('delete-automatic-blacklist', 'nope', false) ?>
+                    <?= t("Don't delete any automatic ban") ?>
+                </label>
+            </div>
+        </form>
+        <div class="dialog-buttons">
+            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+            <button class="btn btn-danger pull-right" data-dialog-action="submit"><?= t('Delete') ?></button>
+        </div>
+    </div>
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <a class="btn btn-danger pull-right" data-launch-dialog="ccm-blacklist-clear-data-dialog"><?= t('Delete') ?></a>
+        </div>
+    </div>
+    <?php
+}
+?>
 <script>
 $(document).ready(function() {
     $('#ccm-ranges-table>tbody')
@@ -119,5 +160,27 @@ $(document).ready(function() {
 
         })
     ;
+    <?php
+    if ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+        ?>
+        var $dialog = $('div[data-dialog="ccm-blacklist-clear-data-dialog"]');
+        $('[data-launch-dialog="ccm-blacklist-clear-data-dialog"]').on('click', function(e) {
+            e.preventDefault();
+            jQuery.fn.dialog.open({
+                element: $dialog,
+                modal: true,
+                width: 480,
+                title: <?= json_encode(t('Removal confirmation')) ?>,
+                height: 'auto'
+            });
+        });
+        ConcreteEvent.subscribe('AjaxFormSubmitSuccess', function(e, data) {
+            if (data.form === 'ccm-blacklist-clear-data-form') {
+                window.location.reload();
+            }
+        });
+        <?php
+    }
+    ?>
 });
 </script>

--- a/concrete/src/Console/Application.php
+++ b/concrete/src/Console/Application.php
@@ -38,6 +38,7 @@ class Application extends SymfonyApplication
             $this->add(new Command\InstallPackageCommand());
             $this->add(new Command\UninstallPackageCommand());
             $this->add(new Command\UpdatePackageCommand());
+            $this->add(new Command\BlacklistClear());
         }
         $this->setupRestrictedCommands();
         $this->setupDoctrineCommands();

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -14,7 +14,7 @@ class BlacklistClear extends Command
     {
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-            ->setName('c5:blacklist-clear')
+            ->setName('c5:blacklist:clear')
             ->setDescription('Clear blacklist-related data')
             ->addEnvOption()
             ->addOption('failed-login-age', 'f', InputOption::VALUE_REQUIRED, 'Clear failed login attempts older that this number of seconds (0 for all)')

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -1,0 +1,89 @@
+<?php
+namespace Concrete\Core\Console\Command;
+
+use Concrete\Core\Console\Command;
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Support\Facade\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BlacklistClear extends Command
+{
+    protected function configure()
+    {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $this
+            ->setName('c5:blacklist-clear')
+            ->setDescription('Clear blacklist-related data')
+            ->addEnvOption()
+            ->addOption('failed-login-age', 'f', InputOption::VALUE_REQUIRED, 'Clear failed login attempts older that this number of seconds (0 for all)')
+            ->addOption('automatic-bans', 'b', InputOption::VALUE_REQUIRED, 'Clear automatic bans ("expired" to only delete expired bans, "all" to delete the current bans too)')
+            ->setHelp(<<<EOT
+You can use this command to clear the data related to IP address blacklist.
+
+To clear the failed login attempts data, use the --failed-login-age option.
+To clear the automatic bans, use the --automatic-bans option.
+
+Returns codes:
+  0 operation completed successfully
+  $errExitCode errors occurred
+
+More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-blacklist-clear
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+        $ipService = $app->make('ip');
+        /* @var \Concrete\Core\Permission\IPService $ipService */
+        $someOperation = false;
+        $failedLoginAge = $input->getOption('failed-login-age');
+        if ($failedLoginAge !== null) {
+            $valn = $app->make('helper/validation/numbers');
+            /* @var \Concrete\Core\Utility\Service\Validation\Numbers $valn */
+            if (!$valn->integer($failedLoginAge, 0)) {
+                throw new UserMessageException('Invalid value of the --failed-login-age option: please specify a non-negative integer.');
+            }
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                $output->write("Clearing failed login attempts older that $failedLoginAge seconds... ");
+            }
+            $count = $ipService->deleteFailedLoginAttempts((int) $failedLoginAge);
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                $output->writeln("$count records deleted.");
+            }
+            $someOperation = true;
+        }
+        $automaticBans = $input->getOption('automatic-bans');
+        if ($automaticBans !== null) {
+            switch ($automaticBans) {
+                case 'expired':
+                    $onlyExpired = true;
+                    break;
+                case 'all':
+                    $onlyExpired = false;
+                    break;
+                default:
+                    throw new UserMessageException('Invalid value of the --automatic-bans option: valid values are "expired" and "all".');
+            }
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                if ($onlyExpired) {
+                    $output->write('Deleting the expired automatic bans... ');
+                } else {
+                    $output->write('Deleting all the automatic bans... ');
+                }
+            }
+            $count = $ipService->deleteAutomaticBlacklist((int) $onlyExpired);
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                $output->writeln("$count records deleted.");
+            }
+            $someOperation = true;
+        }
+        if ($someOperation === false) {
+            throw new UserMessageException('Please specify at least one of the options --automatic-bans option or --automatic-bans');
+        }
+    }
+}

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -83,7 +83,7 @@ EOT
             $someOperation = true;
         }
         if ($someOperation === false) {
-            throw new UserMessageException('Please specify at least one of the options --automatic-bans option or --automatic-bans');
+            throw new UserMessageException('Please specify at least one of the options --failed-login-age option or --automatic-bans');
         }
     }
 }

--- a/concrete/src/Permission/IPService.php
+++ b/concrete/src/Permission/IPService.php
@@ -360,6 +360,40 @@ class IPService
     }
 
     /**
+     * Delete the failed login attempts.
+     *
+     * @param int|null $maxAge the maximum age (in seconds) of the records (specify an empty value do delete all records)
+     *
+     * @return int return the number of records deleted
+     */
+    public function deleteFailedLoginAttempts($maxAge = null)
+    {
+        $sql = 'DELETE FROM FailedLoginAttempts';
+        if ($maxAge) {
+            $platform = $this->connection->getDatabasePlatform();
+            $sql .= ' WHERE flaTimestamp <= ' . $platform->getDateSubSecondsExpression($platform->getNowExpression(), (int) $maxAge);
+        }
+
+        return (int) $this->connection->executeQuery($sql)->rowCount();
+    }
+
+    /**
+     * Clear the IP addresses automatically blacklisted.
+     *
+     * @param bool $onlyExpired Clear only the expired bans?
+     */
+    public function deleteAutomaticBlacklist($onlyExpired = true)
+    {
+        $sql = 'DELETE FROM LoginControlIpRanges WHERE lcirType = ' . (int) static::IPRANGETYPE_BLACKLIST_AUTOMATIC;
+        if ($onlyExpired) {
+            $platform = $this->connection->getDatabasePlatform();
+            $sql .= ' AND lcirExpires <= ' . $platform->getNowExpression();
+        }
+
+        return (int) $this->connection->executeQuery($sql)->rowCount();
+    }
+
+    /**
      * @deprecated Use \Core::make('ip')->getRequestIPAddress()
      */
     public function getRequestIP()


### PR DESCRIPTION
Fix #5357

This PR adds a new CLI command (`c5:blacklist-clear`) and a UI dialog to delete the logged failed login attempts and/or the automatic IP bans.

Here's a screenshot of the newly added dialog (the CLI command has similar options):
![image](https://user-images.githubusercontent.com/928116/27028529-47971a3c-4f65-11e7-80ee-a568cc951385.png)

I also fixed the layout of the blacklist options page:

before:
![image](https://user-images.githubusercontent.com/928116/27028674-c99df3e8-4f65-11e7-9a3b-2f71a63c5501.png)

after:
![image](https://user-images.githubusercontent.com/928116/27028683-cdfbefb2-4f65-11e7-8f12-ea0cf0844f47.png)
