### PR TITLE
Fix updating package translations

### DIFF
--- a/concrete/src/Localization/Translation/Local/Factory.php
+++ b/concrete/src/Localization/Translation/Local/Factory.php
@@ -105,7 +105,7 @@ class Factory implements FactoryInterface
      */
     public function getPackageStats(Package $package, $localeID)
     {
-        return $this->getMoFileStats($package->getPackagePath() . DIRNAME_LANGUAGES . '/' . $localeID . '/LC_MESSAGES/messages.mo');
+        return $this->getMoFileStats($package->getPackagePath() . '/' . DIRNAME_LANGUAGES . '/' . $localeID . '/LC_MESSAGES/messages.mo');
     }
 
     /**


### PR DESCRIPTION
This fix is needed in order to install/update package translations from translate.concrete5.org