### PR TITLE
Declare properties on search column class.

### DIFF
--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -5,13 +5,19 @@ use Concrete\Core\Search\Result\Result;
 
 class Column implements ColumnInterface
 {
+    protected $columnKey;
+    protected $columnName;
+    protected $sortDirection = 'desc';
+    protected $isSortable;
+    protected $callback;
+
     public function getColumnValue($obj)
     {
         if (is_array($this->getColumnCallback())) {
             return call_user_func($this->getColumnCallback(), $obj);
-        } else {
-            return call_user_func(array($obj, $this->getColumnCallback()));
         }
+
+        return call_user_func(array($obj, $this->getColumnCallback()));
     }
 
     public function getColumnKey()

--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -5,11 +5,11 @@ use Concrete\Core\Search\Result\Result;
 
 class Column implements ColumnInterface
 {
-    protected $columnKey;
-    protected $columnName;
-    protected $sortDirection = 'desc';
-    protected $isSortable;
-    protected $callback;
+    public $columnKey;
+    public $columnName;
+    public $sortDirection = 'asc';
+    public $isSortable;
+    public $callback;
 
     public function getColumnValue($obj)
     {

--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -8,10 +8,13 @@ class Column implements ColumnInterface
     /** These properties are to be treated as protected. Use the set and get methods instead */
     /** @deprecated */
     public $columnKey;
+    
     /** @deprecated */
     public $columnName;
+    
     /** @deprecated */
     public $sortDirection = 'asc';
+    
     /** @deprecated */
     public $isSortable;
     

--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -5,10 +5,17 @@ use Concrete\Core\Search\Result\Result;
 
 class Column implements ColumnInterface
 {
+    /** These properties are to be treated as protected. Use the set and get methods instead */
+    /** @deprecated */
     public $columnKey;
+    /** @deprecated */
     public $columnName;
+    /** @deprecated */
     public $sortDirection = 'asc';
+    /** @deprecated */
     public $isSortable;
+    
+    /** @deprecated */
     public $callback;
 
     public function getColumnValue($obj)


### PR DESCRIPTION
This does two things:
1. Declare properties
2. Provide a default value for search direction

The reason we need to make sure that we always declare properties is because if we don't our classes end up costing about 8x as much in terms of memory usage:
https://3v4l.org/h7nVV