### PR TITLE
Add a link to the package translation pages

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -572,6 +572,8 @@ return [
             'progress_limit' => 60,
             // Lifetime (in seconds) of the cache items associated to downloaded data
             'cache_lifetime' => 3600, // 1 hour
+            // Base URI for package details
+            'package_url' => 'https://translate.concrete5.org/translate/package',
         ],
     ],
     'urls' => [

--- a/concrete/single_pages/dashboard/system/basics/multilingual/update.php
+++ b/concrete/single_pages/dashboard/system/basics/multilingual/update.php
@@ -8,6 +8,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Localization\Translation\LocaleStatus[] $data */
 
 $someUpdateAvailable = false;
+$packageUrl = rtrim(Config::get('concrete.i18n.community_translation.package_url'), '/');
 ?>
 <div class="panel-group" id="ccm-packages" role="tablist" aria-multiselectable="true">
     <?php
@@ -32,6 +33,13 @@ $someUpdateAvailable = false;
                         }
                         ?>
                     </a>
+                    <?php
+                    if ($packageUrl) {
+                        ?>
+                        <a target="_blank" class="pull-right" href="<?= h("{$packageUrl}/{$handle}") ?>"><span class="label label-default" style="font-weight: normal"><?= t('more details') ?></span></a>
+                        <?php
+                    }
+                    ?>
                 </h4>
             </div>
             <div id="ccm-package-<?= $handle ?>-body" class="panel-collapse collapse<?= $class ?>" role="tabpanel" aria-labelledby="ccm-package-<?= $handle ?>-header">


### PR DESCRIPTION

What about adding links to the `/dashboard/system/basics/multilingual/update` page pointing to the related page on translate.concrete5.org? Maybe that could encourage people to translate the packages...

Here's a screenshot (I added the two "more details" links, in this case pointing to [here](https://translate.concrete5.org/translate/package/concrete5) and [here](https://translate.concrete5.org/translate/package/customize_editing_interface)):

![translate-links](https://user-images.githubusercontent.com/928116/27322914-01fa9d28-55a0-11e7-8efb-8b2f3f104c0c.png)