### PR TITLE
Make the dispatcher singleton work properly

### DIFF
--- a/concrete/src/Events/EventsServiceProvider.php
+++ b/concrete/src/Events/EventsServiceProvider.php
@@ -1,16 +1,22 @@
 <?php
+
 namespace Concrete\Core\Events;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventsServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        if (!$this->app->bound('director')) {
-            $this->app->bindShared('director', function ($app) {
-                return new \Symfony\Component\EventDispatcher\EventDispatcher();
-            });
-        }
+        // Set the singleton on the dispatcher implementation
+        $this->app->singleton(EventDispatcher::class);
+
+        // Bind the interface to the implementation
+        $this->app->bindIf(EventDispatcherInterface::class, EventDispatcher::class);
+
+        // Add the 'director' alias in a backwards compatible way.
+        $this->app->bindIf('director', EventDispatcherInterface::class);
     }
 }


### PR DESCRIPTION
Before, the following would all be false:

```php
dd(
    $app['director'] === $app[EventDispatcher::class],
    $app['director'] === $app[EventDispatcherInterface::class],
    $app[EventDispatcher::class] === $app[EventDispatcherInterface::class]
);
```

After this pull request they all output true.