### PR TITLE
Fix searching Community Points for user

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/points.php
+++ b/concrete/controllers/single_page/dashboard/users/points.php
@@ -22,6 +22,10 @@ class Points extends DashboardPageController
         $entries = new UserPointEntryList();
         $entries->setItemsPerPage(100);
 
+        if ($_REQUEST['uID']) {
+            $entries->filterByUserID($_REQUEST['uID']);
+        }
+        
         if ($_REQUEST['uName']) {
             $entries->filterByUserName($_REQUEST['uName']);
         }

--- a/concrete/single_pages/dashboard/users/points/view.php
+++ b/concrete/single_pages/dashboard/users/points/view.php
@@ -10,8 +10,8 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
 
     <div class="ccm-pane-options">
         <div class="ccm-pane-options-permanent-search">
-            <?=$form->label('uName', t('User'))?>
-            <?php echo $form_user_selector->quickSelect('uName', $_GET['uName'], array('form-control'));?>
+            <?=$form->label('uID', t('User'))?>
+            <?php echo $form_user_selector->quickSelect('uID', $_GET['uID'], array('form-control'));?>
         </div>
     </div>
 

--- a/concrete/src/User/Point/EntryList.php
+++ b/concrete/src/User/Point/EntryList.php
@@ -51,7 +51,7 @@ class EntryList extends DatabaseItemList
      */
     public function filterByUserID($uID)
     {
-        $this->filter('UserPointHistory.upuID', $upaTypeID);
+        $this->filter('UserPointHistory.upuID', (int) $uID);
     }
 
     public function get($items = 0, $offset = 0)


### PR DESCRIPTION
This PR fixes two problems:

1. When searching for a user, the dashboard page receives an user ID, but it thinks it's a user name. This results in a non functional search
2. The filterByUserID method of the datalist was broken