### PR TITLE
Support PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ matrix:
       env: CODESTYLE="yes"
     - php: 7.1
       env: PREFER_LOWEST="--prefer-lowest"
-    - php: 5.5
-      env: PREFER_LOWEST="--prefer-lowest"
-  allow_failures:
-    - php: nightly
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then cat tests/travis.hhvm.ini >> /etc/hhvm/php.ini; else phpenv config-add tests/travis.php.ini; fi

--- a/composer.lock
+++ b/composer.lock
@@ -2117,16 +2117,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.22.1",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0",
-                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
                 "shasum": ""
             },
             "require": {
@@ -2147,7 +2147,7 @@
                 "phpunit/phpunit-mock-objects": "2.3.0",
                 "ruflin/elastica": ">=0.90 <3.0",
                 "sentry/sentry": "^0.13",
-                "swiftmailer/swiftmailer": "~5.3"
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -2191,7 +2191,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-03-13T07:08:03+00:00"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "natxet/CssMin",
@@ -5285,16 +5285,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.35",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -5353,7 +5353,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06T05:18:07+00:00"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/concrete/src/Foundation/ClassLoader.php
+++ b/concrete/src/Foundation/ClassLoader.php
@@ -254,7 +254,7 @@ class ClassLoader
 
         $loader = new Psr4ClassLoader();
         $loaders = $pkg->getPackageAutoloaderRegistries();
-        if (count($loaders) > 0) {
+        if ($loaders && count($loaders) > 0) {
             foreach ($loaders as $path => $prefix) {
                 $loader->addPrefix($prefix, DIR_PACKAGES . '/' . $pkgHandle . '/' . $path);
             }

--- a/tests/tests/Core/File/FileListTest.php
+++ b/tests/tests/Core/File/FileListTest.php
@@ -233,7 +233,7 @@ class FileListTest extends \FileStorageTestCase
 
         $results = $pagination->getCurrentPageResults();
         $this->assertInstanceOf('\Concrete\Core\Entity\File\File', $results[0]);
-        $this->assertEquals(1, count($results[0]));
+        $this->assertCount(1, $results);
     }
 
     public function testPaginationWithPermissions()

--- a/tests/tests/Core/Session/SessionFactoryTest.php
+++ b/tests/tests/Core/Session/SessionFactoryTest.php
@@ -53,6 +53,10 @@ class SessionFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testHandlerConfiguration()
     {
+        if (headers_sent()) {
+            $this->markTestSkipped('Cannot test sessions after headers have been sent.');
+        }
+
         $config = $this->app['config'];
         $config['concrete.session'] = array('handler' => 'database', 'save_path' => '/tmp');
 
@@ -65,13 +69,6 @@ class SessionFactoryTest extends \PHPUnit_Framework_TestCase
         $pdo_handler = $method->invokeArgs($this->factory, array($config));
         $this->assertNotInstanceOf(
             \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler::class, $pdo_handler);
-
-        if (headers_sent()) {
-            // Alias a basic class over the one we use by default, this is required because The factory doesn't have OCP
-            // and so we have no other way to swap out the instance. Since some versions of PHP cause a E_DEPRECATED warning
-            // when running tests, we must do this to allow our class to be created when headers have been sent.
-            class_alias(NativeSessionHandler::class, NativeFileSessionHandler::class);
-        }
 
         $config['concrete.session.handler'] = 'file';
         // Make sure file session does give us native file session

--- a/tests/tests/Core/Session/SessionFactoryTest.php
+++ b/tests/tests/Core/Session/SessionFactoryTest.php
@@ -66,10 +66,12 @@ class SessionFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertNotInstanceOf(
             \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler::class, $pdo_handler);
 
-        // Alias a basic class over the one we use by default, this is required because The factory doesn't have OCP
-        // and so we have no other way to swap out the instance. Since some versions of PHP cause a E_DEPRECATED warning
-        // when running tests, we must do this to allow our class to be created when headers have been sent.
-        class_alias(NativeSessionHandler::class, NativeFileSessionHandler::class);
+        if (headers_sent()) {
+            // Alias a basic class over the one we use by default, this is required because The factory doesn't have OCP
+            // and so we have no other way to swap out the instance. Since some versions of PHP cause a E_DEPRECATED warning
+            // when running tests, we must do this to allow our class to be created when headers have been sent.
+            class_alias(NativeSessionHandler::class, NativeFileSessionHandler::class);
+        }
 
         $config['concrete.session.handler'] = 'file';
         // Make sure file session does give us native file session

--- a/tests/tests/Core/Session/SessionValidatorTest.php
+++ b/tests/tests/Core/Session/SessionValidatorTest.php
@@ -22,6 +22,10 @@ class SessionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (headers_sent()) {
+            return $this->markTestSkipped('This test cannot run once headers have been sent.');
+        }
+
         $this->app = clone Application::getFacadeApplication();
         $this->app['config'] = clone $this->app['config'];
 
@@ -63,6 +67,7 @@ class SessionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetsOnFirstCheck()
     {
+
         // Change client ip
         $this->request->server->set('REMOTE_ADDR', '111.112.113.114');
         $this->request->server->set('HTTP_USER_AGENT', 'TESTING');


### PR DESCRIPTION
PHP 7.2 added some incompatibilities:
* `count` can no longer count things that aren't arrays or countables
* `each()` is now deprecated

This pull request fixes all of the issues blocking tests.