### PR TITLE
Image Slider block - remove redundant code

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -138,7 +138,7 @@ echo Core::make('helper/concrete/ui')->tabs($tabs);
 
         $('.ccm-image-slider-entries-<?php echo $bID?>').on('click','.ccm-edit-slide', function() {
             $(this).closest('.ccm-image-slider-entry-<?php echo $bID?>').toggleClass('slide-closed');
-            var thisEditButton = $(this).closest('.ccm-image-slider-entry-<?php echo $bID?>').find('.btn.ccm-edit-slide');
+            var thisEditButton = $(this);
             if (thisEditButton.data('slideEditText') === thisEditButton.text()) {
                 thisEditButton.text(thisEditButton.data('slideCloseText'));
             } else if (thisEditButton.data('slideCloseText') === thisEditButton.text()) {


### PR DESCRIPTION
While working on the FAQ block, I realized that I wrote a redundant element selector in the Image Slider block. Since many people use the Image Slider block as a base for their own blocks, I wanted to remove this.