### PR TITLE
Fix reading cached permission access entities

### DIFF
--- a/concrete/src/Permission/Access/Entity/Entity.php
+++ b/concrete/src/Permission/Access/Entity/Entity.php
@@ -57,7 +57,7 @@ abstract class Entity extends Object
     final public static function getByID($peID)
     {
         $obj = CacheLocal::getEntry('permission_access_entity', $peID);
-        if ($obj instanceof PermissionAccessEntity) {
+        if ($obj instanceof self) {
             return $obj;
         }
         $db = Database::connection();


### PR DESCRIPTION
There's no class named `PermissionAccessEntity` in \Permission\Access\Entity\Entity, so the PAE caching system doesn't work.
It's `self`, isn't it?