### PR TITLE
Missing date_time form.php and added print statement in telephone attribute

### DIFF
--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -4,15 +4,13 @@ namespace Concrete\Attribute\DateTime;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
 use Concrete\Core\Entity\Attribute\Value\Value\DateTimeValue;
-use Loader;
-use Core;
 use Concrete\Core\Attribute\Controller as AttributeTypeController;
 use DateTime;
 use Exception;
 
 class Controller extends AttributeTypeController
 {
-    public $helpers = ['form'];
+    public $helpers = ['form', 'date','form/date_time'];
 
     protected $searchIndexFieldDefinition = ['type' => 'datetime', 'options' => ['notnull' => false]];
 
@@ -78,33 +76,10 @@ class Controller extends AttributeTypeController
         if ($datetime === null && $this->akUseNowIfEmpty) {
             $datetime = new DateTime();
         }
-        switch ($this->akDateDisplayMode) {
-            case 'text':
-                $dh = $this->app->make('helper/date');
-                $format = $dh->getPHPDateTimePattern();
-                if ($datetime === null) {
-                    $value = '';
-                    $placeholder = $dh->formatCustom($format, 'now');
-                } else {
-                    $value = $dh->formatCustom($format, $datetime);
-                    $placeholder = $value;
-                }
-                $form = $this->app->make('helper/form');
-                echo $form->text($this->field('value'), $value, ['placeholder' => $placeholder]);
-                break;
-            case 'date':
-                $this->requireAsset('jquery/ui');
-                $dt = $this->app->make('helper/form/date_time');
-                /* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
-                echo $dt->date($this->field('value'), $datetime);
-                break;
-            default:
-                $this->requireAsset('jquery/ui');
-                $dt = $this->app->make('helper/form/date_time');
-                /* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
-                echo $dt->datetime($this->field('value'), $datetime, false, true, null, $this->akTimeResolution);
-                break;
-        }
+        $this->set('value', $datetime);
+        $this->set('displayMode',$this->akDateDisplayMode );
+        $this->set('timeResolution', $this->akTimeResolution);
+
     }
 
     public function exportKey($akey)
@@ -147,7 +122,7 @@ class Controller extends AttributeTypeController
                 if (empty($data['value_dt']) || (!is_numeric($data['value_h'])) || (!is_numeric($data['value_m']))) {
                     return false;
                 }
-                $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
+                $dh = $this->app->make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
                 switch ($dh->getTimeFormat()) {
                     case 12:
                         if (empty($data['value_a'])) {
@@ -164,7 +139,7 @@ class Controller extends AttributeTypeController
 
     public function search()
     {
-        $dt = Loader::helper('form/date_time');
+        $dt = $this->app->make('helper/form/date_time');
         $html = $dt->date($this->field('from'), $this->request('from'), true);
         $html .= ' ' . t('to') . ' ';
         $html .= $dt->date($this->field('to'), $this->request('to'), true);
@@ -223,7 +198,7 @@ class Controller extends AttributeTypeController
                             $dh->getPHPDateTimePattern(),
                             $data['value'],
                             $dh->getTimezone('user')
-                         );
+                        );
                     } catch (Exception $x) {
                     }
                     if ($datetime !== null) {

--- a/concrete/attributes/date_time/form.php
+++ b/concrete/attributes/date_time/form.php
@@ -1,0 +1,23 @@
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+switch ($displayMode) {
+                        case 'text':
+                            $format = $date->getPHPDateTimePattern();
+                            if ($value === null) {
+                                $placeholder = $date->formatCustom($format, 'now');
+                            } else {
+                                $value = $date->formatCustom($format, $value);
+                                $placeholder = $value;
+                            }
+                            $form = $this->app->make('helper/form');
+                            echo $form->text($this->field('value'), $value, ['placeholder' => $placeholder]);
+                            break;
+                        case 'date':
+                            $this->requireAsset('jquery/ui');
+                            echo $form_date_time->date($this->field('value'), $value);
+                            break;
+                        default:
+                            $this->requireAsset('jquery/ui');
+                            echo $form_date_time->datetime($this->field('value'), $value, false, true, null, $timeResolution);
+                            break;
+                    }

--- a/concrete/attributes/telephone/controller.php
+++ b/concrete/attributes/telephone/controller.php
@@ -19,11 +19,7 @@ class Controller extends DefaultController
 
     public function composer()
     {
-        $value = null;
-        if (is_object($this->attributeValue)) {
-            $value = $this->app->make('helper/text')->entities($this->getAttributeValue()->getValue());
-        }
-        echo $this->app->make('helper/form')->telephone($this->field('value'), $value, array('class' => 'span5'));
+        $this->form();
     }
 
     public function getIconFormatter()

--- a/concrete/attributes/telephone/form.php
+++ b/concrete/attributes/telephone/form.php
@@ -1,3 +1,3 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$form->telephone($this->field('value'), $value);
+print $form->telephone($this->field('value'), $value);


### PR DESCRIPTION
There was a missing print/echo statement from the form.php template for telephone attribute. Also date_time didnt have a form template.

Fixed a case where composer is called by a context then form is called by context, causing duplicate entries.