### PR TITLE
check if attribute exists before running migration script

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -28,6 +28,8 @@ use Concrete\Core\Tree\TreeType;
 use Concrete\Core\Tree\Type\ExpressEntryResults;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Attribute\Category\PageCategory;
+use Concrete\Core\Support\Facade\Application;
 
 class Version20160725000000 extends AbstractMigration
 {
@@ -574,6 +576,18 @@ class Version20160725000000 extends AbstractMigration
     protected function addDashboard()
     {
         $this->output(t('Updating Dashboard...'));
+
+        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
+        /* @var PageCategory $pageAttributeCategory */
+        $availableAttributes = [];
+        foreach ([
+            'exclude_nav',
+            'exclude_search_index',
+            'meta_keywords',
+        ] as $akHandle) {
+            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
+        }
+
         $page = Page::getByPath('/dashboard/express');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/express');

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -607,27 +607,37 @@ class Version20160725000000 extends AbstractMigration
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/express/entities');
             $sp->update(['cName' => 'Data Objects']);
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/express/entities/attributes');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/express/entities/attributes');
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/express/entities/associations');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/express/entities/associations');
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/express/entities/forms');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/express/entities/forms');
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/express/entities/customize_search');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/express/entities/customize_search');
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/express/entries');
         if (!is_object($page) || $page->isError()) {
@@ -638,8 +648,12 @@ class Version20160725000000 extends AbstractMigration
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/reports/forms/legacy');
             $sp->update(['cName' => 'Form Results']);
-            $sp->setAttribute('exclude_search_index', true);
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_search_index']) {
+                $sp->setAttribute('exclude_search_index', true);
+            }
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/basics/name');
         if (is_object($page) && !$page->isError()) {
@@ -649,14 +663,20 @@ class Version20160725000000 extends AbstractMigration
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/basics/attributes');
             $sp->update(['cName' => 'Custom Attributes']);
-            $sp->setAttribute('exclude_search_index', true);
-            $sp->setAttribute('exclude_nav', true);
+            if ($availableAttributes['exclude_search_index']) {
+                $sp->setAttribute('exclude_search_index', true);
+            }
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
         }
         $page = Page::getByPath('/dashboard/system/registration/global_password_reset');
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/registration/global_password_reset');
             $sp->update(['cDescription' => 'Signs out all users, resets all passwords and forces users to choose a new one']);
-            $sp->setAttribute('meta_keywords', 'global, password, reset, change password, force, sign out');
+            if ($availableAttributes['meta_keywords']) {
+                $sp->setAttribute('meta_keywords', 'global, password, reset, change password, force, sign out');
+            }
         }
         $page = Page::getByPath('/dashboard/system/registration/notification');
         if (!is_object($page) || $page->isError()) {

--- a/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
@@ -7,18 +8,33 @@ use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
 use Concrete\Core\Page\Page;
 use SinglePage;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Attribute\Category\PageCategory;
 
 class Version20170202000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
+        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
+        /* @var PageCategory $pageAttributeCategory */
+        $availableAttributes = [];
+        foreach ([
+            'exclude_nav',
+            'meta_keywords',
+        ] as $akHandle) {
+            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
+        }
+
         $app = Application::getFacadeApplication();
         $sp = Page::getByPath('/dashboard/system/files/thumbnails/options');
         if (!is_object($sp) || $sp->isError()) {
             $sp = SinglePage::add('/dashboard/system/files/thumbnails/options');
             $sp->update(['cName' => 'Thumbnail Options']);
-            $sp->setAttribute('exclude_nav', true);
-            $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
+            if ($availableAttributes['meta_keywords']) {
+                $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
+            }
         }
         $this->refreshEntities([
             DateTimeSettings::class,

--- a/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
@@ -5,11 +5,23 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Attribute\Category\PageCategory;
 
 class Version20170404000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
+        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
+        /* @var PageCategory $pageAttributeCategory */
+        $availableAttributes = [];
+        foreach ([
+            'exclude_nav',
+            'meta_keywords',
+        ] as $akHandle) {
+            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
+        }
+
         $timezone = \Config::get('app.timezone');
         if ($timezone) {
             // We have a legacy timezone we need to move into the site.
@@ -23,8 +35,12 @@ class Version20170404000000 extends AbstractMigration
         if (!is_object($sp) || $sp->isError()) {
             $sp = SinglePage::add('/dashboard/system/basics/multilingual/update');
             $sp->update(['cName' => 'Update Languages']);
-            $sp->setAttribute('exclude_nav', true);
-            $sp->setAttribute('meta_keywords', 'languages, update, gettext, translation');
+            if ($availableAttributes['exclude_nav']) {
+                $sp->setAttribute('exclude_nav', true);
+            }
+            if ($availableAttributes['meta_keywords']) {
+                $sp->setAttribute('meta_keywords', 'languages, update, gettext, translation');
+            }
         }
     }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
@@ -5,11 +5,20 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Attribute\Category\PageCategory;
 
 class Version20170420000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
+        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
+        /* @var PageCategory $pageAttributeCategory */
+        $availableAttributes = [];
+        foreach (['meta_keywords'] as $akHandle) {
+            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
+        }
+
         Page::getByPath('/dashboard/system/backup')->delete();
         Page::getByPath('/dashboard/system/backup/backup')->delete();
         Page::getByPath('/dashboard/system/backup/update')->delete();
@@ -24,7 +33,9 @@ class Version20170420000000 extends AbstractMigration
         if (!is_object($page) || $page->isError()) {
             $sp = SinglePage::add('/dashboard/system/update/update');
             $sp->update(array('cName' => 'Apply Update'));
-            $sp->setAttribute('meta_keywords', 'upgrade, new version, update');
+            if ($availableAttributes['meta_keywords']) {
+                $sp->setAttribute('meta_keywords', 'upgrade, new version, update');
+            }
         }
     }
 


### PR DESCRIPTION
more details here https://github.com/concrete5/concrete5/issues/5620#issuecomment-311342813

an attribute can always be deleted in concrete5, even if it's used by the core. Since this can happen I'd propose that we skip them in this context too to ensure that the update runs without any problems.