### PR TITLE
Add phpDoc for \Concrete\Core\Page\Page::getCollectionDatePublicObject

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1486,6 +1486,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         return $this->vObj->cvDatePublic;
     }
 
+    /**
+     * @return \DateTime|null Returns the \DateTime instance (or null if the current version doesn't have public date)
+     */
     public function getCollectionDatePublicObject()
     {
         return Core::make('date')->toDateTime($this->getCollectionDatePublic());


### PR DESCRIPTION
I had used `$page->getCollectionDatePublicObject()->format('M j, Y')` some times, but this code will break a site if there's an scheduled page. So I'd like to add this phpdoc to avoid same mistakes.