### PR TITLE
Intercept invalid serialized composer control objects

### DIFF
--- a/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
@@ -184,8 +184,8 @@ class FormLayoutSetControl extends Object
         if ($r && $r['ptComposerFormLayoutSetControlID']) {
             $control = new static();
             $control->setPropertiesFromArray($r);
-            $control->ptComposerControlObject = unserialize($r['ptComposerControlObject']);
-            if (!$control->ptComposerControlObject->objectExists()) {
+            $control->ptComposerControlObject = @unserialize($r['ptComposerControlObject']);
+            if ($control->ptComposerControlObject === false || !$control->ptComposerControlObject->objectExists()) {
                 $control->delete();
 
                 return null;


### PR DESCRIPTION
While debugging the migration of the setup that @patej gave me to solve #5631, I met a broken serialized object that aborted the execution (call of a method on a non object).