### PR TITLE
Express Entry List block - "Alternate Row Background Color" color picker cut off

### DIFF
--- a/concrete/blocks/express_entry_list/edit.php
+++ b/concrete/blocks/express_entry_list/edit.php
@@ -1,4 +1,4 @@
-<?php  
+<?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
 ?>
 
@@ -125,7 +125,7 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             </div>
         </div>
 
-        <div class="form-group" data-options="table-striped">
+        <div class="form-group" data-options="table-striped" style="margin-bottom: 150px;">
             <?=$form->label('rowBackgroundColorAlternate', t('Alternate Row Background Color'))?>
             <div>
                 <?=$color->output('rowBackgroundColorAlternate', $rowBackgroundColorAlternate)?>


### PR DESCRIPTION
This is an ugly fix for the "Alternate Row Background Color" color picker being cut off. The modal is set to overflow hidden, so the color picker only partially displays.

**Current:**

![image](https://user-images.githubusercontent.com/10898145/27679211-faedb6a4-5c85-11e7-9eb3-309b2d8d080c.png)

**Changes:**

![image](https://user-images.githubusercontent.com/10898145/27679220-0147cbc0-5c86-11e7-8371-f6cc759fbec4.png)
