### PR TITLE
Don't escape received keywords

### DIFF
--- a/concrete/controllers/search/pages.php
+++ b/concrete/controllers/search/pages.php
@@ -25,8 +25,8 @@ class Pages extends Standard
     protected function getBasicSearchFieldsFromRequest()
     {
         $fields = parent::getBasicSearchFieldsFromRequest();
-        $keywords = htmlentities($this->request->get('cKeywords'), ENT_QUOTES, APP_CHARSET);
-        if ($keywords) {
+        $keywords = $this->request->get('cKeywords');
+        if (is_string($keywords) && $keywords !== '') {
             $fields[] = new KeywordsField($keywords);
         }
         return $fields;


### PR DESCRIPTION
Fix #5637

It seems that when the search field is rendered, it already escapes the keywords, so we don't need to do it again.