### PR TITLE
Fix enabling alternative canonical URL, fix canonical URL patterns

### DIFF
--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -227,7 +227,7 @@ if (isset($successMessage)) {
                 });
             }
 
-            $('#canonicalUrlChecked,#canonicalUrlALternativeChecked').change(updateCanonicalURLState);
+            $('#canonicalUrlChecked,#canonicalUrlAlternativeChecked').change(updateCanonicalURLState);
             <?php
             if ($setInitialState) {
             ?>
@@ -381,9 +381,9 @@ if (isset($successMessage)) {
                                 <div class="form-group">
                                     <label class="control-label">
                                         <?=$form->checkbox('canonicalUrlChecked', '1')?>
-                                        <?=t('Set canonical URL for HTTP')?>:
+                                        <?=t('Set main canonical URL')?>:
                                     </label>
-                                    <?=$form->url('canonicalUrl', h($canonicalUrl), ['pattern' => 'http:.+', 'placeholder' => 'http://'])?>
+                                    <?=$form->url('canonicalUrl', h($canonicalUrl), ['pattern' => 'https?:.+', 'placeholder' => t('%s or %s', 'http://...', 'https://...')])?>
                                 </div>
 
                                 <div class="form-group">
@@ -391,7 +391,7 @@ if (isset($successMessage)) {
                                         <?=$form->checkbox('canonicalUrlAlternativeChecked', '1')?>
                                         <?=t('Set alternative canonical URL')?>:
                                     </label>
-                                    <?=$form->url('canonicalUrlAlternative', h($canonicalUrlAlternative), ['pattern' => 'https:.+', 'placeholder' => 'https://'])?>
+                                    <?=$form->url('canonicalUrlAlternative', h($canonicalUrlAlternative), ['pattern' => 'https?:.+', 'placeholder' => t('%s or %s', 'http://...', 'https://...')])?>
                                 </div>
                                 <div class="form-group">
                                     <label class="control-label" for="sessionHandler"><?=t('Session Handler')?></label>


### PR DESCRIPTION
Let's fix these problems:
- in the install page, checking `Set alternative canonical URL:` does not activate the related text box.
- rename `Set canonical URL for HTTP` to `Set main canonical URL`
- the html5 `pattern` attributes force users to specify `http:...` for the main canonical URL and `https:...` for the alternative canonical URL: let's allow `http:...` and `https:...` for both canonical URLs.