### PR TITLE
Add confirmations about the risk of being locked out because of blacklisted IP

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist;
 
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Permission\IPRange;
 use Concrete\Core\Permission\IPRangesCsvWriter;
 use Concrete\Core\Permission\IPService;
-use Exception;
 use IPLib\Factory as IPFactory;
 use League\Csv\Writer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -30,7 +30,9 @@ class Range extends DashboardPageController
                 break;
         }
         $this->set('type', $type);
-        $this->set('ranges', $this->app->make('ip')->getRanges($type));
+        $ip = $this->app->make('ip');
+        $this->set('ip', $ip);
+        $this->set('ranges', $ip->getRanges($type));
     }
 
     public function formatRangeRow(IPRange $range)
@@ -55,14 +57,29 @@ class Range extends DashboardPageController
     public function add_range($type)
     {
         if (!$this->token->validate('add_range/' . $type)) {
-            throw new Exception($this->token->getErrorMessage());
+            throw new UserMessageException($this->token->getErrorMessage());
         }
         $range = IPFactory::rangeFromString($this->request->request->get('range'));
         if ($range === null) {
-            throw new Exception(t('The specified IP range is invalid'));
+            throw new UserMessageException(t('The specified IP range is invalid'));
         }
         $ipService = $this->app->make('ip');
         /* @var IPService $ipService */
+        if (!$this->request->request->get('force') && ($type & IPService::IPRANGEFLAG_BLACKLIST) === IPService::IPRANGEFLAG_BLACKLIST) {
+            $myIP = $ipService->getRequestIPAddress();
+            if ($range->contains($myIP)) {
+                if (!$ipService->isWhitelisted($myIP)) {
+                    if ($range instanceof \IPLib\Range\Single) {
+                        $msg = t('The specified IP address is the one you are currently using.');
+                    } else {
+                        $msg = t('The specified IP range contains the IP address you are currently using.');
+                    }
+                    $msg .= "\n" . t("If you don't add your IP address to the whitelist, you won't be able to log-in anymore from the current IP address.");
+
+                    return $this->app->make(ResponseFactoryInterface::class)->json(['require_force' => $msg]);
+                }
+            }
+        }
         $record = $ipService->createRange($range, $type);
 
         return $this->app->make(ResponseFactoryInterface::class)->json(['row' => $this->formatRangeRow($record)]);
@@ -71,34 +88,46 @@ class Range extends DashboardPageController
     public function delete_range($type)
     {
         if (!$this->token->validate('delete_range/' . $type)) {
-            throw new Exception($this->token->getErrorMessage());
+            throw new UserMessageException($this->token->getErrorMessage());
         }
+        $result = true;
         $ipService = $this->app->make('ip');
         /* @var IPService $ipService */
         $record = $ipService->getRangeByID($this->request->request->get('id'));
         if ($record !== null) {
             if ($record->getType() !== (int) $type) {
-                throw new Exception(t('The specified IP range is invalid'));
+                throw new UserMessageException(t('The specified IP range is invalid'));
+            }
+            $myIpWasWhitelisted = false;
+            if (($type & IPService::IPRANGEFLAG_WHITELIST) === IPService::IPRANGEFLAG_WHITELIST) {
+                $myIP = $ipService->getRequestIPAddress();
+                $range = $record->getIpRange();
+                if ($range->contains($myIP)) {
+                    $myIpWasWhitelisted = true;
+                }
             }
             $ipService->deleteRange($record);
+            if ($myIpWasWhitelisted && $ipService->isBlacklisted($myIP)) {
+                $result = t("The removed range contained your current IP address, which is now in the blacklist.\nIf you want to log in again with the current IP address, you should add your IP to the whitelist, or remove the relevant blacklist records.");
+            }
         }
 
-        return $this->app->make(ResponseFactoryInterface::class)->json(true);
+        return $this->app->make(ResponseFactoryInterface::class)->json($result);
     }
 
     public function make_range_permanent($type)
     {
         if (!$this->token->validate('make_range_permanent/' . $type)) {
-            throw new Exception($this->token->getErrorMessage());
+            throw new UserMessageException($this->token->getErrorMessage());
         }
         $ipService = $this->app->make('ip');
         /* @var IPService $ipService */
         $record = $ipService->getRangeByID($this->request->request->get('id'));
         if ($record === null) {
-            throw new Exception(t('Unable to find the IP range specified'));
+            throw new UserMessageException(t('Unable to find the IP range specified'));
         }
         if ($record->getType() !== (int) $type) {
-            throw new Exception(t('The specified IP range is invalid'));
+            throw new UserMessageException(t('The specified IP range is invalid'));
         }
         $ipService->createRange($record->getIpRange(), IPService::IPRANGETYPE_BLACKLIST_MANUAL);
         $ipService->deleteRange($record);
@@ -109,7 +138,7 @@ class Range extends DashboardPageController
     public function export($type, $includeExpired, $token)
     {
         if (!$this->token->validate("iprange/export/range/{$type}/$includeExpired", $token)) {
-            throw new Exception($this->token->getErrorMessage());
+            throw new UserMessageException($this->token->getErrorMessage());
         }
         $type = (int) $type;
         switch ($type) {


### PR DESCRIPTION
Changes included in this pull request:
1. in the whitelist page, show the current user's IP address:  
![image](https://user-images.githubusercontent.com/928116/27737536-c7453a42-5da8-11e7-8c2e-d3694ee3af3f.png)
2. if you try to add to the blacklist an IP range that contains the current user's IP address, and if the current user's IP address is not in the whitelist, let's show this confirmation dialog:  
![image](https://user-images.githubusercontent.com/928116/27737322-0186373e-5da8-11e7-847f-56b2baf85bc6.png)
3. if you remove a whitelist range that contains the current user's IP address, and if after this removal the IP address is in a blacklist, show this warning:  
![image](https://user-images.githubusercontent.com/928116/27737437-743e88bc-5da8-11e7-9b7e-644ba8ff1ecc.png)

