### PR TITLE
Image center

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -374,6 +374,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $args['fID'] = $args['fID'] != '' ? $args['fID'] : 0;
         $args['fOnstateID'] = $args['fOnstateID'] != '' ? $args['fOnstateID'] : 0;
         $args['fileLinkID'] = $args['fileLinkID'] != '' ? $args['fileLinkID'] : 0;
+        $args['centerImage'] = isset($args['centerImage']) ? 1 : 0;
         $args['cropImage'] = isset($args['cropImage']) ? 1 : 0;
         $args['maxWidth'] = intval($args['maxWidth']) > 0 ? intval($args['maxWidth']) : 0;
         $args['maxHeight'] = intval($args['maxHeight']) > 0 ? intval($args['maxHeight']) : 0;

--- a/concrete/blocks/image/db.xml
+++ b/concrete/blocks/image/db.xml
@@ -13,6 +13,10 @@
             <unsigned/>
             <default value="0" />
         </field>
+        <field name="centerImage" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
         <field name="cropImage" type="integer">
             <unsigned/>
             <default value="0" />

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -78,7 +78,7 @@ $al = $app->make('helper/concrete/asset_library');
 </fieldset>
 
 <fieldset>
-    <legend><?php echo t('Resize Image'); ?></legend>
+    <legend><?php echo t('Position & Size'); ?></legend>
 
     <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -81,6 +81,17 @@ $al = $app->make('helper/concrete/asset_library');
     <legend><?php echo t('Position & Size'); ?></legend>
 
     <div class="form-group">
+        <div class="checkbox">
+            <label>
+                <?php
+                echo $form->checkbox('centerImage', 1, $centerImage);
+                echo t('Center Image');
+                ?>
+            </label>
+        </div>
+    </div>
+
+    <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">
             <label>
                 <?php

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -18,6 +18,9 @@ if (is_object($f) && $f->getFileID()) {
     }
 
     $tag->addClass('ccm-image-block img-responsive bID-' . $bID);
+    if ($centerImage) {
+        $tag->addClass('center-block');
+    }
 
     if ($altText) {
         $tag->alt(h($altText));


### PR DESCRIPTION
Image block: option to allow centring (an oft-requested feature in the c5 forum).

The default is not to centre, to retain the same behaviour as currently. However, centring by default makes some sense.

I didn't include options for right alignment, etc, to keep things simple and because I couldn't think of a common use-case for it.

Warning: this is my first submission to the c5 core, and my first attempt at using git. Scrutinise closely!