### PR TITLE
Add a check to prevent null values from breaking the advanced file search

### DIFF
--- a/concrete/src/Search/Result/Item.php
+++ b/concrete/src/Search/Result/Item.php
@@ -15,8 +15,10 @@ class Item
     public function __construct(Result $result, Set $columns, $item)
     {
         foreach ($columns->getColumns() as $col) {
-            $o = new ItemColumn($col->getColumnKey(), $col->getColumnValue($item), $col);
-            $this->columns[] = $o;
+            if ($col) {
+                $o = new ItemColumn($col->getColumnKey(), $col->getColumnValue($item), $col);
+                $this->columns[] = $o;
+            }
         }
     }
 }


### PR DESCRIPTION
In certain circumstances null values can enter a saved file search this has caused some issues when trying to run subsequent searches.

Once resolved I've not been able to replicate the issue, so believe it could be a legacy issue that's since been fixed?

But without this if a null value exists in the Users config then then the site search breaks with the exception listed in the bug tracker link below.

https://www.concrete5.org/developers/bugs/8-1-0/running-an-advanced-search-returns-an-exception/