### PR TITLE
Error fix for null site tree object

### DIFF
--- a/concrete/controllers/panel/page/design.php
+++ b/concrete/controllers/panel/page/design.php
@@ -80,12 +80,14 @@ class Design extends BackendUIPageController
             $templatesSelect[$pt->getPageTemplateID()] = $pt->getPageTemplateDisplayName();
         }
 
-        $tree = $c->getSiteTreeObject();
-        $type = $tree->getSiteType();
-        $typeList = Type::getList(false, $type);
         $typesSelect = array('0' => t('** None'));
-        foreach ($typeList as $_pagetype) {
-            $typesSelect[$_pagetype->getPageTypeID()] = $_pagetype->getPageTypeDisplayName();
+        $tree = $c->getSiteTreeObject();
+        if (is_object($tree)) {
+            $type = $tree->getSiteType();
+            $typeList = Type::getList(false, $type);
+            foreach ($typeList as $_pagetype) {
+                $typesSelect[$_pagetype->getPageTypeID()] = $_pagetype->getPageTypeDisplayName();
+            }
         }
 
         $this->set('templatesSelect', $templatesSelect);


### PR DESCRIPTION
When I'm trying to access Design & Types for pages like login or register, it generates an error. Because it's trying to get siteTreeObject which actually doesn't exists.
![screen shot 2017-07-05 at 7 25 29 pm](https://user-images.githubusercontent.com/2462951/27861769-2961d81c-61bd-11e7-85b7-39b22ae22d41.png)

That's why I've applied a simple check and now it's working as the attached screenshot.

![screen shot 2017-07-05 at 7 24 16 pm](https://user-images.githubusercontent.com/2462951/27861780-3420805a-61bd-11e7-862c-c34ae2c5f967.png)
