### PR TITLE
Fix specifying canonical URLs at install time

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -559,7 +559,7 @@ class Install extends Controller
             if ($this->post('canonicalUrlChecked') === '1') {
                 try {
                     $url = UrlImmutable::createFromUrl($this->post('canonicalUrl'));
-                    if (!preg_match('/^https?/i', $url->getScheme()) !== 0) {
+                    if (!preg_match('/^https?/i', $url->getScheme())) {
                         throw new Exception('The canonical URL must have the http:// scheme or the https:// scheme');
                     }
                     $canonicalUrl = (string) $url;
@@ -572,7 +572,7 @@ class Install extends Controller
             if ($this->post('canonicalUrlAlternativeChecked') === '1') {
                 try {
                     $url = UrlImmutable::createFromUrl($this->post('canonicalUrlAlternative'));
-                    if (!preg_match('/^https?/i', $url->getScheme()) !== 0) {
+                    if (!preg_match('/^https?/i', $url->getScheme())) {
                         throw new Exception('The alternative canonical URL must have the http:// scheme or the https:// scheme');
                     }
                     $canonicalUrlAlternative = (string) $url;


### PR DESCRIPTION
This fixes a bug introduced in #5564 that prevented specifying the canonical URLs during install (!)

I think I'm done with fixing the bugs I keep adding 🤣 I do really need a break :wink: