### PR TITLE
Fix - Cancel button event, for who doesn't have public profile

### DIFF
--- a/concrete/controllers/single_page/account/messages.php
+++ b/concrete/controllers/single_page/account/messages.php
@@ -126,7 +126,8 @@ class Messages extends AccountPageController
     {
         $this->validateUser($uID);
         $profile = $this->get('profile');
-        $this->set('backURL', $profile->getUserPublicProfileURL());
+        $backURL = $profile->getUserPublicProfileURL() ?: 'javascript:history.back()';
+        $this->set('backURL', $backURL);
     }
 
     public function reply($boxID, $msgID)


### PR DESCRIPTION
`Cancel` button doesn't have any event if the sender doesn't have public profile.
I've checked it from `Dashboard -> Members -> MemberName -> Send Private Message`.

**Applied javascript back to previous page, if the `getUserPublicProfileUrl` is null.**

![screen shot 2017-07-06 at 5 26 10 pm](https://user-images.githubusercontent.com/2462951/27903717-3e4fef08-6275-11e7-9cba-91f67e6cc077.png)
