### PR TITLE
Avoid accessing non-existent Users.uIsPasswordReset field

### DIFF
--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -102,7 +102,7 @@ class User extends Object
         if ($session->get('uID') > 0) {
             $db = $app['database']->connection();
 
-            $row = $db->GetRow("select uID, uIsActive, uLastPasswordChange, uIsPasswordReset from Users where uID = ? and uName = ?", array($session->get('uID'), $session->get('uName')));
+            $row = $db->GetRow("select * from Users where uID = ? and uName = ?", array($session->get('uID'), $session->get('uName')));
             $checkUID = (isset($row['uID'])) ? ($row['uID']) : (false);
 
             if ($checkUID == $session->get('uID')) {
@@ -116,7 +116,7 @@ class User extends Object
                     return false;
                 }
 
-                if ($row['uIsPasswordReset']) {
+                if (!empty($row['uIsPasswordReset'])) {
                     return false;
                 }
 


### PR DESCRIPTION
Before the upgrade process starts, we may call the validateUser user method, which is referring to the Users.uIsPasswordReset database field that does not exist yet, since it's added by the upgrade.

Fixes http://www.concrete5.org/developers/bugs/8-1-0/upgrade-from-5.7.5.13-to.-8.1-error/