### PR TITLE
Initialize time zone in CLI commands

### DIFF
--- a/concrete/src/Foundation/Runtime/Run/CLIRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/CLIRunner.php
@@ -18,6 +18,23 @@ class CLIRunner implements RunInterface, ApplicationAwareInterface
         $this->console = $console;
     }
 
+    private function loadBootstrap()
+    {
+        $app = $this->app;
+        $console = $this->console;
+        include DIR_APPLICATION . '/bootstrap/app.php';
+    }
+
+    private function initializeSystemTimezone()
+    {
+        $config = $this->app->make('config');
+        if (!$config->has('app.server_timezone')) {
+            // There is no server timezone set.
+            $config->set('app.server_timezone', @date_default_timezone_get());
+        }
+        @date_default_timezone_set($config->get('app.server_timezone'));
+    }
+
     /**
      * Run the runtime.
      *
@@ -28,9 +45,8 @@ class CLIRunner implements RunInterface, ApplicationAwareInterface
         $console = $this->console;
         $this->app->instance('console', $console);
 
-        $app = $this->app; // useful in bootstrap/app.php
-
-        include DIR_APPLICATION . '/bootstrap/app.php';
+        $this->loadBootstrap();
+        $this->initializeSystemTimezone();
 
         $input = new ArgvInput();
         if ($input->getFirstArgument() !== 'c5:update') {


### PR DESCRIPTION
The [web runner](https://github.com/concrete5/concrete5/blob/6f01a4ec0e146000264e0225e53013633605143b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php) initializes the time zone, but the [CLI runner](https://github.com/concrete5/concrete5/blob/6f01a4ec0e146000264e0225e53013633605143b/concrete/src/Foundation/Runtime/Run/CLIRunner.php) doesn't.
Let's fix this.