### PR TITLE
Added missing return statement for "runAction" and "on_page_view" met…

### DIFF
--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -138,7 +138,7 @@ class Controller extends BlockController
         $bc = $this->getScrapbookBlockController();
 
         if (is_object($bc)) {
-            $bc->runAction($action, $parameters);
+            return $bc->runAction($action, $parameters);
         }
     }
 
@@ -147,7 +147,7 @@ class Controller extends BlockController
         $bc = $this->getScrapbookBlockController();
 
         if ($bc && method_exists($bc, 'on_page_view')) {
-            $bc->on_page_view($page);
+            return $bc->on_page_view($page);
         }
     }
 


### PR DESCRIPTION
Added missing return statement for "runAction" and "on_page_view" methods. This was causing blocks to not return the correct response when proxied through this controller. I am not exactly sure how to re-create the bug but I think its related to when a block is copied to the clipboard and then inserted on the page. For some reason the CoreScrapbookDisplay block controller runs and it basically passes actions through to the underlying controller.
