### PR TITLE
Class not found error fix for PrivateMessage/Limit

### DIFF
--- a/concrete/src/User/PrivateMessage/Limit.php
+++ b/concrete/src/User/PrivateMessage/Limit.php
@@ -58,7 +58,7 @@ class Limit
 
         $admin = UserInfo::getByID(USER_SUPER_ID);
 
-        Log::addEntry(t("User: %s has tried to send more than %s private messages within %s minutes", $offender->getUserName(), Config::get('concrete.user.private_messages.throttle_max'), Config::get('concrete.user.private_messages.throttle_max_timespan')), t('warning'));
+        \Log::addEntry(t("User: %s has tried to send more than %s private messages within %s minutes", $offender->getUserName(), Config::get('concrete.user.private_messages.throttle_max'), Config::get('concrete.user.private_messages.throttle_max_timespan')), t('warning'));
 
         $mh = Loader::helper('mail');
 


### PR DESCRIPTION
This commit fixes the following issue.
![screen shot 2017-07-11 at 1 42 57 pm](https://user-images.githubusercontent.com/2462951/28051764-598bf6a2-6641-11e7-86b6-7b1dcd0b1708.png)
