### PR TITLE
Fix/select sort umlaut

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -636,10 +636,10 @@ class Controller extends AttributeTypeController
                 break;
             case 'alpha_asc':
                 if (isset($like) && strlen($like)) {
-                    $r = $db->Execute('select ID, value, displayOrder from atSelectOptions where akID = ? AND atSelectOptions.value LIKE ? order by value asc',
+                    $r = $db->Execute('select ID, value, displayOrder from atSelectOptions where akID = ? AND atSelectOptions.value LIKE ?',
                         array($this->attributeKey->getAttributeKeyID(), $like));
                 } else {
-                    $r = $db->Execute('select ID, value, displayOrder from atSelectOptions where akID = ? order by value asc',
+                    $r = $db->Execute('select ID, value, displayOrder from atSelectOptions where akID = ?',
                         array($this->attributeKey->getAttributeKeyID()));
                 }
                 break;
@@ -657,6 +657,9 @@ class Controller extends AttributeTypeController
         while ($row = $r->FetchRow()) {
             $opt = new Option($row['ID'], $row['value'], $row['displayOrder']);
             $options->add($opt);
+        }
+        if ($this->akSelectOptionDisplayOrder === 'alpha_asc') {
+            $options->sortByDisplayName();
         }
 
         return $options;

--- a/web/concrete/attributes/select/form.php
+++ b/web/concrete/attributes/select/form.php
@@ -16,7 +16,7 @@ if ($akSelectAllowMultipleValues && !$akSelectAllowOtherValues) {
 		</div>
 
 
-	<? }
+	<?php }
 
 
 }
@@ -35,7 +35,7 @@ if (!$akSelectAllowMultipleValues && !$akSelectAllowOtherValues) {
 	<?=$form->select($view->field('atSelectOptionValue'), $options, $selectedOptions[0]); ?>
 
 
-<? }
+<?php }
 
 /**
  * Select2
@@ -109,4 +109,4 @@ if ($akSelectAllowOtherValues) {
 		});
 	</script>
 
-<? }
+<?php }

--- a/web/concrete/attributes/select/option_list.php
+++ b/web/concrete/attributes/select/option_list.php
@@ -1,7 +1,8 @@
 <?php
 namespace Concrete\Attribute\Select;
-use Loader;
+use Localization;
 use \Concrete\Core\Foundation\Object;
+use \Punic\Comparer;
 
 class OptionList extends Object implements \Iterator {
 
@@ -61,7 +62,9 @@ class OptionList extends Object implements \Iterator {
 	* @return int
 	*/
 	protected static function displayValueSorter($a, $b) {
-		return strcasecmp($a->getSelectAttributeOptionDisplayValue('text'), $b->getSelectAttributeOptionDisplayValue('text'));
+            $locale = Localization::activeLocale();
+            $comparer = new Comparer($locale);
+            return $comparer->compare($a->getSelectAttributeOptionDisplayValue('text'), $b->getSelectAttributeOptionDisplayValue('text'));
 	}
 
 	public function __toString() {


### PR DESCRIPTION
Umlauts get sorted after "z". This fix will use the punic library to get e.g. "ä" after "a".