### PR TITLE
Image block settings to align centre/right

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -374,6 +374,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $args['fID'] = $args['fID'] != '' ? $args['fID'] : 0;
         $args['fOnstateID'] = $args['fOnstateID'] != '' ? $args['fOnstateID'] : 0;
         $args['fileLinkID'] = $args['fileLinkID'] != '' ? $args['fileLinkID'] : 0;
+        $args['alignImage'] = $args['alignImage'] != '' ? $args['alignImage'] : 0;
         $args['cropImage'] = isset($args['cropImage']) ? 1 : 0;
         $args['maxWidth'] = intval($args['maxWidth']) > 0 ? intval($args['maxWidth']) : 0;
         $args['maxHeight'] = intval($args['maxHeight']) > 0 ? intval($args['maxHeight']) : 0;

--- a/concrete/blocks/image/db.xml
+++ b/concrete/blocks/image/db.xml
@@ -13,6 +13,10 @@
             <unsigned/>
             <default value="0" />
         </field>
+        <field name="alignImage" type="integer">
+            <unsigned/>
+            <default value="0" />
+        </field>
         <field name="cropImage" type="integer">
             <unsigned/>
             <default value="0" />

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -106,7 +106,9 @@ $al = $app->make('helper/concrete/asset_library');
             </label>
         </div>
     </div>
+</fieldset>
 
+<fieldset>
     <legend><?php echo t('Size'); ?></legend>
 
     <div class="form-group">

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -78,7 +78,36 @@ $al = $app->make('helper/concrete/asset_library');
 </fieldset>
 
 <fieldset>
-    <legend><?php echo t('Resize Image'); ?></legend>
+    <legend><?php echo t('Alignment'); ?></legend>
+
+    <div class="form-group">
+        <div class="radio">
+            <label>
+                <?php
+                echo $form->radio('alignImage', 0, $alignImage);
+                echo t('Left');
+                ?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?php
+                echo $form->radio('alignImage', 1, $alignImage);
+                echo t('Center');
+                ?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?php
+                echo $form->radio('alignImage', 2, $alignImage);
+                echo t('Right');
+                ?>
+            </label>
+        </div>
+    </div>
+
+    <legend><?php echo t('Size'); ?></legend>
 
     <div class="form-group">
         <div class="checkbox" data-checkbox-wrapper="constrain-image">

--- a/concrete/blocks/image/view.css
+++ b/concrete/blocks/image/view.css
@@ -1,0 +1,9 @@
+img.ccm-image-center {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+img.ccm-image-right {
+    margin-left: auto;
+    margin-right: 0;
+}

--- a/concrete/blocks/image/view.css
+++ b/concrete/blocks/image/view.css
@@ -1,9 +1,11 @@
-img.ccm-image-center {
+.ccm-image-center {
+    display: block;
     margin-left: auto;
     margin-right: auto;
 }
 
-img.ccm-image-right {
+.ccm-image-right {
+    display: block;
     margin-left: auto;
     margin-right: 0;
 }

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -18,6 +18,11 @@ if (is_object($f) && $f->getFileID()) {
     }
 
     $tag->addClass('ccm-image-block img-responsive bID-' . $bID);
+    if ($alignImage == 1) {
+        $tag->addClass('ccm-image-center');
+    } else if ($alignImage == 2) {
+        $tag->addClass('ccm-image-right');
+    }
 
     if ($altText) {
         $tag->alt(h($altText));


### PR DESCRIPTION
Image block: option to allow centring (an oft-requested feature in the c5 forum) and right alignment.

The default is not to centre, to retain the same behaviour as currently. (However, centring by default makes some sense.)

This request supersedes https://github.com/concrete5/concrete5/pull/5668. My thanks to MrKarlDilkington for his guidance there.