### PR TITLE
Clone ItemList object in PagerPagination

### DIFF
--- a/concrete/src/Search/Pagination/PagerPagination.php
+++ b/concrete/src/Search/Pagination/PagerPagination.php
@@ -18,6 +18,7 @@ class PagerPagination extends Pagination
 
     public function __construct(PagerProviderInterface $itemList)
     {
+        $itemList = clone $itemList;
         $adapter = new PagerAdapter($itemList);
         $this->list = $itemList;
         $this->app = Facade::getFacadeApplication();


### PR DESCRIPTION
We can add some additional filtering on Page List block template, because PageList object is passed from block controller to view. It is useful to customize page list without override a block type controller. Here is an example code to do it.

```php
// application/blocks/page_list/templates/example.php
$list->filterByKeywords('Hello');
$pagination = $list->getPagination();
$pages = $pagination->getCurrentPageResults();
foreach ($pages as $page):
```

This code works expected on 8.1.0.

<img width="1191" alt="blog_810" src="https://user-images.githubusercontent.com/514294/28308294-b6214634-6be0-11e7-989f-c3672a7cc46c.png">

However, it doesn't works on 8.2.0RC2.

<img width="1191" alt="blog_820rc2" src="https://user-images.githubusercontent.com/514294/28308295-b80c1ae6-6be0-11e7-93dc-0d5970da7b8a.png">

The new PagerPagination class modifies querybuilder object in page list. This is the why this code won't works. So, I've added simple `clone` call in the constructor.

<img width="1191" alt="blog_820rc2fixed" src="https://user-images.githubusercontent.com/514294/28308300-ba65d458-6be0-11e7-8132-0d8e6437cf48.png">
