### PR TITLE
Stored XSS prevention in <textarea> form elements [fixes H1 247529,247520]

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -203,7 +203,7 @@ class Form
              $value = $requestValue;
          }
 
-         return '<textarea id="' . $key . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>' . $value . '</textarea>';
+         return '<textarea id="' . $key . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>' . h($value) . '</textarea>';
      }
 
     /**


### PR DESCRIPTION
Hi Guys,

This is more general fix, which should prevents <textarea> elements against Stored XSS attempts.

For now this change resolves:

https://hackerone.com/reports/247529
https://hackerone.com/reports/247520

but should fixes any other XSS issues in <textarea> elements as well.

Regards,

bl4de