### PR TITLE
Show 404 for deleted user public profile page

### DIFF
--- a/concrete/controllers/single_page/members/profile.php
+++ b/concrete/controllers/single_page/members/profile.php
@@ -18,7 +18,7 @@ class Profile extends PublicProfilePageController
         if ($userID > 0) {
             $profile = UserInfo::getByID($userID);
             if (!is_object($profile)) {
-                throw new Exception('Invalid User ID.');
+                return $this->replace('/page_not_found');
             }
         } elseif ($u->isRegistered()) {
             $profile = UserInfo::getByID($u->getUserID());


### PR DESCRIPTION
I'm working on a quick fix of Public Profile page.

Client deleted some users because they want to quit.

Then, when Google tried to crawl deleted users' public profile pages, it generated a bunch of exception errors which fired false alert.  (opps)

I think it would be nice to render 404 not as exception error page.

But my method won't send 404 response to browser.
Does anyone know a quick way to render a real 404 page from view() method of single_page?
