### PR TITLE
[Update] Starting point value swapped on cli install

### DIFF
--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -521,7 +521,7 @@ EOT
                 'starting-point',
                 'elemental_blank',
                 function (Question $question, InputInterface $input) {
-                    return new ChoiceQuestion($question->getQuestion(), ['elemental_full', 'elemental_blank'],
+                    return new ChoiceQuestion($question->getQuestion(), ['elemental_blank', 'elemental_full'],
                         $question->getDefault());
                 },
             ],


### PR DESCRIPTION
On CLI install, at the step of-

```
Starting point to use? [Default: elemental_blank]:
 [0] elemental_full
 [1] elemental_blank
```

has changed to-

```
Starting point to use? [Default: elemental_blank]:
 [0] elemental_blank
 [1] elemental_full
```

to make it more meaningful.

[0 for blank and 1 for full]