### PR TITLE
Fixing video view not working in file manager

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -659,7 +659,7 @@ return [
         'PHP' => ['php', FileType::T_TEXT],
         'MS Word' => ['doc,docx', FileType::T_DOCUMENT],
         'Stylesheet' => ['css', FileType::T_TEXT],
-        'MP4' => ['mp4', FileType::T_VIDEO],
+        'MP4' => ['mp4', FileType::T_VIDEO, false, 'video'],
         'FLV' => ['flv', FileType::T_VIDEO, 'flv'],
         'MP3' => ['mp3', FileType::T_AUDIO, false, 'audio'],
         'MP4 Audio' => ['m4a', FileType::T_AUDIO, false, 'audio'],
@@ -675,9 +675,9 @@ return [
         'TAR Archive' => ['tar', FileType::T_APPLICATION],
         'Zip Archive' => ['zip', FileType::T_APPLICATION],
         'GZip Archive' => ['gz,gzip', FileType::T_APPLICATION],
-        'OGG' => ['ogg', FileType::T_AUDIO],
-        'OGG Video' => ['ogv', FileType::T_VIDEO],
-        'WebM' => ['webm', FileType::T_VIDEO],
+        'OGG' => ['ogg', FileType::T_AUDIO, false, 'audio'],
+        'OGG Video' => ['ogv', FileType::T_VIDEO, false, 'video'],
+        'WebM' => ['webm', FileType::T_VIDEO, false, 'video'],
     ],
 
     /*

--- a/concrete/elements/files/view/audio.php
+++ b/concrete/elements/files/view/audio.php
@@ -1,8 +1,9 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?> 
-<?php
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 $path = $fv->getURL();
 ?>
-<object width="500" height="42">
-<param name="src" value="<?=$path?>">
-<embed src="<?=$path?>" width="500" height="42" ></embed>
-</object>
+<audio src="<?=$path?>" controls="controls" preload="auto">
+    <object width="500" height="42">
+        <param name="src" value="<?=$path?>">
+        <embed src="<?=$path?>" width="500" height="42" ></embed>
+    </object>
+</audio>

--- a/concrete/elements/files/view/text.php
+++ b/concrete/elements/files/view/text.php
@@ -1,9 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?> 
 <div style="text-align: left">
-<?php
-$fh = Loader::helper('file');
-echo '<pre style="font-size: 11px; font-family: Courier">';
-echo Loader::helper('text')->entities($fv->getFileContents());
-echo '</pre>';?>
-
+    <pre style="font-size: 11px; font-family: Courier">
+        <?=Core::make('helper/text')->entities($fv->getFileContents())?>
+    </pre>
 </div>

--- a/concrete/elements/files/view/video.php
+++ b/concrete/elements/files/view/video.php
@@ -1,9 +1,9 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?> 
-<?php
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 $path = $fv->getURL();
 ?>
-
-<OBJECT ID="MediaPlayer" WIDTH="80%" HEIGHT="80%">
-<PARAM NAME="FileName" VALUE="<?=$path()?>">
-<EMBED src="<?=$path?>" NAME="MediaPlayer" WIDTH="80%" HEIGHT="80%"  ></EMBED>
-</OBJECT> 
+<video src="<?=$path?>" width="70%" height="70%" preload="auto" controls="controls">
+    <object id="MediaPlayer" width="70%" height="70%">
+        <param name="FileName" value="<?=$path?>">
+        <embed src="<?=$path?>" name="MediaPlayer" width="70%" height="70%"></embed>
+    </object>
+</video>


### PR DESCRIPTION
This pull request fixes the error on the view video element that is caused `<?=path()?>` . It also updates the other view elements in the file manager by replace Loader with Core::make and incorporating video/audio elements.

I have also updated filetypes in app.php to include mp4, ogg, webm etc in the view video element.