### PR TITLE
Fixing issue #5764 - wrong icons for asc/desc order

### DIFF
--- a/concrete/single_pages/dashboard/files/sets.php
+++ b/concrete/single_pages/dashboard/files/sets.php
@@ -128,9 +128,9 @@ $dh = Core::make('helper/date');
                 var bVal = typeof( bTD.attr('data-sort') ) == 'undefined' ? bTD.text().toUpperCase() : parseInt(bTD.attr('data-sort'));
 
                 if (asc) {
-                    return aVal < bVal ? -1 : 1;
-                } else {
                     return bVal < aVal ? -1 : 1;
+                } else {
+                    return aVal < bVal ? -1 : 1;
                 }
             });
             sortableList.append(listItems);


### PR DESCRIPTION
This PR fixes the file sets view icons being wrong for asc/desc order as mentioned in issue #5764 