### PR TITLE
Regex is not taking into account empty query parameters

### DIFF
--- a/concrete/src/Utility/Service/Url.php
+++ b/concrete/src/Utility/Service/Url.php
@@ -23,7 +23,7 @@ class Url
         }
 
         foreach ($vars as $variable => $value) {
-            $url = preg_replace('/(.*)(\?|&)' . $variable . '=[^&]+?(&)(.*)/i', '$1$2$4', $url . '&');
+            $url = preg_replace('/(.*)(\?|&)' . $variable . '=[^&]*?(&)(.*)/i', '$1$2$4', $url . '&');
             $url = substr($url, 0, -1);
             if (strpos($url, '?') === false) {
                 $url = $url . '?' . $variable . '=' . $value;
@@ -55,7 +55,7 @@ class Url
         }
 
         foreach ($vars as $variable) {
-            $url = preg_replace('/(.*)(\?|&)' . $variable . '=[^&]+?(&)(.*)/i', '$1$2$4', $url . '&');
+            $url = preg_replace('/(.*)(\?|&)' . $variable . '=[^&]*?(&)(.*)/i', '$1$2$4', $url . '&');
             $url = substr($url, 0, -1);
         }
 


### PR DESCRIPTION
As an example, in the file concrete\src\Search\ItemList\ItemList.php, in the function getSortURL() you have an array of query parameters you send to the URL helper.

Since 8.2 you have added the parameter ccm_cursor with an empty value (it doesn't seem to be doing anything at the moment but it's there)

The function setVariable() in the URL helper is replacing existing parameters with their new value but is looking for parameters with a value already set (+? in regex looks for at least 1 match) so since we had ccm_cursor= with no value it was never replaced and on each iteration we added a new ccm_cursor= to the query string (?ccm_order_by=name&ccm_order_by_direction=asc&ccm_cursor=&ccm_cursor=&ccm_cursor=)

So by modifying the regex to use *? instead of +? we accept from 0 to many characters instead of from 1 to many and it solves the problem