### PR TITLE
Fixing issue #5761 - allowing legacy option to get image thumbnails f…

### DIFF
--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -231,7 +231,11 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
      */
     private function checkForThumbnailAndCreateIfNecessary($obj, $maxWidth, $maxHeight, $crop = false)
     {
-        $storage = $obj->getFileStorageLocationObject();
+        if ($obj instanceof File) {
+            $storage = $obj->getFileStorageLocationObject();
+        } else {
+            $storage = $this->getStorageLocation();
+        }
         $this->setStorageLocation($storage);
         $filesystem = $storage->getFileSystemObject();
         $configuration = $storage->getConfigurationObject();
@@ -248,7 +252,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
                 $filename = '';
             }
         } else {
-            $filename = md5(implode(':', array($obj, $maxWidth, $maxHeight, $crop, filemtime($obj))))
+            $filename = md5(implode(':', array($obj, $maxWidth, $maxHeight, $crop, @filemtime($obj))))
                 . '.' . $fh->getExtension($obj);
         }
 

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -262,18 +262,30 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
 
         /** Attempt to create the image */
         if (!$filesystem->has($abspath)) {
-            if ($obj instanceof File && $fr->exists()) {
-                $image = \Image::load($fr->read());
-            } else {
-                $image = \Image::open($obj);
+            try {
+                if ($obj instanceof File && $fr->exists()) {
+                    $image = \Image::load($fr->read());
+                } else {
+                    $image = \Image::open($obj);
+                }
+            } catch (\Exception $e) {
+                //If we can't open or load the file
+                $abspath = false;
             }
-            // create image there
-            $this->create($image,
-                $abspath,
-                $maxWidth,
-                $maxHeight,
-                $crop);
+
+            if ($abspath === false) {
+                $src = '';
+            } else {
+                // create image there
+                $this->create($image,
+                    $abspath,
+                    $maxWidth,
+                    $maxHeight,
+                    $crop);
+            }
         }
+
+
 
         $thumb = new \stdClass();
         $thumb->src = $src;


### PR DESCRIPTION
This PR allows the legacy option of thumbnail generation to use strings, as mentioned in issue #5761, to generate thumbnails. It was previously fixed in #5468 but was removed when the new system was put in place.