### PR TITLE
Release the Imagine instances once we're done with them

### DIFF
--- a/concrete/controllers/backend/file/thumbnailer.php
+++ b/concrete/controllers/backend/file/thumbnailer.php
@@ -83,6 +83,7 @@ class Thumbnailer extends \Concrete\Core\Controller\Controller
                 $fv = $file->getVersion($thumbnail['fileVersionID']);
                 if ($fv->getTypeObject()->supportsThumbnails()) {
                     $fv->generateThumbnail($type);
+                    $fv->releaseImagineImage();
                 }
             } elseif ($type = Version::getByHandle($thumbnail['thumbnailTypeHandle'])) {
                 // This is a predefined thumbnail type, lets just call the version->rescan
@@ -90,6 +91,7 @@ class Thumbnailer extends \Concrete\Core\Controller\Controller
 
                 if ($fv->getTypeObject()->supportsThumbnails()) {
                     $fv->generateThumbnail($type);
+                    $fv->releaseImagineImage();
                 }
             }
         } catch (\Exception $e) {

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1032,6 +1032,14 @@ class Version implements ObjectInterface
     }
 
     /**
+     * Unload the loaded image.
+     */
+    public function releaseImagineImage()
+    {
+        $this->imagineImage = null;
+    }
+
+    /**
      * Rescan the thumbnails for a file (images only).
      *
      * @return bool False on failure
@@ -1095,9 +1103,15 @@ class Version implements ObjectInterface
                     $this->generateThumbnail($type);
                 }
             }
+            unset($image);
+            $this->releaseImagineImage();
         } catch (\Imagine\Exception\InvalidArgumentException $e) {
+            unset($image);
+            $this->releaseImagineImage();
             return false;
         } catch (\Imagine\Exception\RuntimeException $e) {
+            unset($image);
+            $this->releaseImagineImage();
             return false;
         }
     }

--- a/concrete/src/File/Type/Inspector/ImageInspector.php
+++ b/concrete/src/File/Type/Inspector/ImageInspector.php
@@ -41,5 +41,6 @@ class ImageInspector extends Inspector
                 }
             }
         }
+        $fv->releaseImagineImage();
     }
 }

--- a/concrete/src/Http/Middleware/ThumbnailMiddleware.php
+++ b/concrete/src/Http/Middleware/ThumbnailMiddleware.php
@@ -130,6 +130,7 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
                 $fv = $file->getVersion($thumbnail['fileVersionID']);
                 if ($fv->getTypeObject()->supportsThumbnails()) {
                     $fv->generateThumbnail($type);
+                    $fv->releaseImagineImage();
                 }
             } elseif ($type = Version::getByHandle($thumbnail['thumbnailTypeHandle'])) {
                 // This is a predefined thumbnail type, lets just call the version->rescan
@@ -137,6 +138,7 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
 
                 if ($fv->getTypeObject()->supportsThumbnails()) {
                     $fv->generateThumbnail($type);
+                    $fv->releaseImagineImage();
                 }
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
When building thumbnails, every File\Version instance loads the image.
Let's add a way to unload that image, otherwise we'll run out of memory when loading many images.