### PR TITLE
Name formatting for entities

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/express/entities.php
+++ b/concrete/controllers/single_page/dashboard/system/express/entities.php
@@ -43,6 +43,7 @@ class Entities extends DashboardPageController
                 $entity->setName($this->request->request->get('name'));
                 $entity->setHandle($this->request->request->get('handle'));
                 $entity->setPluralHandle($this->request->request->get('plural_handle'));
+                $entity->setLabelMask($this->request->request->get('label_mask'));
                 $entity->setDescription($this->request->request->get('description'));
 
                 if ($this->request->request->get('supports_custom_display_order')) {
@@ -236,6 +237,7 @@ class Entities extends DashboardPageController
             $entity->setName($name);
             $entity->setHandle($handle);
             $entity->setPluralHandle($this->request->request->get('plural_handle'));
+            $entity->setLabelMask($this->request->request->get('label_mask'));
             $entity->setDescription($this->request->request->get('description'));
             $entity->setDefaultViewForm($viewForm);
             $entity->setDefaultEditForm($editForm);

--- a/concrete/single_pages/dashboard/system/express/entities/add.php
+++ b/concrete/single_pages/dashboard/system/express/entities/add.php
@@ -23,6 +23,11 @@
         <?= $form->text('plural_handle') ?>
         <p class="help-block"><?= t('The plural representation of the handle above. Used to retrieve this entity if it is used in associations.') ?></p>
     </div>
+    <div class="form-group">
+        <label for="name" class="control-label"><?= t('Name Mask') ?></label>
+        <?= $form->text('label_mask') ?>
+        <p class="help-block"><?= t('Example <code>Entry %name%</code> or <code>Complaint %date% at %hotel%</code>') ?></p>
+    </div>
 
     <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingThree">

--- a/concrete/single_pages/dashboard/system/express/entities/edit.php
+++ b/concrete/single_pages/dashboard/system/express/entities/edit.php
@@ -41,6 +41,11 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="name" class="control-label"><?= t('Name Mask') ?></label>
+                    <?= $form->text('label_mask', $entity->getLabelMask()) ?>
+                    <p class="help-block"><?= t('Example <code>Entry %name%</code> or <code>Complaint %date% at %hotel%</code>') ?></p>
+                </div>
+                <div class="form-group">
                     <label for="name" class="control-label"><?=t('Description')?></label>
                     <?=$form->textarea('description', $entity->getEntityDisplayDescription(), array('rows' => 5))?>
                 </div>

--- a/concrete/src/Entity/Express/Entity.php
+++ b/concrete/src/Entity/Express/Entity.php
@@ -44,6 +44,11 @@ class Entity implements CategoryObjectInterface, ObjectInterface, ExportableInte
     protected $plural_handle;
 
     /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $label_mask;
+
+    /**
      * @ORM\Column(type="boolean")
      */
     protected $supports_custom_display_order = false;
@@ -202,6 +207,22 @@ class Entity implements CategoryObjectInterface, ObjectInterface, ExportableInte
     public function setIncludeInPublicList($include_in_public_list)
     {
         $this->include_in_public_list = $include_in_public_list;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabelMask()
+    {
+        return $this->label_mask ?: '';
+    }
+
+    /**
+     * @param string $label_mask
+     */
+    public function setLabelMask($label_mask)
+    {
+        $this->label_mask = trim($label_mask);
     }
 
     /**

--- a/concrete/src/Express/Entry/Formatter/EntryFormatterInterface.php
+++ b/concrete/src/Express/Entry/Formatter/EntryFormatterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Concrete\Core\Express\Entry\Formatter;
+
+use Concrete\Core\Entity\Express\Entry;
+
+interface EntryFormatterInterface
+{
+    /**
+     * Format a mask given an entry
+     *
+     * Mask format will typically be something like `Example %attribute_key% %association_handle`
+     *
+     * @param string $mask
+     * @param \Concrete\Core\Entity\Express\Entry $entry
+     * @return string|null
+     */
+    public function format($mask, Entry $entry);
+}

--- a/concrete/src/Express/Entry/Formatter/LabelFormatter.php
+++ b/concrete/src/Express/Entry/Formatter/LabelFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Concrete\Core\Express\Entry\Formatter;
+
+use Concrete\Core\Entity\Express\Entry;
+use Concrete\Core\Express\Formatter\FormatterInterface;
+
+class LabelFormatter implements EntryFormatterInterface
+{
+
+    /** @var \Concrete\Core\Express\Formatter\FormatterInterface */
+    protected $formatter;
+
+    public function __construct(FormatterInterface $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
+    /**
+     * Format a mask given an entry
+     * @param string $mask
+     * @param \Concrete\Core\Entity\Express\Entry $entry
+     * @return string|null
+     */
+    public function format($mask, Entry $entry)
+    {
+        return $this->formatter->format($mask, function($key) use ($entry) {
+            $attribute = $entry->getAttribute($key);
+            if ($attribute) {
+                return $attribute;
+            }
+
+            $association = $entry->getAssociation($key);
+            if (is_object($association)) {
+                return $association->getSelectedEntry()->getLabel();
+            }
+        });
+    }
+
+}

--- a/concrete/src/Express/ExpressServiceProvider.php
+++ b/concrete/src/Express/ExpressServiceProvider.php
@@ -1,6 +1,10 @@
 <?php
 namespace Concrete\Core\Express;
 
+use Concrete\Core\Express\Entry\Formatter\EntryFormatterInterface;
+use Concrete\Core\Express\Entry\Formatter\LabelFormatter as EntryLabelFormatter;
+use Concrete\Core\Express\Formatter\FormatterInterface;
+use Concrete\Core\Express\Formatter\LabelFormatter;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
 class ExpressServiceProvider extends ServiceProvider
@@ -19,5 +23,8 @@ class ExpressServiceProvider extends ServiceProvider
            return $app->make('Concrete\Core\Express\ObjectManager');
         });
         $this->app->singleton('Concrete\Core\Express\Controller\Manager');
+
+        $this->app->bind(FormatterInterface::class, LabelFormatter::class);
+        $this->app->bind(EntryFormatterInterface::class, EntryLabelFormatter::class);
     }
 }

--- a/concrete/src/Express/Formatter/FormatterInterface.php
+++ b/concrete/src/Express/Formatter/FormatterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\Core\Express\Formatter;
+
+interface FormatterInterface
+{
+    /**
+     * Format a mask using the standard format given a callable
+     *
+     * Ex: if you have attributes with handles `student_first_name` and `student_last_name`
+     * `%student_last_name%, %student_first_name%`
+     *
+     * @param $mask
+     * @param callable $matchHandler
+     * @return mixed
+     */
+    public function format($mask, callable $matchHandler);
+}

--- a/concrete/src/Express/Formatter/LabelFormatter.php
+++ b/concrete/src/Express/Formatter/LabelFormatter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Concrete\Core\Express\Formatter;
+
+use Psr\Log\LoggerInterface;
+
+class LabelFormatter implements FormatterInterface
+{
+
+    /** @var \Psr\Log\LoggerInterface */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Format a mask using the standard format given a callable
+     *
+     * Ex: if you have attributes with handles `student_first_name` and `student_last_name`
+     * `%student_last_name%, %student_first_name%`
+     *
+     * @param $mask
+     * @param callable $matchHandler
+     * @return mixed
+     */
+    public function format($mask, callable $matchHandler)
+    {
+        try {
+            // Run a regular expression to match the mask
+            return preg_replace_callback('/%(.*?)%/i', function ($matches) use ($matchHandler) {
+                // Return the result returned from the matchHandler
+                return $this->getResult($matches[1], $matchHandler) ?: '';
+            }, $mask);
+        } catch (\Exception $e) {
+            // Log any failures
+            $this->logger->debug(
+                'Failed to format express mask "{mask}": {message}',
+                ['mask' => $mask, 'message' => $e->getMessage(), 'exception' => $e]
+            );
+        }
+    }
+
+    /**
+     * Get a result given a key
+     * @param $key
+     * @param callable $matchHandler
+     * @return string
+     */
+    private function getResult($key, callable $matchHandler)
+    {
+        if ($key = trim($key)) {
+            return $matchHandler($key) ?: '';
+        }
+
+        return '';
+    }
+
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170731021618.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170731021618.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\Express\Entity;
+use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170731021618 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->refreshEntities([
+            Entity::class
+        ]);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}


### PR DESCRIPTION
This copies the name format that was given to associations and allows it to be used for entities as well. This replaces a lot of the association naming functionality.