### PR TITLE
Let users configure the thumbnail generation strategy via UI

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -66,7 +66,7 @@ class Options extends DashboardPageController
     {
         return [
             'now' => t('Create the thumbnails synchronously (may fail with out-of-memory errors)'),
-            'async' => t('Create the thumbnails a synchronously (users may not see thumbnails immediatedly)'),
+            'async' => t('Create the thumbnails asynchronously (users may not see thumbnails immediatedly)'),
         ];
     }
 

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -66,7 +66,7 @@ class Options extends DashboardPageController
     {
         return [
             'now' => t('Create the thumbnails synchronously (may fail with out-of-memory errors)'),
-            'async' => t('Create the thumbnails asynchronously (users may not see thumbnails immediatedly)'),
+            'async' => t('Create the thumbnails asynchronously (users may not see thumbnails immediately)'),
         ];
     }
 

--- a/concrete/single_pages/dashboard/system/files/thumbnails/options.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails/options.php
@@ -17,6 +17,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Page\Page $c */
 /* @var Concrete\Theme\Dashboard\PageTheme $theme */
 
+/* @var array $thumbnail_generation_strategies */
+/* @var string $thumbnail_generation_strategy */
 /* @var array $thumbnail_formats */
 /* @var string $thumbnail_format */
 /* @var int $jpeg_compression */
@@ -28,6 +30,22 @@ defined('C5_EXECUTE') or die('Access Denied.');
 <form method="post" action="<?=$view->action('submit')?>">
 
     <?php $token->output('thumbnails-options') ?>
+
+    <div class="form-group">
+        <?= $form->label('thumbnail_generation_strategy', t('Thumbnail Generation Strategy')) ?>
+        <?php
+        foreach ($thumbnail_generation_strategies as $id => $name) {
+            ?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('thumbnail_generation_strategy', $id, $id === $thumbnail_generation_strategy, ['required' => 'required']) ?>
+                    <?= h($name) ?>
+                </label>
+            </div>
+            <?php
+        }
+        ?>
+    </div>
 
     <div class="form-group">
         <?= $form->label('thumbnail_format', t('Thumbnails Format')) ?>


### PR DESCRIPTION
What about adding this new option to the `/dashboard/system/files/thumbnails/options` dashboard page?

![image](https://user-images.githubusercontent.com/928116/28887043-f6239eda-77bb-11e7-82c5-ae4dc9e2ac49.png)
