### PR TITLE
Feature/option to open image links in new window

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -91,6 +91,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $this->set('altText', $this->getAltText());
         $this->set('title', $this->getTitle());
         $this->set('linkURL', $this->getLinkURL());
+        $this->set('openLinkInNewWindow', $this->shouldLinkOpenInNewWindow());
         $this->set('c', Page::getCurrentPage());
     }
 
@@ -301,6 +302,14 @@ class Controller extends BlockController implements FileTrackableInterface
         }
 
         return $linkUrl;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldLinkOpenInNewWindow()
+    {
+        return (bool) $this->openLinkInNewWindow;
     }
 
     /**

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -368,6 +368,7 @@ class Controller extends BlockController implements FileTrackableInterface
             'linkType' => 0,
             'externalLink' => '',
             'internalLinkCID' => 0,
+            'openLinkInNewWindow' => 0,
             'fileLinkID' => 0,
         ];
 
@@ -402,6 +403,10 @@ class Controller extends BlockController implements FileTrackableInterface
                 $args['internalLinkCID'] = 0;
                 $args['fileLinkID'] = 0;
                 break;
+        }
+
+        if ((int) $args['linkType'] > 0) {
+            $args['openLinkInNewWindow'] = isset($args['openLinkInNewWindow']) ? 1 : 0;
         }
 
         // This doesn't get saved to the database. It's only for UI usage.

--- a/concrete/blocks/image/db.xml
+++ b/concrete/blocks/image/db.xml
@@ -34,6 +34,10 @@
             <unsigned/>
             <default value="0" />
         </field>
+        <field name="openLinkInNewWindow" type="boolean">
+            <unsigned/>
+            <default value="0" />
+        </field>
         <field name="altText" type="string" size="255" />
         <field name="title" type="string" size="255" />
         <index name="fID">

--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -62,6 +62,13 @@ $al = $app->make('helper/concrete/asset_library');
         ?>
     </div>
 
+    <div id="imageLinkOpenInNewWindow" style="display: none;" class="form-group">
+        <?php
+        echo $form->checkbox('openLinkInNewWindow', 'openLinkInNewWindow', $openLinkInNewWindow);
+        echo $form->label('openLinkInNewWindow', t('Open link in new window'));
+        ?>
+    </div>
+
     <div class="form-group">
         <?php
         echo $form->label('altText', t('Alt Text'));
@@ -129,6 +136,7 @@ refreshImageLinkTypeControls = function() {
     $('#imageLinkTypePage').toggle(linkType == 1);
     $('#imageLinkTypeExternal').toggle(linkType == 2);
     $('#imageLinkTypeFile').toggle(linkType == 3);
+    $('#imageLinkOpenInNewWindow').toggle(linkType > 0);
 };
 
 $(document).ready(function() {

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -30,7 +30,7 @@ if (is_object($f) && $f->getFileID()) {
     }
 
     if ($linkURL) {
-        echo '<a href="' . $linkURL . '">';
+        echo '<a href="' . $linkURL . '" '. ($openLinkInNewWindow ? 'target="_blank"' : '') .'>';
     }
 
     echo $tag;


### PR DESCRIPTION
This PR changes the `Image` block so links can be opened in a new window.

Screenshot 1: Checkbox isn't visible if `Image Link` is set to `None`:

![no-link](https://user-images.githubusercontent.com/1431100/28921352-ea79a76a-7855-11e7-89ba-9245cfb87288.png)

Screenshot 2: Checkbox becomes visible if `Image Link` is not `None`:

![open-in-new-window](https://user-images.githubusercontent.com/1431100/28921384-06d4b72e-7856-11e7-8419-07de35dc36a5.png)
