### PR TITLE
Add date created to csv export for express entities

### DIFF
--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -59,6 +59,8 @@ class CsvWriter
      */
     private function projectEntry(Entry $entry)
     {
+        yield $entry->getDateCreated();
+
         $attributes = $entry->getAttributes();
         foreach ($attributes as $attribute) {
             yield $attribute->getPlainTextValue();
@@ -72,6 +74,8 @@ class CsvWriter
      */
     private function getHeaders(Entity $entity)
     {
+        yield 'dateCreated';
+
         $attributes = $entity->getAttributes();
         foreach ($attributes as $attribute) {
             yield $attribute->getAttributeKeyDisplayName();


### PR DESCRIPTION
This adds `dateCreated` to the CSV export of entries.