### PR TITLE
Show only accessible languages in switch_language blocks

### DIFF
--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -6,6 +6,7 @@ use Concrete\Core\Block\BlockController;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Multilingual\Page\Section\Section;
+use Concrete\Core\Permission\Checker;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Cookie;
 use Session;
@@ -108,11 +109,16 @@ class Controller extends BlockController
             $locale = \Localization::activeLocale();
             $al = Section::getByLocale($locale);
         }
+        $mlAccessible = [];
         foreach ($ml as $m) {
-            $languages[$m->getCollectionID()] = $m->getLanguageText($m->getLocale());
+            $pc = new Checker(\Page::getByID($m->getCollectionID()));
+            if ($pc->canRead()) {
+                $mlAccessible[] = $m;
+                $languages[$m->getCollectionID()] = $m->getLanguageText($m->getLocale());
+            }
         }
         $this->set('languages', $languages);
-        $this->set('languageSections', $ml);
+        $this->set('languageSections', $mlAccessible);
         $this->set('activeLanguage', $al ? $al->getCollectionID() : null);
         $dl = $this->app->make('multilingual/detector');
         $this->set('defaultLocale', $dl->getPreferredSection());


### PR DESCRIPTION
The `switch_language` block lists all the language sections, even those not accessible.
Let's show only the accessible language sections.