### PR TITLE
Dont use Object as class name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 env:
   global:
@@ -21,6 +22,7 @@ matrix:
     - php: 7.1
       env: PREFER_LOWEST="--prefer-lowest"
   allow_failures:
+    - php: 7.2
     - php: nightly
 
 before_script:

--- a/concrete/src/Antispam/Library.php
+++ b/concrete/src/Antispam/Library.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\Antispam;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Support\Facade\Facade;
 use Loader;
 use Package;
 use Concrete\Core\Package\PackageList;
 use Core;
 
-class Library extends Object
+class Library extends ConcreteObject
 {
     /**
      * @var string

--- a/concrete/src/Area/Area.php
+++ b/concrete/src/Area/Area.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\Area;
 
 use Core;
 use Database;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Block;
 use PermissionKey;
 use View;
@@ -13,7 +13,7 @@ use User;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Localization\Localization;
 
-class Area extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     /**
      * @var int

--- a/concrete/src/Area/Layout/Column.php
+++ b/concrete/src/Area/Layout/Column.php
@@ -2,13 +2,13 @@
 namespace Concrete\Core\Area\Layout;
 
 use Database;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Area\SubArea;
 use Page;
 use Area;
 use RuntimeException;
 
-abstract class Column extends Object implements ColumnInterface
+abstract class Column extends ConcreteObject implements ColumnInterface
 {
     /**
      * @var Layout

--- a/concrete/src/Area/Layout/Layout.php
+++ b/concrete/src/Area/Layout/Layout.php
@@ -3,11 +3,11 @@ namespace Concrete\Core\Area\Layout;
 
 use Core;
 use Database;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Area;
 use Concrete\Core\Block\Block;
 
-abstract class Layout extends Object
+abstract class Layout extends ConcreteObject
 {
     /**
      * @var Area

--- a/concrete/src/Area/Layout/Preset/UserPreset.php
+++ b/concrete/src/Area/Layout/Preset/UserPreset.php
@@ -4,9 +4,9 @@ namespace Concrete\Core\Area\Layout\Preset;
 use Concrete\Core\Area\Layout\Layout;
 use Concrete\Core\Area\Layout\Preset\Formatter\UserFormatter;
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class UserPreset extends Object
+class UserPreset extends ConcreteObject
 {
     /**
      * @var int

--- a/concrete/src/Asset/AssetList.php
+++ b/concrete/src/Asset/AssetList.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Asset;
 
-use Concrete\Core\Foundation\Object as Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
 class AssetList
 {
@@ -66,7 +66,7 @@ class AssetList
         // overwrite all the defaults with the arguments
         $args = array_merge($defaults, $args);
 
-        $class = '\\Concrete\\Core\\Asset\\' . Object::camelcase($assetType) . 'Asset';
+        $class = '\\Concrete\\Core\\Asset\\' . ConcreteObject::camelcase($assetType) . 'Asset';
         $o = new $class($assetHandle);
         $o->register($filename, $args, $pkg);
         $this->registerAsset($o);
@@ -114,7 +114,7 @@ class AssetList
     public function registerGroup($assetGroupHandle, $assetHandles, $customClass = false)
     {
         if ($customClass) {
-            $class = '\\Concrete\\Core\\Asset\\Group\\' . Object::camelcase($assetGroupHandle) . 'AssetGroup';
+            $class = '\\Concrete\\Core\\Asset\\Group\\' . ConcreteObject::camelcase($assetGroupHandle) . 'AssetGroup';
         } else {
             $class = '\\Concrete\\Core\\Asset\\AssetGroup';
         }

--- a/concrete/src/Attribute/Value/Value.php
+++ b/concrete/src/Attribute/Value/Value.php
@@ -6,13 +6,13 @@ namespace Concrete\Core\Attribute\Value;
 use Concrete\Core\Attribute\AttributeValueInterface;
 use Concrete\Core\Attribute\Key\Key;
 use Concrete\Core\Entity\Attribute\Value\LegacyValue;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 
 /*
  * @deprecated
  */
-class Value extends Object implements AttributeValueInterface
+class Value extends ConcreteObject implements AttributeValueInterface
 {
     protected $attributeType;
     protected $attributeKey;

--- a/concrete/src/Attribute/Value/ValueList.php
+++ b/concrete/src/Attribute/Value/ValueList.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Attribute\Value;
 
-use \Concrete\Core\Foundation\Object;
+use \Concrete\Core\Foundation\ConcreteObject;
 
 /**
  * @deprecated
  */
-class ValueList extends Object implements \Iterator
+class ValueList extends ConcreteObject implements \Iterator
 {
 
     private $attributes = array();

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Authentication;
 
 use Concrete\Authentication\Concrete\Controller;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Core;
 use Environment;
@@ -10,7 +10,7 @@ use Exception;
 use Loader;
 use Package;
 
-class AuthenticationType extends Object
+class AuthenticationType extends ConcreteObject
 {
     /** @var Controller */
     public $controller;

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -9,7 +9,7 @@ use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Feature\Assignment\Assignment as FeatureAssignment;
 use Concrete\Core\Feature\Assignment\CollectionVersionAssignment as CollectionVersionFeatureAssignment;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Foundation\Queue\Queue;
 use Concrete\Core\Package\PackageList;
 use Concrete\Core\StyleCustomizer\Inline\StyleSet;
@@ -19,7 +19,7 @@ use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Page;
 use Concrete\Core\Support\Facade\Facade;
 
-class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Block extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     protected $cID;
     protected $arHandle;

--- a/concrete/src/Block/BlockType/Set.php
+++ b/concrete/src/Block/BlockType/Set.php
@@ -2,13 +2,13 @@
 namespace Concrete\Core\Block\BlockType;
 
 use Concrete\Core\Entity\Block\BlockType\BlockType as BlockTypeEntity;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Doctrine\DBAL\Connection;
 use Loader;
 use Core;
 use Concrete\Core\Package\PackageList;
 
-class Set extends Object
+class Set extends ConcreteObject
 {
     public static function getByID($btsID)
     {

--- a/concrete/src/Captcha/Library.php
+++ b/concrete/src/Captcha/Library.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Captcha;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Concrete\Core\Support\Facade\Package as PackageService;
 use Concrete\Core\Support\Facade\Facade;
 
-class Library extends Object
+class Library extends ConcreteObject
 {
     /**
      * The library handle.

--- a/concrete/src/Conversation/Conversation.php
+++ b/concrete/src/Conversation/Conversation.php
@@ -2,12 +2,12 @@
 namespace Concrete\Core\Conversation;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Page;
 use Config;
 use Concrete\Core\Conversation\Message\MessageList as ConversationMessageList;
 
-class Conversation extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Conversation extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     const POSTING_ENABLED = 10;
     const POSTING_DISABLED_MANUALLY = 5;

--- a/concrete/src/Conversation/Discussion/Discussion.php
+++ b/concrete/src/Conversation/Discussion/Discussion.php
@@ -3,10 +3,10 @@ namespace Concrete\Core\Conversation\Discussion;
 
 use Loader;
 use Core;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Page;
 
-class Discussion extends Object
+class Discussion extends ConcreteObject
 {
     public static function add(Page $c)
     {

--- a/concrete/src/Conversation/Editor/Editor.php
+++ b/concrete/src/Conversation/Editor/Editor.php
@@ -6,11 +6,11 @@ use Core;
 use Database;
 use Environment;
 use Concrete\Core\Conversation\Message\Message;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Package;
 use Concrete\Core\Package\PackageList;
 
-abstract class Editor extends Object
+abstract class Editor extends ConcreteObject
 {
     /** @var string */
     protected $cnvEditorHandle;

--- a/concrete/src/Conversation/FlagType/FlagType.php
+++ b/concrete/src/Conversation/FlagType/FlagType.php
@@ -2,9 +2,9 @@
 namespace Concrete\Core\Conversation\FlagType;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class FlagType extends Object
+class FlagType extends ConcreteObject
 {
     public $id;
     public $handle;

--- a/concrete/src/Conversation/Message/Message.php
+++ b/concrete/src/Conversation/Message/Message.php
@@ -10,13 +10,13 @@ use Core;
 use Loader;
 use Concrete\Core\Conversation\Conversation;
 use Concrete\Core\Conversation\Editor\Editor as ConversationEditor;
-use \Concrete\Core\Foundation\Object;
+use \Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\User\User;
 use Concrete\Core\User\UserInfo;
 use Concrete\Core\Utility\IPAddress;
 use Events;
 
-class Message extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Message extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     public $cnvMessageID;
     protected $cnvMessageDateCreated;

--- a/concrete/src/Conversation/Message/Rating.php
+++ b/concrete/src/Conversation/Message/Rating.php
@@ -1,8 +1,8 @@
 <?php
 namespace Concrete\Core\Conversation\Message;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Rating extends Object
+class Rating extends ConcreteObject
 {
 }

--- a/concrete/src/Conversation/Rating/Type.php
+++ b/concrete/src/Conversation/Rating/Type.php
@@ -2,12 +2,12 @@
 namespace Concrete\Core\Conversation\Rating;
 
 use Concrete\Core\Conversation\Message\Message;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Core;
 use Database;
 
-abstract class Type extends Object
+abstract class Type extends ConcreteObject
 {
     abstract public function outputRatingTypeHTML();
     abstract public function adjustConversationMessageRatingTotalScore(Message $message);

--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -16,9 +16,9 @@ use Page;
 use Loader;
 use URL;
 use Sunra\PhpSimple\HtmlDomParser;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class LinkAbstractor extends Object
+class LinkAbstractor extends ConcreteObject
 {
     /**
      * Takes a chunk of content containing full urls

--- a/concrete/src/Editor/Snippet.php
+++ b/concrete/src/Editor/Snippet.php
@@ -2,12 +2,12 @@
 namespace Concrete\Core\Editor;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Core;
 use Package;
 
-abstract class Snippet extends Object
+abstract class Snippet extends ConcreteObject
 {
     /**
      * Required for snippets to work.

--- a/concrete/src/Feature/Assignment/Assignment.php
+++ b/concrete/src/Feature/Assignment/Assignment.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Feature\Assignment;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Core;
 use Concrete\Core\Feature\Feature;
 use Concrete\Core\Feature\Category\Category as FeatureCategory;
@@ -9,7 +9,7 @@ use Concrete\Core\Feature\Detail\Detail as FeatureDetail;
 use Database;
 use RuntimeException;
 
-abstract class Assignment extends Object
+abstract class Assignment extends ConcreteObject
 {
     abstract public function loadDetails($mixed);
 

--- a/concrete/src/Feature/Category/Category.php
+++ b/concrete/src/Feature/Category/Category.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Feature\Category;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 use Core;
 
-abstract class Category extends Object
+abstract class Category extends ConcreteObject
 {
     abstract public function assignmentIsInUse(\Concrete\Core\Feature\Assignment\Assignment $fa);
 

--- a/concrete/src/Feature/Detail/Detail.php
+++ b/concrete/src/Feature/Detail/Detail.php
@@ -1,10 +1,10 @@
 <?php
 namespace Concrete\Core\Feature\Detail;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Feature\Assignment\Assignment as FeatureAssignment;
 
-class Detail extends Object
+class Detail extends ConcreteObject
 {
     protected $item;
 

--- a/concrete/src/Feature/Feature.php
+++ b/concrete/src/Feature/Feature.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Feature;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 use Core;
 
-class Feature extends Object
+class Feature extends ConcreteObject
 {
     public function getFeatureDetailObject($mixed)
     {

--- a/concrete/src/Foundation/ConcreteObject.php
+++ b/concrete/src/Foundation/ConcreteObject.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Foundation;
 
-class Object
+class ConcreteObject
 {
     public $error = '';
 

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -241,6 +241,9 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
 
         // Autoload some aliases to prevent typehinting errors
         class_exists('\Request');
+        if (version_compare(PHP_VERSION, '7.2.0alpha1') < 0) {
+            $list->register('Concrete\Core\Foundation\Object', 'Concrete\Core\Foundation\ConcreteObject');
+        }
 
         return $list;
     }

--- a/concrete/src/Gathering/DataSource/Configuration/Configuration.php
+++ b/concrete/src/Gathering/DataSource/Configuration/Configuration.php
@@ -2,9 +2,9 @@
 namespace Concrete\Core\Gathering\DataSource\Configuration;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Configuration extends Object
+class Configuration extends ConcreteObject
 {
     protected $dataSource;
 

--- a/concrete/src/Gathering/DataSource/DataSource.php
+++ b/concrete/src/Gathering/DataSource/DataSource.php
@@ -3,11 +3,11 @@ namespace Concrete\Core\Gathering\DataSource;
 
 use Loader;
 use Core;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Gathering\DataSource\Configuration\Configuration as GatheringDataSourceConfiguration;
 use Concrete\Core\Package\PackageList;
 
-abstract class DataSource extends Object
+abstract class DataSource extends ConcreteObject
 {
     abstract public function createConfigurationObject(Gathering $ga, $post);
     abstract public function createGatheringItems(GatheringDataSourceConfiguration $configuration);

--- a/concrete/src/Gathering/Gathering.php
+++ b/concrete/src/Gathering/Gathering.php
@@ -2,9 +2,9 @@
 namespace Concrete\Core\Gathering;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Gathering extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Gathering extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     public function getGatheringID()
     {

--- a/concrete/src/Gathering/Item/Item.php
+++ b/concrete/src/Gathering/Item/Item.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Gathering\Item;
 use Core;
 use Database;
 use View;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Gathering\DataSource\DataSource as GatheringDataSource;
 use RuntimeException;
 
@@ -13,7 +13,7 @@ use RuntimeException;
  *
  * @method static Key[] add(Gathering $ag, GatheringDataSource $ags, string $gaiPublicDateTime, string $gaiTitle, string $gaiKey, int $gaiSlotWidth = 1, int $gaiSlotHeight = 1) Deprecated method. Use Item::create instead.
  */
-abstract class Item extends Object
+abstract class Item extends ConcreteObject
 {
     abstract public function loadDetails();
 

--- a/concrete/src/Gathering/Item/Template/Template.php
+++ b/concrete/src/Gathering/Item/Template/Template.php
@@ -7,9 +7,9 @@ use Concrete\Core\Gathering\Item\Item;
 use Database;
 use Concrete\Core\Package\PackageList;
 use Core;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-abstract class Template extends Object
+abstract class Template extends ConcreteObject
 {
     abstract public function gatheringItemTemplateControlsSlotDimensions();
 

--- a/concrete/src/Gathering/Item/Template/Type.php
+++ b/concrete/src/Gathering/Item/Template/Type.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Gathering\Item\Template;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 use CacheLocal;
 
-class Type extends Object
+class Type extends ConcreteObject
 {
     public function getGatheringItemTemplateTypeID()
     {

--- a/concrete/src/Job/Job.php
+++ b/concrete/src/Job/Job.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\Job;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 use Config;
 use Core;
 use Events;
 
-abstract class Job extends Object
+abstract class Job extends ConcreteObject
 {
     const JOB_SUCCESS = 0;
     const JOB_ERROR_EXCEPTION_GENERAL = 1;

--- a/concrete/src/Job/Set.php
+++ b/concrete/src/Job/Set.php
@@ -4,9 +4,9 @@ namespace Concrete\Core\Job;
 use Gettext\Translations;
 use Loader;
 use JobSet;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Set extends Object
+class Set extends ConcreteObject
 {
     const DEFAULT_JOB_SET_ID = 1;
 

--- a/concrete/src/Mail/Importer/MailImporter.php
+++ b/concrete/src/Mail/Importer/MailImporter.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Mail\Importer;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Core;
 use Database;
 use Concrete\Core\Package\PackageList;
 
-class MailImporter extends Object
+class MailImporter extends ConcreteObject
 {
     /**
      * gets the text string that's used to identify the body of the message.

--- a/concrete/src/Marketplace/RemoteItem.php
+++ b/concrete/src/Marketplace/RemoteItem.php
@@ -6,10 +6,10 @@ use Concrete\Core\Package\Package;
 use Concrete\Core\Package\PackageArchive;
 use Loader;
 use Config;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Exception;
 
-class RemoteItem extends Object
+class RemoteItem extends ConcreteObject
 {
     protected $price = 0.00;
     protected $remoteCID = 0;

--- a/concrete/src/Marketplace/RemoteItemSet.php
+++ b/concrete/src/Marketplace/RemoteItemSet.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Marketplace;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class RemoteItemSet extends Object
+class RemoteItemSet extends ConcreteObject
 {
     public function getMarketplaceRemoteSetName()
     {

--- a/concrete/src/Package/PackageList.php
+++ b/concrete/src/Package/PackageList.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\Package;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use CacheLocal;
 
-class PackageList extends Object
+class PackageList extends ConcreteObject
 {
     protected $packages = array();
 

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -10,7 +10,7 @@ use Concrete\Core\Entity\Attribute\Value\PageValue;
 use Concrete\Core\Entity\Attribute\Value\Value\Value;
 use Concrete\Core\Feature\Assignment\CollectionVersionAssignment as CollectionVersionFeatureAssignment;
 use Concrete\Core\Feature\Feature;
-use Concrete\Core\Foundation\Object as Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Gathering\Item\Page as PageGatheringItem;
 use Concrete\Core\Page\Collection\Version\Version;
 use Concrete\Core\Page\Collection\Version\VersionList;
@@ -29,7 +29,7 @@ use Permissions;
 use Stack;
 use User;
 
-class Collection extends Object implements TrackableInterface
+class Collection extends ConcreteObject implements TrackableInterface
 {
     public $cID;
     protected $vObj;

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Page\Collection\Version;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Attribute\ObjectTrait;
 use Concrete\Core\Entity\Attribute\Value\PageValue;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Block;
 use Page;
 use PageType;
@@ -15,7 +15,7 @@ use Concrete\Core\Permission\ObjectInterface as PermissionObjectInterface;
 use Concrete\Core\Feature\Assignment\CollectionVersionAssignment as CollectionVersionFeatureAssignment;
 use Concrete\Core\Support\Facade\Facade;
 
-class Version extends Object implements PermissionObjectInterface, AttributeObjectInterface
+class Version extends ConcreteObject implements PermissionObjectInterface, AttributeObjectInterface
 {
     use ObjectTrait;
 

--- a/concrete/src/Page/Stack/Pile/Pile.php
+++ b/concrete/src/Page/Stack/Pile/Pile.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Page\Stack\Pile;
 
 use Concrete\Core\Block\Block;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Page;
 use Concrete\Core\User\User;
@@ -17,7 +17,7 @@ use Loader;
  *
  * \@package Concrete\Core\Page\Stack\Pile
  */
-class Pile extends Object
+class Pile extends ConcreteObject
 {
     /**
      * @var int

--- a/concrete/src/Page/Stack/Pile/PileContent.php
+++ b/concrete/src/Page/Stack/Pile/PileContent.php
@@ -2,10 +2,10 @@
 namespace Concrete\Core\Page\Stack\Pile;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Block;
 
-class PileContent extends Object
+class PileContent extends ConcreteObject
 {
     public $p, $pID, $pcID, $itemID, $itemType, $quantity, $timestamp, $displayOrder;
 

--- a/concrete/src/Page/Statistics.php
+++ b/concrete/src/Page/Statistics.php
@@ -2,7 +2,6 @@
 namespace Concrete\Core\Page;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
 
 class Statistics
 {

--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -10,7 +10,7 @@ use Environment;
 use Core;
 use Concrete\Core\Page\Theme\File as PageThemeFile;
 use Concrete\Core\Package\PackageList;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use PageTemplate;
 use Concrete\Core\Page\Theme\GridFramework\GridFramework;
 use Concrete\Core\Page\Single as SinglePage;
@@ -22,7 +22,7 @@ use Localization;
  * A page's theme is a pointer to a directory containing templates, CSS files and optionally PHP includes, images and JavaScript files.
  * Themes inherit down the tree when a page is added, but can also be set at the site-wide level (thereby overriding any previous choices.).
  */
-class Theme extends Object
+class Theme extends ConcreteObject
 {
     const E_THEME_INSTALLED = 1;
     const THEME_EXTENSION = '.php';

--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Page\Type\Composer\Control;
 
 use Concrete\Core\Page\Type\Type;
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Page;
 use Controller;
 use Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
@@ -12,7 +12,7 @@ use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFor
 use Concrete\Core\Page\Type\Composer\Control\Type\Type as PageTypeComposerControlType;
 use HtmlObject\Element;
 
-abstract class Control extends Object
+abstract class Control extends ConcreteObject
 {
     protected $ptComposerControlIdentifier;
     protected $ptComposerControlName;

--- a/concrete/src/Page/Type/Composer/Control/CustomTemplate.php
+++ b/concrete/src/Page/Type/Composer/Control/CustomTemplate.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Page\Type\Composer\Control;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class CustomTemplate extends Object
+class CustomTemplate extends ConcreteObject
 {
     protected $ptComposerControlCustomTemplateFilename;
     protected $ptComposerControlCustomTemplateName;

--- a/concrete/src/Page/Type/Composer/Control/Type/Type.php
+++ b/concrete/src/Page/Type/Composer/Control/Type/Type.php
@@ -3,10 +3,10 @@ namespace Concrete\Core\Page\Type\Composer\Control\Type;
 
 use Loader;
 use Core;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 
-abstract class Type extends Object
+abstract class Type extends ConcreteObject
 {
     abstract public function getPageTypeComposerControlObjects();
     abstract public function getPageTypeComposerControlByIdentifier($identifier);

--- a/concrete/src/Page/Type/Composer/FormLayoutSet.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSet.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Page\Type\Composer;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Type\Type;
 use PageType;
 use Loader;
 
-class FormLayoutSet extends Object
+class FormLayoutSet extends ConcreteObject
 {
     public function getPageTypeComposerFormLayoutSetID()
     {

--- a/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
@@ -3,13 +3,13 @@ namespace Concrete\Core\Page\Type\Composer;
 
 use Concrete\Core\Entity\Page\Template;
 use Concrete\Core\Backup\ContentExporter;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Type\Composer\OutputControl as PageTypeComposerOutputControl;
 use Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
 use Concrete\Core\Page\Type\Composer\Control\Type\Type as PageTypeComposerControlType;
 use Concrete\Core\Support\Facade\Application;
 
-class FormLayoutSetControl extends Object
+class FormLayoutSetControl extends ConcreteObject
 {
     protected $ptTargetParentPageID = 0;
 

--- a/concrete/src/Page/Type/Composer/OutputControl.php
+++ b/concrete/src/Page/Type/Composer/OutputControl.php
@@ -2,12 +2,12 @@
 namespace Concrete\Core\Page\Type\Composer;
 
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Entity\Page\Template;
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
 use PageType;
 
-class OutputControl extends Object
+class OutputControl extends ConcreteObject
 {
     public function getPageTypeComposerOutputControlID()
     {

--- a/concrete/src/Page/Type/PublishTarget/Configuration/Configuration.php
+++ b/concrete/src/Page/Type/PublishTarget/Configuration/Configuration.php
@@ -4,10 +4,10 @@ namespace Concrete\Core\Page\Type\PublishTarget\Configuration;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Type\PublishTarget\Type\Type;
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Type\PublishTarget\Type\Type as PageTypePublishTargetType;
 
-abstract class Configuration extends Object
+abstract class Configuration extends ConcreteObject
 {
     abstract public function canPublishPageTypeBeneathTarget(\Concrete\Core\Page\Type\Type $pagetype, Page $page);
 

--- a/concrete/src/Page/Type/PublishTarget/Type/Type.php
+++ b/concrete/src/Page/Type/PublishTarget/Type/Type.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\Page\Type\PublishTarget\Type;
 
 use Loader;
 use Concrete\Core\Page\Type\Type as PageType;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Environment;
 use Concrete\Core\Package\Package as Package;
@@ -11,7 +11,7 @@ use Core;
 use Database;
 use Symfony\Component\HttpFoundation\Request;
 
-abstract class Type extends Object
+abstract class Type extends ConcreteObject
 {
     protected $ptPublishTargetTypeID;
     protected $ptPublishTargetTypeHandle;

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -10,7 +10,7 @@ use Concrete\Core\Permission\AssignableObjectInterface;
 use Concrete\Core\Permission\AssignableObjectTrait;
 use Concrete\Core\Permission\Key\Key;
 use Loader;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use PageTemplate;
 use PermissionKey;
 use Concrete\Core\Permission\Access\Access as PermissionAccess;
@@ -34,7 +34,7 @@ use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFor
 use Concrete\Core\Page\Collection\Version\VersionList;
 use Concrete\Core\Page\Type\Composer\Control\CorePageProperty\CorePageProperty as CorePagePropertyPageTypeComposerControl;
 
-class Type extends Object implements \Concrete\Core\Permission\ObjectInterface, AssignableObjectInterface
+class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface, AssignableObjectInterface
 {
     protected $ptDefaultPageTemplateID = 0;
 

--- a/concrete/src/Permission/Access/Access.php
+++ b/concrete/src/Permission/Access/Access.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Permission\Access;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use CacheLocal;
 use Concrete\Core\Permission\Access\ListItem\ListItem;
 use Concrete\Core\Permission\Key\Key as PermissionKey;
@@ -12,7 +12,7 @@ use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Permission\Duration as PermissionDuration;
 use Concrete\Core\Workflow\Workflow;
 
-class Access extends Object
+class Access extends ConcreteObject
 {
     protected $paID;
     protected $paIDList = array();

--- a/concrete/src/Permission/Access/Entity/Entity.php
+++ b/concrete/src/Permission/Access/Entity/Entity.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\Permission\Access\Entity;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Database;
 use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use CacheLocal;
 use Core;
 use RuntimeException;
 
-abstract class Entity extends Object
+abstract class Entity extends ConcreteObject
 {
     public function getAccessEntityTypeID()
     {

--- a/concrete/src/Permission/Access/Entity/Type.php
+++ b/concrete/src/Permission/Access/Entity/Type.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\Permission\Access\Entity;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Permission\Category;
 use Gettext\Translations;
 use Loader;
 use Core;
 use Concrete\Core\Package\PackageList;
 
-class Type extends Object
+class Type extends ConcreteObject
 {
     public function getAccessEntityTypeID()
     {

--- a/concrete/src/Permission/Access/ListItem/ListItem.php
+++ b/concrete/src/Permission/Access/ListItem/ListItem.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Permission\Access\ListItem;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\Entity;
 use Concrete\Core\Permission\Duration;
 
-class ListItem extends Object
+class ListItem extends ConcreteObject
 {
     /** @var Duration */
     public $duration;

--- a/concrete/src/Permission/Category.php
+++ b/concrete/src/Permission/Category.php
@@ -3,10 +3,10 @@ namespace Concrete\Core\Permission;
 
 use Core;
 use Database;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 
-class Category extends Object
+class Category extends ConcreteObject
 {
     protected static $categories;
 

--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Permission\Key;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Gettext\Translations;
 use Database;
 use CacheLocal;
@@ -13,7 +13,7 @@ use Concrete\Core\Permission\Category as PermissionKeyCategory;
 use Environment;
 use Core;
 
-abstract class Key extends Object
+abstract class Key extends ConcreteObject
 {
     const ACCESS_TYPE_INCLUDE = 10;
     const ACCESS_TYPE_EXCLUDE = -1;

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Tree\Node;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Permission\Access\Access;
 use Concrete\Core\Permission\Access\Entity\GroupCombinationEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
@@ -23,7 +23,7 @@ use stdClass;
 use Gettext\Translations;
 use Concrete\Core\Tree\Node\Exception\MoveException;
 
-abstract class Node extends Object implements \Concrete\Core\Permission\ObjectInterface, AssignableObjectInterface
+abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface, AssignableObjectInterface
 {
 
     use AssignableObjectTrait;

--- a/concrete/src/Tree/Node/NodeType.php
+++ b/concrete/src/Tree/Node/NodeType.php
@@ -1,13 +1,13 @@
 <?php
 namespace Concrete\Core\Tree\Node;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
 use Concrete\Core\Package\PackageList;
 use Core;
 use Database;
 
-class NodeType extends Object
+class NodeType extends ConcreteObject
 {
     public function getTreeNodeTypeID()
     {

--- a/concrete/src/Tree/Tree.php
+++ b/concrete/src/Tree/Tree.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Tree;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Localization\Localization;
 use Gettext\Translations;
 use SimpleXMLElement;
@@ -9,7 +9,7 @@ use Concrete\Core\Tree\Node\Node as TreeNode;
 use Exception;
 use Concrete\Core\Support\Facade\Application;
 
-abstract class Tree extends Object
+abstract class Tree extends ConcreteObject
 {
     protected $treeNodeSelectedIDs = [];
 

--- a/concrete/src/Tree/TreeType.php
+++ b/concrete/src/Tree/TreeType.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\Tree;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Core;
 use Database;
 
-class TreeType extends Object
+class TreeType extends ConcreteObject
 {
     public function getTreeTypeID()
     {

--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\User\Group;
 
 use CacheLocal;
 use Concrete\Core\Database\Connection\Connection;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
@@ -16,7 +16,7 @@ use GroupTree;
 use GroupTreeNode;
 use Concrete\Core\User\UserList;
 
-class Group extends Object implements \Concrete\Core\Permission\ObjectInterface
+class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     public $ctID;
     public $permissionSet;

--- a/concrete/src/User/Group/GroupSet.php
+++ b/concrete/src/User/Group/GroupSet.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\User\Group;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Gettext\Translations;
 use Loader;
 
-class GroupSet extends Object
+class GroupSet extends ConcreteObject
 {
     public static function getList()
     {

--- a/concrete/src/User/PrivateMessage/Mailbox.php
+++ b/concrete/src/User/PrivateMessage/Mailbox.php
@@ -1,12 +1,12 @@
 <?php
 namespace Concrete\Core\User\PrivateMessage;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use UserInfo;
 use Events;
 
-class Mailbox extends Object
+class Mailbox extends ConcreteObject
 {
     const MBTYPE_INBOX = -1;
     const MBTYPE_SENT = -2;

--- a/concrete/src/User/PrivateMessage/PrivateMessage.php
+++ b/concrete/src/User/PrivateMessage/PrivateMessage.php
@@ -1,14 +1,14 @@
 <?php
 namespace Concrete\Core\User\PrivateMessage;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\PrivateMessage\Mailbox as UserPrivateMessageMailbox;
 use Loader;
 use UserInfo;
 use Events;
 
-class PrivateMessage extends Object implements SubjectInterface
+class PrivateMessage extends ConcreteObject implements SubjectInterface
 {
     protected $authorName = false;
     protected $mailbox;

--- a/concrete/src/User/Statistics.php
+++ b/concrete/src/User/Statistics.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\User;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use UserInfo as ConcreteUserInfo;
 
-class Statistics extends Object
+class Statistics extends ConcreteObject
 {
     protected $ui;
 

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\User;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
 use Concrete\Core\Support\Facade\Application;
@@ -13,7 +13,7 @@ use Hautelook\Phpass\PasswordHash;
 use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\User\Point\Action\Action as UserPointAction;
 
-class User extends Object
+class User extends ConcreteObject
 {
     public $uID = '';
     public $uName = '';

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -13,7 +13,7 @@ use Concrete\Core\Entity\Attribute\Value\Value\Value;
 use Concrete\Core\Entity\User\User as UserEntity;
 use Concrete\Core\Export\ExportableInterface;
 use Concrete\Core\File\StorageLocation\StorageLocationFactory;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Mail\Importer\MailImporter;
 use Concrete\Core\Permission\ObjectInterface as PermissionObjectInterface;
 use Concrete\Core\User\Avatar\AvatarServiceInterface;
@@ -39,7 +39,7 @@ use User as ConcreteUser;
 use View;
 use Concrete\Core\Export\Item\User as UserExporter;
 
-class UserInfo extends Object implements AttributeObjectInterface, PermissionObjectInterface, ExportableInterface
+class UserInfo extends ConcreteObject implements AttributeObjectInterface, PermissionObjectInterface, ExportableInterface
 {
     use ObjectTrait;
 

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -12,7 +12,7 @@
  */
 namespace Concrete\Core\Utility\Service;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Config;
 use DOMDocument;
 use Patchwork\Utf8;
@@ -222,7 +222,7 @@ class Text
      */
     public function camelcase($string)
     {
-        return Object::camelcase($string);
+        return ConcreteObject::camelcase($string);
     }
 
     /**
@@ -332,7 +332,7 @@ class Text
      */
     public function uncamelcase($string)
     {
-        return Object::uncamelcase($string);
+        return ConcreteObject::uncamelcase($string);
     }
 
     /**

--- a/concrete/src/Validation/BannedWord/BannedWord.php
+++ b/concrete/src/Validation/BannedWord/BannedWord.php
@@ -1,10 +1,10 @@
 <?php
 namespace Concrete\Core\Validation\BannedWord;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 
-class BannedWord extends Object
+class BannedWord extends ConcreteObject
 {
     protected $id;
     protected $word;

--- a/concrete/src/Workflow/Description.php
+++ b/concrete/src/Workflow/Description.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Description extends Object
+class Description extends ConcreteObject
 {
     public function getDescription()
     {

--- a/concrete/src/Workflow/Progress/Action/Action.php
+++ b/concrete/src/Workflow/Progress/Action/Action.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow\Progress\Action;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Action extends Object
+class Action extends ConcreteObject
 {
     protected $wrActionStyleClass = '';
     protected $wrActionStyleInnerButtonLeft = '';

--- a/concrete/src/Workflow/Progress/Category.php
+++ b/concrete/src/Workflow/Progress/Category.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\Workflow\Progress;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 
-class Category extends Object
+class Category extends ConcreteObject
 {
     public static function getByID($wpCategoryID)
     {

--- a/concrete/src/Workflow/Progress/History.php
+++ b/concrete/src/Workflow/Progress/History.php
@@ -1,13 +1,13 @@
 <?php
 namespace Concrete\Core\Workflow\Progress;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Workflow\HistoryEntry\HistoryEntry;
 use Concrete\Core\Workflow\Request\Request;
 use Loader;
 use UserInfo;
 
-class History extends Object
+class History extends ConcreteObject
 {
     public function getWorkflowProgressHistoryTimestamp()
     {

--- a/concrete/src/Workflow/Progress/Progress.php
+++ b/concrete/src/Workflow/Progress/Progress.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Workflow\Progress;
 
 use Concrete\Core\Entity\Notification\WorkflowProgressNotification;
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Workflow\Workflow;
 use Concrete\Core\Workflow\Request\Request as WorkflowRequest;
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  *
  * @method static Progress add(string $wpCategoryHandle, Workflow $wf, WorkflowRequest $wr) Deprecated method. Use Progress::create instead.
  */
-abstract class Progress extends Object implements SubjectInterface
+abstract class Progress extends ConcreteObject implements SubjectInterface
 {
     protected $wrID = null;
     protected $wpID;

--- a/concrete/src/Workflow/Progress/Response.php
+++ b/concrete/src/Workflow/Progress/Response.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow\Progress;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 
-class Response extends Object
+class Response extends ConcreteObject
 {
     protected $wprURL = '';
 

--- a/concrete/src/Workflow/Request/Request.php
+++ b/concrete/src/Workflow/Request/Request.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\User\UserInfo;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Workflow;
@@ -11,7 +11,7 @@ use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use PermissionKey;
 use Events;
 
-abstract class Request extends Object
+abstract class Request extends ConcreteObject
 {
     protected $currentWP;
     protected $uID;

--- a/concrete/src/Workflow/Type.php
+++ b/concrete/src/Workflow/Type.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\Workflow;
 
-use Concrete\Core\Foundation\Object;
+use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 use Concrete\Core\Package\PackageList;
 
-class Type extends Object
+class Type extends ConcreteObject
 {
     public function getWorkflowTypeID()
     {

--- a/concrete/src/Workflow/Workflow.php
+++ b/concrete/src/Workflow/Workflow.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Workflow;
 
-use \Concrete\Core\Foundation\Object;
+use \Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\Package;
 use \Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Loader;
@@ -15,7 +15,7 @@ use Concrete\Core\Workflow\Request\Request as WorkflowRequest;
  * @copyright  Copyright (c) 2003-2012 concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
-abstract class Workflow extends Object implements \Concrete\Core\Permission\ObjectInterface
+abstract class Workflow extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface
 {
     protected $wfID = 0;
     protected $allowedTasks = array('cancel', 'approve');


### PR DESCRIPTION
`object` is a reserved keyword for PHP 7.2: we can't use it anymore for class names.

This pull request renames `Concrete\Core\Foundation\Object` to `Concrete\Core\Foundation\ConcreteObject`.

Furthermore, to grant backward compatibility, for PHP versions < 7 this PR defines `Concrete\Core\Foundation\Object` as an alias of `Concrete\Core\Foundation\ConcreteObject`.
