### PR TITLE
Fix saving "thumbnail is built" in ThumbnailMiddleware

### DIFF
--- a/concrete/src/Http/Middleware/ThumbnailMiddleware.php
+++ b/concrete/src/Http/Middleware/ThumbnailMiddleware.php
@@ -259,6 +259,8 @@ class ThumbnailMiddleware implements MiddlewareInterface, ApplicationAwareInterf
      */
     private function completeBuild(File $file, $thumbnail)
     {
+        unset($thumbnail['lockID']);
+        unset($thumbnail['lockExpires']);
         // Update the database to have "1" for isBuilt
         $this->connection->update('FileImageThumbnailPaths', ['isBuilt' => '1'], $thumbnail);
     }


### PR DESCRIPTION
When ThumbnailMiddleware is done building a thumbnail, it [currently persist](https://github.com/concrete5/concrete5/blob/51bf047054a9bce7c76beb1ac4550711aacb9fe9/concrete/src/Http/Middleware/ThumbnailMiddleware.php#L263) that the thumbnail is done by passing all the columns of the database table.

BTW the Doctrine `update` methods builds a query like
```sql
UPDATE
    FileImageThumbnailPaths
SET
    isBuilt = 1
WHERE
    fileID = 123
    AND fileVersionID = 1
    AND thumbnailTypeHandle = 'file_manager_listing'
    AND storageLocationID = 1
    AND path = '/thumbnails/file_manager_listing/1315/0160/3431/test.jpg'
    AND isBuilt = 0
    AND lockID = NULL
    AND lockExpires = NULL
```

Since we compare fields with ` = NULL` instead of ` IS NULL`, no record is being updated, and the thumbnails gets rebuilt at every cycle (!).

Let's fix this.