### PR TITLE
Fix clearing cache settings

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
+++ b/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
@@ -19,8 +19,9 @@ class Clearcache extends DashboardPageController
         if ($this->token->validate("clear_cache")) {
             if ($this->isPost()) {
                 $thumbnails = $this->request('thumbnails') === '1';
-                $this->app->make(Repository::class)->save('concrete.cache.clear.thumbnails', $thumbnails);
-
+                $config = $this->app->make(Repository::class);
+                $config->set('concrete.cache.clear.thumbnails', $thumbnails);
+                $config->save('concrete.cache.clear.thumbnails', $thumbnails);
                 $this->app->clearCaches();
                 $this->redirect('/dashboard/system/optimization/clearcache', 'cache_cleared');
             }


### PR DESCRIPTION
When we save a new configuration option (`$config->save`), its value is persisted, but if we call `$config->get` without reloading the configuration file we still get the previous value.
In order to fix this, we need to call both `$config->set` and `$config->save`