### PR TITLE
Fix clearing cache but keep thumbnails on Windows

### DIFF
--- a/concrete/src/Cache/CacheClearer.php
+++ b/concrete/src/Cache/CacheClearer.php
@@ -153,6 +153,7 @@ class CacheClearer
      */
     protected function filesToClear($directory)
     {
+        $directory = str_replace('/', DIRECTORY_SEPARATOR, $directory);
         try {
             $iterator = new FilesystemIterator($directory);
         } catch (\UnexpectedValueException $e) {
@@ -163,7 +164,7 @@ class CacheClearer
         $exclude = [];
 
         if (!$this->repository->get('concrete.cache.clear.thumbnails', true)) {
-            $exclude[] = $directory . '/thumbnails';
+            $exclude[] = $directory . DIRECTORY_SEPARATOR . 'thumbnails';
         } else {
             $this->logger->notice(t('Clearing cache thumbnails directory.'));
         }


### PR DESCRIPTION
The standard PHP library returns paths with the OS-specific DIRECTORY_SEPARATOR.
So, when we determine the files to be removed from the cache, we check if the path `C:/Path/To/application/files/cache\thumbnails` is contained in the array `['C:/Path/To/application/files/cache/thumbnails']`, which is always false.
That implies that the cache cleaner always remove the thumbnails cache directory.

Let's fix this.
