### PR TITLE
Add an option to the c5:clear-cache CLI command to keep thumbnails

### DIFF
--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -1,10 +1,13 @@
 <?php
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Core;
+use Exception;
 
 class ClearCacheCommand extends Command
 {
@@ -14,8 +17,11 @@ class ClearCacheCommand extends Command
         $this
             ->setName('c5:clear-cache')
             ->setDescription('Clear the concrete5 cache')
+            ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, "Should the thumbnails be removed from the cache? [Y/N]")
             ->addEnvOption()
             ->setHelp(<<<EOT
+If the --thumbnails options is not specified, we'll use the last value set in the dashboard.
+
 Returns codes:
   0 operation completed successfully
   $errExitCode errors occurred
@@ -28,8 +34,23 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->write('Clearing the concrete5 cache... ');
         $cms = Core::make('app');
+        $thumbnails = $input->getOption('thumbnails');
+        if ($thumbnails !== null) {
+            switch (strtolower($thumbnails[0])) {
+                case 'n':
+                    $clearThumbnails = false;
+                    break;
+                case 'y':
+                    $clearThumbnails = true;
+                    break;
+                default:
+                    throw new Exception('Invalid value for the --thumbnails option: please specify Y[es] or N[o]');
+            }
+            $config = $cms->app->make(Repository::class);
+            $config->set('concrete.cache.clear.thumbnails', $clearThumbnails);
+        }
+        $output->write('Clearing the concrete5 cache... ');
         $cms->clearCaches();
         $output->writeln('<info>done.</info>');
     }


### PR DESCRIPTION
The `c5:clear-cache` CLI command clears or keeps the cached thumbnails depending on the `concrete.cache.clear.thumbnails` configuration key.

What about adding an option to the CLI command to explicitly delete/keep the thumbnails?