### PR TITLE
Allow changing site locale

### DIFF
--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -13,11 +13,11 @@ $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 <table class="table table-striped">
     <tr>
-        <th style="width: 1%">&nbsp;</th>
+        <th style="width: 1px">&nbsp;</th>
         <th style="width: auto"><?= t('Home Page') ?></th>
         <th style="width: auto"><?= t('Language') ?></th>
         <th style="width: auto"><?= t('Locale') ?></th>
-        <th style="width: 1%">&nbsp;</th>
+        <th style="width: 1px">&nbsp;</th>
     </tr>
     <?php
     foreach ($locales as $locale) {
@@ -38,12 +38,9 @@ $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
             </td>
             <td><?= $locale->getLanguageText() ?></td>
             <td><?= $locale->getLocale() ?></td>
-            <td>
-                <?php
-                if (!$locale->getIsDefault()) {
-                    ?><a data-dialog-title="<?= t('Delete Locale') ?>" data-dialog="delete-section-<?= $locale->getLocaleID() ?>" href="#" class="icon-link"><i class="fa fa-trash"></i></a><?php
-                }
-                ?>
+            <td style="white-space: nowrap">
+                <a data-dialog-title="<?= t('Delete Locale') ?>" data-dialog="delete-section-<?= $locale->getLocaleID() ?>" href="#" class="icon-link"><i class="fa fa-trash"></i></a>
+                <a data-dialog-title="<?= t('Change Locale') ?>" data-dialog="change-section-<?= $locale->getLocaleID() ?>" href="#" class="icon-link"><i class="fa fa-edit"></i></a>
             </td>
         </tr>
         <?php
@@ -53,33 +50,57 @@ $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 <?php
 foreach ($locales as $locale) {
-    if (!$locale->getIsDefault() && $u->isSuperUser()) {
-        ?>
-        <div style="display: none">
-            <div data-dialog-wrapper="delete-section-<?= $locale->getLocaleID() ?>">
-                <?php
-                if ($u->isSuperUser()) {
-                    ?>
-                    <form data-form="delete-locale-<?= $locale->getLocaleID() ?>" method="post" action="<?= $view->action('remove_locale_section') ?>">
-                        <?php $token->output('remove_locale_section') ?>
-                        <input type="hidden" name="siteLocaleID" value="<?= $locale->getLocaleID() ?>">
-                        <p><?= t('Delete this multilingual section? This will remove the entire site tree and its content from your website.') ?></p>
-                        <div class="dialog-buttons">
-                            <button class="btn btn-default" data-dialog-action="cancel"><?= t('Cancel') ?></button>
-                            <button class="btn btn-danger pull-right" onclick="$('form[data-form=delete-locale-<?= $locale->getLocaleID() ?>]').submit()" type="submit"><?= t('Delete') ?></button>
-                        </div>
-                    </form>
-                    <?php
-                } else {
-                    ?>
-                    <p><?= t('Only the super user may remove a multilingual section.') ?></p>
-                    <?php
-                }
+    ?>
+    <div style="display: none">
+        <div data-dialog-wrapper="delete-section-<?= $locale->getLocaleID() ?>">
+            <?php
+            if ($locale->getIsDefault()) {
                 ?>
-            </div>
+                <p><?= t('The default multilingual section can\'t be removed.') ?></p>
+                <?php
+            } elseif (!$u->isSuperUser()) {
+                ?>
+                <p><?= t('Only the super user may remove a multilingual section.') ?></p>
+                <?php
+            } else {
+                ?>
+                <form data-form="delete-locale-<?= $locale->getLocaleID() ?>" method="post" action="<?= $view->action('remove_locale_section') ?>">
+                    <?php $token->output('remove_locale_section') ?>
+                    <input type="hidden" name="siteLocaleID" value="<?= $locale->getLocaleID() ?>">
+                    <p><?= t('Delete this multilingual section? This will remove the entire site tree and its content from your website.') ?></p>
+                    <div class="dialog-buttons">
+                        <button class="btn btn-default" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+                        <button class="btn btn-danger pull-right" onclick="$('form[data-form=delete-locale-<?= $locale->getLocaleID() ?>]').submit()" type="submit"><?= t('Delete') ?></button>
+                    </div>
+                </form>
+                <?php
+            }
+            ?>
         </div>
-        <?php
-    }
+        <div data-dialog-wrapper="change-section-<?= $locale->getLocaleID() ?>">
+            <form data-form="change-locale-<?= $locale->getLocaleID() ?>" method="post" action="<?= $view->action('change_locale_section') ?>">
+                <?php $token->output('change_locale_section') ?>
+                <input type="hidden" name="siteLocaleID" value="<?= $locale->getLocaleID() ?>">
+                <div class="form-group">
+                    <?= $form->label('msLanguageChange' . $locale->getLocaleID(), t('Choose Language')) ?>
+                    <?= $form->select('msLanguageChange' . $locale->getLocaleID(), $languages, $locale->getLanguage()) ?>
+                </div>
+                <div class="form-group">
+                    <?= $form->label('msCountryChange' . $locale->getLocaleID(), t('Choose Country')) ?>
+                    <?= $form->select('msCountryChange' . $locale->getLocaleID(), array_merge(['' => t('** None Selected')], $countries), $locale->getCountry()) ?>
+                </div>
+                <div class="form-group">
+                    <label class="control-label"><?= t('Icon') ?></label>
+                    <div id="ccm-multilingual-language-icon-change<?= $locale->getLocaleID() ?>"><?= t('None') ?></div>
+                </div>
+                <div class="dialog-buttons">
+                    <button class="btn btn-default" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+                    <button class="btn btn-primary pull-right" onclick="$('form[data-form=change-locale-<?= $locale->getLocaleID() ?>]').submit()" type="submit"><?= t('Update') ?></button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <?php
 }
 
 $defaultLocales = [];
@@ -129,11 +150,6 @@ foreach ($locales as $locale) {
             <?= $form->select('defaultSourceLanguage', array_merge(['' => t('*** Unknown or mixed language')], $languages), $defaultSourceLanguage) ?>
             <?= $form->select('defaultSourceCountry', array_merge(['' => t('*** Undetermined country')], $countries), $defaultSourceCountry) ?>
         </div>
-        <script>
-            $(document).ready(function () {
-                new ccmCountryForLanguageLister($('#defaultSourceLanguage'), $('#defaultSourceCountry'));
-            });
-        </script>
     </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
@@ -186,33 +202,36 @@ foreach ($locales as $locale) {
     </div>
 </div>
 <script>
+$(document).ready(function() {
+    'use strict';
+
     var ccmCountryForLanguageLister = (function () {
-        var countryDictionary = <?= json_encode($countries) ?>;
-        var sortedCountries = (function () {
-            var list = [];
-            $.each(countryDictionary, function (id) {
-                list.push(id);
-            });
-            list.sort(function (aCode, bCode) {
-                var aName = countryDictionary[aCode].toLowerCase(), bName = countryDictionary[bCode].toLowerCase();
-                if (aName < bName) {
-                    return -1;
-                }
-                if (aName > bName) {
-                    return 1;
-                }
-                return 0;
-            });
-            return list;
-        })();
-        var cache = {'': []};
+        var countryDictionary = <?= json_encode($countries) ?>,
+            sortedCountries = (function () {
+                var list = [];
+                $.each(countryDictionary, function (id) {
+                    list.push(id);
+                });
+                list.sort(function (aCode, bCode) {
+                    var aName = countryDictionary[aCode].toLowerCase(), bName = countryDictionary[bCode].toLowerCase();
+                    if (aName < bName) {
+                        return -1;
+                    }
+                    if (aName > bName) {
+                        return 1;
+                    }
+                    return 0;
+                });
+                return list;
+            })(),
+            cache = {'': []},
+            iconCache = {};
 
         function appendCountries($parent, countryCodes) {
             $.each(countryCodes, function (_, countryCode) {
                 $parent.append($('<option />').val(countryCode).text(countryDictionary[countryCode]));
             });
         }
-
         function updateCountrySelect($country, preferredCountryCodes) {
             var preferredCountries = [];
             $.each(preferredCountryCodes, function (_, countryCode) {
@@ -241,7 +260,31 @@ foreach ($locales as $locale) {
             $country.val(selectedCountry);
         }
 
-        function CountryForLanguageLister($language, $country) {
+        function populateIcon($icon, country) {
+            $icon.data('country', country || false);
+            if (country) {
+                if (iconCache.hasOwnProperty(country)) {
+                    $icon.html(iconCache[country]);
+                } else {
+                    $icon.text('...');
+                    $.post(
+                        <?= json_encode($view->action('load_icon')) ?>,
+                        {msCountry: country},
+                        function (data) {
+                            iconCache[country] = data ? data : '';
+                            if ($icon.data('country') === country) {
+                                $icon.html(iconCache[country]);
+                            }
+                        },
+                        'html'
+                    );
+                }
+            } else {
+                $icon.text(<?= json_encode(t('None')) ?>);
+            }
+        }
+        
+        function CountryForLanguageLister($language, $country, $icon) {
             var me = this;
             this.$language = $language;
             this.$country = $country;
@@ -249,7 +292,16 @@ foreach ($locales as $locale) {
                 me.updateCountries();
             });
             this.currentLanguage = null;
+            this.$icon = $icon && $icon.length ? $icon : null;
             this.updateCountries();
+            if (this.$icon !== null) {
+                this.$country
+                    .on('change', function() {
+                        populateIcon(me.$icon, this.value);
+                    })
+                    .trigger('change')
+                ;
+            }
         }
 
         CountryForLanguageLister.prototype = {
@@ -284,27 +336,23 @@ foreach ($locales as $locale) {
                 );
             }
         };
+
         return CountryForLanguageLister;
     })();
 
-    $(function () {
-        new ccmCountryForLanguageLister($('#msLanguage'), $('#msCountry'));
-        $("select[name=msCountry]").change(function () {
-            ccm_multilingualPopulateIcons($(this).val());
-        });
-        ccm_multilingualPopulateIcons($("select[name=msCountry]").val());
+    new ccmCountryForLanguageLister($('#msLanguage'), $('#msCountry'), $('#ccm-multilingual-language-icon'));
+    <?php
+    foreach ($locales as $locale) {
+        ?>new ccmCountryForLanguageLister($('#msLanguageChange<?= $locale->getLocaleID() ?>'), $('#msCountryChange<?= $locale->getLocaleID() ?>'), $('#ccm-multilingual-language-icon-change<?= $locale->getLocaleID() ?>'));<?php
+    }
+    ?>
+    new ccmCountryForLanguageLister($('#defaultSourceLanguage'), $('#defaultSourceCountry'));
 
-        ConcreteEvent.subscribe('AjaxFormSubmitSuccess.addLocale', function (e, data) {
-            if (data.form == 'add-locale') {
-                window.location.reload();
-            }
-        });
+    ConcreteEvent.subscribe('AjaxFormSubmitSuccess.addLocale', function (e, data) {
+        if (data.form == 'add-locale') {
+            window.location.reload();
+        }
     });
 
-    ccm_multilingualPopulateIcons = function (country) {
-        if (country && country != '') {
-            $("#ccm-multilingual-language-icon").load('<?= $view->action('load_icon') ?>', {'msCountry': country});
-        }
-    };
-
+});
 </script>

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -1,8 +1,12 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+$u = new User();
+$app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
+?>
 
 <div class="ccm-dashboard-header-buttons">
-    <button class="btn btn-primary" data-dialog-width="400" data-dialog-height="500"
-            data-dialog="add-locale"><?= t('Add Locale') ?></button>
+    <button class="btn btn-primary" data-dialog-width="400" data-dialog-height="500" data-dialog="add-locale"><?= t('Add Locale') ?></button>
 </div>
 
 <h3><?= t('Locales') ?></h3>
@@ -10,65 +14,75 @@
 <table class="table table-striped">
     <tr>
         <th style="width: 1%">&nbsp;</th>
-        <th style="width: auto"><?php echo t('Home Page') ?></th>
-        <th style="width: auto"><?php echo t('Language') ?></th>
-        <th style="width: auto"><?php echo t('Locale') ?></th>
+        <th style="width: auto"><?= t('Home Page') ?></th>
+        <th style="width: auto"><?= t('Language') ?></th>
+        <th style="width: auto"><?= t('Locale') ?></th>
         <th style="width: 1%">&nbsp;</th>
     </tr>
     <?php
-    /**
-     * @var $locale \Concrete\Core\Entity\Site\Locale
-     */
-    $u = new User();
     foreach ($locales as $locale) {
-        $home = null;
-        if (is_object($locale->getSiteTree())) {
-            $home = $locale->getSiteTree()->getSiteHomePageObject();
-        }
+        /* @var Concrete\Core\Entity\Site\Locale $locale */
+        $localeSiteTree = $locale->getSiteTree();
+        $home = $localeSiteTree === null ? null : $localeSiteTree->getSiteHomePageObject();
         ?>
         <tr>
-            <td><?php echo $flag->getLocaleFlagIcon($locale) ?></td>
-            <td><?php if (is_object($home)) { ?><a
-                    href="<?= $home->getCollectionLink() ?>"><?= $home->getCollectionName() ?></a>
-                <?php } else { ?><span class="text-warning"><?= t('None Created.') ?></span>
-                <?php } ?></td>
-            <td><?php echo $locale->getLanguageText() ?></td>
-            <td><?php echo $locale->getLocale() ?></td>
-            <td><?php if (!$locale->getIsDefault()) { ?><a data-dialog-title="<?= t('Delete Locale') ?>"
-                                                           data-dialog="delete-section-<?= $locale->getLocaleID() ?>"
-                                                           href="#" class="icon-link"><i
-                            class="fa fa-trash"></i></a><?php } ?></td>
+            <td><?= $flag->getLocaleFlagIcon($locale) ?></td>
+            <td>
+                <?php
+                if (is_object($home)) {
+                    ?><a href="<?= $home->getCollectionLink() ?>"><?= $home->getCollectionName() ?></a><?php
+                } else {
+                    ?><span class="text-warning"><?= t('None Created.') ?></span><?php
+                }
+                ?>
+            </td>
+            <td><?= $locale->getLanguageText() ?></td>
+            <td><?= $locale->getLocale() ?></td>
+            <td>
+                <?php
+                if (!$locale->getIsDefault()) {
+                    ?><a data-dialog-title="<?= t('Delete Locale') ?>" data-dialog="delete-section-<?= $locale->getLocaleID() ?>" href="#" class="icon-link"><i class="fa fa-trash"></i></a><?php
+                }
+                ?>
+            </td>
         </tr>
-    <?php } ?>
+        <?php
+    }
+    ?>
 </table>
 
 <?php
 foreach ($locales as $locale) {
-    if (!$locale->getIsDefault() && $u->isSuperUser()) { ?>
+    if (!$locale->getIsDefault() && $u->isSuperUser()) {
+        ?>
         <div style="display: none">
             <div data-dialog-wrapper="delete-section-<?= $locale->getLocaleID() ?>">
-                <?php if ($u->isSuperUser()) { ?>
-                    <form data-form="delete-locale-<?= $locale->getLocaleID() ?>" method="post"
-                          action="<?= $view->action('remove_locale_section') ?>">
-                        <?= $token->output('remove_locale_section') ?>
+                <?php
+                if ($u->isSuperUser()) {
+                    ?>
+                    <form data-form="delete-locale-<?= $locale->getLocaleID() ?>" method="post" action="<?= $view->action('remove_locale_section') ?>">
+                        <?php $token->output('remove_locale_section') ?>
                         <input type="hidden" name="siteLocaleID" value="<?= $locale->getLocaleID() ?>">
                         <p><?= t('Delete this multilingual section? This will remove the entire site tree and its content from your website.') ?></p>
                         <div class="dialog-buttons">
                             <button class="btn btn-default" data-dialog-action="cancel"><?= t('Cancel') ?></button>
-                            <button class="btn btn-danger pull-right"
-                                    onclick="$('form[data-form=delete-locale-<?= $locale->getLocaleID() ?>]').submit()"
-                                    type="submit"><?= t('Delete') ?></button>
+                            <button class="btn btn-danger pull-right" onclick="$('form[data-form=delete-locale-<?= $locale->getLocaleID() ?>]').submit()" type="submit"><?= t('Delete') ?></button>
                         </div>
                     </form>
-                <?php } else { ?>
+                    <?php
+                } else {
+                    ?>
                     <p><?= t('Only the super user may remove a multilingual section.') ?></p>
-                <?php } ?>
+                    <?php
+                }
+                ?>
             </div>
         </div>
-    <?php } ?>
-<?php } ?>
-<?php
-$defaultLocales = array();
+        <?php
+    }
+}
+
+$defaultLocales = [];
 $defaultLocaleID = 0;
 foreach ($locales as $locale) {
     $defaultLocales[$locale->getLocaleID()] = sprintf('%s (%s)', $locale->getLanguageText(), $locale->getLocale());
@@ -77,53 +91,43 @@ foreach ($locales as $locale) {
     }
 }
 ?>
-<h3><?php echo t('Settings') ?></h3>
-<form method="post" action="<?php echo $this->action('set_default') ?>">
+<h3><?= t('Settings') ?></h3>
+<form method="post" action="<?= $this->action('set_default') ?>">
     <div class="form-group">
-        <label class="control-label"><?php echo t('Default Locale'); ?></label>
-        <?= $form->select('defaultLocale', $defaultLocales, $defaultLocaleID, array('required' => 'required')); ?>
+        <label class="control-label"><?= t('Default Locale') ?></label>
+        <?= $form->select('defaultLocale', $defaultLocales, $defaultLocaleID, ['required' => 'required']) ?>
     </div>
-
     <div class="form-group">
         <div class="checkbox">
             <label>
-                <?php echo $form->checkbox('redirectHomeToDefaultLocale', 1, $redirectHomeToDefaultLocale) ?>
-                <span><?php echo t('Redirect home page to default locale.') ?></span>
+                <?= $form->checkbox('redirectHomeToDefaultLocale', 1, $redirectHomeToDefaultLocale) ?>
+                <span><?= t('Redirect home page to default locale.') ?></span>
             </label>
         </div>
         <div style="margin-left: 20px">
             <div class="checkbox<?= $redirectHomeToDefaultLocale ? '' : ' disabled' ?>">
                 <label>
-                    <?php echo $form->checkbox('useBrowserDetectedLocale', 1, $useBrowserDetectedLocale, $redirectHomeToDefaultLocale ? [] : ['disabled' => 'disabled']) ?>
-                    <span><?php echo t('Attempt to use visitor\'s locale based on their browser information.') ?></span>
+                    <?= $form->checkbox('useBrowserDetectedLocale', 1, $useBrowserDetectedLocale, $redirectHomeToDefaultLocale ? [] : ['disabled' => 'disabled']) ?>
+                    <span><?= t('Attempt to use visitor\'s locale based on their browser information.') ?></span>
                 </label>
             </div>
         </div>
     </div>
     <script>
-    $(document).ready(function() {
-        $('#redirectHomeToDefaultLocale').on('change', function() {
-            $('#useBrowserDetectedLocale')
-                .prop('disabled', !this.checked)
-                .closest('div.checkbox')[this.checked ? 'removeClass' : 'addClass']('disabled')
-            ;
+        $(document).ready(function() {
+            $('#redirectHomeToDefaultLocale').on('change', function() {
+                $('#useBrowserDetectedLocale')
+                    .prop('disabled', !this.checked)
+                    .closest('div.checkbox')[this.checked ? 'removeClass' : 'addClass']('disabled')
+                ;
+            });
         });
-    });
     </script>
-
     <div class="form-group">
-        <label class="control-label"><?php echo t('Site interface source locale');
-            ?></label>
+        <label class="control-label"><?= t('Site interface source locale') ?></label>
         <div class="form-inline">
-            <?php
-            echo $form->select('defaultSourceLanguage',
-                array_merge(array('' => t('*** Unknown or mixed language')), $languages), $defaultSourceLanguage);
-            ?>
-
-            <?php
-            echo $form->select('defaultSourceCountry',
-                array_merge(array('' => t('*** Undetermined country')), $countries), $defaultSourceCountry);
-            ?>
+            <?= $form->select('defaultSourceLanguage', array_merge(['' => t('*** Unknown or mixed language')], $languages), $defaultSourceLanguage) ?>
+            <?= $form->select('defaultSourceCountry', array_merge(['' => t('*** Undetermined country')], $countries), $defaultSourceCountry) ?>
         </div>
         <script>
             $(document).ready(function () {
@@ -131,13 +135,9 @@ foreach ($locales as $locale) {
             });
         </script>
     </div>
-
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <?php
-            $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
-            echo $app->make('helper/validation/token')->output('set_default')
-            ?>
+            <?php $token->output('set_default') ?>
             <button class="pull-right btn btn-primary" type="submit" name="save"><?= t('Save Settings') ?></button>
         </div>
     </div>
@@ -150,17 +150,16 @@ foreach ($locales as $locale) {
             <fieldset>
                 <legend><?= t('Locale') ?></legend>
                 <div class="form-group">
-                    <?php echo $form->label('msLanguage', t('Choose Language')) ?>
-                    <?php echo $form->select('msLanguage', $languages); ?>
+                    <?= $form->label('msLanguage', t('Choose Language')) ?>
+                    <?= $form->select('msLanguage', $languages) ?>
                 </div>
                 <div class="form-group">
-                    <?php echo $form->label('msCountry', t('Choose Country')) ?>
-                    <?php echo $form->select('msCountry',
-                        array_merge(array('' => t('** None Selected')), $countries)); ?>
+                    <?= $form->label('msCountry', t('Choose Country')) ?>
+                    <?= $form->select('msCountry', array_merge(['' => t('** None Selected')], $countries)) ?>
                 </div>
                 <div class="form-group">
-                    <label class="control-label"><?php echo t('Icon') ?></label>
-                    <div id="ccm-multilingual-language-icon"><?php echo t('None') ?></div>
+                    <label class="control-label"><?= t('Icon') ?></label>
+                    <div id="ccm-multilingual-language-icon"><?= t('None') ?></div>
                 </div>
             </fieldset>
             <fieldset>
@@ -182,14 +181,13 @@ foreach ($locales as $locale) {
                 <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
                 <button class="btn btn-primary pull-right" data-dialog-action="submit"><?= t('Add Locale') ?></button>
             </div>
-            <?php echo $token->output('add_content_section') ?>
+            <?php $token->output('add_content_section') ?>
         </form>
     </div>
 </div>
-
-<script type="text/javascript">
+<script>
     var ccmCountryForLanguageLister = (function () {
-        var countryDictionary = <?php echo json_encode($countries); ?>;
+        var countryDictionary = <?= json_encode($countries) ?>;
         var sortedCountries = (function () {
             var list = [];
             $.each(countryDictionary, function (id) {
@@ -223,7 +221,7 @@ foreach ($locales as $locale) {
                 }
             });
             var selectedCountry = $country.val();
-            $country.empty().append($('<option value="" />').text(<?php echo json_encode(t('** None Selected')); ?>));
+            $country.empty().append($('<option value="" />').text(<?= json_encode(t('** None Selected')) ?>));
             if (preferredCountries.length) {
                 var otherCountries = [];
                 $.each(sortedCountries, function (_, countryCode) {
@@ -232,9 +230,9 @@ foreach ($locales as $locale) {
                     }
                 });
                 var $group;
-                $country.append($group = $('<optgroup />').attr('label', <?php echo json_encode(t('Suggested countries')); ?>));
+                $country.append($group = $('<optgroup />').attr('label', <?= json_encode(t('Suggested countries')) ?>));
                 appendCountries($group, preferredCountries);
-                $country.append($group = $('<optgroup />').attr('label', <?php echo json_encode(t('Other countries')); ?>));
+                $country.append($group = $('<optgroup />').attr('label', <?= json_encode(t('Other countries')) ?>));
                 appendCountries($group, otherCountries);
             }
             else {
@@ -274,7 +272,7 @@ foreach ($locales as $locale) {
                 }
                 updateCountrySelect(this.$country, []);
                 $.get(
-                    <?php echo json_encode($view->action('get_countries_for_language')); ?>,
+                    <?= json_encode($view->action('get_countries_for_language')) ?>,
                     {language: language},
                     function (data) {
                         cache[language] = data ? data : [];
@@ -305,11 +303,8 @@ foreach ($locales as $locale) {
 
     ccm_multilingualPopulateIcons = function (country) {
         if (country && country != '') {
-            $("#ccm-multilingual-language-icon").load('<?php echo $view->action("load_icon")?>', {'msCountry': country});
+            $("#ccm-multilingual-language-icon").load('<?= $view->action('load_icon') ?>', {'msCountry': country});
         }
     };
-
-</script>
-
 
 </script>


### PR DESCRIPTION
It's currently not possible to change the locale assigned to a specific multilingual section.

What about an *edit* icon for every multilingual section like this?

![new-icon](https://user-images.githubusercontent.com/928116/29374855-38ce1c72-82b3-11e7-91b7-b8944c37de84.png)

When clicked, this new dialog is shown:

![new-dialog](https://user-images.githubusercontent.com/928116/29374871-43277380-82b3-11e7-9f29-a584b79bc87d.png)


