### PR TITLE
PageList and Page List block - sort pages by date modified

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -65,6 +65,9 @@ class Controller extends BlockController
             case 'chrono_asc':
                 $this->list->sortByPublicDate();
                 break;
+            case 'modified_desc':
+                $this->list->sortByDateModifiedDescending();
+                break;
             case 'random':
                 $this->list->sortBy('RAND()');
                 break;

--- a/concrete/blocks/page_list/page_list_form.php
+++ b/concrete/blocks/page_list/page_list_form.php
@@ -339,6 +339,11 @@ $form = Loader::helper('form/page_selector');
                     } ?>>
                         <?= t('Reverse alphabetical order') ?>
                     </option>
+                    <option value="modified_desc" <?php if ($orderBy == 'modified_desc') {
+                        ?> selected <?php
+                    } ?>>
+                        <?= t('Most recently modified first') ?>
+                    </option>
                     <option value="random" <?php if ($orderBy == 'random') {
                         ?> selected <?php
                     } ?>>

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -596,6 +596,22 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     }
 
     /**
+     * Sorts this list by date modified ascending.
+     */
+    public function sortByDateModified()
+    {
+        $this->query->orderBy('c.cDateModified', 'asc');
+    }
+
+    /**
+     * Sorts this list by date modified descending.
+     */
+    public function sortByDateModifiedDescending()
+    {
+        $this->query->orderBy('c.cDateModified', 'desc');
+    }
+
+    /**
      * Sorts by ID in ascending order.
      */
     public function sortByCollectionIDAscending()


### PR DESCRIPTION
This pull request:
- adds 2 new methods to the PageList class for sorting by date modified ascending and descending
- adds a "Most recently modified first" sorting option to the Page List block for sorting by date modified descending

These changes had been previously requested on the forum, but the need for a "Recently Updated" documentation sidebar page list was the driving factor for the pull request.

**Changes:**

![image](https://user-images.githubusercontent.com/10898145/29438258-80892842-8383-11e7-89ce-fe8a9a7fa1c4.png)
