### PR TITLE
Add PhpDocGeneratorCaller.php

### DIFF
--- a/concrete/src/Support/Symbol/PhpDocGeneratorCaller.php
+++ b/concrete/src/Support/Symbol/PhpDocGeneratorCaller.php
@@ -1,4 +1,6 @@
 <?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
 /* Include this file to dump the currently defined vars */
 
 $vars = get_defined_vars();

--- a/concrete/src/Support/Symbol/PhpDocGeneratorCaller.php
+++ b/concrete/src/Support/Symbol/PhpDocGeneratorCaller.php
@@ -1,0 +1,8 @@
+<?php
+/* Include this file to dump the currently defined vars */
+
+$vars = get_defined_vars();
+if (isset($this) && is_object($this)) {
+    $vars['this'] = $this;
+}
+die('</script><pre>'.(new Concrete\Core\Support\Symbol\PhpDocGenerator())->describeVars($vars));


### PR DESCRIPTION
I use a lot the PhpDocGeneratorCaller introduced in #5669, but I always forget how to use it.

What about adding a file that, when included, calls it the right way?

It's enough to add this:

```php
include DIR_BASE_CORE . '/src/Support/Symbol/PhpDocGeneratorCaller.php';
```
