### PR TITLE
Keep the short echo tags in built releases

### DIFF
--- a/build/Gruntfile.parameters-sample.js
+++ b/build/Gruntfile.parameters-sample.js
@@ -27,6 +27,9 @@ module.exports = {
 	ctLocales: [],
 	// The minimum translation progress of locales (percentage).
 	// Default value: 90%
-	ctProgressLimit: 90
+	ctProgressLimit: 90,
+
+	// Keep the short echo tags? Otherwise they'll be expanded [default: true]
+	keepShortEcho: true
 
 };

--- a/build/libraries/short-tags-remover.php
+++ b/build/libraries/short-tags-remover.php
@@ -21,6 +21,9 @@ try {
         $n = count($argv);
         for ($i = 1; $i < $n; ++$i) {
             switch (strtolower($argv[$i])) {
+                case '--keep-short-echo':
+                    ShortTagsRemover::$KEEP_SHORT_ECHO = true;
+                    break;
                 case '--list':
                     if (!is_null($sourceFilename)) {
                         throw new Exception('--list parameter can\'t be used togheter with single-file syntax');
@@ -68,6 +71,8 @@ try {
 
 class ShortTagsRemover
 {
+    public static $KEEP_SHORT_ECHO = false;
+
     public static function fromFileList($listFilename, $overwrite = false)
     {
         if (is_dir($listFilename)) {
@@ -142,7 +147,11 @@ class ShortTagsRemover
             if (is_array($token)) {
                 switch ($token[0]) {
                     case T_OPEN_TAG_WITH_ECHO:
-                        $expanded = '<?php echo';
+                        if (static::$KEEP_SHORT_ECHO) {
+                            $result .= $token[1];
+                        } else {
+                            $expanded = '<?php echo';
+                        }
                         break;
                     case T_OPEN_TAG:
                         $expanded = '<?php';

--- a/build/tasks/build-release/remove-short-tags.js
+++ b/build/tasks/build-release/remove-short-tags.js
@@ -8,6 +8,9 @@ module.exports = function(grunt, config, parameters, done) {
 		var buildParameters = require('util')._extend({}, parameters);
 		buildParameters = parameters;
 		buildParameters.source = workFolder;
+		if (buildParameters.keepShortEcho === null || buildParameters.keepShortEcho === undefined) {
+		    buildParameters.keepShortEcho = true;
+		}
 		require('../remove-short-tags.js')(grunt, config, buildParameters, done);
 	}
 	catch(e) {

--- a/build/tasks/remove-short-tags.js
+++ b/build/tasks/remove-short-tags.js
@@ -153,7 +153,12 @@ module.exports = function(grunt, config, parameters, done) {
 						remover = spawn(parameters.shortTagRemover, ['--list', listFile.path]);
 					}
 					else {
-						remover = spawn('php', ['-d', 'short_open_tag=On', path.join(__dirname, '../libraries/short-tags-remover.php'), '--list', listFile.path]);
+						var args = ['-d', 'short_open_tag=On', path.join(__dirname, '../libraries/short-tags-remover.php')];
+						if (parameters.keepShortEcho) {
+							args.push('--keep-short-echo');
+						}
+						args = args.concat(['--list', listFile.path]);
+						remover = spawn('php', args);
 					}
 					remover.stdout.on('data', function (data) {
 						process.stdout.write(data);


### PR DESCRIPTION
Since concrete5 requires PHP 5.5.9+, and the short echo tag `<?=` is always enabled since PHP 5.4.0, there's no more the need to replace `<?=` with `<?php echo` in concrete5 releases