### PR TITLE
Fix creating new default storage location

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/files/storage.php
+++ b/concrete/controllers/single_page/dashboard/system/files/storage.php
@@ -140,7 +140,7 @@ class Storage extends DashboardPageController
             $factory = $this->app->make(StorageLocationFactory::class);
             /* @var StorageLocationFactory $factory */
             $location = $factory->create($configuration, $this->request->request->get('fslName'));
-            $location->setIsDefault((bool) $this->request->request->get('fslIsDefault'));
+            $location->setIsDefault($this->request->request->get('fslIsDefault'));
             $location = $factory->persist($location);
             $this->redirect('/dashboard/system/files/storage', 'storage_location_added');
         }

--- a/concrete/controllers/single_page/dashboard/system/files/storage.php
+++ b/concrete/controllers/single_page/dashboard/system/files/storage.php
@@ -1,19 +1,19 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Files;
 
-use Concrete\Core\Page\Controller\DashboardPageController;
-use Loader;
 use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
 use Concrete\Core\File\StorageLocation\Type\Type;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Loader;
 
 class Storage extends DashboardPageController
 {
-    public $helpers = array('form', 'concrete/ui', 'validation/token', 'concrete/file');
+    public $helpers = ['form', 'concrete/ui', 'validation/token', 'concrete/file'];
 
     public function view($updated = false)
     {
         $this->set('locations', FileStorageLocation::getList());
-        $types = array();
+        $types = [];
         $storageLocationTypes = Type::getList();
         foreach ($storageLocationTypes as $type) {
             if ($type->getHandle() == 'default') {
@@ -79,7 +79,7 @@ class Storage extends DashboardPageController
             $this->error->add(t('Your file storage location must have a name.'));
         }
 
-        return array($request, $type);
+        return [$request, $type];
     }
 
     public function update()

--- a/concrete/controllers/single_page/dashboard/system/files/storage.php
+++ b/concrete/controllers/single_page/dashboard/system/files/storage.php
@@ -1,18 +1,15 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Files;
 
-use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
+use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\File\StorageLocation\Type\Type;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Loader;
 
 class Storage extends DashboardPageController
 {
-    public $helpers = ['form', 'concrete/ui', 'validation/token', 'concrete/file'];
-
-    public function view($updated = false)
+    public function view()
     {
-        $this->set('locations', FileStorageLocation::getList());
+        $this->set('locations', $this->app->make(StorageLocationFactory::class)->fetchList());
         $types = [];
         $storageLocationTypes = Type::getList();
         foreach ($storageLocationTypes as $type) {
@@ -51,8 +48,9 @@ class Storage extends DashboardPageController
 
     public function edit($fslID = false)
     {
-        $location = FileStorageLocation::getByID($fslID);
-        if (is_object($location)) {
+        $location = $fslID ? $this->app->make(StorageLocationFactory::class)->fetchByID($fslID) : null;
+        if ($location !== null) {
+            /* @var \Concrete\Core\Entity\File\StorageLocation\StorageLocation $location */
             $this->set('location', $location);
             $this->set('type', $location->getTypeObject());
         } else {
@@ -60,93 +58,92 @@ class Storage extends DashboardPageController
         }
     }
 
+    /**
+     * @return \Concrete\Core\Entity\File\StorageLocation\Type\Type|null
+     */
     protected function validateStorageRequest()
     {
-        $request = \Request::getInstance();
-        $val = Loader::helper('validation/strings');
-        $type = Type::getByID($request->get('fslTypeID'));
-
-        if (!is_object($type)) {
+        $val = $this->app->make('helper/validation/strings');
+        $type = Type::getByID($this->request->get('fslTypeID'));
+        if ($type === null) {
             $this->error->add(t('Invalid type object.'));
         } else {
-            $e = $type->getConfigurationObject()->validateRequest($request);
+            $e = $type->getConfigurationObject()->validateRequest($this->request);
             if (is_object($e)) {
                 $this->error->add($e);
             }
         }
-
-        if (!$val->notempty($request->request->get('fslName'))) {
+        if (!$val->notempty($this->request->request->get('fslName'))) {
             $this->error->add(t('Your file storage location must have a name.'));
         }
 
-        return [$request, $type];
+        return $type;
     }
 
     public function update()
     {
-        list($request, $type) = $this->validateStorageRequest();
+        $type = $this->validateStorageRequest();
+        $post = $this->request->request;
 
-        $fsl = FileStorageLocation::getByID($request->request->get('fslID'));
-        if (!Loader::helper('validation/token')->validate('update')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
+        $fslID = $post->get('fslID');
+        $fsl = $fslID ? $this->app->make(StorageLocationFactory::class)->fetchByID($fslID) : null;
+        /* @var \Concrete\Core\Entity\File\StorageLocation\StorageLocation|null $fsl */
+        if (!$this->token->validate('update')) {
+            $this->error->add($this->token->getErrorMessage());
         }
-        if (!is_object($fsl)) {
+        if ($fsl === null) {
             $this->error->add(t('Invalid file storage location object.'));
         }
         if (!$this->error->has()) {
             $configuration = $type->getConfigurationObject();
-            $configuration->loadFromRequest($request);
-            $fsl->setName($request->request->get('fslName'));
+            $configuration->loadFromRequest($this->request);
+            $fsl->setName($post->get('fslName'));
             if (!$fsl->isDefault()) {
-                $fsl->setIsDefault($request->request->get('fslIsDefault'));
+                $fsl->setIsDefault($post->get('fslIsDefault'));
             }
             $fsl->setConfigurationObject($configuration);
             $fsl->save();
             $this->redirect('/dashboard/system/files/storage', 'storage_location_updated');
         }
-
-        $this->edit($request->request->get('fslID'));
+        $this->edit($fslID);
     }
 
     public function delete()
     {
-        $request = \Request::getInstance();
-
-        if (!Loader::helper('validation/token')->validate('delete')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
+        if (!$this->token->validate('delete')) {
+            $this->error->add($this->token->getErrorMessage());
         }
-        $fsl = FileStorageLocation::getByID($request->request->get('fslID'));
-        if (!is_object($fsl)) {
+        $fslID = $this->request->request->get('fslID');
+        $fsl = $fslID ? $this->app->make(StorageLocationFactory::class)->fetchByID($fslID) : null;
+        /* @var \Concrete\Core\Entity\File\StorageLocation\StorageLocation|null $fsl */
+        if ($fsl === null) {
             $this->error->add(t('Invalid file storage location object.'));
-        }
-        if ($fsl->isDefault()) {
+        } elseif ($fsl->isDefault()) {
             $this->error->add(t('You may not delete the default file storage location.'));
         }
-
         if (!$this->error->has()) {
             $fsl->delete();
             $this->redirect('/dashboard/system/files/storage', 'storage_location_deleted');
         }
-        $this->edit($request->request->get('fslID'));
+        $this->edit($fslID);
     }
 
     public function add()
     {
-        list($request, $type) = $this->validateStorageRequest();
-        if (!Loader::helper('validation/token')->validate('add')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
+        $type = $this->validateStorageRequest();
+        if (!$this->token->validate('add')) {
+            $this->error->add($this->token->getErrorMessage());
         }
         if (!$this->error->has()) {
             $configuration = $type->getConfigurationObject();
-            $configuration->loadFromRequest($request);
-            $fsl = FileStorageLocation::add($configuration,
-                $request->request->get('fslName'),
-                $request->request->get('fslIsDefault')
-            );
-
+            $configuration->loadFromRequest($this->request);
+            $factory = $this->app->make(StorageLocationFactory::class);
+            /* @var StorageLocationFactory $factory */
+            $location = $factory->create($configuration, $this->request->request->get('fslName'));
+            $location->setIsDefault((bool) $this->request->request->get('fslIsDefault'));
+            $location = $factory->persist($location);
             $this->redirect('/dashboard/system/files/storage', 'storage_location_added');
         }
-
         $this->set('type', $type);
     }
 }

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <?php if ($this->controller->getTask() == 'select_type'
     || $this->controller->getTask() == 'add'
@@ -19,29 +19,24 @@
         <div class="ccm-dashboard-header-buttons">
             <form method="post" action="<?=$this->action('delete')?>">
                 <input type="hidden" name="fslID" value="<?=$location->getID()?>" />
-                <?=Loader::helper('validation/token')->output('delete');
-            ?>
+                <?=Loader::helper('validation/token')->output('delete'); ?>
                 <button type="button" class="btn btn-danger" data-action="delete-location"><?=t('Delete Location')?></button>
             </form>
         </div>
 
         <?php
-
         }
     } else {
         $method = 'add';
-    }
-    ?>
+    } ?>
     <form method="post" action="<?=$view->action($method)?>" id="ccm-attribute-key-form">
-        <?=Loader::helper('validation/token')->output($method);
-    ?>
+        <?=Loader::helper('validation/token')->output($method); ?>
         <input type="hidden" name="fslTypeID" value="<?=$type->getID()?>" />
         <?php if (is_object($location)) {
-    ?>
+        ?>
             <input type="hidden" name="fslID" value="<?=$location->getID()?>" />
-        <?php 
-}
-    ?>
+        <?php
+    } ?>
         <fieldset>
             <legend><?=t('Basics')?></legend>
             <div class="form-group">
@@ -52,11 +47,10 @@
                 </div>
             </div>
             <?php if ($fslIsDefault) {
-    $args = array('disabled' => 'disabled');
-} else {
-    $args = array();
-}
-    ?>
+        $args = ['disabled' => 'disabled'];
+    } else {
+        $args = [];
+    } ?>
             <div class="form-group">
                 <label><?=t('Default')?>
                 <div class="radio">
@@ -73,28 +67,25 @@
 
         </fieldset>
         <?php if ($type->hasOptionsForm()) {
-    ?>
+        ?>
         <fieldset>
             <legend><?=t('Options %s Storage Type', $type->getName())?></legend>
-            <?php $type->includeOptionsForm($location);
-    ?>
+            <?php $type->includeOptionsForm($location); ?>
         </fieldset>
-        <?php 
-}
-    ?>
+        <?php
+    } ?>
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
                 <a href="<?=URL::page($c)?>" class="btn pull-left btn-default"><?=t('Back')?></a>
                 <?php if (is_object($location)) {
-    ?>
+        ?>
                     <button type="submit" class="btn btn-primary pull-right"><?=t('Save')?></button>
-                <?php 
-} else {
-    ?>
+                <?php
+    } else {
+        ?>
                     <button type="submit" class="btn btn-primary pull-right"><?=t('Add')?></button>
-                <?php 
-}
-    ?>
+                <?php
+    } ?>
             </div>
         </div>
     </form>
@@ -109,18 +100,17 @@
         });
     })
     </script>
-<?php 
+<?php
 } else {
-    ?>
+        ?>
 
     <h3><?=t('Storage Locations')?></h3>
     <ul class="item-select-list">
     <?php foreach ($locations as $location) {
-    ?>
+            ?>
         <li><a href="<?=$this->action('edit', $location->getID())?>"><i class="fa fa-hdd-o"></i> <?=$location->getDisplayName()?></a></li>
-    <?php 
-}
-    ?>
+    <?php
+        } ?>
     </ul>
 
     <form method="get" action="<?=$view->action('select_type')?>" id="ccm-file-storage-location-type-form">
@@ -137,5 +127,5 @@
         </fieldset>
     </form>
 
-<?php 
-} ?>
+<?php
+    } ?>

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -1,131 +1,136 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 
-<?php if ($this->controller->getTask() == 'select_type'
-    || $this->controller->getTask() == 'add'
-    || $this->controller->getTask() == 'edit'
-    || $this->controller->getTask() == 'update'
-    || $this->controller->getTask() == 'delete') {
-    ?>
+switch ($this->controller->getTask()) {
 
-    <?php
-    if (is_object($location)) {
-        $fslName = $location->getName();
-        $fslIsDefault = $location->isDefault();
-        $method = 'update';
-
-        if (!$fslIsDefault && $type->getHandle() != 'default') {
-            ?>
-
-        <div class="ccm-dashboard-header-buttons">
-            <form method="post" action="<?=$this->action('delete')?>">
-                <input type="hidden" name="fslID" value="<?=$location->getID()?>" />
-                <?=Loader::helper('validation/token')->output('delete'); ?>
-                <button type="button" class="btn btn-danger" data-action="delete-location"><?=t('Delete Location')?></button>
-            </form>
-        </div>
-
-        <?php
+    case 'select_type':
+    case 'add':
+    case 'edit':
+    case 'update':
+    case 'delete':
+        if (!isset($location) || !is_object($location)) {
+            $location = null;
         }
-    } else {
-        $method = 'add';
-    } ?>
-    <form method="post" action="<?=$view->action($method)?>" id="ccm-attribute-key-form">
-        <?=Loader::helper('validation/token')->output($method); ?>
-        <input type="hidden" name="fslTypeID" value="<?=$type->getID()?>" />
-        <?php if (is_object($location)) {
-        ?>
-            <input type="hidden" name="fslID" value="<?=$location->getID()?>" />
-        <?php
-    } ?>
-        <fieldset>
-            <legend><?=t('Basics')?></legend>
-            <div class="form-group">
-                <?=$form->label('fslName', t('Name'))?>
-                <div class="input-group">
-                    <?=$form->text('fslName', $fslName)?>
-                    <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+        if ($location !== null) {
+            $fslName = $location->getName();
+            $fslIsDefault = $location->isDefault();
+            $method = 'update';
+            if (!$fslIsDefault && $type->getHandle() != 'default') {
+                ?>
+                <div class="ccm-dashboard-header-buttons">
+                    <form method="post" action="<?= $this->action('delete') ?>">
+                        <input type="hidden" name="fslID" value="<?= $location->getID() ?>" />
+                        <?= Loader::helper('validation/token')->output('delete') ?>
+                        <button type="button" class="btn btn-danger" data-action="delete-location"><?= t('Delete Location') ?></button>
+                    </form>
                 </div>
-            </div>
-            <?php if ($fslIsDefault) {
-        $args = ['disabled' => 'disabled'];
-    } else {
-        $args = [];
-    } ?>
-            <div class="form-group">
-                <label><?=t('Default')?>
-                <div class="radio">
-                    <label><?=$form->radio('fslIsDefault', 1, $fslIsDefault, $args)?>
-                        <?=t('Yes, make this the default storage location for new files.')?>
-                    </label>
-                </div>
-                <div class="radio">
-                    <label><?=$form->radio('fslIsDefault', 0, $fslIsDefault, $args)?>
-                        <?=t('No, this is not the default storage location.')?>
-                    </label>
-                </div>
-            </div>
-
-        </fieldset>
-        <?php if ($type->hasOptionsForm()) {
-        ?>
-        <fieldset>
-            <legend><?=t('Options %s Storage Type', $type->getName())?></legend>
-            <?php $type->includeOptionsForm($location); ?>
-        </fieldset>
-        <?php
-    } ?>
-        <div class="ccm-dashboard-form-actions-wrapper">
-            <div class="ccm-dashboard-form-actions">
-                <a href="<?=URL::page($c)?>" class="btn pull-left btn-default"><?=t('Back')?></a>
-                <?php if (is_object($location)) {
-        ?>
-                    <button type="submit" class="btn btn-primary pull-right"><?=t('Save')?></button>
                 <?php
-    } else {
-        ?>
-                    <button type="submit" class="btn btn-primary pull-right"><?=t('Add')?></button>
-                <?php
-    } ?>
-            </div>
-        </div>
-    </form>
-
-    <script type="text/javascript">
-    $(function() {
-        $('button[data-action=delete-location]').on('click', function(e) {
-            e.preventDefault();
-            if (confirm('<?=t('Delete this storage location? All files using it will have their storage location reset to the default.')?>')) {
-                $(this).closest('form').submit();
             }
-        });
-    })
-    </script>
-<?php
-} else {
+        } else {
+            $fslName = '';
+            $fslIsDefault = false;
+            $method = 'add';
+        }
         ?>
-
-    <h3><?=t('Storage Locations')?></h3>
-    <ul class="item-select-list">
-    <?php foreach ($locations as $location) {
+        <form method="post" action="<?= $view->action($method) ?>" id="ccm-attribute-key-form">
+            <?= Loader::helper('validation/token')->output($method) ?>
+            <input type="hidden" name="fslTypeID" value="<?= $type->getID() ?>" />
+            <?php
+            if ($location !== null) {
+                ?><input type="hidden" name="fslID" value="<?= $location->getID() ?>" /><?php
+            }
             ?>
-        <li><a href="<?=$this->action('edit', $location->getID())?>"><i class="fa fa-hdd-o"></i> <?=$location->getDisplayName()?></a></li>
-    <?php
-        } ?>
-    </ul>
-
-    <form method="get" action="<?=$view->action('select_type')?>" id="ccm-file-storage-location-type-form">
-        <fieldset>
-
-            <legend><?=t('Add Location')?></legend>
-            <label for="atID"><?=t('Choose Type')?></label>
-            <div class="form-inline">
+            <fieldset>
+                <legend><?= t('Basics') ?></legend>
                 <div class="form-group">
-                    <?=$form->select('fslTypeID', $types)?>
+                    <?= $form->label('fslName', t('Name')) ?>
+                    <div class="input-group">
+                        <?= $form->text('fslName', $fslName) ?>
+                        <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+                    </div>
                 </div>
-                <button type="submit" class="btn btn-default"><?=t('Go')?></button>
+                <?php
+                if ($fslIsDefault) {
+                    $args = ['disabled' => 'disabled'];
+                } else {
+                    $args = [];
+                }
+                ?>
+                <div class="form-group">
+                    <label><?= t('Default') ?></label>
+                    <div class="radio">
+                        <label>
+                            <?= $form->radio('fslIsDefault', 1, $fslIsDefault, $args) ?>
+                            <?= t('Yes, make this the default storage location for new files.') ?>
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <?= $form->radio('fslIsDefault', 0, $fslIsDefault, $args) ?>
+                            <?= t('No, this is not the default storage location.') ?>
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+            <?php
+            if ($type->hasOptionsForm()) {
+                ?>
+                <fieldset>
+                    <legend><?= t('Options %s Storage Type', $type->getName()) ?></legend>
+                    <?php $type->includeOptionsForm($location) ?>
+                </fieldset>
+                <?php
+            }
+            ?>
+            <div class="ccm-dashboard-form-actions-wrapper">
+                <div class="ccm-dashboard-form-actions">
+                    <a href="<?= URL::page($c) ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
+                    <?php
+                    if ($location !== null) {
+                        ?><button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button><?php
+                    } else {
+                        ?><button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button><?php
+                    }
+                    ?>
+                </div>
             </div>
-        </fieldset>
-    </form>
+        </form>
+        <script>
+            $(function() {
+                $('button[data-action=delete-location]').on('click', function(e) {
+                    e.preventDefault();
+                    if (confirm(<?= json_encode(t('Delete this storage location? All files using it will have their storage location reset to the default.')) ?>)) {
+                        $(this).closest('form').submit();
+                    }
+                });
+            });
+        </script>
+        <?php
+        break;
 
-<?php
-    } ?>
+    default:
+        ?>
+        <h3><?= t('Storage Locations') ?></h3>
+        <ul class="item-select-list">
+            <?php
+            foreach ($locations as $location) {
+                ?><li><a href="<?= $this->action('edit', $location->getID()) ?>"><i class="fa fa-hdd-o"></i> <?= $location->getDisplayName() ?></a></li><?php
+            }
+            ?>
+        </ul>
+        <form method="get" action="<?= $view->action('select_type') ?>" id="ccm-file-storage-location-type-form">
+            <fieldset>
+                <legend><?= t('Add Location') ?></legend>
+                <label for="atID"><?= t('Choose Type') ?></label>
+                <div class="form-inline">
+                    <div class="form-group">
+                        <?= $form->select('fslTypeID', $types) ?>
+                    </div>
+                    <button type="submit" class="btn btn-default"><?= t('Go') ?></button>
+                </div>
+            </fieldset>
+        </form>
+        <?php
+        break;
+
+}

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -1,26 +1,34 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
 
-switch ($this->controller->getTask()) {
+/* @var Concrete\Controller\SinglePage\Dashboard\System\Files\Storage $controller */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Page\Page $c */
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+
+switch ($controller->getTask()) {
 
     case 'select_type':
     case 'add':
     case 'edit':
     case 'update':
     case 'delete':
+        /* @var Concrete\Core\Entity\File\StorageLocation\Type\Type $type */
         if (!isset($location) || !is_object($location)) {
             $location = null;
         }
         if ($location !== null) {
+            /* @var Concrete\Core\Entity\File\StorageLocation\StorageLocation $location */
             $fslName = $location->getName();
             $fslIsDefault = $location->isDefault();
             $method = 'update';
             if (!$fslIsDefault && $type->getHandle() != 'default') {
                 ?>
                 <div class="ccm-dashboard-header-buttons">
-                    <form method="post" action="<?= $this->action('delete') ?>">
+                    <form method="post" action="<?= $view->action('delete') ?>">
                         <input type="hidden" name="fslID" value="<?= $location->getID() ?>" />
-                        <?= Loader::helper('validation/token')->output('delete') ?>
+                        <?= $token->output('delete') ?>
                         <button type="button" class="btn btn-danger" data-action="delete-location"><?= t('Delete Location') ?></button>
                     </form>
                 </div>
@@ -33,7 +41,7 @@ switch ($this->controller->getTask()) {
         }
         ?>
         <form method="post" action="<?= $view->action($method) ?>" id="ccm-attribute-key-form">
-            <?= Loader::helper('validation/token')->output($method) ?>
+            <?= $token->output($method) ?>
             <input type="hidden" name="fslTypeID" value="<?= $type->getID() ?>" />
             <?php
             if ($location !== null) {
@@ -84,7 +92,7 @@ switch ($this->controller->getTask()) {
             ?>
             <div class="ccm-dashboard-form-actions-wrapper">
                 <div class="ccm-dashboard-form-actions">
-                    <a href="<?= URL::page($c) ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
+                    <a href="<?= URL::to($c) ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
                     <?php
                     if ($location !== null) {
                         ?><button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button><?php
@@ -114,7 +122,7 @@ switch ($this->controller->getTask()) {
         <ul class="item-select-list">
             <?php
             foreach ($locations as $location) {
-                ?><li><a href="<?= $this->action('edit', $location->getID()) ?>"><i class="fa fa-hdd-o"></i> <?= $location->getDisplayName() ?></a></li><?php
+                ?><li><a href="<?= $view->action('edit', $location->getID()) ?>"><i class="fa fa-hdd-o"></i> <?= $location->getDisplayName() ?></a></li><?php
             }
             ?>
         </ul>

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -8,7 +8,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Validation\CSRF\Token $token */
 
 switch ($controller->getTask()) {
-
     case 'select_type':
     case 'add':
     case 'edit':
@@ -140,5 +139,4 @@ switch ($controller->getTask()) {
         </form>
         <?php
         break;
-
 }

--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -89,7 +89,7 @@ class StorageLocation implements StorageLocationInterface
      */
     public function setIsDefault($fslIsDefault)
     {
-        $this->fslIsDefault = $fslIsDefault;
+        $this->fslIsDefault = (bool) $fslIsDefault;
     }
 
     /**

--- a/concrete/src/File/StorageLocation/StorageLocationFactory.php
+++ b/concrete/src/File/StorageLocation/StorageLocationFactory.php
@@ -46,7 +46,13 @@ class StorageLocationFactory
     public function persist(StorageLocationEntity $storageLocation)
     {
         return $this->entityManager->transactional(function (EntityManagerInterface $em) use ($storageLocation) {
-            $em->createQueryBuilder()->update(StorageLocationEntity::class, 'l')->set('fslIsDefault', false);
+            if ($storageLocation->isDefault()) {
+                $qb = $em->createQueryBuilder()->update(StorageLocationEntity::class, 'l')->set('l.fslIsDefault', 0);
+                if ($storageLocation->getID()) {
+                    $qb->andWhere('l.fslID <> :id')->setParameter('id', $storageLocation->getID());
+                }
+                $qb->getQuery()->execute();
+            }
             $em->persist($storageLocation);
 
             return $storageLocation;


### PR DESCRIPTION
When we adding a new Storage Location that's set as as the default one, we currently end up having two default storage locations in the database.

Let's fix this.

I also fixed an HTML error (an unclosed `<label>` tag) and some warnings about accessing undefined variables in the view of dashboard/system/files/storage