### PR TITLE
Removed unused parameter in CookieMiddleware

### DIFF
--- a/concrete/src/Http/Middleware/CookieMiddleware.php
+++ b/concrete/src/Http/Middleware/CookieMiddleware.php
@@ -43,7 +43,7 @@ class CookieMiddleware implements MiddlewareInterface
 
         $cookies = $this->cookies->getCookies();
         foreach ($cookies as $cookie) {
-            $response->headers->setCookie($cookie, DIR_REL . '/');
+            $response->headers->setCookie($cookie);
         }
 
         return $response;


### PR DESCRIPTION
The [`setCookie` method of Symfony `ResponseHeaderBag`](https://github.com/symfony/http-foundation/blob/v3.3.2/ResponseHeaderBag.php#L182) accepts only one parameter (a `Cookie` instance), and not its path (the path is defined by the cookie instance itself).
Let's avoid passing an unused second parameter.