### PR TITLE
Getting rid of an Ajax call in the core styles CKeditor plugin

### DIFF
--- a/concrete/js/ckeditor4/core/concrete5styles/plugin.js
+++ b/concrete/js/ckeditor4/core/concrete5styles/plugin.js
@@ -1,18 +1,21 @@
-(function () {
+(function() {
+
     CKEDITOR.plugins.add('concrete5styles', {
+
         requires: ['widget', 'stylescombo', 'menubutton'],
-        init: function (editor) {
+
+        init: function(editor) {
 
         },
 
-        afterInit: function (editor) {
+        afterInit: function(editor) {
             var plugin = this;
             /**
              * Function taken largely from the htmlbuttons plugin
              */
             function createCommand(definition) {
                 return {
-                    exec: function (editor) {
+                    exec: function(editor) {
                         var strToLook = '> </',
                             code = definition.html;
 
@@ -24,7 +27,8 @@
                             // Build list of block elements to be replaced
                             var blockElems = ['address', 'article', 'aside', 'audio', 'blockquote', 'canvas', 'dd', 'div', 'dl', 'fieldset',
                                 'figcaption', 'figure', 'figcaption', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup',
-                                'hr', 'noscript', 'ol', 'output', 'p', 'pre', 'section', 'span', 'table', 'tfoot', 'ul', 'video'];
+                                'hr', 'noscript', 'ol', 'output', 'p', 'pre', 'section', 'span', 'table', 'tfoot', 'ul', 'video'
+                            ];
 
                             // Get HTML and Text from selection
                             var ranges = sel.getRanges();
@@ -77,14 +81,16 @@
                     };
 
                 }
+
                 editor.addMenuGroup(definition.name, 1);
+
                 editor.addMenuItems(items);
 
                 editor.ui.add(definition.name, CKEDITOR.UI_MENUBUTTON, {
                     label: definition.title,
                     icon: plugin.path + '/icons/' + definition.icon,
                     toolbar: definition.toolbar || 'insert',
-                    onMenu: function () {
+                    onMenu: function() {
                         var activeItems = {};
 
                         for (var item in items)
@@ -95,77 +101,58 @@
                 });
             }
 
-            /**
-             * async is set to false in order to make sure that we load our snippets prior to the toolbar menu getting created
-             * otherwise the button never shows up
-             */
-            $.ajax({
-                'type': 'get',
-                /*
-                'async': false,
-                // Note - do we really need this? It introduces massive slowdown when
-                // multiple editors are used at once.
-                */
-                'dataType': 'json',
-                'url': CCM_DISPATCHER_FILENAME + '/ccm/system/backend/editor_data',
-                'data': {
-                    'ccm_token': CCM_EDITOR_SECURITY_TOKEN,
-                    'cID': CCM_CID
-                },
-
-                success: function (response) {
-                    var buttons = {
-                        name: 'snippets',
-                        icon: 'snippet.png',
-                        title: 'Snippets',
-                        items: []
-                    };
-                    $.each(response.snippets, function (i, snippet) {
-                        editor.widgets.add(snippet.scsHandle, {
-                            template: snippet.scsName
-                        });
-                        var button = {};
-                        button.name = snippet.scsHandle;
-                        button.icon = 'snippet.png';
-                        button.title = snippet.scsName;
-                        button.html =
-                            '<span class="ccm-content-editor-snippet" contenteditable="false" data-scsHandle="' + snippet.scsHandle + '">' +
-                            snippet.scsName +
-                            '</span>';
-                        buttons.items.push(button);
+            var buttons = {
+                name: 'snippets',
+                icon: 'snippet.png',
+                title: 'Snippets',
+                items: []
+            };
+            if (editor.config.snippets) {
+                $.each(editor.config.snippets, function(i, snippet) {
+                    editor.widgets.add(snippet.scsHandle, {
+                        template: snippet.scsName
                     });
-                    createMenuButton(buttons);
-
-                    var additionalStyles = [];
-                    $.each(response.classes, function () {
-                        var style = {};
-                        style.name = this.title;
-                        if (typeof this.element !== 'undefined') {
-                            style.element = this.element;
-                        } else if (typeof this.forceBlock !== 'undefined' && this.forceBlock == 1) {
-                            style.element = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'];
-                        } else {
-                            style.element = 'span';
-                        }
-                        if (typeof this.spanClass !== 'undefined') {
-                            style.attributes = {'class': this.spanClass};
-                        }
-                        if (typeof this.attributes !== 'undefined') {
-                            style.attributes = this.attributes;
-                        }
-                        if (typeof this.styles !== 'undefined') {
-                            style.styles = this.styles;
-                        }
-                        if (this.type === 'widget' && typeof this.widget !== 'undefined') {
-                            style.type = 'widget';
-                            style.widget = this.widget;
-                        }
-                        additionalStyles.push(style);
-                    });
-                    editor.fire('stylesSet', {styles: additionalStyles});
-                }
-            });
-
+                    var button = {};
+                    button.name = snippet.scsHandle;
+                    button.icon = 'snippet.png';
+                    button.title = snippet.scsName;
+                    button.html =
+                        '<span class="ccm-content-editor-snippet" contenteditable="false" data-scsHandle="' + snippet.scsHandle + '">' +
+                        snippet.scsName +
+                        '</span>';
+                    buttons.items.push(button);
+                });
+                createMenuButton(buttons, buttons.name);
+            }
+            if (editor.config.classes) {
+                var additionalStyles = [];
+                $.each(editor.config.classes, function() {
+                    var style = {};
+                    style.name = this.title;
+                    if (typeof this.element !== 'undefined') {
+                        style.element = this.element;
+                    } else if (typeof this.forceBlock !== 'undefined' && this.forceBlock == 1) {
+                        style.element = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'];
+                    } else {
+                        style.element = 'span';
+                    }
+                    if (typeof this.spanClass !== 'undefined') {
+                        style.attributes = { 'class': this.spanClass };
+                    }
+                    if (typeof this.attributes !== 'undefined') {
+                        style.attributes = this.attributes;
+                    }
+                    if (typeof this.styles !== 'undefined') {
+                        style.styles = this.styles;
+                    }
+                    if (this.type === 'widget' && typeof this.widget !== 'undefined') {
+                        style.type = 'widget';
+                        style.widget = this.widget;
+                    }
+                    additionalStyles.push(style);
+                });
+                editor.fire('stylesSet', { styles: additionalStyles });
+            }
         }
     });
 })();


### PR DESCRIPTION
After you removed the async: false setting from the Ajax call, the snippets button couldn't be added to CKeditor's toolbar making snippets unusable.

This pull request gets all our snippets and custom classes while preparing all our editor's data and then sends it to the editor along with all the other config variables.

No more Ajax call and the editor loads way faster