### PR TITLE
Uninstall packaged geolocation libraries

### DIFF
--- a/concrete/src/Package/ItemCategory/GeolocatorLibrary.php
+++ b/concrete/src/Package/ItemCategory/GeolocatorLibrary.php
@@ -28,4 +28,14 @@ class GeolocatorLibrary extends AbstractCategory
 
         return $repo->findBy(['glPackage' => $package]);
     }
+
+    public function removeItem($item)
+    {
+        if ($item instanceof Geolocator && $item->getGeolocatorID() !== null) {
+            $app = Application::getFacadeApplication();
+            $em = $app->make(EntityManagerInterface::class);
+            $em->remove($item);
+            $em->flush($item);
+        }
+    }
 }


### PR DESCRIPTION
I forgot to add the procedure to automatically uninstall geolocation libraries when they are part of packages and when these packages are uninstalled.