### PR TITLE
Fixes duplicating a duplicated file in a folder

### DIFF
--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -517,7 +517,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface
 
         $folder = $this->getFileFolderObject();
         $folderNode = \Concrete\Core\Tree\Node\Type\File::add($nf, $folder);
-        $nf->folderTreeNodeID = $folderNode->getTreeNodeID();
+        $nf->folderTreeNodeID = $folder->getTreeNodeID();
 
         $em->persist($nf);
         $em->flush();

--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -503,7 +503,8 @@ class File implements \Concrete\Core\Permission\ObjectInterface
     {
         $db = Loader::db();
         $em = \ORM::entityManager();
-
+        
+        $thumbs = Type::getVersionList();
         $versions = $this->versions;
 
         // duplicate the core file object
@@ -548,16 +549,10 @@ class File implements \Concrete\Core\Permission\ObjectInterface
 
                 $em->flush();
 
-                do {
-                    $prefix = $importer->generatePrefix();
-                    $path = $cf->prefix($prefix, $version->getFilename());
-                } while ($filesystem->has($path));
-                $filesystem->write($path, $version->getFileResource()->read(), [
-                    'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
-                    'mimetype' => Core::make('helper/mime')->mimeFromExtension($fi->getExtension($version->getFilename())),
-                ]);
-                $cloneVersion->updateFile($version->getFilename(), $prefix);
                 $nf->versions->add($cloneVersion);
+                foreach ($thumbs as $type) {
+                    $cloneVersion->duplicateUnderlyingThumbnailFiles($type, $version);
+                }
             }
         }
 

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -367,7 +367,32 @@ class Version implements ObjectInterface
             $fsl->delete($path);
         }
     }
-
+    
+     /**
+     * Copy the thumbnails from the original to the copy when duplicating a file.
+     *
+     * @param string          $type
+     * @param Version $source
+     */
+    public function duplicateUnderlyingThumbnailFiles($type, Version $source)
+    {
+        if (!($type instanceof ThumbnailTypeVersion)) {
+            $type = ThumbnailTypeVersion::getByHandle($type);
+        }
+        $new = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+        $current = $source->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+        $newPath = $type->getFilePath($this);
+        $currentPath = $type->getFilePath($source);
+        $manager = new \League\Flysystem\MountManager([
+            'current' => $current,
+            'new' => $new,
+        ]);
+        try {
+            $manager->copy('current://' . $currentPath, 'new://' . $newPath);
+        } catch (FileNotFoundException $e) {
+        }
+    }
+    
     /**
      * Move the thumbnails for the current file version to a new storage location.
      *


### PR DESCRIPTION
When a file is inside a folder and is duplicated and the copy duplicated again, the second copy doesn't appear anywhere.

This problem first appeared in #5875 

It is sent to a non-existent folder. This fixes it.

It also makes sure thumbnails get duplicated as well.

Sorry for the double duty on this one, it was an accident.