### PR TITLE
Fixes duplicating a duplicated file in a folder

### DIFF
--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -517,7 +517,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface
 
         $folder = $this->getFileFolderObject();
         $folderNode = \Concrete\Core\Tree\Node\Type\File::add($nf, $folder);
-        $nf->folderTreeNodeID = $folderNode->getTreeNodeID();
+        $nf->folderTreeNodeID = $folder->getTreeNodeID();
 
         $em->persist($nf);
         $em->flush();


### PR DESCRIPTION
When a file is inside a folder and is duplicated and the copy duplicated again, the second copy doesn't appear anywhere.

This problem first appeared in #5875

It is sent to a non-existent folder. This fixes it.