### PR TITLE
Copy thumbs on duplicate

### DIFF
--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -505,7 +505,8 @@ class File implements \Concrete\Core\Permission\ObjectInterface
         $em = \ORM::entityManager();
 
         $versions = $this->versions;
-
+        $thumbs = Type::getVersionList();
+        
         // duplicate the core file object
         $nf = clone $this;
         $dh = Loader::helper('date');
@@ -558,6 +559,9 @@ class File implements \Concrete\Core\Permission\ObjectInterface
                 ]);
                 $cloneVersion->updateFile($version->getFilename(), $prefix);
                 $nf->versions->add($cloneVersion);
+                foreach ($thumbs as $type) {
+                    $cloneVersion->duplicateUnderlyingThumbnailFiles($type, $version);
+                }
             }
         }
 

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -369,6 +369,31 @@ class Version implements ObjectInterface
     }
 
     /**
+     * Copy the thumbnails from the original to the copy when duplicating a file.
+     *
+     * @param string          $type
+     * @param Version $source
+     */
+    public function duplicateUnderlyingThumbnailFiles($type, Version $source)
+    {
+        if (!($type instanceof ThumbnailTypeVersion)) {
+            $type = ThumbnailTypeVersion::getByHandle($type);
+        }
+        $new = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+        $current = $source->getFile()->getFileStorageLocationObject()->getFileSystemObject();
+        $newPath = $type->getFilePath($this);
+        $currentPath = $type->getFilePath($source);
+        $manager = new \League\Flysystem\MountManager([
+            'current' => $current,
+            'new' => $new,
+        ]);
+        try {
+            $manager->copy('current://' . $currentPath, 'new://' . $newPath);
+        } catch (FileNotFoundException $e) {
+        }
+    }
+    
+    /**
      * Move the thumbnails for the current file version to a new storage location.
      *
      * @param string          $type


### PR DESCRIPTION
When duplicating a file, thumbnails don't get duplicated and the file ends up with no thumb in the manager.

This takes care of that issue by copying the thumbnails as well (since we're duplicating, no need to recreate the thumbs, a simple copy should do it)