### PR TITLE
Avoid accessing cPointerID property of Page object if it's not defined

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1418,7 +1418,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function getCollectionPointerID()
     {
-        return $this->cPointerID;
+        return isset($this->cPointerID) ? (int) $this->cPointerID : 0;
     }
 
     /**
@@ -1448,7 +1448,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function isAlias()
     {
-        return $this->cPointerID > 0 || $this->cPointerExternalLink != null;
+        return $this->getCollectionPointerID() > 0 || $this->cPointerExternalLink != null;
     }
 
     /**
@@ -2422,7 +2422,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $siteTreeID = is_object($site) ? $site->getSiteTreeID() : \Core::make('site')->getSite()->getSiteTreeID();
         }
 
-        $v = [$newCID, $siteTreeID, $this->getPageTypeID(), $cParentID, $uID, $this->overrideTemplatePermissions(), (int) $this->getPermissionsCollectionID(), $this->getCollectionInheritance(), $this->cFilename, $this->cPointerID, $this->cPointerExternalLink, $this->cPointerExternalLinkNewWindow, $this->cDisplayOrder, $this->pkgID];
+        $v = [$newCID, $siteTreeID, $this->getPageTypeID(), $cParentID, $uID, $this->overrideTemplatePermissions(), (int) $this->getPermissionsCollectionID(), $this->getCollectionInheritance(), $this->cFilename, $this->getCollectionPointerID(), $this->cPointerExternalLink, $this->cPointerExternalLinkNewWindow, $this->cDisplayOrder, $this->pkgID];
         $q = 'insert into Pages (cID, siteTreeID, ptID, cParentID, uID, cOverrideTemplatePermissions, cInheritPermissionsFromCID, cInheritPermissionsFrom, cFilename, cPointerID, cPointerExternalLink, cPointerExternalLinkNewWindow, cDisplayOrder, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
         $res = $db->executeQuery($q, $v);
 


### PR DESCRIPTION
This should fix this error (see https://travis-ci.org/concrete5/concrete5/jobs/269569618):
```
PageTest::testSinglePagesPath
Whoops\Exception\ErrorException: Undefined property: Concrete\Core\Page\Page::$cPointerID
/home/travis/build/concrete5/concrete5/concrete/src/Page/Page.php:1451
/home/travis/build/concrete5/concrete5/concrete/src/Page/Page.php:2500
/home/travis/build/concrete5/concrete5/tests/tests/Core/Page/PageTest.php:86
```