### PR TITLE
Remove old config dependency and update to use the latest version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -400,16 +400,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
-                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
                 "shasum": ""
             },
             "require": {
@@ -466,7 +466,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2017-07-22T12:49:21+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -609,16 +609,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.12",
+            "version": "v2.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44"
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/7b9e911f9d8b30d43b96853dab26898c710d8f44",
-                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/729340d8d1eec8f01bff708e12e449a3415af873",
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
                 "shasum": ""
             },
             "require": {
@@ -676,7 +676,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08T12:53:47+00:00"
+            "time": "2017-07-22T20:44:48+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -929,23 +929,23 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.6",
+            "version": "v2.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b"
+                "reference": "c78afd51721804f4f76ff30d9b6f6159eb046161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/e6c434196c8ef058239aaa0724b4aadb0107940b",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/c78afd51721804f4f76ff30d9b6f6159eb046161",
+                "reference": "c78afd51721804f4f76ff30d9b6f6159eb046161",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "~1.4",
                 "doctrine/collections": "~1.2",
-                "doctrine/common": ">=2.5-dev,<2.8-dev",
-                "doctrine/dbal": ">=2.5-dev,<2.6-dev",
+                "doctrine/common": ">=2.5-dev,<2.9-dev",
+                "doctrine/dbal": ">=2.5-dev,<2.7-dev",
                 "doctrine/instantiator": "~1.0.1",
                 "ext-pdo": "*",
                 "php": ">=5.4",
@@ -1001,7 +1001,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18T15:42:34+00:00"
+            "time": "2017-08-18T19:17:35+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1057,16 +1057,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.1.9",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "b238974e1c7cc1859b0c16ddc1c02ecb70ecc07f"
+                "reference": "ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/b238974e1c7cc1859b0c16ddc1c02ecb70ecc07f",
-                "reference": "b238974e1c7cc1859b0c16ddc1c02ecb70ecc07f",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec",
+                "reference": "ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec",
                 "shasum": ""
             },
             "require": {
@@ -1114,7 +1114,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2017-06-03T18:33:07+00:00"
+            "time": "2017-08-03T18:23:40+00:00"
         },
         {
             "name": "gettext/gettext",
@@ -1327,33 +1327,33 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v4.2.17",
-            "target-dir": "Illuminate/Config",
+            "version": "v5.2.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
-                "reference": "24b9e07a7c0245eb25574688bef49f873b904385"
+                "reference": "2db869c5b5a675cece410a0d0bc634dba0f69998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/config/zipball/24b9e07a7c0245eb25574688bef49f873b904385",
-                "reference": "24b9e07a7c0245eb25574688bef49f873b904385",
+                "url": "https://api.github.com/repos/illuminate/config/zipball/2db869c5b5a675cece410a0d0bc634dba0f69998",
+                "reference": "2db869c5b5a675cece410a0d0bc634dba0f69998",
                 "shasum": ""
             },
             "require": {
-                "illuminate/filesystem": "4.2.*",
-                "illuminate/support": "4.2.*",
-                "php": ">=5.4.0"
+                "illuminate/contracts": "5.2.*",
+                "illuminate/filesystem": "5.2.*",
+                "illuminate/support": "5.2.*",
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Illuminate\\Config": ""
+                "psr-4": {
+                    "Illuminate\\Config\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1363,10 +1363,12 @@
             "authors": [
                 {
                     "name": "Taylor Otwell",
-                    "email": "taylorotwell@gmail.com"
+                    "email": "taylor@laravel.com"
                 }
             ],
-            "time": "2014-11-15T19:22:33+00:00"
+            "description": "The Illuminate Config package.",
+            "homepage": "http://laravel.com",
+            "time": "2016-08-01T13:49:14+00:00"
         },
         {
             "name": "illuminate/container",
@@ -1455,33 +1457,38 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v4.2.17",
-            "target-dir": "Illuminate/Filesystem",
+            "version": "v5.2.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "9127fb58eb6b721d98d2f7077df6cb8004da24c0"
+                "reference": "39668a50e0cf1d673e58e7dbb437475708cfb508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/9127fb58eb6b721d98d2f7077df6cb8004da24c0",
-                "reference": "9127fb58eb6b721d98d2f7077df6cb8004da24c0",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/39668a50e0cf1d673e58e7dbb437475708cfb508",
+                "reference": "39668a50e0cf1d673e58e7dbb437475708cfb508",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "4.2.*",
-                "php": ">=5.4.0",
-                "symfony/finder": "2.5.*"
+                "illuminate/contracts": "5.2.*",
+                "illuminate/support": "5.2.*",
+                "php": ">=5.5.9",
+                "symfony/finder": "2.8.*|3.0.*"
+            },
+            "suggest": {
+                "league/flysystem": "Required to use the Flysystem local and FTP drivers (~1.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+                "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Illuminate\\Filesystem": ""
+                "psr-4": {
+                    "Illuminate\\Filesystem\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1491,45 +1498,53 @@
             "authors": [
                 {
                     "name": "Taylor Otwell",
-                    "email": "taylorotwell@gmail.com"
+                    "email": "taylor@laravel.com"
                 }
             ],
-            "time": "2014-12-29T18:11:33+00:00"
+            "description": "The Illuminate Filesystem package.",
+            "homepage": "http://laravel.com",
+            "time": "2016-08-17T17:21:29+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v4.2.17",
-            "target-dir": "Illuminate/Support",
+            "version": "v5.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "db61f3f6d507ce417ca993e1f93585db7efd8b12"
+                "reference": "6749fab3f3d38d8b15427536a8e7bbdc57497c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/db61f3f6d507ce417ca993e1f93585db7efd8b12",
-                "reference": "db61f3f6d507ce417ca993e1f93585db7efd8b12",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/6749fab3f3d38d8b15427536a8e7bbdc57497c9e",
+                "reference": "6749fab3f3d38d8b15427536a8e7bbdc57497c9e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "doctrine/inflector": "~1.0",
+                "ext-mbstring": "*",
+                "illuminate/contracts": "5.2.*",
+                "php": ">=5.5.9"
             },
-            "require-dev": {
-                "jeremeamia/superclosure": "~1.0.1",
-                "patchwork/utf8": "~1.1"
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
+                "jeremeamia/superclosure": "Required to be able to serialize closures (~2.2).",
+                "paragonie/random_compat": "Provides a compatible interface like PHP7's random_bytes() in PHP 5 projects (~1.1).",
+                "symfony/polyfill-php56": "Required to use the hash_equals function on PHP 5.5 (~1.0).",
+                "symfony/process": "Required to use the composer class (2.8.*|3.0.*).",
+                "symfony/var-dumper": "Improves the dd function (2.8.*|3.0.*)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Illuminate\\Support": ""
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
                 },
                 "files": [
-                    "Illuminate/Support/helpers.php"
+                    "helpers.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1542,7 +1557,9 @@
                     "email": "taylorotwell@gmail.com"
                 }
             ],
-            "time": "2015-01-27T20:51:43+00:00"
+            "description": "The Illuminate Support package.",
+            "homepage": "http://laravel.com",
+            "time": "2016-02-22T20:29:02+00:00"
         },
         {
             "name": "imagine/imagine",
@@ -1603,16 +1620,16 @@
         },
         {
             "name": "league/csv",
-            "version": "8.2.1",
+            "version": "8.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "43fd8b022815a0758d85e925dd92a43fe0d41bb4"
+                "reference": "fa8bc05f64eb6c66b96edfaf60648f022ecb5f55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/43fd8b022815a0758d85e925dd92a43fe0d41bb4",
-                "reference": "43fd8b022815a0758d85e925dd92a43fe0d41bb4",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/fa8bc05f64eb6c66b96edfaf60648f022ecb5f55",
+                "reference": "fa8bc05f64eb6c66b96edfaf60648f022ecb5f55",
                 "shasum": ""
             },
             "require": {
@@ -1656,20 +1673,20 @@
                 "read",
                 "write"
             ],
-            "time": "2017-02-23T08:25:03+00:00"
+            "time": "2017-07-12T07:18:20+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.40",
+            "version": "1.0.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "3828f0b24e2c1918bb362d57a53205d6dc8fde61"
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3828f0b24e2c1918bb362d57a53205d6dc8fde61",
-                "reference": "3828f0b24e2c1918bb362d57a53205d6dc8fde61",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f400aa98912c561ba625ea4065031b7a41e5a155",
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155",
                 "shasum": ""
             },
             "require": {
@@ -1690,13 +1707,13 @@
                 "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
                 "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
                 "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-copy": "Allows you to use Copy.com storage",
                 "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
                 "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
                 "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
                 "league/flysystem-webdav": "Allows you to use WebDAV storage",
                 "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage"
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
             },
             "type": "library",
             "extra": {
@@ -1739,7 +1756,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-04-28T10:15:08+00:00"
+            "time": "2017-08-06T17:41:04+00:00"
         },
         {
             "name": "league/flysystem-cached-adapter",
@@ -1964,16 +1981,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.5.9",
+            "version": "1.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/concrete5-translation-library.git",
-                "reference": "8e8cbbf67718b9ae12b2a0038ed71df5b18658cf"
+                "reference": "43aa3806c36b095d458fe394feea353013f745dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/8e8cbbf67718b9ae12b2a0038ed71df5b18658cf",
-                "reference": "8e8cbbf67718b9ae12b2a0038ed71df5b18658cf",
+                "url": "https://api.github.com/repos/mlocati/concrete5-translation-library/zipball/43aa3806c36b095d458fe394feea353013f745dd",
+                "reference": "43aa3806c36b095d458fe394feea353013f745dd",
                 "shasum": ""
             },
             "require": {
@@ -2010,7 +2027,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2017-06-29T20:54:30+00:00"
+            "time": "2017-08-25T05:44:27+00:00"
         },
         {
             "name": "mlocati/ip-lib",
@@ -2065,16 +2082,16 @@
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "2.8.25",
+            "version": "2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "f0896b5c7274d1450023b0b376240be902c3251c"
+                "reference": "a0ed86c9d7c04ae27fa6418b55e3beb04dfe3297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/f0896b5c7274d1450023b0b376240be902c3251c",
-                "reference": "f0896b5c7274d1450023b0b376240be902c3251c",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/a0ed86c9d7c04ae27fa6418b55e3beb04dfe3297",
+                "reference": "a0ed86c9d7c04ae27fa6418b55e3beb04dfe3297",
                 "shasum": ""
             },
             "require": {
@@ -2113,7 +2130,7 @@
                 "mobile detector",
                 "php mobile detect"
             ],
-            "time": "2017-03-29T13:59:30+00:00"
+            "time": "2017-08-29T18:23:54+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2534,16 +2551,16 @@
         },
         {
             "name": "primal/color",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrimalPHP/Color.git",
-                "reference": "877e2f7bbf1d27214e8c71ca4b70fdbe19ce4552"
+                "reference": "dca054972fd09cba33f51675878030305b85030a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrimalPHP/Color/zipball/877e2f7bbf1d27214e8c71ca4b70fdbe19ce4552",
-                "reference": "877e2f7bbf1d27214e8c71ca4b70fdbe19ce4552",
+                "url": "https://api.github.com/repos/PrimalPHP/Color/zipball/dca054972fd09cba33f51675878030305b85030a",
+                "reference": "dca054972fd09cba33f51675878030305b85030a",
                 "shasum": ""
             },
             "require": {
@@ -2579,7 +2596,7 @@
             "keywords": [
                 "color"
             ],
-            "time": "2015-12-02T00:07:11+00:00"
+            "time": "2017-07-10T16:28:36+00:00"
         },
         {
             "name": "psr/cache",
@@ -2838,20 +2855,20 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "386a294d621576302e7cc36965d6ed53b8c73c4f"
+                "reference": "9c69968ce57924e9e93550895cd2b0477edf0e19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/386a294d621576302e7cc36965d6ed53b8c73c4f",
-                "reference": "386a294d621576302e7cc36965d6ed53b8c73c4f",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/9c69968ce57924e9e93550895cd2b0477edf0e19",
+                "reference": "9c69968ce57924e9e93550895cd2b0477edf0e19",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/finder": "~2.8|~3.0",
@@ -2890,24 +2907,24 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T09:51:43+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "70d2a29b2911cbdc91a7e268046c395278238b2e"
+                "reference": "d6596cb5022b6a0bd940eae54a1de78646a5fda6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/70d2a29b2911cbdc91a7e268046c395278238b2e",
-                "reference": "70d2a29b2911cbdc91a7e268046c395278238b2e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d6596cb5022b6a0bd940eae54a1de78646a5fda6",
+                "reference": "d6596cb5022b6a0bd940eae54a1de78646a5fda6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
@@ -2920,7 +2937,6 @@
                 "symfony/dependency-injection": "~3.3",
                 "symfony/event-dispatcher": "~2.8|~3.0",
                 "symfony/filesystem": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
@@ -2959,24 +2975,24 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T19:24:58+00:00"
+            "time": "2017-08-27T14:52:21+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e9c50482841ef696e8fa1470d950a79c8921f45d"
+                "reference": "084d804fe35808eb2ef596ec83d85d9768aa6c9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e9c50482841ef696e8fa1470d950a79c8921f45d",
-                "reference": "e9c50482841ef696e8fa1470d950a79c8921f45d",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/084d804fe35808eb2ef596ec83d85d9768aa6c9d",
+                "reference": "084d804fe35808eb2ef596ec83d85d9768aa6c9d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/log": "~1.0"
             },
             "conflict": {
@@ -3015,24 +3031,24 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T21:01:25+00:00"
+            "time": "2017-08-27T14:52:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4054a102470665451108f9b59305c79176ef98f0"
+                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4054a102470665451108f9b59305c79176ef98f0",
-                "reference": "4054a102470665451108f9b59305c79176ef98f0",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/54ca9520a00386f83bca145819ad3b619aaa2485",
+                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.3"
@@ -3078,36 +3094,38 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-04T18:15:29+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.5.12",
-            "target-dir": "Symfony/Component/Finder",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Finder.git",
-                "reference": "e527ebf47ff912a45e148b7d0b107b80ec0b3cc2"
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/e527ebf47ff912a45e148b7d0b107b80ec0b3cc2",
-                "reference": "e527ebf47ff912a45e148b7d0b107b80ec0b3cc2",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9",
+                "reference": "3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3115,34 +3133,34 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Finder Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-03T08:01:13+00:00"
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "80eb5a1f968448b77da9e8b2c0827f6e8d767846"
+                "reference": "14bacad23a4f075bfd3fd456755236cb261320e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/80eb5a1f968448b77da9e8b2c0827f6e8d767846",
-                "reference": "80eb5a1f968448b77da9e8b2c0827f6e8d767846",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/14bacad23a4f075bfd3fd456755236cb261320e3",
+                "reference": "14bacad23a4f075bfd3fd456755236cb261320e3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
@@ -3178,24 +3196,24 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-05T13:06:51+00:00"
+            "time": "2017-08-10T07:07:06+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "be8280f7fa8e95b86514f1e1be997668a53b2888"
+                "reference": "1c1717d28904744dc9a9f6a9d97a8b9bed1680e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/be8280f7fa8e95b86514f1e1be997668a53b2888",
-                "reference": "be8280f7fa8e95b86514f1e1be997668a53b2888",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1c1717d28904744dc9a9f6a9d97a8b9bed1680e9",
+                "reference": "1c1717d28904744dc9a9f6a9d97a8b9bed1680e9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/log": "~1.0",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
@@ -3264,20 +3282,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-06T03:59:58+00:00"
+            "time": "2017-08-28T22:35:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -3289,7 +3307,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -3323,24 +3341,24 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "39804eeafea5cca851946e1eed122eb94459fdb4"
+                "reference": "970326dcd04522e1cd1fe128abaee54c225e27f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/39804eeafea5cca851946e1eed122eb94459fdb4",
-                "reference": "39804eeafea5cca851946e1eed122eb94459fdb4",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/970326dcd04522e1cd1fe128abaee54c225e27f9",
+                "reference": "970326dcd04522e1cd1fe128abaee54c225e27f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/config": "<2.8",
@@ -3401,24 +3419,24 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-06-02T09:51:43+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "cc9b41611f4853cd01216f8765faba3db91a1583"
+                "reference": "f0aba8f6fe23e7de1b68f9d903fc742b8b242dc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/cc9b41611f4853cd01216f8765faba3db91a1583",
-                "reference": "cc9b41611f4853cd01216f8765faba3db91a1583",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/f0aba8f6fe23e7de1b68f9d903fc742b8b242dc9",
+                "reference": "f0aba8f6fe23e7de1b68f9d903fc742b8b242dc9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.2",
@@ -3429,7 +3447,7 @@
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.0",
-                "phpdocumentor/reflection-docblock": "~3.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
                 "symfony/cache": "~3.1",
                 "symfony/config": "~2.8|~3.0",
                 "symfony/dependency-injection": "~3.2",
@@ -3478,24 +3496,24 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-22T09:36:51+00:00"
+            "time": "2017-08-15T13:32:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "dc3b2a0c6cfff60327ba1c043a82092735397543"
+                "reference": "add53753d978f635492dfe8cd6953f6a7361ef90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/dc3b2a0c6cfff60327ba1c043a82092735397543",
-                "reference": "dc3b2a0c6cfff60327ba1c043a82092735397543",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/add53753d978f635492dfe8cd6953f6a7361ef90",
+                "reference": "add53753d978f635492dfe8cd6953f6a7361ef90",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -3543,24 +3561,24 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-22T07:42:36+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.2",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063"
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9752a30000a8ca9f4b34b5227d15d0101b96b063",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/console": "~2.8|~3.0"
@@ -3598,7 +3616,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T22:05:06+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -3882,16 +3900,16 @@
         },
         {
             "name": "wikimedia/composer-merge-plugin",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/composer-merge-plugin.git",
-                "reference": "ca453f9f13d8b05f86f20ea10be992a782e6f78c"
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/ca453f9f13d8b05f86f20ea10be992a782e6f78c",
-                "reference": "ca453f9f13d8b05f86f20ea10be992a782e6f78c",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
+                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
                 "shasum": ""
             },
             "require": {
@@ -3927,7 +3945,7 @@
                 }
             ],
             "description": "Composer plugin to merge multiple composer.json files",
-            "time": "2017-03-13T16:52:55+00:00"
+            "time": "2017-04-25T02:31:25+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -4827,22 +4845,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.3.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -4868,24 +4886,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-08-08T06:39:58+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -4915,7 +4933,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-06-03T08:32:36+00:00"
         },
         {
             "name": "phpspec/prophecy",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -40,7 +40,7 @@
     "symfony/event-dispatcher": "3.*",
     "symfony/serializer": "3.*",
     "illuminate/container": "5.2.*",
-    "illuminate/config": "~4.2",
+    "illuminate/config": "5.2.*",
     "patchwork/utf8": "~1.2.3|~1.3",
     "concrete5/less.php": "v1.7.0.11",
     "imagine/imagine": "0.6.*",

--- a/concrete/src/Config/FileLoader.php
+++ b/concrete/src/Config/FileLoader.php
@@ -3,12 +3,93 @@ namespace Concrete\Core\Config;
 
 use Illuminate\Filesystem\Filesystem;
 
-class FileLoader extends \Illuminate\Config\FileLoader implements LoaderInterface
-{
+class FileLoader implements LoaderInterface {
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * The default configuration path.
+     *
+     * @var string
+     */
+    protected $defaultPath;
+
+    /**
+     * All of the named path hints.
+     *
+     * @var array
+     */
+    protected $hints = array();
+
+    /**
+     * A cache of whether namespaces and groups exists.
+     *
+     * @var array
+     */
+    protected $exists = array();
+
+    /**
+     * Create a new file configuration loader.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  string  $defaultPath
+     * @return void
+     */
     public function __construct(Filesystem $files)
     {
-        parent::__construct($files, DIR_APPLICATION . '/config');
+        $this->files = $files;
+        $this->defaultPath = DIR_APPLICATION . '/config';
         $this->addNamespace('core', DIR_BASE_CORE . '/config');
+    }
+
+    /**
+     * Load the given configuration group.
+     *
+     * @param  string  $environment
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return array
+     */
+    protected function defaultLoad($environment, $group, $namespace = null)
+    {
+        $items = array();
+
+        // First we'll get the root configuration path for the environment which is
+        // where all of the configuration files live for that namespace, as well
+        // as any environment folders with their specific configuration items.
+        $path = $this->getPath($namespace);
+
+        if (is_null($path))
+        {
+            return $items;
+        }
+
+        // First we'll get the main configuration file for the groups. Once we have
+        // that we can check for any environment specific files, which will get
+        // merged on top of the main arrays to make the environments cascade.
+        $file = "{$path}/{$group}.php";
+
+        if ($this->files->exists($file))
+        {
+            $items = $this->getRequire($file);
+        }
+
+        // Finally we're ready to check for the environment specific configuration
+        // file which will be merged on top of the main arrays so that they get
+        // precedence over them if we are currently in an environments setup.
+        $file = "{$path}/{$environment}/{$group}.php";
+
+        if ($this->files->exists($file))
+        {
+            $items = $this->mergeEnvironment($items, $file);
+        }
+
+        return $items;
     }
 
     /**
@@ -47,7 +128,7 @@ class FileLoader extends \Illuminate\Config\FileLoader implements LoaderInterfac
         $paths = array();
         if ($namespace === null || $namespace == '') {
             // No namespace, let's load up the concrete config first.
-            $items = parent::load($environment, $group, 'core');
+            $items = $this->defaultLoad($environment, $group, 'core');
 
             $paths = array(
                 "{$path}/generated_overrides/{$group}.php",
@@ -71,16 +152,147 @@ class FileLoader extends \Illuminate\Config\FileLoader implements LoaderInterfac
         return $items;
     }
 
-    protected function getPath($namespace)
+    /**
+     * Merge the items in the given file into the items.
+     *
+     * @param  array   $items
+     * @param  string  $file
+     * @return array
+     */
+    protected function mergeEnvironment(array $items, $file)
     {
-        $path = parent::getPath($namespace);
-        if (!$path) {
-            $path = "{$this->defaultPath}/{$namespace}";
-        }
-
-        return $path;
+        return array_replace_recursive($items, $this->getRequire($file));
     }
 
+    /**
+     * Determine if the given group exists.
+     *
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return bool
+     */
+    public function exists($group, $namespace = null)
+    {
+        $key = $group.$namespace;
+
+        // We'll first check to see if we have determined if this namespace and
+        // group combination have been checked before. If they have, we will
+        // just return the cached result so we don't have to hit the disk.
+        if (isset($this->exists[$key]))
+        {
+            return $this->exists[$key];
+        }
+
+        $path = $this->getPath($namespace);
+
+        // To check if a group exists, we will simply get the path based on the
+        // namespace, and then check to see if this files exists within that
+        // namespace. False is returned if no path exists for a namespace.
+        if (is_null($path))
+        {
+            return $this->exists[$key] = false;
+        }
+
+        $file = "{$path}/{$group}.php";
+
+        // Finally, we can simply check if this file exists. We will also cache
+        // the value in an array so we don't have to go through this process
+        // again on subsequent checks for the existing of the config file.
+        $exists = $this->files->exists($file);
+
+        return $this->exists[$key] = $exists;
+    }
+
+    /**
+     * Apply any cascades to an array of package options.
+     *
+     * @param  string  $env
+     * @param  string  $package
+     * @param  string  $group
+     * @param  array   $items
+     * @return array
+     */
+    public function cascadePackage($env, $package, $group, $items)
+    {
+        // First we will look for a configuration file in the packages configuration
+        // folder. If it exists, we will load it and merge it with these original
+        // options so that we will easily "cascade" a package's configurations.
+        $file = "packages/{$package}/{$group}.php";
+
+        if ($this->files->exists($path = $this->defaultPath.'/'.$file))
+        {
+            $items = array_merge(
+                $items, $this->getRequire($path)
+            );
+        }
+
+        // Once we have merged the regular package configuration we need to look for
+        // an environment specific configuration file. If one exists, we will get
+        // the contents and merge them on top of this array of options we have.
+        $path = $this->getPackagePath($env, $package, $group);
+
+        if ($this->files->exists($path))
+        {
+            $items = array_merge(
+                $items, $this->getRequire($path)
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Get the package path for an environment and group.
+     *
+     * @param  string  $env
+     * @param  string  $package
+     * @param  string  $group
+     * @return string
+     */
+    protected function getPackagePath($env, $package, $group)
+    {
+        $file = "packages/{$package}/{$env}/{$group}.php";
+
+        return $this->defaultPath.'/'.$file;
+    }
+
+    /**
+     * Get the configuration path for a namespace.
+     *
+     * @param  string  $namespace
+     * @return string
+     */
+    protected function getPath($namespace)
+    {
+        if (is_null($namespace)) {
+            return $this->defaultPath;
+        }
+
+        if (isset($this->hints[$namespace])) {
+            return $this->hints[$namespace];
+        }
+
+        return "{$this->defaultPath}/{$namespace}";
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        $this->hints[$namespace] = $hint;
+    }
+
+    /**
+     * Clear groups in a namespace
+     *
+     * @param $namespace
+     * @return void
+     */
     public function clearNamespace($namespace)
     {
         $path = $this->getPath($namespace);
@@ -88,4 +300,37 @@ class FileLoader extends \Illuminate\Config\FileLoader implements LoaderInterfac
             $this->files->deleteDirectory($path);
         }
     }
+
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        return $this->hints;
+    }
+
+    /**
+     * Get a file's contents by requiring it.
+     *
+     * @param  string  $path
+     * @return mixed
+     */
+    protected function getRequire($path)
+    {
+        return $this->files->getRequire($path);
+    }
+
+    /**
+     * Get the Filesystem instance.
+     *
+     * @return \Illuminate\Filesystem\Filesystem
+     */
+    public function getFilesystem()
+    {
+        return $this->files;
+    }
+
 }

--- a/concrete/src/Config/LoaderInterface.php
+++ b/concrete/src/Config/LoaderInterface.php
@@ -1,10 +1,57 @@
 <?php
 namespace Concrete\Core\Config;
 
-interface LoaderInterface extends \Illuminate\Config\LoaderInterface
+interface LoaderInterface
 {
     /**
      * @param $namespace
      */
     public function clearNamespace($namespace);
+
+    /**
+     * Load the given configuration group.
+     *
+     * @param  string  $environment
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return array
+     */
+    public function load($environment, $group, $namespace = null);
+
+    /**
+     * Determine if the given configuration group exists.
+     *
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return bool
+     */
+    public function exists($group, $namespace = null);
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint);
+
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces();
+
+    /**
+     * Apply any cascades to an array of package options.
+     *
+     * @param  string  $environment
+     * @param  string  $package
+     * @param  string  $group
+     * @param  array   $items
+     * @return array
+     */
+    public function cascadePackage($environment, $package, $group, $items);
 }

--- a/concrete/src/Config/Repository/Repository.php
+++ b/concrete/src/Config/Repository/Repository.php
@@ -1,43 +1,146 @@
 <?php
+
 namespace Concrete\Core\Config\Repository;
 
+use Closure;
 use Concrete\Core\Config\LoaderInterface;
 use Concrete\Core\Config\SaverInterface;
-use Concrete\Core\Support\Facade\Config;
 
 class Repository extends \Illuminate\Config\Repository
 {
-    /**
-     * @var SaverInterface
-     */
-    protected $saver;
 
     /**
-     * @var LoaderInterface
+     * The loader implementation.
+     *
+     * @var \Illuminate\Config\LoaderInterface
      */
     protected $loader;
 
     /**
+     * The loader implementation.
+     *
+     * @var \Illuminate\Config\LoaderInterface
+     */
+    protected $saver;
+
+    /**
+     * The current environment.
+     *
+     * @var string
+     */
+    protected $environment;
+
+    /**
+     * All of the configuration items.
+     *
+     * @var array
+     */
+    protected $items = array();
+
+    /**
+     * All of the registered packages.
+     *
+     * @var array
+     */
+    protected $packages = array();
+
+    /**
+     * The after load callbacks for namespaces.
+     *
+     * @var array
+     */
+    protected $afterLoad = array();
+
+    /**
+     * A cache of the parsed items.
+     *
+     * @var array
+     */
+    protected $parsed = [];
+
+    /**
      * Create a new configuration repository.
      *
-     * @param LoaderInterface $loader
-     * @param SaverInterface  $saver
-     * @param                 $environment
+     * @param  \Illuminate\Config\LoaderInterface $loader
+     * @param \Concrete\Core\Config\SaverInterface $saver
+     * @param  string $environment
      */
     public function __construct(LoaderInterface $loader, SaverInterface $saver, $environment)
     {
+        $this->loader = $loader;
         $this->saver = $saver;
-        parent::__construct($loader, $environment);
+        $this->environment = $environment;
     }
 
     /**
-     * Clear specific key.
+     * Determine if the given configuration value exists.
      *
-     * @param string $key
+     * @param  string $key
+     * @return bool
      */
-    public function clear($key)
+    public function has($key)
     {
-        $this->set($key, null);
+        $default = microtime(true);
+        return $this->get($key, $default) !== $default;
+    }
+
+    /**
+     * Determine if a configuration group exists.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function hasGroup($key)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
+
+        return $this->loader->exists($group, $namespace);
+    }
+
+    /**
+     * Get the specified configuration value.
+     *
+     * @param  string $key
+     * @param  mixed $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
+
+        // Configuration items are actually keyed by "collection", which is simply a
+        // combination of each namespace and groups, which allows a unique way to
+        // identify the arrays of configuration items for the particular files.
+        $collection = $this->getCollection($group, $namespace);
+
+        $this->load($group, $namespace, $collection);
+
+        return array_get($this->items[$collection], $item, $default);
+    }
+
+    /**
+     * Set a given configuration value.
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function set($key, $value = null)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
+
+        $collection = $this->getCollection($group, $namespace);
+
+        // We'll need to go ahead and lazy load each configuration groups even when
+        // we're just setting a configuration item so that the set item does not
+        // get overwritten if a different item in the group is requested later.
+        $this->load($group, $namespace, $collection);
+
+        if (is_null($item)) {
+            $this->items[$collection] = $value;
+        } else {
+            array_set($this->items[$collection], $item, $value);
+        }
     }
 
     /**
@@ -64,52 +167,108 @@ class Repository extends \Illuminate\Config\Repository
     }
 
     /**
-     * Register a package for cascading configuration.
+     * Clear specific key.
      *
-     * @param  string $package
-     * @param  string $hint
-     * @param  string $namespace
+     * @param string $key
+     * @return void
      */
-    public function package($package, $hint = null, $namespace = null)
+    public function clear($key)
     {
-        $namespace = $this->getPackageNamespace($package, $namespace);
-        $hint = $hint ? $hint : $package->getPackagePath() . '/' . DIRNAME_CONFIG;
-        $this->packages[] = $namespace;
-        $this->addNamespace($namespace, $hint);
+        $this->set($key, null);
     }
 
-    protected function getPackageNamespace($package, $namespace)
-    {
-        $package = is_object($package) ? $package->getPackageHandle() : $package;
-        return $namespace ?: $package;
-    }
-
+    /**
+     * Clear cached items
+     *
+     * @return void
+     */
     public function clearCache()
     {
         $this->items = array();
     }
 
+    /**
+     * Clear a namespace (Note: this deletes items permanently)
+     *
+     * @param $namespace
+     * @return void
+     */
     public function clearNamespace($namespace)
     {
         $this->loader->clearNamespace($namespace);
     }
 
     /**
-     * @return SaverInterface
+     * Load the configuration group for the key.
+     *
+     * @param  string $group
+     * @param  string $namespace
+     * @param  string $collection
+     * @return void
      */
-    public function getSaver()
+    protected function load($group, $namespace, $collection)
     {
-        return $this->saver;
+        $env = $this->environment;
+
+        // If we've already loaded this collection, we will just bail out since we do
+        // not want to load it again. Once items are loaded a first time they will
+        // stay kept in memory within this class and not loaded from disk again.
+        if (isset($this->items[$collection])) {
+            return;
+        }
+
+        $items = $this->loader->load($env, $group, $namespace);
+
+        // If we've already loaded this collection, we will just bail out since we do
+        // not want to load it again. Once items are loaded a first time they will
+        // stay kept in memory within this class and not loaded from disk again.
+        if (isset($this->afterLoad[$namespace])) {
+            $items = $this->callAfterLoad($namespace, $group, $items);
+        }
+
+        $this->items[$collection] = $items;
     }
 
     /**
-     * Set the saver instance.
+     * Call the after load callback for a namespace.
      *
-     * @param \Concrete\Core\Config\SaverInterface $saver
+     * @param  string $namespace
+     * @param  string $group
+     * @param  array $items
+     * @return array
      */
-    public function setSaver(SaverInterface $saver)
+    protected function callAfterLoad($namespace, $group, $items)
     {
-        $this->saver = $saver;
+        $callback = $this->afterLoad[$namespace];
+
+        return call_user_func($callback, $this, $group, $items);
+    }
+
+    /**
+     * Parse an array of namespaced segments.
+     *
+     * @param  string $key
+     * @return array
+     */
+    protected function parseNamespacedSegments($key)
+    {
+        list($namespace, $item) = explode('::', $key);
+
+        // If the namespace is registered as a package, we will just assume the group
+        // is equal to the namespace since all packages cascade in this way having
+        // a single file per package, otherwise we'll just parse them as normal.
+        if (in_array($namespace, $this->packages)) {
+            return $this->parsePackageSegments($key, $namespace, $item);
+        }
+
+        // Next we'll just explode the first segment to get the namespace and group
+        // since the item should be in the remaining segments. Once we have these
+        // two pieces of data we can proceed with parsing out the item's value.
+        $itemSegments = explode('.', $item);
+
+        $groupAndItem = array_slice($this->parseBasicSegments($itemSegments), 1);
+
+        return array_merge([$namespace], $groupAndItem);
     }
 
     protected function parsePackageSegments($key, $namespace, $item)
@@ -124,5 +283,224 @@ class Repository extends \Illuminate\Config\Repository
         $groupAndItem = array_slice($this->parseBasicSegments($itemSegments), 1);
 
         return array_merge(array($namespace), $groupAndItem);
+    }
+
+    /**
+     * Register a package for cascading configuration.
+     *
+     * @param  string $package
+     * @param  string $hint
+     * @param  string $namespace
+     */
+    public function package($package, $hint = null, $namespace = null)
+    {
+        $namespace = $this->getPackageNamespace($package, $namespace);
+        $hint = $hint ? $hint : $package->getPackagePath() . '/' . DIRNAME_CONFIG;
+        $this->packages[] = $namespace;
+        $this->addNamespace($namespace, $hint);
+    }
+
+    /**
+     * Get the configuration namespace for a package.
+     *
+     * @param  string|\Concrete\Core\Package\Package $package
+     * @param  string $namespace
+     * @return string
+     */
+    protected function getPackageNamespace($package, $namespace)
+    {
+        $package = is_object($package) ? $package->getPackageHandle() : $package;
+        return $namespace ?: $package;
+    }
+
+    /**
+     * Register an after load callback for a given namespace.
+     *
+     * @param  string $namespace
+     * @param  \Closure $callback
+     * @return void
+     */
+    public function afterLoading($namespace, Closure $callback)
+    {
+        $this->afterLoad[$namespace] = $callback;
+    }
+
+    /**
+     * Get the collection identifier.
+     *
+     * @param  string $group
+     * @param  string $namespace
+     * @return string
+     */
+    protected function getCollection($group, $namespace = null)
+    {
+        $namespace = $namespace ?: '*';
+
+        return $namespace . '::' . $group;
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string $namespace
+     * @param  string $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        $this->loader->addNamespace($namespace, $hint);
+    }
+
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        return $this->loader->getNamespaces();
+    }
+
+    /**
+     * Get the loader implementation.
+     *
+     * @return LoaderInterface
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
+
+    /**
+     * Set the loader implementation.
+     *
+     * @param  LoaderInterface $loader
+     * @return void
+     */
+    public function setLoader(LoaderInterface $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    /**
+     * Get the saver implementation
+     *
+     * @return SaverInterface
+     */
+    public function getSaver()
+    {
+        return $this->saver;
+    }
+
+    /**
+     * Set the saver instance.
+     *
+     * @param SaverInterface $saver
+     */
+    public function setSaver(SaverInterface $saver)
+    {
+        $this->saver = $saver;
+    }
+
+    /**
+     * Get the current configuration environment.
+     *
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * Get the after load callback array.
+     *
+     * @return array
+     */
+    public function getAfterLoadCallbacks()
+    {
+        return $this->afterLoad;
+    }
+
+    /**
+     * Get all of the configuration items.
+     *
+     * @return array
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Parse a key into namespace, group, and item.
+     *
+     * @param  string  $key
+     * @return array
+     */
+    public function parseKey($key)
+    {
+        // If we've already parsed the given key, we'll return the cached version we
+        // already have, as this will save us some processing. We cache off every
+        // key we parse so we can quickly return it on all subsequent requests.
+        if (isset($this->parsed[$key])) {
+            return $this->parsed[$key];
+        }
+
+        // If the key does not contain a double colon, it means the key is not in a
+        // namespace, and is just a regular configuration item. Namespaces are a
+        // tool for organizing configuration items for things such as modules.
+        if (strpos($key, '::') === false) {
+            $segments = explode('.', $key);
+
+            $parsed = $this->parseBasicSegments($segments);
+        } else {
+            $parsed = $this->parseNamespacedSegments($key);
+        }
+
+        // Once we have the parsed array of this key's elements, such as its groups
+        // and namespace, we will cache each array inside a simple list that has
+        // the key and the parsed array for quick look-ups for later requests.
+        return $this->parsed[$key] = $parsed;
+    }
+
+    /**
+     * Parse an array of basic segments.
+     *
+     * @param  array  $segments
+     * @return array
+     */
+    protected function parseBasicSegments(array $segments)
+    {
+        // The first segment in a basic array will always be the group, so we can go
+        // ahead and grab that segment. If there is only one total segment we are
+        // just pulling an entire group out of the array and not a single item.
+        $group = $segments[0];
+
+        if (count($segments) == 1) {
+            return [null, $group, null];
+        }
+
+        // If there is more than one segment in this group, it means we are pulling
+        // a specific item out of a groups and will need to return the item name
+        // as well as the group so we know which item to pull from the arrays.
+        else {
+            $item = implode('.', array_slice($segments, 1));
+
+            return [null, $group, $item];
+        }
+    }
+
+    /**
+     * Set the parsed value of a key.
+     *
+     * @param  string  $key
+     * @param  array   $parsed
+     * @return void
+     */
+    public function setParsedKey($key, $parsed)
+    {
+        $this->parsed[$key] = $parsed;
     }
 }

--- a/concrete/src/Config/Repository/Repository.php
+++ b/concrete/src/Config/Repository/Repository.php
@@ -12,14 +12,14 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * The loader implementation.
      *
-     * @var \Illuminate\Config\LoaderInterface
+     * @var \Concrete\Core\Config\LoaderInterface
      */
     protected $loader;
 
     /**
-     * The loader implementation.
+     * The saver implementation.
      *
-     * @var \Illuminate\Config\LoaderInterface
+     * @var \Concrete\Core\Config\SaverInterface
      */
     protected $saver;
 
@@ -61,9 +61,9 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Create a new configuration repository.
      *
-     * @param  \Illuminate\Config\LoaderInterface $loader
+     * @param \Concrete\Core\Config\LoaderInterface $loader
      * @param \Concrete\Core\Config\SaverInterface $saver
-     * @param  string $environment
+     * @param string $environment
      */
     public function __construct(LoaderInterface $loader, SaverInterface $saver, $environment)
     {


### PR DESCRIPTION
This pull request updates from [4.2.x](https://github.com/illuminate/config/tree/4.2) to [5.2.x](https://github.com/illuminate/config/tree/5.2) which is actually a relatively big jump.

Considerations:
* This is technically a backwards incompatible change since it removes those classes from the illuminate namespace, but our layer is 100% compatible.
* This updates other dependencies that we use quite often too, illuminate/support and illuminate/filesystem. I'm not exactly sure what the full implications of that are yet.
* If we get this done, we will be compatible with [codeception](http://codeception.com/)

All I did was copy out the relevant stuff from the old 4.2 version into our wrapper layer.