### PR TITLE
Fix HOME_CID

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -320,7 +320,6 @@ const NEWSFLOW_VIEWED_THRESHOLD = 86400; // once a day
 /* -- Pages -- */
 const CHECKOUT_TIMEOUT = 300; // # in seconds.
 const VERSION_INITIAL_COMMENT = 'Initial Version';
-const HOME_CID = 1;
 const HOME_NAME = 'Home';
 const HOME_UID = USER_SUPER_ID;
 const HOME_HANDLE = 'home';

--- a/concrete/src/Foundation/Runtime/Run/CLIRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/CLIRunner.php
@@ -45,6 +45,7 @@ class CLIRunner implements RunInterface, ApplicationAwareInterface
         $console = $this->console;
         $this->app->instance('console', $console);
 
+        $this->app->setupConstants();
         $this->loadBootstrap();
         $this->initializeSystemTimezone();
 

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -59,6 +59,7 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
      */
     public function run()
     {
+        $this->app->setupConstants();
         // Load in the /application/bootstrap/app.php file
         $this->loadBootstrap();
 

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -692,7 +692,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $_cParentID = $c->getCollectionID();
         $q = 'select PagePaths.cPath from PagePaths where cID = ?';
         $v = [$_cParentID];
-        if ($_cParentID > 1) {
+        if ($_cParentID > 0 && $_cParentID != HOME_CID) {
             $q .= ' and ppIsCanonical = ?';
             $v[] = 1;
         }
@@ -1718,7 +1718,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $db = Database::connection();
         $cID = $db->fetchColumn("select Pages.cID from Pages inner join CollectionVersions on Pages.cID = CollectionVersions.cID where cvIsApproved = 1 and cParentID = ? order by {$sortColumn}", [$this->cID]);
-        if ($cID > 1) {
+        if ($cID && $cID != HOME_CID) {
             return self::getByID($cID, 'ACTIVE');
         }
 
@@ -2503,7 +2503,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             return;
         }
 
-        if ($cID <= 1) {
+        if ($cID < 1 || $cID == HOME_CID) {
             return false;
         }
 
@@ -3220,9 +3220,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public static function addStatic($data, TreeInterface $parent = null)
     {
         $db = Database::connection();
-        $cParentID = 1;
+        $cParentID = HOME_CID;
         $cDisplayOrder = 0;
-        $cInheritPermissionsFromCID = 1;
+        $cInheritPermissionsFromCID = HOME_CID;
         $cOverrideTemplatePermissions = 1;
         if ($parent instanceof Page) {
             $cParentID = $parent->getCollectionID();


### PR DESCRIPTION
The root page of websites can now change, so the ID of the homepage may not be 1: let's calculate it as soon as possible.

