### PR TITLE
Fix creation global single pages

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3217,7 +3217,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         return $lifetime;
     }
 
-    public static function addStatic($data, TreeInterface $parent = null)
+    public static function addStatic($data, TreeInterface $parent = null, $overrideSiteTreeID = null)
     {
         $db = Database::connection();
         $cParentID = 1;
@@ -3248,9 +3248,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         // These get set to parent by default here, but they can be overridden later
         $cInheritPermissionsFrom = 'PARENT';
 
-        $siteTreeID = 0;
-        if (is_object($parent)) {
-            $siteTreeID = $parent->getSiteTreeID();
+        if ($overrideSiteTreeID !== null) {
+            $siteTreeID = (int) $overrideSiteTreeID;
+        } else {
+            $siteTreeID = $parent === null ? 0 : $parent->getSiteTreeID();
         }
 
         $v = [$cID, $siteTreeID, $cFilename, $cParentID, $cInheritPermissionsFrom, $cOverrideTemplatePermissions, (int) $cInheritPermissionsFromCID, $cDisplayOrder, $uID, $pkgID];

--- a/concrete/src/Page/Single.php
+++ b/concrete/src/Page/Single.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Page;
 
 use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Site\Tree\TreeInterface;
+use Core;
 use Page as CorePage;
 use Loader;
 use Environment;
@@ -127,28 +128,34 @@ class Single
      * Adds a single page outside of any site trees. The global=true declaration in content importer XML must come at
      * on the first URL segment, so we don't have to be smart and check to see if the parents already eixst.
      * @param $cPath
-     * @param null $pkg
-     * @return mixed
+     * @param object|null $pkg
+     * @return CorePage|null
      */
     public static function addGlobal($cPath, $pkg = null)
     {
-        $pathToFile = static::getPathToNode($cPath, $pkg);
-        $txt = Loader::helper('text');
-        $c = CorePage::getByPath("/" . $cPath);
+        $cPath = static::sanitizePath($cPath);
+        $c = CorePage::getByPath('/' . $cPath);
         if ($c->isError() && $c->getError() == COLLECTION_NOT_FOUND) {
-            // create the page at that point in the tree
-
-            $data = array();
-            $data['handle'] = trim($cPath, '/');
-            $data['name'] = $txt->unhandle($data['handle']);
-            $data['filename'] = $pathToFile;
-            $data['uID'] = USER_SUPER_ID;
+            $slugs = explode('/', $cPath);
+            $handle = (string) array_pop($slugs);
+            $data = [
+                'handle' => $handle,
+                'name' => Core::make('helper/text')->unhandle($handle),
+                'filename' => static::getPathToNode($cPath, $pkg),
+                'uID' => USER_SUPER_ID,
+            ];
             if ($pkg != null) {
                 $data['pkgID'] = $pkg->getPackageID();
             }
-
-            $c = Page::addStatic($data, null);
-            $c->moveToRoot();
+            $parentPage = null;
+            if (count($slugs) > 0) {
+                $parentPagePath = '/' . implode('/', $slugs);
+                $parentPage = CorePage::getByPath($parentPagePath);
+                if ($parentPage && $parentPage->isError()) {
+                    $parentPage = null;
+                }
+            }
+            $c = Page::addStatic($data, $parentPage, 0);
             return $c;
         }
     }

--- a/concrete/src/Page/Single.php
+++ b/concrete/src/Page/Single.php
@@ -36,18 +36,17 @@ class Single
         return $singlePages;
     }
 
+    /**
+     * Take a collection path and returns it without slashes at the beginning and at the end, and no more than 1 intermediate slash in the middle at any point.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
     public static function sanitizePath($path)
     {
-        //takes a damn cpath and returns no first slash, and no more than 1 intermediate slash in
-        // the middle at any point
-        $node = preg_replace("/([\/]+)/", "/", $path);
-        if (substr($node, 0, 1) == "/") {
-            $node = substr($node, 1);
-        }
-        // now do the same for the last node
-        if (substr($node, strlen($node) - 1, 1) == '/') {
-            $node = substr($node, 0, strlen($node) - 1);
-        }
+        $node = preg_replace('/\/{2,}/', '/', $path);
+        $node = trim($node, '/');
 
         return $node;
     }


### PR DESCRIPTION
Because of https://github.com/concrete5/concrete5/commit/34d55fb1ced6ba4c29547a1a5721b811f404dfa9, we now create single pages in the dashboard with the SinglePage::addGlobal method, but it seems to me that this method doesn't work (the cParentID field in the Pages table is set to 0).

Is this the correct fix?