### PR TITLE
Add CKEditor configuration options

### DIFF
--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -1,26 +1,17 @@
 <?php
-
 return [
-
     'default' => 'default',
-
     'sites' => [
-
         'default' => [
-
             'handle' => 'default',
-
             'name' => 'concrete5',
-
             'user' => [
-
                 'profiles_enabled' => false,
                 'gravatar' => [
                     'enabled' => false,
                     'max_level' => 0,
                     'image_set' => 0,
                 ],
-
                 /*
                  * Show the account menu in page footer when users are not logged in.
                  * Can be overridden in site themes by setting $display_account_menu when using the footer_required element.
@@ -28,10 +19,7 @@ return [
                  * @var bool
                  */
                 'display_account_menu' => true,
-
-
             ],
-
             'editor' => [
                 'concrete' => [
                     'enable_filemanager' => true,
@@ -131,14 +119,11 @@ return [
                     ],
                 ],
             ],
-
             'multilingual' => [
                 'redirect_home_to_default_locale' => false,
                 'use_browser_detected_locale' => false,
                 'default_source_locale' => 'en_US',
             ],
-
         ],
-
     ],
 ];

--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -38,6 +38,8 @@ return [
                     'enable_sitemap' => true,
                 ],
                 'ckeditor4' => [
+                    'custom_config_options' => '',
+                    'editor_function_options' => '',
                     'plugins' => [
                         'selected' => [
                             'autogrow',
@@ -91,6 +93,33 @@ return [
                             'toolbar',
                             'wysiwygarea',
                         ]
+                    ],
+                    'toolbar_groups' => [
+                        ['name' => 'mode', 'groups' => ['mode']],
+                        ['name' => 'document', 'groups' => ['document']],
+                        ['name' => 'doctools', 'groups' => ['doctools']],
+                        ['name' => 'clipboard', 'groups' => ['clipboard']],
+                        ['name' => 'undo', 'groups' => ['undo']],
+                        ['name' => 'find', 'groups' => ['find']],
+                        ['name' => 'selection', 'groups' => ['selection']],
+                        ['name' => 'spellchecker', 'groups' => ['spellchecker']],
+                        ['name' => 'editing', 'groups' => ['editing']],
+                        ['name' => 'basicstyles', 'groups' => ['basicstyles']],
+                        ['name' => 'cleanup', 'groups' => ['cleanup']],
+                        ['name' => 'list', 'groups' => ['list']],
+                        ['name' => 'indent', 'groups' => ['indent']],
+                        ['name' => 'blocks', 'groups' => ['blocks']],
+                        ['name' => 'align', 'groups' => ['align']],
+                        ['name' => 'bidi', 'groups' => ['bidi']],
+                        ['name' => 'paragraph', 'groups' => ['paragraph']],
+                        ['name' => 'links', 'groups' => ['links']],
+                        ['name' => 'insert', 'groups' => ['insert']],
+                        ['name' => 'forms', 'groups' => ['forms']],
+                        ['name' => 'styles', 'groups' => ['styles']],
+                        ['name' => 'colors', 'groups' => ['colors']],
+                        ['name' => 'tools', 'groups' => ['tools']],
+                        ['name' => 'others', 'groups' => ['others']],
+                        ['name' => 'about', 'groups' => ['about']],
                     ]
                 ],
                 'plugins' => [

--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -91,7 +91,7 @@ EOL;
 
         return $obj;
     }
-    
+
     /**
      * @param array $options
      *
@@ -112,7 +112,7 @@ EOL;
         $this->requireEditorAssets();
         $plugins = $pluginManager->getSelectedPlugins();
         $snippetsAndClasses = $this->getEditorSnippetsAndClasses();
-        
+
         $options = array_merge(
             $options,
             [
@@ -130,37 +130,16 @@ EOL;
                     'content-editor-image-center',
                     'content-editor-image-right',
                 ],
-                'toolbarGroups' => [
-                    ['name' => 'mode', 'groups' => ['mode']],
-                    ['name' => 'document', 'groups' => ['document']],
-                    ['name' => 'doctools', 'groups' => ['doctools']],
-                    ['name' => 'clipboard', 'groups' => ['clipboard']],
-                    ['name' => 'undo', 'groups' => ['undo']],
-                    ['name' => 'find', 'groups' => ['find']],
-                    ['name' => 'selection', 'groups' => ['selection']],
-                    ['name' => 'spellchecker', 'groups' => ['spellchecker']],
-                    ['name' => 'editing', 'groups' => ['editing']],
-                    ['name' => 'basicstyles', 'groups' => ['basicstyles']],
-                    ['name' => 'cleanup', 'groups' => ['cleanup']],
-                    ['name' => 'list', 'groups' => ['list']],
-                    ['name' => 'indent', 'groups' => ['indent']],
-                    ['name' => 'blocks', 'groups' => ['blocks']],
-                    ['name' => 'align', 'groups' => ['align']],
-                    ['name' => 'bidi', 'groups' => ['bidi']],
-                    ['name' => 'paragraph', 'groups' => ['paragraph']],
-                    ['name' => 'links', 'groups' => ['links']],
-                    ['name' => 'insert', 'groups' => ['insert']],
-                    ['name' => 'forms', 'groups' => ['forms']],
-                    ['name' => 'styles', 'groups' => ['styles']],
-                    ['name' => 'colors', 'groups' => ['colors']],
-                    ['name' => 'tools', 'groups' => ['tools']],
-                    ['name' => 'others', 'groups' => ['others']],
-                    ['name' => 'about', 'groups' => ['about']],
-                ],
+                'toolbarGroups' => $this->config->get('editor.ckeditor4.toolbar_groups'),
                 'snippets' => $snippetsAndClasses->snippets,
                 'classes' => $snippetsAndClasses->classes,
             ]
         );
+
+        $customConfigOptions = $this->config->get('editor.ckeditor4.custom_config_options');
+        if ($customConfigOptions) {
+            $options = array_merge($customConfigOptions, $options);
+        }
 
         $options = json_encode($options);
         $removeEmptyIcon = '$removeEmpty[\'i\']';
@@ -193,6 +172,7 @@ EOL;
                     }, 50);
                 });
             }
+            {$this->config->get('editor.ckeditor4.editor_function_options')}
         }
 EOL;
 


### PR DESCRIPTION
This pull request:
- adds CKEditor config and JavaScript configuration options
- allows toolbar button and group reordering and row creation

Currently, CKEditor configuration options are contained in CkeditorEditor.php and not easy accessible. This pull request allows for additional configuration options to be added through the site.php config.

I have created a sample site.php config gist that provides a few examples of what these configuration options allow you to do. Things like controlling what formatting tags are available, removing toolbar buttons, custom ordering of toolbar groups, and removing plugin dialog modal fields and full modal tabs.
https://gist.github.com/MrKarlDilkington/5a14cf2c8aca511c8c9d2026e07b297c

The code changes were tested, but I welcome additional eyes to look for issues.