### PR TITLE
Prevent uncaught type error when editing links in CKEditor

### DIFF
--- a/concrete/js/ckeditor4/core/concrete5link/plugin.js
+++ b/concrete/js/ckeditor4/core/concrete5link/plugin.js
@@ -92,7 +92,7 @@
                                                 label: 'Linking to an image',
                                                 setup: function(data) {
                                                     var link = getSelectedLink();
-                                                    if (link !== null) {
+                                                    if (link !== null && typeof data.target !== 'undefined') {
                                                         if (data.target.name == "lightbox" && link.data('concrete5-link-lightbox') == "image") {
                                                             this.setValue(1);
                                                         } else {
@@ -122,7 +122,7 @@
                                                     id: 'lightboxWidth',
                                                     setup: function(data) {
                                                         var link = getSelectedLink();
-                                                        if (link !== null) {
+                                                        if (link !== null && typeof data.target !== 'undefined') {
                                                             if (data.target.name == "lightbox" && link.hasAttribute('data-concrete5-link-lightbox-width')) {
                                                                 this.setValue(link.data('concrete5-link-lightbox-width'));
                                                             } else {
@@ -141,7 +141,7 @@
                                                     id: 'lightboxHeight',
                                                     setup: function(data) {
                                                         var link = getSelectedLink();
-                                                        if (link !== null) {
+                                                        if (link !== null && typeof data.target !== 'undefined') {
                                                             if (data.target.name == "lightbox" && link.hasAttribute('data-concrete5-link-lightbox-height')) {
                                                                 this.setValue(link.data('concrete5-link-lightbox-height'));
                                                             } else {


### PR DESCRIPTION
**Steps to reproduce:**
- add a Content block to a page
- add some text
- create a link in the text
- edit the link
- when you edit the link, this creates a console error 
`Uncaught TypeError: Cannot read property 'name' of undefined`

I spoke to another developer about this error and they thought it was likely caused by a bug in the CKEditor Link plugin (not the concrete5link plugin that extends it). Instead of modifying a vendor file, it looks like checking the property type before using it fixes the issue.