### PR TITLE
[Update] Page version info animation

### DIFF
--- a/concrete/views/panels/page/versions.php
+++ b/concrete/views/panels/page/versions.php
@@ -297,7 +297,7 @@ $(function() {
 		e.preventDefault();
 		e.stopPropagation();
 		var $parent = $(this).parent();
-		$parent.find('.ccm-panel-page-versions-more-info').show().addClass('animated fadeInDown');
+		$parent.find('.ccm-panel-page-versions-more-info').slideToggle();
 	});
 
 	$('button[data-version-action=delete]').on('click', function() {


### PR DESCRIPTION
This commit improves the page version info display animation.

**Before**

![before mov](https://user-images.githubusercontent.com/2462951/30022658-3311acd8-91a7-11e7-86d8-eac7b660f0bd.gif)

**After**

![after mov](https://user-images.githubusercontent.com/2462951/30022663-38ebbda6-91a7-11e7-9fc4-6742e7bc301f.gif)
