### PR TITLE
Registration Email Notification: Make from name configurable

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -719,6 +719,20 @@ return [
              * @var bool|string Email to notify
              */
             'notification' => false,
+
+            /*
+             * Notifications email's from address.
+             *
+             * @var string Email from
+             */
+            'notification_email' => null,
+
+            /*
+             * Notifications email's from name.
+             *
+             * @var string Email name
+             */
+            'notification_email_name' => null,
         ],
 
         /*

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -116,9 +116,14 @@ class Search extends DashboardPageController
                         $mh->to($this->user->getUserEmail());
                         $config = $this->app->make('config');
                         if ($config->get('concrete.user.registration.notification_email')) {
+                            if ($config->get('concrete.user.registration.notification_email_name')) {
+                                $fromEmailName = $config->get('concrete.user.registration.notification_email_name');
+                            } else {
+                                $fromEmailName = t('Website Registration Notification');
+                            }
                             $mh->from(
                                 $config->get('concrete.user.registration.notification_email'),
-                                t('Website Registration Notification')
+                                $fromEmailName
                             );
                         } else {
                             $adminUser = UserInfo::getByID(USER_SUPER_ID);

--- a/concrete/src/Workflow/Request/ActivateUserRequest.php
+++ b/concrete/src/Workflow/Request/ActivateUserRequest.php
@@ -124,7 +124,7 @@ class ActivateUserRequest extends UserRequest
         $mh->to($ui->getUserEmail());
         if (Config::get('concrete.user.registration.notification_email')) {
             if (Config::get('concrete.user.registration.notification_email_name')) {
-                $fromEmailName = $config->get('concrete.user.registration.notification_email_name');
+                $fromEmailName = Config::get('concrete.user.registration.notification_email_name');
             } else {
                 $fromEmailName = t('Website Registration Notification');
             }

--- a/concrete/src/Workflow/Request/ActivateUserRequest.php
+++ b/concrete/src/Workflow/Request/ActivateUserRequest.php
@@ -123,9 +123,14 @@ class ActivateUserRequest extends UserRequest
         $mh = Loader::helper('mail');
         $mh->to($ui->getUserEmail());
         if (Config::get('concrete.user.registration.notification_email')) {
+            if ($config->get('concrete.user.registration.notification_email_name')) {
+                $fromEmailName = $config->get('concrete.user.registration.notification_email_name');
+            } else {
+                $fromEmailName = t('Website Registration Notification');
+            }
             $mh->from(
-                Config::get('concrete.user.registration.notification_email'),
-                t('Website Registration Notification')
+                $config->get('concrete.user.registration.notification_email'),
+                $fromEmailName
             );
         } else {
             $adminUser = UserInfo::getByID(USER_SUPER_ID);

--- a/concrete/src/Workflow/Request/ActivateUserRequest.php
+++ b/concrete/src/Workflow/Request/ActivateUserRequest.php
@@ -123,13 +123,13 @@ class ActivateUserRequest extends UserRequest
         $mh = Loader::helper('mail');
         $mh->to($ui->getUserEmail());
         if (Config::get('concrete.user.registration.notification_email')) {
-            if ($config->get('concrete.user.registration.notification_email_name')) {
+            if (Config::get('concrete.user.registration.notification_email_name')) {
                 $fromEmailName = $config->get('concrete.user.registration.notification_email_name');
             } else {
                 $fromEmailName = t('Website Registration Notification');
             }
             $mh->from(
-                $config->get('concrete.user.registration.notification_email'),
+                Config::get('concrete.user.registration.notification_email'),
                 $fromEmailName
             );
         } else {


### PR DESCRIPTION
Currently, you can set registration notification FROM email address.
However, the FROM NAME is fixed to `t('Website Registration Notification')`.

So I want to make from name configurable, and add the parameter of `concrete.user.registration.notification_email_name`.

I decided to do this way to keep the compatibility for previous versions.

Thanks,