### PR TITLE
Fix lessphp composer vendor (using 2.0.0)

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -42,7 +42,7 @@
     "illuminate/container": "5.2.*",
     "illuminate/config": "~4.2",
     "patchwork/utf8": "~1.2.3|~1.3",
-    "concrete5/less.php": "v1.7.0.11",
+    "concrete5/less.php": "2.0.0",
     "imagine/imagine": "0.6.*",
     "natxet/cssmin": "3.*",
     "tedivm/jshrink": "1.*",


### PR DESCRIPTION
Update composer.json to have the concrete5 lessphp vendor name. Autoload wasn't working properly because it was looking for the original vendor, fixed here https://github.com/concrete5-forks/less.php/commit/eebead5849b7dd21f450905007cd65a385b894e3 but wasn't being applied.
