### PR TITLE
Update GroupSetEntity.php

### DIFF
--- a/concrete/src/Permission/Access/Entity/GroupSetEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupSetEntity.php
@@ -5,6 +5,7 @@ use Loader;
 use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use Config;
 use Concrete\Core\User\Group\GroupSet;
+use UserInfo;
 
 class GroupSetEntity extends Entity
 {


### PR DESCRIPTION
Fixes a bug with using Group Sets in the "Approve or Deny" permission on the Workflows settings screen for a workflow. The UserInfo class on line 64 throws an exception as the use statement has been left out of the file.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!