### PR TITLE
[Feature] Display single error message by field

### DIFF
--- a/concrete/src/Error/ErrorList/ErrorList.php
+++ b/concrete/src/Error/ErrorList/ErrorList.php
@@ -184,4 +184,20 @@ class ErrorList implements \ArrayAccess, \JsonSerializable
         return false;
     }
 
+    /**
+     * @param $field
+     * @return string | bool
+     */
+    public function getMessage($field)
+    {
+        $identifier = ($field instanceof FieldInterface) ? $field->getFieldElementName() : $field;
+        foreach($this->getList() as $error) {
+            $field = $error->getField();
+            if (is_object($field) && $field->getFieldElementName() == $identifier) {
+                return $error->getMessage();
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Concrete5 shows error messages together on the top of the form. But, sometimes we may need to show the messages underneath of the form field. This PR allows to print error messages for single field by following way-

```
if (is_object($error) && ($error->has())) {
    echo $error->getMessage('uEmail');
}
```