### PR TITLE
Use the timeout setting

### DIFF
--- a/concrete/src/File/Service/File.php
+++ b/concrete/src/File/Service/File.php
@@ -326,6 +326,9 @@ class File
         if (isset($url['scheme']) && isset($url['host'])) {
             $app = CoreApplication::getFacadeApplication();
             $client = $app->make('http/client')->setUri($file);
+            if (!empty($timeout) && $timeout > 0) {
+                $client->setOptions(['timeout' => $timeout]);
+            }
             try {
                 $response = $client->send();
             } catch (TimeoutException $x) {


### PR DESCRIPTION
When using the getContents() function there is a $timeout parameter that is not used. It is most important for cURL uses.

As an example, it is set by the core when getting a package list from the marketplace but not actually used.

This tiny fix corrects that.