### PR TITLE
Make Repository::setLoader compatible with parent class method

### DIFF
--- a/concrete/src/Config/LoaderInterface.php
+++ b/concrete/src/Config/LoaderInterface.php
@@ -1,57 +1,12 @@
 <?php
 namespace Concrete\Core\Config;
 
-interface LoaderInterface
+use Illuminate\Config\LoaderInterface as IlluminateLoaderInterface;
+
+interface LoaderInterface extends IlluminateLoaderInterface
 {
     /**
      * @param $namespace
      */
     public function clearNamespace($namespace);
-
-    /**
-     * Load the given configuration group.
-     *
-     * @param  string  $environment
-     * @param  string  $group
-     * @param  string  $namespace
-     * @return array
-     */
-    public function load($environment, $group, $namespace = null);
-
-    /**
-     * Determine if the given configuration group exists.
-     *
-     * @param  string  $group
-     * @param  string  $namespace
-     * @return bool
-     */
-    public function exists($group, $namespace = null);
-
-    /**
-     * Add a new namespace to the loader.
-     *
-     * @param  string  $namespace
-     * @param  string  $hint
-     * @return void
-     */
-    public function addNamespace($namespace, $hint);
-
-    /**
-     * Returns all registered namespaces with the config
-     * loader.
-     *
-     * @return array
-     */
-    public function getNamespaces();
-
-    /**
-     * Apply any cascades to an array of package options.
-     *
-     * @param  string  $environment
-     * @param  string  $package
-     * @param  string  $group
-     * @param  array   $items
-     * @return array
-     */
-    public function cascadePackage($environment, $package, $group, $items);
 }

--- a/concrete/src/Config/Repository/Repository.php
+++ b/concrete/src/Config/Repository/Repository.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Config\Repository;
 
 use Closure;
@@ -10,18 +9,17 @@ use Illuminate\Config\LoaderInterface as IlluminateLoaderInterface;
 
 class Repository extends \Illuminate\Config\Repository
 {
-
     /**
      * The loader implementation.
      *
-     * @var \Concrete\Core\Config\LoaderInterface
+     * @var LoaderInterface
      */
     protected $loader;
 
     /**
      * The saver implementation.
      *
-     * @var \Concrete\Core\Config\SaverInterface
+     * @var SaverInterface
      */
     protected $saver;
 
@@ -37,21 +35,21 @@ class Repository extends \Illuminate\Config\Repository
      *
      * @var array
      */
-    protected $items = array();
+    protected $items = [];
 
     /**
      * All of the registered packages.
      *
      * @var array
      */
-    protected $packages = array();
+    protected $packages = [];
 
     /**
      * The after load callbacks for namespaces.
      *
      * @var array
      */
-    protected $afterLoad = array();
+    protected $afterLoad = [];
 
     /**
      * A cache of the parsed items.
@@ -63,8 +61,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Create a new configuration repository.
      *
-     * @param \Concrete\Core\Config\LoaderInterface $loader
-     * @param \Concrete\Core\Config\SaverInterface $saver
+     * @param LoaderInterface $loader
+     * @param SaverInterface $saver
      * @param string $environment
      */
     public function __construct(LoaderInterface $loader, SaverInterface $saver, $environment)
@@ -77,19 +75,22 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Determine if the given configuration value exists.
      *
-     * @param  string $key
+     * @param string $key
+     *
      * @return bool
      */
     public function has($key)
     {
         $default = microtime(true);
+
         return $this->get($key, $default) !== $default;
     }
 
     /**
      * Determine if a configuration group exists.
      *
-     * @param  string $key
+     * @param string $key
+     *
      * @return bool
      */
     public function hasGroup($key)
@@ -102,8 +103,9 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Get the specified configuration value.
      *
-     * @param  string $key
-     * @param  mixed $default
+     * @param string $key
+     * @param mixed $default
+     *
      * @return mixed
      */
     public function get($key, $default = null)
@@ -123,9 +125,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Set a given configuration value.
      *
-     * @param  string $key
-     * @param  mixed $value
-     * @return void
+     * @param string $key
+     * @param mixed $value
      */
     public function set($key, $value = null)
     {
@@ -172,7 +173,6 @@ class Repository extends \Illuminate\Config\Repository
      * Clear specific key.
      *
      * @param string $key
-     * @return void
      */
     public function clear($key)
     {
@@ -180,20 +180,17 @@ class Repository extends \Illuminate\Config\Repository
     }
 
     /**
-     * Clear cached items
-     *
-     * @return void
+     * Clear cached items.
      */
     public function clearCache()
     {
-        $this->items = array();
+        $this->items = [];
     }
 
     /**
-     * Clear a namespace (Note: this deletes items permanently)
+     * Clear a namespace (Note: this deletes items permanently).
      *
      * @param $namespace
-     * @return void
      */
     public function clearNamespace($namespace)
     {
@@ -203,10 +200,9 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Load the configuration group for the key.
      *
-     * @param  string $group
-     * @param  string $namespace
-     * @param  string $collection
-     * @return void
+     * @param string $group
+     * @param string $namespace
+     * @param string $collection
      */
     protected function load($group, $namespace, $collection)
     {
@@ -234,9 +230,10 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Call the after load callback for a namespace.
      *
-     * @param  string $namespace
-     * @param  string $group
-     * @param  array $items
+     * @param string $namespace
+     * @param string $group
+     * @param array $items
+     *
      * @return array
      */
     protected function callAfterLoad($namespace, $group, $items)
@@ -249,7 +246,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Parse an array of namespaced segments.
      *
-     * @param  string $key
+     * @param string $key
+     *
      * @return array
      */
     protected function parseNamespacedSegments($key)
@@ -284,15 +282,15 @@ class Repository extends \Illuminate\Config\Repository
 
         $groupAndItem = array_slice($this->parseBasicSegments($itemSegments), 1);
 
-        return array_merge(array($namespace), $groupAndItem);
+        return array_merge([$namespace], $groupAndItem);
     }
 
     /**
      * Register a package for cascading configuration.
      *
-     * @param  string $package
-     * @param  string $hint
-     * @param  string $namespace
+     * @param string $package
+     * @param string $hint
+     * @param string $namespace
      */
     public function package($package, $hint = null, $namespace = null)
     {
@@ -305,22 +303,23 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Get the configuration namespace for a package.
      *
-     * @param  string|\Concrete\Core\Package\Package $package
-     * @param  string $namespace
+     * @param string|\Concrete\Core\Package\Package $package
+     * @param string $namespace
+     *
      * @return string
      */
     protected function getPackageNamespace($package, $namespace)
     {
         $package = is_object($package) ? $package->getPackageHandle() : $package;
+
         return $namespace ?: $package;
     }
 
     /**
      * Register an after load callback for a given namespace.
      *
-     * @param  string $namespace
-     * @param  \Closure $callback
-     * @return void
+     * @param string $namespace
+     * @param Closure $callback
      */
     public function afterLoading($namespace, Closure $callback)
     {
@@ -330,8 +329,9 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Get the collection identifier.
      *
-     * @param  string $group
-     * @param  string $namespace
+     * @param string $group
+     * @param string $namespace
+     *
      * @return string
      */
     protected function getCollection($group, $namespace = null)
@@ -344,9 +344,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Add a new namespace to the loader.
      *
-     * @param  string $namespace
-     * @param  string $hint
-     * @return void
+     * @param string $namespace
+     * @param string $hint
      */
     public function addNamespace($namespace, $hint)
     {
@@ -377,8 +376,7 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Set the loader implementation.
      *
-     * @param  LoaderInterface $loader
-     * @return void
+     * @param LoaderInterface $loader
      */
     public function setLoader(IlluminateLoaderInterface $loader)
     {
@@ -389,7 +387,7 @@ class Repository extends \Illuminate\Config\Repository
     }
 
     /**
-     * Get the saver implementation
+     * Get the saver implementation.
      *
      * @return SaverInterface
      */
@@ -441,7 +439,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Parse a key into namespace, group, and item.
      *
-     * @param  string  $key
+     * @param string $key
+     *
      * @return array
      */
     public function parseKey($key)
@@ -473,7 +472,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Parse an array of basic segments.
      *
-     * @param  array  $segments
+     * @param array $segments
+     *
      * @return array
      */
     protected function parseBasicSegments(array $segments)
@@ -500,9 +500,8 @@ class Repository extends \Illuminate\Config\Repository
     /**
      * Set the parsed value of a key.
      *
-     * @param  string  $key
-     * @param  array   $parsed
-     * @return void
+     * @param string $key
+     * @param array $parsed
      */
     public function setParsedKey($key, $parsed)
     {

--- a/concrete/src/Config/Repository/Repository.php
+++ b/concrete/src/Config/Repository/Repository.php
@@ -5,6 +5,8 @@ namespace Concrete\Core\Config\Repository;
 use Closure;
 use Concrete\Core\Config\LoaderInterface;
 use Concrete\Core\Config\SaverInterface;
+use Exception;
+use Illuminate\Config\LoaderInterface as IlluminateLoaderInterface;
 
 class Repository extends \Illuminate\Config\Repository
 {
@@ -378,8 +380,11 @@ class Repository extends \Illuminate\Config\Repository
      * @param  LoaderInterface $loader
      * @return void
      */
-    public function setLoader(LoaderInterface $loader)
+    public function setLoader(IlluminateLoaderInterface $loader)
     {
+        if (!$loader instanceof LoaderInterface) {
+            throw new Exception('You should pass a ' . LoaderInterface::class . ' instance to ' . __METHOD__);
+        }
         $this->loader = $loader;
     }
 


### PR DESCRIPTION
This PR fixes this warning:

```
Warning:
Declaration of
Concrete\Core\Config\Repository\Repository::setLoader(Concrete\Core\Config\LoaderInterface $loader)
should be compatible with
Illuminate\Config\Repository::setLoader(Illuminate\Config\LoaderInterface $loader)
```
