### PR TITLE
Prevent image upload resizing of SVG files

### DIFF
--- a/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
+++ b/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
@@ -75,7 +75,12 @@ class ConstrainImageProcessor implements ProcessorInterface
 
     public function shouldProcess(Version $version)
     {
-        return $version->getTypeObject()->getGenericType() == Type::T_IMAGE;
+        $versionTypeObject = $version->getTypeObject();
+        if ($versionTypeObject->getGenericType() == Type::T_IMAGE && !$versionTypeObject->isSVG()) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function process(Version $version)


### PR DESCRIPTION
When Image Uploading "Automatically resize uploaded images" is enabled, uploading SVG files fail with an `An image could not be created from the given input` error.
Dashboard > System & Settings > Files > Image Uploading > Automatically resize uploaded images