### PR TITLE
Use global jpeg compression settings on avatar upload, see #5958

### DIFF
--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -248,7 +248,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     public function updateUserAvatar(ImageInterface $image)
     {
         $fsl = $this->application->make(StorageLocationFactory::class)->fetchDefault()->getFileSystemObject();
-        $image = $image->get('jpg');
+        $image = $image->get('jpg', array('jpeg_quality' => \Config::get('concrete.misc.default_jpeg_image_compression')));
         $file = REL_DIR_FILES_AVATARS . '/' . $this->getUserID() . '.jpg';
         if ($fsl->has($file)) {
             $fsl->delete($file);


### PR DESCRIPTION
Avatars have a low quality after upload by default, using the global compression setting allows some control over this feature.