### PR TITLE
Fix startup on unsupported PHP versions

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -1,9 +1,5 @@
 <?php
 
-if (version_compare(PHP_VERSION, '5.5.9') < 0) {
-    die("concrete5 requires PHP 5.5.9+ to run.\nYou are running PHP " . PHP_VERSION . "\n");
-}
-
 /*
  * ----------------------------------------------------------------------------
  * Ensure that all subsequent procedural pages are running inside concrete5.

--- a/concrete/dispatcher.php
+++ b/concrete/dispatcher.php
@@ -1,11 +1,8 @@
 <?php
-/*
- * ----------------------------------------------------------------------------
- * Set our own version of __DIR__ as $__DIR__ so we can include this file on
- * PHP < 5.3 and have it not die wholesale.
- * ----------------------------------------------------------------------------
- */
-$__DIR__ = str_replace(DIRECTORY_SEPARATOR, '/', dirname(__FILE__));
+
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50509) {
+    die("concrete5 requires PHP 5.5.9+ to run.\nYou are running PHP " . PHP_VERSION . "\n");
+}
 
 /*
  * ----------------------------------------------------------------------------
@@ -13,14 +10,14 @@ $__DIR__ = str_replace(DIRECTORY_SEPARATOR, '/', dirname(__FILE__));
  * information, attempt to determine if we ought to skip to an updated core, etc...
  * ----------------------------------------------------------------------------
  */
-require $__DIR__ . '/bootstrap/configure.php';
+require __DIR__ . '/bootstrap/configure.php';
 
 /*
  * ----------------------------------------------------------------------------
  * Include all autoloaders.
  * ----------------------------------------------------------------------------
  */
-require $__DIR__ . '/bootstrap/autoload.php';
+require __DIR__ . '/bootstrap/autoload.php';
 
 /*
  * ----------------------------------------------------------------------------
@@ -28,7 +25,7 @@ require $__DIR__ . '/bootstrap/autoload.php';
  * ----------------------------------------------------------------------------
  */
 /** @var \Concrete\Core\Application\Application $cms */
-$cms = require $__DIR__ . '/bootstrap/start.php';
+$cms = require __DIR__ . '/bootstrap/start.php';
 
 /*
  * ----------------------------------------------------------------------------


### PR DESCRIPTION
The startup process checks the minimum PHP version in the `concrete/bootstrap/configure.php` file.

BTW that file contains PHP syntax not supported in old PHP versions (for example [this line](https://github.com/concrete5/concrete5/blob/5708633433d7eb2a743c252a62803fafd9f5b8de/concrete/bootstrap/configure.php#L21) and [this line](https://github.com/concrete5/concrete5/blob/5708633433d7eb2a743c252a62803fafd9f5b8de/concrete/bootstrap/configure.php#L84) require PHP 5.3.0).

What about checking the PHP version at the very beginning of dispatcher.php (it's the entry point for both web and CLI calls)?