### PR TITLE
Coding style with php cs fixer

### DIFF
--- a/.php_cs.bootstrap
+++ b/.php_cs.bootstrap
@@ -1,0 +1,17 @@
+<?php
+use Concrete\Core\Support\CodingStyle;
+
+if (!class_exists('PhpCsFixer\Config', true)) {
+    fwrite(STDERR, "Your php-cs-version is outdated: please upgrade it.\n");
+    die(16);
+}
+
+require_once __DIR__ . '/concrete/src/Support/CodingStyle.php';
+$codingStyle = new CodingStyle();
+
+return PhpCsFixer\Config::create()
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
+    ->setRules($codingStyle->getRules(CodingStyle::FLAG_BOOTSTRAP))
+    ->setFinder($codingStyle->getFileList(CodingStyle::FLAG_BOOTSTRAP))
+;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,40 +1,36 @@
 <?php
+use Concrete\Core\Support\CodingStyle;
+use PhpCsFixer\Console\ConfigurationResolver;
 
-if (!class_exists('PhpCsFixer\Config', true)) {
-    fwrite(STDERR, "Your php-cs-version is outdated: please upgrade it.\n");
-    die(16);
+$configurationResolver = null;
+foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2) as $backtrace) {
+    if (isset($backtrace['object']) && $backtrace['object'] instanceof ConfigurationResolver) {
+        $configurationResolver = $backtrace['object'];
+        break;
+    }
 }
 
+if ($configurationResolver === null) {
+    fwrite(STDERR, "Unable to find the configuration resolver. Please be sure to use a recent version of php-cs-fixer\n");
+    die(16);
+}
+$path = $configurationResolver->getPath();
+if (!is_array($path) || count($path) !== 1 || !is_file($path[0])) {
+    fwrite(STDERR, "The automatic configuration should be applied to a single file\n");
+    die(16);
+}
+require_once __DIR__ . '/concrete/src/Support/CodingStyle.php';
+$codingStyle = new CodingStyle();
+$flags = $codingStyle->getPathFlags($path[0]);
+if ($flags === null) {
+    fwrite(STDERR, "The automatic configuration can't be applied to {$path[0]}\n");
+    die(16);
+}
+fwrite(STDERR, sprintf("Detected coding style rules: %s\n", $codingStyle->describeFlags($flags)));
+
 return PhpCsFixer\Config::create()
-    ->setCacheFile(__DIR__.'/.php_cs.cache')
-    ->setRules([
-        // Let's start with the standard Symfony rules
-        '@Symfony' => true,
-
-        // Force short array syntax
-        'array_syntax' => ['syntax' => 'short'],
-
-        // A single space between cast and variable
-        'cast_spaces' => true,
-
-        // Concatenation should be spaced with a space
-        'concat_space' => [
-            'spacing' => 'one',
-        ],
-
-        // Don't force an empty line before namespace declaration
-        'single_blank_line_before_namespace' => false,
-        'no_blank_lines_before_namespace' => true,
-        'blank_line_after_opening_tag' => false,
-
-        // Don't vertically align phpdoc tags
-        'phpdoc_align' => false,
-
-        // Allow double-quoted strings, don't force single-quoted strings
-        'single_quote' => false,
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->in(__DIR__)
-    )
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
+    ->setRules($codingStyle->getRules($flags))
+    ->setFinder([new SplFileInfo($path[0])])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,7 +3,7 @@ use Concrete\Core\Support\CodingStyle;
 use PhpCsFixer\Console\ConfigurationResolver;
 
 $configurationResolver = null;
-foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2) as $backtrace) {
+foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 4) as $backtrace) {
     if (isset($backtrace['object']) && $backtrace['object'] instanceof ConfigurationResolver) {
         $configurationResolver = $backtrace['object'];
         break;

--- a/.php_cs.mixed
+++ b/.php_cs.mixed
@@ -1,0 +1,17 @@
+<?php
+use Concrete\Core\Support\CodingStyle;
+
+if (!class_exists('PhpCsFixer\Config', true)) {
+    fwrite(STDERR, "Your php-cs-version is outdated: please upgrade it.\n");
+    die(16);
+}
+
+require_once __DIR__ . '/concrete/src/Support/CodingStyle.php';
+$codingStyle = new CodingStyle();
+
+return PhpCsFixer\Config::create()
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
+    ->setRules($codingStyle->getRules(0))
+    ->setFinder($codingStyle->getFileList(0))
+;

--- a/.php_cs.phponly
+++ b/.php_cs.phponly
@@ -1,0 +1,17 @@
+<?php
+use Concrete\Core\Support\CodingStyle;
+
+if (!class_exists('PhpCsFixer\Config', true)) {
+    fwrite(STDERR, "Your php-cs-version is outdated: please upgrade it.\n");
+    die(16);
+}
+
+require_once __DIR__ . '/concrete/src/Support/CodingStyle.php';
+$codingStyle = new CodingStyle();
+
+return PhpCsFixer\Config::create()
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
+    ->setRules($codingStyle->getRules(CodingStyle::FLAG_PHPONLY))
+    ->setFinder($codingStyle->getFileList(CodingStyle::FLAG_PHPONLY))
+;

--- a/.php_cs.psr4
+++ b/.php_cs.psr4
@@ -1,0 +1,17 @@
+<?php
+use Concrete\Core\Support\CodingStyle;
+
+if (!class_exists('PhpCsFixer\Config', true)) {
+    fwrite(STDERR, "Your php-cs-version is outdated: please upgrade it.\n");
+    die(16);
+}
+
+require_once __DIR__ . '/concrete/src/Support/CodingStyle.php';
+$codingStyle = new CodingStyle();
+
+return PhpCsFixer\Config::create()
+    ->setCacheFile(__DIR__ . '/.php_cs.cache')
+    ->setRiskyAllowed(true)
+    ->setRules($codingStyle->getRules(CodingStyle::FLAG_PSR4CLASS))
+    ->setFinder($codingStyle->getFileList(CodingStyle::FLAG_PSR4CLASS))
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then cat tests/travis.hhvm.ini >> /etc/hhvm/php.ini; else phpenv config-add tests/travis.php.ini; fi
   - travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST # Run once to install magento's composer merger
   - travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST # Run twice to install merged dependencies
-  - mysql -e "SET GLOBAL sql_mode = 'STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY'"
-  - phpunit --version
+  - if [[ $CODESTYLE != "yes" ]]; then mysql -e "SET GLOBAL sql_mode = 'STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY'"; fi
+  - if [[ $CODESTYLE != "yes" ]]; then phpunit --version; fi
+  - if [[ $CODESTYLE = "yes" ]]; then phpenv config-rm xdebug.ini; fi
 
 script:
   # Run PHPUnit if we're not checking code style, otherwise run phpcs

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "wikimedia/composer-merge-plugin": "~1.3"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^2.7",
     "phpunit/phpunit": "^4",
-    "phpunit/dbunit": "^2.0"
+    "phpunit/dbunit": "^2.0",
+    "friendsofphp/php-cs-fixer": "2.2.*"
   },
   "config": {
     "process-timeout": 0,
@@ -49,8 +49,10 @@
   "scripts": {
     "test": "phpunit",
     "phpcs": [
-      "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.WhiteSpace.DisallowTabIndent,Generic.PHP.DisallowShortOpenTag concrete/src concrete/controllers",
-      "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.PHP.DisallowShortOpenTag --ignore=\"*.js,*.css,*.less,concrete/vendor/*,concrete/src/*,concrete/controllers/*\" concrete"
+      "php-cs-fixer fix --no-interaction --dry-run --diff --using-cache=no -v --config=.php_cs.bootstrap",
+      "php-cs-fixer fix --no-interaction --dry-run --diff --using-cache=no -v --config=.php_cs.mixed",
+      "php-cs-fixer fix --no-interaction --dry-run --diff --using-cache=no -v --config=.php_cs.psr4",
+      "php-cs-fixer fix --no-interaction --dry-run --diff --using-cache=no -v --config=.php_cs.phponly"
     ],
     "post-create-project-cmd": [
       "composer config --unset platform.php"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dc78467ecc1826d3eff3bd7c165a10d1",
-    "content-hash": "67bb99b67999e4cfbed7994ae1c40f95",
+    "content-hash": "15a97ca80d8ccefef2e5d453eadd0732",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -47,7 +46,7 @@
                 }
             ],
             "description": "A set of classes to create and manipulate HTML objects abstractions",
-            "time": "2017-05-31 07:52:45"
+            "time": "2017-05-31T07:52:45+00:00"
         },
         {
             "name": "concrete5/doctrine-xml",
@@ -88,7 +87,7 @@
                 "structure",
                 "xml"
             ],
-            "time": "2016-06-22 13:39:14"
+            "time": "2016-06-22T13:39:14+00:00"
         },
         {
             "name": "concrete5/less.php",
@@ -150,7 +149,7 @@
                 "php",
                 "stylesheet"
             ],
-            "time": "2017-02-02 17:13:13"
+            "time": "2017-02-02T17:13:13+00:00"
         },
         {
             "name": "concrete5/oauth-user-data",
@@ -207,7 +206,7 @@
                 "security",
                 "user"
             ],
-            "time": "2017-02-27 05:37:36"
+            "time": "2017-02-27T05:37:36+00:00"
         },
         {
             "name": "concrete5/zend-queue",
@@ -251,7 +250,7 @@
                 "queue",
                 "zf2"
             ],
-            "time": "2016-09-01 14:16:11"
+            "time": "2016-09-01T14:16:11+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -282,7 +281,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "dapphp/securimage",
@@ -329,7 +328,7 @@
                 "captcha",
                 "security"
             ],
-            "time": "2016-12-04 17:45:57"
+            "time": "2016-12-04T17:45:57+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -397,7 +396,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -467,7 +466,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-07-22 12:49:21"
+            "time": "2017-07-22T12:49:21+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -533,7 +532,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -606,7 +605,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2016-11-30 16:50:46"
+            "time": "2016-11-30T16:50:46+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -677,7 +676,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-07-22 20:44:48"
+            "time": "2017-07-22T20:44:48+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -744,7 +743,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -798,7 +797,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -852,7 +851,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "doctrine/migrations",
@@ -926,7 +925,7 @@
                 "database",
                 "migrations"
             ],
-            "time": "2016-12-25 22:54:00"
+            "time": "2016-12-25T22:54:00+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1002,7 +1001,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2017-08-18 19:17:35"
+            "time": "2017-08-18T19:17:35+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1054,7 +1053,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2017-02-03 22:48:59"
+            "time": "2017-02-03T22:48:59+00:00"
         },
         {
             "name": "filp/whoops",
@@ -1115,7 +1114,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2017-08-03 18:23:40"
+            "time": "2017-08-03T18:23:40+00:00"
         },
         {
             "name": "gettext/gettext",
@@ -1173,7 +1172,7 @@
                 "po",
                 "translation"
             ],
-            "time": "2016-02-19 15:18:12"
+            "time": "2016-02-19T15:18:12+00:00"
         },
         {
             "name": "gettext/languages",
@@ -1234,7 +1233,7 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2017-03-23 17:02:28"
+            "time": "2017-03-23T17:02:28+00:00"
         },
         {
             "name": "hautelook/phpass",
@@ -1278,7 +1277,7 @@
                 "password",
                 "security"
             ],
-            "time": "2012-08-31 00:00:00"
+            "time": "2012-08-31T00:00:00+00:00"
         },
         {
             "name": "htmlawed/htmlawed",
@@ -1324,7 +1323,7 @@
                 "strip",
                 "tags"
             ],
-            "time": "2016-08-27 18:53:27"
+            "time": "2016-08-27T18:53:27+00:00"
         },
         {
             "name": "illuminate/config",
@@ -1369,7 +1368,7 @@
             ],
             "description": "The Illuminate Config package.",
             "homepage": "http://laravel.com",
-            "time": "2016-08-01 13:49:14"
+            "time": "2016-08-01T13:49:14+00:00"
         },
         {
             "name": "illuminate/container",
@@ -1412,7 +1411,7 @@
             ],
             "description": "The Illuminate Container package.",
             "homepage": "http://laravel.com",
-            "time": "2016-08-01 13:49:14"
+            "time": "2016-08-01T13:49:14+00:00"
         },
         {
             "name": "illuminate/contracts",
@@ -1454,7 +1453,7 @@
             ],
             "description": "The Illuminate Contracts package.",
             "homepage": "http://laravel.com",
-            "time": "2016-08-08 11:46:08"
+            "time": "2016-08-08T11:46:08+00:00"
         },
         {
             "name": "illuminate/filesystem",
@@ -1504,7 +1503,7 @@
             ],
             "description": "The Illuminate Filesystem package.",
             "homepage": "http://laravel.com",
-            "time": "2016-08-17 17:21:29"
+            "time": "2016-08-17T17:21:29+00:00"
         },
         {
             "name": "illuminate/support",
@@ -1560,7 +1559,7 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "http://laravel.com",
-            "time": "2016-02-22 20:29:02"
+            "time": "2016-02-22T20:29:02+00:00"
         },
         {
             "name": "imagine/imagine",
@@ -1617,7 +1616,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2015-09-19 16:54:05"
+            "time": "2015-09-19T16:54:05+00:00"
         },
         {
             "name": "league/csv",
@@ -1674,7 +1673,7 @@
                 "read",
                 "write"
             ],
-            "time": "2017-07-12 07:18:20"
+            "time": "2017-07-12T07:18:20+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1757,7 +1756,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-08-06 17:41:04"
+            "time": "2017-08-06T17:41:04+00:00"
         },
         {
             "name": "league/flysystem-cached-adapter",
@@ -1805,7 +1804,7 @@
                 }
             ],
             "description": "An adapter decorator to enable meta-data caching.",
-            "time": "2017-03-20 09:59:34"
+            "time": "2017-03-20T09:59:34+00:00"
         },
         {
             "name": "league/url",
@@ -1860,7 +1859,7 @@
                 "url"
             ],
             "abandoned": "league/uri",
-            "time": "2015-07-15 08:24:12"
+            "time": "2015-07-15T08:24:12+00:00"
         },
         {
             "name": "lusitanian/oauth",
@@ -1927,7 +1926,7 @@
                 "oauth",
                 "security"
             ],
-            "time": "2016-07-12 22:15:40"
+            "time": "2016-07-12T22:15:40+00:00"
         },
         {
             "name": "michelf/php-markdown",
@@ -1978,7 +1977,7 @@
             "keywords": [
                 "markdown"
             ],
-            "time": "2016-10-29 18:58:20"
+            "time": "2016-10-29T18:58:20+00:00"
         },
         {
             "name": "mlocati/concrete5-translation-library",
@@ -2028,7 +2027,7 @@
                 "translate",
                 "translation"
             ],
-            "time": "2017-08-25 05:44:27"
+            "time": "2017-08-25T05:44:27+00:00"
         },
         {
             "name": "mlocati/ip-lib",
@@ -2079,7 +2078,7 @@
                 "range",
                 "subnet"
             ],
-            "time": "2017-07-06 07:33:40"
+            "time": "2017-07-06T07:33:40+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -2131,7 +2130,7 @@
                 "mobile detector",
                 "php mobile detect"
             ],
-            "time": "2017-08-29 18:23:54"
+            "time": "2017-08-29T18:23:54+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2209,7 +2208,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19 01:22:40"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "natxet/CssMin",
@@ -2256,7 +2255,7 @@
                 "css",
                 "minify"
             ],
-            "time": "2015-09-25 11:13:11"
+            "time": "2015-09-25T11:13:11+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -2309,7 +2308,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16 07:55:07"
+            "time": "2017-01-16T07:55:07+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -2372,7 +2371,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2015-08-09 04:28:19"
+            "time": "2015-08-09T04:28:19+00:00"
         },
         {
             "name": "pagerfanta/pagerfanta",
@@ -2441,7 +2440,7 @@
                 "paginator",
                 "paging"
             ],
-            "time": "2017-03-20 13:46:15"
+            "time": "2017-03-20T13:46:15+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2489,7 +2488,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13 16:27:32"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "patchwork/utf8",
@@ -2548,7 +2547,7 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2016-05-18 13:57:10"
+            "time": "2016-05-18T13:57:10+00:00"
         },
         {
             "name": "primal/color",
@@ -2597,7 +2596,7 @@
             "keywords": [
                 "color"
             ],
-            "time": "2017-07-10 16:28:36"
+            "time": "2017-07-10T16:28:36+00:00"
         },
         {
             "name": "psr/cache",
@@ -2643,7 +2642,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06 20:24:11"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/container",
@@ -2692,7 +2691,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -2739,7 +2738,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "punic/punic",
@@ -2804,7 +2803,7 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2017-03-23 14:26:42"
+            "time": "2017-03-23T14:26:42+00:00"
         },
         {
             "name": "sunra/php-simple-html-dom-parser",
@@ -2852,7 +2851,7 @@
                 "html",
                 "parser"
             ],
-            "time": "2016-11-22 22:57:47"
+            "time": "2016-11-22T22:57:47+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -2908,7 +2907,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/console",
@@ -2976,7 +2975,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27 14:52:21"
+            "time": "2017-08-27T14:52:21+00:00"
         },
         {
             "name": "symfony/debug",
@@ -3032,7 +3031,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27 14:52:21"
+            "time": "2017-08-27T14:52:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3095,7 +3094,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/finder",
@@ -3144,7 +3143,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -3197,7 +3196,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-10 07:07:06"
+            "time": "2017-08-10T07:07:06+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -3283,7 +3282,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-28 22:35:03"
+            "time": "2017-08-28T22:35:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3342,7 +3341,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14 15:44:48"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
             "name": "symfony/routing",
@@ -3420,7 +3419,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -3497,7 +3496,7 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-15 13:32:50"
+            "time": "2017-08-15T13:32:50+00:00"
         },
         {
             "name": "symfony/translation",
@@ -3562,7 +3561,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -3617,7 +3616,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -3663,7 +3662,7 @@
                 "javascript",
                 "minifier"
             ],
-            "time": "2015-07-04 07:35:09"
+            "time": "2015-07-04T07:35:09+00:00"
         },
         {
             "name": "tedivm/stash",
@@ -3723,7 +3722,7 @@
                 "redis",
                 "sessions"
             ],
-            "time": "2017-04-23 17:16:57"
+            "time": "2017-04-23T17:16:57+00:00"
         },
         {
             "name": "true/punycode",
@@ -3769,7 +3768,7 @@
                 "idna",
                 "punycode"
             ],
-            "time": "2016-11-16 10:37:54"
+            "time": "2016-11-16T10:37:54+00:00"
         },
         {
             "name": "voku/portable-utf8",
@@ -3838,7 +3837,7 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2015-12-06 21:26:23"
+            "time": "2015-12-06T21:26:23+00:00"
         },
         {
             "name": "voku/urlify",
@@ -3897,7 +3896,7 @@
                 "url",
                 "urlify"
             ],
-            "time": "2015-02-10 07:24:31"
+            "time": "2015-02-10T07:24:31+00:00"
         },
         {
             "name": "wikimedia/composer-merge-plugin",
@@ -3946,7 +3945,7 @@
                 }
             ],
             "description": "Composer plugin to merge multiple composer.json files",
-            "time": "2017-04-25 02:31:25"
+            "time": "2017-04-25T02:31:25+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -4015,7 +4014,7 @@
                 "cache",
                 "zf2"
             ],
-            "time": "2016-12-16 11:35:47"
+            "time": "2016-12-16T11:35:47+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -4067,7 +4066,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-04-20 17:26:42"
+            "time": "2016-04-20T17:26:42+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -4111,7 +4110,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30 19:48:38"
+            "time": "2016-06-30T19:48:38+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -4165,7 +4164,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         },
         {
             "name": "zendframework/zend-feed",
@@ -4226,7 +4225,7 @@
                 "feed",
                 "zf2"
             ],
-            "time": "2016-02-11 18:54:29"
+            "time": "2016-02-11T18:54:29+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -4276,7 +4275,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2017-01-31 14:41:02"
+            "time": "2017-01-31T14:41:02+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -4334,7 +4333,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-02-18 22:38:26"
+            "time": "2016-02-18T22:38:26+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -4401,7 +4400,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2016-06-07 21:08:30"
+            "time": "2016-06-07T21:08:30+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -4445,7 +4444,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-mail",
@@ -4505,7 +4504,7 @@
                 "mail",
                 "zf2"
             ],
-            "time": "2017-02-14 18:03:34"
+            "time": "2017-02-14T18:03:34+00:00"
         },
         {
             "name": "zendframework/zend-mime",
@@ -4554,7 +4553,7 @@
                 "mime",
                 "zf2"
             ],
-            "time": "2017-01-16 16:43:38"
+            "time": "2017-01-16T16:43:38+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -4609,7 +4608,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-12-19 19:51:37"
+            "time": "2016-12-19T19:51:37+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -4668,7 +4667,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:17:31"
+            "time": "2016-04-12T21:17:31+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -4715,7 +4714,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -4786,10 +4785,243 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-01-29 17:24:24"
+            "time": "2017-01-29T17:24:24+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "composer/semver",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "b6202ccad4c00778887e7e8282d52f854802b59a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b6202ccad4c00778887e7e8282d52f854802b59a",
+                "reference": "b6202ccad4c00778887e7e8282d52f854802b59a",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "gecko-packages/gecko-php-unit": "^2.0",
+                "php": "^5.3.6 || >=7.0 <7.2",
+                "sebastian/diff": "^1.4",
+                "symfony/console": "^2.4 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.4 || ^3.0",
+                "symfony/finder": "^2.2 || ^3.0",
+                "symfony/options-resolver": "^2.6 || ^3.0",
+                "symfony/polyfill-php54": "^1.0",
+                "symfony/polyfill-php55": "^1.3",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
+            },
+            "conflict": {
+                "hhvm": "<3.18"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.0.1",
+                "justinrainbow/json-schema": "^5.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.4.3",
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/phpunit-bridge": "^3.2.2"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2017-09-11T14:27:07+00:00"
+        },
+        {
+            "name": "gecko-packages/gecko-php-unit",
+            "version": "v2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GeckoPackages/GeckoPHPUnit.git",
+                "reference": "ab525fac9a9ffea219687f261b02008b18ebf2d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GeckoPackages/GeckoPHPUnit/zipball/ab525fac9a9ffea219687f261b02008b18ebf2d1",
+                "reference": "ab525fac9a9ffea219687f261b02008b18ebf2d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.4.3"
+            },
+            "suggest": {
+                "ext-dom": "When testing with xml.",
+                "ext-libxml": "When testing with xml.",
+                "phpunit/phpunit": "This is an extension for it so make sure you have it some way."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GeckoPackages\\PHPUnit\\": "src/PHPUnit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Additional PHPUnit asserts and constraints.",
+            "homepage": "https://github.com/GeckoPackages",
+            "keywords": [
+                "extension",
+                "filesystem",
+                "phpunit"
+            ],
+            "time": "2017-08-23T07:39:54+00:00"
+        },
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20T16:49:30+00:00"
+        },
         {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0",
@@ -4842,7 +5074,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -4887,7 +5119,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08 06:39:58"
+            "time": "2017-08-08T06:39:58+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4934,7 +5166,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03 08:32:36"
+            "time": "2017-06-03T08:32:36+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -4997,7 +5229,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/dbunit",
@@ -5052,7 +5284,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-02 14:39:14"
+            "time": "2016-12-02T14:39:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5114,7 +5346,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5161,7 +5393,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -5202,7 +5434,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -5251,7 +5483,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -5300,7 +5532,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -5372,7 +5604,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21 08:07:12"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -5428,7 +5660,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5492,7 +5724,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5544,7 +5776,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22 07:24:03"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5594,7 +5826,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5661,7 +5893,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5712,7 +5944,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -5765,7 +5997,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5800,85 +6032,436 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "name": "symfony/filesystem",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
+                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
                 "shasum": ""
             },
             "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": "^5.5.9|>=7.0.8"
             },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-29T21:54:42+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v3.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "ee4e22978fe885b54ee5da8c7964f0a5301abfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ee4e22978fe885b54ee5da8c7964f0a5301abfb6",
+                "reference": "ee4e22978fe885b54ee5da8c7964f0a5301abfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
             ],
-            "time": "2017-05-22 02:43:20"
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2017-07-29T21:54:42+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php54",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php54.git",
+                "reference": "b7763422a5334c914ef0298ed21b253d25913a6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/b7763422a5334c914ef0298ed21b253d25913a6e",
+                "reference": "b7763422a5334c914ef0298ed21b253d25913a6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php54\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-06-14T15:44:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php55",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php55.git",
+                "reference": "29b1381d66f16e0581aab0b9f678ccf073288f68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/29b1381d66f16e0581aab0b9f678ccf073288f68",
+                "reference": "29b1381d66f16e0581aab0b9f678ccf073288f68",
+                "shasum": ""
+            },
+            "require": {
+                "ircmaxell/password-compat": "~1.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php55\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-06-14T15:44:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/b6482e68974486984f59449ecea1fbbb22ff840f",
+                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-06-14T15:44:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "8abc9097f5001d310f0edba727469c988acc6ea7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/8abc9097f5001d310f0edba727469c988acc6ea7",
+                "reference": "8abc9097f5001d310f0edba727469c988acc6ea7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-07-11T13:25:55+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
+                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-29T21:54:42+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v3.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "9a5610a8d6a50985a7be485c0ba745c22607beeb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9a5610a8d6a50985a7be485c0ba745c22607beeb",
+                "reference": "9a5610a8d6a50985a7be485c0ba745c22607beeb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5928,7 +6511,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -2012,7 +2012,7 @@
                     "name": "Michele Locati",
                     "email": "mlocati@gmail.com",
                     "homepage": "https://github.com/mlocati",
-                    "role": "developer"
+                    "role": "Developer"
                 }
             ],
             "description": "Library to handle concrete5 core and package translations",
@@ -4853,16 +4853,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.2.7",
+            "version": "v2.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "b6202ccad4c00778887e7e8282d52f854802b59a"
+                "reference": "aca23e791784eade7b377d578d6dfc6fcf1398d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b6202ccad4c00778887e7e8282d52f854802b59a",
-                "reference": "b6202ccad4c00778887e7e8282d52f854802b59a",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/aca23e791784eade7b377d578d6dfc6fcf1398d2",
+                "reference": "aca23e791784eade7b377d578d6dfc6fcf1398d2",
                 "shasum": ""
             },
             "require": {
@@ -4871,7 +4871,7 @@
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "gecko-packages/gecko-php-unit": "^2.0",
-                "php": "^5.3.6 || >=7.0 <7.2",
+                "php": "^5.3.6 || >=7.0 <7.3",
                 "sebastian/diff": "^1.4",
                 "symfony/console": "^2.4 || ^3.0",
                 "symfony/event-dispatcher": "^2.1 || ^3.0",
@@ -4934,7 +4934,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2017-09-11T14:27:07+00:00"
+            "time": "2017-09-29T15:07:49+00:00"
         },
         {
             "name": "gecko-packages/gecko-php-unit",

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -1,0 +1,547 @@
+<?php
+namespace Concrete\Core\Support;
+
+use Exception;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Helper class to handle coding style.
+ *
+ * @see https://mlocati.github.io/php-cs-fixer-configurator/?version=2.2
+ */
+class CodingStyle
+{
+    /**
+     * Coding style rules flag: compatible with PHP versions prior to 5.5.
+     *
+     * @var int
+     */
+    const FLAG_OLDPHP = 0x01;
+
+    /**
+     * Coding style rules flag: PHP-only files.
+     *
+     * @var int
+     */
+    const FLAG_PHPONLY = 0x02;
+
+    /**
+     * Coding style rules flag: bootstrap files.
+     *
+     * @var int
+     */
+    const FLAG_BOOTSTRAP = 0x03; // FLAG_OLDPHP | FLAG_PHPONLY
+
+    /**
+     * Coding style rules flag: files that implements a class following the PSR-4 rules.
+     *
+     * @var int
+     */
+    const FLAG_PSR4CLASS = 0x06; // Includes FLAG_PHPONLY
+
+    /**
+     * The full path to the web directory.
+     *
+     * @var string
+     */
+    protected $webroot = '';
+
+    /**
+     * Set the path to the web directory.
+     *
+     * @param string $value
+     *
+     * @throws Exception throws an exception if the directory does not exist
+     *
+     * @return $this
+     */
+    public function setWebroot($value)
+    {
+        $value = (string) $value;
+        if ('' === $value) {
+            $this->webroot = '';
+        } else {
+            $webroot = @realpath($value);
+            if (false === $webroot || !is_dir($webroot)) {
+                throw new Exception(sprintf('Unable to find the directory %s', $value));
+            }
+            $this->webroot = str_replace(DIRECTORY_SEPARATOR, '/', $webroot);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the path to the web directory.
+     *
+     * @return string
+     */
+    public function getWebroot()
+    {
+        if ('' === $this->webroot) {
+            $this->setWebroot(dirname(dirname(dirname(__DIR__))));
+        }
+
+        return $this->webroot;
+    }
+
+    /**
+     * Return the rules.
+     *
+     * @param int $flags A combination of CodingStyle::FLAG_... flags.
+     *
+     * @return array
+     */
+    public function getRules($flags)
+    {
+        $flags = (int) $flags;
+
+        return [
+            // PHP arrays should be declared using the configured syntax
+            'array_syntax' => [
+                'syntax' => 0 === ($flags & static::FLAG_OLDPHP) ? 'short' : 'long',
+            ],
+            // Binary operators should be surrounded by at least one space.
+            'binary_operator_spaces' => [
+                'align_double_arrow' => false,
+                'align_equals' => false,
+            ],
+            // There MUST be one blank line after the namespace declaration.
+            'blank_line_after_namespace' => true,
+            // Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.
+            'blank_line_after_opening_tag' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            // An empty line feed should precede a return statement.
+            'blank_line_before_return' => true,
+            // The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.
+            'braces' => [
+                'allow_single_line_closure' => true,
+            ],
+            // A single space should be between cast and variable.
+            'cast_spaces' => true,
+            // Whitespace around the keywords of a class, trait or interfaces definition should be one space.
+            'class_definition' => [
+                'singleLine' => true,
+            ],
+            // Concatenation should be spaced according configuration.
+            'concat_space' => [
+                'spacing' => 'one',
+            ],
+            // Equal sign in declare statement should be surrounded by spaces or not following configuration.
+            'declare_equal_normalize' => [
+                'space' => 'single',
+            ],
+            // Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant.
+            'dir_constant' => 0 === ($flags & static::FLAG_OLDPHP) ? true : false,
+            // The keyword `elseif` should be used instead of `else if` so that all control keywords look like single words.
+            'elseif' => true,
+            // PHP code MUST use only UTF-8 without BOM (remove BOM).
+            'encoding' => true,
+            // Replace deprecated `ereg` regular expression functions with preg.
+            'ereg_to_preg' => true,
+            // PHP code must use the long `<?php` tags or short-echo `<?=` tags and not other tag variations.
+            'full_opening_tag' => true,
+            // Spaces should be properly placed in a function declaration.
+            'function_declaration' => true,
+            // Replace core functions calls returning constants with the constants.
+            'function_to_constant' => true,
+            // Add missing space between function's argument and its typehint.
+            'function_typehint_space' => true,
+            // Single line comments should use double slashes `//` and not hash `#`.
+            'hash_to_slash_comment' => true,
+            // Include/Require and file path should be divided with a single space. File path should not be placed under brackets.
+            'include' => true,
+            // Code MUST use configured indentation type.
+            'indentation_type' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            // Replaces is_null(parameter) expression with `null === parameter`.
+            'is_null' => [
+                'use_yoda_style' => false,
+            ],
+            // Ensure there is no code on the same line as the PHP open tag.
+            'linebreak_after_opening_tag' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            // All PHP files must use same line ending.
+            'line_ending' => true,
+            // Cast should be written in lower case.
+            'lowercase_cast' => true,
+            // The PHP constants `true`, `false`, and `null` MUST be in lower case.
+            'lowercase_constants' => true,
+            // PHP keywords MUST be in lower case.
+            'lowercase_keywords' => true,
+            // Magic constants should be referred to using the correct casing.
+            'magic_constant_casing' => true,
+            // In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma.
+            'method_argument_space' => true,
+            // Methods must be separated with one blank line.
+            'method_separation' => true,
+            // Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator.
+            'modernize_types_casting' => true,
+            // Function defined by PHP should be called using the correct casing.
+            'native_function_casing' => true,
+            // All instances created with new keyword must be followed by braces.
+            'new_with_braces' => true,
+            // Master functions shall be used instead of aliases.
+            'no_alias_functions' => true,
+            // There should be no empty lines after class opening brace.
+            'no_blank_lines_after_class_opening' => true,
+            // There should not be blank lines between docblock and the documented element.
+            'no_blank_lines_after_phpdoc' => true,
+            // The closing PHP tag MUST be omitted from files containing only PHP.
+            'no_closing_tag' => true,
+            // There should not be any empty comments.
+            'no_empty_comment' => true,
+            // There should not be empty PHPDoc blocks.
+            'no_empty_phpdoc' => true,
+            // Remove useless semicolon statements.
+            'no_empty_statement' => true,
+            // Removes extra blank lines and/or blank lines following configuration.
+            'no_extra_consecutive_blank_lines' => [
+                'tokens' => ['curly_brace_block', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'throw', 'use'],
+            ],
+            // Remove leading slashes in use clauses.
+            'no_leading_import_slash' => true,
+            // The namespace declaration line shouldn't contain leading whitespace.
+            'no_leading_namespace_whitespace' => true,
+            // Either language construct `print` or `echo` should be used.
+            'no_mixed_echo_print' => [
+                'use' => 'echo',
+            ],
+            // Operator `=>` should not be surrounded by multi-line whitespaces.
+            'no_multiline_whitespace_around_double_arrow' => true,
+            // Convert PHP4-style constructors to `__construct`.
+            'no_php4_constructor' => true,
+            // Short cast `bool` using double exclamation mark should not be used.
+            'no_short_bool_cast' => true,
+            // Replace short-echo `<?=` with long format `<?php echo` syntax.
+            'no_short_echo_tag' => 0 === ($flags & static::FLAG_OLDPHP) ? false : true,
+            // Single-line whitespace before closing semicolon are prohibited.
+            'no_singleline_whitespace_before_semicolons' => true,
+            // When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.
+            'no_spaces_after_function_name' => true,
+            // There MUST NOT be spaces around offset braces.
+            'no_spaces_around_offset' => true,
+            // There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis.
+            'no_spaces_inside_parenthesis' => true,
+            // Remove trailing commas in list function calls.
+            'no_trailing_comma_in_list_call' => true,
+            // PHP single-line arrays should not have trailing comma.
+            'no_trailing_comma_in_singleline_array' => true,
+            // Remove trailing whitespace at the end of non-blank lines.
+            'no_trailing_whitespace' => true,
+            // There MUST be no trailing spaces inside comments and phpdocs.
+            'no_trailing_whitespace_in_comment' => true,
+            // Removes unneeded parentheses around control statements.
+            'no_unneeded_control_parentheses' => true,
+            // Unused use statements must be removed.
+            'no_unused_imports' => true,
+            // There should not be an empty return statement at the end of a function.
+            'no_useless_return' => true,
+            // In array declaration, there MUST NOT be a whitespace before each comma.
+            'no_whitespace_before_comma_in_array' => true,
+            // Remove trailing whitespace at the end of blank lines.
+            'no_whitespace_in_blank_line' => true,
+            // Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.
+            'non_printable_character' => true,
+            // Array index should always be written by using square braces.
+            'normalize_index_brace' => true,
+            // There should not be space before or after object `T_OBJECT_OPERATOR` `->`.
+            'object_operator_without_whitespace' => true,
+            // Orders the elements of classes/interfaces/traits.
+            'ordered_class_elements' => true,
+            // Ordering use statements.
+            'ordered_imports' => true,
+            // Phpdoc should contain @param for all params.
+            'phpdoc_add_missing_param_annotation' => [
+                'only_untyped' => false,
+            ],
+            // Phpdocs annotation descriptions should not be a sentence.
+            'phpdoc_annotation_without_dot' => true,
+            // Docblocks should have the same indentation as the documented subject.
+            'phpdoc_indent' => true,
+            // Fix phpdoc inline tags, make inheritdoc always inline.
+            'phpdoc_inline_tag' => true,
+            // No alias PHPDoc tags should be used.
+            'phpdoc_no_alias_tag' => true,
+            // @return void and @return null annotations should be omitted from phpdocs.
+            'phpdoc_no_empty_return' => true,
+            // Classy that does not inherit must not have inheritdoc tags.
+            'phpdoc_no_useless_inheritdoc' => true,
+            // Annotations in phpdocs should be ordered so that param annotations come first, then throws annotations, then return annotations.
+            'phpdoc_order' => true,
+            // The type of `@return` annotations of methods returning a reference to itself must the configured one.
+            'phpdoc_return_self_reference' => true,
+            // Scalar types should always be written in the same form. `int` not `integer`, `bool` not `boolean`, `float` not `real` or `double`.
+            'phpdoc_scalar' => true,
+            // Annotations in phpdocs should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.
+            'phpdoc_separation' => true,
+            // Single line @var PHPDoc should have proper spacing.
+            'phpdoc_single_line_var_spacing' => true,
+            // Phpdocs summary should end in either a full stop, exclamation mark, or question mark.
+            'phpdoc_summary' => true,
+            // Docblocks should only be used on structural elements.
+            'phpdoc_to_comment' => true,
+            // Phpdocs should start and end with content, excluding the very first and last line of the docblocks.
+            'phpdoc_trim' => true,
+            // The correct case must be used for standard PHP types in phpdoc.
+            'phpdoc_types' => true,
+            // @var and @type annotations should not contain the variable name.
+            'phpdoc_var_without_name' => true,
+            // Pre incrementation/decrementation should be used if possible.
+            'pre_increment' => true,
+            // Class names should match the file name.
+            'psr4' => ($flags && static::FLAG_PSR4CLASS) === static::FLAG_PSR4CLASS ? true : false,
+            // Replaces `rand`, `srand`, `getrandmax` functions calls with their `mt_*` analogs.
+            'random_api_migration' => true,
+            // There should be one or no space before colon, and one space after it in return type declarations, according to configuration.
+            'return_type_declaration' => [
+                'space_before' => 'none',
+            ],
+            // Inside a classy element "self" should be preferred to the class name itself.
+            'self_accessor' => true,
+            // Cast `(boolean)` and `(integer)` should be written as `(bool)` and `(int)`, `(double)` and `(real)` as `(float)`.
+            'short_scalar_cast' => true,
+            // Ensures deprecation notices are silenced.
+            'silenced_deprecation_error' => true,
+            // A PHP file without end tag must always end with a single empty line feed.
+            'single_blank_line_at_eof' => true,
+            // There should be exactly one blank line before a namespace declaration.
+            'single_blank_line_before_namespace' => true,
+            // There MUST NOT be more than one property or constant declared per statement.
+            'single_class_element_per_statement' => true,
+            // There MUST be one use keyword per declaration.
+            'single_import_per_statement' => true,
+            // Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.
+            'single_line_after_imports' => true,
+            // Convert double quotes to single quotes for simple strings.
+            'single_quote' => true,
+            // Fix whitespace after a semicolon.
+            'space_after_semicolon' => true,
+            // Replace all `<>` with `!=`.
+            'standardize_not_equals' => true,
+            // A case should be followed by a colon and not a semicolon.
+            'switch_case_semicolon_to_colon' => true,
+            // Removes extra spaces between colon and case value.
+            'switch_case_space' => true,
+            // Standardize spaces around ternary operator.
+            'ternary_operator_spaces' => true,
+            // PHP multi-line arrays should have a trailing comma.
+            'trailing_comma_in_multiline_array' => true,
+            // Arrays should be formatted like function/method arguments, without leading or trailing single line space.
+            'trim_array_spaces' => true,
+            // Unary operators should be placed adjacent to their operands.
+            'unary_operator_spaces' => true,
+            // Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.
+            'visibility_required' => true,
+            // In array declaration, there MUST be a whitespace after each comma.
+            'whitespace_after_comma_in_array' => true,
+        ];
+    }
+
+    /**
+     * Returns the coding style flags associated to a file.
+     *
+     * @param string $file
+     *
+     * @return int|null return NULL if the file should not be parsed, an integer otherwise
+     */
+    public function getPathFlags($file)
+    {
+        $result = null;
+        $fullpath = @realpath($file);
+        if ($fullpath !== false && is_file($fullpath)) {
+            $fullpath = str_replace(DIRECTORY_SEPARATOR, '/', $fullpath);
+            if (strpos($fullpath, $this->getWebroot()) === 0) {
+                $result = $this->getFileFlags(new SplFileInfo($fullpath));
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the list of files corresponding to a specific category.
+     *
+     * @param int $flags A combination of CodingStyle::FLAG_... flags.
+     *
+     * @return SplFileInfo[]|\Generator
+     */
+    public function getFileList($flags)
+    {
+        $flags = (int) $flags;
+        $bootstrapFilePaths = $this->getBootstrapFilePaths();
+        if (($flags & static::FLAG_OLDPHP) === static::FLAG_OLDPHP) {
+            foreach ($bootstrapFilePaths as $bootstrapFilePath) {
+                yield new SplFileInfo($bootstrapFilePath);
+            }
+        } else {
+            $directory = new RecursiveDirectoryIterator(
+                $this->getWebroot(),
+                FilesystemIterator::KEY_AS_PATHNAME
+                | FilesystemIterator::CURRENT_AS_FILEINFO
+                | FilesystemIterator::SKIP_DOTS
+                | FilesystemIterator::UNIX_PATHS
+            );
+            $iterator = new RecursiveIteratorIterator(
+                $directory,
+                RecursiveIteratorIterator::LEAVES_ONLY
+                | RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($iterator as $item) {
+                /* @var SplFileInfo $item */
+                $itemFlags = $this->getFileFlags($item);
+                if (null !== $itemFlags) {
+                    if ($itemFlags === $flags) {
+                        yield $item;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Get a description of the specified flags.
+     *
+     * @param int $flags A combination of CodingStyle::FLAG_... flags.
+     *
+     * @return string
+     */
+    public function describeFlags($flags)
+    {
+        $flags = (int) $flags;
+        if (($flags & static::FLAG_PSR4CLASS) === static::FLAG_PSR4CLASS) {
+            $result = 'PHP-only file with the same name as the class it implements';
+        } elseif (($flags & static::FLAG_BOOTSTRAP) === static::FLAG_BOOTSTRAP) {
+            $result = 'PHP-only file with syntax compatible with old PHP versions';
+        } elseif ($flags === 0) {
+            $result = 'file with mixed contents';
+        } else {
+            $words = [];
+            if (($flags & static::FLAG_OLDPHP) === static::FLAG_OLDPHP) {
+                $words[] = 'file with syntax compatible with old PHP versions';
+            }
+            if (($flags & static::FLAG_PHPONLY) === static::FLAG_PHPONLY) {
+                $words[] = 'PHP-only file';
+            }
+            $result = implode(', ', $words);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the files accessed diring bootstrap processes.
+     *
+     * @return string[]
+     */
+    protected function getBootstrapFilePaths()
+    {
+        $webroot = $this->getWebroot();
+
+        return [
+            $webroot . '/index.php',
+            $webroot . '/concrete/dispatcher.php',
+            $webroot . '/concrete/bin/concrete5.php',
+        ];
+    }
+
+    /**
+     * Returns the coding style flags associated to a file.
+     *
+     * @param SplFileInfo $file
+     *
+     * @return int|null return NULL if the file should not be parsed, an integer otherwise
+     */
+    protected function getFileFlags(SplFileInfo $file)
+    {
+        if (
+            !$file->isFile()
+            || (
+                !in_array(strtolower($file->getExtension()), ['php'])
+                &&
+                strpos($file->getFilename(), '.php_cs.') !== 0
+            )
+        ) {
+            $result = null;
+        } else {
+            $path = $file->getPathname();
+            $relativePath = substr($path, strlen($this->getWebroot()));
+            switch (true) {
+                // Bootstrap files
+                case in_array($path, $this->getBootstrapFilePaths(), true):
+                    $result = static::FLAG_OLDPHP | static::FLAG_PHPONLY;
+                    break;
+                // Attribute controllers
+                case 1 === preg_match('~^/application/attributes/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/concrete/attributes/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/packages/\w+/attributes/\w+/controller\.php$~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Authentication controllers
+                case 1 === preg_match('~^/application/authentication/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/concrete/authentication/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/packages/\w+/authentication/\w+/controller\.php$~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Block controllers
+                case 1 === preg_match('~^/application/blocks/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/concrete/blocks/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/packages/\w+/blocks/\w+/controller\.php$~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Application and core bootstrap files
+                case 0 === strpos($relativePath, '/application/bootstrap/'):
+                case 0 === strpos($relativePath, '/concrete/bootstrap/'):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Configuration files
+                case 0 === strpos($relativePath, '/application/config/'):
+                case 0 === strpos($relativePath, '/concrete/config/'):
+                case 1 === preg_match('~^/packages/\w+/config/~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Other controller files
+                case 0 === strpos($relativePath, '/application/controllers/'):
+                case 0 === strpos($relativePath, '/concrete/controllers/'):
+                case 1 === preg_match('~^/packages/\w+/controllers/~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Geolocation controllers
+                case 1 === preg_match('~^/application/geolocation/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/concrete/geolocation/\w+/controller\.php$~', $relativePath):
+                case 1 === preg_match('~^/packages/\w+/geolocation/\w+/controller\.php$~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Automated jobs
+                case 0 === strpos($relativePath, '/application/jobs/'):
+                case 0 === strpos($relativePath, '/concrete/jobs/'):
+                case 1 === preg_match('~^/packages/\w+/jobs/~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Classes
+                case 0 === strpos($relativePath, '/application/src/'):
+                case 0 === strpos($relativePath, '/concrete/src/'):
+                case 1 === preg_match('~^/packages/\w+/src/~', $relativePath):
+                    $result = static::FLAG_PSR4CLASS;
+                    break;
+                // Theme controllers
+                case 1 === preg_match('~^/application/themes/\w+/page_theme\.php$~', $relativePath):
+                case 1 === preg_match('~^/concrete/themes/\w+/page_theme\.php$~', $relativePath):
+                case 1 === preg_match('~^/packages/\w+/themes/\w+/page_theme\.php$~', $relativePath):
+                    $result = static::FLAG_PHPONLY;
+                    break;
+                // Vendor files
+                case 0 === strpos($relativePath, '/concrete/vendor/'):
+                case 1 === preg_match('~^/packages/\w+/vendor/~', $relativePath):
+                    $result = null;
+                    break;
+                // All the other files
+                default:
+                    $result = 0;
+                    break;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -116,9 +116,7 @@ class CodingStyle
             // An empty line feed should precede a return statement.
             'blank_line_before_return' => true,
             // The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.
-            'braces' => [
-                'allow_single_line_closure' => true,
-            ],
+            'braces' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? ['allow_single_line_closure' => true] : false,
             // A single space should be between cast and variable.
             'cast_spaces' => true,
             // Whitespace around the keywords of a class, trait or interfaces definition should be one space.

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -535,6 +535,10 @@ class CodingStyle
                 case 1 === preg_match('~^/packages/\w+/vendor/~', $relativePath):
                     $result = null;
                     break;
+                // Application files
+                case 0 === strpos($relativePath, '/application/files/'):
+                    $result = null;
+                    break;
                 // All the other files
                 default:
                     $result = 0;

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -492,8 +492,11 @@ class CodingStyle
                 case 0 === strpos($relativePath, '/concrete/bootstrap/'):
                     $result = static::FLAG_PHPONLY;
                     break;
-                // Configuration files
+                // Runtime configuration files
                 case 0 === strpos($relativePath, '/application/config/'):
+                    $result = null;
+                    break;
+                // Core and package configuration files
                 case 0 === strpos($relativePath, '/concrete/config/'):
                 case 1 === preg_match('~^/packages/\w+/config/~', $relativePath):
                     $result = static::FLAG_PHPONLY;
@@ -515,6 +518,11 @@ class CodingStyle
                 case 0 === strpos($relativePath, '/concrete/jobs/'):
                 case 1 === preg_match('~^/packages/\w+/jobs/~', $relativePath):
                     $result = static::FLAG_PHPONLY;
+                    break;
+                // IDE Symbols
+                case '/concrete/src/Support/.phpstorm.meta.php' === $relativePath:
+                case '/concrete/src/Support/__IDE_SYMBOLS__.php' === $relativePath:
+                    $result = null;
                     break;
                 // Classes
                 case 0 === strpos($relativePath, '/application/src/'):

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Support;
 
 use Exception;

--- a/concrete/src/Support/CodingStyle.php
+++ b/concrete/src/Support/CodingStyle.php
@@ -99,10 +99,14 @@ class CodingStyle
     {
         $flags = (int) $flags;
 
+        $hasFlag = function ($flag) use ($flags) {
+            return ($flags & $flag) === $flag;
+        };
+
         return [
             // PHP arrays should be declared using the configured syntax
             'array_syntax' => [
-                'syntax' => 0 === ($flags & static::FLAG_OLDPHP) ? 'short' : 'long',
+                'syntax' => $hasFlag(static::FLAG_OLDPHP) ? 'long' : 'short',
             ],
             // Binary operators should be surrounded by at least one space.
             'binary_operator_spaces' => [
@@ -112,11 +116,11 @@ class CodingStyle
             // There MUST be one blank line after the namespace declaration.
             'blank_line_after_namespace' => true,
             // Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.
-            'blank_line_after_opening_tag' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            'blank_line_after_opening_tag' => $hasFlag(static::FLAG_PHPONLY) ? true : false,
             // An empty line feed should precede a return statement.
             'blank_line_before_return' => true,
             // The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.
-            'braces' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? ['allow_single_line_closure' => true] : false,
+            'braces' => $hasFlag(static::FLAG_PHPONLY) ? ['allow_single_line_closure' => true] : false,
             // A single space should be between cast and variable.
             'cast_spaces' => true,
             // Whitespace around the keywords of a class, trait or interfaces definition should be one space.
@@ -132,7 +136,7 @@ class CodingStyle
                 'space' => 'single',
             ],
             // Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant.
-            'dir_constant' => 0 === ($flags & static::FLAG_OLDPHP) ? true : false,
+            'dir_constant' => $hasFlag(static::FLAG_OLDPHP) ? false : true,
             // The keyword `elseif` should be used instead of `else if` so that all control keywords look like single words.
             'elseif' => true,
             // PHP code MUST use only UTF-8 without BOM (remove BOM).
@@ -152,13 +156,13 @@ class CodingStyle
             // Include/Require and file path should be divided with a single space. File path should not be placed under brackets.
             'include' => true,
             // Code MUST use configured indentation type.
-            'indentation_type' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            'indentation_type' => $hasFlag(static::FLAG_PHPONLY) ? true : false,
             // Replaces is_null(parameter) expression with `null === parameter`.
             'is_null' => [
                 'use_yoda_style' => false,
             ],
             // Ensure there is no code on the same line as the PHP open tag.
-            'linebreak_after_opening_tag' => ($flags && static::FLAG_PHPONLY) === static::FLAG_PHPONLY ? true : false,
+            'linebreak_after_opening_tag' => $hasFlag(static::FLAG_PHPONLY) ? true : false,
             // All PHP files must use same line ending.
             'line_ending' => true,
             // Cast should be written in lower case.
@@ -212,7 +216,7 @@ class CodingStyle
             // Short cast `bool` using double exclamation mark should not be used.
             'no_short_bool_cast' => true,
             // Replace short-echo `<?=` with long format `<?php echo` syntax.
-            'no_short_echo_tag' => 0 === ($flags & static::FLAG_OLDPHP) ? false : true,
+            'no_short_echo_tag' => $hasFlag(static::FLAG_OLDPHP) ? true : false,
             // Single-line whitespace before closing semicolon are prohibited.
             'no_singleline_whitespace_before_semicolons' => true,
             // When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.
@@ -288,7 +292,7 @@ class CodingStyle
             // Pre incrementation/decrementation should be used if possible.
             'pre_increment' => true,
             // Class names should match the file name.
-            'psr4' => ($flags && static::FLAG_PSR4CLASS) === static::FLAG_PSR4CLASS ? true : false,
+            'psr4' => $hasFlag(static::FLAG_PSR4CLASS) ? true : false,
             // Replaces `rand`, `srand`, `getrandmax` functions calls with their `mt_*` analogs.
             'random_api_migration' => true,
             // There should be one or no space before colon, and one space after it in return type declarations, according to configuration.


### PR DESCRIPTION
This pull request defines a common set of rules, to be executed both by TravisCI (to check the coding style) and by developers (to automatically fix the coding style).

This pull request implements a quite intelligent approach, that takes in account these cases:
1. we have some file that needs to be compatible with old PHP versions (notably `/index.php`, `/concrete/dispatcher.php` and `/concrete/bin/concrete5.php`)', where we can't use the PHP 5.5+ syntax (short array syntax, short echo tags, ...).
2. we have files with mixed PHP and HTML, where the indentation and the position of opening/closing PHP tags shouldn't be touched
3. we have files whose file names should be the same as the class names they implements (PSR-4).
4. we have PHP-only files implementing classes that don't follow the PSR-4 rules (for instance, block controllers)

This pull request applies the correct fixes for the files, determining the relevant rule set by checking their paths.

Since concrete5 doesn't currently follow all the rules defined in the included `CodingStyle.php` file, the coding style checks of TravisCI should fail. In order to fix this, we could run these commands to fix all the above file classes:
1. `composer fix --config=.php_cs.bootstrap`
2. `composer fix --config=.php_cs.mixed`
3. `composer fix --config=.php_cs.psr4`
4. `composer fix --config=.php_cs.phponly`

When developers write a file, they don't have to specify the correct configuration file (`.php_cs.bootstrap`, `.php_cs.mixed`, `.php_cs.psr4` or `.php_cs.phponly`): by using the `.php_cs.dist` configuration file (eg `composer php-cs-fixer fix --config=.php_cs.dist <filename>`), the correct rule set is used.

Of course, the list of rules defined here is just a proposal: others interested in this subject can comment here (or create pull requests against https://github.com/mlocati/concrete5/tree/coding-style-with-php-cs-fixer ).

Close #3539