### PR TITLE
Fix BlockTypeList: new Block object isn't created properly

### DIFF
--- a/concrete/src/Block/BlockType/BlockTypeList.php
+++ b/concrete/src/Block/BlockType/BlockTypeList.php
@@ -89,7 +89,7 @@ class BlockTypeList extends DatabaseItemList
                             $bt = new BlockTypeEntity();
                             $bt->setBlockTypeHandle($file);
                             $class = $bt->getBlockTypeClass();
-                            $bta = Application::getFacadeRoot()->make($class);
+                            $bta = Application::getFacadeRoot()->build($class);
                             $bt->setBlockTypeName($bta->getBlockTypeName());
                             $bt->setBlockTypeDescription($bta->getBlockTypeDescription());
                             $bt->hasCustomViewTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_VIEW);

--- a/concrete/src/Block/BlockType/BlockTypeList.php
+++ b/concrete/src/Block/BlockType/BlockTypeList.php
@@ -89,7 +89,7 @@ class BlockTypeList extends DatabaseItemList
                             $bt = new BlockTypeEntity();
                             $bt->setBlockTypeHandle($file);
                             $class = $bt->getBlockTypeClass();
-                            $bta = Application::getFacadeRoot()->build($class);
+                            $bta = Application::getFacadeApplication()->build($class);
                             $bt->setBlockTypeName($bta->getBlockTypeName());
                             $bt->setBlockTypeDescription($bta->getBlockTypeDescription());
                             $bt->hasCustomViewTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_VIEW);

--- a/concrete/src/Block/BlockType/BlockTypeList.php
+++ b/concrete/src/Block/BlockType/BlockTypeList.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Block\BlockType;
 
 use Concrete\Core\Entity\Block\BlockType\BlockType as BlockTypeEntity;
+use Concrete\Core\Support\Facade\Application;
 use Core;
 use Loader;
 use Package;
@@ -88,7 +89,7 @@ class BlockTypeList extends DatabaseItemList
                             $bt = new BlockTypeEntity();
                             $bt->setBlockTypeHandle($file);
                             $class = $bt->getBlockTypeClass();
-                            $bta = new $class();
+                            $bta = Application::getFacadeRoot()->make($class);
                             $bt->setBlockTypeName($bta->getBlockTypeName());
                             $bt->setBlockTypeDescription($bta->getBlockTypeDescription());
                             $bt->hasCustomViewTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_VIEW);


### PR DESCRIPTION
The block object isn't created the correct way. The error popped up when creating a new BlockType with additional constructor parameters.
To reproduce:
1. Copy autonav block to application folder and rewrite namespace as usual
2. rename folder name to `test_autonav` & adapt namespace
3. add the following `Connection $database` param to the constructor:
```
use Concrete\Core\Database\Connection\Connection;
//...
protected $database;
//...
class Controller extends BlockController
{
//...
    public function __construct(Connection $database, $obj = null)
    {
        parent::__construct($obj);
        $this->database = $database;
    }
//...
}
```
4. head over to `/dashboard/blocks/types/install`
5. Install the new BlockType
Result:
> Exception: Argument 2 passed to Application\Block\TestAutonav\Controller::__construct() must be an instance of Concrete\Core\Database\Connection\Connection, none given, called in /var/www/html/absolute_latest/concrete5-8.2.1/concrete/src/Block/BlockType/BlockTypeList.php on line 91