### PR TITLE
Return collection pointer ID for alias pages instead of the target ID

### DIFF
--- a/concrete/src/Page/EditResponse.php
+++ b/concrete/src/Page/EditResponse.php
@@ -8,7 +8,11 @@ class EditResponse extends \Concrete\Core\Application\EditResponse
 
     public function setPage(Page $page)
     {
-        $this->cID = $page->getCollectionID();
+        if ($page->isAlias()) {
+            $this->cID = $page->getCollectionPointerOriginalID();
+        } else {
+            $this->cID = $page->getCollectionID();
+        }
     }
 
     public function setPages($pages)

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -211,7 +211,11 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $r = new \stdClass();
         $r->name = $this->getCollectionName();
-        $r->cID = $this->getCollectionID();
+        if ($this->isAlias()) {
+            $r->cID = $this->getCollectionPointerOriginalID();
+        } else {
+            $r->cID = $this->getCollectionID();
+        }
 
         return $r;
     }


### PR DESCRIPTION
Fixes #4633, where page selector replaces alias ID by original ID when selecting a page alias. Please review before accepting.