### PR TITLE
Faster file rescan

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -50,11 +50,15 @@ class File extends Controller
         if ($resize) {
             $width = (int) \Config::get('concrete.file_manager.restrict_max_width');
             $height = (int) \Config::get('concrete.file_manager.restrict_max_height');
-            $quality = (int) \Config::get('concrete.file_manager.restrict_resize_quality');
-            $resizeProcessor = new ConstrainImageProcessor($width, $height);
-            $qualityProcessor = new SetJPEGQualityProcessor($quality);
-            $processors[] = $resizeProcessor;
-            $processors[] = $qualityProcessor;
+            $fWidth = (int) $f->getAttribute('width');
+            $fHeight = (int) $f->getAttribute('height');
+            if ($fWidth > $width || $fHeight > $height) {
+                $quality = (int) \Config::get('concrete.file_manager.restrict_resize_quality');
+                $resizeProcessor = new ConstrainImageProcessor($width, $height);
+                $qualityProcessor = new SetJPEGQualityProcessor($quality);
+                $processors[] = $resizeProcessor;
+                $processors[] = $qualityProcessor;
+            }
         }
 
         if (count($processors)) {


### PR DESCRIPTION
When rescanning images the first thing that happens is whether the setting to constraint image sizes is enabled. Normally this setting applies on upload but if it was set after some images were already uploaded, it didn't apply to those images. Hence the check on rescan.

The problem is, if constraints are enabled, the system doesn't check whether the image is already within constraints. It goes through the whole process of creating a new version and going through imagine which will eventually figure out the image doesn't need processing.

This modification checks the size of the image BEFORE doing all this so if it is already within constraint, we don't waste time.

I did a quick microtime() measuring on 6 images and, doing it this way, it gets between 3x to 5x faster processing one image and its thumbnails.