### PR TITLE
Fix rescan multiple files error

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -106,6 +106,10 @@ class File extends Controller
             foreach($messages as $key => $msg) {
                 // delete the page here
                 $file = unserialize($msg->body);
+                if ($file === false) {
+                    $q->deleteMessage($msg);
+                    continue;
+                }
                 $f = \Concrete\Core\File\File::getByID($file['fID']);
                 if (is_object($f)) {
                     $this->doRescan($f);
@@ -114,7 +118,7 @@ class File extends Controller
             }
             $obj->totalItems = $q->count();
             if ($q->count() == 0) {
-                $q->deleteQueue(5);
+                $q->deleteQueue();
             }
             print json_encode($obj);
             exit;


### PR DESCRIPTION
* Delete message if `unserialize` returns false.
* Remove `5` argument as `deleteQueue` does not take any
  arguments

If there is bad data in the queue, for example, the string "7164",
the `unserialize` call with return false which make `file['fID']` `null`.
This causes the `getByID` call to fail with the error
`The identifier fID is missing for a query of Concrete\Core\Entity\File\File`
Then the offending queue message is never removed breaking
multiple file rescan until it is manually removed from the database.

This seems to happen after upgrade of sites with a lot of files
from version 5.7 to 8.

See this forum post for more report of the issue
https://www.concrete5.org/community/forums/installation/error-the-identifier-fid-is-missing-for-a-query-of-concretecoree/