### PR TITLE
Make jobs and packages aware of the console

### DIFF
--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -79,9 +79,7 @@ EOT
 
         // Provide the console objects to objects that are aware of the console
         if ($pkg instanceof ConsoleAwareInterface) {
-            $pkg->setOutput($output);
-            $pkg->setInput($input);
-            $pkg->setConsole($this->getApplication());
+            $pkg->setConsole($this->getApplication(), $output, $input);
         }
 
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Console\Command;
+use Concrete\Core\Console\ConsoleAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,6 +76,14 @@ EOT
         if ($pkg === null) {
             throw new Exception(sprintf("No package with handle '%s' was found", $pkgHandle));
         }
+
+        // Provide the console objects to objects that are aware of the console
+        if ($pkg instanceof ConsoleAwareInterface) {
+            $pkg->setOutput($output);
+            $pkg->setInput($input);
+            $pkg->setConsole($this->getApplication());
+        }
+
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));
 
         $output->write('Checking preconditions... ');

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Console\ConsoleAwareInterface;
 use Job;
 use JobSet;
 use RuntimeException;
@@ -106,6 +107,13 @@ EOT
 
             if (!empty($jobs)) {
                 foreach ($jobs as $job) {
+                    // Provide the console objects to objects that are aware of the console
+                    if ($job instanceof ConsoleAwareInterface) {
+                        $job->setOutput($output);
+                        $job->setInput($input);
+                        $job->setConsole($this->getApplication());
+                    }
+
                     $result = $job->executeJob();
                     if ($result->isError()) {
                         $rc = 1;

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -109,9 +109,7 @@ EOT
                 foreach ($jobs as $job) {
                     // Provide the console objects to objects that are aware of the console
                     if ($job instanceof ConsoleAwareInterface) {
-                        $job->setOutput($output);
-                        $job->setInput($input);
-                        $job->setConsole($this->getApplication());
+                        $job->setConsole($this->getApplication(), $output, $input);
                     }
 
                     $result = $job->executeJob();

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Concrete\Core\Console\ConsoleAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,6 +47,14 @@ EOT
         if ($pkg === null) {
             throw new Exception(sprintf("No package with handle '%s' is installed", $pkgHandle));
         }
+
+        // Provide the console objects to objects that are aware of the console
+        if ($pkg instanceof ConsoleAwareInterface) {
+            $pkg->setOutput($output);
+            $pkg->setInput($input);
+            $pkg->setConsole($this->getApplication());
+        }
+
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));
 
         $output->write('Checking preconditions... ');

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -50,9 +50,7 @@ EOT
 
         // Provide the console objects to objects that are aware of the console
         if ($pkg instanceof ConsoleAwareInterface) {
-            $pkg->setOutput($output);
-            $pkg->setInput($input);
-            $pkg->setConsole($this->getApplication());
+            $pkg->setConsole($this->getApplication(), $output, $input);
         }
 
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -91,9 +91,7 @@ EOT
 
         // Provide the console objects to objects that are aware of the console
         if ($pkg instanceof ConsoleAwareInterface) {
-            $pkg->setOutput($output);
-            $pkg->setInput($input);
-            $pkg->setConsole($this->getApplication());
+            $pkg->setConsole($this->getApplication(), $output, $input);
         }
 
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Concrete\Core\Console\ConsoleAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -64,7 +65,7 @@ EOT
         }
         foreach ($updatableHandles as $updatableHandle) {
             try {
-                $this->updatePackage($updatableHandle, $output, $force);
+                $this->updatePackage($updatableHandle, $output, $input, $force);
             } catch (Exception $x) {
                 $this->writeError($output, $x);
                 $rc = 1;
@@ -74,7 +75,7 @@ EOT
         return $rc;
     }
 
-    protected function updatePackage($pkgHandle, OutputInterface $output, $force)
+    protected function updatePackage($pkgHandle, OutputInterface $output, InputInterface $input, $force)
     {
         $output->write("Looking for package '$pkgHandle'... ");
         $pkg = null;
@@ -87,6 +88,14 @@ EOT
         if ($pkg === null) {
             throw new Exception(sprintf("No package with handle '%s' is installed", $pkgHandle));
         }
+
+        // Provide the console objects to objects that are aware of the console
+        if ($pkg instanceof ConsoleAwareInterface) {
+            $pkg->setOutput($output);
+            $pkg->setInput($input);
+            $pkg->setConsole($this->getApplication());
+        }
+
         $output->writeln(sprintf('<info>found (%s).</info>', $pkg->getPackageName()));
 
         $output->write('Checking preconditions... ');

--- a/concrete/src/Console/ConsoleAwareInterface.php
+++ b/concrete/src/Console/ConsoleAwareInterface.php
@@ -18,15 +18,17 @@ interface ConsoleAwareInterface
      * Set the console object
      *
      * @param \Symfony\Component\Console\Application $console
-     * @return void
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
+     * @param \Symfony\Component\Console\Input\InputInterface|null $input
+     * @return static Returns itself
      */
-    public function setConsole(SymfonyApplication $console);
+    public function setConsole(SymfonyApplication $console, OutputInterface $output = null, InputInterface $input = null);
 
     /**
      * Set the output object to use
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return static Returns itself
      */
     public function setOutput(OutputInterface $output);
 
@@ -34,7 +36,7 @@ interface ConsoleAwareInterface
      * Set the input object to use
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @return void
+     * @return static Returns itself
      */
     public function setInput(InputInterface $input);
 

--- a/concrete/src/Console/ConsoleAwareInterface.php
+++ b/concrete/src/Console/ConsoleAwareInterface.php
@@ -2,9 +2,8 @@
 
 namespace Concrete\Core\Console;
 
-use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -21,7 +20,7 @@ interface ConsoleAwareInterface
      * @param \Symfony\Component\Console\Application $console
      * @return void
      */
-    public function setConsole(Application $console);
+    public function setConsole(SymfonyApplication $console);
 
     /**
      * Set the output object to use

--- a/concrete/src/Console/ConsoleAwareInterface.php
+++ b/concrete/src/Console/ConsoleAwareInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Concrete\Core\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Interface to flag an object as being aware of the symfony console components.
+ *
+ * Be aware that these objects are not guaranteed to be provided
+ */
+interface ConsoleAwareInterface
+{
+
+    /**
+     * Set the console object
+     *
+     * @param \Symfony\Component\Console\Application $console
+     * @return void
+     */
+    public function setConsole(Application $console);
+
+    /**
+     * Set the output object to use
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    public function setOutput(OutputInterface $output);
+
+    /**
+     * Set the input object to use
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return void
+     */
+    public function setInput(InputInterface $input);
+
+}

--- a/concrete/src/Console/ConsoleAwareTrait.php
+++ b/concrete/src/Console/ConsoleAwareTrait.php
@@ -27,33 +27,43 @@ trait ConsoleAwareTrait
      * Set the console object
      *
      * @param \Symfony\Component\Console\Application $console
-     * @return void
+     * @return static
      */
-    public function setConsole(Application $console)
+    public function setConsole(Application $console, OutputInterface $output = null, InputInterface $input = null)
     {
         $this->traitConsole = $console;
+        if ($output) {
+            $this->setOutput($output);
+        }
+        if ($input) {
+            $this->setInput($input);
+        }
+
+        return $this;
     }
 
     /**
      * Set the output object to use
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return static
      */
     public function setOutput(OutputInterface $output)
     {
         $this->traitOutput = $output;
+        return $this;
     }
 
     /**
      * Set the input object to use
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @return void
+     * @return static
      */
     public function setInput(InputInterface $input)
     {
         $this->traitInput = $input;
+        return $this;
     }
 
     /**

--- a/concrete/src/Console/ConsoleAwareTrait.php
+++ b/concrete/src/Console/ConsoleAwareTrait.php
@@ -27,6 +27,8 @@ trait ConsoleAwareTrait
      * Set the console object
      *
      * @param \Symfony\Component\Console\Application $console
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
+     * @param \Symfony\Component\Console\Input\InputInterface|null $input
      * @return static
      */
     public function setConsole(Application $console, OutputInterface $output = null, InputInterface $input = null)

--- a/concrete/src/Console/ConsoleAwareTrait.php
+++ b/concrete/src/Console/ConsoleAwareTrait.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Core\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * A trait that provides awareness of the console to objects
+ */
+trait ConsoleAwareTrait
+{
+
+    /** @var Application|null */
+    protected $traitConsole;
+
+    /** @var OutputInterface|null */
+    protected $traitOutput;
+
+    /** @var InputInterface|null */
+    protected $traitInput;
+
+    /**
+     * Set the console object
+     *
+     * @param \Symfony\Component\Console\Application $console
+     * @return void
+     */
+    public function setConsole(Application $console)
+    {
+        $this->traitConsole = $console;
+    }
+
+    /**
+     * Set the output object to use
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    public function setOutput(OutputInterface $output)
+    {
+        $this->traitOutput = $output;
+    }
+
+    /**
+     * Set the input object to use
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return void
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->traitInput = $input;
+    }
+
+    /**
+     * Get an output object
+     *
+     * @return OutputInterface
+     */
+    protected function getOutput()
+    {
+        return $this->traitOutput ?: new NullOutput();
+    }
+
+    /**
+     * Get an input object
+     *
+     * @return InputInterface
+     */
+    protected function getInput()
+    {
+        return $this->traitInput ?: new StringInput('');
+    }
+
+    /**
+     * Find out if we are in console context
+     * @return bool
+     */
+    protected function hasConsole()
+    {
+        return $this->traitConsole !== null;
+    }
+
+}


### PR DESCRIPTION
This makes it easy for jobs and packages to output to the console when being manipulated via cli. As an example I added a progress bar to the generate_sitemap job.