### PR TITLE
Add "name" attribute to exported topic trees

### DIFF
--- a/concrete/src/Tree/Type/Topic.php
+++ b/concrete/src/Tree/Type/Topic.php
@@ -84,6 +84,8 @@ class Topic extends Tree
         $default = self::getDefault();
         if (is_object($default) && $default->getTreeID() == $this->getTreeID()) {
             $sx->addAttribute('default', 1);
+        } else {
+            $sx->addAttribute('name', $this->getTreeName());
         }
     }
 


### PR DESCRIPTION
When importing topic trees we need a `name` attribute ([link](https://github.com/concrete5/concrete5/blob/d5658e0b592bdcd176ad1b342f0e5d5db346adaf/concrete/src/Tree/Type/Topic.php#L96)), but it's not set while exporting them ([link](https://github.com/concrete5/concrete5/blob/d5658e0b592bdcd176ad1b342f0e5d5db346adaf/concrete/src/Tree/Type/Topic.php#L82)).

Let's fix this issue.