### PR TITLE
Fixed issue with existing ratings not being populated in edit mode - Update form.php

### DIFF
--- a/concrete/attributes/rating/form.php
+++ b/concrete/attributes/rating/form.php
@@ -1,3 +1,3 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-print $rating->output($this->field('value'), $caValue);
+print $rating->output($this->field('value'), $value);


### PR DESCRIPTION
Fixed issue in form.php with incorrect variable being called. Previously, the ratings attribute was not being passed correctly into service.php when output method was called.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!