### PR TITLE
Introduce package dependencies

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -22,10 +22,7 @@ class Update extends DashboardPageController
         if ($tp->canInstallPackages()) {
             if ($pkgHandle) {
                 $pkg = \Concrete\Core\Support\Facade\Package::getClass($pkgHandle);
-                $r = $pkg->testForInstall(false);
-                if ($r === true) {
-                    $r = $pkg->testForUpgrade(false);
-                }
+                $r = $pkg->testForUpgrade();
                 if ($r !== true) {
                     $this->error->add($r);
                 } else {

--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -23,7 +23,10 @@ class Update extends DashboardPageController
             if ($pkgHandle) {
                 $pkg = \Concrete\Core\Support\Facade\Package::getClass($pkgHandle);
                 $r = $pkg->testForInstall(false);
-                if (is_object($r)) {
+                if ($r === true) {
+                    $r = $pkg->testForUpgrade(false);
+                }
+                if ($r !== true) {
                     $this->error->add($r);
                 } else {
                     $p = Package::getByHandle($pkgHandle);

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -107,10 +107,7 @@ EOT
         if ($upPkg === null && $force !== true) {
             $output->writeln(sprintf("<info>the package is already up-to-date (v%s)</info>", $pkg->getPackageVersion()));
         } else {
-            $test = $pkg->testForInstall(false);
-            if ($test === true) {
-                $test = $pkg->testForUpgrade();
-            }
+            $test = $pkg->testForUpgrade();
             if ($test !== true) {
                 throw new Exception(implode("\n", $test->getList()));
             }

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -108,10 +108,10 @@ EOT
             $output->writeln(sprintf("<info>the package is already up-to-date (v%s)</info>", $pkg->getPackageVersion()));
         } else {
             $test = $pkg->testForInstall(false);
-            if (is_object($test)) {
-                /*
-                 * @var Error $test
-                 */
+            if ($test === true) {
+                $test = $pkg->testForUpgrade();
+            }
+            if ($test !== true) {
                 throw new Exception(implode("\n", $test->getList()));
             }
             $output->writeln('<info>good.</info>');

--- a/concrete/src/Package/Dependency/DependencyChecker.php
+++ b/concrete/src/Package/Dependency/DependencyChecker.php
@@ -1,0 +1,162 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Package;
+use Concrete\Core\Package\PackageService;
+
+class DependencyChecker
+{
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    /**
+     * @var Package[]|null
+     */
+    protected $installedPackages;
+
+    /**
+     * Initializes the instance.
+     *
+     * @param Application $application
+     */
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    /**
+     * Set the list of installed packages.
+     *
+     * @param Package[] $installedPackages
+     *
+     * @return $this
+     */
+    public function setInstalledPackages(array $installedPackages)
+    {
+        $dictionary = [];
+        foreach ($installedPackages as $installedPackage) {
+            $dictionary[$installedPackage->getPackageHandle()] = $installedPackage;
+        }
+        $this->installedPackages = $dictionary;
+
+        return $this;
+    }
+
+    /**
+     * @param Package $package
+     *
+     * @return ErrorList
+     */
+    public function testForInstall(Package $package)
+    {
+        $result = $this->application->make(ErrorList::class);
+        $installedPackages = $this->getInstalledPackages();
+        // Check that this package is compatible with the installed packages
+        foreach ($installedPackages as $installedPackage) {
+            $requirements = $this->getPackageRequirementsForPackage($installedPackage, $package);
+            $error = $this->checkPackageCompatibility($installedPackage, $package, $requirements);
+            if ($error !== null) {
+                $result->add($error);
+            }
+        }
+        // Check that the installed packages are compatible with this package
+        foreach ($package->getPackageDependencies() as $handle => $requirements) {
+            if (isset($installedPackages[$handle])) {
+                $installedPackage = $installedPackages[$handle];
+                $error = $this->checkPackageCompatibility($package, $installedPackage, $requirements);
+                if ($error !== null) {
+                    $result->add($error);
+                }
+            } else {
+                if ($requirements !== false) {
+                    $result->add(new MissingRequiredPackageException($package, $handle, $requirements));
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Package $package
+     *
+     * @return ErrorList
+     */
+    public function testForUninstall(Package $package)
+    {
+        $result = $this->application->make(ErrorList::class);
+        foreach ($this->getInstalledPackages() as $installedPackage) {
+            $requirements = $this->getPackageRequirementsForPackage($installedPackage, $package);
+            if ($requirements !== null && $requirements !== false) {
+                $result->add(new RequiredPackageException($package, $installedPackage));
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the list of installed packages.
+     *
+     * @return Package[] keys are package handles, values are Package instances
+     */
+    protected function getInstalledPackages()
+    {
+        if ($this->installedPackages === null) {
+            $installedPackages = [];
+            $packageService = $this->app->make(PackageService::class);
+            foreach ($packageService->getInstalledHandles() as $packageHandle) {
+                $installedPackages[$packageHandle] = $packageService->getClass($packageHandle);
+            }
+            $this->installedPackages = $installedPackages;
+        }
+
+        return $this->installedPackages;
+    }
+
+    /**
+     * Get the requirements for a package in respect to another package.
+     *
+     * @param Package $package
+     * @param Package $otherPackage
+     *
+     * @return string[]|string|bool|null
+     */
+    protected function getPackageRequirementsForPackage(Package $package, Package $otherPackage)
+    {
+        $dependencies = $package->getPackageDependencies();
+        $otherPackageHandle = $otherPackage->getPackageHandle();
+
+        return isset($dependencies[$otherPackageHandle]) ? $dependencies[$otherPackageHandle] : null;
+    }
+
+    /**
+     * @param Package $package
+     * @param Package $dependentPackage
+     * @param string[]|string|bool|null $requirements
+     *
+     * @return \LogicException|null
+     */
+    protected function checkPackageCompatibility(Package $package, Package $dependentPackage, $requirements)
+    {
+        $result = null;
+        $version = $dependentPackage->getPackageVersion();
+        if ($requirements === false) {
+            $result = new IncompatiblePackagesException($package, $dependentPackage);
+        } elseif (is_string($requirements)) {
+            if (version_compare($version, $requirements) < 0) {
+                $result = new VersionMismatchException($package, $dependentPackage, $requirements);
+            }
+        } elseif (is_array($requirements)) {
+            if (version_compare($version, $requirements[0]) < 0 || version_compare($version, $requirements[1]) > 0) {
+                $result = new VersionMismatchException($package, $dependentPackage, $requirements);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/concrete/src/Package/Dependency/DependencyException.php
+++ b/concrete/src/Package/Dependency/DependencyException.php
@@ -1,0 +1,27 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Error\ErrorList\Error\ErrorInterface;
+use LogicException;
+
+/**
+ * Package dependency failure.
+ */
+abstract class DependencyException extends LogicException implements ErrorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->getMessage();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return ['message' => $this->getMessage()];
+    }
+}

--- a/concrete/src/Package/Dependency/IncompatiblePackagesException.php
+++ b/concrete/src/Package/Dependency/IncompatiblePackagesException.php
@@ -1,0 +1,61 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Package\Package;
+
+/**
+ * Package dependency failure: a package doesn't want another package.
+ */
+class IncompatiblePackagesException extends DependencyException
+{
+    /**
+     * The package that doesn't want the other package.
+     *
+     * @var Package
+     */
+    protected $blockingPackage;
+
+    /**
+     * The incompatible package.
+     *
+     * @var Package
+     */
+    protected $incompatiblePackage;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param Package $blockingPackage the package that doesn't want the other package
+     * @param Package $incompatiblePackage the incompatible package
+     */
+    public function __construct(Package $blockingPackage, Package $incompatiblePackage)
+    {
+        $this->blockingPackage = $blockingPackage;
+        $this->incompatiblePackage = $incompatiblePackage;
+        parent::__construct(t(
+            'The package "%1$s" can\'t be installed if the package "%2$s" is installed.',
+            $incompatiblePackage->getPackageName(),
+            $blockingPackage->getPackageName()
+        ));
+    }
+
+    /**
+     * Get the package that can't be uninstalled.
+     *
+     * @return Package
+     */
+    public function getBlockingPackage()
+    {
+        return $this->blockingPackage;
+    }
+
+    /**
+     * Get the incompatible package.
+     *
+     * @return Package
+     */
+    public function getIncompatiblePackage()
+    {
+        return $this->incompatiblePackage;
+    }
+}

--- a/concrete/src/Package/Dependency/MissingRequiredPackageException.php
+++ b/concrete/src/Package/Dependency/MissingRequiredPackageException.php
@@ -1,0 +1,98 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Package\Package;
+
+/**
+ * Package dependency failure: a package can't be installed since it requires another package that's not installed.
+ */
+class MissingRequiredPackageException extends DependencyException
+{
+    /**
+     * The package that can't be installed.
+     *
+     * @var Package
+     */
+    protected $notInstallablePackage;
+
+    /**
+     * The handle of the package that's not installed.
+     *
+     * @var Package
+     */
+    protected $missingPackageHandle;
+
+    /**
+     * The version requirements of the not installed package.
+     *
+     * @var string|string[]|bool
+     */
+    protected $requirements;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param Package $notInstallablePackage the package that can't be installed
+     * @param string $missingPackageHandle the handle of the package that's not installed
+     * @param string|string[]|bool $requirements the version requirements of the package
+     */
+    public function __construct(Package $notInstallablePackage, $missingPackageHandle, $requirements)
+    {
+        $this->notInstallablePackage = $notInstallablePackage;
+        $this->missingPackageHandle = $missingPackageHandle;
+        $this->requirements = $requirements;
+        if (is_string($requirements)) {
+            $message = t(
+                'The package "%1$s" requires the package with handle "%2$s" (version %3$s or greater)',
+                $notInstallablePackage->getPackageName(),
+                $missingPackageHandle,
+                $requirements
+            );
+        } elseif (is_array($requirements)) {
+            $message = t(
+                'The package "%1$s" requires the package with handle "%2$s" (version between %3$s and %4$s)',
+                $notInstallablePackage->getPackageName(),
+                $missingPackageHandle,
+                $requirements[0],
+                $requirements[1]
+            );
+        } else {
+            $message = t(
+                'The package "%1$s" requires the package with handle "%2$s"',
+                $notInstallablePackage->getPackageName(),
+                $missingPackageHandle
+            );
+        }
+        parent::__construct($message);
+    }
+
+    /**
+     * Get the package that can't be installed.
+     *
+     * @return Package
+     */
+    public function getNotInstallablePackage()
+    {
+        return $this->notInstallablePackage;
+    }
+
+    /**
+     * Get the handle of the package that's not installed.
+     *
+     * @return Package
+     */
+    public function getMissingPackageHandle()
+    {
+        return $this->missingPackageHandle;
+    }
+
+    /**
+     * Get the version requirements of the not installed package.
+     *
+     * @var string|string[]|bool
+     */
+    public function getRequirements()
+    {
+        return $this->requirements;
+    }
+}

--- a/concrete/src/Package/Dependency/RequiredPackageException.php
+++ b/concrete/src/Package/Dependency/RequiredPackageException.php
@@ -1,0 +1,61 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Package\Package;
+
+/**
+ * Package dependency failure: an installed package can't be uninstalled since it's required by another package.
+ */
+class RequiredPackageException extends DependencyException
+{
+    /**
+     * The package that can't be uninstalled.
+     *
+     * @var Package
+     */
+    protected $uninstallablePackage;
+
+    /**
+     * The package that requires the package that can't be uninstalled.
+     *
+     * @var Package
+     */
+    protected $blockingPackage;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param Package $uninstallablePackage the package that can't be uninstalled
+     * @param Package $blockingPackage the package that requires the package that can't be uninstalled
+     */
+    public function __construct(Package $uninstallablePackage, Package $blockingPackage)
+    {
+        $this->uninstallablePackage = $uninstallablePackage;
+        $this->blockingPackage = $blockingPackage;
+        parent::__construct(t(
+            'The package "%1$s" can\'t be uninstalled since the package "%2$s" requires it.',
+            $uninstallablePackage->getPackageName(),
+            $blockingPackage->getPackageName()
+        ));
+    }
+
+    /**
+     * Get the package that can't be uninstalled.
+     *
+     * @return Package
+     */
+    public function getUninstallablePackage()
+    {
+        return $this->uninstallablePackage;
+    }
+
+    /**
+     * Get the package that requires the package that can't be uninstalled.
+     *
+     * @return Package
+     */
+    public function getBlockingPackage()
+    {
+        return $this->blockingPackage;
+    }
+}

--- a/concrete/src/Package/Dependency/VersionMismatchException.php
+++ b/concrete/src/Package/Dependency/VersionMismatchException.php
@@ -1,0 +1,92 @@
+<?php
+namespace Concrete\Core\Package\Dependency;
+
+use Concrete\Core\Package\Package;
+
+/**
+ * Package dependency failure: a package requires specific versions of another package.
+ */
+class VersionMismatchException extends DependencyException
+{
+    /**
+     * The package that causes the dependency problem.
+     *
+     * @var Package
+     */
+    protected $blockingPackage;
+
+    /**
+     * The package that fails the requirement.
+     *
+     * @var Package
+     */
+    protected $package;
+
+    /**
+     * The required package version.
+     *
+     * @var string|string[]
+     */
+    protected $requiredVersion;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param Package $blockingPackage the package that causes the dependency problem
+     * @param Package $package the package that fails the requirement
+     * @param string|string[] $requiredVersion the required package version
+     */
+    public function __construct(Package $blockingPackage, Package $package, $requiredVersion)
+    {
+        $this->package = $package;
+        $this->blockingPackage = $blockingPackage;
+        $this->requiredVersion = $requiredVersion;
+        if (is_array($requiredVersion)) {
+            $message = t(
+                'The package "%1$s" requires that package "%2$s" has a version between %3$s and %4$s',
+                $blockingPackage->getPackageName(),
+                $package->getPackageName(),
+                $requiredVersion[0],
+                $requiredVersion[1]
+            );
+        } else {
+            $message = t(
+                'The package "%1$s" requires that package "%2$s" has a version %3$s or greater',
+                $blockingPackage->getPackageName(),
+                $package->getPackageName(),
+                $requiredVersion
+            );
+        }
+        parent::__construct($message);
+    }
+
+    /**
+     * Get the package that causes the dependency problem.
+     *
+     * @return Package
+     */
+    public function getBlockingPackage()
+    {
+        return $this->blockingPackage;
+    }
+
+    /**
+     * Get the package that fails the requirement.
+     *
+     * @return Package
+     */
+    public function getPackage()
+    {
+        return $this->package;
+    }
+
+    /**
+     * Get the required package version.
+     *
+     * @return string|string[]
+     */
+    public function getRequiredVersion()
+    {
+        return $this->requiredVersion;
+    }
+}

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -615,6 +615,8 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * @deprecated
      * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledList()
+     *
+     * @return PackageEntity[]
      */
     public static function getInstalledList()
     {
@@ -624,6 +626,8 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * @deprecated
      * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledHandles()
+     *
+     * @return string[]
      */
     public static function getInstalledHandles()
     {
@@ -635,6 +639,8 @@ abstract class Package implements LocalizablePackageInterface
      * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledHandles()
      *
      * @param string $pkgHandle
+     *
+     * @return PackageEntity|null
      */
     public static function getByHandle($pkgHandle)
     {
@@ -644,6 +650,8 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * @deprecated
      * Use $app->make('Concrete\Core\Package\PackageService')->getLocalUpgradeablePackages()
+     *
+     * @return PackageEntity[]
      */
     public static function getLocalUpgradeablePackages()
     {
@@ -653,6 +661,8 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * @deprecated
      * Use $app->make('Concrete\Core\Package\PackageService')->getRemotelyUpgradeablePackages()
+     *
+     * @return PackageEntity[]
      */
     public static function getRemotelyUpgradeablePackages()
     {
@@ -664,6 +674,8 @@ abstract class Package implements LocalizablePackageInterface
      * Use $app->make('Concrete\Core\Package\PackageService')->getAvailablePackages($filterInstalled)
      *
      * @param bool $filterInstalled
+     *
+     * @return Package[]
      */
     public static function getAvailablePackages($filterInstalled = true)
     {
@@ -675,6 +687,8 @@ abstract class Package implements LocalizablePackageInterface
      * Use $app->make('Concrete\Core\Package\PackageService')->getByID($pkgID)
      *
      * @param int $pkgID
+     *
+     * @return PackageEntity|null
      */
     public static function getByID($pkgID)
     {
@@ -686,6 +700,8 @@ abstract class Package implements LocalizablePackageInterface
      * Use $app->make('Concrete\Core\Package\PackageService')->getClass($pkgHandle)
      *
      * @param string $pkgHandle
+     *
+     * @return Package
      */
     public static function getClass($pkgHandle)
     {
@@ -783,7 +799,7 @@ abstract class Package implements LocalizablePackageInterface
      *
      * @param mixed $testForAlreadyInstalled
      *
-     * @return \Concrete\Core\Error\ErrorList\ErrorList|null return null if the package can be upgraded, an ErrorList instance otherwise
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|true return null if the package can be upgraded, an ErrorList instance otherwise
      */
     public function testForUpgrade($testForAlreadyInstalled = true)
     {
@@ -806,7 +822,7 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        return $errors->has() ? $errors : null;
+        return $errors->has() ? $errors : true;
     }
 
     /**

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -182,14 +182,14 @@ abstract class Package implements LocalizablePackageInterface
     protected $appVersionRequired = '5.7.0';
 
     /**
-     * Override this value setting it to true if your package clear all existing website content when it's being installed.
+     * Override this value and set it to true if your package clears all existing website content when it's being installed.
      *
      * @var bool
      */
     protected $pkgAllowsFullContentSwap = false;
 
     /**
-     * Override this value setting it to true if your package provide the file thumbnails.
+     * Override this value and set it to true if your package provides the file thumbnails.
      * If it's false, the file thumbnails are generated during the install process.
      *
      * @var bool
@@ -293,7 +293,7 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Should this pacakge enable legacy namespaces?
+     * Should this package enable legacy namespaces?
      *
      * This returns true IF:
      * 1. $this->pkgAutoloaderMapCoreExtensions is false or unset
@@ -770,11 +770,11 @@ abstract class Package implements LocalizablePackageInterface
                         $packageVersion = $packageService->getByHandle($packageHandle)->getPackageVersion();
                         if (is_array($requirements)) {
                             if (version_compare($packageVersion, $requirements[0]) < 0 || version_compare($packageVersion, $requirements[1]) > 0) {
-                                $errors[] = t('This package requires the package with handle %1$s has a version from %2$s to %3$s', $packageHandle, $requirements[0], $requirements[1]);
+                                $errors[] = t('This package requires that package with handle %1$s has a version from %2$s to %3$s', $packageHandle, $requirements[0], $requirements[1]);
                             }
                         } else {
                             if (version_compare($packageVersion, $requirements) < 0) {
-                                $errors[] = t('This package requires the package with handle %1$s has a version %2$s or greater', $packageHandle, $requirements);
+                                $errors[] = t('This package requires that package with handle %1$s has a version %2$s or greater', $packageHandle, $requirements);
                             }
                         }
                     }
@@ -833,7 +833,7 @@ abstract class Package implements LocalizablePackageInterface
             if (isset($packageDependencies[$myPackageHandle])) {
                 $requirements = $packageDependencies[$myPackageHandle];
                 if (is_array($requirements) && version_compare($myPackageVersion, $requirements[1]) > 0) {
-                    $errors[] = t('This package can\'t be upgrade since the package with handle %1$s requires a maximum version of %2$s for it', $packageHandle, $requirements[1]);
+                    $errors[] = t('This package can\'t be upgraded since the package with handle %1$s requires a maximum version of %2$s for it', $packageHandle, $requirements[1]);
                 }
             }
         }
@@ -1080,19 +1080,19 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Get the namespace of the package by the package handle.
      *
-     * @param bool $withLeadingBacksalsh
+     * @param bool $withLeadingBackslash
      *
      * @return string
      */
-    public function getNamespace($withLeadingBacksalsh = false)
+    public function getNamespace($withLeadingBackslash = false)
     {
-        $leadingBkslsh = $withLeadingBacksalsh ? '\\' : '';
+        $leadingBackslash = $withLeadingBackslash ? '\\' : '';
 
-        return $leadingBkslsh . 'Concrete\\Package\\' . camelcase($this->getPackageHandle());
+        return $leadingBackslash . 'Concrete\\Package\\' . camelcase($this->getPackageHandle());
     }
 
     /**
-     * Create a entity manager used for the package installation, update and unistall process.
+     * Create an entity manager used for the package install, upgrade and unistall process.
      *
      * @return EntityManager|null
      */
@@ -1196,7 +1196,7 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Get the error text corresponsing to an errro code.
+     * Get the error text corresponsing to an error code.
      *
      * @param array|int $errorCode one of the Package::E_PACKAGE_ constants, or an array with the first value is one of the Package::E_PACKAGE_ constants and the other values are used to fill in fields
      *

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -727,7 +727,7 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Perform tests before this package is installed.
      *
-     * @param bool $testForAlreadyInstalled
+     * @param bool $testForAlreadyInstalled Set to false to skip checking if this package is already installed
      *
      * @return \Concrete\Core\Error\ErrorList\ErrorList|true return true if the package can be installed, an ErrorList instance otherwise
      */
@@ -813,32 +813,13 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Perform tests before this package is upgraded.
      *
-     * @param mixed $testForAlreadyInstalled
-     *
      * @return \Concrete\Core\Error\ErrorList\ErrorList|true return null if the package can be upgraded, an ErrorList instance otherwise
      */
-    public function testForUpgrade($testForAlreadyInstalled = true)
+    public function testForUpgrade()
     {
-        $errors = $this->app->make('error');
+        $result = $this->testForInstall(false);
 
-        // Step 1 - Check for package dependencies
-        $packageService = $this->app->make(PackageService::class);
-        /* @var PackageService $packageService */
-        $installedPackageHandles = $packageService->getInstalledHandles();
-        $myPackageHandle = $this->getPackageHandle();
-        $myPackageVersion = $this->getPackageVersion();
-        foreach ($installedPackageHandles as $packageHandle) {
-            $packageController = $packageService->getClass($packageHandle);
-            $packageDependencies = $packageController->getPackageDependencies();
-            if (isset($packageDependencies[$myPackageHandle])) {
-                $requirements = $packageDependencies[$myPackageHandle];
-                if (is_array($requirements) && version_compare($myPackageVersion, $requirements[1]) > 0) {
-                    $errors[] = t('This package can\'t be upgraded since the package with handle %1$s requires a maximum version of %2$s for it', $packageHandle, $requirements[1]);
-                }
-            }
-        }
-
-        return $errors->has() ? $errors : true;
+        return $result;
     }
 
     /**

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -765,7 +765,7 @@ abstract class Package implements LocalizablePackageInterface
             foreach ($myDependencies as $packageHandle => $requirements) {
                 if (in_array($packageHandle, $installedPackageHandles)) {
                     if ($requirements === false) {
-                        $errors[] = t('This package can\'t be installed if the package with handle %s is already installed', $packageHandle);
+                        $errors[] = t('This package can\'t be installed because the package with handle %s is already installed', $packageHandle);
                     } elseif ($requirements !== true) {
                         $packageVersion = $packageService->getByHandle($packageHandle)->getPackageVersion();
                         if (is_array($requirements)) {
@@ -793,7 +793,7 @@ abstract class Package implements LocalizablePackageInterface
                 $packageController = $packageService->getClass($packageHandle);
                 $packageDependencies = $packageController->getPackageDependencies();
                 if (isset($packageDependencies[$myPackageHandle]) && $packageDependencies[$myPackageHandle] === false) {
-                    $errors[] = t('This package can\'t be installed if the package with handle %s is already installed', $packageHandle);
+                    $errors[] = t('This package can\'t be installed because the package with handle %s is already installed', $packageHandle);
                 }
             }
         }

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -4,118 +4,264 @@ namespace Concrete\Core\Package;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Config\Repository\Liaison;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Database\EntityManager\Driver\CoreDriver;
 use Concrete\Core\Database\EntityManager\Provider\PackageProviderFactory;
 use Concrete\Core\Database\Schema\Schema;
-use Concrete\Core\Package\ItemCategory\ItemInterface;
+use Concrete\Core\Entity\Package as PackageEntity;
 use Concrete\Core\Package\ItemCategory\Manager;
 use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Common\Proxy\ProxyGenerator;
+use Doctrine\DBAL\Schema\Comparator as SchemaComparator;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Setup;
 use Gettext\Translations;
+use Localization;
+use stdClass;
 
 abstract class Package implements LocalizablePackageInterface
 {
+    /**
+     * Error code: Invalid Package.
+     *
+     * @var int
+     */
     const E_PACKAGE_NOT_FOUND = 1;
+
+    /**
+     * Error code: You've already installed that package.
+     *
+     * @var int
+     */
     const E_PACKAGE_INSTALLED = 2;
+
+    /**
+     * Error code: This package requires concrete5 version %s or greater.
+     *
+     * @var int
+     */
     const E_PACKAGE_VERSION = 3;
+
+    /**
+     * Error code: An error occurred while downloading the package.
+     *
+     * @var int
+     */
     const E_PACKAGE_DOWNLOAD = 4;
+
+    /**
+     * Error code: concrete5 was not able to save the package after download.
+     *
+     * @var int
+     */
     const E_PACKAGE_SAVE = 5;
+
+    /**
+     * Error code: An error occurred while trying to unzip the package.
+     *
+     * @var int
+     */
     const E_PACKAGE_UNZIP = 6;
+
+    /**
+     * Error code: An error occurred while trying to install the package.
+     *
+     * @var int
+     */
     const E_PACKAGE_INSTALL = 7;
+
+    /**
+     * Error code: Unable to backup old package directory to %s.
+     *
+     * @var int
+     */
     const E_PACKAGE_MIGRATE_BACKUP = 8;
+
+    /**
+     * Error code: This package isn't currently available for this version of concrete5.
+     *
+     * @var int
+     */
     const E_PACKAGE_INVALID_APP_VERSION = 20;
+
+    /**
+     * Error code: This package contains the active site theme, please change the theme before uninstalling.
+     *
+     * @var int
+     */
     const E_PACKAGE_THEME_ACTIVE = 21;
+
+    /**
+     * Absolute path to the /concrete/packages directory.
+     *
+     * @var string
+     */
     protected $DIR_PACKAGES_CORE = DIR_PACKAGES_CORE;
+
+    /**
+     * Absolute path to the /packages directory.
+     *
+     * @var string
+     */
     protected $DIR_PACKAGES = DIR_PACKAGES;
+
+    /**
+     * Path to the /concrete/packages directory relative to the web root.
+     *
+     * @var string
+     */
     protected $REL_DIR_PACKAGES_CORE = REL_DIR_PACKAGES_CORE;
+
+    /**
+     * Path to the /concrete/packages directory relative to the web root.
+     *
+     * @var string
+     */
     protected $REL_DIR_PACKAGES = REL_DIR_PACKAGES;
 
     /**
-     * @var \Concrete\Core\Entity\Package
+     * Associated package entity.
+     *
+     * @var PackageEntity|null
      */
     protected $entity;
 
     /**
+     * The Application instance.
+     *
      * @var Application
      */
     protected $app;
 
     /**
-     * @var \Concrete\Core\Config\Repository\Liaison
+     * The database configuration liaison.
+     *
+     * @var Liaison|null
      */
     protected $config;
 
     /**
-     * @var \Concrete\Core\Config\Repository\Liaison
+     * The file configuration liaison.
+     *
+     * @var Liaison|null
      */
     protected $fileConfig;
 
     /**
      * @deprecated
-     * This will be set to FALSE in 8.1
-     * Additionally, if your package requires 8.0 or greater, it will be set to false automatically
-     * Whether to automatically map core extensions into the packages src/Concrete directory (and map them to Concrete\Package\MyPackage), or map the entire src/
-     * directory to Concrete\Package\MyPackage\Src (and automatically map core extensions
-     * to Concrete\Package\MyPackage\Src)
+     * Whether to automatically map core extensions into the packages src/Concrete directory (and map them to Concrete\Package\MyPackage),
+     * or map the entire src/ directory to Concrete\Package\MyPackage\Src
+     * (and automatically map core extensions to Concrete\Package\MyPackage\Src).
+     * This will be ALWAYS considered as FALSE if your package requires 8.0 or greater or if your package defines the pkgAutoloaderMapCoreExtensions property.
      *
      * @var bool
      */
     protected $pkgEnableLegacyNamespace = true;
 
     /**
-     * Array of location -> namespace autoloader entries for the package. Will automatically
-     * be added to the class loader. (e.g. array('src/PortlandLabs' => \PortlandLabs')).
+     * The custom autoloader prefixes to be automatically added to the class loader.
+     * Array keys are the locations (relative to the package directory).
+     * Array values are the paths (not relative to the package namespace).
      *
      * @var array
+     *
+     * @example ['src/PortlandLabs' => \PortlandLabs']
      */
     protected $pkgAutoloaderRegistries = [];
 
+    /**
+     * The minimum concrete5 version compatible with the package.
+     * Override this value according to the minimum required version for your package.
+     *
+     * @var string
+     */
     protected $appVersionRequired = '5.7.0';
 
+    /**
+     * Override this value setting it to true if your package clear all existing website content when it's being installed.
+     *
+     * @var bool
+     */
     protected $pkgAllowsFullContentSwap = false;
 
+    /**
+     * Override this value setting it to true if your package provide the file thumbnails.
+     * If it's false, the file thumbnails are generated during the install process.
+     *
+     * @var bool
+     */
     protected $pkgContentProvidesFileThumbnails = false;
 
     /**
-     * @var \Concrete\Core\Database\DatabaseStructureManager
+     * The full path of the package directory moved to the trash folder.
+     *
+     * @var string|null
      */
-    protected $databaseStructureManager;
+    protected $backedUpFname;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param Application $app the application instance
+     */
     public function __construct(Application $app)
     {
         $this->app = $app;
     }
 
     /**
-     * @return \Concrete\Core\Entity\Package
+     * Get the associated package entity (if available).
+     *
+     * @return PackageEntity|null May return NULL if the package is invalid and/or if it's not installed
      */
     public function getPackageEntity()
     {
-        if (!isset($this->entity)) {
-            $this->entity = $this->app->make('Concrete\Core\Package\PackageService')->getByHandle($this->getPackageHandle());
+        if ($this->entity === null) {
+            $this->entity = $this->app->make(PackageService::class)->getByHandle($this->getPackageHandle());
         }
 
         return $this->entity;
     }
 
-    public function setPackageEntity(\Concrete\Core\Entity\Package $entity)
+    /**
+     * Set the associated package entity.
+     *
+     * @param PackageEntity $entity
+     */
+    public function setPackageEntity(PackageEntity $entity)
     {
         $this->entity = $entity;
     }
 
+    /**
+     * Get the Application instance.
+     *
+     * @return Application
+     */
     public function getApplication()
     {
         return $this->app;
     }
 
+    /**
+     * Get the content swapper.
+     *
+     * @return \Concrete\Core\Package\ContentSwapperInterface
+     */
     public function getContentSwapper()
     {
         return new ContentSwapper();
     }
 
+    /**
+     * Import a concrete5-cif XML file.
+     *
+     * @param string $file the path to the file, relative to the package directory
+     */
     public function installContentFile($file)
     {
         $ci = new ContentImporter();
@@ -123,7 +269,7 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Should this pacakge enable legacy namespaces.
+     * Should this pacakge enable legacy namespaces?
      *
      * This returns true IF:
      * 1. $this->pkgAutoloaderMapCoreExtensions is false or unset
@@ -150,9 +296,9 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Get the standard database config liaison.
+     * Get the default configuration liaison.
      *
-     * @return \Concrete\Core\Config\Repository\Liaison
+     * @return Liaison
      */
     public function getConfig()
     {
@@ -160,9 +306,9 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Get the standard database config liaison.
+     * Get the database configuration liaison.
      *
-     * @return \Concrete\Core\Config\Repository\Liaison
+     * @return Liaison
      */
     public function getDatabaseConfig()
     {
@@ -174,9 +320,9 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Get the standard filesystem config liaison.
+     * Get the filesystem configuration liaison.
      *
-     * @return \Concrete\Core\Config\Repository\Liaison
+     * @return Liaison
      */
     public function getFileConfig()
     {
@@ -188,52 +334,61 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Returns custom autoloader prefixes registered by the class loader.
+     * Get the custom autoloader prefixes to be automatically added to the class loader.
+     * Array keys are the locations (relative to the package directory).
+     * Array values are the paths (not relative to the package namespace).
      *
-     * @return array Keys represent the namespace, not relative to the package's namespace. Values are the path, and are relative to the package directory
+     * @return array
+     *
+     * @example ['src/PortlandLabs' => \PortlandLabs']
      */
     public function getPackageAutoloaderRegistries()
     {
         return $this->pkgAutoloaderRegistries;
     }
 
+    /**
+     * Get the package handle.
+     *
+     * @return string
+     */
     public function getPackageHandle()
     {
-        return $this->pkgHandle;
+        return isset($this->pkgHandle) ? $this->pkgHandle : '';
     }
 
     /**
-     * Returns the translated name of the package.
+     * Get the translated name of the package.
      *
      * @return string
      */
     public function getPackageName()
     {
-        return t($this->pkgName);
+        return isset($this->pkgName) ? t($this->pkgName) : '';
     }
 
     /**
-     * Returns the translated package description.
+     * Get the translated package description.
      *
      * @return string
      */
     public function getPackageDescription()
     {
-        return t($this->pkgDescription);
+        return isset($this->pkgDescription) ? t($this->pkgDescription) : '';
     }
 
     /**
-     * Returns the installed package version.
+     * Get the installed package version.
      *
      * @return string
      */
     public function getPackageVersion()
     {
-        return $this->pkgVersion;
+        return isset($this->pkgVersion) ? $this->pkgVersion : '';
     }
 
     /**
-     * Returns the version of concrete5 required by the package.
+     * Get the minimum concrete5 version compatible with the package.
      *
      * @return string
      */
@@ -243,7 +398,8 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Returns true if the package has an install options screen.
+     * Should the install options page be shown?
+     * The install options page may be for install notes and/or full contents swap confirmation.
      *
      * @return bool
      */
@@ -252,56 +408,81 @@ abstract class Package implements LocalizablePackageInterface
         return $this->hasInstallNotes() || $this->allowsFullContentSwap();
     }
 
+    /**
+     * Does this package have install notes?
+     *
+     * @return bool
+     */
     public function hasInstallNotes()
     {
         return file_exists($this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/install.php');
     }
 
+    /**
+     * Does this package have uninstall notes?
+     *
+     * @return bool
+     */
     public function hasUninstallNotes()
     {
         return file_exists($this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/uninstall.php');
     }
 
     /**
-     * Returns true if the package has a post install screen.
+     * Does this package have a post-install page?
      *
      * @return bool
      */
     public function hasInstallPostScreen()
     {
-        return file_exists(
-            $this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/install_post.php');
+        return file_exists($this->getPackagePath() . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_DASHBOARD . '/install_post.php');
     }
 
+    /**
+     * Does this package clear all existing website content when it's being installed?
+     *
+     * @return bool
+     */
     public function allowsFullContentSwap()
     {
         return $this->pkgAllowsFullContentSwap;
     }
 
+    /**
+     * Get the absolute path to the package.
+     *
+     * @return string
+     */
     public function getPackagePath()
     {
-        $dirp = (is_dir(
-            $this->DIR_PACKAGES . '/' . $this->getPackageHandle())) ? $this->DIR_PACKAGES : $this->DIR_PACKAGES_CORE;
-        $path = $dirp . '/' . $this->getPackageHandle();
+        $packageHandle = $this->getPackageHandle();
+        $result = $this->DIR_PACKAGES . '/' . $packageHandle;
+        if (!is_dir($result)) {
+            $result = $this->DIR_PACKAGES_CORE . '/' . $packageHandle;
+        }
 
-        return $path;
+        return $result;
     }
 
     /**
-     * Returns the path to the package's folder, relative to the install path.
+     * Get the path to the package relative to the web root.
      *
      * @return string
      */
     public function getRelativePath()
     {
-        $dirp = (is_dir(
-            $this->DIR_PACKAGES . '/' . $this->getPackageHandle())) ? $this->REL_DIR_PACKAGES : $this->REL_DIR_PACKAGES_CORE;
+        $packageHandle = $this->getPackageHandle();
+        if (is_dir($this->DIR_PACKAGES . '/' . $packageHandle)) {
+            $result = $this->REL_DIR_PACKAGES . '/' . $packageHandle;
+        } else {
+            $result = $this->REL_DIR_PACKAGES_CORE . '/' . $packageHandle;
+        }
 
-        return $dirp . '/' . $this->pkgHandle;
+        return $result;
     }
 
     /**
-     * Returns the path starting from c5 installation folder to the package folder.
+     * Get the path to the package relative to the concrete5 installation folder.
      *
      * @return string
      */
@@ -310,18 +491,21 @@ abstract class Package implements LocalizablePackageInterface
         return '/' . DIRNAME_PACKAGES . '/' . $this->getPackageHandle();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see LocalizablePackageInterface::getTranslationFile()
+     */
     public function getTranslationFile($locale)
     {
-        $path = $this->getPackagePath() . '/' . DIRNAME_LANGUAGES;
-        $languageFile = "$path/$locale/LC_MESSAGES/messages.mo";
-
-        return $languageFile;
+        return $this->getPackagePath() . '/' . DIRNAME_LANGUAGES . "/{$locale}/LC_MESSAGES/messages.mo";
     }
 
     /**
-     * Returns a path to where the packages files are located.
+     * Does this package provide the file thumbnails?
+     * If false, the file thumbnails are generated during the install process.
      *
-     * @return string $path
+     * @return bool
      */
     public function contentProvidesFileThumbnails()
     {
@@ -329,16 +513,16 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Installs the package info row and installs the database. Packages installing additional content should override this method, call the parent method,
-     * and use the resulting package object for further installs.
+     * Install the package info row and the database (doctrine entities and db.xml).
+     * Packages installing additional content should override this method, call the parent method (`parent::install()`).
      *
-     * @return Package
+     * @return PackageEntity
      */
     public function install()
     {
         PackageList::refreshCache();
-        $em = \Database::connection()->getEntityManager();
-        $package = new \Concrete\Core\Entity\Package();
+        $em = $this->app->make(EntityManagerInterface::class);
+        $package = new PackageEntity();
         $package->setPackageName($this->getPackageName());
         $package->setPackageDescription($this->getPackageDescription());
         $package->setPackageVersion($this->getPackageVersion());
@@ -346,15 +530,21 @@ abstract class Package implements LocalizablePackageInterface
         $em->persist($package);
         $em->flush();
 
+        $this->app->make('cache/overrides')->flush();
+
         $this->installDatabase();
 
-        $env = \Environment::get();
-        $env->clearOverrideCache();
-        \Localization::clearCache();
+        Localization::clearCache();
 
         return $package;
     }
 
+    /**
+     * Uninstall the package:
+     * - delete the installed items associated to the package
+     * - destroy the package proxy classes of entities
+     * - remove the package info row.
+     */
     public function uninstall()
     {
         $manager = new Manager($this->app);
@@ -366,180 +556,176 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        \Config::clearNamespace($this->getPackageHandle());
+        $this->app->make('config')->clearNamespace($this->getPackageHandle());
         $this->app->make('config/database')->clearNamespace($this->getPackageHandle());
 
         $em = $this->getPackageEntityManager();
-        if (is_object($em)) {
+        if ($em !== null) {
             $this->destroyProxyClasses($em);
         }
 
-        $em = \ORM::entityManager();
+        $em = $this->app->make(EntityManagerInterface::class);
         $em->remove($package);
         $em->flush();
 
-        \Localization::clearCache();
+        Localization::clearCache();
     }
 
     /**
-     * Gets the contents of the package's CHANGELOG file. If no changelog is available an empty string is returned.
+     * Get the contents of the package's CHANGELOG file.
      *
-     * @return string
+     * @return string if no changelog is available an empty string is returned
      */
     public function getChangelogContents()
     {
-        if (file_exists($this->getPackagePath() . '/CHANGELOG')) {
-            $contents = \Core::make('helper/file')->getContents($this->getPackagePath() . '/CHANGELOG');
-
-            return nl2br(\Core::make('helper/text')->entities($contents));
+        $result = '';
+        $file = $this->getPackagePath() . '/CHANGELOG';
+        if (is_file($file)) {
+            $contents = $this->app->make('helper/file')->getContents($file);
+            $result = nl2br(h($contents));
         }
 
-        return '';
+        return $result;
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledList()
      */
     public static function getInstalledList()
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getInstalledList();
+        return $this->app->make(PackageService::class)->getInstalledList();
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledHandles()
      */
     public static function getInstalledHandles()
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getInstalledHandles();
+        return $this->app->make(PackageService::class)->getInstalledHandles();
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledHandles()
      *
-     * @param mixed $pkgHandle
+     * @param string $pkgHandle
      */
     public static function getByHandle($pkgHandle)
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getByHandle($pkgHandle);
+        return $this->app->make(PackageService::class)->getByHandle($pkgHandle);
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getLocalUpgradeablePackages()
      */
     public static function getLocalUpgradeablePackages()
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getLocalUpgradeablePackages();
+        return $this->app->make(PackageService::class)->getLocalUpgradeablePackages();
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getRemotelyUpgradeablePackages()
      */
     public static function getRemotelyUpgradeablePackages()
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getRemotelyUpgradeablePackages();
+        return $this->app->make(PackageService::class)->getRemotelyUpgradeablePackages();
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getAvailablePackages($filterInstalled)
      *
-     * @param mixed $filterInstalled
+     * @param bool $filterInstalled
      */
     public static function getAvailablePackages($filterInstalled = true)
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getAvailablePackages($filterInstalled);
+        return $this->app->make(PackageService::class)->getAvailablePackages($filterInstalled);
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getByID($pkgID)
      *
-     * @param mixed $pkgID
+     * @param int $pkgID
      */
     public static function getByID($pkgID)
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getByID($pkgID);
+        return $this->app->make(PackageService::class)->getByID($pkgID);
     }
 
     /**
      * @deprecated
+     * Use $app->make('Concrete\Core\Package\PackageService')->getClass($pkgHandle)
      *
-     * @param mixed $pkgHandle
+     * @param string $pkgHandle
      */
     public static function getClass($pkgHandle)
     {
-        // this should go through the facade instead
-        return \Concrete\Core\Support\Facade\Package::getClass($pkgHandle);
+        return $this->app->make(PackageService::class)->getClass($pkgHandle);
     }
 
     /**
-     * This is the pre-test routine that packages run through before they are installed. Any errors that come here are
-     * to be returned in the form of an array so we can show the user. If it's all good we return true.
+     * Perform tests before this package is installed.
      *
-     * @param string $package Package handle
      * @param bool $testForAlreadyInstalled
      *
-     * @return array|bool Returns an array of errors or true if the package can be installed
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|true return true if the package can be installed, an ErrorList instance otherwise
      */
     public function testForInstall($testForAlreadyInstalled = true)
     {
         $errors = [];
 
         // Step 1 does that package exist ?
-        if ((!is_dir(DIR_PACKAGES . '/' . $this->getPackageHandle()) && (!is_dir(
-                    DIR_PACKAGES_CORE . '/' . $this->getPackageHandle()))) || $this->getPackageHandle() == ''
-        ) {
+        if ($this instanceof BrokenPackage) {
             $errors[] = self::E_PACKAGE_NOT_FOUND;
-        } elseif ($this instanceof BrokenPackage) {
+        } elseif ($this->getPackageHandle() === '' || !is_dir($this->getPackagePath())) {
             $errors[] = self::E_PACKAGE_NOT_FOUND;
         }
 
         // Step 2 - check to see if the user has already installed a package w/this handle
         if ($testForAlreadyInstalled) {
             $entity = $this->getPackageEntity();
-            if (is_object($entity) && $entity->isPackageInstalled()) {
+            if ($entity !== null && $entity->isPackageInstalled()) {
                 $errors[] = self::E_PACKAGE_INSTALLED;
             }
         }
 
-        if (count($errors) == 0) {
-            // test minimum application version requirement
-            if (version_compare(APP_VERSION, $this->getApplicationVersionRequired(), '<')) {
-                $errors[] = [self::E_PACKAGE_VERSION, $this->getApplicationVersionRequired()];
+        // Step 3 - test minimum application version requirement
+        if (empty($errors)) {
+            $applicationVersionRequired = $this->getApplicationVersionRequired();
+            if (version_compare(APP_VERSION, $applicationVersionRequired, '<')) {
+                $errors[] = [self::E_PACKAGE_VERSION, $applicationVersionRequired];
             }
         }
 
-        if (count($errors) > 0) {
-            $e = $this->app->make('error');
-            foreach ($errors as $error) {
-                $e->add($this->getErrorText($error));
-            }
-
-            return $e;
+        if (empty($errors)) {
+            $result = true;
         } else {
-            return true;
+            $result = $this->app->make('error');
+            foreach ($errors as $error) {
+                $result->add($this->getErrorText($error));
+            }
         }
+
+        return $result;
     }
 
     /**
-     * @return bool|int[] true on success, array of error codes on failure
+     * Perform tests before this package is uninstalled.
+     *
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|true return true if the package can be uninstalled, an ErrorList instance otherwise
      */
     public function testForUninstall()
     {
         $errors = [];
         $manager = new Manager($this->app);
 
-        /**
-         * @var ItemInterface
-         */
         $driver = $manager->driver('theme');
         $themes = $driver->getItems($this->getPackageEntity());
-        /** @var Theme[] $themes */
 
         // Step 1, check for active themes
         $active_theme = Theme::getSiteTheme();
@@ -550,56 +736,69 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        if (count($errors) > 0) {
-            $e = $this->app->make('error');
-            foreach ($errors as $error) {
-                $e->add($this->getErrorText($error));
-            }
-
-            return $e;
+        if (empty($errors)) {
+            $result = true;
         } else {
-            return true;
+            $result = $this->app->make('error');
+            foreach ($errors as $error) {
+                $result->add($this->getErrorText($error));
+            }
         }
+
+        return $result;
     }
 
     /**
-     * Moves the current package's directory to the trash directory renamed with the package handle and a date code.
+     * Move the current package directory to the trash directory, and rename it with the package handle and a date code.
+     *
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|null return NULL if the package has been moved, an ErrorList instance otherwise
      */
     public function backup()
     {
-        // you can only backup root level packages.
-        // Need to figure something else out for core level
-        if ($this->getPackageHandle() != '' && is_dir(DIR_PACKAGES . '/' . $this->getPackageHandle())) {
-            $trash = \Config::get('concrete.misc.package_backup_directory');
+        $packageHandle = $this->getPackageHandle();
+        $errors = $this->app->make('error');
+        if ($packageHandle === '' || !is_dir(DIR_PACKAGES . '/' . $packageHandle)) {
+            $errors->add($this->getErrorText(self::E_PACKAGE_NOT_FOUND));
+        } else {
+            $config = $this->app->make('config');
+            $trash = $config->get('concrete.misc.package_backup_directory');
             if (!is_dir($trash)) {
-                mkdir($trash, \Config::get('concrete.filesystem.permissions.directory'));
+                @mkdir($trash, $config->get('concrete.filesystem.permissions.directory'));
             }
-            $trashName = $trash . '/' . $this->getPackageHandle() . '_' . date('YmdHis');
-            $ret = rename(DIR_PACKAGES . '/' . $this->getPackageHandle(), $trashName);
-            if (!$ret) {
-                $e = \Core::make('error');
-                $e->add($this->getErrorText(self::E_PACKAGE_MIGRATE_BACKUP));
-
-                return $e;
+            if (!is_dir($trash)) {
+                $errors->add($this->getErrorText(self::E_PACKAGE_MIGRATE_BACKUP));
             } else {
-                $this->backedUpFname = $trashName;
+                $trashName = $trash . '/' . $packageHandle . '_' . date('YmdHis');
+                if (!@rename(DIR_PACKAGES . '/' . $this->getPackageHandle(), $trashName)) {
+                    $errors->add($this->getErrorText(self::E_PACKAGE_MIGRATE_BACKUP));
+                } else {
+                    $this->backedUpFname = $trashName;
+                }
             }
         }
 
-        return $this;
+        return $errors->has() ? $errors : null;
     }
 
     /**
-     * If a package was just backed up by this instance of the package object and the packages/package handle directory doesn't exist, this will restore the
-     * package from the trash.
+     * If a package was just backed up by this instance of the package object and the packages/package handle directory doesn't exist,
+     * this will restore the package from the trash.
+     *
+     * @return bool
      */
     public function restore()
     {
-        if (strlen($this->backedUpFname) && is_dir($this->backedUpFname) && !is_dir(DIR_PACKAGES . '/' . $this->getPackageHandle())) {
-            return @rename($this->backedUpFname, DIR_PACKAGES . '/' . $this->pkgHandle);
+        $result = false;
+        if ($this->backedUpFname !== null && is_dir($this->backedUpFname)) {
+            $newPath = DIR_PACKAGES . '/' . $this->getPackageHandle();
+            if (!is_dir($newPath)) {
+                if (@rename($this->backedUpFname, $newPath)) {
+                    $result = true;
+                }
+            }
         }
 
-        return false;
+        return $result;
     }
 
     /**
@@ -627,8 +826,7 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Installs the packages database through doctrine entities and db.xml
-     * database definitions.
+     * Installs the packages database through doctrine entities and db.xml database definitions.
      */
     public function installDatabase()
     {
@@ -639,7 +837,7 @@ abstract class Package implements LocalizablePackageInterface
     public function installEntitiesDatabase()
     {
         $em = $this->getPackageEntityManager();
-        if (is_object($em)) {
+        if ($em !== null) {
             $structure = new DatabaseStructureManager($em);
             $structure->installDatabase();
 
@@ -650,52 +848,54 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Installs a package's database from an XML file.
+     * Installs a package database from an XML file.
      *
      * @param string $xmlFile Path to the database XML file
      *
      * @throws \Doctrine\DBAL\ConnectionException
      *
-     * @return bool|\stdClass Returns false if the XML file could not be found
+     * @return bool|stdClass Returns false if the XML file could not be found
      */
     public static function installDB($xmlFile)
     {
-        if (!file_exists($xmlFile)) {
-            return false;
+        if (file_exists($xmlFile)) {
+            $app = ApplicationFacade::getFacadeApplication();
+            $db = $app->make(Connection::class);
+            /* @var Connection $db */
+            $db->beginTransaction();
+
+            $parser = Schema::getSchemaParser(simplexml_load_file($xmlFile));
+            $parser->setIgnoreExistingTables(false);
+            $toSchema = $parser->parse($db);
+
+            $fromSchema = $db->getSchemaManager()->createSchema();
+            $comparator = new SchemaComparator();
+            $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+            $saveQueries = $schemaDiff->toSaveSql($db->getDatabasePlatform());
+
+            foreach ($saveQueries as $query) {
+                $db->query($query);
+            }
+
+            $db->commit();
+
+            $result = new stdClass();
+            $result->result = false;
+        } else {
+            $result = false;
         }
-
-        $db = \Database::connection();
-        $db->beginTransaction();
-
-        $parser = Schema::getSchemaParser(simplexml_load_file($xmlFile));
-        $parser->setIgnoreExistingTables(false);
-        $toSchema = $parser->parse($db);
-
-        $fromSchema = $db->getSchemaManager()->createSchema();
-        $comparator = new \Doctrine\DBAL\Schema\Comparator();
-        $schemaDiff = $comparator->compare($fromSchema, $toSchema);
-        $saveQueries = $schemaDiff->toSaveSql($db->getDatabasePlatform());
-
-        foreach ($saveQueries as $query) {
-            $db->query($query);
-        }
-
-        $db->commit();
-
-        $result = new \stdClass();
-        $result->result = false;
 
         return $result;
     }
 
     /**
-     * Updates a package's name, description, version and ID using the current class properties.
+     * Updates the package entity name, description and version using the current class properties.
      */
     public function upgradeCoreData()
     {
-        $em = \Database::connection()->getEntityManager();
         $entity = $this->getPackageEntity();
-        if (is_object($entity)) {
+        if ($entity !== null) {
+            $em = $this->app->make(EntityManagerInterface::class);
             $entity->setPackageName($this->getPackageName());
             $entity->setPackageDescription($this->getPackageDescription());
             $entity->setPackageVersion($this->getPackageVersion());
@@ -718,7 +918,7 @@ abstract class Package implements LocalizablePackageInterface
             $item->refresh();
         }
 
-        \Localization::clearCache();
+        Localization::clearCache();
     }
 
     /**
@@ -730,7 +930,7 @@ abstract class Package implements LocalizablePackageInterface
     public function upgradeDatabase()
     {
         $em = $this->getPackageEntityManager();
-        if (is_object($em)) {
+        if ($em !== null) {
             $this->destroyProxyClasses($em);
             $this->installEntitiesDatabase();
         }
@@ -746,38 +946,35 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function getNamespace($withLeadingBacksalsh = false)
     {
-        $leadingBkslsh = '';
-        if ($withLeadingBacksalsh) {
-            $leadingBkslsh = '\\';
-        }
+        $leadingBkslsh = $withLeadingBacksalsh ? '\\' : '';
 
         return $leadingBkslsh . 'Concrete\\Package\\' . camelcase($this->getPackageHandle());
     }
 
     /**
-     * Create a entity manager used for the package installation,
-     * update and unistall process.
+     * Create a entity manager used for the package installation, update and unistall process.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return EntityManager|null
      */
     public function getPackageEntityManager()
     {
         $providerFactory = new PackageProviderFactory($this->app, $this);
         $provider = $providerFactory->getEntityManagerProvider();
         $drivers = $provider->getDrivers();
-        if (count($drivers)) {
+        if (empty($drivers)) {
+            $result = null;
+        } else {
             $config = Setup::createConfiguration(true, $this->app->make('config')->get('database.proxy_classes'));
             $driverImpl = new MappingDriverChain();
             $coreDriver = new CoreDriver($this->app);
 
-            // Add all the installed packages so that the new package could potentially extend packages that are already
-            // installed
+            // Add all the installed packages so that the new package could potentially extend packages that are already / installed
             $packages = $this->app->make(PackageService::class)->getInstalledList();
             foreach($packages as $package) {
                 $existingProviderFactory = new PackageProviderFactory($this->app, $package->getController());
                 $existingProvider = $existingProviderFactory->getEntityManagerProvider();
                 $existingDrivers = $existingProvider->getDrivers();
-                if (count($existingDrivers)) {
+                if (!empty($existingDrivers)) {
                     foreach($existingDrivers as $existingDriver) {
                         $driverImpl->addDriver($existingDriver->getDriver(), $existingDriver->getNamespace());
                     }
@@ -791,30 +988,35 @@ abstract class Package implements LocalizablePackageInterface
                 $driverImpl->addDriver($driver->getDriver(), $driver->getNamespace());
             }
             $config->setMetadataDriverImpl($driverImpl);
-            $em = EntityManager::create(\Database::connection(), $config);
-
-            return $em;
+            $db = $this->app->make(Connection::class);
+            $result = EntityManager::create($db, $config);
         }
+
+        return $result;
     }
 
     /**
      * @deprecated
+     * Use $app->make('Doctrine\ORM\EntityManagerInterface')
+     *
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
-        return \ORM::entityManager();
+        return $this->app->make(EntityManagerInterface::class);
     }
 
     /**
      * @deprecated
-     * This should be handled by the Concrete\Core\Entity\Package object, not by this object
+     * use the getPackageID method of the package entity
+     *
+     * @return int|null
      */
     public function getPackageID()
     {
-        // If this package is installed, we will query the database for this field.
-        if ($this->getPackageEntity()) {
-            return $this->getPackageEntity()->getPackageID();
-        }
+        $packageEntity = $this->getPackageEntity();
+
+        return $packageEntity === null ? null : $packageEntity->getPackageID();
     }
 
     /**
@@ -841,49 +1043,51 @@ abstract class Package implements LocalizablePackageInterface
     {
     }
 
-    protected function getErrorText($result)
+    /**
+     * Get the error text corresponsing to an errro code.
+     *
+     * @param array|int $errorCode one of the Package::E_PACKAGE_ constants, or an array with the first value is one of the Package::E_PACKAGE_ constants and the other values are used to fill in fields
+     *
+     * @return string
+     */
+    protected function getErrorText($errorCode)
     {
-        $errorText = [
-            self::E_PACKAGE_INSTALLED => t("You've already installed that package."),
-            self::E_PACKAGE_NOT_FOUND => t('Invalid Package.'),
-            self::E_PACKAGE_VERSION => t('This package requires concrete5 version %s or greater.'),
-            self::E_PACKAGE_DOWNLOAD => t('An error occurred while downloading the package.'),
-            self::E_PACKAGE_SAVE => t('concrete5 was not able to save the package after download.'),
-            self::E_PACKAGE_UNZIP => t('An error occurred while trying to unzip the package.'),
-            self::E_PACKAGE_INSTALL => t('An error occurred while trying to install the package.'),
-            self::E_PACKAGE_MIGRATE_BACKUP => t(
-                'Unable to backup old package directory to %s',
-                \Config::get('concrete.misc.package_backup_directory')
-            ),
-            self::E_PACKAGE_INVALID_APP_VERSION => t(
-                'This package isn\'t currently available for this version of concrete5. Please contact the maintainer of this package for assistance.'
-            ),
-            self::E_PACKAGE_THEME_ACTIVE => t('This package contains the active site theme, please change the theme before uninstalling.'),
-        ];
-
-        $testResultsText = [];
-        if (is_array($result)) {
-            $et = $errorText[$result[0]];
-            array_shift($result);
-            $testResultsText = vsprintf($et, $result);
-        } elseif (is_int($result)) {
-            $testResultsText = $errorText[$result];
-        } elseif (!empty($result)) {
-            $testResultsText = $result;
+        if (is_array($errorCode)) {
+            $code = array_shift($errorCode);
+            $result = vsprintf($this->getErrorText($code), $errorCode);
+        } else {
+            $config = $this->app->make('config');
+            $dictionary = [
+                self::E_PACKAGE_INSTALLED => t("You've already installed that package."),
+                self::E_PACKAGE_NOT_FOUND => t('Invalid Package.'),
+                self::E_PACKAGE_VERSION => t('This package requires concrete5 version %s or greater.'),
+                self::E_PACKAGE_DOWNLOAD => t('An error occurred while downloading the package.'),
+                self::E_PACKAGE_SAVE => t('concrete5 was not able to save the package after download.'),
+                self::E_PACKAGE_UNZIP => t('An error occurred while trying to unzip the package.'),
+                self::E_PACKAGE_INSTALL => t('An error occurred while trying to install the package.'),
+                self::E_PACKAGE_MIGRATE_BACKUP => t('Unable to backup old package directory to %s', $config->get('concrete.misc.package_backup_directory')),
+                self::E_PACKAGE_INVALID_APP_VERSION => t('This package isn\'t currently available for this version of concrete5. Please contact the maintainer of this package for assistance.'),
+                self::E_PACKAGE_THEME_ACTIVE => t('This package contains the active site theme, please change the theme before uninstalling.'),
+            ];
+            if (isset($dictionary[$errorCode])) {
+                $result = $dictionary[$errorCode];
+            } else {
+                $result = (string) $errorCode;
+            }
         }
 
-        return $testResultsText;
+        return $result;
     }
 
     /**
      * Destroys all proxies related to a package.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param EntityManagerInterface $em
      */
-    protected function destroyProxyClasses(\Doctrine\ORM\EntityManagerInterface $em)
+    protected function destroyProxyClasses(EntityManagerInterface $em)
     {
         $config = $em->getConfiguration();
-        $proxyGenerator = new \Doctrine\Common\Proxy\ProxyGenerator($config->getProxyDir(), $config->getProxyNamespace());
+        $proxyGenerator = new ProxyGenerator($config->getProxyDir(), $config->getProxyNamespace());
 
         $classes = $em->getMetadataFactory()->getAllMetadata();
         foreach ($classes as $class) {

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -222,7 +222,7 @@ abstract class Package implements LocalizablePackageInterface
      *     // This package can't be installed if a package with handle other_package_3 is not installed, or it has a version prior to 1.0
      *     'other_package_3' => '1.0',
      *     // This package can't be installed if a package with handle other_package_4 is not installed, or it has a version prior to 2.0, or it has a version after 2.9
-     *     'other_package_3' => ['2.0', '2.9'],
+     *     'other_package_4' => ['2.0', '2.9'],
      * ]
      */
     protected $packageDependencies = [];

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -770,11 +770,11 @@ abstract class Package implements LocalizablePackageInterface
                         $packageVersion = $packageService->getByHandle($packageHandle)->getPackageVersion();
                         if (is_array($requirements)) {
                             if (version_compare($packageVersion, $requirements[0]) < 0 || version_compare($packageVersion, $requirements[1]) > 0) {
-                                $errors[] = t('This package requires the package with handle %1$s has a version from %2%s to %3$s', $packageHandle, $requirements[0], $requirements[1]);
+                                $errors[] = t('This package requires the package with handle %1$s has a version from %2$s to %3$s', $packageHandle, $requirements[0], $requirements[1]);
                             }
                         } else {
                             if (version_compare($packageVersion, $requirements) < 0) {
-                                $errors[] = t('This package requires the package with handle %1$s has a version %2%s or greater', $packageHandle, $requirements);
+                                $errors[] = t('This package requires the package with handle %1$s has a version %2$s or greater', $packageHandle, $requirements);
                             }
                         }
                     }
@@ -833,7 +833,7 @@ abstract class Package implements LocalizablePackageInterface
             if (isset($packageDependencies[$myPackageHandle])) {
                 $requirements = $packageDependencies[$myPackageHandle];
                 if (is_array($requirements) && version_compare($myPackageVersion, $requirements[1]) > 0) {
-                    $errors[] = t('This package can\'t be upgrade since the package with handle %1$s requires a maximum version of %2%s for it', $packageHandle, $requirements[1]);
+                    $errors[] = t('This package can\'t be upgrade since the package with handle %1$s requires a maximum version of %2$s for it', $packageHandle, $requirements[1]);
                 }
             }
         }

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -828,7 +828,7 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Move the current package directory to the trash directory, and rename it with the package handle and a date code.
      *
-     * @return \Concrete\Core\Error\ErrorList\ErrorList|null return NULL if the package has been moved, an ErrorList instance otherwise
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|static return the Package instance if the package has been moved, an ErrorList instance otherwise
      */
     public function backup()
     {
@@ -854,7 +854,7 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        return $errors->has() ? $errors : null;
+        return $errors->has() ? $errors : $this;
     }
 
     /**

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -853,7 +853,7 @@ abstract class Package implements LocalizablePackageInterface
             $packageController = $packageService->getClass($packageHandle);
             $packageDependencies = $packageController->getPackageDependencies();
             if (isset($packageDependencies[$myPackageHandle]) && $packageDependencies[$myPackageHandle] !== false) {
-                $errors[] = t('This package can\'t be installed since the package with handle %s requires it', $packageHandle);
+                $errors[] = t('This package can\'t be uninstalled since the package with handle %s requires it', $packageHandle);
             }
         }
 

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -620,7 +620,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getInstalledList()
     {
-        return $this->app->make(PackageService::class)->getInstalledList();
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getInstalledList();
     }
 
     /**
@@ -631,7 +633,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getInstalledHandles()
     {
-        return $this->app->make(PackageService::class)->getInstalledHandles();
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getInstalledHandles();
     }
 
     /**
@@ -644,7 +648,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getByHandle($pkgHandle)
     {
-        return $this->app->make(PackageService::class)->getByHandle($pkgHandle);
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getByHandle($pkgHandle);
     }
 
     /**
@@ -655,7 +661,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getLocalUpgradeablePackages()
     {
-        return $this->app->make(PackageService::class)->getLocalUpgradeablePackages();
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getLocalUpgradeablePackages();
     }
 
     /**
@@ -666,7 +674,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getRemotelyUpgradeablePackages()
     {
-        return $this->app->make(PackageService::class)->getRemotelyUpgradeablePackages();
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getRemotelyUpgradeablePackages();
     }
 
     /**
@@ -679,7 +689,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getAvailablePackages($filterInstalled = true)
     {
-        return $this->app->make(PackageService::class)->getAvailablePackages($filterInstalled);
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getAvailablePackages($filterInstalled);
     }
 
     /**
@@ -692,7 +704,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getByID($pkgID)
     {
-        return $this->app->make(PackageService::class)->getByID($pkgID);
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getByID($pkgID);
     }
 
     /**
@@ -705,7 +719,9 @@ abstract class Package implements LocalizablePackageInterface
      */
     public static function getClass($pkgHandle)
     {
-        return $this->app->make(PackageService::class)->getClass($pkgHandle);
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return $app->make(PackageService::class)->getClass($pkgHandle);
     }
 
     /**

--- a/tests/tests/Core/Package/DependencyCheckerTest.php
+++ b/tests/tests/Core/Package/DependencyCheckerTest.php
@@ -1,0 +1,246 @@
+<?php
+namespace Concrete\Tests\Core\Package;
+
+use Concrete\Core\Package\Dependency\DependencyChecker;
+use Concrete\Core\Package\Dependency\IncompatiblePackagesException;
+use Concrete\Core\Package\Dependency\MissingRequiredPackageException;
+use Concrete\Core\Package\Dependency\RequiredPackageException;
+use Concrete\Core\Package\Dependency\VersionMismatchException;
+use Concrete\Core\Package\Package;
+use Concrete\Core\Support\Facade\Application;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+use ReflectionException;
+
+class DependencyCheckerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private static $app;
+
+    /**
+     * @var DependencyChecker
+     */
+    private static $checker;
+
+    public static function setupBeforeClass()
+    {
+        self::$app = Application::getFacadeApplication();
+        self::$checker = self::$app->build(DependencyChecker::class);
+    }
+
+    public function testForInstallProvider()
+    {
+        $packages = [
+            self::createPackage('handle0', '0.1', 'Name 0', []),
+            self::createPackage('handle1', '1.1', 'Name 1', ['handle0' => true]),
+            self::createPackage('handle2', '2.1', 'Name 2', ['handle1' => false]),
+            self::createPackage('handle3', '3.1', 'Name 3', ['handle0' => '0.1']),
+            self::createPackage('handle4', '4.1', 'Name 4', ['handle0' => '99']),
+            self::createPackage('handle5', '5.1', 'Name 5', ['handle0' => ['0.1', '0.1.99']]),
+            self::createPackage('handle6', '6.1', 'Name 6', ['handle0' => ['99.0', '99.1']]),
+        ];
+
+        return [
+            [
+                $packages[0],
+                [],
+            ],
+            [
+                $packages[1],
+                [],
+                [
+                    new MissingRequiredPackageException($packages[1], 'handle0', true),
+                ],
+            ],
+            [
+                $packages[1],
+                [
+                    $packages[0],
+                ],
+            ],
+            [
+                $packages[2],
+                [
+                    $packages[0],
+                ],
+            ],
+            [
+                $packages[2],
+                [
+                    $packages[1],
+                ],
+                [
+                    new IncompatiblePackagesException($packages[2], $packages[1]),
+                ],
+            ],
+            [
+                $packages[3],
+                [
+                ],
+                [
+                    new MissingRequiredPackageException($packages[3], 'handle0', '0.1'),
+                ],
+            ],
+            [
+                $packages[3],
+                [
+                    $packages[0],
+                ],
+            ],
+            [
+                $packages[4],
+                [
+                ],
+                [
+                    new MissingRequiredPackageException($packages[4], 'handle0', '99'),
+                ],
+            ],
+            [
+                $packages[4],
+                [
+                    $packages[0],
+                ],
+                [
+                    new VersionMismatchException($packages[4], $packages[0], '99'),
+                ],
+            ],
+
+            [
+                $packages[5],
+                [
+                ],
+                [
+                    new MissingRequiredPackageException($packages[5], 'handle0', ['0.1', '0.1.99']),
+                ],
+            ],
+            [
+                $packages[5],
+                [
+                    $packages[0],
+                ],
+            ],
+            [
+                $packages[6],
+                [
+                ],
+                [
+                    new MissingRequiredPackageException($packages[6], 'handle0', ['99.0', '99.1']),
+                ],
+            ],
+            [
+                $packages[6],
+                [
+                    $packages[0],
+                ],
+                [
+                    new VersionMismatchException($packages[6], $packages[0], ['99.0', '99.1']),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider testForInstallProvider
+     *
+     * @param Package $package
+     * @param array $installedPackages
+     * @param array $expectedErrors
+     */
+    public function testTestForInstall(Package $package, array $installedPackages, array $expectedErrors = [])
+    {
+        self::$checker->setInstalledPackages($installedPackages);
+        $errors = self::$checker->testForInstall($package)->getList();
+        $this->assertEquals($expectedErrors, $errors);
+    }
+
+    public function testForUninstallProvider()
+    {
+        $packages = [
+            self::createPackage('handle0', '0.1', 'Name 0', []),
+            self::createPackage('handle1', '1.1', 'Name 1', ['handle0' => false]),
+            self::createPackage('handle2', '2.1', 'Name 2', ['handle0' => true]),
+            self::createPackage('handle3', '3.1', 'Name 3', ['handle0' => '0.1']),
+        ];
+
+        return [
+            [
+                $packages[0],
+                [],
+            ],
+            [
+                $packages[0],
+                [
+                    $packages[1],
+                ],
+            ],
+            [
+                $packages[0],
+                [
+                    $packages[2],
+                ],
+                [
+                    new RequiredPackageException($packages[0], $packages[2]),
+                ],
+            ],
+            [
+                $packages[0],
+                [
+                    $packages[3],
+                ],
+                [
+                    new RequiredPackageException($packages[0], $packages[3]),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider testForUninstallProvider
+     *
+     * @param Package $package
+     * @param array $otherInstalledPackages
+     * @param array $expectedErrors
+     */
+    public function testTestForUninstall(Package $package, array $otherInstalledPackages, array $expectedErrors = [])
+    {
+        self::$checker->setInstalledPackages(array_merge([$package], $otherInstalledPackages));
+        $errors = self::$checker->testForUninstall($package)->getList();
+        $this->assertEquals($expectedErrors, $errors);
+    }
+
+    /**
+     * @param string $handle
+     * @param string $version
+     * @param string $name
+     * @param array $packageDependencies
+     *
+     * @return Package
+     */
+    private function createPackage($handle, $version, $name, array $packageDependencies)
+    {
+        $package = $this->getMockForAbstractClass(Package::class, [], '', false);
+        $reflectionClass = new ReflectionClass($package);
+        foreach ([
+            'pkgHandle' => $handle,
+            'pkgVersion' => $version,
+            'pkgName' => $name,
+            'packageDependencies' => $packageDependencies,
+        ] as $propertyName => $propertyValue) {
+            try {
+                $reflectionProperty = $reflectionClass->getProperty($propertyName);
+            } catch (ReflectionException $x) {
+                $reflectionProperty = null;
+            }
+            if ($reflectionProperty === null) {
+                $package->$propertyName = $propertyValue;
+            } else {
+                $reflectionProperty->setAccessible(true);
+                $reflectionProperty->setValue($package, $propertyValue);
+            }
+        }
+
+       return $package;
+    }
+}


### PR DESCRIPTION
What about introducing package dependencies?

Package dependencies are described by a [`$packageDependencies ` property](https://github.com/concrete5/concrete5/blob/d1902925555ffe44b2d811d0fb2f152381d892c4/concrete/src/Package/Package.php#L206-L228), that's an array with:

- keys: the other package
- values: the dependency description from the other package.

The dependency description can be:
- `false` to say that the current package can't be installed in the other package is installed
- `true` to say that the current package requires that the other package must be installed (any version)
- a string to say that the current package requires that the other package must be installed (minimum version)
- an array with two strings to say that the current package requires that the other package must be installed (minimum version and maximum version)

The dependency checks must be done:
- when installing a package
- when upgrading a package
- when uninstalling a package