### PR TITLE
Add pager pagination page number

### DIFF
--- a/concrete/src/Search/Pagination/View/ConcreteBootstrap3PagerTemplate.php
+++ b/concrete/src/Search/Pagination/View/ConcreteBootstrap3PagerTemplate.php
@@ -8,7 +8,7 @@ class ConcreteBootstrap3PagerTemplate extends Template
 {
 
     static protected $defaultOptions = array(
-        'css_container_class' => 'pager',
+        'css_container_class' => 'pagination',
     );
 
     public function container()
@@ -62,7 +62,14 @@ class ConcreteBootstrap3PagerTemplate extends Template
 
     public function current($page)
     {
-        return null;
+        $href = $this->generateRoute($page);
+        $pageResult = '/ccm_cursor=([\d\|]+)/';
+        preg_match_all($pageResult, $href, $pageResultMatches);
+        $page = '/(\d+)/';
+        preg_match_all($page, $pageResultMatches[1][0], $pageMatches);
+        $pageNumber = count($pageMatches[1]) + 1;
+
+        return '<li class="active"><span>' . $pageNumber . '</span></li>';
     }
 
     public function first()


### PR DESCRIPTION
This pull request adds a page number for non-superuser pagination. The goal is to add more feedback to how many pages are available and where you are within the results.
https://github.com/concrete5/concrete5/issues/5116#issuecomment-330837336
https://www.concrete5.org/community/forums/usage/why-diff.-pagination-for-diff.-admins/

![all](https://user-images.githubusercontent.com/10898145/31006178-b0fd7764-a4c9-11e7-881d-6d735dbaff02.png)


