### PR TITLE
Fix filemanager when sortcolumn isn't found

### DIFF
--- a/concrete/src/Tree/Node/Type/FileFolder.php
+++ b/concrete/src/Tree/Node/Type/FileFolder.php
@@ -75,9 +75,10 @@ class FileFolder extends Category
                 }
             }
             if (is_array($sort)) {
-                $sortColumn = $available->getColumnByKey($sort[0]);
-                $sortColumn->setColumnSortDirection($sort[1]);
-                $list->sortBySearchColumn($sortColumn);
+                if ($sortColumn = $available->getColumnByKey($sort[0])) {
+                    $sortColumn->setColumnSortDirection($sort[1]);
+                    $list->sortBySearchColumn($sortColumn);
+                }
             }
         }
         return $list;


### PR DESCRIPTION
Previously you'd get an error when viewing the file manager.