### PR TITLE
Fix package restore after failed update

### DIFF
--- a/concrete/src/Marketplace/RemoteItem.php
+++ b/concrete/src/Marketplace/RemoteItem.php
@@ -227,10 +227,12 @@ class RemoteItem extends ConcreteObject
         }
 
         $r = $pkg->backup();
-        if (is_object($r)) {
+        if (is_object($r) && !($r instanceof Package)) {
             return $r;
         }
 
+        $pkg = $r;
+        
         try {
             $am = new PackageArchive($this->getHandle());
             $am->install($file, true);

--- a/concrete/src/Marketplace/RemoteItem.php
+++ b/concrete/src/Marketplace/RemoteItem.php
@@ -227,12 +227,12 @@ class RemoteItem extends ConcreteObject
         }
 
         $r = $pkg->backup();
-        if (is_object($r) && !($r instanceof Package)) {
+        if (is_object($r) && $r instanceof Error) {
             return $r;
         }
 
         $pkg = $r;
-        
+
         try {
             $am = new PackageArchive($this->getHandle());
             $am->install($file, true);

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -611,6 +611,8 @@ abstract class Package implements LocalizablePackageInterface
                 $this->backedUpFname = $trashName;
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When updating a package, C5 first makes a backup in the trash directory and puts the backup directory's path in the package object's variable $this->backedUpFname.

Later, if updating fails, C5 attempts to restore the package from the backup.

The problem is $this->backedUpFname returns an empty value and the package is not restored breaking C5.

This fixes the restore system by returning the package after backup so we can access $this->backedUpFname