### PR TITLE
#4354 #5785 Facebook authentication register issue fix

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -263,6 +263,13 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         }
 
         $email = $this->getEmail();
+
+        // Sometimes we may not receive email address from SNS apps
+        // Lets create a dummy email address if it's because it's already passed all validations
+        if (!$email) {
+            $email = $this->getUniqueId() . '@' . $this->getHandle();
+        }
+
         if (\UserInfo::getByEmail($email)) {
             throw new Exception('Email is already in use.');
         }


### PR DESCRIPTION
This PR fixes #4354 and a portion of #5785 

Sometimes we may not receive email address from SNS apps
Lets create a dummy email address to skip the error