### PR TITLE
[Feature] Make username and confirm password display/hide configurable for registration form from dashboard

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -704,6 +704,11 @@ return [
             'display_username_field' => true,
 
             /*
+             * Determines whether the confirm password field is displayed when registering
+             */
+            'display_confirm_password_field' => true,
+
+            /*
              * Validate emails during registration
              *
              * @var bool

--- a/concrete/controllers/single_page/dashboard/system/registration/open.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/open.php
@@ -21,6 +21,7 @@ class Open extends DashboardPageController
 
             $config->save('concrete.user.registration.type', $this->post('registration_type'));
             $config->save('concrete.user.registration.captcha', ($this->post('enable_registration_captcha')) ? true : false);
+            $config->save('concrete.user.registration.display_username_field', ($this->post('display_username_field')) ? true : false);
             $security = $this->app->make('helper/security');
 
             switch ($this->post('registration_type')) {
@@ -70,5 +71,6 @@ class Open extends DashboardPageController
         $this->set('enable_registration_captcha', $config->get('concrete.user.registration.captcha'));
         $this->set('register_notification', (bool) $config->get('concrete.user.registration.notification'));
         $this->set('register_notification_email', $config->get('concrete.user.registration.notification_email'));
+        $this->set('display_username_field', $config->get('concrete.user.registration.display_username_field'));
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/registration/open.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/open.php
@@ -22,6 +22,7 @@ class Open extends DashboardPageController
             $config->save('concrete.user.registration.type', $this->post('registration_type'));
             $config->save('concrete.user.registration.captcha', ($this->post('enable_registration_captcha')) ? true : false);
             $config->save('concrete.user.registration.display_username_field', ($this->post('display_username_field')) ? true : false);
+            $config->save('concrete.user.registration.display_confirm_password_field', ($this->post('display_confirm_password_field')) ? true : false);
             $security = $this->app->make('helper/security');
 
             switch ($this->post('registration_type')) {
@@ -72,5 +73,6 @@ class Open extends DashboardPageController
         $this->set('register_notification', (bool) $config->get('concrete.user.registration.notification'));
         $this->set('register_notification_email', $config->get('concrete.user.registration.notification_email'));
         $this->set('display_username_field', $config->get('concrete.user.registration.display_username_field'));
+        $this->set('display_confirm_password_field', $config->get('concrete.user.registration.display_confirm_password_field'));
     }
 }

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -115,7 +115,8 @@ class Register extends PageController
 
             \Core::make('validator/password')->isValid($password, $e);
 
-            if ($password) {
+            $displayConfirmPasswordField = $config->get('concrete.user.registration.display_confirm_password_field');
+            if ($password && $displayConfirmPasswordField) {
                 if ($password != $passwordConfirm) {
                     $e->add(t('The two passwords provided do not match.'));
                 }

--- a/concrete/single_pages/dashboard/system/registration/open.php
+++ b/concrete/single_pages/dashboard/system/registration/open.php
@@ -69,7 +69,7 @@ $h = Loader::helper('concrete/ui');
         <label class="control-label"><?php echo t('Login form') ?></label>
         <div class="radio">
             <label>
-                <input type="radio" name="email_as_username" value="0"
+                <input type="radio" name="email_as_username" value="0" id="display_username_on_login"
                        style="" <?php echo (!$email_as_username) ? 'checked' : '' ?> />
                     <span>
                         <?php echo t('Ask for Username & password on login form') ?>
@@ -110,6 +110,13 @@ $h = Loader::helper('concrete/ui');
     </div>
 </form>
 
+<div id="dialog-confirm" style="display: none" title="<?= t('Do you want to apply?') ?>">
+    <p><?=t('You have to disable ask for Username on login form, if you want to disable it.') ?></p>
+    <div class="dialog-buttons">
+        <button class="btn btn-default" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></button>
+        <button class="btn btn-success pull-right" onclick="enableEmailAsUsername()"><?php echo  t('Apply') ?></button>
+    </div>
+</div>
 
 <script type="text/javascript">
 
@@ -143,4 +150,22 @@ $h = Loader::helper('concrete/ui');
             $('.notify_email').hide();
         }
     });
+
+    $("input[name=display_username_field]").click(function (e) {
+        console.log($("input[name=email_as_username]").val());
+        if (!$(this).is(':checked') && $("#display_username_on_login").is(":checked")) {
+            $.fn.dialog.open({
+                width: 500,
+                height: 100,
+                element: $("#dialog-confirm"),
+            });
+            return false;
+        }
+    });
+
+    function enableEmailAsUsername() {
+        $('input[name=display_username_field]').prop('checked', false);
+        $('input[name=email_as_username]').prop('checked', true);
+        $.fn.dialog.closeTop();
+    }
 </script>

--- a/concrete/single_pages/dashboard/system/registration/open.php
+++ b/concrete/single_pages/dashboard/system/registration/open.php
@@ -95,6 +95,13 @@ $h = Loader::helper('concrete/ui');
                 <span><?php echo t('Ask for Username on registration form') ?></span>
             </label>
         </div>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" name="display_confirm_password_field" value="1"
+                       style="" <?php echo ($display_confirm_password_field) ? 'checked' : '' ?> />
+                <span><?php echo t('Ask to confirm password on registration form') ?></span>
+            </label>
+        </div>
     </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">

--- a/concrete/single_pages/dashboard/system/registration/open.php
+++ b/concrete/single_pages/dashboard/system/registration/open.php
@@ -66,7 +66,7 @@ $h = Loader::helper('concrete/ui');
         </div>
     </div>
     <div class="form-group">
-        <label class="control-label"><?php echo t('Username') ?></label>
+        <label class="control-label"><?php echo t('Login form') ?></label>
         <div class="radio">
             <label>
                 <input type="radio" name="email_as_username" value="0"
@@ -86,7 +86,16 @@ $h = Loader::helper('concrete/ui');
             </label>
         </div>
     </div>
-
+    <div class="form-group">
+        <label class="control-label"><?php echo t('Registration form') ?></label>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" name="display_username_field" value="1"
+                       style="" <?php echo ($display_username_field) ? 'checked' : '' ?> />
+                <span><?php echo t('Ask for Username on registration form') ?></span>
+            </label>
+        </div>
+    </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <?= $h->submit(t('Save'), 'registration-type-form', 'right', 'btn-primary'); ?>

--- a/concrete/single_pages/dashboard/system/registration/open.php
+++ b/concrete/single_pages/dashboard/system/registration/open.php
@@ -152,7 +152,6 @@ $h = Loader::helper('concrete/ui');
     });
 
     $("input[name=display_username_field]").click(function (e) {
-        console.log($("input[name=email_as_username]").val());
         if (!$(this).is(':checked') && $("#display_username_on_login").is(":checked")) {
             $.fn.dialog.open({
                 width: 500,

--- a/concrete/single_pages/register.php
+++ b/concrete/single_pages/register.php
@@ -59,7 +59,6 @@ if ($registerSuccess) {
                             <?= $form->text('uName') ?>
                         </div>
                         <?php
-
                     }
                     ?>
                     <div class="form-group">
@@ -70,10 +69,12 @@ if ($registerSuccess) {
                         <?= $form->label('uPassword', t('Password')) ?>
                         <?= $form->password('uPassword', array('autocomplete' => 'off')) ?>
                     </div>
-                    <div class="form-group">
-                        <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
-                        <?= $form->password('uPasswordConfirm', array('autocomplete' => 'off')) ?>
-                    </div>
+                    <?php if (Config::get('concrete.user.registration.display_confirm_password_field')): ?>
+                        <div class="form-group">
+                            <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
+                            <?= $form->password('uPasswordConfirm', array('autocomplete' => 'off')) ?>
+                        </div>
+                    <?php endif; ?>
 
                 </fieldset>
             </div>

--- a/concrete/single_pages/register.php
+++ b/concrete/single_pages/register.php
@@ -69,12 +69,16 @@ if ($registerSuccess) {
                         <?= $form->label('uPassword', t('Password')) ?>
                         <?= $form->password('uPassword', array('autocomplete' => 'off')) ?>
                     </div>
-                    <?php if (Config::get('concrete.user.registration.display_confirm_password_field')): ?>
+                    <?php
+                    if (Config::get('concrete.user.registration.display_confirm_password_field')) {
+                        ?>
                         <div class="form-group">
                             <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
                             <?= $form->password('uPasswordConfirm', array('autocomplete' => 'off')) ?>
                         </div>
-                    <?php endif; ?>
+                        <?php
+                    }
+                    ?>
 
                 </fieldset>
             </div>


### PR DESCRIPTION
- In current version of concrete5, display username on registration form is configurable from config file. But can't do it from dashboard. This PR allows to do it.
- Additionally, it's very common for us, sometimes our clients want to remove confirm password field, as it can reset by forgot password. Let's control it also from dashboard.
- If we skip username on registration form, but we don't configure it to login with email, it may not work. I've added a dialog for it.

![screen shot 2017-10-06 at 11 13 08 am](https://user-images.githubusercontent.com/2462951/31270196-4742e7b4-aabe-11e7-9672-7ad9a84732b0.png)

![screen shot 2017-10-06 at 5 35 12 pm](https://user-images.githubusercontent.com/2462951/31270214-587a5670-aabe-11e7-9b52-f3cdc7d896a7.png)


