### PR TITLE
Remove entries from 'FileSetFiles' database table too after deleting a File Set

### DIFF
--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -471,6 +471,7 @@ class Set
         $db = Database::connection();
         $db->delete('FileSets', array('fsID' => $this->fsID));
         $db->executeQuery('DELETE FROM FileSetSavedSearches WHERE fsID = ?', array($this->fsID));
+        $db->executeQuery('DELETE FROM FileSetFiles WHERE fsID = ?', array($this->fsID));
     }
 
     /*


### PR DESCRIPTION
After you delete a File Set, it only makes sense all relations in the "FileSetFiles" database table get deleted too. For some reason, this wasn't happening yet though. It already IS deleting entries from the "FileSetSavedSearches" database table though, so this should be a nice addition to keep the database clean.