### PR TITLE
Safer migration of btSearch table

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
@@ -8,7 +8,7 @@ class Version20170926000000 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        $this->connection->executeQuery("UPDATE btSearch SET postTo_cID = NULL WHERE postTo_cID = ''");
+        $this->connection->executeQuery('UPDATE btSearch SET postTo_cID = NULL WHERE IFNULL(CAST(postTo_cID AS SIGNED), 0) < 1');
         $this->refreshBlockType('search');
     }
 


### PR DESCRIPTION
In #5986 I changed the type of the `postTo_cID` field (`btSearch` table) from string to integer.

In order to avoid migration problems, I set to `null` all the `btSearch` fields that contain empty strings.

BTW, in case the `btSearch` column contain other values that can't be converted to integers, the migration will break. There shouldn't exist records with such invalid values, but it's safer to not assume anything :wink: