### PR TITLE
Add support for custom entity managers

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/entities.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/entities.php
@@ -2,49 +2,77 @@
 namespace Concrete\Controller\SinglePage\Dashboard\System\Environment;
 
 use Concrete\Core\Database\DatabaseStructureManager;
-use Concrete\Core\Package\Package;
+use Concrete\Core\Package\CustomEntityManagersInterface;
+use Concrete\Core\Package\PackageService;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Core;
-use Config;
-use Doctrine\ORM\Tools\SchemaTool;
-use ORM;
+use Doctrine\ORM\EntityManagerInterface;
 
 class Entities extends DashboardPageController
 {
     public function view()
     {
         // Retrieve all entity manager drivers and show data about them
-        $config = $this->getEntityManager()->getConfiguration();
-        $driverChain = $config->getMetadataDriverImpl();
-        $drivers = $driverChain->getDrivers();
+        $drivers = [];
+        foreach ($this->getAllEntityManagers() as $em) {
+            $config = $em->getConfiguration();
+            $thisDriverChain = $config->getMetadataDriverImpl();
+            if ($thisDriverChain !== null) {
+                $theseDrivers = $thisDriverChain->getDrivers();
+                if (!empty($theseDrivers)) {
+                    $drivers = array_merge($drivers, $theseDrivers);
+                }
+            }
+        }
+        $this->set('doctrine_dev_mode', (bool) $this->app->make('config')->get('concrete.cache.doctrine_dev_mode'));
         $this->set('drivers', $drivers);
     }
 
-
     public function update_entity_settings()
     {
-        if (!$this->token->validate("update_entity_settings")) {
+        if (!$this->token->validate('update_entity_settings')) {
             $this->error->add($this->token->getErrorMessage());
         }
         if (!$this->error->has()) {
             if ($this->isPost()) {
-                $ddm = $this->post('DOCTRINE_DEV_MODE') == 1 ? 1 : 0;
+                $ddm = $this->post('DOCTRINE_DEV_MODE') === 'yes';
 
                 if ($this->request->request->get('refresh')) {
-                    $em = ORM::entityManager();
-                    $manager = new DatabaseStructureManager($em);
-                    $manager->refreshEntities();
+                    foreach ($this->getAllEntityManagers() as $em) {
+                        $manager = new DatabaseStructureManager($em);
+                        $manager->refreshEntities();
+                    }
 
                     $this->flash('success', t('Doctrine cache cleared, proxy classes regenerated, entity database table schema updated.'));
                     $this->redirect('/dashboard/system/environment/entities', 'view');
                 } else {
-                    Config::save('concrete.cache.doctrine_dev_mode', (bool) $ddm);
+                    $this->app->make('config')->save('concrete.cache.doctrine_dev_mode', $ddm);
                     $this->flash('success', t('Doctrine development settings updated.'));
                 }
                 $this->redirect('/dashboard/system/environment/entities', 'view');
             }
         } else {
-            $this->set('error', array($this->token->getErrorMessage()));
+            $this->set('error', [$this->token->getErrorMessage()]);
         }
+    }
+
+    /**
+     * @return EntityManagerInterface[]
+     */
+    private function getAllEntityManagers()
+    {
+        $result = [$this->app->make(EntityManagerInterface::class)];
+        $packageService = $this->app->make(PackageService::class);
+        foreach ($packageService->getInstalledHandles() as $packageHandle) {
+            $package = $packageService->getClass($packageHandle);
+            if ($package instanceof CustomEntityManagersInterface) {
+                foreach ($package->getCustomPackageEntityManagers() as $em) {
+                    if (!in_array($em, $result, true)) {
+                        $result[] = $em;
+                    }
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/concrete/single_pages/dashboard/system/environment/entities.php
+++ b/concrete/single_pages/dashboard/system/environment/entities.php
@@ -1,85 +1,85 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Html\Service\Html $html */
+/* @var Concrete\Core\Page\View\PageView $this */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Page\View\PageView $view */
+
+/* @var bool $doctrine_dev_mode */
+/* @var Doctrine\ORM\Mapping\Driver\AnnotationDriver[] $drivers */
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
 ?>
 
-
 <form method="post" id="entities-settings-form" action="<?= $view->action('update_entity_settings') ?>" style="position: relative">
-    <?= $this->controller->token->output('update_entity_settings') ?>
+    <?= $token->output('update_entity_settings') ?>
 
     <fieldset>
         <legend><?= t('Settings') ?></legend>
-
         <div class="form-group">
+            <label class="launch-tooltip" data-placement="right" title="<?= t('Defines whether the Doctrine proxy classes are created on the fly. On the fly generation is active when development mode is enabled.') ?>"><?= t('Doctrine Development Mode') ?></label>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('DOCTRINE_DEV_MODE', 'yes', $doctrine_dev_mode) ?>
+                    <span><?= t('On - Proxy classes will be generated on the fly. Good for development.') ?></span>
+                </label>
+            </div>
 
-        <label class="launch-tooltip" data-placement="right" title="<?= t('Defines whether the Doctrine proxy classes are created on the fly. On the fly generation is active when development mode is enabled.') ?>"><?= t('Doctrine Development Mode') ?></label>
-
-        <div class="radio">
-            <label>
-                <input type="radio" name="DOCTRINE_DEV_MODE" value="1" <?php if (Config::get('concrete.cache.doctrine_dev_mode')) {
-                    ?> checked <?php
-                } ?> />
-                <span><?=t('On - Proxy classes will be generated on the fly. Good for development.')?></span>
-            </label>
-        </div>
-
-        <div class="radio">
-            <label>
-                <input type="radio" name="DOCTRINE_DEV_MODE" value="0" <?php if (!Config::get('concrete.cache.doctrine_dev_mode')) {
-                    ?> checked <?php
-                } ?> />
-                <span><?= t('Off - Proxy classes need to be manually generated. Helps speed up a live site.') ?></span>
-            </label>
-        </div>
-
+            <div class="radio">
+                <label>
+                    <?= $form->radio('DOCTRINE_DEV_MODE', 'no', !$doctrine_dev_mode) ?>
+                    <span><?= t('Off - Proxy classes need to be manually generated. Helps speed up a live site.') ?></span>
+                </label>
+            </div>
         </div>
     </fieldset>
 
     <fieldset>
-        <legend><?=t("Entities")?></legend>
+        <legend><?=t('Entities')?></legend>
 
         <div class="form-group">
-        <?php foreach($drivers as $namespace => $driver) { ?>
-
-            <h4><?=$namespace?></h4>
-            <div class="row">
-                <div class="col-md-1"><span class="text-muted"><?=t('Paths')?></span></div>
-                <div class="col-md-11">
-                    <?php 
-                    
-                    if($driver instanceof \Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver){
-                        $paths = $driver->getPaths();
-                    }elseif($driver instanceof \Doctrine\Common\Persistence\Mapping\Driver\FileDriver){
-                        $paths = $driver->getLocator()->getPaths();
-                    }else{
-                        $paths = [];
-                    }
-                    
-                    if(!empty($paths)){
-                    foreach($paths as $path) { ?>
-                       <small><?=$path?></small>
-                    <?php }
-                    } ?>
+            <?php
+            foreach($drivers as $namespace => $driver) {
+                ?>
+                <h4><?= $namespace ?></h4>
+                <div class="row">
+                    <div class="col-md-1"><span class="text-muted"><?= t('Paths') ?></span></div>
+                    <div class="col-md-11">
+                        <?php 
+                        if ($driver instanceof Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver) {
+                            $paths = $driver->getPaths();
+                        } elseif ($driver instanceof Doctrine\Common\Persistence\Mapping\Driver\FileDriver) {
+                            $paths = $driver->getLocator()->getPaths();
+                        } else {
+                            $paths = [];
+                        }
+                        if (!empty($paths)) {
+                            foreach ($paths as $path) {
+                                $shownPath = str_replace('/', DIRECTORY_SEPARATOR, strpos($path, DIR_BASE) === 0 ? substr($path, strlen(DIR_BASE) + 1) : $path);
+                                ?><small><?= $shownPath ?></small><br><?php
+                            }
+                        }
+                        ?>
+                    </div>
                 </div>
-            </div>
-
-            <div class="row">
-                <div class="col-md-1"><span class="text-muted"><?=t('Driver')?></span></div>
-                <div class="col-md-11">
-                    <?=get_class($driver)?>
+                <div class="row">
+                    <div class="col-md-1"><span class="text-muted"><?= t('Driver') ?></span></div>
+                    <div class="col-md-11">
+                        <?= get_class($driver) ?>
+                    </div>
                 </div>
-            </div>
-
-            <hr/>
-
-        <?php } ?>
-
+                <hr/>
+                <?php
+            }
+            ?>
         </div>
     </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button class="pull-left btn btn-danger" name="refresh" value="1" type="submit" ><?=t('Refresh Entities')?></button>
-            <button class="pull-right btn btn-primary" type="submit" ><?=t('Save')?></button>
+            <button class="pull-left btn btn-danger" name="refresh" value="1" type="submit" ><?= t('Refresh Entities') ?></button>
+            <button class="pull-right btn btn-primary" type="submit" ><?= t('Save') ?></button>
         </div>
     </div>
 

--- a/concrete/src/Package/CustomEntityManagersInterface.php
+++ b/concrete/src/Package/CustomEntityManagersInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Concrete\Core\Package;
+
+/**
+ * Package controllers that implements this interface provide their own EntityMangerInterface instance with the getCustomPackageEntityManagers method.
+ */
+interface CustomEntityManagersInterface
+{
+    /**
+     * Return custom package entity managers.
+     *
+     * @return \Doctrine\ORM\EntityManagerInterface[]
+     */
+    public function getCustomPackageEntityManagers();
+}

--- a/concrete/src/Package/NoDefaultEntityManagerInterface.php
+++ b/concrete/src/Package/NoDefaultEntityManagerInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Concrete\Core\Package;
+
+/**
+ * Package controllers that implement this interface won't have the default EntityManager handling them.
+ */
+interface NoDefaultEntityManagerInterface
+{
+}


### PR DESCRIPTION
In a custom package, I need to handle entities that are persisted in another database.

This requires that the package must create its own EntityManager instance, but currently the core doesn't allow that.

Let's introduce a new `CustomEntityManagersInterface` interface: packages that implement it have the responsibility to create their own EntityManagers.

Bonus track: I also added a `NoDefaultEntityManagerInterface` interface: packages that implement it won't have entities that are going to be handled by the default entity manager.