### PR TITLE
Allow custom date/time formats for date_time attributes

### DIFF
--- a/concrete/attributes/date_time/form.php
+++ b/concrete/attributes/date_time/form.php
@@ -4,7 +4,14 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $app = Facade::getFacadeApplication();
 switch ($displayMode) {
     case 'text':
-        $format = $date->getPHPDateTimePattern();
+    case 'date_text':
+        if ($textCustomFormat !== '') {
+            $format = $textCustomFormat;
+        } elseif ($displayMode === 'date_text') {
+            $format = $date->getPHPDatePattern();
+        } else {
+            $format = $date->getPHPDateTimePattern();
+        }
         if ($value === null) {
             $placeholder = $date->formatCustom($format, 'now');
         } else {

--- a/concrete/attributes/date_time/type_form.php
+++ b/concrete/attributes/date_time/type_form.php
@@ -17,22 +17,19 @@
         $akDateDisplayModeOptions = [
             'date_time' => t('Both Date and Time'),
             'date' => t('Date Only'),
-            'text' => t('Text Input Field'),
+            'date_text' => t('Text Input Field with Date'),
+            'text' => t('Text Input Field with Date and Time'),
         ];
         if (!isset($akDateDisplayMode) || !isset($akDateDisplayModeOptions[$akDateDisplayMode])) {
             $akDateDisplayMode = key($akDateDisplayModeOptions);
         }
         ?>
-        <?=$form->select('akDateDisplayMode', $akDateDisplayModeOptions, $akDateDisplayMode, [
-            'onchange' => <<<'EOT'
-if (this.value === 'date_time') {
-    $('#akTimeResolution').removeAttr('disabled');
-} else {
-    $('#akTimeResolution').attr('disabled', 'disabled');
-}
-EOT
-            ,
-        ])?>
+        <?=$form->select('akDateDisplayMode', $akDateDisplayModeOptions, $akDateDisplayMode) ?>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('akTextCustomFormat', '<a href="http://php.net/manual/function.date.php" target="_blank">' . t('Custom format') . ' ' . '<i class="fa fa-question-circle"></i></a>', ['class' => 'launch-tooltip', 'data-html' => 'true', 'title' => h(t('Here you can specify an optional custom format for text inputs (click to see the PHP manual for the %s function)', '<code>date</code>'))]) ?>
+        <?= $form->text('akTextCustomFormat', isset($akTextCustomFormat) ? $akTextCustomFormat : '') ?>
     </div>
 
     <div class="form-group">
@@ -76,3 +73,27 @@ EOT
     </div>
 
 </fieldset>
+
+<script>
+$(document).ready(function() {
+    $('#akDateDisplayMode')
+        .on('change', function() {
+            if (this.value === 'date_time') {
+                $('#akTimeResolution').removeAttr('disabled');
+            } else {
+                $('#akTimeResolution').attr('disabled', 'disabled');
+            }
+            switch (this.value) {
+                case 'text':
+                case 'date_text':
+                    $('#akTextCustomFormat').removeAttr('disabled');
+                    break;
+                default:
+                    $('#akTextCustomFormat').attr('disabled', 'disabled');
+                    break;
+            }
+        })
+        .trigger('change')
+    ;
+});
+</script>

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.3.0a1',
     'version_installed' => '8.3.0a1',
-    'version_db' => '20170926000000', // the key of the latest database migration
+    'version_db' => '20171012000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Entity/Attribute/Key/Settings/DateTimeSettings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/DateTimeSettings.php
@@ -20,6 +20,11 @@ class DateTimeSettings extends Settings
     protected $akDateDisplayMode = '';
 
     /**
+     * @ORM\Column(type="text", nullable=false, options={"default": "", "comment": "Custom format for text inputs"})
+     */
+    protected $akTextCustomFormat = '';
+
+    /**
      * @ORM\Column(type="integer", nullable=false, options={"default": 60, "unsigned": true, "comment": "Time resolution (in seconds)"})
      */
     protected $akTimeResolution = 60;
@@ -54,6 +59,22 @@ class DateTimeSettings extends Settings
     public function setMode($mode)
     {
         $this->akDateDisplayMode = (string) $mode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTextCustomFormat()
+    {
+        return $this->akTextCustomFormat;
+    }
+
+    /**
+     * @param string $textCustomFormat
+     */
+    public function setTextCustomFormat($textCustomFormat)
+    {
+        $this->akTextCustomFormat = (string) $textCustomFormat;
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20171012000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171012000000.php
@@ -1,0 +1,20 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20171012000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->refreshEntities([
+            DateTimeSettings::class,
+        ]);
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
In order to allow custom formats for the date/time attributes, we need to know if we have to convert the timezone or to keep the user's time zone (for instance, a birth date shouldn't follow the time zone, but the date/time of a meeting should).

So, we need to add another type of `Text Input Field`, to know if the time zone should be converted or not.
To simplify its description, I split `Text Input Field` to `Text Input Field with Date` and `Text Input Field with Date and Time` (but I'm obviously open to comments about that :wink:).

Fix #6039