### PR TITLE
Fix the generation of __IDE_SYMBOLS__.php

### DIFF
--- a/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
+++ b/concrete/src/Support/Symbol/ClassSymbol/ClassSymbol.php
@@ -72,14 +72,9 @@ class ClassSymbol
         $this->reflectionClass = new ReflectionClass($fqn);
         $this->fqn = ltrim($fqn, '\\');
         $this->alias = ltrim($alias, '/');
-        $p = strrpos($this->alias, '\\');
-        if ($p === false) {
-            $this->aliasNamespace = '';
-            $this->aliasBasename = $this->alias;
-        } else {
-            $this->aliasNamespace = substr($this->alias, 0, $p);
-            $this->aliasBasename = substr($this->alias, $p + 1);
-        }
+        $chunks = explode('\\', $this->alias);
+        $this->aliasBasename = array_pop($chunks);
+        $this->aliasNamespace = implode('\\', $chunks);
         $this->comment = $this->reflectionClass->getDocComment();
 
         if (

--- a/concrete/src/Support/Symbol/SymbolGenerator.php
+++ b/concrete/src/Support/Symbol/SymbolGenerator.php
@@ -4,6 +4,7 @@
  * Concrete5 symbol file generator.
  * Inspired by Laravel IDE Helper Generator by Barry vd. Heuvel <barryvdh@gmail.com>.
  */
+
 namespace Concrete\Core\Support\Symbol;
 
 use Concrete\Core\Foundation\ClassAliasList;
@@ -16,7 +17,14 @@ class SymbolGenerator
      *
      * @var ClassSymbol[]
      */
-    protected $classes = array();
+    protected $classes = [];
+
+    /**
+     * All the alias namespaces.
+     *
+     * @var array
+     */
+    protected $aliasNamespaces = [''];
 
     public function __construct()
     {
@@ -38,7 +46,12 @@ class SymbolGenerator
      */
     public function registerClass($alias, $class)
     {
-        $this->classes[$alias] = new ClassSymbol($alias, $class);
+        $classSymbol = new ClassSymbol($alias, $class);
+        $this->classes[$alias] = $classSymbol;
+        $aliasNamespace = $classSymbol->getAliasNamespace();
+        if (!in_array($aliasNamespace, $this->aliasNamespaces, true)) {
+            $this->aliasNamespaces[] = $aliasNamespace;
+        }
     }
 
     /**
@@ -52,16 +65,36 @@ class SymbolGenerator
      */
     public function render($eol = "\n", $padding = '    ', $methodFilter = null)
     {
-        $rendered = "<?php{$eol}namespace {{$eol}{$padding}die('Intended for use with IDE symbol matching only.');{$eol}";
-        $rendered .= $padding . "//Generated on " . date('r') . $eol;
-        foreach ($this->classes as $class) {
-            $rendered_class = $class->render($eol, $padding, $methodFilter);
-            if ($rendered_class !== '') {
-                $rendered .= $eol . $padding . str_replace($eol, $eol . $padding, rtrim($rendered_class)) . $eol;
+        $lines = [];
+        $lines[] = '<?php';
+        $lines[] = '';
+        $lines[] = '// Generated on ' . date('c');
+        foreach ($this->aliasNamespaces as $namespace) {
+            $lines[] = '';
+            $lines[] = rtrim("namespace {$namespace}");
+            $lines[] = '{';
+            $addNewline = false;
+            if ($namespace === '') {
+                $lines[] = "{$padding}die('Intended for use with IDE symbol matching only.');";
+                $addNewline = true;
             }
+            foreach ($this->classes as $class) {
+                if ($class->getAliasNamespace() === $namespace) {
+                    $rendered_class = $class->render($eol, $padding, $methodFilter);
+                    if ($rendered_class !== '') {
+                        if ($addNewline === true) {
+                            $lines[] = '';
+                        } else {
+                            $addNewline = true;
+                        }
+                        $lines[] = $padding . str_replace($eol, $eol . $padding, rtrim($rendered_class));
+                    }
+                }
+            }
+            $lines[] = '}';
         }
-        $rendered .= '}' . $eol;
+        $lines[] = '';
 
-        return $rendered;
+        return implode($eol, $lines);
     }
 }


### PR DESCRIPTION
Currently, the `__IDE_SYMBOLS__.php` file generated by the `c5:ide-symbols` is invalid, since it contains the following code:

```php
<?php
namespace {
    class Area extends \Concrete\Core\Area\Area
    {
    }
    // [...]
    class Concrete\Core\Foundation\Object extends Concrete\Core\Foundation\ConcreteObject
    {
    }
    // [...]
}
```

which is invalid.

Let's generate the following code:

```php
<?php
namespace {
    class Area extends \Concrete\Core\Area\Area
    {
    }
    // [...]
}
namespace Concrete\Core\Foundation {
    class Object extends \Concrete\Core\Foundation\ConcreteObject
    {
    }
    // [...]
}
```
