### PR TITLE
Add the Whoops\Run instance to Application

### DIFF
--- a/concrete/src/Error/Provider/WhoopsServiceProvider.php
+++ b/concrete/src/Error/Provider/WhoopsServiceProvider.php
@@ -32,5 +32,6 @@ class WhoopsServiceProvider extends Provider
         }
 
         $run->register();
+        $this->app->instance(Run::class, $run);
     }
 }


### PR DESCRIPTION
I don't know if it's already possible to add a custom error handler, but this PR would allow to add a custom error handler with
```php
$app->make(Whoops\Run::class)->pushHandler($myErrorHandler);
```