### PR TITLE
Add console command aliases

### DIFF
--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -21,6 +21,7 @@ class InstallLanguageCommand extends Command
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
         ->setName('c5:language-install')
+        ->setAliases(['c5:install-language'])
         ->setDescription('Install or update concrete5 languages')
         ->addEnvOption()
         ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -17,7 +17,11 @@ class InstallPackageCommand extends Command
     {
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-            ->setName('c5:package-install')
+            ->setName('c5:package:install')
+            ->setAliases([
+                'c5:package-install',
+                'c5:install-package',
+            ])
             ->addOption('full-content-swap', null, InputOption::VALUE_NONE, 'If this option is specified a full content swap will be performed (if the package supports it)')
             ->setDescription('Install a concrete5 package')
             ->addEnvOption()

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -38,7 +38,11 @@ final class PackPackageCommand extends Command
         $keepSources = static::KEEP_SOURCES;
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-            ->setName('c5:package-pack')
+            ->setName('c5:package:pack')
+            ->setAliases([
+                'c5:package-pack',
+                'c5:pack-package',
+            ])
             ->setDescription('Process a package (expand PHP short tags, compile icons and translations, create zip archive)')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to work on (or the path to a directory containing a concrete5 package)')
             ->addEnvOption()

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -19,7 +19,11 @@ class TranslatePackageCommand extends Command
     {
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-        ->setName('c5:package-translate')
+            ->setName('c5:package:translate')
+            ->setAliases([
+                'c5:package-translate',
+                'c5:translate-package',
+            ])
         ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a concrete5 package)')
         ->addEnvOption()
         ->addOption('locale', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of locale codes to handle')

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -16,7 +16,11 @@ class UninstallPackageCommand extends Command
     {
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-            ->setName('c5:package-uninstall')
+            ->setName('c5:package:uninstall')
+            ->setAliases([
+                'c5:package-uninstall',
+                'c5:uninstall-package',
+            ])
             ->addEnvOption()
             ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -16,7 +16,11 @@ class UpdatePackageCommand extends Command
     {
         $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
-            ->setName('c5:package-update')
+            ->setName('c5:package:update')
+            ->setAliases([
+                'c5:package-update',
+                'c5:update-package',
+            ])
             ->addEnvOption()
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the installed packages')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')


### PR DESCRIPTION
I think it makes more sense to type `c5:translate-package`, than to type `c5:package-translate`.

Because the commands are alphabatically sorted, I added the following aliases:

- `c5:install-language`
- `c5:install-package`
- `c5:pack-package`
- `c5:translate-package`
- `c5:uninstall-package`
- `c5:update-package`

<img width="444" alt="aliases" src="https://user-images.githubusercontent.com/1431100/31587071-24a1de26-b1db-11e7-871b-178273ce5565.png">
