### PR TITLE
fix #5957 An invalid form control with name='width' is not focusable.

### DIFF
--- a/concrete/blocks/video/form_setup_html.php
+++ b/concrete/blocks/video/form_setup_html.php
@@ -58,7 +58,7 @@ if (!isset($width)) {
     <div id="video-width" class="form-group" style="display: none;">
         <?= $form->label('width', t('Max Width')); ?>
         <div class="input-group">
-            <?= $form->number('width', $width, array('min' => 1)); ?>
+            <?= $form->hidden('width', $width, array('min' => 1, 'class' => 'form-control')); ?>
             <div class="input-group-addon"><?= t('px'); ?></div>
         </div>
     </div>
@@ -73,10 +73,10 @@ $(document).ready(function() {
     $('input[name=videoSize]').on('change', function() {
         if ($(this).val() === '2') {
             $('#video-width').show();
-            $('#width').attr('min', 1);
+            $('#width').attr({'min' : 1 , 'type' : 'number'});
         } else {
             $('#video-width').hide();
-            $('#width').attr('min', 0);
+            $('#width').attr({'min' : 0, 'type' : 'hidden'});
         }
     });
 });

--- a/concrete/blocks/video/form_setup_html.php
+++ b/concrete/blocks/video/form_setup_html.php
@@ -58,7 +58,7 @@ if (!isset($width)) {
     <div id="video-width" class="form-group" style="display: none;">
         <?= $form->label('width', t('Max Width')); ?>
         <div class="input-group">
-            <?= $form->hidden('width', $width, array('min' => 1, 'class' => 'form-control')); ?>
+            <?= $form->number('width', $width ?: '', array('min' => 1)); ?>
             <div class="input-group-addon"><?= t('px'); ?></div>
         </div>
     </div>
@@ -73,10 +73,10 @@ $(document).ready(function() {
     $('input[name=videoSize]').on('change', function() {
         if ($(this).val() === '2') {
             $('#video-width').show();
-            $('#width').attr({'min' : 1 , 'type' : 'number'});
+            $('#width').attr('min', 1);
         } else {
             $('#video-width').hide();
-            $('#width').attr({'min' : 0, 'type' : 'hidden'});
+            $('#width').attr('min', 0);
         }
     });
 });


### PR DESCRIPTION
fix #5957 An invalid form control with name='width' is not focusable.

This problem occurs when you want to edit the blok and 'Set Max Width' is not checked. The 'width' input is hidden and can not be focused because of this. 

The solution switches the type of the input.