### PR TITLE
Add method to clear the Flysystem cache

### DIFF
--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -139,6 +139,16 @@ class StorageLocation implements StorageLocationInterface
         return $filesystem;
     }
 
+    /**
+     * Clear the Flysystem cache.
+     */
+    public function clearCache()
+    {
+        $pool = \Core::make(ExpensiveCache::class)->pool;
+        $cache = new Psr6Cache($pool, 'flysystem-id-' . $this->getID());
+        $cache->flush();
+    }
+
     public function delete()
     {
         $default = \Concrete\Core\File\StorageLocation\StorageLocation::getDefault();


### PR DESCRIPTION
When
- caching is enabled, and
- a file on the file system is modified (e.g. decreases in size)

The Rescan file doesn't update the file size correctly. 

This PR adds a method that would allow us to clear the Flysystem [cache](https://github.com/concrete5/concrete5/blob/develop/concrete/src/Entity/File/StorageLocation/StorageLocation.php#L135).

See also: https://github.com/concrete5/concrete5/issues/5933#issuecomment-333260534