### PR TITLE
Stop change password page invalid access

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -251,6 +251,8 @@ class Controller extends AuthenticationTypeController
         $e = Core::make('helper/validation/error');
         if (is_string($uHash)) {
             $ui = UserInfo::getByValidationHash($uHash);
+        } else {
+            $ui = null;
         }
         if (is_object($ui)) {
             $vh = new ValidationHash();

--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -249,7 +249,9 @@ class Controller extends AuthenticationTypeController
     {
         $this->set('authType', $this->getAuthenticationType());
         $e = Core::make('helper/validation/error');
-        $ui = UserInfo::getByValidationHash($uHash);
+        if (is_string($uHash)) {
+            $ui = UserInfo::getByValidationHash($uHash);
+        }
         if (is_object($ui)) {
             $vh = new ValidationHash();
             if ($vh->isValid($uHash)) {


### PR DESCRIPTION
Now, if someone try to access http://concrete5.dev/index.php/login/concrete/change_password (which is an invalid url) it shows some errors. Let's stop it with a simple check.

![screen shot 2017-10-23 at 11 26 04 am](https://user-images.githubusercontent.com/2462951/31869901-e81b5cfa-b7e5-11e7-8ff4-b9e38f038511.png)
