### PR TITLE
Add support to foreign keys in attribute index tables

### DIFF
--- a/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
@@ -56,6 +56,18 @@ class StandardSearchIndexer implements SearchIndexerInterface
                         $table->addColumn($column['name'], $column['type'], $column['options']);
                     }
                 }
+                if (isset($details['foreignKeys'])) {
+                    foreach ($details['foreignKeys'] as $foreignKey) {
+                        $options = [];
+                        if (!empty($foreignKey['onUpdate'])) {
+                            $options['onUpdate'] = $foreignKey['onUpdate'];
+                        }
+                        if (!empty($foreignKey['onDelete'])) {
+                            $options['onDelete'] = $foreignKey['onDelete'];
+                        }
+                        $table->addForeignKeyConstraint($foreignKey['foreignTable'], $foreignKey['localColumns'], $foreignKey['foreignColumns'], $options);
+                    }
+                }
 
                 if (isset($details['primary'])) {
                     $table->setPrimaryKey($details['primary']);


### PR DESCRIPTION
What about adding support to foreign keys creation in attribute index tables?

For instance, for the file attributes, we may have [here](https://github.com/concrete5/concrete5/blob/1388634e32b526b66f0ae0d74245c9cd40cca3dc/concrete/src/Attribute/Category/FileCategory.php#L27) a code like this:

```php
return [
    'columns' => [
        [
            'name' => 'fID',
            'type' => 'integer',
            'options' => ['unsigned' => true, 'default' => 0, 'notnull' => true],
        ],
    ],
    'primary' => array['fID'],
    'foreignKeys' => [
        [
            'foreignTable' => 'Files',
            'localColumns' => ['fID'],
            'foreignColumns' => ['fID'],
            'onUpdate' => 'CASCADE',
            'onDelete' => 'CASCADE',
        ]
    ],
];
```

That way, when a record in the Files  table is deleted, we won't have records in the FileSearchIndexAttributes table anymore.