### PR TITLE
Prepare MultilingualPageRelations table for upgrading

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -86,6 +86,8 @@ class Version20160725000000 extends AbstractMigration
         $this->deleteInvalidForeignKey('AttributeSetKeys', 'asID', 'AttributeSets', 'asID');
         // Fix Stack orphans 
         $this->deleteInvalidForeignKey('Stacks', 'cID', 'Pages', 'cID');
+        // Delete invalid records from MultilingualPageRelations
+        $this->deleteInvalidForeignKey('MultilingualPageRelations', 'cID', 'Pages', 'cID');
     }
 
     protected function nullifyInvalidForeignKeys()


### PR DESCRIPTION
This should fix the migration problem reported here: http://www.concrete5.org/community/forums/internationalization/multilingual-site-error-after-upgrade-to-8.2