### PR TITLE
Define the meaning of `Set Order` with a context

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -127,7 +127,7 @@ class Controller extends BlockController
 
         $orderByOptions = array(
             'title' => t('Title'),
-            'set' => t('Set Order'),
+            'set' => tc('Order of a set', 'Set Order'),
             'date' => t('Date Posted'),
             'filename' => t('Filename')
         );


### PR DESCRIPTION
`Set Order` may stand for `Order of the set` or `Configure the order`.
Different meanings imply different translations. Let's add a translation context to define what it exactly means.