### PR TITLE
Replace deprecated method call_user_method with call_user_func

### DIFF
--- a/concrete/controllers/single_page/account/edit_profile.php
+++ b/concrete/controllers/single_page/account/edit_profile.php
@@ -57,7 +57,7 @@ class EditProfile extends AccountPageController
             }
         }
         try {
-            $message = call_user_method($method, $at->controller);
+            $message = call_user_func([$at->controller, $method]);
             if (trim($message)) {
                 $this->set('message', $message);
             }


### PR DESCRIPTION
File: concrete/controllers/single_page/account/edit_profile.php

Use
```
$message = call_user_func([$at->controller, $method]);
```
istead of 
```
$message = call_user_method($method, $at->controller);
```
