### PR TITLE
[Fix#4907] Fix duplicated results of topic filter

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -566,6 +566,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->query->innerJoin('av', 'atSelectedTopics', 'atst', 'av.avID = atst.avID');
         $this->query->andWhere('atst.treeNodeID = :TopicNodeID');
         $this->query->setParameter('TopicNodeID', $treeNodeID);
+        $this->query->select('distinct p.cID');
     }
 
     public function filterByBlockType(BlockType $bt)

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -367,7 +367,7 @@ class Version20160725000000 extends AbstractMigration
             $this->importAttributeKeySettings($row['atID'], $row['akID']);
             switch ($akCategory) {
                 case 'pagekey':
-                    $rb = $this->connection->executeQuery('select * from CollectionAttributeValues where akID = ?', [$row['akID']]);
+                    $rb = $this->connection->executeQuery('select * from CollectionAttributeValues where akID = ? group by avID', [$row['akID']]);
                     while ($rowB = $rb->fetch()) {
                         $this->addAttributeValue($row['atID'], $row['akID'], $rowB['avID']);
                     }


### PR DESCRIPTION
This PR fixes issue https://github.com/concrete5/concrete5/issues/4907

## Reason

```
$rb = $this->connection->executeQuery('select * from CollectionAttributeValues where akID = ?', [$row['akID']])
```
[This query](https://github.com/concrete5/concrete5/blob/develop/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php#L370) was causing duplicate entries on `atSelectedTopics` table.

## Solution

### Who don't already have duplicate results

```
$rb = $this->connection->executeQuery("select * from CollectionAttributeValues where akID = ? group by avID", array($row['akID'])); 
```

or,

```
$rb = $this->connection->executeQuery("select distinct akID, avID, atID  from CollectionAttributeValues where akID = ? ", array($row['akID'])); 
```

As `atID` isn't available on most recent version, I think using `group by` is safer than `distinct`.

### Who already have duplicate results
Have to remove the duplicate entries from `atSelectedTopics` table. Simply, I've applied `distinct` on `select` query.

Core team should decide how to handle the duplicate contents. Can add a query on next migration.

## Screenshots

### _atSelectedTopics 
![screen shot 2017-10-31 at 6 56 13 pm](https://user-images.githubusercontent.com/2462951/32218122-44fea7be-be6d-11e7-8ab1-abebdfc20356.png)

### atSelectedTopics
![screen shot 2017-10-31 at 6 56 01 pm](https://user-images.githubusercontent.com/2462951/32218133-5044aaf6-be6d-11e7-8e7b-d553c1615b02.png)
