### PR TITLE
Fix W3C HTML Validator Error for Meta Canonical

### DIFF
--- a/concrete/src/Url/SeoCanonical.php
+++ b/concrete/src/Url/SeoCanonical.php
@@ -110,7 +110,7 @@ class SeoCanonical
         $url = $this->getPageCanonicalURL($page, $querystring);
         if ($url !== null) {
             $result = new \HtmlObject\Element(
-                'meta',
+                'link',
                 null,
                 [
                     'rel' => 'canonical',


### PR DESCRIPTION
On w3c Online Checker For HTML we get two errors on <meta rel="canonical" :

Error: Attribute rel not allowed on element meta at this point.
Error: Attribute href not allowed on element meta at this point.

It must be a link instead of meta : https://support.google.com/webmasters/answer/139066?hl=fr.