### PR TITLE
Allow converting an error list to plain text

### DIFF
--- a/concrete/src/Error/ErrorList/ErrorList.php
+++ b/concrete/src/Error/ErrorList/ErrorList.php
@@ -8,6 +8,7 @@ use Concrete\Core\Error\ErrorList\Field\Field;
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
 use Concrete\Core\Error\ErrorList\Formatter\JsonFormatter;
 use Concrete\Core\Error\ErrorList\Formatter\StandardFormatter;
+use Concrete\Core\Error\ErrorList\Formatter\TextFormatter;
 
 class ErrorList implements \ArrayAccess, \JsonSerializable
 {
@@ -170,6 +171,13 @@ class ErrorList implements \ArrayAccess, \JsonSerializable
     {
         $formatter = new JsonFormatter($this);
         return $formatter->asArray();
+    }
+
+    public function toText()
+    {
+        $formatter = new TextFormatter($this);
+
+        return $formatter->getText();
     }
 
     public function containsField($field)

--- a/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
@@ -1,0 +1,30 @@
+<?php
+namespace Concrete\Core\Error\ErrorList\Formatter;
+
+class TextFormatter extends AbstractFormatter
+{
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        $lines = [];
+        if ($this->error->has()) {
+            foreach ($this->error->getList() as $error) {
+                $lines[] = (string) $error;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Formatter\FormatterInterface::render()
+     */
+    public function render()
+    {
+        return $this->getText();
+    }
+}


### PR DESCRIPTION
We have a way to convert an ErrorList to JSON or to HTML: what about adding a way to get a plain text representation?