### PR TITLE
set 0 as uID when writing config record without being logged in

### DIFF
--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -863,7 +863,7 @@ class User extends ConcreteObject
     public function saveConfig($cfKey, $cfValue)
     {
         $app = Application::getFacadeApplication();
-        $app['database']->connection()->Replace('ConfigStore', array('cfKey' => $cfKey, 'cfValue' => $cfValue, 'uID' => $this->getUserID()), array('cfKey', 'uID'), true);
+        $app['database']->connection()->Replace('ConfigStore', array('cfKey' => $cfKey, 'cfValue' => $cfValue, 'uID' => $this->getUserID() ?: 0), array('cfKey', 'uID'), true);
     }
 
     /**


### PR DESCRIPTION
After reverting this https://github.com/concrete5/concrete5/issues/6093 I still wasn't able to install concrete5. The XML defines a default value of 0, but since we pass a null value into the replace function it tries to write an empty value.