### PR TITLE
Increase form block height

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -46,7 +46,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 {
     protected $btInterfaceWidth = 640;
     protected $btCacheBlockOutput = false;
-    protected $btInterfaceHeight = 480;
+    protected $btInterfaceHeight = 700;
     protected $btTable = 'btExpressForm';
     protected $entityManager;
 


### PR DESCRIPTION
When creating new forms I often see people missing the `Add Question` button. It's not really surprising as you can't see the button and there's another `Add` button that can easily confuse users. The modals in concrete5 have a maximum height, even if a screen is smaller, the block will still work.

With this PR the button is at least visible to the majority of the users:

![image](https://user-images.githubusercontent.com/129864/32430377-519d5482-c2cf-11e7-9003-9e6bf5f4bfed.png)
