### PR TITLE
update node name in addition to form entity name

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -434,6 +434,10 @@ class Controller extends BlockController implements NotificationProviderInterfac
             $entity->setName($name);
             $entityManager->persist($entity);
             $entityManager->flush();
+
+            $nodeId = $entity->getEntityResultsNodeId();
+            $node = Node::getByID($nodeId);
+            $node->setTreeNodeName($name);
         }
 
         $attributeKeyCategory = $entity->getAttributeKeyCategory();


### PR DESCRIPTION
The form name isn't update properly.

* Create a form with the name "test"
* Edit the form block and change the name to "test 123"
* When you then edit the block, you'll see the new name, but when you check the reports in the backend, you'll still see the old name

This PR fixes this