### PR TITLE
fix inline edit detection for blocks pasted from the clipboard

### DIFF
--- a/concrete/elements/block_footer_edit.php
+++ b/concrete/elements/block_footer_edit.php
@@ -5,6 +5,19 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 $bt = $b->getBlockTypeObject();
 
+if ($b->getBlockTypeHandle() === BLOCK_HANDLE_SCRAPBOOK_PROXY) {
+    $originalBlockId = $b->getController()->getOriginalBlockID();
+    $originalBlock = Block::getByID($originalBlockId);
+    $originalBlockType = $originalBlock->getBlockTypeObject();
+    $supportsInlineEdit =  $originalBlockType->supportsInlineEdit();
+
+    $cont = $originalBlock->getController();
+}
+else {
+    $supportsInlineEdit = $bt->supportsInlineEdit();
+
+    $cont = $bt->getController();
+}
 ?>
             </div>
         <?php
@@ -14,8 +27,8 @@ $bt = $b->getBlockTypeObject();
                 ?><input type="hidden" name="<?= $key ?>" value="<?= $value ?>" /><?php
             }
         }
-        if (!$b->getProxyBlock() && !$bt->supportsInlineEdit()) {
-            ?>	
+        if (!$b->getProxyBlock() && !$supportsInlineEdit) {
+            ?>
             <div class="ccm-buttons dialog-buttons">
                 <a href="javascript:clickedButton = true;$('#ccm-form-submit-button').get(0).click()" class="btn pull-right btn-primary"><?= t('Save') ?></a>
                 <a style="float:left" href="javascript:void(0)" class="btn btn-default btn-hover-danger" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></a>
@@ -25,12 +38,4 @@ $bt = $b->getBlockTypeObject();
         ?>
         <input type="submit" name="ccm-edit-block-submit" value="submit" style="display: none" id="ccm-form-submit-button" />
     </form>
-    <?php
-    if ($b->getBlockTypeHandle() === BLOCK_HANDLE_SCRAPBOOK_PROXY) {
-        $bx = Block::getByID($b->getController()->getOriginalBlockID());
-        $cont = $bx->getController();
-    } else {
-        $cont = $bt->getController();
-    }
-    ?>
 </div>

--- a/concrete/elements/block_header_edit.php
+++ b/concrete/elements/block_header_edit.php
@@ -32,12 +32,19 @@ if (isset($headerItems) && is_array($headerItems)) {
         }
     }
 }
+
+if ($b->getBlockTypeHandle() === BLOCK_HANDLE_SCRAPBOOK_PROXY) {
+    $supportsInlineEdit =  Block::getByID($b->getController()->getOriginalBlockID())->getBlockTypeObject()->supportsInlineEdit();
+}
+else {
+    $supportsInlineEdit = $bt->supportsInlineEdit();
+}
 ?>
 $(function() {
 	$('#ccm-block-form').concreteAjaxBlockForm({
 		task: 'edit',
 		bID: <?= is_object($b->getProxyBlock()) ? $b->getProxyBlock()->getBlockID() : $b->getBlockID() ?>,
-        btSupportsInlineEdit: <?= $bt->supportsInlineEdit() ? 'true' : 'false' ?>
+        btSupportsInlineEdit: <?= $supportsInlineEdit ? 'true' : 'false' ?>
 	});
 });
 </script>
@@ -61,13 +68,13 @@ if (!$message && $cont->getBlockTypeHelp()) {
 if (is_object($message) && !$bt->supportsInlineEdit()) {
     ?>
 	<div class="dialog-help" id="ccm-menu-help-content"><?php echo $message->getContent() ?></div>
-<?php 
+<?php
 } ?>
 
 <div <?php if (!$bt->supportsInlineEdit()) {
-    ?>ccm-ui"<?php 
+    ?>ccm-ui"<?php
 } else {
-    ?>data-container="inline-toolbar"<?php 
+    ?>data-container="inline-toolbar"<?php
 }
 ?>>
     <?php
@@ -76,13 +83,13 @@ if (is_object($message) && !$bt->supportsInlineEdit()) {
     <form method="post" id="ccm-block-form" class="validate" action="<?= $dialogController->action($method) ?>" enctype="multipart/form-data">
         <?php
         foreach ($this->controller->getJavaScriptStrings() as $key => $val) {
-            ?><input type="hidden" name="ccm-string-<?= $key ?>" value="<?= h($val) ?>" /><?php 
+            ?><input type="hidden" name="ccm-string-<?= $key ?>" value="<?= h($val) ?>" /><?php
         }
         if ($bt->supportsInlineEdit()) {
             $css = $b->getCustomStyle();
             ?>
             <div<?php if (is_object($css) && $b->getBlockTypeHandle() != BLOCK_HANDLE_LAYOUT_PROXY) {
-                ?> class="<?= $css->getContainerClass() ?>"<?php 
+                ?> class="<?= $css->getContainerClass() ?>"<?php
             }
             ?>><?php
         } else {


### PR DESCRIPTION
* Add a content block
* Put content block in clipboard
* Paste content block from clipboard

You'll see the save/cancel buttons for non-inline blocks. The reason for this is because the block type handle is pulled form the current block which is a the scrapbook display block and not the original block. This PR should fix this problem.