### PR TITLE
reset answer type form after adding question

### DIFF
--- a/concrete/blocks/express_form/auto.js
+++ b/concrete/blocks/express_form/auto.js
@@ -128,6 +128,7 @@ $(function() {
                 data: data,
                 success: function(r) {
                     $types.find('option').eq(0).prop('selected', true);
+                    $types.find('select').trigger('change');
                     $types.closest('.ui-dialog-content').scrollTop(0);
                     $tabAdd.find('input[name=question]').val('');
                     $tabAdd.find('input[name=required][value=0]').prop('checked', true);


### PR DESCRIPTION
When you add a question in the form block the type is reset (1), but the form fields stay (2). Triggering the change event fixes this.

![image](https://user-images.githubusercontent.com/129864/32535197-68897fbe-c459-11e7-8138-3595e708caa1.png)
