### PR TITLE
fix migration namespace

### DIFF
--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -16,7 +16,7 @@ class Configuration extends DoctrineMigrationConfiguration
         parent::__construct($db);
         $directory = DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Updater/Migrations/Migrations';
         $this->setName(t('concrete5 Migrations'));
-        $this->setMigrationsNamespace(('\Concrete\Core\Updater\Migrations\Migrations'));
+        $this->setMigrationsNamespace(('Concrete\Core\Updater\Migrations\Migrations'));
         $this->setMigrationsDirectory($directory);
         if ($registerMigrations) {
             $this->registerMigrationsFromDirectory($directory);


### PR DESCRIPTION
I don't think a namespace should start with a backslash. I'm not 100% certain that this is only used when generating migrations though?