### PR TITLE
hide block and area design features if disabled

### DIFF
--- a/concrete/css/build/core/app/inline-toolbar.less
+++ b/concrete/css/build/core/app/inline-toolbar.less
@@ -152,7 +152,14 @@
       .border-radius(0px);
     }
   }
-
+  > li.ccm-inline-toolbar-select {
+    select {
+      border: none;
+      height: 27px;
+      padding: 2px 28px 2px 2px;
+      background-position: right 5px top 5px;
+    }
+  }
   > li.ccm-inline-toolbar-button-cancel button {
     #gradient > .vertical(#f3f3f3, #eaeaea);
   }

--- a/concrete/elements/block_area_footer.php
+++ b/concrete/elements/block_area_footer.php
@@ -63,7 +63,9 @@ $class = 'ccm-area-footer';
                                 ?>
                                 <li class="divider"></li>
                                 <li><a href="javascript:void(0)" data-container-layout-block-id="<?=$bx->getBlockID()?>" data-menu-action="edit-container-layout" data-area-grid-maximum-columns="<?=$a->getAreaGridMaximumColumns()?>"><?=t("Edit Container Layout")?></a></li>
-                                <li><a href="javascript:void(0)" data-container-layout-block-id="<?=$bx->getBlockID()?>" data-menu-action="edit-container-layout-style"><?=t("Edit Layout Design")?></a></li>
+                                <?php if ($showAreaDesign) { ?>
+                                    <li><a href="javascript:void(0)" data-container-layout-block-id="<?=$bx->getBlockID()?>" data-menu-action="edit-container-layout-style"><?=t("Edit Layout Design")?></a></li>
+                                <?php } ?>
                                 <?php
                                 if ($pk->validate()) {
                                     $btc = $bx->getController();

--- a/concrete/elements/custom_block_template.php
+++ b/concrete/elements/custom_block_template.php
@@ -2,16 +2,14 @@
 
 <form method="post" action="<?=$saveAction?>" id="ccm-inline-design-form">
     <ul class="ccm-inline-toolbar ccm-ui">
-        <li>
-            <div class="ccm-inline-select-container">
-                <select id="bFilename" name="bFilename" class="form-control" style="border: none; height: 27px; padding: 2px 28px 2px 2px; background-position: right 5px top 5px;">
-                    <option value="">(<?=t('None selected')?>)</option>
-                    <?php
-                    foreach ($templates as $tpl) { ?>
-                        <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) { ?> selected <?php } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
-                    <?php } ?>
-                </select>
-            </div>
+        <li class="ccm-inline-toolbar-select">
+            <select id="bFilename" name="bFilename" class="form-control">
+                <option value="">(<?=t('None selected')?>)</option>
+                <?php
+                foreach ($templates as $tpl) { ?>
+                    <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) { ?> selected <?php } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
+                <?php } ?>
+            </select>
         </li>
         <li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-cancel">
             <button data-action="cancel-design" type="button" class="btn btn-mini"><?=t("Cancel")?></button>

--- a/concrete/elements/custom_block_template.php
+++ b/concrete/elements/custom_block_template.php
@@ -1,0 +1,28 @@
+<?php if ($style instanceof \Concrete\Core\Block\CustomStyle) { ?>
+
+<form method="post" action="<?=$saveAction?>" id="ccm-inline-design-form">
+    <ul class="ccm-inline-toolbar ccm-ui">
+        <li>
+            <div class="ccm-inline-select-container">
+                <select id="bFilename" name="bFilename" class="form-control" style="border: none; height: 27px; padding: 2px 28px 2px 2px; background-position: right 5px top 5px;">
+                    <option value="">(<?=t('None selected')?>)</option>
+                    <?php
+                    foreach ($templates as $tpl) { ?>
+                        <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) { ?> selected <?php } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
+                    <?php } ?>
+                </select>
+            </div>
+        </li>
+        <li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-cancel">
+            <button data-action="cancel-design" type="button" class="btn btn-mini"><?=t("Cancel")?></button>
+        </li>
+        <li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-save">
+            <button data-action="save-design" class="btn btn-primary" type="button"><?=t('Save')?></button>
+        </li>
+    </ul>
+</form>
+<script>
+  $('#ccm-inline-design-form').concreteBlockInlineStyleCustomizer();
+</script>
+<?php } ?>
+

--- a/concrete/src/Block/Menu/Menu.php
+++ b/concrete/src/Block/Menu/Menu.php
@@ -170,7 +170,13 @@ class Menu extends ContextMenu
             if ($canDesign || $canEditCustomTemplate || $canEditName || $canEditCacheSettings) {
                 $this->addItem(new DividerItem());
                 if ($canDesign || $canEditCustomTemplate) {
-                    $this->addItem(new LinkItem('#', t('Design &amp; Custom Template'), [
+                    if ($canDesign) {
+                        $menuItemText = t('Design &amp; Custom Template');
+                    }
+                    else {
+                        $menuItemText = t('Custom Template');
+                    }
+                    $this->addItem(new LinkItem('#', $menuItemText, [
                         'data-menu-action' => 'block_design',
                     ]));
                 }

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -533,9 +533,15 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Retrieves all custom style rules that should be inserted into the header on a page, whether they are defined in areas
      * or blocks.
+     * @param bool $return
+     * @return string
      */
     public function outputCustomStyleHeaderItems($return = false)
     {
+        if (!Config::get('concrete.design.enable_custom')) {
+            return;
+        }
+
         $db = Loader::db();
         $psss = array();
         $txt = Loader::helper('text');

--- a/concrete/views/dialogs/block/design.php
+++ b/concrete/views/dialogs/block/design.php
@@ -38,19 +38,31 @@ if ($pt->supportsGridFramework() && $b->overrideBlockTypeContainerSettings()) {
 
 $gf = $pt->getThemeGridFrameworkObject();
 
-Loader::element("custom_style", array(
-    'saveAction' => $controller->action('submit'),
-    'resetAction' => $controller->action('reset'),
-    'style' => $b->getCustomStyle(true),
-    'bFilename' => $bFilename,
-    'bName' => $b->getBlockName(),
-    'displayBlockContainerSettings' => $pt->supportsGridFramework(),
-    'enableBlockContainer' => $enableBlockContainer,
-    'gf' => $gf,
-    'templates' => $templates,
-    'customClasses' => $customClasses,
-    'canEditCustomTemplate' => $canEditCustomTemplate,
-));
+if (Config::get('concrete.design.enable_custom')) {
+    Loader::element('custom_style', array(
+        'saveAction' => $controller->action('submit'),
+        'resetAction' => $controller->action('reset'),
+        'style' => $b->getCustomStyle(true),
+        'bFilename' => $bFilename,
+        'bName' => $b->getBlockName(),
+        'displayBlockContainerSettings' => $pt->supportsGridFramework(),
+        'enableBlockContainer' => $enableBlockContainer,
+        'gf' => $gf,
+        'templates' => $templates,
+        'customClasses' => $customClasses,
+        'canEditCustomTemplate' => $canEditCustomTemplate,
+    ));
+}
+else {
+    Loader::element('custom_block_template', array(
+        'saveAction' => $controller->action('submit'),
+        'resetAction' => $controller->action('reset'),
+        'style' => $b->getCustomStyle(true),
+        'bFilename' => $bFilename,
+        'templates' => $templates,
+    ));
+}
+
 
 $pt->registerAssets();
 $bv->render('view');


### PR DESCRIPTION
As described here https://github.com/concrete5/concrete5/issues/6115

* This completely removes the area design menu item if `concrete.design.enable_custom` is set to false
* It changes the menu item text in the block menu from `Design & Custom Template`  to `Custom Template` if the design feature is disabled
* It shows the template list in the toolbar to save another click

![image](https://user-images.githubusercontent.com/129864/32645912-f621d6c8-c5e9-11e7-9e50-57e2d29623d0.png)

I'd be happy to hear anyone's thoughts about this.