### PR TITLE
Multilingual redirect based on browser locale not always working

### DIFF
--- a/concrete/src/Multilingual/Page/Section/Section.php
+++ b/concrete/src/Multilingual/Page/Section/Section.php
@@ -339,10 +339,10 @@ class Section extends Page
      *
      * @return Section|false
      */
-    public static function getByLanguage($language, TreeInterface $treeInterface = null)
+    public static function getByLanguage($language, Site $site = null)
     {
-        if (!is_object($treeInterface)) {
-            $treeInterface = \Site::getSite();
+        if (!$site) {
+            $site = \Core::make('site')->getSite();
         }
 
         $em = Database::get()->getEntityManager();
@@ -350,7 +350,7 @@ class Section extends Page
          * @var $section Locale
          */
         $section = $em->getRepository('Concrete\Core\Entity\Site\Locale')
-            ->findOneBy(['tree' => $treeInterface->getSiteTreeObject(), 'msLanguage' => $language]);
+            ->findOneBy(['site' => $site, 'msLanguage' => $language]);
 
         if (is_object($section)) {
             $obj = parent::getByID($section->getSiteTree()->getSiteHomePageID(), 'RECENT');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
             <directory>tests/tests/CodingStyle/</directory>
             <directory>tests/tests/Core/</directory>
             <directory>tests/tests/Localization/</directory>
+            <directory>tests/tests/Multilingual/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/tests/Multilingual/SectionTest.php
+++ b/tests/tests/Multilingual/SectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+class SectionTest extends PageTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // get entity manager from database connection
+        $em = $this->connection()->getEntityManager();
+
+        // initialize locale service
+        $service = new \Concrete\Core\Localization\Locale\Service($em);
+
+        // get current site
+        $site = \Core::make('site')->getSite();
+
+        // get page template "full"
+        $template = \Concrete\Core\Page\Template::getByHandle('full');
+
+        // add locale with home page
+        $locale = $service->add($site, 'de', 'CH');
+        $service->addHomePage($locale, $template, 'Second language', 'chde');
+    }
+
+    public function testGetByLocale()
+    {
+        // load second language section with locale
+        $section = \Concrete\Core\Multilingual\Page\Section\Section::getByLocale('de_CH');
+
+        // check section
+        $this->assertNotFalse($section, 'Unable to load Section by locale');
+        $this->assertEquals('de_CH', $section->getLocale());
+    }
+
+    public function testGetByLanguage()
+    {
+        // load second language section with language
+        $section = \Concrete\Core\Multilingual\Page\Section\Section::getByLanguage('de');
+
+        // check section
+        $this->assertNotFalse($section, 'Unable to load Section by language');
+        $this->assertEquals('de_CH', $section->getLocale());
+    }
+}


### PR DESCRIPTION
I noticed the Multilingual option `multilingual.use_browser_detected_locale` is not working as expected with some browsers:

- When there is a full locale in the headers it works well (e.g. `Accept-Language: de-CH, en-US, en`).

- However, when it only includes the language it fails to redirect to the correct language section (e.g. `Accept-Language: de, en`).

Here's what happens behind the scenes:

- [`Detector::getPreferredSection`](https://github.com/concrete5/concrete5/blob/9a5bc417bf31f3a106b19ad36bede54cd5ed963a/concrete/src/Multilingual/Service/Detector.php#L65) tries to detect the language with the browser headers

- [`Section::getByLocaleOrLanguage`](https://github.com/concrete5/concrete5/blob/9a5bc417bf31f3a106b19ad36bede54cd5ed963a/concrete/src/Multilingual/Page/Section/Section.php#L415) is called with `de`

- [`Section::getByLanguage`](https://github.com/concrete5/concrete5/blob/9a5bc417bf31f3a106b19ad36bede54cd5ed963a/concrete/src/Multilingual/Page/Section/Section.php#L342) is called with `de` and fails to load the correct page

Comparing [`Section::getByLocale`](https://github.com/concrete5/concrete5/blob/9a5bc417bf31f3a106b19ad36bede54cd5ed963a/concrete/src/Multilingual/Page/Section/Section.php#L370) (which works as expected) and [`Section::getByLanguage`](https://github.com/concrete5/concrete5/blob/9a5bc417bf31f3a106b19ad36bede54cd5ed963a/concrete/src/Multilingual/Page/Section/Section.php#L342) I noticed the difference in the second optional argument which is used for filtering the site locale search.

It looks like [`Section::getByLocale`](https://github.com/concrete5/concrete5/commit/e59275604c199d3458bbf87b7262a1534ddb462f#diff-070211a5cd6a43eb444b5f843f2ca8ddL136) has been updated but [`Section::getByLanguage`](https://github.com/concrete5/concrete5/commit/e59275604c199d3458bbf87b7262a1534ddb462f#diff-070211a5cd6a43eb444b5f843f2ca8ddL111) has been forgotten in https://github.com/concrete5/concrete5/commit/e59275604c199d3458bbf87b7262a1534ddb462f.

Ping @mlocati as author of https://github.com/concrete5/concrete5/pull/5287 and @aembler as author of the above commit.

I've created a test which shows `Section::getByLocale` working and `Section:: getByLanguage` failing. I will send another commit with a proposed fix.