### PR TITLE
Fix calendar event translatable strings

### DIFF
--- a/concrete/src/Workflow/Request/ApproveCalendarEventRequest.php
+++ b/concrete/src/Workflow/Request/ApproveCalendarEventRequest.php
@@ -54,13 +54,20 @@ class ApproveCalendarEventRequest extends CalendarEventRequest
             if (!$this->isNewEventRequest()) {
                 // new version of existing page
                 $d->setEmailDescription(t("\"%s\" has pending changes and needs to be approved.", $v->getName()));
-                $d->setDescription(t('Version <a href="%s" dialog-title="' . t('View Requested Version') . '" dialog-width="640" dialog-height="500" class="dialog-launch">%s</a> of Event <strong>%s</strong> submitted for Approval.', $url, $this->eventVersionID, $v->getName()));
+                $d->setDescription(t(
+                    'Version %1$s of Event %2$s submitted for Approval.',
+                    '<a href="' . $url . '" dialog-title="' . t('View Requested Version') . '" dialog-width="640" dialog-height="500" class="dialog-launch">' . $this->eventVersionID . '</a>,
+                    <strong>' . $v->getName() . '</strong>'
+                ));
                 $d->setInContextDescription(t("Event Version %s Submitted for Approval.", $v->getName()));
                 $d->setShortStatus(t("Pending Approval"));
             } else {
                 // Completely new page.
                 $d->setEmailDescription(t("New event created: \"%s\". This event requires approval.", $v->getName()));
-                $d->setDescription(t('New Event: <a href="%s" dialog-title="' . t('View Requested Version') . '" dialog-width="640" dialog-height="500" class="dialog-launch">%s</a>.', $url, $v->getName()));
+                $d->setDescription(t(
+                    'New Event: %s',
+                    '<a href="' . $url . '" dialog-title="' . t('View Requested Version') . '" dialog-width="640" dialog-height="500" class="dialog-launch">' . $v->getName() . '</a>'
+                ));
                 $d->setInContextDescription(t("New Event %s submitted for approval.", $v->getName()));
                 $d->setShortStatus(t("New Event"));
             }


### PR DESCRIPTION
There are two strings that aren't translatable in the new Calendar system (the translatable argument of `t()` functions must be a **literal** string).
