### PR TITLE
Enabled searching by event

### DIFF
--- a/concrete/attributes/calendar_event/controller.php
+++ b/concrete/attributes/calendar_event/controller.php
@@ -31,7 +31,10 @@ class Controller extends \Concrete\Attribute\Number\Controller
 
     public function getSearchIndexValue()
     {
-        return '1';
+        $value = $this->getAttributeValue()->getValueObject();
+        if ($value) {
+            return intval($value->getValue());
+        }
     }
 
     public function getPlainTextValue()
@@ -99,5 +102,19 @@ class Controller extends \Concrete\Attribute\Number\Controller
             $calendars[$calendar->getID()] = $calendar->getName();
         }
         $this->set('calendars', $calendars);
+    }
+
+    public function search()
+    {
+        $this->form();
+        $v = $this->getView();
+        $v->render();
+    }
+
+    public function searchForm($list)
+    {
+        $eventID = (int) ($this->request('eventID'));
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $eventID, '=');
+        return $list;
     }
 }


### PR DESCRIPTION
I was having issues with filtering by event in page lists, this seems to fix it for me. The first change was to actually return the value for the attribute to the search index table rather than just "1" so that there's actually a valid value to search against. The second was to use the actual form method for the attribute to use in advanced search, instead of the one inherited from the number attribute. Nobody's going to know the ID number for the event they want to use. 

I wasn't able to get the event ID to persist in the selector, though. I'm not sure how to do that, but this is a lot better overall so submitting. The calendar ID does persist, so I'm really not sure what's up. I figure anyone wanting to modify the search query is going to be picking another event, anyway, so it's kind of a moot point. But they could be wanting to change something *else* in the query, so that could create problems. Regardless, it's a step up from two number inputs, even if potentially a bit buggy. 