### PR TITLE
Fix area blacklist in IndexedSearch.php

### DIFF
--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -61,9 +61,9 @@ class IndexedSearch
             $searchableAreaNamesInitial = $this->getSavedSearchableAreas();
             if ($this->getSearchableAreaAction() == 'blacklist') {
                 $areas = Area::getHandleList();
-                foreach ($areas as $arHandle) {
-                    if (!in_array($arHandle, $searchableAreaNamesInitial)) {
-                        $this->searchableAreaNames[] = $arHandle;
+                foreach ($areas as $blArHandle) {
+                    if (!in_array($blArHandle, $searchableAreaNamesInitial)) {
+                        $this->searchableAreaNames[] = $blArHandle;
                     }
                 }
             } else {


### PR DESCRIPTION
The foreach loop overwrote the passed in $arHandle variable whilst setting up the blacklisted areas. I have renamed the variable in the loop. This appears to now allow non blacklisted areas to be indexed.