### PR TITLE
Help build factory method

### DIFF
--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -40,6 +40,7 @@ class MetadataGenerator
 
         // Define $app->make('');
         $bindings = $this->getAllBindings();
+        ksort($bindings);
 
         $makeMethod = [
             '' => "'@'",

--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -30,9 +30,13 @@ class MetadataGenerator
     {
         $output = [
             '<?php',
+            '',
             'namespace PHPSTORM_META;',
             '',
         ];
+
+        // Define $app->build('');
+        $output = array_merge($output, $this->getOverride('\Illuminate\Contracts\Container\Container::build(0)', ['' => "'@'"], '$app->build(SomeClass::class)'));
 
         // Define $app->make('');
         $bindings = $this->getAllBindings();
@@ -45,7 +49,7 @@ class MetadataGenerator
             $makeMethod[$name] = "\\{$className}::class";
         }
 
-        $output = array_merge($output, $this->getOverride('\Illuminate\Contracts\Container\Container::make(0)', $makeMethod, '$app->make(SomeClass::class)'));
+        $output = array_merge($output, $this->getOverride('\Illuminate\Contracts\Container\Container::make(0)', $makeMethod, '$app->make(\'something\') or $app->make(SomeClass::class)'));
         $output = array_merge($output, $this->getOverride('new \Illuminate\Contracts\Container\Container', $makeMethod, '$app[SomeClass::class]'));
 
         return implode("\n", $output);

--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace Concrete\Core\Support\Symbol;
 
-use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Support\Facade\Application;
 
 class MetadataGenerator
 {
-
     public function getAllBindings()
     {
         $bindings = [];
@@ -20,7 +19,6 @@ class MetadataGenerator
                 if (ltrim($name, '\\') != ltrim($className, '\\')) {
                     $bindings[$name] = $className;
                 }
-
             } catch (\Exception $e) {
             }
         }
@@ -33,14 +31,14 @@ class MetadataGenerator
         $output = [
             '<?php',
             'namespace PHPSTORM_META;',
-            ''
+            '',
         ];
 
         // Define $app->make('');
         $bindings = $this->getAllBindings();
 
         $makeMethod = [
-            "" => "'@'"
+            '' => "'@'",
         ];
 
         foreach ($bindings as $name => $className) {
@@ -57,17 +55,16 @@ class MetadataGenerator
     {
         $output = [
             "// {$comment}",
-            "override({$string}, map(["
+            "override({$string}, map([",
         ];
 
         foreach ($makeMethod as $name => $className) {
             $output[] = "  '{$name}' => {$className},";
         }
 
-        $output[] = "]));";
-        $output[] = "";
+        $output[] = ']));';
+        $output[] = '';
 
         return $output;
     }
-
 }


### PR DESCRIPTION
We have the great `c5:ide-symbols` that generates metadata files to help IDE resolving for instance the result of `$app->make('config')`.

What about also telling the IDE that the results of `$app->build(ClassName::class)` is an instance of the `ClassName` class?