### PR TITLE
Bugfix calendar link formatting

### DIFF
--- a/concrete/attributes/calendar_event/controller.php
+++ b/concrete/attributes/calendar_event/controller.php
@@ -31,10 +31,7 @@ class Controller extends \Concrete\Attribute\Number\Controller
 
     public function getSearchIndexValue()
     {
-        $value = $this->getAttributeValue()->getValueObject();
-        if ($value) {
-            return intval($value->getValue());
-        }
+        return '1';
     }
 
     public function getPlainTextValue()
@@ -102,19 +99,5 @@ class Controller extends \Concrete\Attribute\Number\Controller
             $calendars[$calendar->getID()] = $calendar->getName();
         }
         $this->set('calendars', $calendars);
-    }
-
-    public function search()
-    {
-        $this->form();
-        $v = $this->getView();
-        $v->render();
-    }
-
-    public function searchForm($list)
-    {
-        $eventID = (int) ($this->request('eventID'));
-        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $eventID, '=');
-        return $list;
     }
 }

--- a/concrete/attributes/calendar_event/controller.php
+++ b/concrete/attributes/calendar_event/controller.php
@@ -31,7 +31,10 @@ class Controller extends \Concrete\Attribute\Number\Controller
 
     public function getSearchIndexValue()
     {
-        return '1';
+        $value = $this->getAttributeValue()->getValueObject();
+        if ($value) {
+            return intval($value->getValue());
+        }
     }
 
     public function getPlainTextValue()
@@ -99,5 +102,19 @@ class Controller extends \Concrete\Attribute\Number\Controller
             $calendars[$calendar->getID()] = $calendar->getName();
         }
         $this->set('calendars', $calendars);
+    }
+
+    public function search()
+    {
+        $this->form();
+        $v = $this->getView();
+        $v->render();
+    }
+
+    public function searchForm($list)
+    {
+        $eventID = (int) ($this->request('eventID'));
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $eventID, '=');
+        return $list;
     }
 }

--- a/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
+++ b/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
@@ -86,7 +86,7 @@ class LinkFormatter implements LinkFormatterInterface
     {
         $url = $this->getEventFrontendViewLink($occurrence->getEvent());
         if ($url) {
-            $url .= '?versionOccurrenceID=' . $occurrence->getId();
+            $url .= '?occurrenceID=' . $occurrence->getId();
         }
         return $url;
     }


### PR DESCRIPTION
The link formatter for the details page was using versionOccurenceID as the url get parameter, but the calendar_event block was looking for occurenceID, so the links from a calendar to a detail page using the request method weren't working. 

This PR is a little unclean, though, I messed up and put some changes in the develop branch last night rather than doing a feature branch. Oops. So I'm not sure if that changes if this one can be merged or not, but it did seem like it should be a separate PR because it's unrelated to the attribute stuff that I did before. So I have an extra commit that removes those changes... 

Sorry about that, I don't contribute to the core very much, I'm a little rusty. 