### PR TITLE
Add aliases too PHPStorm metadata file

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -447,6 +447,16 @@ class Application extends Container
     }
 
     /**
+     * Get the list of registered aliases.
+     *
+     * @return string[]
+     */
+    public function getRegisteredAliases()
+    {
+        return array_keys($this->aliases);
+    }
+
+    /**
      * @deprecated Use the singleton method
      *
      * @param $abstract


### PR DESCRIPTION
Registered aliases that have not yet been evaluated aren't included in the `.phpstorm.meta.php` file generated by the `c5:ide-symbols` IDE command.

In order to include them, we need to get the list of registered aliases. Since there's no current method to do that, I've had to add it to our `Application` class.

This will let PHPStorm (and Eclipse+PDT+[concrete5 plugin](https://github.com/mlocati/concrete5-eclipse-plugin)) to autocomplete stuff like

```php
$app->make('date')->|
```

Here's the list of additional items recognized with this pull request:

```php
'captcha'
'date'
'helper/date'
'helper/lists/countries'
'helper/lists/states_provinces'
'helper/localization/countries'
'helper/localization/states_provinces'
'helper/validation/captcha'
'http/client'
'lists/countries'
'lists/states_provinces'
'localization/countries'
'localization/languages'
'localization/states_provinces'
```