### PR TITLE
Add custom entity repositories support to .phpstorm.meta.php

### DIFF
--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -3,7 +3,9 @@
 namespace Concrete\Core\Support\Symbol;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Package\Event\PackageEntities as PackageEntitiesEvent;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use Throwable;
 
@@ -32,6 +34,39 @@ class MetadataGenerator
         return $bindings;
     }
 
+    /**
+     * Return the list of custom entity manager repositories.
+     *
+     * @return array array keys are the entity fully-qualified class names, values are the custom repository fully-qualified class names
+     */
+    public function getCustomEntityRepositories()
+    {
+        $result = [];
+        $app = ApplicationFacade::getFacadeApplication();
+        $pev = new PackageEntitiesEvent();
+        $app->make('director')->dispatch('on_list_package_entities', $pev);
+        $entityManagers = array_merge([$app->make(EntityManagerInterface::class)], $pev->getEntityManagers());
+        foreach ($entityManagers as $entityManager) {
+            /* @var EntityManagerInterface $entityManager */
+            $metadataFactory = $entityManager->getMetadataFactory();
+            foreach ($metadataFactory->getAllMetadata() as $metadata) {
+                /* @var \Doctrine\Common\Persistence\Mapping\ClassMetadata $metadata */
+                $entityClassName = $metadata->getName();
+                $entityRepository = $entityManager->getRepository($entityClassName);
+                $entityRepositoryClassName = get_class($entityRepository);
+                switch ($entityRepositoryClassName) {
+                    case \Doctrine\ORM\EntityRepository::class:
+                        break;
+                    default:
+                        $result[$entityClassName] = $entityRepositoryClassName;
+                        break;
+                }
+            }
+        }
+
+        return $result;
+    }
+
     public function render()
     {
         $output = [
@@ -58,6 +93,16 @@ class MetadataGenerator
 
         $output = array_merge($output, $this->getOverride('\Illuminate\Contracts\Container\Container::make(0)', $makeMethod, '$app->make(\'something\') or $app->make(SomeClass::class)'));
         $output = array_merge($output, $this->getOverride('new \Illuminate\Contracts\Container\Container', $makeMethod, '$app[SomeClass::class]'));
+
+        $customEntityRepositories = $this->getCustomEntityRepositories();
+        if (!empty($customEntityRepositories)) {
+            ksort($customEntityRepositories);
+            $getRepositoryMethod = [];
+            foreach ($customEntityRepositories as $entityClass => $repositoryClass) {
+                $getRepositoryMethod[$entityClass] = "\\{$repositoryClass}::class";
+            }
+            $output = array_merge($output, $this->getOverride('\Doctrine\ORM\EntityManagerInterface::getRepository(0)', $getRepositoryMethod, '$em->getRepository(EntityClass::class)'));
+        }
 
         return implode("\n", $output);
     }


### PR DESCRIPTION
We can associate custom repositories to Doctrine entities (via the `@Doctrine\ORM\Mapping\Entity(repositoryClass="...")` annotation).

What about suggesting the IDE what's the exact result of `$em->getRepository(EntityClass::class)` for such cases?

For instance, because of the PHPDoc of the `EntityManagerInterface::getRepository`, the IDE thinks that the result of
```php
$em->getRepository('Concrete\Core\Entity\Attribute\Key\UserKey');
```
is an instance of `Doctrine\Common\Persistence\ObjectRepository`, but for concrete5 this is more specifically an instance of `Concrete\Core\Entity\User\AttributeRepository`.

PS: this will help developers using PHPStorm or Eclipse+[concrete5 plugin](https://mlocati.github.io/concrete5-eclipse-plugin/), provided that they run the `c5:ide-symbols` CLI command.