### PR TITLE
raise event when page not found is shown

### DIFF
--- a/concrete/controllers/single_page/page_not_found.php
+++ b/concrete/controllers/single_page/page_not_found.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\SinglePage;
 
 use Concrete\Core\Http\Response;
 use Concrete\Core\Page\Controller\PageController;
+use Events;
 
 class PageNotFound extends PageController
 {
@@ -16,6 +17,8 @@ class PageNotFound extends PageController
     {
         $view = $this->getViewObject();
         $contents = $view->render();
+
+        Events::dispatch('on_page_not_found');
 
         return new Response($contents, 404);
     }


### PR DESCRIPTION
what about an event to hook into the 404 process? That way it would be easier to redirect old urls from a package.