### PR TITLE
Thumbnail fixes... fixed

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -18,7 +18,11 @@ class Options extends DashboardPageController
         $this->set('thumbnail_generation_strategies', $this->getThumbnailGenerationStrategies());
         $this->set('thumbnail_generation_strategy', $config->get('concrete.misc.basic_thumbnailer_generation_strategy'));
         $this->set('thumbnail_formats', $this->getThumbnailsFormats());
-        $this->set('thumbnail_format', $config->get('concrete.misc.default_thumbnail_format'));
+        $thumbnail_format = $config->get('concrete.misc.default_thumbnail_format');
+        if ($thumbnail_format === 'jpg') {
+            $thumbnail_format = ThumbnailFormatService::FORMAT_JPEG;
+        }
+        $this->set('thumbnail_format', $thumbnail_format);
         $this->set('jpeg_compression', $config->get('concrete.misc.default_jpeg_image_compression'));
         $this->set('png_compression', $config->get('concrete.misc.default_png_image_compression'));
         $this->set('manipulation_library', $config->get('concrete.file_manager.images.manipulation_library'));

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Files\Thumbnails;
 
+use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Http\Response;
@@ -76,9 +77,9 @@ class Options extends DashboardPageController
     protected function getThumbnailsFormats()
     {
         return [
-            'png' => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
-            'jpg' => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
-            'auto' => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
+            ThumbnailFormatService::FORMAT_PNG => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
+            ThumbnailFormatService::FORMAT_JPEG => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
+            ThumbnailFormatService::FORMAT_AUTO => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
         ];
     }
 

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Files\Thumbnails;
 
 use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
-use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Http\Response;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\DashboardPageController;
 use Exception;
-use Throwable;
 use Imagine\Image\Box;
+use Throwable;
 
 class Options extends DashboardPageController
 {
@@ -66,31 +67,6 @@ class Options extends DashboardPageController
         }
     }
 
-    protected function getThumbnailGenerationStrategies()
-    {
-        return [
-            'now' => t('Create the thumbnails synchronously (may fail with out-of-memory errors)'),
-            'async' => t('Create the thumbnails asynchronously (users may not see thumbnails immediately)'),
-        ];
-    }
-
-    protected function getThumbnailsFormats()
-    {
-        return [
-            ThumbnailFormatService::FORMAT_PNG => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
-            ThumbnailFormatService::FORMAT_JPEG => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
-            ThumbnailFormatService::FORMAT_AUTO => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
-        ];
-    }
-
-    protected function getManipulationLibraries()
-    {
-        return [
-            'gd' => t('GD Library: faster, available in almost any environment, but less powerful'),
-            'imagick' => t('ImageMagick Library: much more powerful, but often not available or misconfigured'),
-        ];
-    }
-
     public function test_manipulation_library($handle, $token)
     {
         $rf = $this->app->make(ResponseFactoryInterface::class);
@@ -116,5 +92,30 @@ class Options extends DashboardPageController
         }
 
         return $response;
+    }
+
+    protected function getThumbnailGenerationStrategies()
+    {
+        return [
+            'now' => t('Create the thumbnails synchronously (may fail with out-of-memory errors)'),
+            'async' => t('Create the thumbnails asynchronously (users may not see thumbnails immediately)'),
+        ];
+    }
+
+    protected function getThumbnailsFormats()
+    {
+        return [
+            ThumbnailFormatService::FORMAT_PNG => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
+            ThumbnailFormatService::FORMAT_JPEG => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
+            ThumbnailFormatService::FORMAT_AUTO => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
+        ];
+    }
+
+    protected function getManipulationLibraries()
+    {
+        return [
+            'gd' => t('GD Library: faster, available in almost any environment, but less powerful'),
+            'imagick' => t('ImageMagick Library: much more powerful, but often not available or misconfigured'),
+        ];
     }
 }

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -147,10 +147,18 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     public function setThumbnailsFormat($thumbnailsFormat)
     {
         $thumbnailsFormat = $thumbnailsFormat ? strtolower(trim((string) $thumbnailsFormat)) : '';
-        if ($thumbnailsFormat === 'jpg') {
-            $thumbnailsFormat = 'jpeg';
+        switch ($thumbnailsFormat) {
+            case ThumbnailFormatService::FORMAT_JPEG:
+            case ThumbnailFormatService::FORMAT_PNG:
+            case ThumbnailFormatService::FORMAT_AUTO:
+                $this->thumbnailsFormat = $thumbnailsFormat;
+                break;
+            case 'jpg':
+                $this->thumbnailsFormat = ThumbnailFormatService::FORMAT_JPEG;
+                break;
+            default:
+                $this->thumbnailsFormat = ThumbnailFormatService::FORMAT_JPEG;
         }
-        $this->thumbnailsFormat = in_array($thumbnailsFormat, ['jpeg', 'png', 'auto']) ? $thumbnailsFormat : 'jpeg';
 
         return $this;
     }

--- a/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
@@ -131,7 +131,7 @@ class ThumbnailFormatService
             case static::FORMAT_AUTO:
                 return $format;
             case 'jpg':
-                case static::FORMAT_JPEG:
+                return static::FORMAT_JPEG;
             default:
                 return static::FORMAT_AUTO;
         }

--- a/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
@@ -130,6 +130,8 @@ class ThumbnailFormatService
             case static::FORMAT_JPEG:
             case static::FORMAT_AUTO:
                 return $format;
+            case 'jpg':
+                case static::FORMAT_JPEG:
             default:
                 return static::FORMAT_AUTO;
         }


### PR DESCRIPTION
Let's fix a format naming problem introduced in #5900: we sometimes called the JPEG format as `'jpg'` and sometimes as `'jpeg'`.
Let's always use the format constant to represent it (`'jpeg'`), and automatically convert the wrong representation.