### PR TITLE
Creating page from multilingual page report

### DIFF
--- a/concrete/controllers/backend/page/multilingual.php
+++ b/concrete/controllers/backend/page/multilingual.php
@@ -116,6 +116,7 @@ class Multilingual extends Page
                     }
                     $ih = Core::make('multilingual/interface/flag');
                     $icon = (string) $ih->getSectionFlagIcon($ms);
+                    $pr->setPage($newPage);
                     $pr->setAdditionalDataAttribute('name', $newPage->getCollectionName());
                     $pr->setAdditionalDataAttribute('link', $newPage->getCollectionLink());
                     $pr->setAdditionalDataAttribute('icon', $icon);


### PR DESCRIPTION
I currently can't create a new mapped page from the multilingual page report screen.
That happens because `r.pages` isn't available in this line https://github.com/concrete5/concrete5/blob/develop/concrete/single_pages/dashboard/system/multilingual/page_report.php#L261