### PR TITLE
Fix the site tree filter of MultilingualPageList in multilingual/page_report

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/multilingual/page_report.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/page_report.php
@@ -67,6 +67,7 @@ class PageReport extends DashboardSitePageController
         if (isset($sectionID) && $sectionID > 0) {
             $pl = new MultilingualPageList();
             $pc = \Page::getByID($sectionID);
+            $pl->setSiteTreeObject($pc->getSiteTreeObject());
             $path = $pc->getCollectionPath();
             if (strlen($path) > 1) {
                 $pl->filterByPath($path);


### PR DESCRIPTION
Without this fix, the list of pages in the multilingual/page_report dashboard page was empty for me.