### PR TITLE
Use Custom Display Order in Express Entry List Block

### DIFF
--- a/concrete/src/Express/Search/ColumnSet/DefaultSet.php
+++ b/concrete/src/Express/Search/ColumnSet/DefaultSet.php
@@ -39,7 +39,7 @@ class DefaultSet extends ColumnSet
             $column = $this->getColumnByKey('e.exEntryDateCreated');
             $this->setDefaultSortColumn($column, 'desc');
         }
-        $this->removeColumnByKey('e.exEntryDisplayOrder'); // It shouldn't be in the set
+
         $i = 0;
         foreach($category->getSearchableList() as $ak) {
             $this->addColumn(new AttributeKeyColumn($ak));


### PR DESCRIPTION
The use of Custom Display Order was suppressed.
Now you can sort at your own, 
step 1: activate Custom Display Order
step 2: Re-Order Entries by Drag n Drop
![image](https://user-images.githubusercontent.com/8862838/33484990-f2de0434-d6a4-11e7-9836-ccc1be0f5304.png)

step 3: choose Custom Display Order
![image](https://user-images.githubusercontent.com/8862838/33485173-a9e85008-d6a5-11e7-92f9-87053d75bd46.png)

If you don't activate the Custom Display Order in step 1, you will see no choose-row in step 3!