### PR TITLE
PHP 7.2 must not fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
     - php: 7.1
       env: PREFER_LOWEST="--prefer-lowest"
   allow_failures:
-    - php: 7.2
     - php: nightly
 
 before_script:


### PR DESCRIPTION
Now that PHP 7.2 has been released, what about telling TravisCI that failing tests are not allowed?

PS: we should have a PHP 7.2 warning. That's caused by PHPUnit 4.8. [I tried](https://github.com/sebastianbergmann/phpunit/pull/2773) to fix this issue, but @sebastianbergmann [closed my pull request](https://github.com/sebastianbergmann/phpunit/pull/2773#issuecomment-331136709).