### PR TITLE
Next/Previous showing unapproved pages

### DIFF
--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -116,19 +116,19 @@ class Controller extends BlockController
                     break;
                 case 'display_desc':
                     $cID = $db->GetOne(
-                        'select cID from Pages where cID != ? and cDisplayOrder < ? and cParentID = ? order by cDisplayOrder desc',
+                        'select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and Pages.cID != ? and cDisplayOrder < ? and cParentID = ? order by cDisplayOrder desc',
                         [$cID, $currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_asc':
                 default:
                     $cID = $db->GetOne(
-                        'select cID from Pages where cID != ? and  cDisplayOrder > ? and cParentID = ? order by cDisplayOrder asc',
+                        'select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and Pages.cID != ? and  cDisplayOrder > ? and cParentID = ? order by cDisplayOrder asc',
                         [$cID, $currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
             }
 
             if ($cID > 0) {
-                $page = Page::getByID($cID, 'RECENT');
+                $page = Page::getByID($cID, 'ACTIVE');
                 $currentPage = $page;
                 $cp = new Permissions($page);
                 if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
@@ -184,16 +184,16 @@ class Controller extends BlockController
                     $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cvDatePublic > ? and cParentID = ?  order by cvDatePublic asc', [$currentPage->getCollectionDatePublic(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_desc':
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder > ? and cParentID = ? order by cDisplayOrder asc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cDisplayOrder > ? and cParentID = ? order by cDisplayOrder asc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
                 case 'display_asc':
                 default:
-                    $cID = $db->GetOne('select cID from Pages where cDisplayOrder < ? and cParentID = ? order by cDisplayOrder desc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
+                    $cID = $db->GetOne('select Pages.cID from Pages inner join CollectionVersions cv on Pages.cID = cv.cID where cvIsApproved = 1 and cDisplayOrder < ? and cParentID = ? order by cDisplayOrder desc', [$currentPage->getCollectionDisplayOrder(), $currentPage->getCollectionParentID()]);
                     break;
             }
 
             if ($cID > 0) {
-                $page = Page::getByID($cID, 'RECENT');
+                $page = Page::getByID($cID, 'ACTIVE');
                 $currentPage = $page;
                 $cp = new Permissions($page);
                 if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {


### PR DESCRIPTION
The issue is as follows, when using a workflow to approve or deny added pages the next previous block will show these when using sitemap order.

This is because we weren't checking if the cID we got from the sitemap order was approved or not. We also get the most recent object and not the active version of the page object. This can also cause issues if users are using the pageObject to get information which may have been changed by an unapproved version (thumbnail, description, etc..)

This pull request fixes the above issues.