### PR TITLE
Fix: All drafts or no drafts are listed in "Add Pages and Navigate Your Site" panel

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -262,7 +262,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         // this is a hack but it's a really good one for performance
         // if the permission access entity for page owner exists in the database, then we return the collection ID. Otherwise, we just return the permission collection id
         // this is because page owner is the ONLY thing that makes it so we can't use getPermissionsCollectionID, and for most sites that will DRAMATICALLY reduce the number of queries.
-        if (\Concrete\Core\Permission\Access\PageAccess::usePermissionCollectionIDForIdentifier()) {
+        // Drafts are exceptions to this rule because some permission keys of these pages are inherited from "Edit Page Type Draft" permission.
+        if (\Concrete\Core\Permission\Access\PageAccess::usePermissionCollectionIDForIdentifier() && !$this->isPageDraft()) {
             return $this->getPermissionsCollectionID();
         } else {
             return $this->getCollectionID();


### PR DESCRIPTION
This PR fixes this issue.

Detail of the issue:

Draft pages are pulled from database with the following code in sitemap panel.

```php
// \Concrete\Controller\Panel\Sitemap::view
$this->requireAsset('core/sitemap');
$drafts = ConcretePage::getDrafts($this->site);
$mydrafts = array();
foreach ($drafts as $d) {
    $dp = new Permissions($d);
    if ($dp->canEditPageContents()) {
        $mydrafts[] = $d;
    }
}
```

It looks like concrete5 checks `edit_page_contents` permission of every draft. However, in practice, concrete5 checks only the permission of the first one. Why? The reason is cache. concrete5 stores Permission Access Object in request level cache when checking page permission. Here is the code.

```php
// \Concrete\Core\Permission\Assignment\PageAssignment::getPermissionAccessObject
$cache = Core::make('cache/request');
$identifier = sprintf('permission/assignment/access/%s/%s',
    $this->pk->getPermissionKeyHandle(),
    $this->getPermissionObject()->getPermissionObjectIdentifier()
);
$item = $cache->getItem($identifier);
if (!$item->isMiss()) {
    return $item->get();
}
```

In above code, `$this->getPermissionObject()->getPermissionObjectIdentifier()` returns the cID of Permission Collection Object. This works in most of cases, but drafts are exceptions to this case because some permission keys of drafts are inherited from "Edit Page Type Draft" permission.