### PR TITLE
Fix composer publish to child pages

### DIFF
--- a/concrete/controllers/dialog/type/update_from_type.php
+++ b/concrete/controllers/dialog/type/update_from_type.php
@@ -64,7 +64,7 @@ class UpdateFromType extends BackendInterfaceController
         $pageTypeDefaultPageRelBlocks = [];
 
         foreach ($pageTypeDefaultPage->getBlocks() as $b) {
-            $pageTypeDefaultPageBlocks[$b->getBlockID()] = $pageTypeDefaultPageRelBlocks[$b->getBlockRelationID()] = $b;            
+            $pageTypeDefaultPageBlocks[$b->getBlockID()] = $pageTypeDefaultPageRelBlocks[$b->getBlockRelationID()] = $b;
         }
 
         $db = $this->app->make(Connection::class);
@@ -73,12 +73,12 @@ class UpdateFromType extends BackendInterfaceController
         $siteTreeID = $site->getSiteTreeID();
 
         $ptID = $pageTypeDefaultPage->getPageTypeID();
-        
+
         $pagesPlusCV = $db->fetchAll('select p.cID, max(cvID) as cvID from Pages p inner join CollectionVersions cv on p.cID = cv.cID where ptID = ? and pTemplateID = ? and cIsTemplate = 0 and cIsActive = 1 and siteTreeID = ? group by cID order by cID', [$ptID, $this->template->getPageTemplateID(), $siteTreeID]);
 
         foreach ($pagesPlusCV as $pagePlusCV) {
             $pageTypeDefaultPageBlocksClone = $pageTypeDefaultPageRelBlocks;
-            
+
             $associatedBlocks = $db->fetchAll(
                 'select cbDisplayOrder, arHandle, bID, cbRelationID from CollectionVersionBlocks where cID = ? and cvID = ?',
                 [$pagePlusCV['cID'], $pagePlusCV['cvID']]
@@ -263,15 +263,15 @@ class UpdateFromType extends BackendInterfaceController
 
                 foreach ($blocksToAdd as $blockToAdd) {
                     $pageTypeBlock = $blockService->getByID($blockToAdd['bID'], $pageTypeDefaultPage, $blockToAdd['pageTypeArHandle']);
-                    
+
                     $bi = $pageTypeBlock->getInstance();
                     $output = $bi->getComposerOutputControlObject();
                     $control = FormLayoutSetControl::getByID($output->getPageTypeComposerFormLayoutSetControlID());
                     $object = $control->getPageTypeComposerControlObject();
-                    
+
                     if ($object instanceof BlockControl) {
                         $a = Area::get($page, $blockToAdd['pageTypeArHandle']);
-                        
+
                         $bt = $object->getBlockTypeObject();
                         $b = $page->addBlock($bt, $a, ['cbRelationID' => $pageTypeBlock->getBlockRelationID()]);
                         $object->setPageTypeComposerControlBlockObject($b);
@@ -287,10 +287,9 @@ class UpdateFromType extends BackendInterfaceController
                         if ($defaultStyles) {
                             $b->setCustomStyleSet($defaultStyles->getStyleSet());
                         }
-                        
+
                         $object->recordPageTypeComposerOutputBlock($b);
                     }
-                    
                 }
 
                 foreach ($blocksToUpdate as $blockToUpdate) {

--- a/concrete/controllers/dialog/type/update_from_type.php
+++ b/concrete/controllers/dialog/type/update_from_type.php
@@ -273,7 +273,7 @@ class UpdateFromType extends BackendInterfaceController
                         $a = Area::get($page, $blockToAdd['pageTypeArHandle']);
                         
                         $bt = $object->getBlockTypeObject();
-                        $b = $page->addBlock($bt, $a, [], $pageTypeBlock->getBlockRelationID());
+                        $b = $page->addBlock($bt, $a, ['cbRelationID' => $pageTypeBlock->getBlockRelationID()]);
                         $object->setPageTypeComposerControlBlockObject($b);
                         $b->setAbsoluteBlockDisplayOrder($blockToAdd['actualDisplayOrder']);
 

--- a/concrete/controllers/dialog/type/update_from_type.php
+++ b/concrete/controllers/dialog/type/update_from_type.php
@@ -16,6 +16,8 @@ use View;
 class UpdateFromType extends BackendInterfaceController
 {
     protected $viewPath = '/dialogs/type/update_from_type';
+    protected $pageType = null;
+    protected $template = null;
 
     public function on_start()
     {
@@ -67,11 +69,12 @@ class UpdateFromType extends BackendInterfaceController
         $siteTreeID = $site->getSiteTreeID();
 
         $ptID = $pageTypeDefaultPage->getPageTypeID();
-        $pagesPlusCV = $db->fetchAll('select p.cID, max(cvID) as cvID from Pages p inner join CollectionVersions cv on p.cID = cv.cID where ptID = ? and cIsTemplate = 0 and cIsActive = 1 and siteTreeID = ? group by cID order by cID', [$ptID, $siteTreeID]);
+        
+        $pagesPlusCV = $db->fetchAll('select p.cID, max(cvID) as cvID from Pages p inner join CollectionVersions cv on p.cID = cv.cID where ptID = ? and pTemplateID = ? and cIsTemplate = 0 and cIsActive = 1 and siteTreeID = ? group by cID order by cID', [$ptID, $this->template->getPageTemplateID(), $siteTreeID]);
 
         foreach ($pagesPlusCV as $pagePlusCV) {
             $pageTypeDefaultPageBlocksClone = $pageTypeDefaultPageRelBlocks;
-
+            
             $associatedBlocks = $db->fetchAll(
                 'select cbDisplayOrder, arHandle, bID, cbRelationID from CollectionVersionBlocks where cID = ? and cvID = ?',
                 [$pagePlusCV['cID'], $pagePlusCV['cvID']]

--- a/concrete/controllers/dialog/type/update_from_type.php
+++ b/concrete/controllers/dialog/type/update_from_type.php
@@ -128,7 +128,6 @@ class UpdateFromType extends BackendInterfaceController
 
                 unset($pageTypeDefaultPageBlocksClone[$cbRelationID]);
 
-
                 if (!empty($blockToUpdate['actions'])) {
                     $blocksToUpdate[] = $blockToUpdate;
                 }
@@ -177,7 +176,7 @@ class UpdateFromType extends BackendInterfaceController
 
                 $bFilename = $pageTypeBlock->getBlockFilename();
                 $defaultStyles = $pageTypeBlock->getCustomStyle();
-                
+
                 if ($bFilename) {
                     $pageBlock->setCustomTemplate($bFilename);
                 }

--- a/concrete/src/Calendar/Event/EventList.php
+++ b/concrete/src/Calendar/Event/EventList.php
@@ -44,8 +44,10 @@ class EventList extends \Concrete\Core\Search\ItemList\Database\AttributedItemLi
 
     public function finalizeQuery(\Doctrine\DBAL\Query\QueryBuilder $query)
     {
-        if (!$this->includeInactiveEvents) {
-            $query->andWhere('e.approved = 1');
+        if ($this->includeInactiveEvents) {
+            $query->andWhere('ve.eventVersionID = (select max(eventVersionID) from CalendarEventVersions where eventID = e.eventID)');
+        } else {
+            $query->andWhere('ve.evIsApproved = 1');
         }
 
         return $query;
@@ -66,6 +68,7 @@ class EventList extends \Concrete\Core\Search\ItemList\Database\AttributedItemLi
     public function createQuery()
     {
         $this->query->select('e.eventID')->from('CalendarEvents', 'e')
+            ->innerJoin('e', 'CalendarEventVersions', 've', 'e.eventID = ve.eventID')
             ->leftJoin('e', 'CalendarEventSearchIndexAttributes', 'ea', 'e.eventID = ea.eventID');
     }
 

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -860,7 +860,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         return $result;
     }
 
-    public function addBlock($bt, $a, $data)
+    public function addBlock($bt, $a, $data, $cbRelationID = null)
     {
         $db = Loader::db();
 
@@ -885,13 +885,15 @@ class Collection extends ConcreteObject implements TrackableInterface
             $newBlockDisplayOrder = $this->getCollectionAreaDisplayOrder($arHandle);
         }
 
-        $cbRelationID = $db->GetOne('select max(cbRelationID) as cbRelationID from CollectionVersionBlocks');
-        if (!$cbRelationID) {
-            $cbRelationID = 1;
-        } else {
-            ++$cbRelationID;
+        if (empty($cbRelationID)) {
+            $cbRelationID = $db->GetOne('select max(cbRelationID) as cbRelationID from CollectionVersionBlocks');
+            if (!$cbRelationID) {
+                $cbRelationID = 1;
+            } else {
+                ++$cbRelationID;
+            }
         }
-
+        
         $v = array(
             $cID,
             $vObj->getVersionID(),

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -37,7 +37,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     protected $cDateAdded;
     protected $cDateModified;
 
-    protected $attributes = array();
+    protected $attributes = [];
 
     /* version specific stuff */
 
@@ -67,20 +67,18 @@ class Collection extends ConcreteObject implements TrackableInterface
 
         $r = $db->query(
                 'select Collections.cID, Pages.cID as pcID from Collections left join Pages on Collections.cID = Pages.cID where Collections.cHandle = ?',
-                array($handle)
+                [$handle]
         );
         if ($r->numRows() == 0) {
-
             // there is nothing in the collections table for this page, so we create and grab
 
-            $data = array(
+            $data = [
                 'handle' => $handle,
-            );
+            ];
             $cObj = self::createCollection($data);
         } else {
             $row = $r->fetchRow();
             if ($row['cID'] > 0 && $row['pcID'] == null) {
-
                 // there is a collection, but it is not a page. so we grab it
                 $cObj = self::getByID($row['cID']);
             }
@@ -108,14 +106,14 @@ class Collection extends ConcreteObject implements TrackableInterface
         $cDate = $dh->getOverridableNow();
 
         $data = array_merge(
-            array(
+            [
                 'name' => '',
                 'pTemplateID' => 0,
                 'handle' => null,
                 'uID' => null,
                 'cDatePublic' => $cDate,
                 'cDescription' => null,
-            ),
+            ],
             $data
         );
 
@@ -124,13 +122,13 @@ class Collection extends ConcreteObject implements TrackableInterface
         if (isset($data['cID'])) {
             $res = $db->query(
                       'insert into Collections (cID, cHandle, cDateAdded, cDateModified) values (?, ?, ?, ?)',
-                      array($data['cID'], $data['handle'], $cDate, $cDate)
+                      [$data['cID'], $data['handle'], $cDate, $cDate]
             );
             $newCID = $data['cID'];
         } else {
             $res = $db->query(
                       'insert into Collections (cHandle, cDateAdded, cDateModified) values (?, ?, ?)',
-                      array($data['handle'], $cDate, $cDate)
+                      [$data['handle'], $cDate, $cDate]
             );
             $newCID = $db->Insert_ID();
         }
@@ -156,7 +154,7 @@ class Collection extends ConcreteObject implements TrackableInterface
 
         if ($res) {
             // now we add a pending version to the collectionversions table
-            $v2 = array(
+            $v2 = [
                 $newCID,
                 1,
                 $pTemplateID,
@@ -170,7 +168,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                 $cvIsApproved,
                 $cvIsNew,
                 $pThemeID,
-            );
+            ];
             $q2 = 'insert into CollectionVersions (cID, cvID, pTemplateID, cvName, cvHandle, cvDescription, cvDatePublic, cvDateCreated, cvComments, cvAuthorUID, cvIsApproved, cvIsNew, pThemeID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
             $r2 = $db->prepare($q2);
             $res2 = $db->execute($r2, $v2);
@@ -191,7 +189,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     {
         $db = Loader::db();
         $q = 'select Collections.cDateAdded, Collections.cDateModified, Collections.cID from Collections where cID = ?';
-        $row = $db->getRow($q, array($cID));
+        $row = $db->getRow($q, [$cID]);
 
         $c = new self();
         $c->setPropertiesFromArray($row);
@@ -232,7 +230,8 @@ class Collection extends ConcreteObject implements TrackableInterface
     }
 
     /**
-     * Get the attached version object
+     * Get the attached version object.
+     *
      * @return Version|null
      */
     public function getVersionObject()
@@ -280,15 +279,16 @@ class Collection extends ConcreteObject implements TrackableInterface
             while ($row = $r->FetchRow()) {
                 $db->Execute(
                    'insert into CollectionVersionAreaStyles (cID, cvID, arHandle, issID) values (?, ?, ?, ?)',
-                   array(
+                   [
                        $this->getCollectionID(),
                        $nvObj->getVersionID(),
                        $row['arHandle'],
                        $row['issID'],
-                   )
+                   ]
                 );
             }
         }
+
         return $nc;
     }
 
@@ -311,7 +311,7 @@ class Collection extends ConcreteObject implements TrackableInterface
             return CollectionVersionFeatureAssignment::getList($this);
         }
 
-        return array();
+        return [];
     }
 
     public function getVersionID()
@@ -328,12 +328,11 @@ class Collection extends ConcreteObject implements TrackableInterface
             return false;
         }
         if ($actuallyDoReindex || Config::get('concrete.page.search.always_reindex') == true) {
-
             // Retrieve the attribute values for the current page
             $category = \Core::make('Concrete\Core\Attribute\Category\PageCategory');
             $indexer = $category->getSearchIndexer();
             $values = $category->getAttributeValues($this);
-            foreach($values as $value) {
+            foreach ($values as $value) {
                 $indexer->indexEntry($category, $value, $this);
             }
 
@@ -346,8 +345,8 @@ class Collection extends ConcreteObject implements TrackableInterface
             $db = \Database::connection();
             $db->Replace(
                'PageSearchIndex',
-               array('cID' => $this->getCollectionID(), 'cRequiresReindex' => 0),
-               array('cID'),
+               ['cID' => $this->getCollectionID(), 'cRequiresReindex' => 0],
+               ['cID'],
                false
             );
 
@@ -366,8 +365,8 @@ class Collection extends ConcreteObject implements TrackableInterface
             Config::save('concrete.misc.do_page_reindex_check', true);
             $db->Replace(
                'PageSearchIndex',
-               array('cID' => $this->getCollectionID(), 'cRequiresReindex' => 1),
-               array('cID'),
+               ['cID' => $this->getCollectionID(), 'cRequiresReindex' => 1],
+               ['cID'],
                false
             );
         }
@@ -417,7 +416,6 @@ class Collection extends ConcreteObject implements TrackableInterface
         }
     }
 
-
     /**
      * @deprecated
      */
@@ -428,22 +426,22 @@ class Collection extends ConcreteObject implements TrackableInterface
 
     // get's an array of collection attribute objects that are attached to this collection. Does not get values
 
-    public function clearCollectionAttributes($retainAKIDs = array())
+    public function clearCollectionAttributes($retainAKIDs = [])
     {
         $db = Loader::db();
         if (count($retainAKIDs) > 0) {
-            $cleanAKIDs = array();
+            $cleanAKIDs = [];
             foreach ($retainAKIDs as $akID) {
                 $cleanAKIDs[] = intval($akID);
             }
             $akIDStr = implode(',', $cleanAKIDs);
-            $v2 = array($this->getCollectionID(), $this->getVersionID());
+            $v2 = [$this->getCollectionID(), $this->getVersionID()];
             $db->query(
                 "delete from CollectionAttributeValues where cID = ? and cvID = ? and akID not in ({$akIDStr})",
                 $v2
             );
         } else {
-            $v2 = array($this->getCollectionID(), $this->getVersionID());
+            $v2 = [$this->getCollectionID(), $this->getVersionID()];
             $db->query('delete from CollectionAttributeValues where cID = ? and cvID = ?', $v2);
         }
         $this->reindex();
@@ -459,7 +457,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         $category = $this->vObj->getObjectAttributeCategory();
         $values = $category->getAttributeValues($this->vObj);
 
-        $attribs = array();
+        $attribs = [];
         foreach ($values as $value) {
             $attribs[] = $value->getAttributeKey();
         }
@@ -487,17 +485,17 @@ class Collection extends ConcreteObject implements TrackableInterface
         $db = Loader::db();
         // aliased content is content on the particular page that is being
         // used elsewhere - but the content on the PAGE is the original version
-        $v = array($this->cID);
+        $v = [$this->cID];
         $q = 'select bID from CollectionVersionBlocks where cID = ? and isOriginal = 1';
         $r = $db->query($q, $v);
-        $bIDArray = array();
+        $bIDArray = [];
         if ($r) {
             while ($row = $r->fetchRow()) {
                 $bIDArray[] = $row['bID'];
             }
             if (count($bIDArray) > 0) {
                 $bIDList = implode(',', $bIDArray);
-                $v2 = array($bIDList, $this->cID);
+                $v2 = [$bIDList, $this->cID];
                 $q2 = 'select cID from CollectionVersionBlocks where bID in (?) and cID <> ? limit 1';
                 $aliasedCID = $db->getOne($q2, $v2);
                 if ($aliasedCID > 0) {
@@ -533,7 +531,9 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Retrieves all custom style rules that should be inserted into the header on a page, whether they are defined in areas
      * or blocks.
+     *
      * @param bool $return
+     *
      * @return string
      */
     public function outputCustomStyleHeaderItems($return = false)
@@ -543,17 +543,17 @@ class Collection extends ConcreteObject implements TrackableInterface
         }
 
         $db = Loader::db();
-        $psss = array();
+        $psss = [];
         $txt = Loader::helper('text');
-        CacheLocal::set('pssCheck', $this->getCollectionID().':'.$this->getVersionID(), true);
+        CacheLocal::set('pssCheck', $this->getCollectionID() . ':' . $this->getVersionID(), true);
 
         $r1 = $db->GetAll(
                  'select bID, arHandle, issID from CollectionVersionBlockStyles where cID = ? and cvID = ? and issID > 0',
-                 array($this->getCollectionID(), $this->getVersionID())
+                 [$this->getCollectionID(), $this->getVersionID()]
         );
         $r2 = $db->GetAll(
                  'select arHandle, issID from CollectionVersionAreaStyles where cID = ? and cvID = ? and issID > 0',
-                 array($this->getCollectionID(), $this->getVersionID())
+                 [$this->getCollectionID(), $this->getVersionID()]
         );
         foreach ($r1 as $r) {
             $issID = $r['issID'];
@@ -569,7 +569,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                 $psss[] = $obj;
                 CacheLocal::set(
                           'pssObject',
-                          $this->getCollectionID().':'.$this->getVersionID().':'.$r['arHandle'].':'.$r['bID'],
+                          $this->getCollectionID() . ':' . $this->getVersionID() . ':' . $r['arHandle'] . ':' . $r['bID'],
                           $obj
                 );
             }
@@ -584,7 +584,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                 $psss[] = $obj;
                 CacheLocal::set(
                           'pssObject',
-                          $this->getCollectionID().':'.$this->getVersionID().':'.$r['arHandle'],
+                          $this->getCollectionID() . ':' . $this->getVersionID() . ':' . $r['arHandle'],
                           $obj
                 );
             }
@@ -593,7 +593,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         // grab all the header block style rules for items in global areas on this page
         $rs = $db->GetCol(
                  'select arHandle from Areas where arIsGlobal = 1 and cID = ?',
-                 array($this->getCollectionID())
+                 [$this->getCollectionID()]
         );
         if (count($rs) > 0) {
             $pcp = new Permissions($this);
@@ -604,10 +604,10 @@ class Collection extends ConcreteObject implements TrackableInterface
                     $s = Stack::getByName($garHandle, 'ACTIVE');
                 }
                 if (is_object($s)) {
-                    CacheLocal::set('pssCheck', $s->getCollectionID().':'.$s->getVersionID(), true);
+                    CacheLocal::set('pssCheck', $s->getCollectionID() . ':' . $s->getVersionID(), true);
                     $rs1 = $db->GetAll(
                               'select bID, issID, arHandle from CollectionVersionBlockStyles where cID = ? and cvID = ? and issID > 0',
-                              array($s->getCollectionID(), $s->getVersionID())
+                              [$s->getCollectionID(), $s->getVersionID()]
                     );
                     foreach ($rs1 as $r) {
                         $issID = $r['issID'];
@@ -621,7 +621,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                             $psss[] = $obj;
                             CacheLocal::set(
                                       'pssObject',
-                                      $s->getCollectionID().':'.$s->getVersionID().':'.$r['arHandle'].':'.$r['bID'],
+                                      $s->getCollectionID() . ':' . $s->getVersionID() . ':' . $r['arHandle'] . ':' . $r['bID'],
                                       $obj
                             );
                         }
@@ -672,11 +672,11 @@ class Collection extends ConcreteObject implements TrackableInterface
         $db = Loader::db();
         $db->Execute(
            'delete from CollectionVersionAreaStyles where cID = ? and cvID = ? and arHandle = ?',
-           array(
+           [
                $this->getCollectionID(),
                $this->getVersionID(),
                $area->getAreaHandle(),
-           )
+           ]
         );
     }
 
@@ -685,13 +685,13 @@ class Collection extends ConcreteObject implements TrackableInterface
         $db = Loader::db();
         $db->Replace(
            'CollectionVersionAreaStyles',
-           array(
+           [
                'cID' => $this->getCollectionID(),
                'cvID' => $this->getVersionID(),
                'arHandle' => $area->getAreaHandle(),
                'issID' => $set->getID(),
-           ),
-           array('cID', 'cvID', 'arHandle'),
+           ],
+           ['cID', 'cvID', 'arHandle'],
            true
         );
     }
@@ -699,12 +699,12 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function relateVersionEdits($oc)
     {
         $db = Loader::db();
-        $v = array(
+        $v = [
             $this->getCollectionID(),
             $this->getVersionID(),
             $oc->getCollectionID(),
             $oc->getVersionID(),
-        );
+        ];
         $r = $db->GetOne(
                 'select count(*) from CollectionVersionRelatedEdits where cID = ? and cvID = ? and cRelationID = ? and cvRelationID = ?',
                 $v
@@ -744,14 +744,14 @@ class Collection extends ConcreteObject implements TrackableInterface
         $db = Loader::db();
         $cID = $this->cID;
         $cvID = $this->vObj->cvID;
-        $args = array($cID, $cvID, $arHandle);
+        $args = [$cID, $cvID, $arHandle];
         $q = "select bID from CollectionVersionBlocks where cID = ? and cvID = ? and arHandle=? order by cbDisplayOrder asc";
         $r = $db->query($q, $args);
 
         if ($r) {
             $displayOrder = 0;
             while ($row = $r->fetchRow()) {
-                $args = array($displayOrder, $cID, $cvID, $arHandle, $row['bID']);
+                $args = [$displayOrder, $cID, $cvID, $arHandle, $row['bID']];
                 $q = "update CollectionVersionBlocks set cbDisplayOrder = ? where cID = ? and cvID = ? and arHandle = ? and bID = ?";
                 $db->query($q, $args);
                 ++$displayOrder;
@@ -768,9 +768,9 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function getGlobalBlocks()
     {
         $db = Loader::db();
-        $v = array(Stack::ST_TYPE_GLOBAL_AREA);
+        $v = [Stack::ST_TYPE_GLOBAL_AREA];
         $rs = $db->GetCol('select stName from Stacks where Stacks.stType = ?', $v);
-        $blocks = array();
+        $blocks = [];
         if (count($rs) > 0) {
             $pcp = new Permissions($this);
             foreach ($rs as $garHandle) {
@@ -800,7 +800,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     {
         $blockIDs = $this->getBlockIDs($arHandle);
 
-        $blocks = array();
+        $blocks = [];
         if (is_array($blockIDs)) {
             foreach ($blockIDs as $row) {
                 $ab = Block::getByID($row['bID'], $this, $row['arHandle']);
@@ -824,24 +824,24 @@ class Collection extends ConcreteObject implements TrackableInterface
     {
         $blockIDs = CacheLocal::getEntry(
                               'collection_block_ids',
-                              $this->getCollectionID().':'.$this->getVersionID()
+                              $this->getCollectionID() . ':' . $this->getVersionID()
         );
 
         if (!is_array($blockIDs)) {
-            $v = array($this->getCollectionID(), $this->getVersionID());
+            $v = [$this->getCollectionID(), $this->getVersionID()];
             $db = Loader::db();
             $q = 'select Blocks.bID, CollectionVersionBlocks.arHandle from CollectionVersionBlocks inner join Blocks on (CollectionVersionBlocks.bID = Blocks.bID) inner join BlockTypes on (Blocks.btID = BlockTypes.btID) where CollectionVersionBlocks.cID = ? and (CollectionVersionBlocks.cvID = ? or CollectionVersionBlocks.cbIncludeAll=1) order by CollectionVersionBlocks.cbDisplayOrder asc';
             $r = $db->GetAll($q, $v);
-            $blockIDs = array();
+            $blockIDs = [];
             if (is_array($r)) {
                 foreach ($r as $bl) {
                     $blockIDs[strtolower($bl['arHandle'])][] = $bl;
                 }
             }
-            CacheLocal::set('collection_block_ids', $this->getCollectionID().':'.$this->getVersionID(), $blockIDs);
+            CacheLocal::set('collection_block_ids', $this->getCollectionID() . ':' . $this->getVersionID(), $blockIDs);
         }
 
-        $result = array();
+        $result = [];
         if ($arHandle != false) {
             $key = strtolower($arHandle);
             if (isset($blockIDs[$key])) {
@@ -895,8 +895,8 @@ class Collection extends ConcreteObject implements TrackableInterface
                 ++$cbRelationID;
             }
         }
-        
-        $v = array(
+
+        $v = [
             $cID,
             $vObj->getVersionID(),
             $nb->getBlockID(),
@@ -905,7 +905,7 @@ class Collection extends ConcreteObject implements TrackableInterface
             $newBlockDisplayOrder,
             1,
             intval($bt->includeAll()),
-        );
+        ];
         $q = 'insert into CollectionVersionBlocks (cID, cvID, bID, arHandle, cbRelationID, cbDisplayOrder, isOriginal, cbIncludeAll) values (?, ?, ?, ?, ?, ?, ?, ?)';
 
         $res = $db->Execute($q, $v);
@@ -918,12 +918,12 @@ class Collection extends ConcreteObject implements TrackableInterface
                 $fa = CollectionVersionFeatureAssignment::add($fe, $fd, $this);
                 $db->Execute(
                    'insert into BlockFeatureAssignments (cID, cvID, bID, faID) values (?, ?, ?, ?)',
-                   array(
+                   [
                        $this->getCollectionID(),
                        $this->getVersionID(),
                        $nb->getBlockID(),
                        $fa->getFeatureAssignmentID(),
-                   )
+                   ]
                 );
             }
         }
@@ -941,10 +941,10 @@ class Collection extends ConcreteObject implements TrackableInterface
         $cvID = $this->vObj->cvID;
         if ($ignoreVersions) {
             $q = 'select max(cbDisplayOrder) as cbdis from CollectionVersionBlocks where cID = ? and arHandle = ?';
-            $v = array($cID, $arHandle);
+            $v = [$cID, $arHandle];
         } else {
             $q = 'select max(cbDisplayOrder) as cbdis from CollectionVersionBlocks where cID = ? and cvID = ? and arHandle = ?';
-            $v = array($cID, $cvID, $arHandle);
+            $v = [$cID, $cvID, $arHandle];
         }
         $r = $db->query($q, $v);
         if ($r) {
@@ -970,8 +970,8 @@ class Collection extends ConcreteObject implements TrackableInterface
         $db = Loader::db();
         $db->Replace(
            'CollectionVersionFeatures',
-           array('cID' => $this->getCollectionID(), 'cvID' => $this->getVersionID(), 'feID' => $fe->getFeatureID()),
-           array('cID', 'cvID', 'feID'),
+           ['cID' => $this->getCollectionID(), 'cvID' => $this->getVersionID(), 'feID' => $fe->getFeatureID()],
+           ['cID', 'cvID', 'feID'],
            true
         );
     }
@@ -983,7 +983,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         $dh = Loader::helper('date');
         $cDateModified = $dh->getOverridableNow();
 
-        $v = array($cDateModified, $this->cID);
+        $v = [$cDateModified, $this->cID];
         $q = 'update Collections set cDateModified = ? where cID = ?';
         $r = $db->prepare($q);
         $res = $db->execute($r, $v);
@@ -1025,12 +1025,11 @@ class Collection extends ConcreteObject implements TrackableInterface
         $dh = Loader::helper('date');
         $cDate = $dh->getOverridableNow();
 
-        $v = array($cDate, $cDate, $this->cHandle);
+        $v = [$cDate, $cDate, $this->cHandle];
         $r = $db->query('insert into Collections (cDateAdded, cDateModified, cHandle) values (?, ?, ?)', $v);
         $newCID = $db->Insert_ID();
 
         if ($r) {
-
             // first, we get the creation date of the active version in this collection
             //$q = "select cvDateCreated from CollectionVersions where cvIsApproved = 1 and cID = {$this->cID}";
             //$dcOriginal = $db->getOne($q);
@@ -1040,12 +1039,12 @@ class Collection extends ConcreteObject implements TrackableInterface
 
             // now we grab all of the current versions
             $rv = $db->query($qv);
-            $cvList = array();
+            $cvList = [];
             while ($row = $rv->fetchRow()) {
                 // insert
                 $cvList[] = $row['cvID'];
                 $cDate = date('Y-m-d H:i:s', strtotime($cDate) + 1);
-                $vv = array(
+                $vv = [
                     $newCID,
                     $row['cvID'],
                     $row['cvName'],
@@ -1058,7 +1057,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                     $row['cvIsApproved'],
                     $row['pThemeID'],
                     $row['pTemplateID'],
-                );
+                ];
                 $qv = 'insert into CollectionVersions (cID, cvID, cvName, cvHandle, cvDescription, cvDatePublic, cvDateCreated, cvComments, cvAuthorUID, cvIsApproved, pThemeID, pTemplateID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
                 $db->query($qv, $vv);
             }
@@ -1066,14 +1065,14 @@ class Collection extends ConcreteObject implements TrackableInterface
             $ql = "select * from CollectionVersionBlockStyles where cID = '{$this->cID}'";
             $rl = $db->query($ql);
             while ($row = $rl->fetchRow()) {
-                $vl = array($newCID, $row['cvID'], $row['bID'], $row['arHandle'], $row['issID']);
+                $vl = [$newCID, $row['cvID'], $row['bID'], $row['arHandle'], $row['issID']];
                 $ql = 'insert into CollectionVersionBlockStyles (cID, cvID, bID, arHandle, issID) values (?, ?, ?, ?, ?)';
                 $db->query($ql, $vl);
             }
             $ql = "select * from CollectionVersionAreaStyles where cID = '{$this->cID}'";
             $rl = $db->query($ql);
             while ($row = $rl->fetchRow()) {
-                $vl = array($newCID, $row['cvID'], $row['arHandle'], $row['issID']);
+                $vl = [$newCID, $row['cvID'], $row['arHandle'], $row['issID']];
                 $ql = 'insert into CollectionVersionAreaStyles (cID, cvID, arHandle, issID) values (?, ?, ?, ?)';
                 $db->query($ql, $vl);
             }
@@ -1081,7 +1080,7 @@ class Collection extends ConcreteObject implements TrackableInterface
             $ql = "select * from CollectionVersionThemeCustomStyles where cID = '{$this->cID}'";
             $rl = $db->query($ql);
             while ($row = $rl->fetchRow()) {
-                $vl = array($newCID, $row['cvID'], $row['pThemeID'], $row['scvlID'], $row['preset'], $row['sccRecordID']);
+                $vl = [$newCID, $row['cvID'], $row['pThemeID'], $row['scvlID'], $row['preset'], $row['sccRecordID']];
                 $ql = 'insert into CollectionVersionThemeCustomStyles (cID, cvID, pThemeID, scvlID, preset, sccRecordID) values (?, ?, ?, ?, ?, ?)';
                 $db->query($ql, $vl);
             }
@@ -1091,7 +1090,7 @@ class Collection extends ConcreteObject implements TrackableInterface
             $q = "select bID, cvID, arHandle, cbDisplayOrder, cbOverrideAreaPermissions, cbIncludeAll, cbRelationID from CollectionVersionBlocks where cID = '{$this->cID}' and cvID in ({$cvList})";
             $r = $db->query($q);
             while ($row = $r->fetchRow()) {
-                $v = array(
+                $v = [
                     $newCID,
                     $row['cvID'],
                     $row['bID'],
@@ -1101,7 +1100,7 @@ class Collection extends ConcreteObject implements TrackableInterface
                     0,
                     $row['cbOverrideAreaPermissions'],
                     $row['cbIncludeAll'],
-                );
+                ];
                 $q = 'insert into CollectionVersionBlocks (cID, cvID, bID, arHandle, cbDisplayOrder, cbRelationID, isOriginal, cbOverrideAreaPermissions, cbIncludeAll) values (?, ?, ?, ?, ?, ?, ?, ?, ?)';
                 $db->query($q, $v);
                 if ($row['cbOverrideAreaPermissions'] != 0) {
@@ -1110,14 +1109,14 @@ class Collection extends ConcreteObject implements TrackableInterface
                     while ($row2 = $r2->fetchRow()) {
                         $db->Replace(
                            'BlockPermissionAssignments',
-                           array(
+                           [
                                'cID' => $newCID,
                                'cvID' => $row['cvID'],
                                'bID' => $row['bID'],
                                'paID' => $row2['paID'],
                                'pkID' => $row2['pkID'],
-                           ),
-                           array('cID', 'cvID', 'bID', 'paID', 'pkID'),
+                           ],
+                           ['cID', 'cvID', 'bID', 'paID', 'pkID'],
                            true
                         );
                     }
@@ -1127,9 +1126,9 @@ class Collection extends ConcreteObject implements TrackableInterface
             // duplicate any attributes belonging to the collection
             $list = CollectionKey::getAttributeValues($this->vObj);
             $em = \Database::connection()->getEntityManager();
-            foreach($list as $av) {
+            foreach ($list as $av) {
                 /**
-                 * @var $av PageValue
+                 * @var PageValue
                  */
                 $cav = new PageValue();
                 $cav->setPageID($newCID);
@@ -1139,7 +1138,6 @@ class Collection extends ConcreteObject implements TrackableInterface
                 $em->persist($cav);
             }
             $em->flush();
-
 
             return self::getByID($newCID);
         }

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -860,7 +860,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         return $result;
     }
 
-    public function addBlock($bt, $a, $data, $cbRelationID = null)
+    public function addBlock($bt, $a, $data)
     {
         $db = Loader::db();
 
@@ -885,7 +885,9 @@ class Collection extends ConcreteObject implements TrackableInterface
             $newBlockDisplayOrder = $this->getCollectionAreaDisplayOrder($arHandle);
         }
 
-        if (empty($cbRelationID)) {
+        if (isset($data['cbRelationID']) && !empty($data['cbRelationID'])) {
+            $cbRelationID = $data['cbRelationID'];
+        } else {
             $cbRelationID = $db->GetOne('select max(cbRelationID) as cbRelationID from CollectionVersionBlocks');
             if (!$cbRelationID) {
                 $cbRelationID = 1;

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -390,16 +390,6 @@ class Collection extends ConcreteObject implements TrackableInterface
         }
     }
 
-    /**
-     * Get the attached version object.
-     *
-     * @return Version|null
-     */
-    public function getVersionObject()
-    {
-        return $this->vObj;
-    }
-
     // remove the collection attributes for this version of a page
 
     public function cloneVersion($versionComments, $createEmpty = false)

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2234,9 +2234,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
     }
 
-    public function addBlock($bt, $a, $data, $cbRelationID = null)
+    public function addBlock($bt, $a, $data)
     {
-        $b = parent::addBlock($bt, $a, $data, $cbRelationID);
+        $b = parent::addBlock($bt, $a, $data);
         $btHandle = $bt->getBlockTypeHandle();
         if ($b->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
             $bi = $b->getInstance();

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2234,9 +2234,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
     }
 
-    public function addBlock($bt, $a, $data)
+    public function addBlock($bt, $a, $data, $cbRelationID = null)
     {
-        $b = parent::addBlock($bt, $a, $data);
+        $b = parent::addBlock($bt, $a, $data, $cbRelationID);
         $btHandle = $bt->getBlockTypeHandle();
         if ($b->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
             $bi = $b->getInstance();

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2238,6 +2238,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $b = parent::addBlock($bt, $a, $data);
         $btHandle = $bt->getBlockTypeHandle();
+
         if ($b->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
             $bi = $b->getInstance();
             $output = $bi->getComposerOutputControlObject();
@@ -2248,17 +2249,24 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 $btHandle = $_bt->getBlockTypeHandle();
             }
         }
+
         $theme = $this->getCollectionThemeObject();
+
         if ($btHandle && $theme) {
             $areaTemplates = [];
+
             if (is_object($a)) {
                 $areaTemplates = $a->getAreaCustomTemplates();
             }
+
             $themeTemplates = $theme->getThemeDefaultBlockTemplates();
+
             if (!is_array($themeTemplates)) {
                 $themeTemplates = [];
             }
+
             $templates = array_merge($themeTemplates, $areaTemplates);
+            
             if (count($templates) && isset($templates[$btHandle])) {
                 $template = $templates[$btHandle];
                 $b->updateBlockInformation(['bFilename' => $template]);

--- a/concrete/src/Page/Type/Composer/Control/BlockControl.php
+++ b/concrete/src/Page/Type/Composer/Control/BlockControl.php
@@ -358,11 +358,12 @@ class BlockControl extends Control
         $blockDisplayOrder = $b->getBlockDisplayOrder();
         $bFilename = $b->getBlockFilename();
         $defaultStyles = $b->getCustomStyle();
-        $cbRelationID = $b->getBlockRelationID();
+        $data['cbRelationID'] = $b->getBlockRelationID();
 
         $b->deleteBlock();
         $ax = Area::getOrCreate($c, $arHandle);
-        $b = $c->addBlock($bt, $ax, $data, $cbRelationID);
+        
+        $b = $c->addBlock($bt, $ax, $data);
         $this->setPageTypeComposerControlBlockObject($b);
         $b->setAbsoluteBlockDisplayOrder($blockDisplayOrder);
         if ($bFilename) {

--- a/concrete/src/Page/Type/Composer/Control/BlockControl.php
+++ b/concrete/src/Page/Type/Composer/Control/BlockControl.php
@@ -358,9 +358,11 @@ class BlockControl extends Control
         $blockDisplayOrder = $b->getBlockDisplayOrder();
         $bFilename = $b->getBlockFilename();
         $defaultStyles = $b->getCustomStyle();
+        $cbRelationID = $b->getBlockRelationID();
+
         $b->deleteBlock();
         $ax = Area::getOrCreate($c, $arHandle);
-        $b = $c->addBlock($bt, $ax, $data);
+        $b = $c->addBlock($bt, $ax, $data, $cbRelationID);
         $this->setPageTypeComposerControlBlockObject($b);
         $b->setAbsoluteBlockDisplayOrder($blockDisplayOrder);
         if ($bFilename) {

--- a/concrete/src/Page/Type/Composer/Control/BlockControl.php
+++ b/concrete/src/Page/Type/Composer/Control/BlockControl.php
@@ -362,7 +362,7 @@ class BlockControl extends Control
 
         $b->deleteBlock();
         $ax = Area::getOrCreate($c, $arHandle);
-        
+
         $b = $c->addBlock($bt, $ax, $data);
         $this->setPageTypeComposerControlBlockObject($b);
         $b->setAbsoluteBlockDisplayOrder($blockDisplayOrder);


### PR DESCRIPTION
Pull request #5510 which was merged in the core didn't work and led to issue #6168 

Problems were:
First, when adding blocks to a page through COmposer publishing, the blocks would get the wrong cbRelationID in table CollectionVersionBlocks 

Because of that error, when modifying page type defaults and publishing to child pages, the blocks already inserted were not taken into account so were deleted and replaced with new ones.

As a result, all content was lost.

Trying to publish modifications to all child pages again would then simply not do anything since the blocks added to the page would now have a btID of core_page_type_composer_control_output so not editable.

I tested this fix and it seems to work.

I added styling to default blocks on page types, I added extra blocks, I modified the order of blocks and moved one block from one area to another. After that publishing all changes to child pages worked.

All changes were published on pages based on that page type AND all the blocks' content was still there and not deleted like it previously was.