### PR TITLE
Update select controller

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -873,7 +873,12 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
         $r = $em->getRepository('\Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption');
         $type = $this->attributeKey->getAttributeKeySettings();
 
-        $values = explode(',', $value);
+        if (!is_array($value)) {
+            $values = explode(',', $value);
+        } else {
+            $values = $value;
+        }
+        
         $response = [];
         foreach ($values as $value) {
             $value = trim($value);


### PR DESCRIPTION
I have run into the occasion when adding a select attribute to express form and leaving a text attribute (that is required) blank that the function will receive the $value parameter as an array - the issue is that you can't call explode on an array of course as it fatally crashes.

*Check these before submitting new pull requests*

- [ ] I read the __guidelines for contributing__ linked above  

- [ ] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!