### PR TITLE
Do not allow folder names to be null in file manager

### DIFF
--- a/concrete/controllers/backend/file/folder.php
+++ b/concrete/controllers/backend/file/folder.php
@@ -34,8 +34,12 @@ class Folder extends AbstractController
         if (!$permissions->canAddTreeSubNode()) {
             $error->add(t('You do not have permission to add a folder here.'));
         }
+        $folderName = $this->request->request->get('folderName');
+        if (empty($folderName)) {
+            $error->add(t('Folder Name can not be empty.'));
+        }
         if (!$error->has()) {
-            $folder = $filesystem->addFolder($folder, $this->request->request->get('folderName'));
+            $folder = $filesystem->addFolder($folder, $folderName);
             $response->setMessage(t('Folder added.'));
             $response->setAdditionalDataAttribute('folder', $folder);
         }

--- a/concrete/controllers/backend/file/folder.php
+++ b/concrete/controllers/backend/file/folder.php
@@ -35,7 +35,7 @@ class Folder extends AbstractController
             $error->add(t('You do not have permission to add a folder here.'));
         }
         $folderName = $this->request->request->get('folderName');
-        if (empty($folderName)) {
+        if (!is_string($folderName) || trim($folderName) === '') {
             $error->add(t('Folder Name can not be empty.'));
         }
         if (!$error->has()) {


### PR DESCRIPTION
This pull request stops users putting in null/empty folders in the file manager.