### PR TITLE
User attribute update issue fix

### DIFF
--- a/concrete/src/Page/Controller/DashboardAttributesPageController.php
+++ b/concrete/src/Page/Controller/DashboardAttributesPageController.php
@@ -101,7 +101,7 @@ abstract class DashboardAttributesPageController extends DashboardPageController
         if ($category->getSetManager()->allowAttributeSets()) {
             $set = Set::getByID($request->request->get('asID'));
             $setKeys = Set::getByAttributeKey($key);
-            if (in_array($set, $setKeys)) {
+            if (!in_array($set, $setKeys)) {
                 return;
             }
 

--- a/concrete/src/Page/Controller/DashboardAttributesPageController.php
+++ b/concrete/src/Page/Controller/DashboardAttributesPageController.php
@@ -101,7 +101,7 @@ abstract class DashboardAttributesPageController extends DashboardPageController
         if ($category->getSetManager()->allowAttributeSets()) {
             $set = Set::getByID($request->request->get('asID'));
             $setKeys = Set::getByAttributeKey($key);
-            if (!in_array($set, $setKeys)) {
+            if (is_object($set) && !in_array($set, $setKeys)) {
                 return;
             }
 


### PR DESCRIPTION
User attribute can't update when the attribute belongs to any set.
This PR fixes the issue.

# How to reproduce
- Add custom attribute for members.
- Add a group set.
- Associate the attributes into the set.
- Now, try to edit the attribute.
- It'll show updated successfully, but not.