### PR TITLE
Revert "Use t method in better way"

### DIFF
--- a/concrete/single_pages/dashboard/system/registration/open.php
+++ b/concrete/single_pages/dashboard/system/registration/open.php
@@ -82,21 +82,21 @@ $h = Loader::helper('concrete/ui');
             <label>
                 <input type="checkbox" name="display_username_field" value="1"
                        style="" <?php echo ($display_username_field) ? 'checked' : '' ?> />
-                <span><?php echo t('%s required', 'Username') ?></span>
+                <span><?php echo t('Username required') ?></span>
             </label>
         </div>
         <div class="checkbox">
             <label>
                 <input type="checkbox" name="display_confirm_password_field" value="1"
                        style="" <?php echo ($display_confirm_password_field) ? 'checked' : '' ?> />
-                <span><?php echo t('%s required', 'Confirm password') ?></span>
+                <span><?php echo t('Confirm Password required') ?></span>
             </label>
         </div>
         <div class="checkbox">
             <label>
                 <input type="checkbox" name="enable_registration_captcha" value="1"
                        style="" <?php echo ($enable_registration_captcha) ? 'checked' : '' ?> />
-                <span><?php echo t('%s required', 'CAPTCHA') ?></span>
+                <span><?php echo t('CAPTCHA required') ?></span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
This reverts commit f6b607d7835df41912b446bc3248034010278063 which was wrong, for two reasons:
1. only the first argument can be translated  
  So, for instance, in `t('%s required', 'Username')` only the `%s required` part will be translated, but `Username` will  be inserted in the translated string as is.
2. building sentences by concatenating words is a bad practice for localization.  
  Why?
  For instance, for Italian:  
    - we have only two genders (male and female) no neutral.
    - "Username" is male (translated as "Nome utente")
    - "Password" is female (we use the English term for it, no translation)
    - usually the last vowel of adjectives follow the gender ("Alice is beautiful" -> "Alice è bell**a**", "Bob is beautiful" -> "Bob è bell**o**")
    - So, I'd translate "Username is required" as "Nome utente richiest**o**", and "Password is required" as "Password richiest**a**".
  As you can see, concatenating words (or using placeholders like "%s required") won't work for us.