### PR TITLE
 File inspectors: improve, add PHPDoc, and get rid of deprecated methods 

### DIFF
--- a/concrete/src/File/Type/Inspector/FlvInspector.php
+++ b/concrete/src/File/Type/Inspector/FlvInspector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;

--- a/concrete/src/File/Type/Inspector/FlvInspector.php
+++ b/concrete/src/File/Type/Inspector/FlvInspector.php
@@ -3,40 +3,418 @@
 namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;
-use Core;
-use FileAttributeKey;
+use Exception;
+use Throwable;
+use UnexpectedValueException;
 
+/**
+ * An inspector to process FLV (Flash Video) files.
+ */
 class FlvInspector extends Inspector
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\File\Type\Inspector\Inspector::inspect()
+     */
     public function inspect(Version $fv)
     {
-        $at1 = FileAttributeKey::getByHandle('duration');
-        $at2 = FileAttributeKey::getByHandle('width');
-        $at3 = FileAttributeKey::getByHandle('height');
+        $metadata = $this->getFlvMetadata($fv);
+        if ($metadata !== null) {
+            $attributeCategory = $fv->getObjectAttributeCategory();
+            if (isset($metadata['duration']) && is_float($metadata['duration']) && $metadata['duration'] > 0) {
+                $atDuration = $attributeCategory->getAttributeKeyByHandle('duration');
+                if ($atDuration !== null) {
+                    $fv->setAttribute($atDuration, $metadata['duration']);
+                }
+            }
+            if (isset($metadata['width']) && is_float($metadata['width'])) {
+                $width = (int) round($metadata['width']);
+                if ($width > 0) {
+                    $atWidth = $attributeCategory->getAttributeKeyByHandle('width');
+                    if ($atWidth !== null) {
+                        $fv->setAttribute($atWidth, $width);
+                    }
+                }
+            }
+            if (isset($metadata['height']) && is_float($metadata['height'])) {
+                $height = (int) round($metadata['height']);
+                if ($height > 0) {
+                    $atHeight = $attributeCategory->getAttributeKeyByHandle('height');
+                    if ($atHeight !== null) {
+                        $fv->setAttribute($atHeight, $height);
+                    }
+                }
+            }
+        }
+    }
 
-        // we killed $path here because the file might be hosted remotely.
-        // @TODO add in support for streams through the $filesystem object.
+    /**
+     * @param Version $fv
+     *
+     * @return array|null
+     *
+     * @see http://www.adobe.com/devnet/f4v.html
+     */
+    public function getFlvMetadata(Version $fv)
+    {
+        $result = null;
+        $fp = $this->getStream($fv);
+        if ($fp !== null) {
+            try {
+                $headerData = $this->readFlvHeader($fp);
+                if ($headerData !== null) {
+                    $tagOffset = $headerData['dataOffset'];
+                    for ($tagIndex = 0; ; ++$tagIndex) {
+                        $tagData = $this->readFlvTag($fp, $tagOffset);
+                        if ($tagData === null) {
+                            break;
+                        }
+                        switch ($tagData['tagType']) {
+                            case 18: // Script data
+                                if ($tagData['filter'] === 0) { // Not encrypted
+                                    $data = @fread($fp, $tagData['dataSize']);
+                                    if ($data !== false && isset($data[$tagData['dataSize'] - 1])) {
+                                        $scriptBody = $this->extractScriptTagBody($data);
+                                        if ($scriptBody !== null) {
+                                            list($bodyName, $bodyData) = $scriptBody;
+                                            if ($bodyName === 'onMetaData') {
+                                                $result = $bodyData;
+                                                break 2;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                        $tagOffset += $dataSize + 15;
+                        break; // Let's just parse the first tag
+                    }
+                }
+            } catch (Exception $x) {
+                $result = null;
+            } catch (Throwable $x) {
+                $result = null;
+            }
+            if (is_resource($fp)) {
+                @fclose($fp);
+            }
+        }
 
-        $cf = Core::make('helper/concrete/file');
-        $fs = $fv->getFile()->getFileStorageLocationObject()->getFileSystemObject();
-        $fp = $fs->readStream($cf->prefix($fv->getPrefix(), $fv->getFileName()));
+        return $result;
+    }
 
-        @fseek($fp, 27);
-        $onMetaData = fread($fp, 10);
+    /**
+     * @param Version $version
+     * @param Version $fv
+     *
+     * @return resource|null
+     */
+    private function getStream(Version $fv)
+    {
+        try {
+            return $fv->getFileResource()->readStream() ?: null;
+        } catch (Exception $x) {
+            return null;
+        } catch (Throwable $x) {
+            return null;
+        }
+    }
 
-        //if ($onMetaData != 'onMetaData') exit('No meta data available in this file! Fix it using this tool: http://www.buraks.com/flvmdi/');
+    /**
+     * @param resource $fp
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array|null
+     */
+    private function readFlvHeader($fp)
+    {
+        $result = null;
+        $flvHeaderChunk = @fread($fp, 9); // 3 bytes signature + 1 byte version + 1 byte flags + 4 bytes data offset
+        if ($flvHeaderChunk !== false && isset($flvHeaderChunk[8])) {
+            if (substr($flvHeaderChunk, 0, 3) === 'FLV') { // Signature ok
+                $version = $this->parseUI8($flvHeaderChunk[3]);
+                if ($version === 1) { // Version ok
+                    $flags = $this->parseUI8($flvHeaderChunk[4]); // Bit 0x01 set: has video; bit 0x04: has audio
+                    $dataOffset = $this->parseUI32(substr($flvHeaderChunk, 5, 4));
+                    $result = [
+                        'version' => $version,
+                        'flags' => $flags,
+                        'dataOffset' => $dataOffset,
+                    ];
+                }
+            }
+        }
 
-        @fseek($fp, 16, SEEK_CUR);
-        $duration = array_shift(unpack('d', strrev(fread($fp, 8))));
+        return $result;
+    }
 
-        @fseek($fp, 8, SEEK_CUR);
-        $width = array_shift(unpack('d', strrev(fread($fp, 8))));
+    /**
+     * @param resource $fp
+     * @param int $tagOffset
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array|null
+     */
+    private function readFlvTag($fp, $tagOffset)
+    {
+        $result = null;
+        $seeked = @fseek($fp, $tagOffset + 4); // +4 to skip PreviousTagSize
+        if ($seeked === 0) {
+            $tagHeaderChunk = @fread($fp, 11); // (2 bits reserved + 1 bit filter + 5 bits TagType) + 3 bytes DataSize + 3 bytes Timestamp + 1 byte TimestampExtended + 3 bytes StreamID
+            if ($tagHeaderChunk !== false && isset($tagHeaderChunk[10])) {
+                $byte = $this->parseUI8($tagHeaderChunk[0]);
+                $result = [
+                    'filter' => ($byte >> 5) & 0x01,
+                    'tagType' => $byte & 0x1F,
+                    'dataSize' => $this->parseUI24(substr($tagHeaderChunk, 1, 3)),
+                ];
+            }
+        }
 
-        @fseek($fp, 9, SEEK_CUR);
-        $height = array_shift(unpack('d', strrev(fread($fp, 8))));
+        return $result;
+    }
 
-        $fv->setAttribute($at1, $duration);
-        $fv->setAttribute($at2, $width);
-        $fv->setAttribute($at3, $height);
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return int
+     */
+    private function parseUI8($data)
+    {
+        if (!isset($data[0])) {
+            throw new UnexpectedValueException();
+        }
+
+        return ord($data);
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return int
+     */
+    private function parseUI16($data)
+    {
+        if (!isset($data[1])) {
+            throw new UnexpectedValueException();
+        }
+        $unpacked = unpack('n', $data);
+
+        return array_shift($unpacked);
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return int
+     */
+    private function parseUI24($data)
+    {
+        if (!isset($data[2])) {
+            throw new UnexpectedValueException();
+        }
+        $unpacked = unpack('N', "\x00" . $data);
+
+        return array_shift($unpacked);
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return int
+     */
+    private function parseUI32($data)
+    {
+        if (!isset($data[3])) {
+            throw new UnexpectedValueException();
+        }
+        $unpacked = unpack('N', $data);
+
+        return array_shift($unpacked);
+    }
+
+    /**
+     * IEEE 754.
+     *
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return float
+     */
+    private function parseDouble($data)
+    {
+        if (!isset($data[7])) {
+            throw new UnexpectedValueException();
+        }
+        $unpacked = unpack('E', $data);
+
+        return array_shift($unpacked);
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array|null
+     */
+    private function extractScriptTagBody(&$data)
+    {
+        $result = null;
+        $name = $this->extractScriptDataValue($data);
+        if (is_string($name)) {
+            $value = $this->extractScriptDataValue($data);
+            if (is_array($value)) {
+                $result = [$name, $value];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws \UnexpectedValueException
+     *
+     * @return mixed
+     */
+    private function extractScriptDataValue(&$data)
+    {
+        $result = null;
+        if (isset($data[0])) {
+            $type = $this->parseUI8($data[0]);
+            $data = substr($data, 1);
+            switch ($type) {
+                case 0: // Number
+                    $result = $this->extractScriptDataValue_Double($data);
+                    break;
+                case 1: // Boolean
+                    $result = $this->extractScriptDataValue_Boolean($data);
+                    break;
+                case 2: // String
+                    $result = $this->extractScriptDataValue_String($data);
+                    break;
+                case 7: // Reference
+                    $result = $this->extractScriptDataValue_UI16($data);
+                    break;
+                case 8: // ECMA array
+                    $result = $this->extractScriptDataValue_ECMAArray($data);
+                case 9: // Object end marker
+                    $result = null;
+                    break;
+                //case 3: // Object
+                //case 4: // MovieClip (reserved, not supported)
+                //case 5: // Null
+                //case 6: // Undefined
+                //case 10: // Strict array
+                //case 11: // Date
+                //case 12: // Long string
+                default:
+                    throw new UnexpectedValueException();
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return int
+     */
+    private function extractScriptDataValue_UI16(&$data)
+    {
+        $result = $this->parseUI16(substr($data, 0, 2));
+        $data = substr($data, 2);
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return float
+     */
+    private function extractScriptDataValue_Double(&$data)
+    {
+        $result = $this->parseDouble(substr($data, 0, 8));
+        $data = substr($data, 8);
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return bool
+     */
+    private function extractScriptDataValue_Boolean(&$data)
+    {
+        $result = $this->parseUI8($data[0]) !== 0;
+        $data = substr($data, 1);
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return string
+     */
+    private function extractScriptDataValue_String(&$data)
+    {
+        $stringLength = $this->parseUI16(substr($data, 0, 2));
+        $result = substr($data, 2, $stringLength);
+        $data = substr($data, 2 + $stringLength);
+
+        return $result;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @throws UnexpectedValueException
+     *
+     * @return array
+     */
+    private function extractScriptDataValue_ECMAArray(&$data)
+    {
+        $result = [];
+        if (isset($data[4])) {
+            $approximateLength = $this->parseUI32(substr($data, 0, 4));
+            $data = substr($data, 4);
+            while ($data !== '') {
+                $propertyName = $this->extractScriptDataValue_String($data);
+                $propertyValue = $this->extractScriptDataValue($data);
+                if ($propertyName === '' && $propertyValue === null) {
+                    // Object end marker
+                    break;
+                }
+                $result[$propertyName] = $propertyValue;
+            }
+        }
+
+        return $result;
     }
 }

--- a/concrete/src/File/Type/Inspector/ImageInspector.php
+++ b/concrete/src/File/Type/Inspector/ImageInspector.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;
-use Image;
 use FileAttributeKey;
-use Core;
+use Image;
 
 class ImageInspector extends Inspector
 {
@@ -24,7 +24,7 @@ class ImageInspector extends Inspector
         if (\Config::get('concrete.file_manager.images.use_exif_data_to_rotate_images')) {
             $metadata = $image->metadata();
             if (isset($metadata['ifd0.Orientation'])) {
-                \Log::info('EXIF data found: '. $metadata['ifd0.Orientation']);
+                \Log::info('EXIF data found: ' . $metadata['ifd0.Orientation']);
                 switch ($metadata['ifd0.Orientation']) {
                     case 3:
                         $image->rotate(180);

--- a/concrete/src/File/Type/Inspector/ImageInspector.php
+++ b/concrete/src/File/Type/Inspector/ImageInspector.php
@@ -3,44 +3,107 @@
 namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;
-use FileAttributeKey;
-use Image;
+use Concrete\Core\Support\Facade\Application;
+use Exception;
+use Imagine\Image\ImageInterface;
+use Throwable;
 
+/**
+ * An inspector to process image files.
+ */
 class ImageInspector extends Inspector
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\File\Type\Inspector\Inspector::inspect()
+     */
     public function inspect(Version $fv)
     {
-        $image = $fv->getImagineImage();
-        $data = $image->getSize();
+        try {
+            $image = $fv->getImagineImage() ?: null;
+        } catch (Exception $x) {
+            $image = null;
+        } catch (Throwable $x) {
+            $image = null;
+        }
+        if ($image !== null) {
+            $app = Application::getFacadeApplication();
+            $config = $app->make('config');
+            $this->updateSize($fv, $image);
+            if ($config->get('concrete.file_manager.images.use_exif_data_to_rotate_images')) {
+                $this->fixOrientation($fv, $image);
+            }
+            $fv->releaseImagineImage();
+        }
+    }
 
-        // sets an attribute - these file attribute keys should be added
-        // by the system and "reserved"
-        $at1 = FileAttributeKey::getByHandle('width');
-        $at2 = FileAttributeKey::getByHandle('height');
-        $fv->setAttribute($at1, $data->getWidth());
-        $fv->setAttribute($at2, $data->getHeight());
+    /**
+     * Update the width and height attributes of the file version starting from the image data.
+     *
+     * @param Version $fv
+     * @param ImageInterface $image
+     *
+     * @return bool true if success, false otherwise
+     */
+    private function updateSize(Version $fv, ImageInterface $image)
+    {
+        $result = false;
+        try {
+            $size = $image->getSize();
+        } catch (Exception $x) {
+            $size = null;
+        } catch (Throwable $x) {
+            $size = null;
+        }
+        if ($size !== null) {
+            $attributeCategory = $fv->getObjectAttributeCategory();
+            $atWidth = $attributeCategory->getAttributeKeyByHandle('width');
+            if ($atWidth !== null) {
+                $fv->setAttribute($atWidth, $size->getWidth());
+            }
+            $atHeight = $attributeCategory->getAttributeKeyByHandle('height');
+            if ($atHeight !== null) {
+                $fv->setAttribute($atHeight, $size->getHeight());
+            }
+            $result = true;
+        }
 
-        // Set image aspect ratio if we can.
-        if (\Config::get('concrete.file_manager.images.use_exif_data_to_rotate_images')) {
-            $metadata = $image->metadata();
-            if (isset($metadata['ifd0.Orientation'])) {
-                \Log::info('EXIF data found: ' . $metadata['ifd0.Orientation']);
-                switch ($metadata['ifd0.Orientation']) {
-                    case 3:
-                        $image->rotate(180);
-                        $fv->updateContents($image->get($fv->getExtension()));
-                        break;
-                    case 6:
-                        $image->rotate(90);
-                        $fv->updateContents($image->get($fv->getExtension()));
-                        break;
-                    case 8:
-                        $image->rotate(-90);
-                        $fv->updateContents($image->get($fv->getExtension()));
-                        break;
-                }
+        return $result;
+    }
+
+    /**
+     * Fix the orientation of the file accordingly to the EXIF metadata.
+     *
+     * @param Version $fv
+     * @param ImageInterface $image
+     *
+     * @return bool true if changed, false otherwise
+     */
+    private function fixOrientation(Version $fv, ImageInterface $image)
+    {
+        $result = false;
+        $metadata = $image->metadata();
+        if (isset($metadata['ifd0.Orientation'])) {
+            switch ($metadata['ifd0.Orientation']) {
+                case 3:
+                    $image->rotate(180);
+                    $fv->updateContents($image->get($fv->getExtension()));
+                    $result = true;
+                    break;
+                case 6:
+                    $image->rotate(90);
+                    $fv->updateContents($image->get($fv->getExtension()));
+                    $result = true;
+                    break;
+                case 8:
+                    $image->rotate(-90);
+                    $fv->updateContents($image->get($fv->getExtension()));
+                    $result = true;
+                    break;
             }
         }
-        $fv->releaseImagineImage();
+
+        return $result;
     }
 }

--- a/concrete/src/File/Type/Inspector/Inspector.php
+++ b/concrete/src/File/Type/Inspector/Inspector.php
@@ -4,7 +4,16 @@ namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;
 
+/**
+ * Abstract class that all the file inspectors must extend.
+ */
 abstract class Inspector
 {
+    /**
+     * This method is called when a File\Version class refreshes its attributes.
+     * This can be used to update the File\Version attributes as well as its contents.
+     *
+     * @param \Concrete\Core\Entity\File\Version $fv
+     */
     abstract public function inspect(Version $fv);
 }

--- a/concrete/src/File/Type/Inspector/Inspector.php
+++ b/concrete/src/File/Type/Inspector/Inspector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\File\Type\Inspector;
 
 use Concrete\Core\Entity\File\Version;


### PR DESCRIPTION
- add PHPDoc to File inspectors
- get rid of reprecated methods
- don't die in case of errors (missing attributes, failure to inspect the image size, ...)

Bonus track: even if I don't think that someone still uses it, I fixed the FLV inspector (it gave me totally random values for the width/height/duration)