### PR TITLE
Improve performance of file manager

### DIFF
--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -185,6 +185,8 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         $u = new User();
         // Super user can access all files
         if (!$u->isSuperUser()) {
+            $query->leftJoin('tf', 'Files', 'f', 'tf.fID = f.fID');
+
             $pk = FileFolderKey::getByHandle('search_file_folder');
             if (is_object($pk)) {
                 /** @var PermissionAccess $pa */
@@ -201,12 +203,11 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
                     // Can't access without "File Uploader" entity?
                     if (!$pa->validateAccessEntities($validateEntities)) {
                         $query
-                            ->leftJoin('tf', 'Files', 'f', 'tf.fID = f.fID')
-                            ->andWhere('f.uID = :fileUploaderID OR n.treeNodeOverridePermissions = 1')
+                            ->andWhere('(f.uID = :fileUploaderID OR f.fOverrideSetPermissions = 1) OR nt.treeNodeTypeHandle != \'file\'')
                             ->setParameter('fileUploaderID', $u->getUserID());
                     }
                 } else {
-                    $query->andWhere('n.treeNodeOverridePermissions = 1');
+                    $query->andWhere('f.fOverrideSetPermissions = 1 OR nt.treeNodeTypeHandle != \'file\'');
                 }
             }
         }

--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -155,16 +155,14 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
 
     public function deliverQueryObject()
     {
-        if (isset($this->parent)) {
-            $parent = $this->parent;
-        } else {
+        if (!isset($this->parent)) {
             $filesystem = new Filesystem();
-            $parent = $filesystem->getRootFolder();
+            $this->parent = $filesystem->getRootFolder();
         }
 
         if ($this->searchSubFolders) {
             // determine how many subfolders are within the parent folder.
-            $subFolders = $parent->getHierarchicalNodesOfType('file_folder', 1, false, true);
+            $subFolders = $this->parent->getHierarchicalNodesOfType('file_folder', 1, false, true);
             $subFolderIds = array();
             foreach($subFolders as $subFolder) {
                 $subFolderIds[] = $subFolder['treeNodeID'];
@@ -174,7 +172,7 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
             );
         } else {
             $this->query->andWhere('n.treeNodeParentID = :treeNodeParentID');
-            $this->query->setParameter('treeNodeParentID', $parent->getTreeNodeID());
+            $this->query->setParameter('treeNodeParentID', $this->parent->getTreeNodeID());
         }
 
         return parent::deliverQueryObject();
@@ -187,6 +185,7 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         if (!$u->isSuperUser()) {
             $pk = FileFolderKey::getByHandle('search_file_folder');
             if (is_object($pk)) {
+                $pk->setPermissionObject($this->parent);
                 /** @var PermissionAccess $pa */
                 $pa = $pk->getPermissionAccessObject();
                 // Whether or not current user can access the file manager


### PR DESCRIPTION
I'm building a website that has 200+ editors. Each editor can upload files to the file manager, but they can search only files that uploaded by themselves. 2k+ files are already uploaded to the file manager.

Now, the file manager is extremely slow. The reason is new `PagerAdapter`. Let me clear the recent change of Pager class.

Before: Get 1k items, then check permission of each items, then slice
After: Get 10 items, then check permission of each items. If the number of result is less than 10 items, get more 10 items repeatedly.

The new style should improve performance in the case "The user can access almost all of files". However, it generate a lot of queries and decrease performance in the case "The user can't access almost all of files".

For example, if the current user can only 1 file that uploaded by him, concrete5 will get 2k files and check permission of 2k files! It's worse than old way.

IMO, we can fix this issue easily, just add where query to care the case "The user can't access almost all of files". With this PR, the performance of file manager is improved for me.

![improve performance of folderitemlist 1](https://user-images.githubusercontent.com/514294/34076791-ad24f91a-e334-11e7-9948-413960a9e9a8.png)
