### PR TITLE
Resolve #6178; Add search for forms in Form Results section

### DIFF
--- a/concrete/controllers/element/dashboard/reports/forms/header.php
+++ b/concrete/controllers/element/dashboard/reports/forms/header.php
@@ -2,19 +2,22 @@
 namespace Concrete\Controller\Element\Dashboard\Reports\Forms;
 
 use Concrete\Core\Controller\ElementController;
+use Concrete\Core\Entity\Express\Entity;
 
 class Header extends ElementController
 {
     protected $nodeId;
+    protected $entity;
 
     /**
      * Header constructor.
      *
      * @param $nodeId
      */
-    public function __construct($nodeId)
+    public function __construct($nodeId, Entity $entity = null)
     {
         parent::__construct();
+        $this->entity = $entity;
         $this->nodeId = $nodeId;
     }
 
@@ -26,10 +29,17 @@ class Header extends ElementController
     public function view()
     {
         $db = \Database::connection();
-        $this->set('supportsLegacy', $db->tableExists('btFormQuestions'));
-
-        if ($this->nodeId) {
+        if ($this->entity) {
+            $this->set('entity', $this->entity);
             $this->set('exportURL', \URL::to('/dashboard/express/entries', 'csv_export', $this->nodeId));
+            $managePage = \Page::getByPath('/dashboard/system/express/entities');
+            $permissions = new \Permissions($managePage);
+            if ($permissions->canViewPage()) {
+                $this->set('manageURL', \URL::to('/dashboard/system/express/entities', 'view_entity', $this->entity->getID()));
+            }
+
+        } else {
+            $this->set('supportsLegacy', $db->tableExists('btFormQuestions'));
         }
     }
 }

--- a/concrete/controllers/single_page/dashboard/express/entries.php
+++ b/concrete/controllers/single_page/dashboard/express/entries.php
@@ -20,7 +20,12 @@ class Entries extends DashboardExpressEntityPageController
 
     public function getEntity(\Concrete\Core\Tree\Node\Type\ExpressEntryResults $parent = null)
     {
-        return $this->entity;
+        if ($this->entity) {
+            return $this->entity;
+        } else {
+            return $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entity')
+                ->findOneByResultsNode($parent);
+        }
     }
 
     protected function getBackURL(Entity $entity)

--- a/concrete/controllers/single_page/dashboard/reports/forms.php
+++ b/concrete/controllers/single_page/dashboard/reports/forms.php
@@ -19,7 +19,14 @@ class Forms extends DashboardExpressEntriesPageController
 
     public function view($folder = null)
     {
-        $this->set('headerMenu', new Header($folder));
+        if ($folder) {
+            $parent = $this->getParentNode($folder);
+            $entity = $this->getEntity($parent);
+            $this->set('headerMenu', new Header($folder, $entity));
+        } else {
+            $this->set('headerMenu', new Header($folder));
+
+        }
         $this->renderList($folder);
     }
 }

--- a/concrete/elements/dashboard/reports/forms/header.php
+++ b/concrete/elements/dashboard/reports/forms/header.php
@@ -1,11 +1,49 @@
-<?php
-defined('C5_EXECUTE') or die("Access Denied.");
-?>
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-<?php if (!empty($exportURL)): ?>
-    <a class="btn btn-default" href="<?=$exportURL?>"><i class="fa fa-download"></i> <?=t('Export to CSV') ?></a>
-<?php endif ?>
+<?php if (isset($entity)) { ?>
 
-<?php if (!empty($supportsLegacy)): ?>
-    <a href="<?=URL::to('/dashboard/reports/forms/legacy')?>" class="btn btn-default"><?=t('Legacy Forms')?></a>
-<?php endif ?>
+    <div class="ccm-header-search-form ccm-ui" data-header="express-search">
+        <form method="get" action="<?php echo URL::to('/ccm/system/search/express/basic')?>?exEntityID=<?=$entity->getID()?>">
+            <div class="input-group">
+
+                <div class="ccm-header-search-form-input">
+                    <a class="ccm-header-reset-search" href="#"
+                       data-button-action-url="<?= URL::to('/ccm/system/search/express/clear') ?>?exEntityID=<?=$entity->getID()?>"
+                       data-button-action="clear-search"><?= t('Reset Search') ?></a>
+                    <a class="ccm-header-launch-advanced-search"
+                       href="<?php echo URL::to('/ccm/system/dialogs/express/advanced_search')?>?exEntityID=<?=$entity->getID()?>"
+                       data-launch-dialog="advanced-search"><?= t('Advanced') ?></a>
+                    <input type="text" class="form-control" autocomplete="off" name="eKeywords"
+                           placeholder="<?= t('Search') ?>">
+                </div>
+
+                  <span class="input-group-btn">
+                    <button class="btn btn-info" type="submit"><i class="fa fa-search"></i></button>
+                  </span>
+            </div>
+
+            <ul class="ccm-header-search-navigation">
+                <li>
+                    <a href="<?= $exportURL ?>">
+                        <i class="fa fa-download"></i> <?= t('Export to CSV') ?>
+                    </a>
+                </li>
+                <?php if ($manageURL) { ?>
+                <li>
+                    <a href="<?= $manageURL ?>">
+                        <i class="fa fa-cog"></i> <?= t('Manage Data Object') ?>
+                    </a>
+                </li>
+                <?php } ?>
+            </ul>
+
+        </form>
+    </div>
+
+ <?php } else { ?>
+
+    <?php if (!empty($supportsLegacy)): ?>
+        <a href="<?=URL::to('/dashboard/reports/forms/legacy')?>" class="btn btn-default"><?=t('Legacy Forms')?></a>
+    <?php endif ?>
+
+<?php } ?>

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -111,7 +111,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
      *
      * @return \Concrete\Core\Entity\Express\Entity
      */
-    private function getEntity(\Concrete\Core\Tree\Node\Type\ExpressEntryResults $parent)
+    protected function getEntity(\Concrete\Core\Tree\Node\Type\ExpressEntryResults $parent)
     {
         return $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entity')
             ->findOneByResultsNode($parent);
@@ -321,7 +321,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
     /**
      * @param $treeNodeParentID
      */
-    private function getParentNode($treeNodeParentID)
+    protected function getParentNode($treeNodeParentID)
     {
         $parent = null;
         if ($treeNodeParentID) {


### PR DESCRIPTION
This does a few things: 

1. It shows a link over to the Express Data Object from the detail page of the form you're looking at, making it clearer as to where to go to clean up data, etc...

2. Enables the new express form search for form results, which had been missing:

![screen shot 2017-12-19 at 11 50 34 am](https://user-images.githubusercontent.com/527809/34175908-d8c011c0-e4b2-11e7-854c-39ca0c778a85.png)
