### PR TITLE
Register assets from copied block

### DIFF
--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -142,6 +142,15 @@ class Controller extends BlockController
         }
     }
 
+    public function registerViewAssets($outputContent = '')
+    {
+        $bc = $this->getScrapbookBlockController();
+
+        if (is_object($bc) && is_callable(array($bc, 'registerViewAssets'))) {
+            $bc->registerViewAssets($outputContent);
+        }
+    }
+
     public function on_page_view($page)
     {
         $bc = $this->getScrapbookBlockController();


### PR DESCRIPTION
Blocks that register assets break when pasted from the clipboard after reload. By calling registerViewAssets (if available) this is solved.