### PR TITLE
Fix exception accessing /login with mobile theme switching enabled using a mobile device

### DIFF
--- a/concrete/src/Html/Image.php
+++ b/concrete/src/Html/Image.php
@@ -15,7 +15,11 @@ class Image
     {
         $c = \Page::getCurrentPage();
         if (is_object($c)) {
-            $th = PageTheme::getByHandle($c->getPageController()->getTheme());
+            $pt = $c->getPageController()->getTheme();
+            if (is_object($pt)) {
+                $pt = $pt->getThemeHandle();
+            }
+            $th = PageTheme::getByHandle($pt);
             if (is_object($th)) {
                 $this->theme = $th;
                 $this->usePictureTag = count($th->getThemeResponsiveImageMap()) > 0;


### PR DESCRIPTION
As detailed in my bug report <http://www.concrete5.org/developers/bugs/8-3-1/exception-on-login-page-when-mobile-theme-switcher-is-active-and>, if mobile theme switching is enabled, and you visit the login page on a mobile device, an exception is raised, because in this case a theme object is returned and fed into an SQL query. Simple fix which extracts the theme handle and uses that instead.