### PR TITLE
Add EntityManagerInterface::find support to .phpstorm.meta.php

### DIFF
--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -103,6 +103,7 @@ class MetadataGenerator
             }
             $output = array_merge($output, $this->getOverride('\Doctrine\ORM\EntityManagerInterface::getRepository(0)', $getRepositoryMethod, '$em->getRepository(EntityClass::class)'));
         }
+        $output = array_merge($output, $this->getOverride('\Doctrine\ORM\EntityManagerInterface::find(0)', ['' => "'@'"], '$em->find(EntityClass::class, $id)'));
 
         return implode("\n", $output);
     }


### PR DESCRIPTION
What about suggesting the IDE that the result of `$em->find(EntityClass::class)` is an instance of `EntityClass`?

PS: this will help developers using PHPStorm or Eclipse+[concrete5 plugin](https://mlocati.github.io/concrete5-eclipse-plugin/), provided that they run the `c5:ide-symbols` CLI command.