### PR TITLE
Allow using DI to get the configured Image library

### DIFF
--- a/concrete/src/File/FileServiceProvider.php
+++ b/concrete/src/File/FileServiceProvider.php
@@ -25,8 +25,23 @@ class FileServiceProvider extends ServiceProvider
 
         $this->app->singleton(\Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService::class);
 
-        $this->app->bind('image/imagick', '\Imagine\Imagick\Imagine');
-        $this->app->bind('image/gd', '\Imagine\Gd\Imagine');
+        $this->app->bind('image/imagick', \Imagine\Imagick\Imagine::class);
+        $this->app->bind('image/gd', \Imagine\Gd\Imagine::class);
+        $this->app->bind(\Imagine\Image\ImagineInterface::class, function (Application $app) {
+            $config = $app->make('config');
+            $libraryHandle = $config->get('concrete.file_manager.images.manipulation_library');
+            switch ($libraryHandle) {
+                case 'imagick':
+                    $abstract = 'image/imagick';
+                    break;
+                case 'gd':
+                default:
+                    $abstract = 'image/gd';
+                    break;
+            }
+
+            return $app->make($abstract);
+        });
         $this->app->bind('image/thumbnailer', '\Concrete\Core\File\Image\BasicThumbnailer');
 
         $this->app->bind(StorageLocationInterface::class, function ($app) {

--- a/concrete/src/File/FileServiceProvider.php
+++ b/concrete/src/File/FileServiceProvider.php
@@ -1,22 +1,23 @@
 <?php
+
 namespace Concrete\Core\File;
 
+use Concrete\Core\Application\Application;
 use Concrete\Core\File\StorageLocation\StorageLocation;
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
-use Concrete\Core\Application\Application;
 
 class FileServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $singletons = array(
+        $singletons = [
             'helper/file' => '\Concrete\Core\File\Service\File',
             'helper/concrete/file' => '\Concrete\Core\File\Service\Application',
             'helper/image' => '\Concrete\Core\File\Image\BasicThumbnailer',
             'helper/mime' => '\Concrete\Core\File\Service\Mime',
             'helper/zip' => '\Concrete\Core\File\Service\Zip',
-        );
+        ];
 
         foreach ($singletons as $key => $value) {
             $this->app->singleton($key, $value);
@@ -28,7 +29,7 @@ class FileServiceProvider extends ServiceProvider
         $this->app->bind('image/gd', '\Imagine\Gd\Imagine');
         $this->app->bind('image/thumbnailer', '\Concrete\Core\File\Image\BasicThumbnailer');
 
-        $this->app->bind(StorageLocationInterface::class, function($app) {
+        $this->app->bind(StorageLocationInterface::class, function ($app) {
             return StorageLocation::getDefault();
         });
 

--- a/concrete/src/Support/Facade/Image.php
+++ b/concrete/src/Support/Facade/Image.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Support\Facade;
 
 class Image extends Facade

--- a/concrete/src/Support/Facade/Image.php
+++ b/concrete/src/Support/Facade/Image.php
@@ -2,16 +2,12 @@
 
 namespace Concrete\Core\Support\Facade;
 
+use Imagine\Image\ImagineInterface;
+
 class Image extends Facade
 {
     public static function getFacadeAccessor()
     {
-        $library = \Config::get('concrete.file_manager.images.manipulation_library');
-        switch ($library) {
-            case 'gd':
-                return 'image/gd';
-            case 'imagick':
-                return 'image/imagick';
-        }
+        return ImagineInterface::class;
     }
 }


### PR DESCRIPTION
To retrieve the currently defined image library we currently have these options:
1. use the Image facade
2. manually check the `concrete.file_manager.images.manipulation_library` configuration key

What about simplifying our life simply by calling
```php
$app->make(\Imagine\Image\ImagineInterface::class);
```
(that would also allow us to use `ImagineInterface` with dependency iniection).