### PR TITLE
Fixed Youtube block video issues with showinfo and loop.

### DIFF
--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -43,6 +43,9 @@ if (isset($iv_load_policy) && $iv_load_policy > 0) {
 
 if (isset($loopEnd) && $loopEnd) {
     $params[] = 'loop=1';
+    if (!isset($playlist) && $videoID !== '') {
+        $params[] = 'playlist='.$videoID;
+    }
 }
 
 if (isset($modestbranding) && $modestbranding) {

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -57,6 +57,8 @@ if (isset($rel) && $rel) {
 
 if (isset($showinfo) && $showinfo) {
     $params[] = 'showinfo=1';
+} else {
+    $params[] = 'showinfo=0';
 }
 
 $paramstring = '?' . implode('&', $params);


### PR DESCRIPTION
This small change just forces the parameter show info to be set to 0 when disabling show video information. Currently if you disable show video information, it will still show video information.

I also updated the loop parameter to work correctly according to the YouTube documents ( https://developers.google.com/youtube/player_parameters#loop ) regarding single videos.
  