### PR TITLE
Fixed users being able to delete core and active themes.

### DIFF
--- a/concrete/controllers/single_page/dashboard/pages/themes.php
+++ b/concrete/controllers/single_page/dashboard/pages/themes.php
@@ -58,21 +58,29 @@ class Themes extends DashboardPageController
 
     public function remove($pThemeID, $token = '')
     {
-        $v = Loader::helper('validation/error');
+
         try {
             $valt = Loader::helper('validation/token');
             if (!$valt->validate('remove', $token)) {
                 throw new Exception($valt->getErrorMessage());
             }
+            /** @var \Concrete\Core\Page\Theme\Theme $pl */
             $pl = PageTheme::getByID($pThemeID);
             if (!is_object($pl)) {
                 throw new Exception(t('Invalid theme.'));
             }
-            /*
-            if ($pl->getPackageID() > 0) {
-                throw new Exception('You may not uninstall a packaged theme.');
+
+            if (!$pl->isUninstallable()) {
+                throw new Exception(t('You can not uninstall a core theme'));
             }
-            */
+            $obj = PageTheme::getSiteTheme();
+            if (is_object($obj)) {
+                $siteThemeID = $obj->getThemeID();
+            }
+            if ($siteThemeID === $pl->getThemeID()) {
+                 throw new Exception(t('You can not unistall an active theme'));
+            }
+
 
             $localUninstall = true;
             if ($pl->getPackageID() > 0) {
@@ -92,8 +100,7 @@ class Themes extends DashboardPageController
             }
             $this->set('message', t('Theme uninstalled.'));
         } catch (Exception $e) {
-            $v->add($e);
-            $this->set('error', $v);
+            $this->error->add($e);
         }
         $this->view();
     }

--- a/concrete/controllers/single_page/dashboard/pages/themes.php
+++ b/concrete/controllers/single_page/dashboard/pages/themes.php
@@ -78,7 +78,7 @@ class Themes extends DashboardPageController
                 $siteThemeID = $obj->getThemeID();
             }
             if ($siteThemeID === $pl->getThemeID()) {
-                 throw new Exception(t('You can not unistall an active theme'));
+                 throw new Exception(t('You can not uninstall an active theme'));
             }
 
 

--- a/concrete/single_pages/dashboard/pages/themes/view.php
+++ b/concrete/single_pages/dashboard/pages/themes/view.php
@@ -58,7 +58,7 @@ if (isset($activate_confirm)) {
                             }
                 echo $bt->button(t('Page Templates'), $view->url('/dashboard/pages/themes/inspect', $t->getThemeID()), 'left');
                 if ($siteThemeID == $t->getThemeID()) {
-                    echo $bt->button(t('Remove'), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger', array('disabled' => 'disabled'));
+                    echo $bt->button(t('Remove'), '', 'right', 'btn-danger', array('disabled' => 'disabled'));
                 } else {
                     echo $bt->button(t('Remove'), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger');
                 }


### PR DESCRIPTION
Currently in concrete5 in the themes page in the dashboard it is possible to delete the active theme (or core themes) by just clicking on remove (works on chrome 63) even though it is shown as disabled it is not disabled. if a theme removal fails no error message is shown.

This pull requests removes the ability for users to be able to delete core themes and active site themes. This also fixes the issue with no error messages being shown on the theme page if an uninstall fails.

