### PR TITLE
Scan the SRC directory within the application for translatable strings

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -84,7 +84,6 @@ const NAMESPACE_SEGMENT_VENDOR = 'Concrete';
  * Directory names
  * ----------------------------------------------------------------------------
  */
-const DIRNAME_SRC = 'src';
 const DIRNAME_BLOCKS = 'blocks';
 const DIRNAME_PAGES = 'single_pages';
 const DIRNAME_VIEWS = 'views';

--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -84,6 +84,7 @@ const NAMESPACE_SEGMENT_VENDOR = 'Concrete';
  * Directory names
  * ----------------------------------------------------------------------------
  */
+const DIRNAME_SRC = 'src';
 const DIRNAME_BLOCKS = 'blocks';
 const DIRNAME_PAGES = 'single_pages';
 const DIRNAME_VIEWS = 'views';

--- a/concrete/src/Multilingual/Service/Extractor.php
+++ b/concrete/src/Multilingual/Service/Extractor.php
@@ -47,6 +47,7 @@ class Extractor
             DIRNAME_PAGES => [$phpParser],
             DIRNAME_THEMES => [$phpParser, $themesPresetsParser, $blockTemplatesParser],
             DIRNAME_VIEWS => [$phpParser],
+            DIRNAME_SRC => [$phpParser]
         ];
         foreach ($processApplication as $dirname => $parsers) {
             if (is_dir(DIR_APPLICATION.'/'.$dirname)) {

--- a/concrete/src/Multilingual/Service/Extractor.php
+++ b/concrete/src/Multilingual/Service/Extractor.php
@@ -47,7 +47,7 @@ class Extractor
             DIRNAME_PAGES => [$phpParser],
             DIRNAME_THEMES => [$phpParser, $themesPresetsParser, $blockTemplatesParser],
             DIRNAME_VIEWS => [$phpParser],
-            DIRNAME_SRC => [$phpParser]
+            DIRNAME_CLASSES => [$phpParser]
         ];
         foreach ($processApplication as $dirname => $parsers) {
             if (is_dir(DIR_APPLICATION.'/'.$dirname)) {


### PR DESCRIPTION
Some translation requirements could be in service code i.e. a form builder 

```php
application/src/Forms

$builder->add('input', InputType::Text, ['placeholder' => t('hello world')]);
```

Adding this scan would be a nice little enhancement
  