### PR TITLE
Fix storing/reading cache item about last available version

### DIFF
--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -81,10 +81,13 @@ class Update
         $r = $cache->getItem('APP_UPDATE_INFO');
         if ($r->isMiss()) {
             $r->lock();
-            $r->set(static::getLatestAvailableUpdate());
+            $result = static::getLatestAvailableUpdate();
+            $r->set($result)->save();
+        } else {
+            $result = $r->get();
         }
 
-        return $r->get();
+        return $result;
     }
 
     /**


### PR DESCRIPTION
The current "check for updates" dashboard page doesn't report the latest version because of a bug in the cache reading/writing process: let's fix this.