### PR TITLE
Asset refactoring

### DIFF
--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -10,93 +10,124 @@ use Symfony\Component\HttpFoundation\Response;
 abstract class Asset implements AssetInterface
 {
     /**
+     * The location of the asset (used to build the path & URL).
+     *
      * @var string
      */
     protected $location;
 
     /**
+     * Does the URL/path have already been resolved (starting from the location) for this (local) assets?
+     *
      * @var bool
      */
     protected $assetHasBeenMapped = false;
 
     /**
+     * The asset version.
+     *
      * @var string
      */
     protected $assetVersion = '0';
 
     /**
+     * The handle of this asset (together with getAssetType, identifies this asset).
+     *
      * @var string
      */
     protected $assetHandle;
 
     /**
+     * Is this asset a locally available file (accessible with the getAssetPath method)?
+     *
      * @var bool
      */
     protected $local = true;
 
     /**
+     * The name of the file of this asset.
+     *
      * @var string
      */
     protected $filename;
 
     /**
+     * The URL of this asset.
+     *
      * @var string
      */
     protected $assetURL;
 
     /**
+     * The path to this asset.
+     *
      * @var string
      */
     protected $assetPath;
 
     /**
+     * Does this asset support minification?
+     *
      * @var bool
      */
     protected $assetSupportsMinification = false;
 
     /**
+     * Can this asset be combined with other assets?
+     *
      * @var bool
      */
     protected $assetSupportsCombination = false;
 
     /**
-     * @var \Package
+     * The package that defines this asset.
+     *
+     * @var \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|null
      */
     protected $pkg;
 
     /**
+     * The URL of the source files this asset has been built from (useful to understand the origin of this asset).
+     *
      * @var array
      */
     protected $combinedAssetSourceFiles = [];
 
     /**
-     * @param bool|string $assetHandle
+     * Initialize the instance.
+     *
+     * @param string $assetHandle the handle of this asset (together with getAssetType, identifies this asset)
      */
-    public function __construct($assetHandle = false)
+    public function __construct($assetHandle = '')
     {
-        $this->assetHandle = $assetHandle;
+        $this->assetHandle = (string) $assetHandle;
         $this->position = $this->getAssetDefaultPosition();
     }
 
     /**
-     * @param Asset[] $assets
+     * {@inheritdoc}
      *
-     * @return Asset[]
-     *
-     * @abstract
+     * @see \Concrete\Core\Asset\AssetInterface::process()
      */
     public static function process($assets)
     {
         return $assets;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getOutputAssetType()
+     */
     public function getOutputAssetType()
     {
         return $this->getAssetType();
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::assetSupportsMinification()
      */
     public function assetSupportsMinification()
     {
@@ -104,7 +135,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::assetSupportsCombination()
      */
     public function assetSupportsCombination()
     {
@@ -112,7 +145,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param mixed $location
+     * Set the location of this asset.
+     *
+     * @param string $location
      */
     public function setAssetLocation($location)
     {
@@ -120,7 +155,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param bool $minify
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetSupportsMinification()
      */
     public function setAssetSupportsMinification($minify)
     {
@@ -128,7 +165,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param bool $combine
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetSupportsCombination()
      */
     public function setAssetSupportsCombination($combine)
     {
@@ -136,7 +175,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetURL()
      */
     public function getAssetURL()
     {
@@ -148,7 +189,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetHashKey()
      */
     public function getAssetHashKey()
     {
@@ -173,6 +216,11 @@ abstract class Asset implements AssetInterface
         return $result;
     }
 
+    /**
+     * Get an AssetPointer instance that identifies this asset.
+     *
+     * @return \Concrete\Core\Asset\AssetPointer
+     */
     public function getAssetPointer()
     {
         $pointer = new AssetPointer($this->getAssetType(), $this->getAssetHandle());
@@ -181,7 +229,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetPath()
      */
     public function getAssetPath()
     {
@@ -193,7 +243,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetHandle()
      */
     public function getAssetHandle()
     {
@@ -201,7 +253,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetFilename()
      */
     public function getAssetFilename()
     {
@@ -209,7 +263,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param string $version
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetVersion()
      */
     public function setAssetVersion($version)
     {
@@ -217,7 +273,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param array $paths
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setCombinedAssetSourceFiles()
      */
     public function setCombinedAssetSourceFiles($paths)
     {
@@ -225,7 +283,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetVersion()
      */
     public function getAssetVersion()
     {
@@ -233,7 +293,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param string $position
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetPosition()
      */
     public function setAssetPosition($position)
     {
@@ -241,7 +303,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param \Package $pkg
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setPackageObject()
      */
     public function setPackageObject($pkg)
     {
@@ -249,7 +313,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param string $url
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetURL()
      */
     public function setAssetURL($url)
     {
@@ -258,7 +324,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param string $path
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetPath()
      */
     public function setAssetPath($path)
     {
@@ -272,7 +340,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetURLPath()
      */
     public function getAssetURLPath()
     {
@@ -280,7 +350,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::isAssetLocal()
      */
     public function isAssetLocal()
     {
@@ -288,7 +360,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param bool $isLocal
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::setAssetIsLocal()
      */
     public function setAssetIsLocal($isLocal)
     {
@@ -296,7 +370,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetPosition()
      */
     public function getAssetPosition()
     {
@@ -304,7 +380,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @param string $path
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::mapAssetLocation()
      */
     public function mapAssetLocation($path)
     {
@@ -323,7 +401,9 @@ abstract class Asset implements AssetInterface
     }
 
     /**
-     * @return string|null
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::getAssetContents()
      */
     public function getAssetContents()
     {
@@ -332,6 +412,11 @@ abstract class Asset implements AssetInterface
         return ($result === false) ? null : $result;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\AssetInterface::register()
+     */
     public function register($filename, $args, $pkg = false)
     {
         if ($pkg != false) {
@@ -357,6 +442,8 @@ abstract class Asset implements AssetInterface
     }
 
     /**
+     * Get the contents of an asset given its route.
+     *
      * @param string $route
      *
      * @return string|null

--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Asset;
 
 use Concrete\Core\Package\Package;
@@ -8,6 +9,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class Asset implements AssetInterface
 {
+    const ASSET_POSITION_HEADER = 'H';
+
+    const ASSET_POSITION_FOOTER = 'F';
+
     /**
      * @var string
      */
@@ -68,12 +73,13 @@ abstract class Asset implements AssetInterface
      */
     protected $combinedAssetSourceFiles = [];
 
-    const ASSET_POSITION_HEADER = 'H';
-    const ASSET_POSITION_FOOTER = 'F';
-
-    public function getOutputAssetType()
+    /**
+     * @param bool|string $assetHandle
+     */
+    public function __construct($assetHandle = false)
     {
-        return $this->getAssetType();
+        $this->assetHandle = $assetHandle;
+        $this->position = $this->getAssetDefaultPosition();
     }
 
     /**
@@ -86,6 +92,11 @@ abstract class Asset implements AssetInterface
     public static function process($assets)
     {
         return $assets;
+    }
+
+    public function getOutputAssetType()
+    {
+        return $this->getAssetType();
     }
 
     /**
@@ -191,15 +202,6 @@ abstract class Asset implements AssetInterface
     public function getAssetHandle()
     {
         return $this->assetHandle;
-    }
-
-    /**
-     * @param bool|string $assetHandle
-     */
-    public function __construct($assetHandle = false)
-    {
-        $this->assetHandle = $assetHandle;
-        $this->position = $this->getAssetDefaultPosition();
     }
 
     /**
@@ -334,6 +336,30 @@ abstract class Asset implements AssetInterface
         return ($result === false) ? null : $result;
     }
 
+    public function register($filename, $args, $pkg = false)
+    {
+        if ($pkg != false) {
+            if ($pkg !== false && is_string($pkg)) {
+                $pkg = Package::getByHandle($pkg);
+            }
+            $this->setPackageObject($pkg);
+        }
+        $this->setAssetIsLocal($args['local']);
+        $this->setAssetLocation($filename);
+        if ($args['minify'] === true || $args['minify'] === false) {
+            $this->setAssetSupportsMinification($args['minify']);
+        }
+        if ($args['combine'] === true || $args['combine'] === false) {
+            $this->setAssetSupportsCombination($args['combine']);
+        }
+        if ($args['version']) {
+            $this->setAssetVersion($args['version']);
+        }
+        if ($args['position']) {
+            $this->setAssetPosition($args['position']);
+        }
+    }
+
     /**
      * @param string $route
      *
@@ -397,29 +423,5 @@ abstract class Asset implements AssetInterface
         }
 
         return $result;
-    }
-
-    public function register($filename, $args, $pkg = false)
-    {
-        if ($pkg != false) {
-            if ($pkg !== false && is_string($pkg)) {
-                $pkg = Package::getByHandle($pkg);
-            }
-            $this->setPackageObject($pkg);
-        }
-        $this->setAssetIsLocal($args['local']);
-        $this->setAssetLocation($filename);
-        if ($args['minify'] === true || $args['minify'] === false) {
-            $this->setAssetSupportsMinification($args['minify']);
-        }
-        if ($args['combine'] === true || $args['combine'] === false) {
-            $this->setAssetSupportsCombination($args['combine']);
-        }
-        if ($args['version']) {
-            $this->setAssetVersion($args['version']);
-        }
-        if ($args['position']) {
-            $this->setAssetPosition($args['position']);
-        }
     }
 }

--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -9,10 +9,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class Asset implements AssetInterface
 {
-    const ASSET_POSITION_HEADER = 'H';
-
-    const ASSET_POSITION_FOOTER = 'F';
-
     /**
      * @var string
      */

--- a/concrete/src/Asset/AssetInterface.php
+++ b/concrete/src/Asset/AssetInterface.php
@@ -50,11 +50,32 @@ interface AssetInterface
     public function getAssetDefaultPosition();
 
     /**
+     * Set the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     *
+     * @param string $position
+     */
+    public function setAssetPosition($position);
+
+    /**
+     * Get the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     *
+     * @return string
+     */
+    public function getAssetPosition();
+
+    /**
      * Get the unique identifier of the asset type.
      *
      * @return string
      */
     public function getAssetType();
+
+    /**
+     * Get the handle of this asset (together with getAssetType, identifies this asset).
+     *
+     * @return string
+     */
+    public function getAssetHandle();
 
     /**
      * Get the resulting type of the asset (\Concrete\Core\Asset\AssetInterface::OUTPUTASSETTYPE_CSS, \Concrete\Core\Asset\AssetInterface::OUTPUTASSETTYPE_JAVASCRIPT or other values).
@@ -64,15 +85,25 @@ interface AssetInterface
     public function getOutputAssetType();
 
     /**
-     * Asset-type specific post-processing.
+     * Is this asset a locally available file (accessible with the getAssetPath method)?
      *
-     * @param \Concrete\Core\Asset\AssetInterface[] $assets The original assets
-     *
-     * @return \Concrete\Core\Asset\AssetInterface[] The final assets
-     *
-     * @example Compress JavaScripts, merge CSS files...
+     * @param bool $isLocal
      */
-    public static function process($assets);
+    public function setAssetIsLocal($isLocal);
+
+    /**
+     * Is this asset a locally available file (accessible with the getAssetPath method)?
+     *
+     * @return bool
+     */
+    public function isAssetLocal();
+
+    /**
+     * Does this asset support minification?
+     *
+     * @param bool $minify
+     */
+    public function setAssetSupportsMinification($minify);
 
     /**
      * Does this asset support minification?
@@ -84,93 +115,16 @@ interface AssetInterface
     /**
      * Can this asset be combined with other assets?
      *
-     * @return bool
-     */
-    public function assetSupportsCombination();
-
-    /**
-     * Does this asset support minification?
-     *
-     * @param bool $minify
-     */
-    public function setAssetSupportsMinification($minify);
-
-    /**
-     * Can this asset be combined with other assets?
-     *
      * @param bool $combine
      */
     public function setAssetSupportsCombination($combine);
 
     /**
-     * Get the URL of this asset.
+     * Can this asset be combined with other assets?
      *
-     * @return string
+     * @return bool
      */
-    public function getAssetURL();
-
-    /**
-     * Get a string that unambiguously identifies this asset.
-     *
-     * @return string
-     */
-    public function getAssetHashKey();
-
-    /**
-     * Get the path to this asset.
-     *
-     * @return string
-     */
-    public function getAssetPath();
-
-    /**
-     * Get the handle of this asset (together with getAssetType, identifies this asset).
-     *
-     * @return string
-     */
-    public function getAssetHandle();
-
-    /**
-     * Get the name of the file of this asset.
-     *
-     * @return string
-     */
-    public function getAssetFilename();
-
-    /**
-     * Set the version of this asset.
-     *
-     * @param string $version
-     */
-    public function setAssetVersion($version);
-
-    /**
-     * Set the URL of the source files this asset has been built from (useful to understand the origin of this asset).
-     *
-     * @param string[] $paths
-     */
-    public function setCombinedAssetSourceFiles($paths);
-
-    /**
-     * Get the version of this asset.
-     *
-     * @return string
-     */
-    public function getAssetVersion();
-
-    /**
-     * Set the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
-     *
-     * @param string $position
-     */
-    public function setAssetPosition($position);
-
-    /**
-     * Set the package that defines this asset.
-     *
-     * @param \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|null|false $pkg
-     */
-    public function setPackageObject($pkg);
+    public function assetSupportsCombination();
 
     /**
      * Set the URL of this asset.
@@ -180,6 +134,13 @@ interface AssetInterface
     public function setAssetURL($url);
 
     /**
+     * Get the URL of this asset.
+     *
+     * @return string
+     */
+    public function getAssetURL();
+
+    /**
      * Set the path to this asset.
      *
      * @param string $path
@@ -187,32 +148,11 @@ interface AssetInterface
     public function setAssetPath($path);
 
     /**
-     * Get the path of the parent "folder" that contains this asset.
+     * Get the path to this asset.
      *
      * @return string
      */
-    public function getAssetURLPath();
-
-    /**
-     * Is this asset a locally available file (accessible with the getAssetPath method)?
-     *
-     * @return bool
-     */
-    public function isAssetLocal();
-
-    /**
-     * Is this asset a locally available file (accessible with the getAssetPath method)?
-     *
-     * @param bool $isLocal
-     */
-    public function setAssetIsLocal($isLocal);
-
-    /**
-     * Get the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
-     *
-     * @return string
-     */
-    public function getAssetPosition();
+    public function getAssetPath();
 
     /**
      * If the asset is local, set its path and URL starting from the relative path. If it's not local, set its URL.
@@ -222,11 +162,60 @@ interface AssetInterface
     public function mapAssetLocation($path);
 
     /**
+     * Get the path of the parent "folder" that contains this asset.
+     *
+     * @return string
+     */
+    public function getAssetURLPath();
+
+    /**
+     * Get the name of the file of this asset.
+     *
+     * @return string
+     */
+    public function getAssetFilename();
+
+    /**
+     * Get a string that unambiguously identifies this asset.
+     *
+     * @return string
+     */
+    public function getAssetHashKey();
+
+    /**
+     * Set the version of this asset.
+     *
+     * @param string $version
+     */
+    public function setAssetVersion($version);
+
+    /**
+     * Get the version of this asset.
+     *
+     * @return string
+     */
+    public function getAssetVersion();
+
+    /**
+     * Set the package that defines this asset.
+     *
+     * @param \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|null|false $pkg
+     */
+    public function setPackageObject($pkg);
+
+    /**
      * Get the contents of the asset (if applicable).
      *
      * @return string|null
      */
     public function getAssetContents();
+
+    /**
+     * Set the URL of the source files this asset has been built from (useful to understand the origin of this asset).
+     *
+     * @param string[] $paths
+     */
+    public function setCombinedAssetSourceFiles($paths);
 
     /**
      * Register the asset properties.
@@ -244,4 +233,15 @@ interface AssetInterface
      * @param \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|string|null|false $pkg the package that defines this asset (or its handle)
      */
     public function register($filename, $args, $pkg = false);
+
+    /**
+     * Asset-type specific post-processing.
+     *
+     * @param \Concrete\Core\Asset\AssetInterface[] $assets The original assets
+     *
+     * @return \Concrete\Core\Asset\AssetInterface[] The final assets
+     *
+     * @example Compress JavaScripts, merge CSS files...
+     */
+    public static function process($assets);
 }

--- a/concrete/src/Asset/AssetInterface.php
+++ b/concrete/src/Asset/AssetInterface.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Korvin
- * Date: 7/25/15
- * Time: 8:35 AM.
- */
+
 namespace Concrete\Core\Asset;
 
 interface AssetInterface
 {
+    public function __toString();
+
     public function getAssetDefaultPosition();
 
     public function getAssetType();
@@ -135,6 +132,4 @@ interface AssetInterface
     public function getAssetContents();
 
     public function register($filename, $args, $pkg = false);
-
-    public function __toString();
 }

--- a/concrete/src/Asset/AssetInterface.php
+++ b/concrete/src/Asset/AssetInterface.php
@@ -220,7 +220,7 @@ interface AssetInterface
     /**
      * Register the asset properties.
      *
-     * @param string $filename the position of the asset
+     * @param string $filename the location of the asset
      * @param array $args {
      *
      *     @var bool $local is this asset a locally available file (accessible with the getAssetPath method)?

--- a/concrete/src/Asset/AssetInterface.php
+++ b/concrete/src/Asset/AssetInterface.php
@@ -2,134 +2,246 @@
 
 namespace Concrete\Core\Asset;
 
+/**
+ * Interface that all the assets must implement.
+ */
 interface AssetInterface
 {
+    /**
+     * Asset position: in the <head> tag.
+     *
+     * @var string
+     */
+    const ASSET_POSITION_HEADER = 'H';
+
+    /**
+     * Asset position: at the end of the <body> tag.
+     *
+     * @var string
+     */
+    const ASSET_POSITION_FOOTER = 'F';
+
+    /**
+     * Output asset type: CSS.
+     *
+     * @var string
+     */
+    const OUTPUTASSETTYPE_CSS = 'javascript';
+
+    /**
+     * Output asset type: JavaScript.
+     *
+     * @var string
+     */
+    const OUTPUTASSETTYPE_JAVASCRIPT = 'javascript';
+
+    /**
+     * Render the HTML tag that will load this asset.
+     *
+     * @return string
+     */
     public function __toString();
 
+    /**
+     * Get the default asset position (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     *
+     * @return string
+     */
     public function getAssetDefaultPosition();
 
+    /**
+     * Get the unique identifier of the asset type.
+     *
+     * @return string
+     */
     public function getAssetType();
 
+    /**
+     * Get the resulting type of the asset (\Concrete\Core\Asset\AssetInterface::OUTPUTASSETTYPE_CSS, \Concrete\Core\Asset\AssetInterface::OUTPUTASSETTYPE_JAVASCRIPT or other values).
+     *
+     * @return string
+     */
     public function getOutputAssetType();
 
     /**
-     * @param Asset[] $assets
+     * Asset-type specific post-processing.
      *
-     * @return Asset[]
+     * @param \Concrete\Core\Asset\AssetInterface[] $assets The original assets
      *
-     * @abstract
+     * @return \Concrete\Core\Asset\AssetInterface[] The final assets
+     *
+     * @example Compress JavaScripts, merge CSS files...
      */
     public static function process($assets);
 
     /**
+     * Does this asset support minification?
+     *
      * @return bool
      */
     public function assetSupportsMinification();
 
     /**
+     * Can this asset be combined with other assets?
+     *
      * @return bool
      */
     public function assetSupportsCombination();
 
     /**
+     * Does this asset support minification?
+     *
      * @param bool $minify
      */
     public function setAssetSupportsMinification($minify);
 
     /**
+     * Can this asset be combined with other assets?
+     *
      * @param bool $combine
      */
     public function setAssetSupportsCombination($combine);
 
     /**
+     * Get the URL of this asset.
+     *
      * @return string
      */
     public function getAssetURL();
 
     /**
+     * Get a string that unambiguously identifies this asset.
+     *
      * @return string
      */
     public function getAssetHashKey();
 
     /**
+     * Get the path to this asset.
+     *
      * @return string
      */
     public function getAssetPath();
 
     /**
+     * Get the handle of this asset (together with getAssetType, identifies this asset).
+     *
      * @return string
      */
     public function getAssetHandle();
 
     /**
+     * Get the name of the file of this asset.
+     *
      * @return string
      */
     public function getAssetFilename();
 
     /**
+     * Set the version of this asset.
+     *
      * @param string $version
      */
     public function setAssetVersion($version);
 
     /**
-     * @param array $paths
+     * Set the URL of the source files this asset has been built from (useful to understand the origin of this asset).
+     *
+     * @param string[] $paths
      */
     public function setCombinedAssetSourceFiles($paths);
 
     /**
+     * Get the version of this asset.
+     *
      * @return string
      */
     public function getAssetVersion();
 
     /**
+     * Set the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     *
      * @param string $position
      */
     public function setAssetPosition($position);
 
     /**
-     * @param \Package $pkg
+     * Set the package that defines this asset.
+     *
+     * @param \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|null|false $pkg
      */
     public function setPackageObject($pkg);
 
     /**
+     * Set the URL of this asset.
+     *
      * @param string $url
      */
     public function setAssetURL($url);
 
     /**
+     * Set the path to this asset.
+     *
      * @param string $path
      */
     public function setAssetPath($path);
 
     /**
+     * Get the path of the parent "folder" that contains this asset.
+     *
      * @return string
      */
     public function getAssetURLPath();
 
     /**
+     * Is this asset a locally available file (accessible with the getAssetPath method)?
+     *
      * @return bool
      */
     public function isAssetLocal();
 
     /**
+     * Is this asset a locally available file (accessible with the getAssetPath method)?
+     *
      * @param bool $isLocal
      */
     public function setAssetIsLocal($isLocal);
 
     /**
+     * Get the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     *
      * @return string
      */
     public function getAssetPosition();
 
     /**
+     * If the asset is local, set its path and URL starting from the relative path. If it's not local, set its URL.
+     *
      * @param string $path
      */
     public function mapAssetLocation($path);
 
     /**
+     * Get the contents of the asset (if applicable).
+     *
      * @return string|null
      */
     public function getAssetContents();
 
+    /**
+     * Register the asset properties.
+     *
+     * @param string $filename the position of the asset
+     * @param array $args {
+     *
+     *     @var bool $local is this asset a locally available file (accessible with the getAssetPath method)?
+     *     @var bool $minify does this asset support minification?
+     *     @var bool $combine can this asset be combined with other assets?
+     *     @var string $version the version of this asset
+     *     @var string $position the position of this asset (\Concrete\Core\Asset\AssetInterface::ASSET_POSITION_HEADER or \Concrete\Core\Asset\AssetInterface::ASSET_POSITION_FOOTER).
+     * }
+     *
+     * @param \Concrete\Core\Package\Package|\Concrete\Core\Entity\Package|string|null|false $pkg the package that defines this asset (or its handle)
+     */
     public function register($filename, $args, $pkg = false);
 }


### PR DESCRIPTION
- Add PHPDoc to `AssetInterface`
- Add PHPDoc to `Asset`
- move `ASSET_POSITION_HEADER` and `ASSET_POSITION_FOOTER` from `Asset` to `AssetInterface`
- get rid of deprecated methods in `Asset`
- avoid accessing undefined array indexes in `Asset::register`

Ref. #4723