### PR TITLE
Install language files when installing packages

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -564,7 +564,8 @@ return [
          * @var bool
          */
         'choose_language_login' => false,
-
+        // Fetch language files when installing a package connected to the marketplace [boolean]
+        'auto_install_package_languages' => true,
         // Community Translation instance offering concrete5 translations
         'community_translation' => [
             // API entry point of the Community Translation instance

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -1,20 +1,22 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Extend;
 
+use Concrete\Core\Entity\Package as PackageEntity;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Foundation\ClassLoader;
+use Concrete\Core\Localization\Service\TranslationsInstaller;
+use Concrete\Core\Logging\Logger;
+use Concrete\Core\Marketplace\Marketplace;
+use Concrete\Core\Marketplace\RemoteItem as MarketplaceRemoteItem;
 use Concrete\Core\Package\BrokenPackage;
 use Concrete\Core\Package\ItemCategory\Manager;
+use Concrete\Core\Package\PackageService;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Support\Facade\Package;
+use Exception;
 use Loader;
 use TaskPermission;
-use Concrete\Core\Support\Facade\Package;
-use Concrete\Core\Entity\Package as PackageEntity;
-use Localization;
-use Marketplace;
-use Concrete\Core\Marketplace\RemoteItem as MarketplaceRemoteItem;
-use Exception;
-use User;
 
 class Install extends DashboardPageController
 {
@@ -33,7 +35,7 @@ class Install extends DashboardPageController
 
         $pkg = Package::getByID($pkgID);
         if (!is_object($pkg)) {
-            $this->redirect("/dashboard/extend/install");
+            $this->redirect('/dashboard/extend/install');
         }
         $manager = new Manager($this->app);
         $this->set('text', Loader::helper('text'));
@@ -111,7 +113,8 @@ class Install extends DashboardPageController
     {
         $tp = new TaskPermission();
         if ($tp->canInstallPackages()) {
-            $p = Package::getClass($package);
+            $packageService = $this->app->make(PackageService::class);
+            $p = $packageService->getClass($package);
             if ($p instanceof BrokenPackage) {
                 $this->error->add($p->getInstallErrorMessage());
             } elseif (is_object($p)) {
@@ -125,7 +128,7 @@ class Install extends DashboardPageController
                     if (is_object($tests)) {
                         $this->error->add($tests);
                     } else {
-                        $r = Package::install($p, $this->post());
+                        $r = $packageService->install($p, $this->post());
                         if ($r instanceof ErrorList) {
                             $this->error->add($r);
                             if ($p->showInstallOptionsScreen()) {

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -118,6 +118,18 @@ class Install extends DashboardPageController
             if ($p instanceof BrokenPackage) {
                 $this->error->add($p->getInstallErrorMessage());
             } elseif (is_object($p)) {
+                $config = $this->app->make('config');
+                if ($config->get('concrete.i18n.auto_install_package_languages')) {
+                    $associatedPackages = Marketplace::getAvailableMarketplaceItems(false);
+                    if (isset($associatedPackages[$p->getPackageHandle()])) {
+                        try {
+                            $this->app->make(TranslationsInstaller::class)->installMissingPackageTranslations($p);
+                        } catch (Exception $x) {
+                            $logger = $this->app->make(Logger::class);
+                            $logger->addError($x);
+                        }
+                    }
+                }
                 $loader = new ClassLoader();
                 $loader->registerPackageCustomAutoloaders($p);
                 if (

--- a/concrete/single_pages/dashboard/extend/connect.php
+++ b/concrete/single_pages/dashboard/extend/connect.php
@@ -13,6 +13,6 @@
 		div.ccm-pane-body div.ccm-error { padding:15px 20px; };
 		</style>
 		<?php
-        echo $mi->getMarketplaceFrame('100%', '400', false, h($startStep));
+        echo $mi->getMarketplaceFrame('100%', '400', false, isset($startStep) ? h($startStep) : null);
     }
 ?>

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -5,9 +5,12 @@ namespace Concrete\Core\Console\Command;
 use Concrete\Core\Console\Command;
 use Concrete\Core\Console\ConsoleAwareInterface;
 use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Localization\Service\TranslationsInstaller;
+use Concrete\Core\Marketplace\Marketplace;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Support\Facade\Application;
 use Exception;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,6 +28,7 @@ class InstallPackageCommand extends Command
                 'c5:install-package',
             ])
             ->addOption('full-content-swap', null, InputOption::VALUE_NONE, 'If this option is specified a full content swap will be performed (if the package supports it)')
+            ->addOption('languages', 'l', InputOption::VALUE_REQUIRED, 'Force to install ("yes") or to not install ("no") language files. If "auto", language files will be installed if the package is connected to the project ("auto" requires that the canonical URL is set)', 'auto')
             ->setDescription('Install a concrete5 package')
             ->addEnvOption()
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
@@ -43,8 +47,25 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $app = Application::getFacadeApplication();
+        $config = $app->make('config');
         $packageService = $app->make(PackageService::class);
         $pkgHandle = $input->getArgument('package');
+        switch (strtolower($input->getOption('languages'))) {
+            case 'yes':
+            case 'y':
+                $getLanguages = true;
+                break;
+            case 'no':
+            case 'n':
+                $getLanguages = false;
+                break;
+            case 'auto':
+                $associatedPackages = Marketplace::getAvailableMarketplaceItems(false);
+                $getLanguages = isset($associatedPackages[$pkgHandle]);
+                break;
+            default:
+                throw new InvalidOptionException('Invalid value for the --languages option. Valid values are "yes", "no", "auto"');
+        }
         $packageOptions = [];
         foreach ($input->getArgument('package-options') as $keyValuePair) {
             list($key, $value) = explode('=', $keyValuePair, 2);
@@ -105,6 +126,25 @@ EOT
             throw new Exception(implode("\n", $r->getList()));
         }
         $output->writeln('<info>installed.</info>');
+
+        if ($getLanguages) {
+            $output->write('Fetching language files... ');
+            $languageResult = $app->make(TranslationsInstaller::class)->installMissingPackageTranslations($pkg);
+            if (count($languageResult) === 0) {
+                $output->writeln('<info>no languages downloaded.</info>');
+            } else {
+                $output->writeln('done. Results:');
+                foreach ($languageResult as $localeID => $result) {
+                    if ($result === true) {
+                        $output->writeln(" - {$localeID}: <info>downloaded</info>");
+                    } elseif ($result === false) {
+                        $output->writeln(" - {$localeID}: <error>non available</error>");
+                    } else {
+                        $output->writeln(" - $localeID: <error>" . ((string) $result) . '</error>');
+                    }
+                }
+            }
+        }
 
         $swapper = $pkg->getContentSwapper();
         if ($swapper->allowsFullContentSwap($pkg) && $input->getOption('full-content-swap')) {

--- a/concrete/src/Localization/Service/TranslationsChecker.php
+++ b/concrete/src/Localization/Service/TranslationsChecker.php
@@ -30,8 +30,9 @@ class TranslationsChecker
     protected $remoteProvider;
 
     /**
-     * @param LocalTranslationFactoryInterface $localFactory
-     * @param RemoteTranslationsProviderInterface $remoteProvider
+     * @param Application $app
+     * @param LocalFactory $localFactory
+     * @param RemoteProvider $remoteProvider
      */
     public function __construct(Application $app, LocalFactory $localFactory, RemoteProvider $remoteProvider)
     {

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -191,6 +191,7 @@ class Marketplace
             $frameURL = Config::get('concrete.urls.concrete5_secure');
         }
         if ($tp->canInstallPackages()) {
+            $csToken = null;
             if (!$this->isConnected()) {
                 if (!$completeURL) {
                     $completeURL = URL::to('/dashboard/extend/connect', 'connect_complete');
@@ -235,7 +236,7 @@ class Marketplace
                 $csiBaseURL = urlencode(Core::getApplicationURL());
                 $url = $frameURL . Config::get('concrete.urls.paths.marketplace.connect_success') . '?csToken=' . $this->getSiteToken() . '&csiBaseURL=' . $csiBaseURL;
             }
-            if ($csToken == false && !$this->isConnected()) {
+            if (!$csToken && !$this->isConnected()) {
                 return '<div class="ccm-error">' . t(
                     'Unable to generate a marketplace token. Please ensure that allow_url_fopen is turned on, or that cURL is enabled on your server. If these are both true, It\'s possible your site\'s IP address may be blacklisted for some reason on our server. Please ask your webhost what your site\'s outgoing cURL request IP address is, and email it to us at <a href="mailto:help@concrete5.org">help@concrete5.org</a>.') . '</div>';
             } else {

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -7,6 +7,7 @@ use Concrete\Core\Support\Facade\Package;
 use TaskPermission;
 use URL;
 use Zend\Http\Client\Adapter\Exception\TimeoutException;
+use Exception;
 
 class Marketplace
 {
@@ -116,7 +117,7 @@ class Marketplace
         $em->flush();
     }
 
-    public function getAvailableMarketplaceItems($filterInstalled = true)
+    public static function getAvailableMarketplaceItems($filterInstalled = true)
     {
         $fh = Core::make('helper/file');
         if (!$fh) {


### PR DESCRIPTION
What about automatically downloading language files when a package is installed?

When installing a package via the dashboard, this option is controlled by the new `concrete.i18n.auto_install_package_languages` configuration key.

When installing a package via the CLI command, users may specify if they want to download the language files or not with the new `--get-languages` option (if this option is not specified, we'll use the `concrete.i18n.auto_install_package_languages` configuration key).

The language files that will be downloaded are the ones used in the site (that is, the languages of the multilingual sections and the languages of the site interface).