### PR TITLE
[BUG]Fix Broken Migration - Update 5.7.5.13 to 8.3.1

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -526,6 +526,8 @@ class Version20160725000000 extends AbstractMigration
                                 'akSelectAllowOtherValues' => $rowA['akSelectAllowOtherValues'],
                                 'avSelectOptionListID' => $listID,
                                 'akID' => $akID,
+                                'akHideNoneOption' => 0,
+                                'akDisplayMultipleValuesOnSelect' => 0,
                             ]);
 
                             $options = $this->connection->fetchAll('select * from _atSelectOptions where akID = ?', [$akID]);


### PR DESCRIPTION
I've encounterd an issue with migrations when updating from 5.7.5.13 to 8.3.1:

The Update failed during the processing of the 20160705 Migration with the following error:

`An exception occurred while executing 'INSERT INTO atSelectSettings (akSelectAllowMultipleValues, akSelectOptionDisplayOrder, akSelectAllowOtherValues, avSelectOptionListID, akID) VALUES (?, ?, ?, ?, ?)' with params ["1", "display_asc", "1", "4", "8"]: SQLSTATE[HY000]: General error: 1364 Field 'akHideNoneOption' doesn't have a default value`

In order to fix this i've modified the migration to set the newly added columns to a default value instead of relying on the Database default value. - This fixed the issue im my case.

I am a bit curious why i seem to be the first one to encounter this. Even with a freshly setup 5.7.5.13 installation i could reproduce this issue reliably.