### PR TITLE
Add indexes on text fields

### DIFF
--- a/concrete/config/database.php
+++ b/concrete/config/database.php
@@ -16,4 +16,21 @@ return [
     'proxy_exclusions' => [
         DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Support/',
     ],
+
+    /*
+     * Workaround for not being able to define indexes on TEXT fields with the current version of Doctrine DBAL.
+     * This feature will be removed when DBAL will support it, so don't use this feature.
+     */
+    'text_indexes' => [
+        'PagePaths' => [
+            'cPath' => [
+                ['cPath', 255],
+            ],
+        ],
+        'Groups' => [
+            'gPath' => [
+                ['gPath', 255],
+            ],
+        ],
+    ],
 ];

--- a/concrete/config/database.php
+++ b/concrete/config/database.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
-    'drivers' => array(
+return [
+    'drivers' => [
         'c5_pdo_mysql' => '\Concrete\Core\Database\Driver\PDOMySqlConcrete5\Driver',
-    ),
+    ],
 
     /*
      * The location of the doctrine Proxy Classes
@@ -13,7 +13,7 @@ return array(
     /*
      * Paths to exclude from the doctrine proxy classes
      */
-    'proxy_exclusions' => array(
+    'proxy_exclusions' => [
         DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Support/',
-    ),
-);
+    ],
+];

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -387,8 +387,8 @@ class StartingPointPackage extends BasePackage
     {
         $db = Database::get();
 
-        $db->Execute('ALTER TABLE PagePaths ADD INDEX (`cPath` (255))');
-        $db->Execute('ALTER TABLE Groups ADD INDEX (`gPath` (255))');
+        $textIndexes = $this->app->make('config')->get('database.text_indexes');
+        $db->createTextIndexes($textIndexes);
     }
 
     protected function add_users()

--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -12,6 +12,7 @@ use ORM;
 use Exception;
 use Concrete\Core\Cache\CacheClearer;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Database\Connection\Connection;
 
 class Update
 {
@@ -193,5 +194,7 @@ class Update
         }
         Config::save('concrete.version_installed', Config::get('concrete.version'));
         Config::save('concrete.version_db_installed', Config::get('concrete.version_db'));
+        $textIndexes = $cms->make('config')->get('database.text_indexes');
+        $cms->make(Connection::class)->createTextIndexes($textIndexes);
     }
 }


### PR DESCRIPTION
Doctrine DBAL does not currently support creating indexes on TEXT fields (see https://github.com/doctrine/dbal/issues/1597, https://github.com/doctrine/dbal/pull/2412, https://github.com/doctrine/dbal/issues/2368), so we currently create them at install time (see [`StartingPointPackage::indexAdditionalDatabaseFields()`](https://github.com/concrete5/concrete5/blob/8.3.1/concrete/src/Package/StartingPointPackage.php#L386-L392).
What about being sure that those indexes are created even after upgrades?

In particular, the lack of the index on the `PagePaths`.`cPath` database field has a big performance impact...