### PR TITLE
Fix migrations - Part II

### DIFF
--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -7,8 +7,8 @@ use Concrete\Core\Console\Command;
 use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Foundation\Environment;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Package;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,9 +40,6 @@ EOT
         $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
         $schemas = [];
         $sm = $db->getSchemaManager();
-        /*
-         * @var MySqlSchemaManager $sm
-         */
         $dbSchema = $sm->createSchema();
 
         // core xml tables
@@ -110,13 +107,20 @@ EOT
      */
     protected function filterQueries($queries)
     {
+        $app = Application::getFacadeApplication();
+        $config = $app->make('config');
+
+        $textIndexDrops = [];
+        foreach ($config->get('database.text_indexes') as $indexTable => $indexDefinition) {
+            foreach (array_keys($indexDefinition) as $indexName) {
+                $textIndexDrops[] = strtolower("DROP INDEX {$indexName} ON {$indexTable}");
+            }
+        }
+
         $returnQueries = [];
         foreach ($queries as $query) {
-            $addQuery = true;
-            if (preg_match('/drop index.*[Groups|UserBannedIPs|SignupRequests|PagePaths]/i', $query)) {
-                $addQuery = false;
-            }
-            if ($addQuery) {
+            $queryLowerCase = strtolower($query);
+            if (!in_array($queryLowerCase, $textIndexDrops, true)) {
                 $returnQueries[] = $query;
             }
         }

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Block\BlockType\BlockTypeList;
+use Concrete\Core\Console\Command;
 use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Foundation\Environment;
+use Concrete\Core\Support\Facade\Package;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
-use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Concrete\Core\Support\Facade\Package;
 
 class CompareSchemaCommand extends Command
 {
@@ -102,6 +103,10 @@ EOT
      * Doctrine doens't give us a good way to deal with. This is mostly
      * index lengths that are set in installation that Doctrine doesn't
      * support.
+     *
+     * @param string[] $queries
+     *
+     * @return string[]
      */
     protected function filterQueries($queries)
     {

--- a/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
@@ -6,7 +6,7 @@ use Concrete\Core\Entity\Calendar\CalendarEventVersion;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 
-class Version20180118000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20180119000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
@@ -3,6 +3,9 @@
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Entity\Calendar\CalendarEventVersion;
+use Concrete\Core\Entity\Express\Entity as ExpressEntity;
+use Concrete\Core\Entity\Express\Form as ExpressForm;
+use Concrete\Core\Entity\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 
@@ -17,6 +20,9 @@ class Version20180119000000 extends AbstractMigration implements DirectSchemaUpg
     {
         $this->refreshEntities([
             CalendarEventVersion::class,
+            ExpressEntity::class,
+            ExpressForm::class,
+            Package::class,
         ]);
         $this->refreshDatabaseTables([
             'Workflows',


### PR DESCRIPTION
This is a continuation of #6311

I installed concrete5 7.5.12, and I migrated it to the `release/8.3.2`.
The only schema differences were 3 missing foreign keys in the `ExpressEntities` table: this pull request fixes this.
I also fixed the `c5:compare-schema` CLI command: it now "hides" only the difference about the indexes of TEXT fields.

With this PR here's the results after migration from 7.5.12 to 8.3.2:
```sh
$ ./concrete/bin/concrete5 c5:compare-schema
No differences found between schema and database.
```
