### PR TITLE
ItemList: fix order by fields not in selected fields

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -593,8 +593,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->query->innerJoin('av', 'atSelectedTopics', 'atst', 'av.avID = atst.avID');
         $this->query->andWhere('atst.treeNodeID = :TopicNodeID');
         $this->query->setParameter('TopicNodeID', $treeNodeID);
-        $this->query->select('distinct p.cID');
-        $this->query->addSelect('p.cDisplayOrder');
+        $this->selectDistinct();
     }
 
     public function filterByBlockType(BlockType $bt)
@@ -696,6 +695,15 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     {
         if ($this->isFulltextSearch) {
             $this->sortBy('cIndexScore', 'desc');
+        }
+    }
+
+    protected function selectDistinct()
+    {
+        $selects = $this->query->getQueryPart('select');
+        if ($selects[0] === 'p.cID') {
+            $selects[0] = 'distinct p.cID';
+            $this->query->select($selects);
         }
     }
 

--- a/concrete/src/Search/ItemList/Database/ItemList.php
+++ b/concrete/src/Search/ItemList/Database/ItemList.php
@@ -81,6 +81,7 @@ abstract class ItemList extends AbstractItemList
     {
         if (in_array(strtolower($direction), array('asc', 'desc'))) {
             $this->query->orderBy($column, $direction);
+            $this->ensureSelected($column);
         }
     }
 
@@ -102,6 +103,22 @@ abstract class ItemList extends AbstractItemList
             $this->query->andWhere(implode(' ', array(
                $field, $comparison, $this->query->createNamedParameter($value),
             )));
+        }
+    }
+
+    protected function ensureSelected($field)
+    {
+        $rx = '/\b' . preg_quote($field, '/') . '\b/i';
+        $selects = $this->query->getQueryPart('select');
+        $add = true;
+        foreach ($selects as $select) {
+            if (preg_match($rx, $select)) {
+                $add = false;
+                break;
+            }
+        }
+        if ($add) {
+            $this->query->addSelect($field);
         }
     }
 


### PR DESCRIPTION
In MySQL 5.7, the fields included in the `ORDER BY` list of `SELECT DISTINCT` queries must be present in the selected fields.

This causes, for instance, this error in the default content at the page `/blog/topic/32/humor`:
```
An exception occurred while executing '
SELECT distinct
    p.cID,
    p.cDisplayOrder
FROM
    Pages p
    LEFT JOIN PagePaths pp ON (p.cID = pp.cID and pp.ppIsCanonical = true)
    LEFT JOIN PageSearchIndex psi ON p.cID = psi.cID
    LEFT JOIN PageTypes pt ON p.ptID = pt.ptID
    INNER JOIN Collections c ON p.cID = c.cID
    INNER JOIN CollectionVersions cv ON p.cID = cv.cID
    LEFT JOIN CollectionSearchIndexAttributes csi ON c.cID = csi.cID
    INNER JOIN CollectionAttributeValues cavTopics ON cv.cID = cavTopics.cID and cv.cvID = cavTopics.cvID
    INNER JOIN AttributeValues av ON cavTopics.avID = av.avID
    INNER JOIN atSelectedTopics atst ON av.avID = atst.avID
WHERE
    (cvName != ?)
    AND (pt.ptID = ?)
    AND (ak_exclude_page_list <> 1 or ak_exclude_page_list is null)
    AND (atst.treeNodeID = ?)
    AND (p.cPointerID < 1)
    AND (p.cIsTemplate = 0)
    AND (cvIsApproved = 1)
    AND ((cvPublishDate <= ? or cvPublishDate is null))
    AND (p.cIsActive = ?)
    AND (p.siteTreeID = ?)
    AND (p.cIsSystemPage = ?)
ORDER BY
    cv.cvDatePublic desc
LIMIT
    1000
' with params ["", "6", 32, "2018-01-19 18:30:53", true, 1, false]:
SQLSTATE[HY000]: General error: 3065
Expression #1 of ORDER BY clause is not in SELECT list,
references column 'concrete5.cv.cvDatePublic'
which is not in SELECT list;
this is incompatible with DISTINCT
```

IMHO the solution is to always add to SELECT the fields we add to the ORDER BY...