### PR TITLE
Convert db.xml files from AXMLS to DoctrineXML

### DIFF
--- a/concrete/blocks/calendar/db.xml
+++ b/concrete/blocks/calendar/db.xml
@@ -1,29 +1,32 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-    <table name="btCalendar">
-        <field name="bID" type="I">
-            <key/>
-            <unsigned/>
-        </field>
-        <field name="caID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="calendarAttributeKeyHandle" type="C" size="255">
-        </field>
-        <field name="filterByTopicAttributeKeyID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="filterByTopicID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="lightboxProperties" type="X2">
-        </field>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd"
+>
 
-    </table>
+  <table name="btCalendar">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="caID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="calendarAttributeKeyHandle" type="string" size="255"/>
+    <field name="filterByTopicAttributeKeyID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="filterByTopicID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="lightboxProperties" type="text"/>
+  </table>
+
 </schema>

--- a/concrete/blocks/document_library/db.xml
+++ b/concrete/blocks/document_library/db.xml
@@ -1,111 +1,90 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btDocumentLibrary">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
-		<field name="setIds" type="C" size="255">
-			<notnull />
-		</field>
-		<field name="folderID" type="I">
-			<default value="0"/>
-			<notnull />
-		</field>
-		<field name="setMode" type="C" size="32">
-		</field>
-		<field name="onlyCurrentUser" type="I">
-			<default value="0"/>
-		</field>
-		<field name="tags" type="C" size="128">
-		</field>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd"
+>
 
-		<field name="viewProperties" type="X2">
-		</field>
+  <table name="btDocumentLibrary">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="setIds" type="string" size="255">
+      <notnull/>
+    </field>
+    <field name="folderID" type="integer">
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="setMode" type="string" size="32"/>
+    <field name="onlyCurrentUser" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="tags" type="string" size="128"/>
+    <field name="viewProperties" type="text"/>
+    <field name="expandableProperties" type="string" size="255"/>
+    <field name="searchProperties" type="string" size="255"/>
+    <field name="orderBy" type="string" size="64">
+      <default value="title"/>
+    </field>
+    <field name="displayLimit" type="integer">
+      <default value="20"/>
+    </field>
+    <field name="displayOrderDesc" type="boolean">
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="addFilesToSetID" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="maxThumbWidth" type="integer">
+      <default value="100"/>
+    </field>
+    <field name="maxThumbHeight" type="integer">
+      <default value="150"/>
+    </field>
+    <field name="enableSearch" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="heightMode" type="string" size="32">
+      <default value="auto"/>
+    </field>
+    <field name="downloadFileMethod" type="string" size="32">
+      <default value="force"/>
+    </field>
+    <field name="fixedHeightSize" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="headerBackgroundColor" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="headerBackgroundColorActiveSort" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="headerTextColor" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="allowFileUploading" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="allowInPageFileManagement" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="tableName" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="tableDescription" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="tableStriped" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="rowBackgroundColorAlternate" type="string" size="32">
+      <default value=""/>
+    </field>
+  </table>
 
-		<field name="expandableProperties" type="C" size="255">
-		</field>
-
-		<field name="searchProperties" type="C" size="255">
-		</field>
-
-		<field name="orderBy" type="C" size="64">
-			<default value="title"/>
-		</field>
-
-		<field name="displayLimit" type="i">
-			<default value="20"/>
-		</field>
-
-		<field name="displayOrderDesc" type="I1">
-			<default value="0"/>
-			<notnull/>
-		</field>
-
-		<field name="addFilesToSetID" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-
-		<field name="maxThumbWidth" type="i">
-			<default value="100"/>
-		</field>
-
-		<field name="maxThumbHeight" type="i">
-			<default value="150"/>
-		</field>
-
-		<field name="enableSearch" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="heightMode" type="C" size="32">
-			<default value="auto"/>
-		</field>
-
-		<field name="downloadFileMethod" type="C" size="32">
-			<default value="force"/>
-		</field>
-
-		<field name="fixedHeightSize" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="headerBackgroundColor" type="C" size="32">
-			<default value=""/>
-		</field>
-
-		<field name="headerBackgroundColorActiveSort" type="C" size="32">
-			<default value=""/>
-		</field>
-
-		<field name="headerTextColor" type="C" size="32">
-			<default value=""/>
-		</field>
-		<field name="allowFileUploading" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="allowInPageFileManagement" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="tableName" type="C" size="255">
-			<default value=""/>
-		</field>
-
-		<field name="tableDescription" type="C" size="255">
-			<default value=""/>
-		</field>
-
-		<field name="tableStriped" type="I1" size="1">
-			<default value="0"/>
-		</field>
-
-		<field name="rowBackgroundColorAlternate" type="C" size="32">
-			<default value=""/>
-		</field>
-
-	</table>
 </schema>

--- a/concrete/blocks/event_list/db.xml
+++ b/concrete/blocks/event_list/db.xml
@@ -1,48 +1,51 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-    <table name="btEventList">
-        <field name="bID" type="I">
-            <key/>
-            <unsigned/>
-        </field>
-        <field name="caID" type="X">
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="calendarAttributeKeyHandle" type="C" size="255">
-        </field>
-        <field name="totalToRetrieve" type="I2">
-            <unsigned />
-            <notnull />
-            <default value="10" />
-        </field>
-        <field name="totalPerPage" type="I2">
-            <unsigned />
-            <notnull />
-            <default value="10" />
-        </field>
-        <field name="filterByTopicAttributeKeyID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="filterByTopicID" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="filterByPageTopicAttributeKeyHandle" type="C" size="255">
-        </field>
-        <field name="filterByFeatured" type="I1" size="1">
-            <notnull />
-            <default value="0" />
-        </field>
-        <field name="eventListTitle" type="C" size="255">
-        </field>
-        <field name="linkToPage" type="I" size="10">
-            <unsigned />
-            <notnull />
-            <default value="0" />
-        </field>
-    </table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd"
+>
+
+  <table name="btEventList">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="caID" type="text" size="65535">
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="calendarAttributeKeyHandle" type="string" size="255"/>
+    <field name="totalToRetrieve" type="smallint">
+      <unsigned/>
+      <default value="10"/>
+      <notnull/>
+    </field>
+    <field name="totalPerPage" type="smallint">
+      <unsigned/>
+      <default value="10"/>
+      <notnull/>
+    </field>
+    <field name="filterByTopicAttributeKeyID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="filterByTopicID" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="filterByPageTopicAttributeKeyHandle" type="string" size="255"/>
+    <field name="filterByFeatured" type="boolean">
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="eventListTitle" type="string" size="255"/>
+    <field name="linkToPage" type="integer" size="10">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+  </table>
+
 </schema>

--- a/concrete/blocks/express_entry_list/db.xml
+++ b/concrete/blocks/express_entry_list/db.xml
@@ -1,71 +1,56 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-	<table name="btExpressEntryList">
-		<field name="bID" type="I">
-			<key />
-			<unsigned />
-		</field>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd"
+>
 
-		<field name="exEntityID" type="C">
-			<notnull />
-		</field>
+  <table name="btExpressEntryList">
+    <field name="bID" type="integer">
+      <unsigned/>
+      <key/>
+    </field>
+    <field name="exEntityID" type="string" size="255">
+      <notnull/>
+    </field>
+    <field name="detailPage" type="integer">
+      <unsigned/>
+      <default value="0"/>
+      <notnull/>
+    </field>
+    <field name="linkedProperties" type="string" size="255"/>
+    <field name="searchProperties" type="string" size="255"/>
+    <field name="columns" type="text"/>
+    <field name="displayLimit" type="integer">
+      <default value="20"/>
+    </field>
+    <field name="enableSearch" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="enableKeywordSearch" type="integer">
+      <default value="0"/>
+    </field>
+    <field name="headerBackgroundColor" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="headerBackgroundColorActiveSort" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="headerTextColor" type="string" size="32">
+      <default value=""/>
+    </field>
+    <field name="tableName" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="tableDescription" type="string" size="255">
+      <default value=""/>
+    </field>
+    <field name="tableStriped" type="boolean">
+      <default value="0"/>
+    </field>
+    <field name="rowBackgroundColorAlternate" type="string" size="32">
+      <default value=""/>
+    </field>
+  </table>
 
-		<field name="detailPage" type="I">
-			<unsigned />
-			<notnull />
-			<default value="0" />
-		</field>
-
-
-		<field name="linkedProperties" type="C" size="255">
-		</field>
-
-		<field name="searchProperties" type="C" size="255">
-		</field>
-
-		<field name="columns" type="X2">
-
-		</field>
-
-		<field name="displayLimit" type="i">
-			<default value="20"/>
-		</field> 		
-		
-		<field name="enableSearch" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="enableKeywordSearch" type="i">
-			<default value="0"/>
-		</field>
-
-		<field name="headerBackgroundColor" type="C" size="32">
-			<default value=""/>
-		</field>
-
-		<field name="headerBackgroundColorActiveSort" type="C" size="32">
-			<default value=""/>
-		</field>
-
-		<field name="headerTextColor" type="C" size="32">
-			<default value=""/>
-		</field>
-
-		<field name="tableName" type="C" size="255">
-			<default value=""/>
-		</field>		
-		
-		<field name="tableDescription" type="C" size="255">
-			<default value=""/>
-		</field>
-
-		<field name="tableStriped" type="I1" size="1">
-			<default value="0"/>
-		</field>
-
-		<field name="rowBackgroundColorAlternate" type="C" size="32">
-			<default value=""/>
-		</field>
-
-	</table>
 </schema>

--- a/concrete/blocks/express_entry_list/db.xml
+++ b/concrete/blocks/express_entry_list/db.xml
@@ -17,10 +17,10 @@
 		</field>
 
 
-		<field name="linkedProperties" type="C" size="X">
+		<field name="linkedProperties" type="C" size="255">
 		</field>
 
-		<field name="searchProperties" type="C" size="X">
+		<field name="searchProperties" type="C" size="255">
 		</field>
 
 		<field name="columns" type="X2">


### PR DESCRIPTION
What about getting rid of the old AXMLS for these db.xml files?

Please remark that [we had a couple of errors](https://github.com/concrete5/concrete5/commit/5867893d575d56db2f8f6d16f0d91e236026f56d)  in the db.xml file of the ExpressEntryList block type.
It's not clear if we wanted the fields `btExpressEntryList`.`linkedProperties` and `btExpressEntryList`.`searchProperties` as `TEXT` fileds or as `VARCHAR` fields. For now I just kept the currently definition we have in the generated schema (`VARCHAR(255)`): is this ok? Or should they be `TEXT`?

PS: to convert from AXMLS to DoctrineXML I used http://concrete5.github.io/doctrine-xml/