### PR TITLE
Amend unmap method to delete the relevant locale cID instead of the p…

### DIFF
--- a/concrete/controllers/backend/page/multilingual.php
+++ b/concrete/controllers/backend/page/multilingual.php
@@ -31,11 +31,18 @@ class Multilingual extends Page
 
     public function unmap()
     {
-        Section::unregisterPage($this->page);
-        $r = new PageEditResponse();
-        $r->setPage($this->page);
-        $r->setMessage(t('Page unmapped.'));
-        $r->outputJSON();
+        $section = Section::getByID((int) $_POST['section']);
+        if (is_object($section)) {
+            $relatedID = $section->getTranslatedPageID($this->page);
+            $relatedPage = \Page::getByID((int) $relatedID);
+            $r = new PageEditResponse();
+            $r->setPage($relatedPage);
+            if (!$relatedPage->isError()) {
+                Section::unregisterPage($relatedPage);
+                $r->setMessage(t('Page unmapped.'));
+            }
+            $r->outputJSON();
+        }
     }
 
     public function assign()

--- a/concrete/single_pages/dashboard/system/multilingual/page_report.php
+++ b/concrete/single_pages/dashboard/system/multilingual/page_report.php
@@ -186,6 +186,7 @@ $nav = Loader::helper('navigation');
                                                     data-btn-action="unmap"
                                                     data-btn-url="<?=$multilingualController->action('unmap')?>"
                                                     data-btn-multilingual-page-source="<?php echo $pc->getCollectionID()?>"
+                                                    data-btn-multilingual-section="<?php echo $sc->getCollectionID()?>"
                                                 ><?=t('Un-Map')?></button>
                                         <?php 
 }
@@ -258,7 +259,7 @@ $nav = Loader::helper('navigation');
                             'message': r.message,
                             'title': r.title
                         });
-                        if (r.pages[0]) {
+                        if (typeof r.pages != 'undefined') {
                             replaceLinkWithPage(cID, sectionID, r.link, r.icon, r.name);
                         }
 
@@ -308,16 +309,18 @@ $nav = Loader::helper('navigation');
             });
 
             $('button[data-btn-action=unmap]').on('click', function(e) {
-                var cID = $(this).attr('data-btn-multilingual-page-source');
+                var sectionID = $(this).attr('data-btn-multilingual-section'),
+                  cID = $(this).attr('data-btn-multilingual-page-source');
                 e.preventDefault();
                 $.concreteAjax({
                     url: $(this).attr('data-btn-url'),
                     method: 'post',
                     data: {
+                        'section': sectionID,
                         'cID': cID
                     },
                     success: function(r) {
-                        var $wrapper = $('div[data-multilingual-page-source=' + cID + ']');
+                        var $wrapper = $('div[data-multilingual-page-section=' + sectionID + '][data-multilingual-page-source=' + cID + ']');
                         $wrapper.find('div[data-wrapper=page]').html('<?=t('Unmapped')?>');
                         $wrapper.find('div[data-wrapper=buttons]').hide();
                     }


### PR DESCRIPTION
Attempt to resolve #6290

Added the section CID to the unregister page method to delete the relevant locale and not the core locale. Updated the selector to only change the correct locale column.

Also added the CID to the create_new method to prevent an issue with the pages array not being created when past back to the view.
