### PR TITLE
PageList: add match score before sorting by it

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -225,10 +225,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 break;
         }
 
-        if ($this->isFulltextSearch) {
-            $query->addSelect('match(psi.cName, psi.cDescription, psi.content) against (:fulltext) as cIndexScore');
-        }
-
         if (!$this->includeInactivePages) {
             $query->andWhere('p.cIsActive = :cIsActive');
             $query->setParameter('cIsActive', true);
@@ -572,6 +568,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     {
         $this->isFulltextSearch = true;
         $this->autoSortColumns[] = 'cIndexScore';
+        $this->query->addSelect('match(psi.cName, psi.cDescription, psi.content) against (:fulltext) as cIndexScore');
         $this->query->where('match(psi.cName, psi.cDescription, psi.content) against (:fulltext)');
         $this->query->orderBy('cIndexScore', 'desc');
         $this->query->setParameter('fulltext', $keywords);


### PR DESCRIPTION
In #6318 we added to the selected fields the ones we sort by.
This causes prolems in the PageList::sortByRelevance method, which tries to sort by an undefined field.