### PR TITLE
Be sure that caches are singletons

### DIFF
--- a/concrete/src/Cache/CacheServiceProvider.php
+++ b/concrete/src/Cache/CacheServiceProvider.php
@@ -9,11 +9,16 @@ class CacheServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('cache', Level\ObjectCache::class);
-        $this->app->singleton('cache/request', Level\RequestCache::class);
-        $this->app->singleton('cache/expensive', Level\ExpensiveCache::class);
-        $this->app->singleton('cache/overrides', Level\OverridesCache::class);
-        $this->app->singleton('cache/page', function() {
+        foreach ([
+            'cache' => Level\ObjectCache::class,
+            'cache/request' => Level\RequestCache::class,
+            'cache/expensive' => Level\ExpensiveCache::class,
+            'cache/overrides' => Level\OverridesCache::class,
+        ] as $alias => $class) {
+            $this->app->singleton($class);
+            $this->app->alias($class, $alias);
+        }
+        $this->app->singleton('cache/page', function () {
             return PageCache::getLibrary();
         });
     }


### PR DESCRIPTION
We currently declare that cache *handles* (`'cache/request'`, `'cache/expensive'`, ...) are singletons.
BTW the actual classes (`Concrete\Core\Cache\Level\RequestCache`, `Concrete\Core\Cache\Level\ExpensiveCache`, ...) are not singletons.

That means that
```php
$app->make('cache/request')
```
always returns the same instance, but
```php
$app->make('Concrete\Core\Cache\Level\RequestCache')
```
always returns a new instance.

What about always using the same instance?