### PR TITLE
Avoid accessing an undefined array index in StandardSearchIndexer::setTypeLength

### DIFF
--- a/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
@@ -48,7 +48,7 @@ class StandardSearchIndexer implements SearchIndexerInterface
     private function setTypeLength($options)
     {
         // If we have explicitly set a length, use it
-        if ($options['length']) {
+        if (isset($options['length']) && $options['length']) {
             return $options;
         }
         if ($options['type']->getName() == 'text') {


### PR DESCRIPTION
Ref. #4723