### PR TITLE
Add a way to re-apply already executed migrations

### DIFF
--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -87,10 +87,10 @@ EOT
                 }
                 if (!$input->getOption('force')) {
                     if (!$input->isInteractive()) {
-                        throw new Exception('You have to specify the --force option in order to run this command when you specify the --after / --since options.');
+                        throw new Exception('You have to specify the --force option in order to run this command when you specify the --rerun option.');
                     }
                     $confirmQuestion = new ConfirmationQuestion(<<<'EOT'
-WARNING: re-running already executed migrations (with the --after / --since options) may be dangerous!
+WARNING: re-running already executed migrations (with the --rerun option) may be dangerous!
 
 Are you sure you want to proceed?
 EOT

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -21,8 +21,9 @@ class UpdateCommand extends Command
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addEnvOption()
-            ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration')
-            ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration')
+            ->addOption('rerun', null, InputOption::VALUE_NONE, '(Re)apply already executed migrations')
+            ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration (requires --rerun)')
+            ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration (requires --rerun)')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the update')
             ->setHelp(<<<EOT
 Examples:
@@ -30,16 +31,19 @@ Examples:
   ./concrete/bin/concrete5 c5:update
     Execute the migrations that haven't het been executed
 
-  ./concrete/bin/concrete5 c5:update --after=8.3.1
+  ./concrete/bin/concrete5 c5:update --rerun
+    (Re)Execute all the migrations, including the ones that have already been executed (if possible).
+
+  ./concrete/bin/concrete5 c5:update --rerun --after=8.3.1
     Execute the migrations after the 8.3.1 release (even if they have already been marked as executed)
 
-  ./concrete/bin/concrete5 c5:update --after=20171218000000
+  ./concrete/bin/concrete5 c5:update --rerun --after=20171218000000
     Execute the migrations after the 20171218000000 migration (even if they have already been marked as executed)
 
-  ./concrete/bin/concrete5 c5:update --since=8.3.1
+  ./concrete/bin/concrete5 c5:update --rerun --since=8.3.1
     Execute the migrations starting from the 8.3.1 release (even if they have already been marked as executed)
 
-  ./concrete/bin/concrete5 c5:update --since=20171218000000
+  ./concrete/bin/concrete5 c5:update --rerun --since=20171218000000
     Execute the migrations starting from the 20171218000000 migration (even if they have already been marked as executed)
 
 Please remark that re-executing old migrations (with the --after or --since options) may be dangerous.
@@ -54,41 +58,49 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->getOption('after') === null && $input->getOption('since') === null) {
-            $initialMigration = null;
-        } elseif ($input->getOption('after') === null) {
-            $initialMigration = [$input->getOption('since'), Configuration::FORCEDMIGRATION_INCLUSIVE];
-        } elseif ($input->getOption('since') === null) {
-            $initialMigration = [$input->getOption('after'), Configuration::FORCEDMIGRATION_EXCLUSIVE];
-        } else {
-            throw new Exception('You can\'t specify both the --after and --since options.');
+        if ($input->getOption('rerun')) {
+            if ($input->getOption('after') === null && $input->getOption('since') === null) {
+                $initialMigration = 'max';
+            } elseif ($input->getOption('after') === null) {
+                $initialMigration = [$input->getOption('since'), Configuration::FORCEDMIGRATION_INCLUSIVE];
+            } elseif ($input->getOption('since') === null) {
+                $initialMigration = [$input->getOption('after'), Configuration::FORCEDMIGRATION_EXCLUSIVE];
+            } else {
+                throw new Exception('You can\'t specify both the --after and --since options.');
+            }
+        } elseif ($input->getOption('after') !== null || $input->getOption('since') !== null) {
+            throw new Exception('The --after / --since options require the --rerun option.');
         }
+        $configuration = new Configuration();
+        $configuration->setOutputWriter(new OutputWriter(function ($message) use ($output) {
+            $output->writeln($message);
+        }));
         if ($initialMigration !== null) {
-            if (!$input->getOption('force')) {
-                if (!$input->isInteractive()) {
-                    throw new Exception('You have to specify the --force option in order to run this command when you specify the --after / --since options.');
+            if ($initialMigration === 'max') {
+                $configuration->forceMaxInitialMigration();
+            } else {
+                $configuration->forceInitialMigration($initialMigration[0], $initialMigration[1]);
+            }
+            if ($configuration->getForcedInitialMigration() !== null) {
+                if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
+                    $output->writeln(sprintf('Initial migration to be executed: %s', $configuration->getForcedInitialMigration()->getVersion()));
                 }
-                $confirmQuestion = new ConfirmationQuestion(<<<'EOT'
+                if (!$input->getOption('force')) {
+                    if (!$input->isInteractive()) {
+                        throw new Exception('You have to specify the --force option in order to run this command when you specify the --after / --since options.');
+                    }
+                    $confirmQuestion = new ConfirmationQuestion(<<<'EOT'
 WARNING: re-running already executed migrations (with the --after / --since options) may be dangerous!
 
 Are you sure you want to proceed?
 EOT
-                );
-                if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                    throw new Exception('Operation aborted.');
+                    );
+                    if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
+                        throw new Exception('Operation aborted.');
+                    }
                 }
             }
         }
-        $configuration = new Configuration();
-        if ($initialMigration !== null) {
-            $configuration->forceInitialMigration($initialMigration[0], $initialMigration[1]);
-            if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
-                $output->writeln(sprintf('Initial migration to be executed: %s', $configuration->getForcedInitialMigration()->getVersion()));
-            }
-        }
-        $configuration->setOutputWriter(new OutputWriter(function ($message) use ($output) {
-            $output->writeln($message);
-        }));
         Update::updateToCurrentVersion($configuration);
     }
 }

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Console\Command;
 use Concrete\Core\Updater\Update;
 use Doctrine\DBAL\Migrations\OutputWriter;
-use Concrete\Core\Console\Command;
-use Symfony\Component\Console\Input\InputOption;
+use Exception;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Database;
-use Exception;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class UpdateCommand extends Command
@@ -35,11 +35,11 @@ EOT
     {
         if (!$input->getOption('force')) {
             if (!$input->isInteractive()) {
-                throw new Exception("You have to specify the --force option in order to run this command");
+                throw new Exception('You have to specify the --force option in order to run this command');
             }
             $confirmQuestion = new ConfirmationQuestion('Are you sure you want to update this concrete5 installation?');
             if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                throw new Exception("Operation aborted.");
+                throw new Exception('Operation aborted.');
             }
         }
         $configuration = new \Concrete\Core\Updater\Migrations\Configuration();

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -29,7 +29,7 @@ class UpdateCommand extends Command
 Examples:
 
   ./concrete/bin/concrete5 c5:update
-    Execute the migrations that haven't het been executed
+    Execute the migrations that haven't yet been executed
 
   ./concrete/bin/concrete5 c5:update --rerun
     (Re)Execute all the migrations, including the ones that have already been executed (if possible).

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -3,12 +3,12 @@
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Concrete\Core\Updater\Migrations\Configuration;
 use Concrete\Core\Updater\Update;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -21,8 +21,29 @@ class UpdateCommand extends Command
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addEnvOption()
+            ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration')
+            ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the update')
             ->setHelp(<<<EOT
+Examples:
+
+  ./concrete/bin/concrete5 c5:update
+    Execute the migrations that haven't het been executed
+
+  ./concrete/bin/concrete5 c5:update --after=8.3.1
+    Execute the migrations after the 8.3.1 release (even if they have already been marked as executed)
+
+  ./concrete/bin/concrete5 c5:update --after=20171218000000
+    Execute the migrations after the 20171218000000 migration (even if they have already been marked as executed)
+
+  ./concrete/bin/concrete5 c5:update --since=8.3.1
+    Execute the migrations starting from the 8.3.1 release (even if they have already been marked as executed)
+
+  ./concrete/bin/concrete5 c5:update --since=20171218000000
+    Execute the migrations starting from the 20171218000000 migration (even if they have already been marked as executed)
+
+Please remark that re-executing old migrations (with the --after or --since options) may be dangerous.
+
 Returns codes:
   0 operation completed successfully
   $errExitCode errors occurred
@@ -33,17 +54,38 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$input->getOption('force')) {
-            if (!$input->isInteractive()) {
-                throw new Exception('You have to specify the --force option in order to run this command');
-            }
-            $confirmQuestion = new ConfirmationQuestion('Are you sure you want to update this concrete5 installation?');
-            if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                throw new Exception('Operation aborted.');
+        if ($input->getOption('after') === null && $input->getOption('since') === null) {
+            $initialMigration = null;
+        } elseif ($input->getOption('after') === null) {
+            $initialMigration = [$input->getOption('since'), Configuration::FORCEDMIGRATION_INCLUSIVE];
+        } elseif ($input->getOption('since') === null) {
+            $initialMigration = [$input->getOption('after'), Configuration::FORCEDMIGRATION_EXCLUSIVE];
+        } else {
+            throw new Exception('You can\'t specify both the --after and --since options.');
+        }
+        if ($initialMigration !== null) {
+            if (!$input->getOption('force')) {
+                if (!$input->isInteractive()) {
+                    throw new Exception('You have to specify the --force option in order to run this command when you specify the --after / --since options.');
+                }
+                $confirmQuestion = new ConfirmationQuestion(<<<'EOT'
+WARNING: re-running already executed migrations (with the --after / --since options) may be dangerous!
+
+Are you sure you want to proceed?
+EOT
+                );
+                if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
+                    throw new Exception('Operation aborted.');
+                }
             }
         }
-        $configuration = new \Concrete\Core\Updater\Migrations\Configuration();
-        $output = new ConsoleOutput();
+        $configuration = new Configuration();
+        if ($initialMigration !== null) {
+            $configuration->forceInitialMigration($initialMigration[0], $initialMigration[1]);
+            if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
+                $output->writeln(sprintf('Initial migration to be executed: %s', $configuration->getForcedInitialMigration()->getVersion()));
+            }
+        }
         $configuration->setOutputWriter(new OutputWriter(function ($message) use ($output) {
             $output->writeln($message);
         }));

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -10,7 +10,6 @@ use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class UpdateCommand extends Command
 {
@@ -24,7 +23,6 @@ class UpdateCommand extends Command
             ->addOption('rerun', null, InputOption::VALUE_NONE, '(Re)apply already executed migrations')
             ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration (requires --rerun)')
             ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration (requires --rerun)')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the update')
             ->setHelp(<<<EOT
 Examples:
 
@@ -45,8 +43,6 @@ Examples:
 
   ./concrete/bin/concrete5 c5:update --rerun --since=20171218000000
     Execute the migrations starting from the 20171218000000 migration (even if they have already been marked as executed)
-
-Please remark that re-executing old migrations (with the --after or --since options) may be dangerous.
 
 Returns codes:
   0 operation completed successfully
@@ -84,20 +80,6 @@ EOT
             if ($configuration->getForcedInitialMigration() !== null) {
                 if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
                     $output->writeln(sprintf('Initial migration to be executed: %s', $configuration->getForcedInitialMigration()->getVersion()));
-                }
-                if (!$input->getOption('force')) {
-                    if (!$input->isInteractive()) {
-                        throw new Exception('You have to specify the --force option in order to run this command when you specify the --rerun option.');
-                    }
-                    $confirmQuestion = new ConfirmationQuestion(<<<'EOT'
-WARNING: re-running already executed migrations (with the --rerun option) may be dangerous!
-
-Are you sure you want to proceed?
-EOT
-                    );
-                    if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                        throw new Exception('Operation aborted.');
-                    }
                 }
             }
         }

--- a/concrete/src/Updater/Migrations/AbstractMigration.php
+++ b/concrete/src/Updater/Migrations/AbstractMigration.php
@@ -185,6 +185,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
     {
         $sp = Page::getByPath($path);
         if (!is_object($sp) || $sp->isError()) {
+            $this->output(t('Creating single page at %s...', $path));
             $sp = SinglePage::add($path);
             $update = [];
             $name = (string) $name;

--- a/concrete/src/Updater/Migrations/AbstractMigration.php
+++ b/concrete/src/Updater/Migrations/AbstractMigration.php
@@ -2,8 +2,12 @@
 
 namespace Concrete\Core\Updater\Migrations;
 
+use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Database\DatabaseStructureManager;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Facade;
 use Doctrine\DBAL\Migrations\AbstractMigration as DoctrineAbstractMigration;
 use Doctrine\DBAL\Migrations\Version;
@@ -13,6 +17,8 @@ use Doctrine\ORM\Tools\SchemaTool;
 abstract class AbstractMigration extends DoctrineAbstractMigration
 {
     protected $app;
+
+    protected $validAttributes = [];
 
     public function __construct(Version $version)
     {
@@ -149,5 +155,59 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
             left join {$sqlLinkedTable} on {$sqlTable}.{$sqlField} = {$sqlLinkedTable}.{$sqlLinkedField}
             where {$sqlLinkedTable}.{$sqlLinkedField} is null
         ");
+    }
+
+    protected function isAttributeHandleValid($categoryClass, $handle)
+    {
+        if (!isset($this->validAttributes[$categoryClass])) {
+            $this->validAttributes[$categoryClass] = [];
+        }
+        if (!isset($this->validAttributes[$categoryClass][$handle])) {
+            $app = Application::getFacadeApplication();
+            $category = $app->make($categoryClass);
+            $this->validAttributes[$categoryClass][$handle] = $category->getAttributeKeyByHandle($handle) ? true : false;
+        }
+
+        return $this->validAttributes[$categoryClass][$handle];
+    }
+
+    /**
+     * Create a new SinglePage (if it does not exist).
+     *
+     * @param string $path the single page path
+     * @param string $name the single page name
+     * @param array $attributes the attribute values (keys are the attribute handles, values are the attribute values)
+
+     *
+     * @return \Concrete\Core\Page\Page
+     */
+    protected function createSinglePage($path, $name = '', array $attributes = [])
+    {
+        $sp = Page::getByPath($path);
+        if (!is_object($sp) || $sp->isError()) {
+            $sp = SinglePage::add($path);
+            $update = [];
+            $name = (string) $name;
+            if ($name !== '') {
+                $update['cName'] = $name;
+            }
+            if (array_key_exists('cDescription', $attributes)) {
+                $description = (string) $attributes['cDescription'];
+                unset($attributes['cDescription']);
+                if ($description !== '') {
+                    $update['cDescription'] = $description;
+                }
+            }
+            if (count($update) > 0) {
+                $sp->update($update);
+            }
+            foreach ($attributes as $attributeHandle => $attributeValue) {
+                if ($this->isAttributeHandleValid(PageCategory::class, $attributeHandle)) {
+                    $sp->setAttribute($attributeHandle, $attributeValue);
+                }
+            }
+        }
+
+        return $sp;
     }
 }

--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -234,6 +234,9 @@ class Configuration extends DoctrineMigrationConfiguration
     protected function findInitialMigrationByCoreVersion($coreVersion, $criteria)
     {
         $coreVersionNormalized = preg_replace('/(\.0+)+$/', '', $coreVersion);
+        if (version_compare($coreVersionNormalized, '5.7') < 0) {
+            throw new Exception(t('Invalid version specified (%s).', $coreVersion));
+        }
         $migrations = $this->getMigrations();
         $migrationIdentifiers = array_keys($migrations);
         $maxMigrationIndex = count($migrationIdentifiers) - 1;

--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -3,6 +3,9 @@
 namespace Concrete\Core\Updater\Migrations;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration as DoctrineMigrationConfiguration;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Database\Connection\Connection;
+use Exception;
 
 class Configuration extends DoctrineMigrationConfiguration
 {
@@ -13,11 +16,12 @@ class Configuration extends DoctrineMigrationConfiguration
      */
     public function __construct($registerMigrations = true)
     {
-        $db = \Database::get();
+        $app = Application::getFacadeApplication();
+        $db = $app->make(Connection::class);
         parent::__construct($db);
         $directory = DIR_BASE_CORE . '/' . DIRNAME_CLASSES . '/Updater/Migrations/Migrations';
         $this->setName(t('concrete5 Migrations'));
-        $this->setMigrationsNamespace(('Concrete\Core\Updater\Migrations\Migrations'));
+        $this->setMigrationsNamespace('Concrete\Core\Updater\Migrations\Migrations');
         $this->setMigrationsDirectory($directory);
         if ($registerMigrations) {
             $this->registerMigrationsFromDirectory($directory);
@@ -34,10 +38,11 @@ class Configuration extends DoctrineMigrationConfiguration
      */
     public function registerPreviousMigratedVersions()
     {
-        $db = \Database::get();
+        $app = Application::getFacadeApplication();
+        $db = $app->make(Connection::class);
         try {
-            $minimum = $db->GetOne('select min(version) from SystemDatabaseMigrations');
-        } catch (\Exception $e) {
+            $minimum = $db->fetchColumn('select min(version) from SystemDatabaseMigrations');
+        } catch (Exception $e) {
             return;
         }
         $migrations = $this->getMigrations();

--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -162,7 +162,7 @@ class Configuration extends DoctrineMigrationConfiguration
             foreach (array_reverse($forcedMigrationKeys) as $forcedMigrationKey) {
                 $migration = $allMigrations[$forcedMigrationKey];
                 if ($migration->isMigrated() && !$migration->getMigration() instanceof RepeatableMigrationInterface) {
-                    throw new Exception(t('The migration %s has already been executed, and can\'t be executeg again.'));
+                    throw new Exception(t('The migration %s has already been executed, and can\'t be executed again.'));
                 }
                 $forcedMigrations[$forcedMigrationKey] = $migration;
             }

--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -152,7 +152,7 @@ class Configuration extends DoctrineMigrationConfiguration
         if ($forcedInitialMigration !== null && $direction === Version::DIRECTION_UP) {
             $allMigrations = $this->getMigrations();
             $allMigrationKeys = array_keys($allMigrations);
-            $forcedInitialMigrationIndex = array_search($forcedInitialMigration->getVersion(), $allMigrationKeys, true);
+            $forcedInitialMigrationIndex = array_search($forcedInitialMigration->getVersion(), $allMigrationKeys, false);
             if ($forcedInitialMigrationIndex === false) {
                 // This should never occur
                 throw new Exception(t('Unable to find the forced migration with version %s', $forcedInitialMigration->getVersion()));
@@ -216,7 +216,7 @@ class Configuration extends DoctrineMigrationConfiguration
                 break;
             case static::FORCEDMIGRATION_EXCLUSIVE:
                 $allIdentifiers = array_keys($this->getMigrations());
-                $migrationIndex = array_search($identifier, $allIdentifiers, true);
+                $migrationIndex = array_search($identifier, $allIdentifiers, false);
                 if ($migrationIndex === false) {
                     $result = null;
                 } elseif ($migrationIndex === count($allIdentifiers) - 1) {
@@ -272,7 +272,7 @@ class Configuration extends DoctrineMigrationConfiguration
                             $result = $migration;
                             break;
                         case static::FORCEDMIGRATION_EXCLUSIVE:
-                            $migrationIndex = array_search($identifier, $migrationIdentifiers, true);
+                            $migrationIndex = array_search($identifier, $migrationIdentifiers, false);
                             $result = $migrationIndex === $maxMigrationIndex ? null : $migrations[$migrationIdentifiers[$migrationIndex + 1]];
                             break;
                         default:

--- a/concrete/src/Updater/Migrations/Migrations/Version20140919000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20140919000000.php
@@ -6,8 +6,9 @@ use Concrete\Core\Permission\Access\Entity\Type;
 use Concrete\Core\Permission\Category;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaChangerInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20140919000000 extends AbstractMigration implements DirectSchemaChangerInterface
+class Version20140919000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaChangerInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20140930000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20140930000000.php
@@ -3,10 +3,10 @@
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
-use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
-use Doctrine\DBAL\Schema\Comparator;
+use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Doctrine\DBAL\Schema\Schema;
 
-class Version20140930000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20140930000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}
@@ -21,25 +21,22 @@ class Version20140930000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
-     * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::preUp()
      */
-    public function upgradeDatabase()
+    public function preUp(Schema $schema)
     {
         \Database::query('UPDATE Config SET configNamespace="" WHERE configNamespace IS NULL');
+    }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface::upgradeSchema()
+     */
+    public function upgradeSchema(Schema $schema)
+    {
         $config = $schema->getTable('Config');
-        $fromConfig = clone $config;
-        $db = \Database::get();
-        $platform = $db->getDatabasePlatform();
         $config->dropPrimaryKey();
         $config->setPrimaryKey(['configNamespace', 'configGroup', 'configItem']);
-        $comparator = new Comparator();
-        $diff = $comparator->diffTable($fromConfig, $config);
-        $sql = $platform->getAlterTableSQL($diff);
-        if (is_array($sql) && count($sql)) {
-            foreach ($sql as $q) {
-                $db->query($q);
-            }
-        }
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20140930000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20140930000000.php
@@ -4,9 +4,10 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20140930000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface
+class Version20140930000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
@@ -8,11 +8,12 @@ use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Exception;
 use SinglePage;
 
-class Version20141017000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20141017000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
@@ -33,18 +33,22 @@ class Version20141017000000 extends AbstractMigration implements ManagedSchemaUp
     {
         /* refresh CollectionVersionBlocks, CollectionVersionBlocksCacheSettings tables */
         $cvb = $schema->getTable('CollectionVersionBlocks');
-        $cvb->addColumn('cbOverrideBlockTypeCacheSettings', 'boolean', ['default' => 0]);
+        if (!$cvb->hasColumn('cbOverrideBlockTypeCacheSettings')) {
+            $cvb->addColumn('cbOverrideBlockTypeCacheSettings', 'boolean', ['default' => 0]);
+        }
 
-        $cvbcs = $schema->createTable('CollectionVersionBlocksCacheSettings');
-        $cvbcs->addColumn('cID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
-        $cvbcs->addColumn('cvID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 1]);
-        $cvbcs->addColumn('bID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
-        $cvbcs->addColumn('arHandle', 'string', ['notnull' => false]);
-        $cvbcs->addColumn('btCacheBlockOutput', 'boolean', ['default' => 0]);
-        $cvbcs->addColumn('btCacheBlockOutputOnPost', 'boolean', ['default' => 0]);
-        $cvbcs->addColumn('btCacheBlockOutputForRegisteredUsers', 'boolean', ['default' => 0]);
-        $cvbcs->addColumn('btCacheBlockOutputLifetime', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
-        $cvbcs->setPrimaryKey(['cID', 'cvID', 'bId', 'arHandle']);
+        if (!$schema->hasTable('CollectionVersionBlocksCacheSettings')) {
+            $cvbcs = $schema->createTable('CollectionVersionBlocksCacheSettings');
+            $cvbcs->addColumn('cID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
+            $cvbcs->addColumn('cvID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 1]);
+            $cvbcs->addColumn('bID', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
+            $cvbcs->addColumn('arHandle', 'string', ['notnull' => false]);
+            $cvbcs->addColumn('btCacheBlockOutput', 'boolean', ['default' => 0]);
+            $cvbcs->addColumn('btCacheBlockOutputOnPost', 'boolean', ['default' => 0]);
+            $cvbcs->addColumn('btCacheBlockOutputForRegisteredUsers', 'boolean', ['default' => 0]);
+            $cvbcs->addColumn('btCacheBlockOutputLifetime', 'integer', ['notnull' => true, 'unsigned' => true, 'default' => 0]);
+            $cvbcs->setPrimaryKey(['cID', 'cvID', 'bId', 'arHandle']);
+        }
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141017000000.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
+use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Key\Key;
@@ -11,7 +12,6 @@ use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Exception;
-use SinglePage;
 
 class Version20141017000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
@@ -70,24 +70,9 @@ class Version20141017000000 extends AbstractMigration implements RepeatableMigra
         }
 
         /* Add marketplace single pages */
-        $sp = Page::getByPath('/dashboard/extend/connect');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/extend/connect');
-            $sp->update(['cName' => 'Connect to the Community']);
-            $sp->setAttribute('meta_keywords', 'concrete5.org, my account, marketplace');
-        }
-        $sp = Page::getByPath('/dashboard/extend/themes');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/extend/themes');
-            $sp->update(['cName' => 'Get More Themes']);
-            $sp->setAttribute('meta_keywords', 'buy theme, new theme, marketplace, template');
-        }
-        $sp = Page::getByPath('/dashboard/extend/addons');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/extend/addons');
-            $sp->update(['cName' => 'Get More Add-Ons']);
-            $sp->setAttribute('meta_keywords', 'buy addon, buy add on, buy add-on, purchase addon, purchase add on, purchase add-on, find addon, new addon, marketplace');
-        }
+        $this->createSinglePage('/dashboard/extend/connect', 'Connect to the Community', ['meta_keywords' => 'concrete5.org, my account, marketplace']);
+        $this->createSinglePage('/dashboard/extend/themes', 'Get More Themes', ['meta_keywords' => 'buy theme, new theme, marketplace, template']);
+        $this->createSinglePage('/dashboard/extend/addons', 'Get More Add-Ons', ['meta_keywords' => 'buy addon, buy add on, buy add-on, purchase addon, purchase add on, purchase add-on, find addon, new addon, marketplace']);
 
         /* Add auth types ("handle|name") "twitter|Twitter" and "community|concrete5.org" */
         try {
@@ -116,7 +101,7 @@ class Version20141017000000 extends AbstractMigration implements RepeatableMigra
 
         /* exclude nav from flat view in dashboard */
         $flat = Page::getByPath('/dashboard/sitemap/explore');
-        if (is_object($customize) && !$customize->isError()) {
+        if (is_object($customize) && !$customize->isError() && $this->isAttributeHandleValid(PageCategory::class, 'exclude_nav')) {
             $flat->setAttribute('exclude_nav', false);
         }
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
@@ -10,7 +9,6 @@ use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Exception;
-use SinglePage;
 
 class Version20141024000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
@@ -54,12 +52,7 @@ class Version20141024000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         /* Add query log single pages */
-        $sp = Page::getByPath('/dashboard/system/optimization/query_log');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/optimization/query_log');
-            $sp->update(['cName' => 'Database Query Log']);
-            $sp->setAttribute('meta_keywords', 'queries, database, mysql');
-        }
+        $this->createSinglePage('/dashboard/system/optimization/query_log', 'Database Query Log', ['meta_keywords' => 'queries, database, mysql']);
 
         /* Refresh image block */
         $this->refreshBlockType('image');

--- a/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
@@ -63,9 +62,6 @@ class Version20141024000000 extends AbstractMigration implements RepeatableMigra
         }
 
         /* Refresh image block */
-        $bt = BlockType::getByHandle('image');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('image');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141024000000.php
@@ -7,12 +7,13 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Exception;
 use SinglePage;
 
-class Version20141024000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20141024000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
@@ -6,10 +6,11 @@ use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Database;
 use SinglePage;
 
-class Version20141113000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20141113000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
@@ -7,7 +7,6 @@ use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Database;
-use SinglePage;
 
 class Version20141113000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
@@ -35,18 +34,9 @@ class Version20141113000000 extends AbstractMigration implements RepeatableMigra
         }
 
         /* Add inspect single page back if it's missing */
-        $sp = Page::getByPath('/dashboard/pages/themes/inspect');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/pages/themes/inspect');
-            $sp->setAttribute('meta_keywords', 'inspect, templates');
-            $sp->setAttribute('exclude_nav', 1);
-        }
+        $this->createSinglePage('/dashboard/pages/themes/inspect', '', ['meta_keywords' => 'inspect, templates', 'exclude_nav' => 1]);
 
-        $sp = Page::getByPath('/members/directory');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/members/directory');
-            $sp->setAttribute('exclude_nav', 1);
-        }
+        $this->createSinglePage('/members/directory', '', ['exclude_nav' => 1]);
 
         $this->refreshBlockType('feature');
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
@@ -49,15 +48,9 @@ class Version20141113000000 extends AbstractMigration implements RepeatableMigra
             $sp->setAttribute('exclude_nav', 1);
         }
 
-        $bt = BlockType::getByHandle('feature');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('feature');
 
-        $bt = BlockType::getByHandle('image_slider');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('image_slider');
 
         $db = Database::get();
         $sm = $db->getSchemaManager();

--- a/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
@@ -79,8 +79,7 @@ class Version20141219000000 extends AbstractMigration implements RepeatableMigra
             FlagType::add('spam');
         }
 
-        $bt = BlockType::getByHandle('image_slider');
-        $bt->refresh();
+        $this->refreshBlockType('image_slider');
 
         $types = [Type::getByHandle('group'), Type::getByHandle('user'), Type::getByHandle('group_set'), Type::getByHandle('group_combination')];
         $categories = [Category::getByHandle('conversation'), Category::getByHandle('conversation_message')];

--- a/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
@@ -15,7 +15,6 @@ use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Exception;
 use Page;
-use SinglePage;
 
 class Version20141219000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
@@ -176,31 +175,10 @@ class Version20141219000000 extends AbstractMigration implements RepeatableMigra
         }
 
         // single pages
-        $sp = Page::getByPath('/dashboard/system/multilingual');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/multilingual');
-            $sp->update(['cName' => 'Multilingual']);
-            $sp->setAttribute('meta_keywords', 'multilingual, localization, internationalization, i18n');
-        }
-        $sp = Page::getByPath('/dashboard/system/multilingual/setup');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/multilingual/setup');
-            $sp->update(['cName' => 'Multilingual Setup']);
-        }
-        $sp = Page::getByPath('/dashboard/system/multilingual/page_report');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/multilingual/page_report');
-            $sp->update(['cName' => 'Page Report']);
-        }
-        $sp = Page::getByPath('/dashboard/system/multilingual/translate_interface');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/multilingual/translate_interface');
-            $sp->update(['cName' => 'Translate Interface']);
-        }
-        $sp = Page::getByPath('/dashboard/pages/types/attributes');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/pages/types/attributes');
-            $sp->update(['cName' => 'Page Type Attributes']);
-        }
+        $this->createSinglePage('/dashboard/system/multilingual', 'Multilingual', ['meta_keywords' => 'multilingual, localization, internationalization, i18n']);
+        $this->createSinglePage('/dashboard/system/multilingual/setup', 'Multilingual Setup');
+        $this->createSinglePage('/dashboard/system/multilingual/page_report', 'Page Report');
+        $this->createSinglePage('/dashboard/system/multilingual/translate_interface', 'Translate Interface');
+        $this->createSinglePage('/dashboard/pages/types/attributes', 'Page Type Attributes');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
@@ -11,12 +11,13 @@ use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Exception;
 use Page;
 use SinglePage;
 
-class Version20141219000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20141219000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150109000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150109000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -26,9 +25,6 @@ class Version20150109000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $bt = BlockType::getByHandle('google_map');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('google_map');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150109000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150109000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150109000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150109000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Permission\Access\Access;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
 use Concrete\Core\Permission\Access\Entity\Type;
@@ -123,20 +122,11 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
         $db = \Database::get();
         $db->Execute('DROP TABLE IF EXISTS PageStatistics');
 
-        $bt = BlockType::getByHandle('page_list');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_list');
 
-        $bt = BlockType::getByHandle('page_title');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_title');
 
-        $bt = BlockType::getByHandle('form');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('form');
 
         $c = \Page::getByPath('/dashboard/system/seo/urls');
         if (is_object($c) && !$c->isError()) {

--- a/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
@@ -12,10 +12,11 @@ use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\User\Group\Group;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20150504000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20150504000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     private $updateSectionPlurals = false;
     private $updateMultilingualTranslations = false;

--- a/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
@@ -133,12 +133,7 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
             $c->update(['cName' => 'URLs and Redirection']);
         }
 
-        $sp = \Page::getByPath('/dashboard/system/environment/entities');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = \SinglePage::add('/dashboard/system/environment/entities');
-            $sp->update(['cName' => 'Database Entities']);
-            $sp->setAttribute('meta_keywords', 'database, entities, doctrine, orm');
-        }
+        $this->createSinglePage('/dashboard/system/environment/entities', 'Database Entities', ['meta_keywords' => 'database, entities, doctrine, orm']);
 
         $pkx = Category::getByHandle('multilingual_section');
         if (!is_object($pkx)) {

--- a/concrete/src/Updater/Migrations/Migrations/Version20150515000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150515000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150515000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150515000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
@@ -15,10 +15,7 @@ class Version20150610000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $bt = \BlockType::getByHandle('file');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('file');
         if (\Config::get('conversation.banned_words')) {
             \Config::set('conversations.banned_words', true);
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150610000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150610000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150610000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150612000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150612000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150612000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150612000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150612000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150612000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -16,10 +15,6 @@ class Version20150612000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $sp = Page::getByPath('/dashboard/system/multilingual/copy');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = \Concrete\Core\Page\Single::add('/dashboard/system/multilingual/copy');
-            $sp->update(['cName' => 'Copy Languages']);
-        }
+        $this->createSinglePage('/dashboard/system/multilingual/copy', 'Copy Languages');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150615000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150615000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Type\Type;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150615000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150615000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150616000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150616000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Stack\StackList;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150616000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150616000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150619000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150619000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150619000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150619000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150622000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150622000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150622000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150622000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150623000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150623000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150623000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150623000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20150713000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20150713000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
@@ -10,6 +10,16 @@ class Version20150713000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '5.7.5';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
@@ -48,9 +48,6 @@ class Version20150731000000 extends AbstractMigration implements RepeatableMigra
         $db->executeQuery('DELETE FROM DownloadStatistics WHERE fID NOT IN (SELECT fID FROM Files)');
         $db->executeQuery('DELETE FROM FilePermissionAssignments WHERE fID NOT IN (SELECT fID FROM Files)');
 
-        $bt = \BlockType::getByHandle('page_list');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_list');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
@@ -5,9 +5,10 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20150731000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20150731000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
@@ -12,6 +12,16 @@ class Version20150731000000 extends AbstractMigration implements ManagedSchemaUp
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '5.7.5.2';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface::upgradeSchema()
      */
     public function upgradeSchema(Schema $schema)

--- a/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
@@ -11,6 +11,16 @@ class Version20151221000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '5.7.5.4';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20151221000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20151221000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -27,11 +26,7 @@ class Version20151221000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         // image resizing options
-        $sp = Page::getByPath('/dashboard/system/files/image_uploading');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = \Concrete\Core\Page\Single::add('/dashboard/system/files/image_uploading');
-            $sp->update(['cName' => 'Image Uploading']);
-        }
+        $this->createSinglePage('/dashboard/system/files/image_uploading', 'Image Uploading');
 
         // background size/position
         \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema([

--- a/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20151221000000.php
@@ -38,19 +38,10 @@ class Version20151221000000 extends AbstractMigration implements RepeatableMigra
             'StyleCustomizerInlineStyleSets',
         ]);
 
-        $bt = \BlockType::getByHandle('image_slider');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('image_slider');
 
-        $bt = \BlockType::getByHandle('youtube');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('youtube');
 
-        $bt = \BlockType::getByHandle('autonav');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('autonav');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160107000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160107000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20160107000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20160107000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20160213000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160213000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20160213000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20160213000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20160213000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160213000000.php
@@ -16,9 +16,6 @@ class Version20160213000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         // added new delimiter settings.
-        $bt = \BlockType::getByHandle('page_attribute_display');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_attribute_display');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160314000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160314000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20160314000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20160314000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20160314000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160314000000.php
@@ -15,9 +15,6 @@ class Version20160314000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $bt = \BlockType::getByHandle('image_slider');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('image_slider');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
@@ -10,6 +10,16 @@ class Version20160412000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '5.7.5.7';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160412000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20160412000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20160412000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20160615000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20160615000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
@@ -11,6 +11,16 @@ class Version20160615000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '5.7.5.9';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160615000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -26,13 +25,7 @@ class Version20160615000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $bt = BlockType::getByHandle('page_list');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
-        $bt = BlockType::getByHandle('form');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_list');
+        $this->refreshBlockType('form');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -14,7 +14,6 @@ use Concrete\Core\Entity\Attribute\Key\PageKey;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Page\Template;
 use Concrete\Core\Permission\Access\Access;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
@@ -647,112 +646,23 @@ class Version20160725000000 extends AbstractMigration implements DirectSchemaUpg
     {
         $this->output(t('Updating Dashboard...'));
 
-        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
-        /* @var PageCategory $pageAttributeCategory */
-        $availableAttributes = [];
-        foreach ([
-            'exclude_nav',
-            'exclude_search_index',
-            'meta_keywords',
-        ] as $akHandle) {
-            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
-        }
-
-        $page = Page::getByPath('/dashboard/express');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/express');
-            $sp->update(['cName' => 'Express', 'cDescription' => 'Express Data Objects']);
-        }
-        $page = Page::getByPath('/dashboard/express/entries');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/express/entries');
-            $sp->update(['cName' => 'View Entries']);
-        }
-        $page = Page::getByPath('/dashboard/system/express');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express');
-            $sp->update(['cName' => 'Express']);
-        }
-        $page = Page::getByPath('/dashboard/system/express/entities');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entities');
-            $sp->update(['cName' => 'Data Objects']);
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/express/entities/attributes');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entities/attributes');
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/express/entities/associations');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entities/associations');
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/express/entities/forms');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entities/forms');
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/express/entities/customize_search');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entities/customize_search');
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/express/entries');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/express/entries');
-            $sp->update(['cName' => 'Custom Entry Locations']);
-        }
-        $page = Page::getByPath('/dashboard/reports/forms/legacy');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/reports/forms/legacy');
-            $sp->update(['cName' => 'Form Results']);
-            if ($availableAttributes['exclude_search_index']) {
-                $sp->setAttribute('exclude_search_index', true);
-            }
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
+        $this->createSinglePage('/dashboard/express', 'Express', ['cDescription' => 'Express Data Objects']);
+        $this->createSinglePage('/dashboard/express/entries', 'View Entries');
+        $this->createSinglePage('/dashboard/system/express', 'Express');
+        $this->createSinglePage('/dashboard/system/express/entities', 'Data Objects', ['exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/express/entities/attributes', '', ['exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/express/entities/associations', '', ['exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/express/entities/forms', '', ['exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/express/entities/customize_search', '', ['exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/express/entries', 'Custom Entry Locations');
+        $this->createSinglePage('/dashboard/reports/forms/legacy', 'Form Results', ['exclude_search_index' => true, 'exclude_nav' => true]);
         $page = Page::getByPath('/dashboard/system/basics/name');
         if (is_object($page) && !$page->isError()) {
             $page->update(['cName' => 'Name & Attributes']);
         }
-        $page = Page::getByPath('/dashboard/system/basics/attributes');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/basics/attributes');
-            $sp->update(['cName' => 'Custom Attributes']);
-            if ($availableAttributes['exclude_search_index']) {
-                $sp->setAttribute('exclude_search_index', true);
-            }
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/registration/global_password_reset');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/registration/global_password_reset');
-            $sp->update(['cDescription' => 'Signs out all users, resets all passwords and forces users to choose a new one']);
-            if ($availableAttributes['meta_keywords']) {
-                $sp->setAttribute('meta_keywords', 'global, password, reset, change password, force, sign out');
-            }
-        }
-        $page = Page::getByPath('/dashboard/system/registration/notification');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/registration/notification');
-            $sp->update(['cName' => 'Notification Settings']);
-        }
+        $this->createSinglePage('/dashboard/system/basics/attributes', 'Custom Attributes', ['exclude_search_index' => true, 'exclude_nav' => true]);
+        $this->createSinglePage('/dashboard/system/registration/global_password_reset', '', ['cDescription' => 'Signs out all users, resets all passwords and forces users to choose a new one', 'meta_keywords' => 'global, password, reset, change password, force, sign out']);
+        $this->createSinglePage('/dashboard/system/registration/notification', 'Notification Settings']);
     }
 
     protected function addBlockTypes()
@@ -964,7 +874,7 @@ class Version20160725000000 extends AbstractMigration implements DirectSchemaUpg
         }
 
         // Private Messages tweak
-        SinglePage::add('/account/messages');
+        $this->createSinglePage('/account/messages');
 
         $bt = BlockType::getByHandle('rss_displayer');
         if (!is_object($bt)) {
@@ -987,10 +897,7 @@ class Version20160725000000 extends AbstractMigration implements DirectSchemaUpg
         if (is_object($page) && !$page->isError()) {
             $page->moveToTrash();
         }
-        $page = \Page::getByPath('/dashboard/system/permissions/workflows');
-        if (!is_object($page) || $page->isError()) {
-            SinglePage::add('/dashboard/system/permissions/workflows');
-        }
+        $this->createSinglePage('/dashboard/system/permissions/workflows', '');
     }
 
     protected function installSite()

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -3,7 +3,6 @@
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Block\ExpressForm\Controller as ExpressFormBlockController;
-use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Attribute\Key\Category;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Attribute\Type;
@@ -662,7 +661,7 @@ class Version20160725000000 extends AbstractMigration implements DirectSchemaUpg
         }
         $this->createSinglePage('/dashboard/system/basics/attributes', 'Custom Attributes', ['exclude_search_index' => true, 'exclude_nav' => true]);
         $this->createSinglePage('/dashboard/system/registration/global_password_reset', '', ['cDescription' => 'Signs out all users, resets all passwords and forces users to choose a new one', 'meta_keywords' => 'global, password, reset, change password, force, sign out']);
-        $this->createSinglePage('/dashboard/system/registration/notification', 'Notification Settings']);
+        $this->createSinglePage('/dashboard/system/registration/notification', 'Notification Settings');
     }
 
     protected function addBlockTypes()

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -875,25 +875,13 @@ class Version20160725000000 extends AbstractMigration implements DirectSchemaUpg
 
         $desktopSet->addBlockType($bt);
 
-        $bt = BlockType::getByHandle('page_title');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_title');
 
-        $bt = BlockType::getByHandle('page_list');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('page_list');
 
-        $bt = BlockType::getByHandle('next_previous');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('next_previous');
 
-        $bt = BlockType::getByHandle('autonav');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('autonav');
     }
 
     protected function addTreeNodeTypes()

--- a/concrete/src/Updater/Migrations/Migrations/Version20161109000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161109000000.php
@@ -5,9 +5,10 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20161109000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20161109000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20161109000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161109000000.php
@@ -12,6 +12,16 @@ class Version20161109000000 extends AbstractMigration implements ManagedSchemaUp
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.0.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface::upgradeSchema()
      */
     public function upgradeSchema(Schema $schema)

--- a/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
@@ -10,6 +10,16 @@ class Version20161203000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.0.1';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20161203000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20161203000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -38,15 +37,8 @@ class Version20161208000000 extends AbstractMigration implements RepeatableMigra
 
     protected function updateBlocks()
     {
-        $this->output(t('Refreshing blocks.'));
-        $bt = BlockType::getByHandle('express_entry_detail');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
-        $bt = BlockType::getByHandle('page_attribute_display');
-        if (is_object($bt)) {
-            $bt->refresh();
-        }
+        $this->refreshBlockType('express_entry_detail');
+        $this->refreshBlockType('page_attribute_display');
     }
 
     protected function updateDoctrineXmlTables()

--- a/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20161208000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20161208000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
@@ -11,6 +11,16 @@ class Version20161208000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.0.2';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20161216000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161216000000.php
@@ -6,9 +6,10 @@ use Concrete\Block\ExpressForm\Controller as ExpressFormBlockController;
 use Concrete\Core\Tree\Node\Type\ExpressEntryCategory;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\User\Group\Group;
 
-class Version20161216000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20161216000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20161216000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161216000000.php
@@ -13,6 +13,16 @@ class Version20161216000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.0.3';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20161216100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161216100000.php
@@ -6,8 +6,9 @@ use Concrete\Core\File\Set\Set;
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20161216100000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20161216100000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170118000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170118000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170118000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170118000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170123000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170123000000.php
@@ -10,6 +10,16 @@ class Version20170123000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.1.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20170123000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170123000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170123000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170123000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170201000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170201000000.php
@@ -7,8 +7,9 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaDowngraderInterface;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170201000000 extends AbstractMigration implements DirectSchemaUpgraderInterface, DirectSchemaDowngraderInterface
+class Version20170201000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface, DirectSchemaDowngraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
@@ -2,9 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
-use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
@@ -12,7 +10,6 @@ use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\Updater\Migrations\Routine\AddPageDraftsBooleanTrait;
 use Doctrine\DBAL\Schema\Schema;
-use SinglePage;
 
 class Version20170202000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
@@ -45,27 +42,7 @@ class Version20170202000000 extends AbstractMigration implements RepeatableMigra
             $config->save('app.http_client.sslverifypeer', false);
         }
         $this->migrateDrafts();
-        $app = Application::getFacadeApplication();
-        $pageAttributeCategory = $app->make(PageCategory::class);
-        /* @var PageCategory $pageAttributeCategory */
-        $availableAttributes = [];
-        foreach ([
-            'exclude_nav',
-            'meta_keywords',
-        ] as $akHandle) {
-            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
-        }
 
-        $sp = Page::getByPath('/dashboard/system/files/thumbnails/options');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/files/thumbnails/options');
-            $sp->update(['cName' => 'Thumbnail Options']);
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-            if ($availableAttributes['meta_keywords']) {
-                $sp->setAttribute('meta_keywords', 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency');
-            }
-        }
+        $this->createSinglePage('/dashboard/system/files/thumbnails/options', 'Thumbnail Options', ['exclude_nav' => true, 'meta_keywords' => 'thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency']);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170202000000.php
@@ -9,11 +9,12 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\Updater\Migrations\Routine\AddPageDraftsBooleanTrait;
 use Doctrine\DBAL\Schema\Schema;
 use SinglePage;
 
-class Version20170202000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20170202000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     use AddPageDraftsBooleanTrait;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170227063249.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170227063249.php
@@ -4,11 +4,12 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
  * Conversations Ratings Page Review Migration.
  */
-class Version20170227063249 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170227063249 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170313000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170313000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
@@ -6,6 +6,7 @@ use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Express\EntryList;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
  * Class Version20170316000000.
@@ -17,7 +18,7 @@ use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
  * After refreshing all columns we go though all entities and re-fill the search indexes so that any values that are
  * longer than 255 chars will now be indexed properly.
  */
-class Version20170316000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170316000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
@@ -2,10 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Page\Single as SinglePage;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -19,16 +16,6 @@ class Version20170404000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
-        /* @var PageCategory $pageAttributeCategory */
-        $availableAttributes = [];
-        foreach ([
-            'exclude_nav',
-            'meta_keywords',
-        ] as $akHandle) {
-            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
-        }
-
         $timezone = \Config::get('app.timezone');
         if ($timezone) {
             // We have a legacy timezone we need to move into the site.
@@ -38,16 +25,6 @@ class Version20170404000000 extends AbstractMigration implements RepeatableMigra
         }
 
         // Add the new dashboard page to update language files
-        $sp = Page::getByPath('/dashboard/system/basics/multilingual/update');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = SinglePage::add('/dashboard/system/basics/multilingual/update');
-            $sp->update(['cName' => 'Update Languages']);
-            if ($availableAttributes['exclude_nav']) {
-                $sp->setAttribute('exclude_nav', true);
-            }
-            if ($availableAttributes['meta_keywords']) {
-                $sp->setAttribute('meta_keywords', 'languages, update, gettext, translation');
-            }
-        }
+        $this->createSinglePage('/dashboard/system/basics/multilingual/update', 'Update Languages', ['exclude_nav' => true, 'meta_keywords' => 'languages, update, gettext, translation']);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170404000000.php
@@ -8,8 +8,9 @@ use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170404000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170404000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170406000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170406000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170406000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170406000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170407000001 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170407000001 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170412000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170412000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170418000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170418000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170418000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170418000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
@@ -2,10 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Page\Single as SinglePage;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -19,30 +16,12 @@ class Version20170420000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $pageAttributeCategory = Application::getFacadeApplication()->make(PageCategory::class);
-        /* @var PageCategory $pageAttributeCategory */
-        $availableAttributes = [];
-        foreach (['meta_keywords'] as $akHandle) {
-            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
-        }
-
         Page::getByPath('/dashboard/system/backup')->delete();
         Page::getByPath('/dashboard/system/backup/backup')->delete();
         Page::getByPath('/dashboard/system/backup/update')->delete();
 
-        $page = Page::getByPath('/dashboard/system/update');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/update');
-            $sp->update(['cName' => 'Update concrete5']);
-        }
+        $this->createSinglePage('/dashboard/system/update', 'Update concrete5');
 
-        $page = Page::getByPath('/dashboard/system/update/update');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/update/update');
-            $sp->update(['cName' => 'Apply Update']);
-            if ($availableAttributes['meta_keywords']) {
-                $sp->setAttribute('meta_keywords', 'upgrade, new version, update');
-            }
-        }
+        $this->createSinglePage('/dashboard/system/update/update', 'Apply Update', ['meta_keywords' => 'upgrade, new version, update']);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170420000000.php
@@ -8,8 +8,9 @@ use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170420000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170420000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170421000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170421000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170421000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170421000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170424000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170424000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170424000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170424000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170505000000.php
@@ -4,9 +4,10 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20170505000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface
+class Version20170505000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170512000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170512000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170512000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170512000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170519000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170519000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170519000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170519000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170608000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170608000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170608000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170608000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170608100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170608100000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170608100000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170608100000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170609000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170609000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170609000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170609000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170609000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170609000000.php
@@ -20,17 +20,13 @@ class Version20170609000000 extends AbstractMigration implements DirectSchemaUpg
         ]);
         $config = \Core::make('config');
         $type = Type::getByHandle($config->get('concrete.icons.file_manager_listing.handle'));
-        /**
-         * @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type
-         */
+        /* @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type $type */
         if ($type) {
             $type->setSizingMode($type::RESIZE_EXACT);
             $type->save();
         }
         $type = Type::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
-        /**
-         * @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type
-         */
+        /* @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type $type */
         if ($type) {
             $type->setSizingMode($type::RESIZE_EXACT);
             $type->save();

--- a/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Single;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -24,11 +23,6 @@ class Version20170609100000 extends AbstractMigration implements RepeatableMigra
         $this->connection->executeQuery('DROP TABLE IF EXISTS UserBannedIPs');
 
         // Add the new dashboard page to show IP ranges
-        $sp = \Page::getByPath('/dashboard/system/permissions/blacklist/range');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = Single::add('/dashboard/system/permissions/blacklist/range');
-            $sp->update(['cName' => 'IP Range']);
-            $sp->setAttribute('exclude_nav', true);
-        }
+        $this->createSinglePage('/dashboard/system/permissions/blacklist/range', 'IP Range', ['exclude_nav' => true]);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Single;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170609100000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170609100000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170610000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170610000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\File\File;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170610000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170610000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170611000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170611000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170611000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170611000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170613000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170613000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
@@ -20,7 +20,7 @@ class Version20170613000000 extends AbstractMigration implements DirectSchemaUpg
         $folder = $filesystem->getRootFolder();
         if ($folder) {
             $this->connection->executeQuery(
-                'update btExpressForm set addFilesToFolder = ?', [$folder->getTreeNodeID()]
+                'update btExpressForm set addFilesToFolder = ? where addFilesToFolder IS NULL or addFilesToFolder = 0', [$folder->getTreeNodeID()]
             );
         }
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170614000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170614000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170614000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170614000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170626000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170626000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170626000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170626000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170711151953.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170711151953.php
@@ -10,6 +10,16 @@ class Version20170711151953 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.2.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20170711151953.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170711151953.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170711151953 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170711151953 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170731021618.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170731021618.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170731021618 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170731021618 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
@@ -10,6 +10,16 @@ class Version20170802000000 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.2.1';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170802000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170802000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170804000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170804000000.php
@@ -17,10 +17,10 @@ class Version20170804000000 extends AbstractMigration implements DirectSchemaUpg
     {
         $type = Type::getByHandle('file_manager_detail');
         if ($type) {
-            /**
+            /*
              * Fix issue where file manager detail thumbnails were being added without a height.
              *
-             * @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type
+             * @var \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type $type
              */
             if (!$type->getHeight()) {
                 $type->setHeight($type->getWidth());

--- a/concrete/src/Updater/Migrations/Migrations/Version20170804000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170804000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170804000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170804000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170810000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170810000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170810000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170810000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170818000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170818000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Entity\Site\Locale;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170818000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170818000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170824000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170824000000.php
@@ -2,12 +2,9 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Attribute\Category\PageCategory;
 use Concrete\Core\Entity\Attribute\Key\Settings\AddressSettings;
 use Concrete\Core\Entity\Geolocator;
 use Concrete\Core\Geolocator\GeolocatorService;
-use Concrete\Core\Page\Page;
-use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
@@ -65,20 +62,6 @@ class Version20170824000000 extends AbstractMigration implements RepeatableMigra
             $em->flush($geolocator);
         }
 
-        $pageAttributeCategory = $app->make(PageCategory::class);
-        /* @var PageCategory $pageAttributeCategory */
-        $availableAttributes = [];
-        foreach (['meta_keywords'] as $akHandle) {
-            $availableAttributes[$akHandle] = $pageAttributeCategory->getAttributeKeyByHandle($akHandle) ? true : false;
-        }
-
-        $page = Page::getByPath('/dashboard/system/environment/geolocation');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/environment/geolocation');
-            $sp->update(['cName' => 'Geolocation']);
-            if ($availableAttributes['meta_keywords']) {
-                $sp->setAttribute('meta_keywords', 'geolocation, ip, address, country, nation, place, locate');
-            }
-        }
+        $this->createSinglePage('/dashboard/system/environment/geolocation', 'Geolocation', ['meta_keywords' => 'geolocation, ip, address, country, nation, place, locate']);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170824000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170824000000.php
@@ -12,10 +12,11 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\Updater\Migrations\Routine\AddPageDraftsBooleanTrait;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20170824000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20170824000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     use AddPageDraftsBooleanTrait;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170905000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170905000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170905000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170905000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170915000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170915000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Attribute\Type;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170915000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170915000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170926000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20170926000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171012000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171012000000.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171012000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171012000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171025000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171025000000.php
@@ -6,8 +6,9 @@ use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171025000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171025000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171109000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171109000000.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171109000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171109000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171109065758.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171109065758.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Entity\Attribute\Key\Settings\SelectSettings;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171109065758 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171109065758 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
@@ -20,7 +20,6 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
-use Doctrine\DBAL\Schema\Schema;
 
 class Version20171110032423 extends AbstractMigration implements DirectSchemaUpgraderInterface
 {

--- a/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
@@ -20,8 +20,9 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171110032423 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171110032423 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
@@ -6,9 +6,10 @@ use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20171121000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20171121000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Single;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -26,10 +25,6 @@ class Version20171129190607 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $sp = \Page::getByPath('/dashboard/system/calendar/import');
-        if (!is_object($sp) || $sp->isError()) {
-            $sp = Single::add('/dashboard/system/calendar/import');
-            $sp->update(['cName' => 'Import Calendar Data']);
-        }
+        $this->createSinglePage('/dashboard/system/calendar/import', 'Import Calendar Data');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
@@ -5,8 +5,9 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Page\Single;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171129190607 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171129190607 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171129190607.php
@@ -11,6 +11,16 @@ class Version20171129190607 extends AbstractMigration implements DirectSchemaUpg
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.3.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
      */
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20171218000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171218000000.php
@@ -15,6 +15,16 @@ class Version20171218000000 extends AbstractMigration implements ManagedSchemaUp
     /**
      * {@inheritdoc}
      *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.3.1';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface::upgradeSchema()
      */
     public function upgradeSchema(Schema $schema)

--- a/concrete/src/Updater/Migrations/Migrations/Version20171218000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171218000000.php
@@ -5,10 +5,11 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\Updater\Migrations\Routine\AddPageDraftsBooleanTrait;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20171218000000 extends AbstractMigration implements ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
+class Version20171218000000 extends AbstractMigration implements RepeatableMigrationInterface, ManagedSchemaUpgraderInterface, DirectSchemaUpgraderInterface
 {
     use AddPageDraftsBooleanTrait;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20171221194440.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171221194440.php
@@ -7,8 +7,9 @@ use Concrete\Core\Geolocator\GeolocatorService;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171221194440 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20171221194440 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180119000000.php
@@ -8,8 +8,9 @@ use Concrete\Core\Entity\Express\Form as ExpressForm;
 use Concrete\Core\Entity\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20180119000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20180119000000 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180122213656.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180122213656.php
@@ -11,7 +11,21 @@ use Doctrine\ORM\EntityManager;
 
 class Version20180122213656 extends AbstractMigration implements DirectSchemaUpgraderInterface
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\DBAL\Migrations\AbstractMigration::getDescription()
+     */
+    public function getDescription()
+    {
+        return '8.3.2';
+    }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface::upgradeDatabase()
+     */
     public function upgradeDatabase()
     {
         $app = Facade::getFacadeApplication();
@@ -26,7 +40,7 @@ class Version20180122213656 extends AbstractMigration implements DirectSchemaUpg
             $type = $typeFactory->add('express', 'Express Entity');
         }
 
-        foreach (array('collection', 'user', 'file', 'site') as $handle) {
+        foreach (['collection', 'user', 'file', 'site'] as $handle) {
             $category = $categoryService->getByHandle($handle);
             if ($category !== null) {
                 $categoryTypes = $category->getAttributeTypes();
@@ -36,6 +50,5 @@ class Version20180122213656 extends AbstractMigration implements DirectSchemaUpg
             }
         }
         $em->flush();
-
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180122213656.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180122213656.php
@@ -7,9 +7,10 @@ use Concrete\Core\Attribute\TypeFactory;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Doctrine\ORM\EntityManager;
 
-class Version20180122213656 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20180122213656 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
@@ -6,8 +6,9 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20180122220813 extends AbstractMigration implements DirectSchemaUpgraderInterface
+class Version20180122220813 extends AbstractMigration implements RepeatableMigrationInterface, DirectSchemaUpgraderInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
@@ -2,8 +2,6 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Page\Page;
-use Concrete\Core\Page\Single as SinglePage;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
@@ -17,11 +15,6 @@ class Version20180122220813 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $page = Page::getByPath('/dashboard/system/mail/addresses');
-        if (!is_object($page) || $page->isError()) {
-            $sp = SinglePage::add('/dashboard/system/mail/addresses');
-            $sp->update(['cName' => 'System Email Addresses']);
-            $sp->setAttribute('meta_keywords', 'mail settings, mail configuration, email, sender');
-        }
+        $this->createSinglePage('/dashboard/system/mail/addresses', 'System Email Addresses', ['meta_keywords' => 'mail settings, mail configuration, email, sender']);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180122220813.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Page\Page;

--- a/concrete/src/Updater/Migrations/RepeatableMigrationInterface.php
+++ b/concrete/src/Updater/Migrations/RepeatableMigrationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations;
+
+/**
+ * Interface that migrations that can be safely re-executed should implement.
+ */
+interface RepeatableMigrationInterface
+{
+}


### PR DESCRIPTION
When we release a new concrete5 version, we may fix migrations that were already executed.
What about adding a way to let users re-execute the already executed migrations too?

In order to declare if a migration can be safely re-executed, I introduced a new `RepeatableMigrationInterface` interface.

In order to re-execute old migrations:
`./concrete/bin/concrete5 c5:update --rerun`
(you can also specify a specific starting migration by using the `--since` and `--after` options, which accept both a migration identifier (eg `20180122220813`) or a concrete5 version (eg `8.3.0`).
Type
`./concrete/bin/concrete5 c5:update --help`
for more details.