### PR TITLE
Add to IDE Metadata the registered instances

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -457,6 +457,16 @@ class Application extends Container
     }
 
     /**
+     * Get the list of registered instances.
+     *
+     * @return string[]
+     */
+    public function getRegisteredInstances()
+    {
+        return array_keys($this->instances);
+    }
+
+    /**
      * @deprecated Use the singleton method
      *
      * @param $abstract

--- a/concrete/src/Captcha/SecurimageController.php
+++ b/concrete/src/Captcha/SecurimageController.php
@@ -69,7 +69,7 @@ class SecurimageController extends AbstractController implements CaptchaWithPict
         $this->request = $request;
         $this->urlResolver = $urlResolver;
         $this->formService = $formService;
-        $this->securimage = new Securimage();
+        $this->securimage = new Securimage(['no_session' => PHP_SAPI === 'cli']);
         $this->securimage->image_width = 190;
         $this->securimage->image_height = 60;
         $this->securimage->image_bg_color = new Securimage_Color(227, 218, 237);

--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -30,6 +30,14 @@ class MetadataGenerator
                 }
             }
         }
+        foreach ($app->getRegisteredInstances() as $instance) {
+            if (!isset($bindings[$instance])) {
+                $className = $this->resolveAbstractToClassName($app, $instance);
+                if ($className !== null) {
+                    $bindings[$instance] = $className;
+                }
+            }
+        }
 
         return $bindings;
     }


### PR DESCRIPTION
This allows IDEs that use `.phpstorm.meta.php` to resolve the followings:

- `$app->make('Concrete\Core\Captcha\CaptchaInterface')`
  🠞 `Concrete\Core\Captcha\SecurimageController`
- `$app->make('Illuminate\Container\Container')`
  🠞 `Concrete\Core\Application\Application`
- `$app->make('app')`
  🠞 `Concrete\Core\Application\Application`
- `$app->make('console')`
  🠞 `Concrete\Core\Console\Application`
