### PR TITLE
Convert special characters to HTML entities on log view

### DIFF
--- a/concrete/single_pages/dashboard/reports/logs.php
+++ b/concrete/single_pages/dashboard/reports/logs.php
@@ -101,7 +101,7 @@ $th = Loader::helper('text');
                         }
                     }
                     ?></strong></td>
-                    <td style="width: 100%"><?=$th->makenice($ent->getMessage())?></td>
+                    <td style="width: 100%"><?=$th->makenice(h($ent->getMessage()))?></td>
                 </tr>
             <?php } ?>
             </tbody>


### PR DESCRIPTION
I have a package that logs XML data. The XML tags are being removed by the makenice function. This fixes that so that log data is never removed when displayed.