### PR TITLE
Url::route(): avoid accessing a non-static method statically

### DIFF
--- a/concrete/src/Support/Facade/Url.php
+++ b/concrete/src/Support/Facade/Url.php
@@ -46,7 +46,7 @@ class Url extends Facade
         if (!$arguments) {
             $arguments = array();
         }
-        $route = \Router::route($data);
+        $route = static::getFacadeApplication()->make(\Router::class)->route($data);
         array_unshift($arguments, $route);
 
         return static::getFacadeRoot()->resolve($arguments);


### PR DESCRIPTION
`Router::route()` is not a static method: let's call in in a non-static way.

Ref: #4723