### PR TITLE
Use email as username when email is displaying as username on login and registration form

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -193,11 +193,7 @@ class Controller extends AuthenticationTypeController
                 if ($oUser) {
                     $mh = Core::make('helper/mail');
                     //$mh->addParameter('uPassword', $oUser->resetUserPassword());
-                    if (Config::get('concrete.user.registration.email_registration')) {
-                        $mh->addParameter('uName', $oUser->getUserEmail());
-                    } else {
-                        $mh->addParameter('uName', $oUser->getUserName());
-                    }
+                    $mh->addParameter('uName', $oUser->getUserDisplayName());
                     $mh->to($oUser->getUserEmail());
 
                     //generate hash that'll be used to authenticate user, allowing them to change their password

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -808,11 +808,16 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     }
 
     /**
-     * @see \Concrete\Core\Entity\User\User::getUserName()
+     * @return string
      */
     public function getUserDisplayName()
     {
-        return $this->entity->getUserName();
+        $config = $this->application->make('config');
+        if ($config->get('concrete.user.registration.email_registration')) {
+            return $this->getUserEmail();
+        } else {
+            return $this->getUserName();
+        }
     }
 
     /**


### PR DESCRIPTION
When we use `email` as `username` on login & registration form, sometimes we don't want to show the `uName` field to the user.

So, lets set the `uEmail` as `displayUserName` on that case.