### PR TITLE
Discourage running some CLI commands as root

### DIFF
--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace Concrete\Core\Console;
 
-use Symfony\Component\Console\Command\Command as SymfonyCommand;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Exception;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 abstract class Command extends SymfonyCommand

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -19,7 +19,7 @@ class ClearCacheCommand extends Command
             ->setDescription('Clear the concrete5 cache')
             ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, "Should the thumbnails be removed from the cache? [Y/N]")
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->setHelp(<<<EOT
 If the --thumbnails options is not specified, we'll use the last value set in the dashboard.
 

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -19,6 +19,7 @@ class ClearCacheCommand extends Command
             ->setDescription('Clear the concrete5 cache')
             ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, "Should the thumbnails be removed from the cache? [Y/N]")
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->setHelp(<<<EOT
 If the --thumbnails options is not specified, we'll use the last value set in the dashboard.
 

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -34,7 +34,7 @@ class ConfigCommand extends Command
             ->addArgument('item', InputArgument::REQUIRED, 'The configuration item (eg: concrete.debug.display_errors)')
             ->addArgument('value', InputArgument::OPTIONAL, 'The new value of the configuration item')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->addOption('generated-overrides', 'g', InputOption::VALUE_NONE, 'Set this option to save configurations to the generated_overrides folder')
         ;

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -34,6 +34,7 @@ class ConfigCommand extends Command
             ->addArgument('item', InputArgument::REQUIRED, 'The configuration item (eg: concrete.debug.display_errors)')
             ->addArgument('value', InputArgument::OPTIONAL, 'The new value of the configuration item')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('environment', 'e', InputOption::VALUE_REQUIRED, 'The environment (if not specified, we\'ll work with the configuration item valid for all environments)')
             ->addOption('generated-overrides', 'g', InputOption::VALUE_NONE, 'Set this option to save configurations to the generated_overrides folder')
         ;

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -19,6 +19,7 @@ class GenerateIDESymbolsCommand extends Command
             ->setName('c5:ide-symbols')
             ->setDescription('Generate IDE symbols')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', ['all'])
             ->setHelp(<<<EOT
 Returns codes:

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -19,7 +19,7 @@ class GenerateIDESymbolsCommand extends Command
             ->setName('c5:ide-symbols')
             ->setDescription('Generate IDE symbols')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', ['all'])
             ->setHelp(<<<EOT
 Returns codes:

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -52,6 +52,7 @@ class InstallCommand extends Command
             ->setName('c5:install')
             ->setDescription('Install concrete5')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('db-server', null, InputOption::VALUE_REQUIRED, 'Location of database server')
             ->addOption('db-username', null, InputOption::VALUE_REQUIRED, 'Database username')
             ->addOption('db-password', null, InputOption::VALUE_REQUIRED, 'Database password')

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -52,7 +52,7 @@ class InstallCommand extends Command
             ->setName('c5:install')
             ->setDescription('Install concrete5')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('db-server', null, InputOption::VALUE_REQUIRED, 'Location of database server')
             ->addOption('db-username', null, InputOption::VALUE_REQUIRED, 'Database username')
             ->addOption('db-password', null, InputOption::VALUE_REQUIRED, 'Database password')

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -24,6 +24,7 @@ class InstallLanguageCommand extends Command
         ->setAliases(['c5:install-language'])
         ->setDescription('Install or update concrete5 languages')
         ->addEnvOption()
+        ->discourageRunAsRoot()
         ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
         ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
         ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the concrete5 core')

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -24,7 +24,7 @@ class InstallLanguageCommand extends Command
         ->setAliases(['c5:install-language'])
         ->setDescription('Install or update concrete5 languages')
         ->addEnvOption()
-        ->discourageRunAsRoot()
+        ->setCanRunAsRoot(false)
         ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
         ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
         ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the concrete5 core')

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -31,6 +31,7 @@ class InstallPackageCommand extends Command
             ->addOption('languages', 'l', InputOption::VALUE_REQUIRED, 'Force to install ("yes") or to not install ("no") language files. If "auto", language files will be installed if the package is connected to the project ("auto" requires that the canonical URL is set)', 'auto')
             ->setDescription('Install a concrete5 package')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
             ->setHelp(<<<EOT

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -31,7 +31,7 @@ class InstallPackageCommand extends Command
             ->addOption('languages', 'l', InputOption::VALUE_REQUIRED, 'Force to install ("yes") or to not install ("no") language files. If "auto", language files will be installed if the package is connected to the project ("auto" requires that the canonical URL is set)', 'auto')
             ->setDescription('Install a concrete5 package')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
             ->setHelp(<<<EOT

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -19,6 +19,7 @@ class ResetCommand extends Command
             ->setName('c5:reset')
             ->setDescription('Reset the concrete5 installation, deleting files and emptying the database')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
             ->setHelp(<<<EOT
 Returns codes:

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -19,7 +19,7 @@ class ResetCommand extends Command
             ->setName('c5:reset')
             ->setDescription('Reset the concrete5 installation, deleting files and emptying the database')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
             ->setHelp(<<<EOT
 Returns codes:

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -26,6 +26,7 @@ class TranslatePackageCommand extends Command
             ])
         ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a concrete5 package)')
         ->addEnvOption()
+        ->discourageRunAsRoot()
         ->addOption('locale', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of locale codes to handle')
         ->addOption('contact', 'c', InputOption::VALUE_REQUIRED, 'Contact information to be put in the language files to report bugs to (eg the "Report-Msgid-Bugs-To" gettext header)', '')
         ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -26,7 +26,7 @@ class TranslatePackageCommand extends Command
             ])
         ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a concrete5 package)')
         ->addEnvOption()
-        ->discourageRunAsRoot()
+        ->setCanRunAsRoot(false)
         ->addOption('locale', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of locale codes to handle')
         ->addOption('contact', 'c', InputOption::VALUE_REQUIRED, 'Contact information to be put in the language files to report bugs to (eg the "Report-Msgid-Bugs-To" gettext header)', '')
         ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -22,6 +22,7 @@ class UninstallPackageCommand extends Command
                 'c5:uninstall-package',
             ])
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')
             ->setDescription('Uninstall a concrete5 package')

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -22,7 +22,7 @@ class UninstallPackageCommand extends Command
                 'c5:uninstall-package',
             ])
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')
             ->setDescription('Uninstall a concrete5 package')

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -22,6 +22,7 @@ class UpdateCommand extends Command
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('rerun', null, InputOption::VALUE_NONE, '(Re)apply already executed migrations')
             ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration (requires --rerun)')
             ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration (requires --rerun)')

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -22,7 +22,7 @@ class UpdateCommand extends Command
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('rerun', null, InputOption::VALUE_NONE, '(Re)apply already executed migrations')
             ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration (requires --rerun)')
             ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration (requires --rerun)')

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -22,7 +22,7 @@ class UpdatePackageCommand extends Command
                 'c5:update-package',
             ])
             ->addEnvOption()
-            ->discourageRunAsRoot()
+            ->setCanRunAsRoot(false)
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the installed packages')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')
             ->addArgument('packages', InputArgument::IS_ARRAY, 'The handle of the package to be updated (multiple values allowed)')

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -22,6 +22,7 @@ class UpdatePackageCommand extends Command
                 'c5:update-package',
             ])
             ->addEnvOption()
+            ->discourageRunAsRoot()
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the installed packages')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')
             ->addArgument('packages', InputArgument::IS_ARRAY, 'The handle of the package to be updated (multiple values allowed)')

--- a/concrete/src/Foundation/Environment/User.php
+++ b/concrete/src/Foundation/Environment/User.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Concrete\Core\Foundation\Environment;
+
+class User
+{
+    /**
+     * @var FunctionInspector
+     */
+    protected $functionInspector;
+
+    /**
+     * @param FunctionInspector $functionInspector
+     */
+    public function __construct(FunctionInspector $functionInspector)
+    {
+        $this->functionInspector = $functionInspector;
+    }
+
+    /**
+     * Check if the current user is root/superuser.
+     *
+     * @return bool|null return true if the current user is root, false if not root, or NULL if we don't know
+     */
+    public function isSuperUser()
+    {
+        $result = null;
+        if ($result === null && $this->functionInspector->functionAvailable('posix_getuid')) {
+            $uid = posix_getuid();
+            if (is_int($uid)) {
+                $result = $uid === 0;
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Some commands shouldn't be executed as root.
What about discouraging it?
- add a new `--allow-as-root` option: if specified, we have the current behaviour (users may execute the commands as root)
- if the `--allow-as-root` option is not specified
  - if the user is root and the `--no-interaction` option is specified: abort operation
  - if the user is root and the `--no-interaction` option is not specified: ask users if they want to proceed

Examples:

## running as normal user (nothing changes):

![allow-as-root--user](https://user-images.githubusercontent.com/928116/35680148-c0d15a32-0759-11e8-8140-5fd138376dcc.png)

## running as root:

![allow-as-root--root](https://user-images.githubusercontent.com/928116/35680130-b5005abe-0759-11e8-97c0-10056dab0833.png)
