### PR TITLE
Survey block - missing cID when voting

### DIFF
--- a/concrete/blocks/survey/controller.php
+++ b/concrete/blocks/survey/controller.php
@@ -106,6 +106,10 @@ class Controller extends BlockController
             $c = $this->getCollectionObject();
         }
 
+	if (is_object($c)) {
+            $this->cID = $c->getCollectionID();
+        }
+
         if ($this->requiresRegistration()) {
             if (!$u->isRegistered()) {
                 $this->redirect('/login');


### PR DESCRIPTION
`$this->cID` is no longer declared in `action_form_save_vote()` because the `on_start()` method has been removed