### PR TITLE
Return 404 when requesting an invalid tool

### DIFF
--- a/concrete/src/Legacy/Controller/ToolController.php
+++ b/concrete/src/Legacy/Controller/ToolController.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Legacy\Controller;
 use Controller;
 use Environment;
 use BlockType;
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\View\DialogView;
 
 class ToolController extends Controller
@@ -34,6 +35,8 @@ class ToolController extends Controller
             $v = new DialogView($query);
             $v->setViewRootDirectoryName(DIRNAME_TOOLS);
             $this->setViewObject($v);
+        } else {
+            return $this->app->make(ResponseFactoryInterface::class)->notFound('');
         }
     }
 


### PR DESCRIPTION
When requesting an invalid tool path (eg `/index.php/tools/required/foo/bar`), we currently return an empty 200 response.

Let's return a 404 response instead.