### PR TITLE
Fix handling of page_forbidden

### DIFF
--- a/concrete/controllers/single_page/page_forbidden.php
+++ b/concrete/controllers/single_page/page_forbidden.php
@@ -1,19 +1,47 @@
 <?php
+
 namespace Concrete\Controller\SinglePage;
 
-use PageController;
-use User;
-use Config;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\PageController;
+use Concrete\Core\User\User;
 
 class PageForbidden extends PageController
 {
     protected $viewPath = '/frontend/page_forbidden';
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\AbstractController::on_start()
+     */
     public function on_start()
     {
-        $u = new User();
-        if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
-            $this->redirect('/login');
+        return $this->checkRedirectToLogin();
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response|null
+     */
+    public function view()
+    {
+        return $this->checkRedirectToLogin();
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response|null
+     */
+    protected function checkRedirectToLogin()
+    {
+        $result = null;
+        $user = User::isLoggedIn() ? new User() : null;
+        if ($user === null || !$user->isRegistered()) {
+            $config = $this->app->make('config');
+            if ($config->get('concrete.permissions.forward_to_login')) {
+                $result = $this->app->make(ResponseFactoryInterface::class)->redirect('/login');
+            }
         }
+
+        return $result;
     }
 }

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -256,7 +256,7 @@ class PageController extends Controller
             $valid = false;
         }
 
-        if (is_callable(array($this, $this->action))  && (get_class($this) != '\Concrete\Controller\PageForbidden')) {
+        if ($valid && is_callable(array($this, $this->action))  && !($this instanceof \Concrete\Controller\SinglePage\PageForbidden)) {
             // we use reflection to see if the task itself, which now much exist, takes fewer arguments than
             // what is specified
             $r = new \ReflectionMethod(get_class($this), $this->action);


### PR DESCRIPTION
The PageController::isValidControllerTask checks against the non-existing `Concrete\Controller\PageForbidden` class.
Furthermore, it doesn't support extending the (correct) `Concrete\Controller\SinglePage\PageForbidden` class: let's check with `instanceof` instead of matching the exact class name,
