### PR TITLE
Avoid deprecated methods in dashboard/sitemap/explore, fix logic

### DIFF
--- a/concrete/controllers/single_page/dashboard/sitemap/explore.php
+++ b/concrete/controllers/single_page/dashboard/sitemap/explore.php
@@ -1,42 +1,62 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Sitemap;
 
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Page\Controller\DashboardSitePageController;
-use Loader;
-use Page;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\Page\Page;
 
 class Explore extends DashboardPageController
 {
     public function view($nodeID = 0, $auxMessage = false)
     {
+        $dh = $this->app->make('helper/concrete/dashboard/sitemap');
+        $this->set('dh', $dh);
+        if (!$dh->canRead()) {
+            return;
+        }
         $this->requireAsset('core/sitemap');
-
-        $dh = Loader::helper('concrete/dashboard/sitemap');
-        if ($dh->canRead()) {
-            $this->set('nodeID', $nodeID);
+        $task = $this->request->request->get('task');
+        if ($task === null) {
+            $task = $this->request->query->get('task');
         }
-
-        if (isset($_REQUEST['task']) && isset($_REQUEST['cNodeID'])) {
-            $nc = Page::getByID($_REQUEST['cNodeID']);
-            if ($_REQUEST['task'] == 'send_to_top') {
-                $nc->movePageDisplayOrderToTop();
-            } else {
-                if ($_REQUEST['task'] == 'send_to_bottom') {
+        $cNodeID = $this->request->request->get('cNodeID');
+        if ($cNodeID === null) {
+            $cNodeID = $this->request->query->get('cNodeID');
+        }
+        if ($task !== null && $cNodeID !== null) {
+            $nc = Page::getByID($cNodeID);
+            switch ($task) {
+                case 'send_to_top':
+                    $nc->movePageDisplayOrderToTop();
+                    break;
+                case 'send_to_bottom':
                     $nc->movePageDisplayOrderToBottom();
-                }
+                    break;
             }
-            $this->redirect('/dashboard/sitemap/explore', $nc->getCollectionParentID(), 'order_updated');
-        }
+            $redirectTo = $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/sitemap/explore', $nc->getCollectionParentID(), 'order_updated']);
 
-        if ($auxMessage != false) {
+            return $this->app->make(ResponseFactoryInterface::class)->redirect($redirectTo);
+        }
+        $nodeID = (int) $nodeID;
+        $this->set('nodeID', $nodeID);
+        
+        if ($auxMessage) {
             switch ($auxMessage) {
                 case 'order_updated':
                     $this->set('message', t('Sort order saved'));
                     break;
             }
         }
-        $this->set('dh', $dh);
-        $this->set('includeSystemPages', $dh->includeSystemPages());
+        $this->set('includeSystemPages', (bool) $dh->includeSystemPages());
+        $this->addHeaderItem(<<<'EOT'
+<style type="text/css">
+    div.ccm-sitemap-explore ul li.ccm-sitemap-explore-paging {
+        display: none;
+    }
+</style>
+EOT
+        );
     }
 }

--- a/concrete/single_pages/dashboard/sitemap/explore.php
+++ b/concrete/single_pages/dashboard/sitemap/explore.php
@@ -1,69 +1,71 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-$view = View::getInstance();
-?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 
-    <style type="text/css">
-        div.ccm-sitemap-explore ul li.ccm-sitemap-explore-paging {
-            display: none;
-        }
-    </style>
+/* @var Concrete\Controller\SinglePage\Dashboard\Sitemap\Explore $controller */
+/* @var Concrete\Core\Application\Service\Dashboard $dashboard */
+/* @var Concrete\Core\Application\Service\Dashboard\Sitemap $dh */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Html\Service\Html $html */
+/* @var Concrete\Core\Application\Service\UserInterface $interface */
+/* @var Concrete\Core\Page\View\PageView $this */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Page\View\PageView $view */
 
-    <script type="text/javascript">
-        (function () {
-            var my_url = '<?= $view->action(''); ?>';
-            $(function () {
-                $('div#ccm-flat-sitemap-container').concreteSitemap({
-                    displayNodePagination: true,
-                    cParentID: '<?=$nodeID?>',
-                    displaySingleLevel: true,
-                    includeSystemPages: <?= $includeSystemPages ? 'true' : 'false'; ?>,
-                    persist: false,
-                    onDisplaySingleLevel: function (node) {
-                        if (window && window.history && window.history.pushState) {
-                            window.history.pushState({
+/* @var bool $includeSystemPages */
+/* @var int $nodeID */
+
+if ($dh->canRead()) {
+    ?>
+    <script>
+    (function () {
+        var my_url = <?= json_encode($view->action('')) ?>;
+        $(function () {
+            $('div#ccm-flat-sitemap-container').concreteSitemap({
+                displayNodePagination: true,
+                cParentID: '<?=$nodeID?>',
+                displaySingleLevel: true,
+                includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
+                persist: false,
+                onDisplaySingleLevel: function (node) {
+                    if (window && window.history && window.history.pushState) {
+                        window.history.pushState(
+                            {
                                 key: node.data.cID
-                            }, 'title', my_url + '/-/' + node.data.cID);
-                        }
+                            },
+                            'title',
+                            my_url + '/-/' + node.data.cID
+                        );
                     }
-                });
-            });
-            $(window).on('popstate', function (event) {
-                var redirect;
-                if (event.originalEvent.state && event.originalEvent.state.key) {
-                    redirect = my_url + '/-/' + event.originalEvent.state.key;
-                } else {
-                    return true;
                 }
-                window.location = redirect;
-                $.fn.dialog.showLoader();
-                return false;
             });
-        }());
+        });
+        $(window).on('popstate', function (event) {
+            var redirect;
+            if (event.originalEvent.state && event.originalEvent.state.key) {
+                redirect = my_url + '/-/' + event.originalEvent.state.key;
+            } else {
+                return true;
+            }
+            window.location = redirect;
+            $.fn.dialog.showLoader();
+            return false;
+        });
+    }());
     </script>
-
-<?= Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(
-    t('Sitemap'),
-    t(
-        'Sitemap flat view lets you page through particular long lists of pages.'),
-    'span10 offset1',
-    false); ?>
-    <div class="ccm-pane-body">
-
-        <?php if ($dh->canRead()) {
+    <?php
+}
+?>
+<?= $dashboard->getDashboardPaneHeaderWrapper(t('Sitemap'), t('Sitemap flat view lets you page through particular long lists of pages.'), 'span10 offset1', false) ?>
+<div class="ccm-pane-body">
+    <?php
+    if ($dh->canRead()) {
+        ?><div id="ccm-flat-sitemap-container" data-sitemap="container"></div><?php 
+    } else {
+        ?><p><?= t('You do not have access to the dashboard sitemap.') ?></p><?php 
+    }
     ?>
+</div>
+<div class="ccm-pane-footer" id="ccm-explore-paging-footer">
+</div>
+<?= $dashboard->getDashboardPaneFooterWrapper(false) ?>
 
-            <div id="ccm-flat-sitemap-container" data-sitemap="container"></div>
-
-        <?php 
-} else {
-    ?>
-            <p><?= t('You do not have access to the dashboard sitemap.') ?></p>
-        <?php 
-} ?>
-
-    </div>
-    <div class="ccm-pane-footer" id="ccm-explore-paging-footer">
-
-    </div>
-
-<?= Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false);


### PR DESCRIPTION
In the flat sitemap we output the sitemaplogic even if the users don't have access to the sitemap (leading to unnecessary assets loading and accessing undefined vars).

Ref #4723