### PR TITLE
Execute tests that require that headers are not sent

### DIFF
--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Session;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Permission\IPService;
 use Concrete\Core\Utility\IPAddress;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
@@ -26,14 +27,18 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     /** @var \Concrete\Core\Http\Request */
     private $request;
 
+    /** @var \Concrete\Core\Permission\IPService */
+    private $ipService;
+    
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
-    public function __construct(Application $app, Repository $config, Request $request, LoggerInterface $logger = null)
+    public function __construct(Application $app, Repository $config, Request $request, IPService $ipService, LoggerInterface $logger = null)
     {
         $this->app = $app;
         $this->config = $config;
         $this->request = $request;
+        $this->ipService = $ipService;
         $this->logger = $logger;
     }
 
@@ -43,7 +48,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
      */
     public function handleSessionValidation(SymfonySession $session)
     {
-        $request_ip = (string) $this->app->make('ip')->getRequestIPAddress();
+        $request_ip = (string) $this->ipService->getRequestIPAddress();
 
         $invalidate = false;
 

--- a/tests/helpers/TestHeadersTrait.php
+++ b/tests/helpers/TestHeadersTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Concrete\TestHelpers;
+
+trait TestHeadersTrait
+{
+    /**
+     * @throws \PHPUnit_Framework_SkippedTestError
+     */
+    protected function skipIfHeadersSent()
+    {
+        if (headers_sent($file, $line)) {
+            $this->markTestSkipped("This test cannot run once headers have been sent (headers sent on {$file}:{$line}.");
+        }
+    }
+}

--- a/tests/tests/Session/SessionFactoryTest.php
+++ b/tests/tests/Session/SessionFactoryTest.php
@@ -7,10 +7,13 @@ use Concrete\Core\Http\Request;
 use Concrete\Core\Session\SessionFactory;
 use Concrete\Core\Session\SessionFactoryInterface;
 use Concrete\Core\Session\Storage\Handler\NativeFileSessionHandler;
+use Concrete\TestHelpers\TestHeadersTrait;
 use PHPUnit_Framework_TestCase;
 
 class SessionFactoryTest extends PHPUnit_Framework_TestCase
 {
+    use TestHeadersTrait;
+
     /** @var Application */
     protected $app;
 
@@ -52,11 +55,13 @@ class SessionFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\SessionInterface', $this->request->getSession());
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testHandlerConfiguration()
     {
-        if (headers_sent()) {
-            $this->markTestSkipped('Cannot test sessions after headers have been sent.');
-        }
+        $this->skipIfHeadersSent();
 
         $config = $this->app['config'];
         $config['concrete.session'] = ['handler' => 'database', 'save_path' => '/tmp'];

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -3,6 +3,7 @@
 namespace Concrete\Tests\Session;
 
 use Concrete\Core\Http\Request;
+use Concrete\Core\Permission\IPService;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\TestHelpers\TestHeadersTrait;
@@ -38,7 +39,8 @@ class SessionValidatorTest extends PHPUnit_Framework_TestCase
         $this->app['config'] = clone $this->app['config'];
 
         $this->request = Request::create('http://url.com/');
-        $this->validator = new SessionValidator($this->app, $this->app['config'], $this->request);
+        $config = $this->app->make('config');
+        $this->validator = new SessionValidator($this->app, $this->app['config'], $this->request, $this->app->build(IPService::class, ['config' => $config, 'request' => $this->request]));
 
         $store = [];
         $mock = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -5,11 +5,19 @@ namespace Concrete\Tests\Session;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\TestHelpers\TestHeadersTrait;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class SessionValidatorTest extends PHPUnit_Framework_TestCase
 {
+    use TestHeadersTrait;
+
+    protected $preserveGlobalState = false;
+
     /** @var \Concrete\Core\Application\Application */
     protected $app;
 
@@ -24,9 +32,7 @@ class SessionValidatorTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (headers_sent()) {
-            return $this->markTestSkipped('This test cannot run once headers have been sent.');
-        }
+        $this->skipIfHeadersSent();
 
         $this->app = clone Application::getFacadeApplication();
         $this->app['config'] = clone $this->app['config'];


### PR DESCRIPTION
Let's execute the tests that require that the headers are not sent.

This relealed a failing test: `SessionValidatorTest::testSetsOnFirstCheck()` sets a `Request` instance, but the `IPService` used by `SessionValidator` was using a different `Request` instance: let's fix that too.