### PR TITLE
Fix autorotate image processor

### DIFF
--- a/concrete/src/File/ImportProcessor/AutorotateImageProcessor.php
+++ b/concrete/src/File/ImportProcessor/AutorotateImageProcessor.php
@@ -1,12 +1,15 @@
 <?php
+
 namespace Concrete\Core\File\ImportProcessor;
 
 use Concrete\Core\Entity\File\Version;
-use Concrete\Core\Support\Facade\Image;
+use Concrete\Core\Support\Facade\Application;
+use Exception;
 use Imagine\Filter\Basic\Autorotate;
 use Imagine\Filter\Transformation;
+use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\ExifMetadataReader;
-use Concrete\Core\Support\Facade\Application;
+use Throwable;
 
 class AutorotateImageProcessor implements ProcessorInterface
 {
@@ -14,26 +17,59 @@ class AutorotateImageProcessor implements ProcessorInterface
      * @var \Concrete\Core\Application\Application
      */
     protected $app;
-    
+
     public function __construct()
     {
         $this->app = Application::getFacadeApplication();
     }
-    
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\File\ImportProcessor\ProcessorInterface::shouldProcess()
+     */
     public function shouldProcess(Version $version)
     {
-        return function_exists('exif_read_data')
-                && $version->getTypeObject()->getName() == 'JPEG';
+        $result = false;
+        if (ExifMetadataReader::isSupported()) {
+            if ($version->getTypeObject()->getName() == 'JPEG') {
+                try {
+                    $fr = $version->getFileResource();
+                    $medatadaReader = new ExifMetadataReader();
+                    $metadata = $medatadaReader->readStream($fr);
+                    switch (isset($metadata['ifd0.Orientation']) ? $metadata['ifd0.Orientation'] : null) {
+                        case 2: // top-right
+                        case 3: // bottom-right
+                        case 4: // bottom-left
+                        case 5: // left-top
+                        case 6: // right-top
+                        case 7: // right-bottom
+                        case 8: // left-bottom
+                            $result = true;
+                            break;
+                    }
+                } catch (Exception $x) {
+                } catch (Throwable $x) {
+                }
+            }
+        }
+
+        return $result;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\File\ImportProcessor\ProcessorInterface::process()
+     */
     public function process(Version $version)
     {
         $fr = $version->getFileResource();
-        
-        $imagine = $this->app->make(Image::getFacadeAccessor());
-        $imagine->setMetadataReader(new ExifMetadataReader);
+
+        $imagine = $this->app->make(ImagineInterface::class);
+        $imagine->setMetadataReader(new ExifMetadataReader());
         $image = $imagine->load($fr->read());
-        
+
         $transformation = new Transformation($imagine);
         $transformation->applyFilter($image, new Autorotate());
         $version->updateContents($image->get('jpg'));


### PR DESCRIPTION
1. Don't load (and save) the image if it's not rotated
2. Use the configured JPEG quality compression when saving the rotated image

Point 1 requires loading the file once more, but it's fast since since we don't actually create an image, just read its metadata. Furthermore for a cleaner approach we'd require https://github.com/avalanche123/Imagine/pull/580 (but since Imagine is updated very infrequently I opted for the approach included in this PR).