### PR TITLE
Update slider height in event list block

### DIFF
--- a/concrete/blocks/event_list/view.php
+++ b/concrete/blocks/event_list/view.php
@@ -136,7 +136,8 @@ if ($calendar) {
                         start     = 0,
                         container = $('<div />').css({
                             position: 'relative',
-                            overflow: 'hidden'
+                            overflow: 'hidden',
+                            transition: 'height .5s'
                         }),
                         set_container = $('<div />'),
                         slider    = $('<div />').css({
@@ -220,6 +221,7 @@ if ($calendar) {
                                     position: 'static',
                                     left: 0
                                 }).append(subset);
+                                container.height(subset.parent().height());
                                 slider.remove();
                                 callback.apply(this, Array.prototype.slice.call(arguments));
                             });
@@ -237,6 +239,7 @@ if ($calendar) {
                                     position: 'static',
                                     left: 0
                                 }).append(subset);
+                                container.height(subset.parent().height());
                                 slider.remove();
                                 callback.apply(this, Array.prototype.slice.call(arguments));
                             });


### PR DESCRIPTION
The container's height is not updated when sliding between pages in the **Event List** block.