### PR TITLE
Centralize the handling of image formats

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1460,7 +1460,7 @@ class Version implements ObjectInterface
         $thumbnailFormat = $app->make(ThumbnailFormatService::class)->getFormatForFile($this);
 
         $mimetype = $bitmapFormat->getFormatMimeType($thumbnailFormat);
-        $thumbnailOptions = $bitmapFormat->getFormatImagineSaveOptions($format);
+        $thumbnailOptions = $bitmapFormat->getFormatImagineSaveOptions($thumbnailFormat);
 
         $filesystem->write(
             $thumbnailPath,

--- a/concrete/src/File/Image/BitmapFormat.php
+++ b/concrete/src/File/Image/BitmapFormat.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Concrete\Core\File\Image;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Utility\Service\Validation\Numbers;
+
+/**
+ * Helper class for bitmap image formats.
+ */
+class BitmapFormat
+{
+    /**
+     * Bitmap image format: PNG.
+     *
+     * @var string
+     */
+    const FORMAT_PNG = 'png';
+
+    /**
+     * Bitmap image format: JPEG.
+     *
+     * @var string
+     */
+    const FORMAT_JPEG = 'jpeg';
+
+    /**
+     * Bitmap image format: GIF.
+     *
+     * @var string
+     */
+    const FORMAT_GIF = 'gif';
+
+    /**
+     * Bitmap image format: WBMP.
+     *
+     * @var string
+     */
+    const FORMAT_WBMP = 'wbmp';
+
+    /**
+     * Bitmap image format: XBM.
+     *
+     * @var string
+     */
+    const FORMAT_XBM = 'xbm';
+
+    /**
+     * Default JPEG quality (from 0 to 100) - to be used when there's no (valid) configured value.
+     *
+     * @var int
+     */
+    const DEFAULT_JPEG_QUALITY = 80;
+
+    /**
+     * Default PNG compression level (from 0 to 9) - to be used when there's no (valid) configured value.
+     *
+     * @var int
+     */
+    const DEFAULT_PNG_COMPRESSIONLEVEL = 9;
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * @var \Concrete\Core\Utility\Service\Validation\Numbers
+     */
+    protected $valn;
+
+    /**
+     * All the image formats (if initialized).
+     *
+     * @var string[]|null
+     */
+    protected $allImageFormats;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     * @param \Concrete\Core\Utility\Service\Validation\Numbers $valn
+     */
+    public function __construct(Repository $config, Numbers $valn)
+    {
+        $this->config = $config;
+        $this->valn = $valn;
+    }
+
+    /**
+     * Get all the image formats.
+     *
+     * @return string[]
+     */
+    public function getAllImageFormats()
+    {
+        if ($this->allImageFormats === null) {
+            $this->allImageFormats = [
+                static::FORMAT_PNG,
+                static::FORMAT_JPEG,
+                static::FORMAT_GIF,
+                static::FORMAT_WBMP,
+                static::FORMAT_XBM,
+            ];
+        }
+
+        return $this->allImageFormats;
+    }
+
+    /**
+     * Check if a format identifier is valid.
+     *
+     * @param string|mixed $format
+     *
+     * @return bool
+     */
+    public function isFormatValid($format)
+    {
+        return in_array($format, $this->getAllImageFormats(), true);
+    }
+
+    /**
+     * Get the MIME type for a specific format.
+     *
+     * @param string $format One of the BitmapFormat::FORMAT_...  constants.
+     *
+     * @return string return an empty string is $format is invalid
+     */
+    public function getFormatMimeType($format)
+    {
+        $format = $this->normalizeFormat($format);
+        $result = '';
+        switch ($format) {
+            case static::FORMAT_PNG:
+            case static::FORMAT_JPEG:
+            case static::FORMAT_GIF:
+            case static::FORMAT_XBM:
+                $result = 'image/' . $format;
+                break;
+            case static::FORMAT_WBMP:
+                $result = 'image/vnd.wap.wbmp';
+                break;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the bitmap format corresponding to a specific MIME type.
+     *
+     * @param string $mimeType the MIME type to analyze
+     * @param mixed $fallback what to return if $mimeType is not recognized
+     *
+     * @return string|mixed
+     */
+    public function getFormatFromMimeType($mimeType, $fallback = '')
+    {
+        $mimeType = trim(strtolower((string) $mimeType));
+        switch ($mimeType) {
+            case 'image/png':
+                $result = static::FORMAT_PNG;
+                break;
+            case 'image/jpeg':
+                $result = static::FORMAT_JPEG;
+                break;
+            case 'image/gif':
+                $result = static::FORMAT_GIF;
+                break;
+            case 'image/vnd.wap.wbmp':
+                $result = static::FORMAT_WBMP;
+                break;
+            case 'image/xbm':
+            case 'image/x-xbm':
+            case 'image/x-xbitmap':
+                $result = static::FORMAT_XBM;
+                break;
+            default:
+                $result = $fallback;
+                break;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the Imagine save options for the specified image format.
+     *
+     * @param string $format One of the BitmapFormat::FORMAT_...  constants.
+     *
+     * @return array
+     */
+    public function getFormatImagineSaveOptions($format)
+    {
+        $result = [];
+        $format = $this->normalizeFormat($format);
+        switch ($format) {
+            case static::FORMAT_PNG:
+                $result['png_compression_level'] = $this->getDefaultPngCompressionLevel();
+                break;
+            case static::FORMAT_JPEG:
+                $result['jpeg_quality'] = $this->getDefaultJpegQuality();
+                break;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the file extension for the specified format.
+     *
+     * @param string $format One of the BitmapFormat::FORMAT_...  constants.
+     *
+     * @return string returns an empty string if $format is invalid
+     *
+     * @example $bitmapFormat->getFormatFileExtension(BitmapFormat::FORMAT_GIF) === 'gif'
+     */
+    public function getFormatFileExtension($format)
+    {
+        $format = $this->normalizeFormat($format);
+        switch ($format) {
+            case static::FORMAT_PNG:
+                $result = 'png';
+                break;
+            case static::FORMAT_JPEG:
+                $result = 'jpg';
+                break;
+            case static::FORMAT_GIF:
+                $result = 'gif';
+                break;
+            case static::FORMAT_WBMP:
+                $result = 'wbmp';
+                break;
+            case static::FORMAT_XBM:
+                $result = 'xbm';
+                break;
+            default:
+                $result = '';
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set the default JPEG quality.
+     *
+     * @param int $value an integer from 0 to 100
+     *
+     * @return $this
+     */
+    public function setDefaultJpegQuality($value)
+    {
+        if ($this->valn->integer($value, 0, 100)) {
+            $value = (int) $value;
+            $this->config->set('concrete.misc.default_jpeg_image_compression', $value);
+            $this->config->save('concrete.misc.default_jpeg_image_compression', $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the default JPEG quality.
+     *
+     * @return int an integer from 0 to 100
+     */
+    public function getDefaultJpegQuality()
+    {
+        $result = $this->config->get('concrete.misc.default_jpeg_image_compression');
+        if ($this->valn->integer($result, 0, 100)) {
+            $result = (int) $result;
+        } else {
+            $result = static::DEFAULT_JPEG_QUALITY;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set the default PNG compression level.
+     *
+     * @param int $value an integer from 0 to 9
+     *
+     * @return $this
+     */
+    public function setDefaultPngCompressionLevel($value)
+    {
+        if ($this->valn->integer($value, 0, 9)) {
+            $value = (int) $value;
+            $this->config->set('concrete.misc.default_png_image_compression', $value);
+            $this->config->save('concrete.misc.default_png_image_compression', $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the default PNG compression level.
+     *
+     * @return int an integer from 0 to 9
+     */
+    public function getDefaultPngCompressionLevel()
+    {
+        $result = $this->config->get('concrete.misc.default_png_image_compression');
+        if ($this->valn->integer($result, 0, 9)) {
+            $result = (int) $result;
+        } else {
+            $result = static::DEFAULT_PNG_COMPRESSIONLEVEL;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Normalize a format.
+     *
+     * @param string|mixed $format
+     *
+     * @return string
+     */
+    protected function normalizeFormat($format)
+    {
+        $format = strtolower(trim((string) $format));
+        if ($format === 'jpg') {
+            $format = static::FORMAT_JPEG;
+        }
+
+        return $format;
+    }
+}

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -63,7 +63,7 @@ interface ThumbnailerInterface
     /**
      * Set the format of the generated thumbnails.
      *
-     * @param string $thumbnailsFormat one of the \Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService::FORMAT_... constants
+     * @param string $thumbnailsFormat one of the \Concrete\Core\File\Image\BitmapFormat::FORMAT_ constants, or \Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService::FORMAT_AUTO
      *
      * @return static
      */
@@ -72,7 +72,7 @@ interface ThumbnailerInterface
     /**
      * Get the format of the generated thumbnails.
      *
-     * @return string one of the \Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService::FORMAT_... constants
+     * @return string one of the \Concrete\Core\File\Image\BitmapFormat::FORMAT_ constants, or \Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService::FORMAT_AUTO
      */
     public function getThumbnailsFormat();
 

--- a/concrete/src/File/Image/Thumbnail/Type/Version.php
+++ b/concrete/src/File/Image/Thumbnail/Type/Version.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\File\Image\Thumbnail\Type;
 
 use Concrete\Core\Entity\File\Version as FileVersion;
+use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
 use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
 use Concrete\Core\Support\Facade\Application;
@@ -289,15 +290,7 @@ class Version
         $prefix = $fv->getPrefix();
         $filename = $fv->getFileName();
         $thumbnailFormat = $app->make(ThumbnailFormatService::class)->getFormatForFile($filename);
-        switch ($thumbnailFormat) {
-            case ThumbnailFormatService::FORMAT_JPEG:
-                $extension = 'jpg';
-                break;
-            case ThumbnailFormatService::FORMAT_PNG:
-            default:
-                $extension = 'png';
-                break;
-        }
+        $extension = $app->make(BitmapFormat::class)->getFormatFileExtension($thumbnailFormat);
 
         return REL_DIR_FILES_THUMBNAILS . '/' . $this->getDirectoryName() . $ii->prefix($prefix, $hi->replaceExtension($filename, $extension));
     }

--- a/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
+++ b/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
@@ -1,10 +1,14 @@
 <?php
 namespace Concrete\Core\File\ImportProcessor;
 
+use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\File\Type\Type;
 use Concrete\Core\Entity\File\Version;
+use Concrete\Core\Support\Facade\Application;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+use InvalidArgumentException;
 
 class ConstrainImageProcessor implements ProcessorInterface
 {
@@ -180,28 +184,10 @@ class ConstrainImageProcessor implements ProcessorInterface
             $thumbnail = $image->thumbnail(new Box($width, $height), $mode);
         }
         $mimetype = $fr->getMimeType();
-        $thumbnailOptions = array();
-        switch ($mimetype) {
-            case 'image/jpeg':
-                $thumbnailType = 'jpeg';
-                $thumbnailOptions = array('jpeg_quality' => \Config::get('concrete.misc.default_jpeg_image_compression'));
-                break;
-            case 'image/png':
-                $thumbnailType = 'png';
-                break;
-            case 'image/gif':
-                $thumbnailType = 'gif';
-                break;
-            case 'image/xbm':
-                $thumbnailType = 'xbm';
-                break;
-            case 'image/vnd.wap.wbmp':
-                $thumbnailType = 'wbmp';
-                break;
-            default:
-                $thumbnailType = 'png';
-                break;
-        }
+        $app = Application::getFacadeApplication();
+        $bitmapFormat = $app->make(BitmapFormat::class);
+        $thumbnailType = $bitmapFormat->getFormatFromMimeType($mimetype, BitmapFormat::FORMAT_PNG);
+        $thumbnailOptions = $bitmapFormat->getFormatImagineSaveOptions($thumbnailType);
 
         $version->updateContents($thumbnail->get($thumbnailType, $thumbnailOptions));
     }

--- a/concrete/src/File/ImportProcessor/ForceImageFormatProcessor.php
+++ b/concrete/src/File/ImportProcessor/ForceImageFormatProcessor.php
@@ -1,8 +1,9 @@
 <?php
 namespace Concrete\Core\File\ImportProcessor;
 
-use Concrete\Core\File\Type\Type;
 use Concrete\Core\Entity\File\Version;
+use Concrete\Core\File\Image\BitmapFormat;
+use Concrete\Core\File\Type\Type;
 
 class ForceImageFormatProcessor implements ProcessorInterface
 {
@@ -45,19 +46,21 @@ class ForceImageFormatProcessor implements ProcessorInterface
     {
         switch ($this->getFormat()) {
             case self::FORMAT_JPEG:
-                $extension = 'jpg';
+                $format = BitmapFormat::FORMAT_JPEG;
             default:
-                $extension = 'jpg';
+                $format = BitmapFormat::FORMAT_JPEG;
                 break;
         }
 
-        if ($extension) {
+        if ($format !== null) {
+            $bitmapFormat = \Core::make(BitmapFormat::class);
+            $extension = $bitmapFormat->getFormatFileExtension($format);
             $fr = $version->getFileResource();
             $image = \Image::load($fr->read());
             $filename = $version->getFileName();
             $service = \Core::make('helper/file');
             $newFilename = $service->replaceExtension($filename, $extension);
-            $version->updateContents($image->get($extension));
+            $version->updateContents($image->get($format, $bitmapFormat->getFormatImagineSaveOptions($format)));
             $version->rename($newFilename);
         }
     }

--- a/concrete/src/File/ImportProcessor/SetJPEGQualityProcessor.php
+++ b/concrete/src/File/ImportProcessor/SetJPEGQualityProcessor.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\File\ImportProcessor;
 
 use Concrete\Core\Entity\File\Version;
+use Concrete\Core\File\Image\BitmapFormat;
 
 class SetJPEGQualityProcessor implements ProcessorInterface
 {
@@ -37,6 +38,6 @@ class SetJPEGQualityProcessor implements ProcessorInterface
     {
         $fr = $version->getFileResource();
         $image = \Image::load($fr->read());
-        $version->updateContents($image->get('jpg', array('jpeg_quality' => $this->getQuality())));
+        $version->updateContents($image->get(BitmapFormat::FORMAT_JPEG, array('jpeg_quality' => $this->getQuality())));
     }
 }

--- a/concrete/src/File/Service/Application.php
+++ b/concrete/src/File/Service/Application.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\File\Service;
 use Concrete\Core\File\StorageLocation\StorageLocation;
 use Config;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
 
 class Application
@@ -30,15 +31,7 @@ class Application
         }
         $app = ApplicationFacade::getFacadeApplication();
         $format = $app->make(ThumbnailFormatService::class)->getFormatForFile($filename);
-        switch ($format) {
-            case ThumbnailFormatService::FORMAT_JPEG:
-                $extension = 'jpg';
-                break;
-            case ThumbnailFormatService::FORMAT_PNG:
-            default:
-                $extension = 'png';
-                break;
-        }
+        $extension = $app->make(BitmapFormat::class)->getFormatFileExtension($format);
         $hi = $app->make('helper/file');
         $filename = $hi->replaceExtension($filename, $extension);
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
+use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
 use Concrete\Core\Updater\Migrations\ManagedSchemaUpgraderInterface;
@@ -50,7 +50,7 @@ class Version20171121000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         $db = $this->connection;
-        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = '' AND (path LIKE '%.jpg' OR path LIKE '%.jpeg' OR path LIKE '%.pjpg' OR path LIKE '%.pjpeg')", [ThumbnailFormatService::FORMAT_JPEG]);
-        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = ''", [ThumbnailFormatService::FORMAT_PNG]);
+        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = '' AND (path LIKE '%.jpg' OR path LIKE '%.jpeg' OR path LIKE '%.pjpg' OR path LIKE '%.pjpeg')", [BitmapFormat::FORMAT_JPEG]);
+        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = ''", [BitmapFormat::FORMAT_PNG]);
     }
 }

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -38,6 +38,7 @@ use stdClass;
 use User as ConcreteUser;
 use View;
 use Concrete\Core\Export\Item\User as UserExporter;
+use Concrete\Core\File\Image\BitmapFormat;
 
 class UserInfo extends ConcreteObject implements AttributeObjectInterface, PermissionObjectInterface, ExportableInterface
 {
@@ -251,10 +252,9 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     public function updateUserAvatar(ImageInterface $image)
     {
         $fsl = $this->application->make(StorageLocationFactory::class)->fetchDefault()->getFileSystemObject();
+        $bitmapFormat = $this->application->make(BitmapFormat::class);
         $config = $this->application->make('config');
-        $image = $image->get('jpg', [
-            'jpeg_quality' => $config->get('concrete.misc.default_jpeg_image_compression')
-        ]);
+        $image = $image->get(BitmapFormat::FORMAT_JPEG, $bitmapFormat->getFormatImagineSaveOptions(BitmapFormat::FORMAT_JPEG));
         $file = REL_DIR_FILES_AVATARS . '/' . $this->getUserID() . '.jpg';
         if ($fsl->has($file)) {
             $fsl->delete($file);

--- a/concrete/views/image-editor/editor.php
+++ b/concrete/views/image-editor/editor.php
@@ -2,6 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\ImageEditor\ImageEditor;
+use Concrete\Core\File\Image\BitmapFormat;
 use Whoops\Exception\ErrorException;
 
 $editorid = substr(sha1(time()), 0, 5); // Just enough entropy.
@@ -118,7 +119,7 @@ foreach ($filters as $filter) {
                         controlsets: {},
                         filters: {},
                         debug: false,
-                        jpegCompression: <?= Config::get('concrete.misc.default_jpeg_image_compression') / 100 ?>,
+                        jpegCompression: <?= Core::make(BitmapFormat::class)->getDefaultJpegQuality() / 100 ?>,
                         mime: '<?= $fv->getMimeType() ?>'
                     },
                     settings = _.extend(defaults, <?= json_encode($settings) ?>);


### PR DESCRIPTION
We have many places where we need the configured, JPEG quality level/PNG compression level, as well as to know which is the extension/mime time of a particular image type.