### PR TITLE
Fix locale and language of MultilingualPageRelations when site locale changes

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.3.3a1',
     'version_installed' => '8.3.3a1',
-    'version_db' => '20180130000000', // the key of the latest database migration
+    'version_db' => '20180213000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Entity/Site/Locale.php
+++ b/concrete/src/Entity/Site/Locale.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Entity
  * @ORM\Table(name="SiteLocales")
+ * @ORM\EntityListeners({"\Concrete\Core\Site\Locale\Listener"})
  */
 class Locale implements LocaleInterface, TreeInterface
 {

--- a/concrete/src/Site/Locale/Listener.php
+++ b/concrete/src/Site/Locale/Listener.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Concrete\Core\Site\Locale;
+
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Site\Locale as LocaleEntity;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+
+class Listener
+{
+    public function preUpdate(LocaleEntity $locale, PreUpdateEventArgs $args)
+    {
+        $changeset = $args->getEntityChangeSet();
+        if (isset($changeset['msLanguage']) || isset($changeset['msCountry'])) {
+            $tree = $locale->getSiteTree();
+            if ($tree !== null) {
+                $homeCID = (int) $tree->getSiteHomePageID();
+                if ($homeCID !== 0) {
+                    $cn = $args->getEntityManager()->getConnection();
+                    $sqlLanguage = $cn->quote($locale->getLanguage());
+                    $sqlLocale = $cn->quote($locale->getLocale());
+                    $updateMultilingualRelation = <<<EOT
+UPDATE MultilingualPageRelations
+SET mpLocale = {$sqlLocale}, mpLanguage = {$sqlLanguage}
+WHERE cID IN (:cIDs:)
+EOT
+                    ;
+                    $this->fixMultilingualPageRelations($cn, $updateMultilingualRelation, [$homeCID]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Connection $cn
+     * @param string $selectChildren
+     * @param string $updateMultilingualRelation
+     * @param int[] $pageIDs
+     */
+    private function fixMultilingualPageRelations(Connection $cn, $updateMultilingualRelation, array $pageIDs)
+    {
+        $pageIDsJoined = implode(',', $pageIDs);
+        $cn->query(str_replace(':cIDs:', $pageIDsJoined, $updateMultilingualRelation));
+        $childPageIDs = $cn->query('SELECT cID FROM Pages WHERE cParentID IN (' . $pageIDsJoined . ')')->fetchAll();
+        if (!empty($childPageIDs)) {
+            $childPageIDs = array_map('intval', array_map('array_pop', $childPageIDs));
+            foreach (array_chunk($childPageIDs, 500) as $chunk) {
+                $this->fixMultilingualPageRelations($cn, $updateMultilingualRelation, $chunk);
+            }
+        }
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180213000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180213000000.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\Site\Locale;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\DirectSchemaUpgraderInterface;
+
+class Version20180213000000 extends AbstractMigration implements DirectSchemaUpgraderInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            Locale::class,
+        ]);
+    }
+}


### PR DESCRIPTION
Since #5866 we have the possibility to change the locale of a site section.
I forgot to update the `mpLocale` and `mpLanguage` columns of the table `MultilingualPageRelations` for the affected pages.