### PR TITLE
Revise fill thumbnail job name, description and return text

### DIFF
--- a/concrete/jobs/fill_thumbnails_table.php
+++ b/concrete/jobs/fill_thumbnails_table.php
@@ -111,7 +111,7 @@ class FillThumbnailsTable extends QueueableJob
      */
     public function finish(Queue $q)
     {
-        return t('All thumbnail path have been processed.');
+        return t('All thumbnail paths have been processed.');
     }
 
     /**

--- a/concrete/jobs/fill_thumbnails_table.php
+++ b/concrete/jobs/fill_thumbnails_table.php
@@ -49,7 +49,7 @@ class FillThumbnailsTable extends QueueableJob
      */
     public function getJobName()
     {
-        return t('Fill thumbnails table');
+        return t('Fill thumbnail database table');
     }
 
     /**
@@ -59,7 +59,7 @@ class FillThumbnailsTable extends QueueableJob
      */
     public function getJobDescription()
     {
-        return t('Populate the thumbnail table with all the files.');
+        return t('Re-populate the thumbnail path database table.');
     }
 
     /**
@@ -111,7 +111,7 @@ class FillThumbnailsTable extends QueueableJob
      */
     public function finish(Queue $q)
     {
-        return t('All image files have been processed.');
+        return t('All thumbnail path have been processed.');
     }
 
     /**


### PR DESCRIPTION
I was translating the job and got confused.
So I would like to suggest the change of the name, description and return text.

When I was translating the new text string, I got confused which "table" this job is going to fill.
When I read the code and understood that it's repopulating the path in thumbnail path database table.

I think the beginner concrete5 user will confuse the name of the current job, description and return text.

But I don't want to change too much to change too much such as Class name, installation files and etc.

@biplobice, @deek87 and I had a short discussion and came to this sentences.

Thanks.
