### PR TITLE
Implement Conditional thumbnails

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -7,8 +7,7 @@ return [
      * @var string
      */
     'version' => '8.4.0a1',
-    'version_installed' => '8.4.0a1',
-    'version_db' => '20180227035239', // the key of the latest database migration
+    'version_installed' => '8.4.0a1',    'version_db' => '20180302080830', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/controllers/backend/file/thumbnailer.php
+++ b/concrete/controllers/backend/file/thumbnailer.php
@@ -124,7 +124,7 @@ class Thumbnailer extends \Concrete\Core\Controller\Controller
     private function getDimensions($thumbnail)
     {
         $matches = null;
-        if (preg_match('/ccm_(\d+)x(\d+)(?:_([10]))?/', $thumbnail['thumbnailTypeHandle'], $matches)) {
+        if (preg_match('/^ccm_(\d+)x(\d+)(?:_([10]))?$/', $thumbnail['thumbnailTypeHandle'], $matches)) {
             return array_pad(array_slice($matches, 1), 3, 0);
         }
     }

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -76,6 +76,8 @@ class Thumbnails extends DashboardPageController
                 $this->error->add(t('Your thumbnail type must have a handle.'));
             } elseif (!$valStrings->handle($handle)) {
                 $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
+            } elseif (substr($handle, -strlen(TypeEntity::HIGHDPI_SUFFIX)) === TypeEntity::HIGHDPI_SUFFIX) {
+                $this->error->add(t('Thumbnail type handles can\'t end with "%s".', TypeEntity::HIGHDPI_SUFFIX));
             } else {
                 $alreadyExists = false;
                 foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -70,28 +70,30 @@ class Thumbnails extends DashboardPageController
             $valNumbers = $this->app->make('helper/validation/numbers');
             $valStrings = $this->app->make('helper/validation/strings');
 
-            $handle = $post->get('ftTypeHandle');
-            $handle = is_string($handle) ? trim($handle) : '';
-            if ($handle === '') {
-                $this->error->add(t('Your thumbnail type must have a handle.'));
-            } elseif (!$valStrings->handle($handle)) {
-                $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
-            } elseif (substr($handle, -strlen(TypeEntity::HIGHDPI_SUFFIX)) === TypeEntity::HIGHDPI_SUFFIX) {
-                $this->error->add(t('Thumbnail type handles can\'t end with "%s".', TypeEntity::HIGHDPI_SUFFIX));
-            } elseif (preg_match('/^ccm_(\d+)x(\d+)/', $handle)) {
-                $this->error->add(t('Thumbnail type handles start with "%s" followed by numbers.', 'ccm_'));
-            } else {
-                $alreadyExists = false;
-                foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {
-                    if ($existingType !== $type) {
-                        $alreadyExists = true;
-                        break;
-                    }
-                }
-                if ($alreadyExists) {
-                    $this->error->add(t('That handle is in use.'));
+            if ($type->getID() === null || !$type->isRequired()) {
+                $handle = $post->get('ftTypeHandle');
+                $handle = is_string($handle) ? trim($handle) : '';
+                if ($handle === '') {
+                    $this->error->add(t('Your thumbnail type must have a handle.'));
+                } elseif (!$valStrings->handle($handle)) {
+                    $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
+                } elseif (substr($handle, -strlen(TypeEntity::HIGHDPI_SUFFIX)) === TypeEntity::HIGHDPI_SUFFIX) {
+                    $this->error->add(t('Thumbnail type handles can\'t end with "%s".', TypeEntity::HIGHDPI_SUFFIX));
+                } elseif (preg_match('/^ccm_(\d+)x(\d+)/', $handle)) {
+                    $this->error->add(t('Thumbnail type handles start with "%s" followed by numbers.', 'ccm_'));
                 } else {
-                    $type->setHandle($handle);
+                    $alreadyExists = false;
+                    foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {
+                        if ($existingType !== $type) {
+                            $alreadyExists = true;
+                            break;
+                        }
+                    }
+                    if ($alreadyExists) {
+                        $this->error->add(t('That handle is in use.'));
+                    } else {
+                        $type->setHandle($handle);
+                    }
                 }
             }
 

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -138,7 +138,7 @@ class Thumbnails extends DashboardPageController
             if ($ftTypeID === 'new' || !$type->isRequired()) {
                 $fileSetOption = $post->get('fileSetOption');
                 if (!in_array($fileSetOption, array_keys($this->getFileSetOptions()), true)) {
-                    $this->error->add(t('Please specify the Conditional thumbnails criteria.'));
+                    $this->error->add(t('Please specify the Conditional Thumbnails criteria.'));
                 } elseif ($fileSetOption === static::FILESETOPTION_ALL) {
                     $type->getAssociatedFileSets()->clear();
                     $type->setLimitedToFileSets(false);
@@ -157,7 +157,7 @@ class Thumbnails extends DashboardPageController
                         }
                     }
                     if (empty($receivedFileSetIDs)) {
-                        $this->error->add(t('Please specify the file sets for the Conditional thumbnails criteria.'));
+                        $this->error->add(t('Please specify the file sets for the Conditional Thumbnails criteria.'));
                     } else {
                         $type->setLimitedToFileSets($fileSetOption === static::FILESETOPTION_ONLY);
                         foreach ($type->getAssociatedFileSets() as $afs) {

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -78,6 +78,8 @@ class Thumbnails extends DashboardPageController
                 $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
             } elseif (substr($handle, -strlen(TypeEntity::HIGHDPI_SUFFIX)) === TypeEntity::HIGHDPI_SUFFIX) {
                 $this->error->add(t('Thumbnail type handles can\'t end with "%s".', TypeEntity::HIGHDPI_SUFFIX));
+            } elseif (preg_match('/^ccm_(\d+)x(\d+)/', $handle)) {
+                $this->error->add(t('Thumbnail type handles start with "%s" followed by numbers.', 'ccm_'));
             } else {
                 $alreadyExists = false;
                 foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -1,201 +1,192 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Files;
 
-use Concrete\Core\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type as TypeEntity;
+use Concrete\Core\File\Image\Thumbnail\Type\Type as TypeService;
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Loader;
-use Request;
+use Doctrine\ORM\EntityManagerInterface;
 
 class Thumbnails extends DashboardPageController
 {
     public function view()
     {
-        $list = Type::getList();
+        $list = TypeService::getList();
         $this->set('types', $list);
     }
 
     public function edit($ftTypeID = false)
     {
-        $type = Type::getByID($ftTypeID);
+        if ($ftTypeID === 'new') {
+            $type = new TypeEntity();
+        } else {
+            $type = $ftTypeID ? $this->app->make(EntityManagerInterface::class)->find(TypeEntity::class, $ftTypeID) : null;
+            if ($type === null) {
+                $this->flash('error', t('Invalid thumbnail type object.'));
+
+                return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
+            }
+        }
         $this->set('type', $type);
-
-        $this->get_sizing_values();
+        $this->set('sizingModes', $this->getSizingModes());
+        $this->set('sizingModeHelps', $this->getSizingModeHelps());
     }
 
-    public function add()
+    public function save($ftTypeID = false)
     {
-        $this->get_sizing_values();
-    }
-
-    protected function get_sizing_values()
-    {
-        $sizingModes = [
-            Type::RESIZE_PROPORTIONAL => t('Resize Proportionally'),
-            Type::RESIZE_EXACT => t('Resize and Crop to the Exact Size')
-        ];
-        $this->set('sizingModes', $sizingModes);
-
-        $sizingModeHelp = [
-            Type::RESIZE_PROPORTIONAL => t("The original image will be scaled down so it is fully contained within the thumbnail dimensions. The specified width and height will be considered maximum limits. Unless the given dimensions are equal to the original image's aspect ratio, one dimension in the resulting thumbnail will be smaller than the given limit."),
-            Type::RESIZE_EXACT => t("The thumbnail will be scaled so that its smallest side will equal the length of the corresponding side in the original image. Any excess outside of the scaled thumbnail's area will be cropped, and the returned thumbnail will have the exact width and height specified. Both width and height must be specified.")
-        ];
-        $this->set('sizingModeHelp', $sizingModeHelp);
-
-        $this->set('ftTypeSizingMode', Type::RESIZE_DEFAULT);
-
-        $this->set('sizingHelpText', $sizingModeHelp[Type::RESIZE_DEFAULT]);
-    }
-
-    public function thumbnail_type_added()
-    {
-        $this->set('success', t('Thumbnail type added.'));
-        $this->view();
-    }
-
-    public function thumbnail_type_updated()
-    {
-        $this->set('success', t('Thumbnail type updated.'));
-        $this->view();
-    }
-
-    protected function validateThumbnailRequest()
-    {
-        $request = \Request::getInstance();
-        $valStrings = Loader::helper('validation/strings');
-        $valNumbers = Loader::helper('validation/numbers');
-
-        if (!$valStrings->notempty($request->request->get('ftTypeName'))) {
-            $this->error->add(t("Your thumbnail type must have a name."));
-        }
-
-        if (!$valStrings->handle($request->request->get('ftTypeHandle'))) {
-            $this->error->add(t("Your thumbnail type handle must only contain lowercase letters and underscores."));
-        }
-
-        $width = (int) $request->request->get('ftTypeWidth');
-        $height = (int) $request->request->get('ftTypeHeight');
-        if ($width < 1 && $height < 1) {
-            $this->error->add(t("Width and height can't both be empty or less than zero."));
-        }
-
-        if ($request->request->get('ftTypeSizingMode') === Type::RESIZE_EXACT && ($width < 1 || $height < 1)) {
-            $this->error->add(t("With the 'Exact' sizing mode (with cropping), both width and height must be specified and greater than zero."));
-        }
-
-        if ($valStrings->notempty($width)) {
-            if (!$valNumbers->integer($width)) {
-                $this->error->add(t("If used, width can only be an integer, with no units."));
+        if (!$this->token->validate('thumbnailtype-save-' . $ftTypeID)) {
+            $this->error->add($this->token->getErrorMessage());
+        } else {
+            $em = $this->app->make(EntityManagerInterface::class);
+            $repo = $em->getRepository(TypeEntity::class);
+            if ($ftTypeID === 'new') {
+                $type = new TypeEntity();
             } else {
-                if ($width < 1) {
-                    $this->error->add(t("If used, width must be greater than zero."));
+                $type = $ftTypeID ? $this->app->make(EntityManagerInterface::class)->find(TypeEntity::class, $ftTypeID) : null;
+                if ($type === null) {
+                    $this->flash('error', t('Invalid thumbnail type object.'));
+
+                    return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
                 }
             }
-        }
+            $post = $this->request->request;
+            $valNumbers = $this->app->make('helper/validation/numbers');
+            $valStrings = $this->app->make('helper/validation/strings');
 
-        if ($valStrings->notempty($height)) {
-            if (!$valNumbers->integer($height)) {
-                $this->error->add(t("If used, height can only be an integer, with no units."));
+            $handle = $post->get('ftTypeHandle');
+            $handle = is_string($handle) ? trim($handle) : '';
+            if ($handle === '') {
+                $this->error->add(t('Your thumbnail type must have a handle.'));
+            } elseif (!$valStrings->handle($handle)) {
+                $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
             } else {
-                if ($height < 1) {
-                    $this->error->add(t("If used, height must be greater than zero."));
+                $alreadyExists = false;
+                foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {
+                    if ($existingType !== $type) {
+                        $alreadyExists = true;
+                        break;
+                    }
+                }
+                if ($alreadyExists) {
+                    $this->error->add(t('That handle is in use.'));
+                } else {
+                    $type->setHandle($handle);
                 }
             }
-        }
 
-        return $request;
-    }
-
-    public function thumbnail_type_deleted()
-    {
-        $this->set('message', t('Thumbnail type removed.'));
-        $this->view();
-    }
-
-    public function delete()
-    {
-        $request = \Request::getInstance();
-
-        if (!Loader::helper('validation/token')->validate('delete')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
-        }
-        $type = Type::getByID($request->request->get('ftTypeID'));
-        if (!is_object($type)) {
-            $this->error->add(t('Invalid thumbnail type object.'));
-        }
-        if ($type->isRequired()) {
-            $this->error->add(t('You may not delete a required thumbnail type.'));
-        }
-
-        if (!$this->error->has()) {
-            $type->delete();
-            $this->redirect('/dashboard/system/files/thumbnails', 'thumbnail_type_deleted');
-        }
-        $this->edit($request->request->get('ftTypeID'));
-    }
-
-    public function update()
-    {
-        $request = $this->validateThumbnailRequest();
-
-        $type = Type::getByID($request->request->get('ftTypeID'));
-        if (!Loader::helper('validation/token')->validate('update')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
-        }
-        if (!is_object($type)) {
-            $this->error->add(t('Invalid thumbnail type object.'));
-        }
-        if (!$this->error->has()) {
-            $height = (int) $request->request->get('ftTypeHeight');
-            $width = (int) $request->request->get('ftTypeWidth');
-            if ($height > 0) {
-                $type->setHeight($height);
+            $name = $post->get('ftTypeName');
+            $name = is_string($name) ? trim($name) : '';
+            if ($name === '') {
+                $this->error->add(t('Your thumbnail type must have a name.'));
             } else {
-                $type->setHeight(null);
+                $alreadyExists = false;
+                foreach ($repo->findBy(['ftTypeName' => $name]) as $existingType) {
+                    if ($existingType !== $type) {
+                        $alreadyExists = true;
+                        break;
+                    }
+                }
+                if ($alreadyExists) {
+                    $this->error->add(t('Another thumbnail type exists with the name "%s".', h($name)));
+                } else {
+                    $type->setName($name);
+                }
             }
-            if ($width > 0) {
+            $width = $post->get('ftTypeWidth');
+            if ($valNumbers->integer($width, 1)) {
+                $width = (int) $width;
+            } else {
+                $width = null;
+            }
+            $height = $post->get('ftTypeHeight');
+            if ($valNumbers->integer($height, 1)) {
+                $height = (int) $height;
+            } else {
+                $height = null;
+            }
+            if ($width === null && $height === null) {
+                $this->error->add(t("Width and height can't both be empty or less than zero."));
+            } else {
                 $type->setWidth($width);
-            } else {
-                $type->setWidth(null);
-            }
-            $type->setName($request->request->get('ftTypeName'));
-            $type->setHandle($request->request->get('ftTypeHandle'));
-            $type->setSizingMode($request->request->get('ftTypeSizingMode'));
-            $type->save();
-            $this->redirect('/dashboard/system/files/thumbnails', 'thumbnail_type_updated');
-        }
-
-        $this->edit($request->request->get('ftTypeID'));
-    }
-
-    public function do_add()
-    {
-        $request = $this->validateThumbnailRequest();
-        if (!Loader::helper('validation/token')->validate('do_add')) {
-            $this->error->add(Loader::helper('validation/token')->getErrorMessage());
-        }
-        $thumbtype = Type::getByHandle($request->request->get('ftTypeHandle'));
-        if (is_object($thumbtype)) {
-            $this->error->add(t('That handle is in use.'));
-        }
-        if (!$this->error->has()) {
-            $type = new \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type();
-            $height = (int) $request->request->get('ftTypeHeight');
-            $width = (int) $request->request->get('ftTypeWidth');
-            if ($height > 0) {
                 $type->setHeight($height);
             }
-            if ($width > 0) {
-                $type->setWidth($width);
+            $sizingMode = $post->get('ftTypeSizingMode');
+            if (!is_string($sizingMode) || !array_key_exists($sizingMode, $this->getSizingModes())) {
+                $this->error->add(t('Please specify the sizing mode.'));
+            } elseif ($sizingMode === TypeEntity::RESIZE_EXACT && ($width === null || $height === null)) {
+                $this->error->add(t("With the 'Exact' sizing mode (with cropping), both width and height must be specified and greater than zero."));
+            } else {
+                $type->setSizingMode($sizingMode);
             }
-            
-            $type->setName($request->request->get('ftTypeName'));
-            $type->setHandle($request->request->get('ftTypeHandle'));
-            $type->setSizingMode($request->request->get('ftTypeSizingMode'));
-            $type->save();
-            $this->redirect('/dashboard/system/files/thumbnails', 'thumbnail_type_added');
+
+            if (!$this->error->has()) {
+                if ($ftTypeID === 'new') {
+                    $em->persist($type);
+                }
+                $em->flush($type);
+                if ($ftTypeID === 'new') {
+                    $this->flash('success', t('Thumbnail type added.'));
+                } else {
+                    $this->flash('success', t('Thumbnail type updated.'));
+                }
+
+                return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
+            }
+        }
+        $this->edit($ftTypeID);
+    }
+
+    public function delete($ftTypeID = false)
+    {
+        if (!$this->token->validate('thumbnailtype-delete-' . $ftTypeID)) {
+            $this->error->add($this->token->getErrorMessage());
+        } else {
+            $em = $this->app->make(EntityManagerInterface::class);
+            $type = $ftTypeID ? $em->find(TypeEntity::class, $ftTypeID) : null;
+            if ($type === null) {
+                $this->flash('error', t('Invalid thumbnail type object.'));
+
+                return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
+            }
+            if ($type->isRequired()) {
+                $this->error->add(t('You may not delete a required thumbnail type.'));
+            }
+        }
+        if (!$this->error->has()) {
+            $em->remove($type);
+            $em->flush($type);
+            $this->flash('success', t('Thumbnail type removed.'));
+
+            return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''));
+        }
+        $this->edit($ftTypeID);
+    }
+
+    protected function getSizingModes()
+    {
+        return [
+            TypeEntity::RESIZE_PROPORTIONAL => t('Resize Proportionally'),
+            TypeEntity::RESIZE_EXACT => t('Resize and Crop to the Exact Size'),
+        ];
+    }
+
+    protected function getSizingModeHelps()
+    {
+        $result = [];
+        foreach (array_keys($this->getSizingModes()) as $sizingMode) {
+            switch ($sizingMode) {
+                case TypeEntity::RESIZE_PROPORTIONAL:
+                    $result[$sizingMode] = t("The original image will be scaled down so it is fully contained within the thumbnail dimensions. The specified width and height will be considered maximum limits. Unless the given dimensions are equal to the original image's aspect ratio, one dimension in the resulting thumbnail will be smaller than the given limit.");
+                    break;
+                case TypeEntity::RESIZE_EXACT:
+                    $result[$sizingMode] = t("The thumbnail will be scaled so that its smallest side will equal the length of the corresponding side in the original image. Any excess outside of the scaled thumbnail's area will be cropped, and the returned thumbnail will have the exact width and height specified. Both width and height must be specified.");
+                    break;
+                default:
+                    $result[$sizingMode] = '';
+            }
         }
 
-        $this->set('type', $type);
-        $this->get_sizing_values();
+        return $result;
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -79,8 +79,8 @@ class Thumbnails extends DashboardPageController
                     $this->error->add(t('Your thumbnail type handle must only contain lowercase letters and underscores.'));
                 } elseif (substr($handle, -strlen(TypeEntity::HIGHDPI_SUFFIX)) === TypeEntity::HIGHDPI_SUFFIX) {
                     $this->error->add(t('Thumbnail type handles can\'t end with "%s".', TypeEntity::HIGHDPI_SUFFIX));
-                } elseif (preg_match('/^ccm_(\d+)x(\d+)/', $handle)) {
-                    $this->error->add(t('Thumbnail type handles start with "%s" followed by numbers.', 'ccm_'));
+                } elseif (stripos($handle, 'ccm_') === 0) {
+                    $this->error->add(t('Thumbnail type handles can\'t start with "%s".', 'ccm_'));
                 } else {
                     $alreadyExists = false;
                     foreach ($repo->findBy(['ftTypeHandle' => $handle]) as $existingType) {

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -259,7 +259,7 @@ class Thumbnails extends DashboardPageController
         $result = [];
         foreach (FileSet::getMySets() as $fileSet) {
             if ($fileSet->getFileSetType() == FileSet::TYPE_PUBLIC) {
-                $result[$fileSet->getFileSetID()] = $asObjects ? $fileSet : $fileSet->getFileSetName();
+                $result[$fileSet->getFileSetID()] = $asObjects ? $fileSet : $fileSet->getFileSetDisplayName();
             }
         }
 

--- a/concrete/jobs/fill_thumbnails_table.php
+++ b/concrete/jobs/fill_thumbnails_table.php
@@ -94,7 +94,7 @@ class FillThumbnailsTable extends QueueableJob
                         $imageWidth = (int) $fileVersion->getAttribute('width');
                         $imageHeight = (int) $fileVersion->getAttribute('height');
                         foreach ($this->getThumbnailTypeVersions() as $thumbnailTypeVersion) {
-                            if ($thumbnailTypeVersion->shouldExistFor($imageWidth, $imageHeight)) {
+                            if ($thumbnailTypeVersion->shouldExistFor($imageWidth, $imageHeight, $file)) {
                                 $this->thumbnailPathResolver->getPath($fileVersion, $thumbnailTypeVersion);
                             }
                         }

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -127,7 +127,9 @@ if (isset($type)) {
         if ($allowConditionalThumbnails) {
             ?>
             var $fileSets = $('#fileSets');
-            $fileSets.selectize();
+            $fileSets.selectize({
+                plugins: ['remove_button']
+            });
             $('#fileSetOption')
                 .on('change', function() {
                     if ($(this).val() === <?= json_encode($controller::FILESETOPTION_ALL) ?>) {

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -1,157 +1,133 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
 
-<?php if ($this->controller->getTask() == 'add'
-    || $this->controller->getTask() == 'do_add'
-    || $this->controller->getTask() == 'edit'
-    || $this->controller->getTask() == 'update'
-    || $this->controller->getTask() == 'delete') {
-    ?>
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
 
-    <?php
-    if (is_object($type)) {
-        $sizingHelpText = $sizingModeHelp[$type->getSizingMode()];
-        $ftTypeName = $type->getName();
-        $ftTypeSizingMode = $type->getSizingMode();
-        $ftTypeHandle = $type->getHandle();
-        $ftTypeWidth = $type->getWidth();
-        $ftTypeHeight = $type->getHeight();
-        $ftTypeIsRequired = $type->isRequired();
-        $method = 'update';
+defined('C5_EXECUTE') or die('Access Denied.');
 
-        if (!$ftTypeIsRequired) {
-            ?>
-
-            <div class="ccm-dashboard-header-buttons">
-                <form method="post" action="<?=$this->action('delete')?>">
-                    <input type="hidden" name="ftTypeID" value="<?=$type->getID()?>" />
-                    <?=Loader::helper('validation/token')->output('delete');
-            ?>
-                    <button type="button" class="btn btn-danger" data-action="delete-type"><?=t('Delete Type')?></button>
-                </form>
-            </div>
-
+if (isset($type)) {
+    /* @var Concrete\Core\Entity\File\Image\Thumbnail\Type\Type $type */
+    /* @var array $sizingModes */
+    /* @var array $sizingModeHelps */
+    if ($type->getID() !== null && !$type->isRequired()) {
+        ?>
+        <div class="ccm-dashboard-header-buttons">
+            <form method="post" action="<?= $view->action('delete', $type->getID())?> ">
+                <?php $token->output('thumbnailtype-delete-' . $type->getID()) ?>
+                <button type="button" class="btn btn-danger" data-action="delete-type"><?= t('Delete Type') ?></button>
+            </form>
+        </div>
         <?php
-
-        }
-    } else {
-        $method = 'do_add';
     }
     ?>
-
-    <form method="post" action="<?=$view->action($method)?>" id="ccm-attribute-key-form">
-        <?=Loader::helper('validation/token')->output($method);
-    ?>
-        <?php if (is_object($type)) {
-    ?>
-            <input type="hidden" name="ftTypeID" value="<?=$type->getID()?>" />
-        <?php
-}
-    ?>
+    <form method="POST" action="<?= $view->action('save', $type->getID() ?: 'new') ?>">
+        <?php $token->output('thumbnailtype-save-' . ($type->getID() ?: 'new')) ?>
         <fieldset>
             <div class="form-group">
-                <?=$form->label('ftTypeHandle', t('Handle'))?>
+                <?= $form->label('ftTypeHandle', t('Handle')) ?>
                 <div class="input-group">
-                    <?=$form->text('ftTypeHandle', $ftTypeHandle)?>
+                    <?= $form->text('ftTypeHandle', $type->getHandle(), ['required' => 'required', 'maxlength' => '255']) ?>
                     <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
                 </div>
             </div>
             <div class="form-group">
-                <?=$form->label('ftTypeName', t('Name'))?>
+                <?= $form->label('ftTypeName', t('Name')) ?>
                 <div class="input-group">
-                    <?=$form->text('ftTypeName', $ftTypeName)?>
+                    <?=$form->text('ftTypeName', $type->getName(), ['required' => 'required', 'maxlength' => '255']) ?>
                     <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
                 </div>
             </div>
             <div class="form-group">
-                <?=$form->label('ftTypeWidth', t('Width'))?>
+                <?= $form->label('ftTypeWidth', t('Width')) ?>
                 <div class="input-group">
-                    <?=$form->text('ftTypeWidth', $ftTypeWidth)?>
-                    <span class="input-group-addon"><?php echo t('px'); ?></span>
+                    <?= $form->number('ftTypeWidth', $type->getWidth() ?: '', ['min' => '1']) ?>
+                    <span class="input-group-addon"><?= t('px') ?></span>
                 </div>
             </div>
             <div class="form-group">
-                <?=$form->label('ftTypeHeight', t('Height'))?>
+                <?= $form->label('ftTypeHeight', t('Height')) ?>
                 <div class="input-group">
-                    <?=$form->text('ftTypeHeight', $ftTypeHeight)?>
-                    <span class="input-group-addon"><?php echo t('px'); ?></span>
+                    <?=$form->text('ftTypeHeight', $type->getHeight() ?: '', ['min' => '1']) ?>
+                    <span class="input-group-addon"><?= t('px') ?></span>
                 </div>
             </div>
             <div class="form-group">
-                <?=$form->label('ftTypeSizingMode', t('Sizing Mode'))?>
-                <?=$form->select('ftTypeSizingMode', $sizingModes, $ftTypeSizingMode)?>
-                <p class="sizingmode-help help-block"><span><?=$sizingHelpText?></span></p>
+                <?= $form->label('ftTypeSizingMode', t('Sizing Mode')) ?>
+                <?= $form->select('ftTypeSizingMode', $sizingModes, $type->getSizingMode()) ?>
+                <p class="help-block" id="sizingmode-help"><span><?= $sizingModeHelps[$type->getSizingMode()] ?></span></p>
             </div>
         </fieldset>
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
-                <a href="<?=URL::page($c)?>" class="btn pull-left btn-default"><?=t('Back')?></a>
-                <?php if (is_object($type)) {
-    ?>
-                    <button type="submit" class="btn btn-primary pull-right"><?=t('Save')?></button>
+                <a href="<?= $view->action('') ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
                 <?php
-} else {
-    ?>
-                    <button type="submit" class="btn btn-primary pull-right"><?=t('Add')?></button>
-                <?php
-}
-    ?>
+                if ($type->getID() !== null) {
+                    ?>
+                    <button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button>
+                    <?php
+                } else {
+                    ?>
+                    <button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button>
+                    <?php
+                }
+                ?>
             </div>
         </div>
     </form>
-
-    <script type="text/javascript">
-        $(function() {
-            var sizingModeHelp = <?php echo json_encode($sizingModeHelp)?>;
-            $('button[data-action=delete-type]').on('click', function(e) {
-                e.preventDefault();
-                if (confirm('<?=t('Delete this thumbnail type?')?>')) {
-                    $(this).closest('form').submit();
-                }
-            });
-
-            $('#ftTypeSizingMode').on('change', function(e) {
-                $('.sizingmode-help').find('span').html(sizingModeHelp[$(this).val()]);
-            });
-
-            $('#ftTypeSizingMode').trigger('change');
-        })
+    <script>
+    $(document).ready(function() {
+        $('button[data-action=delete-type]').on('click', function(e) {
+            e.preventDefault();
+            if (window.confirm(<?= json_encode(t('Delete this thumbnail type?')) ?>)) {
+                $(this).closest('form').submit();
+            }
+        });
+        var sizingModeHelps = <?= json_encode($sizingModeHelps)?>;
+        $('#ftTypeSizingMode')
+            .on('change', function(e) {
+                var mode = $(this).val();
+                $('#sizingmode-help span').html(mode in sizingModeHelps ? sizingModeHelps[mode] : '');
+            })
+            .trigger('change')
+        ;
+    });
     </script>
-
-<?php
+    <?php
 } else {
+    /* @var Concrete\Core\Entity\File\Image\Thumbnail\Type\Type[] $types */
     ?>
-
     <div class="ccm-dashboard-header-buttons btn-group">
-        <a href="<?php echo $view->action('options')?>" class="btn btn-default"><?php echo t('Options')?></a>
-        <a href="<?php echo $view->action('add')?>" class="btn btn-primary"><?php echo t("Add Type")?></a>
+        <a href="<?= $view->action('options')?>" class="btn btn-default"><?= t('Options') ?></a>
+        <a href="<?= $view->action('edit', 'new')?>" class="btn btn-primary"><?= t('Add Type') ?></a>
     </div>
-
     <table class="table">
-    <thead>
-    <tr>
-        <th><?=t('Handle')?></th>
-        <th><?=t('Name')?></th>
-        <th><?=t('Width')?></th>
-        <th><?=t('Height')?></th>
-        <th><?=t('Sizing')?></th>
-        <th><?=t('Required')?></th>
-    </tr>
-    </thead>
-    <tbody>
-    <?php foreach ($types as $type) {
-    ?>
-    <tr>
-        <td><a href="<?=$view->action('edit', $type->getID())?>"><?=$type->getHandle()?></a></td>
-        <td><?=$type->getDisplayName()?></td>
-        <td><?=$type->getWidth() ? $type->getWidth() : '<span class="text-muted">' . t('Automatic') . '</span>' ?></td>
-        <td><?=$type->getHeight() ? $type->getHeight() : '<span class="text-muted">' . t('Automatic') . '</span>' ?></td>
-        <td><?=$type->getSizingModeDisplayName()?></td>
-        <td><?=$type->isRequired() ? t('Yes') : t('No')?></td>
-    </tr>
+        <thead>
+            <tr>
+                <th><?= t('Handle') ?></th>
+                <th><?= t('Name') ?></th>
+                <th><?= t('Width') ?></th>
+                <th><?= t('Height') ?></th>
+                <th><?= t('Sizing') ?></th>
+                <th><?= t('Required') ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            foreach ($types as $type) {
+                ?>
+                <tr>
+                    <td><a href="<?= $view->action('edit', $type->getID()) ?>"><?= h($type->getHandle()) ?></a></td>
+                    <td><?= h($type->getDisplayName()) ?></td>
+                    <td><?= $type->getWidth() ?: '<span class="text-muted">' . t('Automatic') . '</span>' ?></td>
+                    <td><?= $type->getHeight() ?: '<span class="text-muted">' . t('Automatic') . '</span>' ?></td>
+                    <td><?= h($type->getSizingModeDisplayName()) ?></td>
+                    <td><?= $type->isRequired() ? t('Yes') : t('No') ?></td>
+                </tr>
+                <?php
+            }
+            ?>
+        </tbody>
+    </table>
     <?php
 }
-    ?>
-    </tbody>
-    </table>
-<?php
-} ?>

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -87,25 +87,25 @@ if (isset($type)) {
                     <?= $form->selectMultiple('fileSets', $fileSets, $selectedFileSets, $fileSetAttributes) ?>
                 </div>
             </div>
-            <div class="ccm-dashboard-form-actions-wrapper">
-                <div class="ccm-dashboard-form-actions">
-                    <a href="<?= $view->action('') ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
-                    <?php
-                    if ($type->getID() !== null) {
-                        ?>
-                        <button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button>
-                        <?php
-                    } else {
-                        ?>
-                        <button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button>
-                        <?php
-                    }
-                    ?>
-                </div>
-            </div>
             <?php
         }
         ?>
+        <div class="ccm-dashboard-form-actions-wrapper">
+            <div class="ccm-dashboard-form-actions">
+                <a href="<?= $view->action('') ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
+                <?php
+                if ($type->getID() !== null) {
+                    ?>
+                    <button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button>
+                    <?php
+                } else {
+                    ?>
+                    <button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button>
+                    <?php
+                }
+                ?>
+            </div>
+        </div>
     </form>
     <script>
     $(document).ready(function() {

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -30,7 +30,7 @@ if (isset($type)) {
         <div class="form-group">
             <?= $form->label('ftTypeHandle', t('Handle')) ?>
             <div class="input-group">
-                <?= $form->text('ftTypeHandle', $type->getHandle(), ['required' => 'required', 'maxlength' => '255']) ?>
+                <?= $form->text('ftTypeHandle', $type->getHandle(), ['required' => 'required', 'maxlength' => '255'] + ($type->getID() !== null && $type->isRequired() ? ['readonly' => 'readonly'] : []) ) ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -78,7 +78,7 @@ if (isset($type)) {
             }
             ?>
             <div class="form-group">
-                <?= $form->label('fileSetOption', t('Conditional thumbnails')) ?>
+                <?= $form->label('fileSetOption', t('Conditional Thumbnails')) ?>
                 <?= $form->select('fileSetOption', $fileSetOptions, $fileSetOption, ['required' => 'required']) ?>
             </div>
             <div class="form-group">

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
@@ -37,8 +37,8 @@ class ImportFileImportantThumbnailTypesRoutine extends AbstractRoutine
                 if (isset($l['limitedToFileSets'])) {
                     $type->setLimitedToFileSets((bool) (string) $l['limitedToFileSets']);
                 }
-                if (isset($l->fileSets)) {
-                    foreach ($l->fileSets as $xFileSet) {
+                if (isset($l->filesets)) {
+                    foreach ($l->filesets->fileset as $xFileSet) {
                         $name = isset($xFileSet['name']) ? trim((string) $xFileSet['name']) : '';
                         if ($name !== '') {
                             $fileSet = FileSet::getByName($name);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet;
@@ -41,13 +42,15 @@ class ImportFileImportantThumbnailTypesRoutine extends AbstractRoutine
                         $name = isset($xFileSet['name']) ? trim((string) $xFileSet['name']) : '';
                         if ($name !== '') {
                             $fileSet = FileSet::getByName($name);
-                            if ($fileSet !== null && $fileSet->getFileSetType() === FileSet::TYPE_PUBLIC) {
+                            if ($fileSet === null) {
+                                $fileSet = FileSet::create($name);
+                            }
+                            if ($fileSet->getFileSetType() == FileSet::TYPE_PUBLIC) {
                                 $type->getAssociatedFileSets()->add(new TypeFileSet($type, $fileSet));
                             }
                         }
                     }
                 }
-                
                 $type->save();
             }
         }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
@@ -1,7 +1,8 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Permission\Category;
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet;
+use Concrete\Core\File\Set\Set as FileSet;
 
 class ImportFileImportantThumbnailTypesRoutine extends AbstractRoutine
 {
@@ -17,13 +18,36 @@ class ImportFileImportantThumbnailTypesRoutine extends AbstractRoutine
                 $type = new \Concrete\Core\Entity\File\Image\Thumbnail\Type\Type();
                 $type->setName((string) $l['name']);
                 $type->setHandle((string) $l['handle']);
-                $type->setSizingMode((string) $l['sizingMode']);
-                $type->setWidth((string) $l['width']);
-                $type->setHeight((string) $l['height']);
-                $required = (string) $l['required'];
-                if ($required) {
-                    $type->requireType();
+                if (isset($l['sizingMode'])) {
+                    $type->setSizingMode((string) $l['sizingMode']);
                 }
+                if (isset($l['width'])) {
+                    $type->setWidth((string) $l['width']);
+                }
+                if (isset($l['height'])) {
+                    $type->setHeight((string) $l['height']);
+                }
+                if (isset($l['required'])) {
+                    $required = (string) $l['required'];
+                    if ($required) {
+                        $type->requireType();
+                    }
+                }
+                if (isset($l['limitedToFileSets'])) {
+                    $type->setLimitedToFileSets((bool) (string) $l['limitedToFileSets']);
+                }
+                if (isset($l->fileSets)) {
+                    foreach ($l->fileSets as $xFileSet) {
+                        $name = isset($xFileSet['name']) ? trim((string) $xFileSet['name']) : '';
+                        if ($name !== '') {
+                            $fileSet = FileSet::getByName($name);
+                            if ($fileSet !== null && $fileSet->getFileSetType() === FileSet::TYPE_PUBLIC) {
+                                $type->getAssociatedFileSets()->add(new TypeFileSet($type, $fileSet));
+                            }
+                        }
+                    }
+                }
+                
                 $type->save();
             }
         }

--- a/concrete/src/Console/Application.php
+++ b/concrete/src/Console/Application.php
@@ -40,6 +40,7 @@ class Application extends SymfonyApplication
             $this->add(new Command\UninstallPackageCommand());
             $this->add(new Command\UpdatePackageCommand());
             $this->add(new Command\BlacklistClear());
+            $this->add(new Command\FillThumbnailsTableCommand());
         }
         $this->setupRestrictedCommands();
         $this->setupDoctrineCommands();

--- a/concrete/src/Console/Command/FillThumbnailsTableCommand.php
+++ b/concrete/src/Console/Command/FillThumbnailsTableCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Concrete\Core\Console\Command;
+
+use Concrete\Core\Console\Command;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\File\FileList;
+use Concrete\Core\File\Image\Thumbnail\Path\Resolver as ThumbnailPathResolver;
+use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
+use Concrete\Core\File\Type\Type as FileType;
+use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FillThumbnailsTableCommand extends Command
+{
+    protected function configure()
+    {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $this
+            ->setName('c5:fill-thumbnails-table')
+            ->setDescription('Populate the thumbnail table with all the files.')
+            ->addEnvOption()
+            ->setHelp(<<<EOT
+Returns codes:
+  0 operation completed successfully
+  $errExitCode errors occurred
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->write('Populating thumbnail table... ');
+        $count = 0;
+        $app = Application::getFacadeApplication();
+        $thumbnailPathResolver = $app->make(ThumbnailPathResolver::class);
+        $thumbnailTypeVersions = ThumbnailType::getVersionList();
+        foreach ($this->generateFileList() as $file) {
+            $fileVersion = $file->getApprovedVersion();
+            if ($fileVersion !== null) {
+                if ($fileVersion->getTypeObject()->supportsThumbnails()) {
+                    $imageWidth = (int) $fileVersion->getAttribute('width');
+                    $imageHeight = (int) $fileVersion->getAttribute('height');
+                    foreach ($thumbnailTypeVersions as $thumbnailTypeVersion) {
+                        if ($thumbnailTypeVersion->shouldExistFor($imageWidth, $imageHeight, $file)) {
+                            $thumbnailPathResolver->getPath($fileVersion, $thumbnailTypeVersion);
+                            ++$count;
+                        }
+                    }
+                }
+            }
+        }
+        $output->writeln("{$count} thumbnail paths processed.");
+    }
+
+    /**
+     * @return \Generator|\Concrete\Core\Entity\File\File[]
+     */
+    protected function generateFileList()
+    {
+        $app = Application::getFacadeApplication();
+        $em = $app->make(EntityManagerInterface::class);
+        $list = new FileList();
+        $list->filterByType(FileType::T_IMAGE);
+        $q = $list->deliverQueryObject()->execute();
+        while (false !== ($row = $q->fetch())) {
+            $fID = (int) $row['fID'];
+            $file = $em->find(File::class, $fID);
+            if ($file !== null) {
+                yield $file;
+            }
+        }
+    }
+}

--- a/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
@@ -103,7 +103,7 @@ class Type
     protected $ftTypeSizingMode = self::RESIZE_DEFAULT;
 
     /**
-     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     * Should the thumbnails be build for every file that ARE NOT in the file sets (false), or only for files that ARE in the specified file sets (true)?
      *
      * @ORM\Column(type="boolean", nullable=false)
      *
@@ -302,7 +302,7 @@ class Type
     }
 
     /**
-     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     * Should the thumbnails be build for every file that ARE NOT in the file sets (false), or only for files that ARE in the specified file sets (true)?
      *
      * @param bool $value
      *
@@ -316,7 +316,7 @@ class Type
     }
 
     /**
-     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     * Should the thumbnails be build for every file that ARE NOT in the file sets (false), or only for files that ARE in the specified file sets (true)?
      *
      * @return bool
      */
@@ -362,7 +362,7 @@ class Type
      */
     public function getBaseVersion()
     {
-        return new Version($this->getHandle(), $this->getHandle(), $this->getName(), $this->getWidth(), $this->getHeight(), false, $this->getSizingMode());
+        return $this->getVersion(false);
     }
 
     /**
@@ -372,15 +372,36 @@ class Type
      */
     public function getDoubledVersion()
     {
+        return $this->getVersion(true);
+    }
+
+    /**
+     * @param bool $doubled
+     *
+     * @return \Concrete\Core\File\Image\Thumbnail\Type\Version
+     */
+    private function getVersion($doubled)
+    {
+        $suffix = $doubled ? '_2x' : '';
+        $handle = $this->getHandle();
         $width = $this->getWidth();
-        if ($width !== null) {
+        if ($width && $doubled) {
             $width *= 2;
         }
         $height = $this->getHeight();
-        if ($height !== null) {
+        if ($height && $doubled) {
             $height *= 2;
         }
-
-        return new Version($this->getHandle() . '_2x', $this->getHandle() . '_2x', $this->getName(), $width, $height, true, $this->getSizingMode());
+        if ($this->isRequired()) {
+            $limitedToFileSets = false;
+            $filesetIDs = [];
+        } else {
+            $limitedToFileSets = $this->isLimitedToFileSets();
+            $filesetIDs = [];
+            foreach ($this->getAssociatedFileSets() as $afs) {
+                $filesetIDs[] = $afs->getFileSetID();
+            }
+        }
+        return new Version($handle . $suffix, $handle . $suffix, $this->getName(), $width, $height, $doubled, $this->getSizingMode(), $limitedToFileSets, $filesetIDs);
     }
 }

--- a/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
@@ -38,6 +38,13 @@ class Type
     const RESIZE_DEFAULT = self::RESIZE_PROPORTIONAL;
 
     /**
+     * Suffix for high DPI thumbnails (eg. Retina).
+     * 
+     * @var string
+     */
+    const HIGHDPI_SUFFIX = '_2x';
+
+    /**
      * The thumbnail unique identifier.
      *
      * @ORM\Id
@@ -382,7 +389,7 @@ class Type
      */
     private function getVersion($doubled)
     {
-        $suffix = $doubled ? '_2x' : '';
+        $suffix = $doubled ? static::HIGHDPI_SUFFIX : '';
         $handle = $this->getHandle();
         $width = $this->getWidth();
         if ($width && $doubled) {

--- a/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Entity\File\Image\Thumbnail\Type;
 
 use Concrete\Core\File\Image\Thumbnail\Type\Version;
 use Concrete\Core\Support\Facade\Application;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -39,7 +40,8 @@ class Type
     /**
      * The thumbnail unique identifier.
      *
-     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\Column(type="integer")
      * @ORM\GeneratedValue
      *
      * @var int|null
@@ -99,6 +101,29 @@ class Type
      * @var string
      */
     protected $ftTypeSizingMode = self::RESIZE_DEFAULT;
+
+    /**
+     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     *
+     * @ORM\Column(type="boolean", nullable=false)
+     *
+     * @var bool
+     */
+    protected $ftLimitedToFileSets = false;
+
+    /**
+     * Associated file sets (whose meaning depends on the value of ftLimitedToFileSets).
+     *
+     * @ORM\OneToMany(targetEntity="TypeFileSet", mappedBy="ftfsThumbnailType", cascade={"all"}, orphanRemoval=true)
+     *
+     * @var ArrayCollection|TypeFileSet[]
+     */
+    protected $ftAssociatedFileSets;
+
+    public function __construct()
+    {
+        $this->ftAssociatedFileSets = new ArrayCollection();
+    }
 
     /**
      * Get the thumbnail unique identifier.
@@ -274,6 +299,40 @@ class Type
         ];
 
         return $sizingModeDisplayNames[$this->getSizingMode()];
+    }
+
+    /**
+     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setLimitedToFileSets($value)
+    {
+        $this->ftLimitedToFileSets = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * Should the thumbnails be build for files in every set except the specified ones (false), or for files only in the specified file sets (true)?
+     *
+     * @return bool
+     */
+    public function isLimitedToFileSets()
+    {
+        return $this->ftLimitedToFileSets;
+    }
+
+    /**
+     * Get the associated file sets (whose meaning depends on the value of ftLimitedToFileSets).
+     *
+     * @return ArrayCollection|TypeFileSet[]
+     */
+    public function getAssociatedFileSets()
+    {
+        return $this->ftAssociatedFileSets;
     }
 
     /**

--- a/concrete/src/Entity/File/Image/Thumbnail/Type/TypeFileSet.php
+++ b/concrete/src/Entity/File/Image/Thumbnail/Type/TypeFileSet.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Concrete\Core\Entity\File\Image\Thumbnail\Type;
+
+use Concrete\Core\File\Set\Set as FileSet;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Entity representing the association between a thumbnail type and file sets.
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="FileImageThumbnailTypeFileSets")
+ */
+class TypeFileSet
+{
+    /**
+     * The associated thumbnail type.
+     *
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Type", inversedBy="ftAssociatedFileSets")
+     * @ORM\JoinColumn(name="ftfsThumbnailType", referencedColumnName="ftTypeID", nullable=false, onDelete="CASCADE")
+     *
+     * @var Type
+     */
+    protected $ftfsThumbnailType;
+
+    /**
+     * The ID of the associated file set.
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer", nullable=false, options={"unsigned":true})
+     *
+     * @var int
+     */
+    protected $ftfsFileSetID;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param Type $thumbnailType
+     * @param FileSet $fileSet
+     */
+    public function __construct(Type $thumbnailType, FileSet $fileSet)
+    {
+        $this->ftfsThumbnailType = $thumbnailType;
+        $this->ftfsFileSetID = (int) $fileSet->getFileSetID();
+    }
+
+    /**
+     * Get the associated thumbnail type.
+     *
+     * @return Type
+     */
+    public function getThumbnailType()
+    {
+        return $this->ftfsThumbnailType;
+    }
+
+    /**
+     * Get the ID of the associated file set.
+     *
+     * @return int
+     */
+    public function getFileSetID()
+    {
+        return $this->ftfsFileSetID;
+    }
+}

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1392,10 +1392,11 @@ class Version implements ObjectInterface
                     $imageWidth = (int) $this->getAttribute('width') ?: (int) $image->getSize()->getWidth();
                     $imageHeight = (int) $this->getAttribute('height') ?: (int) $image->getSize()->getHeight();
                     $types = Type::getVersionList();
+                    $file = $this->getFile();
                     foreach ($types as $type) {
                         // delete the file if it exists
                         $this->deleteThumbnail($type);
-                        if ($type->shouldExistFor($imageWidth, $imageHeight)) {
+                        if ($type->shouldExistFor($imageWidth, $imageHeight, $file)) {
                             $this->generateThumbnail($type);
                         }
                     }
@@ -1545,7 +1546,8 @@ class Version implements ObjectInterface
         if ($type !== null) {
             $imageWidth = (int) $this->getAttribute('width');
             $imageHeight = (int) $this->getAttribute('height');
-            if ($type->shouldExistFor($imageWidth, $imageHeight)) {
+            $file = $this->getFile();
+            if ($type->shouldExistFor($imageWidth, $imageHeight, $file)) {
                 $path_resolver = $app->make(Resolver::class);
                 $path = $path_resolver->getPath($this, $type);
             }
@@ -1576,7 +1578,7 @@ class Version implements ObjectInterface
         $types = Type::getVersionList();
         $file = $this->getFile();
         foreach ($types as $type) {
-            if ($type->shouldExistFor($imageWidth, $imageHeight)) {
+            if ($type->shouldExistFor($imageWidth, $imageHeight, $file)) {
                 $thumbnailPath = $type->getFilePath($this);
                 $location = $file->getFileStorageLocationObject();
                 $configuration = $location->getConfigurationObject();

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1525,7 +1525,7 @@ class Version implements ObjectInterface
 
     /**
      * Get the URL of a thumbnail type.
-     * If the thumbnail is smaller than the image you'll get the URL of the image itself.
+     * If the thumbnail is smaller than the image (or if the file does not satisfy the Conditional Thumbnail criterias) you'll get the URL of the image itself.
      *
      * Please remark that the path is resolved using the default core path resolver: avoid using this method when you have access to the resolver instance.
      *

--- a/concrete/src/File/Image/Thumbnail/Path/Resolver.php
+++ b/concrete/src/File/Image/Thumbnail/Path/Resolver.php
@@ -175,7 +175,7 @@ class Resolver
      */
     protected function determineThumbnailPath(Version $file_version, ThumbnailVersion $thumbnail, StorageLocation $storage, ConfigurationInterface $configuration, $format)
     {
-        if ($thumbnail->shouldExistFor($file_version->getAttribute('width'), $file_version->getAttribute('height'))) {
+        if ($thumbnail->shouldExistFor($file_version->getAttribute('width'), $file_version->getAttribute('height'), $file_version->getFile())) {
             $path = $thumbnail->getFilePath($file_version, $format);
     
             if ($configuration instanceof DeferredConfigurationInterface) {

--- a/concrete/src/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/File/Image/Thumbnail/Type/Type.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\File\Image\Thumbnail\Type;
 
 use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type as ThumbnailTypeEntity;
+use Concrete\Core\File\Set\Set as FileSet;
 use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -79,6 +80,7 @@ class Type
             $linkNode = $child->addChild('thumbnailtype');
             $linkNode->addAttribute('name', $link->getName());
             $linkNode->addAttribute('handle', $link->getHandle());
+            $linkNode->addAttribute('sizingMode', $link->getSizingMode());
             if ($link->getWidth()) {
                 $linkNode->addAttribute('width', $link->getWidth());
             }
@@ -87,6 +89,17 @@ class Type
             }
             if ($link->isRequired()) {
                 $linkNode->addAttribute('required', $link->isRequired());
+            }
+            $linkNode->addAttribute('limitedToFileSets', $link->isLimitedToFileSets() ? '1' : '0');
+            $filesetsNode = null;
+            foreach ($link->getAssociatedFileSets() as $afs) {
+                $fileSet = FileSet::getByID($afs->getFileSetID());
+                if ($fileSet !== null) {
+                    if ($filesetsNode === null) {
+                        $filesetsNode = $linkNode->addChild('fileSets');
+                    }
+                    $filesetsNode->addChild('fileSet')->addAttribute('name', $fileSet->getFileSetName());
+                }
             }
         }
     }

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -475,6 +475,7 @@ class Set
         $db->delete('FileSets', array('fsID' => $this->fsID));
         $db->executeQuery('DELETE FROM FileSetSavedSearches WHERE fsID = ?', array($this->fsID));
         $db->executeQuery('DELETE FROM FileSetFiles WHERE fsID = ?', array($this->fsID));
+        $db->executeQuery('DELETE FROM FileImageThumbnailTypeFileSets WHERE ftfsFileSetID = ?', [$this->fsID]);
     }
 
     /*

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -71,7 +71,7 @@ class Set
     /**
      * @param bool|\User $u
      *
-     * @return array
+     * @return static[]
      */
     public static function getMySets($u = false)
     {

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -421,25 +421,31 @@ class Set
     {
         $app = Application::getFacadeApplication();
         if (is_object($f_id)) {
-            $fileVersion = $f_id;
-            $f_id = (int) $fileVersion->getFileID();
-            if ($fileVersion instanceof FileEntity) {
-                $fileVersion = $fileVersion->getApprovedVersion() ?: $fileVersion->getRecentVersion();
+            $f = $f_id;
+            if ($f instanceof FileEntity) {
+                $file = $f;
+                $fileVersion = $file->getApprovedVersion();
+            } else {
+                $fileVersion = $f;
+                $file = $fileVersion->getFile();
             }
+            $f_id = (int) $file->getFileID();
         } else {
             $f_id = (int) $f_id;
             $em = $app->make(EntityManagerInterface::class);
             $file = $em->find(FileEntity::class, $f_id);
-            $fileVersion = $file->getApprovedVersion() ?: $file->getRecentVersion();
+            $fileVersion = $file->getApprovedVersion();
         }
-        if ($fileVersion === null) {
+        if ($file === null) {
             $result = null;
         } else {
             $file_set_file = File::createAndGetFile($f_id, $this->fsID);
             $fe = new \Concrete\Core\File\Event\FileSetFile($file_set_file);
             $director = $app->make(EventDispatcherInterface::class);
             $director->dispatch('on_file_added_to_set', $fe);
-            $fileVersion->refreshThumbnails(false);
+            if ($fileVersion !== null) {
+                $fileVersion->refreshThumbnails(false);
+            }
             $result = $file_set_file;
         }
 
@@ -465,18 +471,22 @@ class Set
     {
         $app = Application::getFacadeApplication();
         if (is_object($f_id)) {
-            $fileVersion = $f_id;
-            $f_id = (int) $fileVersion->getFileID();
-            if ($fileVersion instanceof FileEntity) {
-                $fileVersion = $fileVersion->getApprovedVersion() ?: $fileVersion->getRecentVersion();
+            $f = $f_id;
+            if ($f instanceof FileEntity) {
+                $file = $f;
+                $fileVersion = $file->getApprovedVersion();
+            } else {
+                $fileVersion = $f;
+                $file = $fileVersion->getFile();
             }
+            $f_id = (int) $file->getFileID();
         } else {
             $f_id = (int) $f_id;
             $em = $app->make(EntityManagerInterface::class);
             $file = $em->find(FileEntity::class, $f_id);
-            $fileVersion = $file->getApprovedVersion() ?: $file->getRecentVersion();
+            $fileVersion = $file->getApprovedVersion();
         }
-        if ($fileVersion === null) {
+        if ($file === null) {
             $result = false;
         } else {
             $file_set_file = File::createAndGetFile($f_id, $this->fsID);
@@ -488,7 +498,9 @@ class Set
             $fe = new \Concrete\Core\File\Event\FileSetFile($file_set_file);
             $director = $app->make(EventDispatcherInterface::class);
             $director->dispatch('on_file_removed_from_set', $fe);
-            $fileVersion->refreshThumbnails(false);
+            if ($fileVersion !== null) {
+                $fileVersion->refreshThumbnails(false);
+            }
             $result = true;
         }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20180215000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180215000000.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20180215000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            Type::class,
+            TypeFileSet::class,
+        ]);
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20180302080830.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180302080830.php
@@ -7,7 +7,7 @@ use Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20180215000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20180302080830 extends AbstractMigration implements RepeatableMigrationInterface
 {
     public function upgradeDatabase()
     {

--- a/concrete/views/dialogs/file/thumbnails.php
+++ b/concrete/views/dialogs/file/thumbnails.php
@@ -7,6 +7,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <div class="ccm-ui">
     <?php
+    $file = $version->getFile();
     $imageWidth = (int) $version->getAttribute('width');
     $imageHeight = (int) $version->getAttribute('height');
     $location = $version->getFile()->getFileStorageLocationObject();
@@ -20,7 +21,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         $sizingMode = $type->getSizingModeDisplayName();
         $thumbnailPath = $type->getFilePath($version);
         $hasFile = $filesystem->has($thumbnailPath);
-        $shouldHaveFile = $type->shouldExistFor($imageWidth, $imageHeight);
+        $shouldHaveFile = $type->shouldExistFor($imageWidth, $imageHeight, $file);
         $query = http_build_query([
             'fID' => $version->getFileID(),
             'fvID' => $version->getFileVersionID(),
@@ -66,7 +67,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                     } elseif ($shouldHaveFile) {
                         echo t('Thumbnail not found.');
                     } else {
-                        echo t('Source image too small for this thumbnail.');
+                        echo t('Thumbnail not to be generated for this file.');
                     }
                     ?>
                 </div>


### PR DESCRIPTION
This PR allows us to specify that a specific thumbnail type is valid only for files in specific file sets (or for files that are not in specific file sets).

Here's a screenshot of the relevant part of the dashboard page:

![conditional-thumbnails](https://user-images.githubusercontent.com/928116/36269757-4bc7a512-127a-11e8-9d46-1c774fb4b6f1.png)



Fix #3559 

