### PR TITLE
Adds a DocBlock for the addBlock method in Concrete\Core\Page

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2242,8 +2242,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     /**
      * Adds a block to the page.
      *
-     * @param Concrete\Core\Block\BlockType\BlockType $bt   The type of block to be added. 
-     * @param Concrete\Core\Area\Area $a    The area the block will appear. 
+     * @param \Concrete\Core\Block\BlockType\BlockType $bt   The type of block to be added. 
+     * @param \Concrete\Core\Area\Area $a    The area the block will appear. 
      * @param array $data   An array of settings for the block.
      * 
      * @return Block

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2239,6 +2239,15 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
     }
 
+    /**
+     * Adds a block to the page.
+     *
+     * @param Concrete\Core\Block\BlockType\BlockType $bt   The type of block to be added. 
+     * @param Concrete\Core\Area\Area $a    The area the block will appear. 
+     * @param array $data   An array of settings for the block.
+     * 
+     * @return Block
+     */
     public function addBlock($bt, $a, $data)
     {
         $b = parent::addBlock($bt, $a, $data);


### PR DESCRIPTION
This adds a DocBlock to the addBlock method in Concrete\Core\Page\Page class.

It was unclear what parameters needed to be passed to this method with the names given to the parameters. This adds a DocBlock for this method detailing what parameters are passed and what is returned.