### PR TITLE
Adds search header to express entity selector

### DIFF
--- a/concrete/controllers/dialog/express/search.php
+++ b/concrete/controllers/dialog/express/search.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\Dialog\Express;
 
 use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
 use Concrete\Controller\Search\Express\Entries;
+use Concrete\Controller\Element\Dashboard\Express\Entries\Header;
 
 class Search extends BackendInterfaceController
 {
@@ -30,6 +31,8 @@ class Search extends BackendInterfaceController
         $search = new Entries();
         $search->search($this->getEntity());
         $result = json_encode($search->getSearchResultObject()->getJSONObject());
+        $header = new Header($this->getEntity());
+        $this->set('headerMenu', $header);
         $this->set('result', $result);
         $this->set('searchController', $search);
     }

--- a/concrete/controllers/element/dashboard/express/entries/header.php
+++ b/concrete/controllers/element/dashboard/express/entries/header.php
@@ -42,13 +42,16 @@ class Header extends ElementController
         $this->exportURL = $exportURL;
     }
 
-    public function __construct($entity, $page)
+    public function __construct($entity, $page = null)
     {
         parent::__construct();
         $this->entity = $entity;
-        $this->page = $page;
-        $this->setCreateURL(\URL::to($page->getCollectionPath(), 'create_entry', $entity->getID()));
-        $this->setExportURL(\URL::to($page->getCollectionPath(), 'csv_export', $entity->getEntityResultsNodeId()));
+        
+        if ($page != null) {
+            $this->page = $page;
+            $this->setCreateURL(\URL::to($page->getCollectionPath(), 'create_entry', $entity->getID()));
+            $this->setExportURL(\URL::to($page->getCollectionPath(), 'csv_export', $entity->getEntityResultsNodeId()));
+        }
     }
 
     /**

--- a/concrete/elements/dashboard/express/entries/header.php
+++ b/concrete/elements/dashboard/express/entries/header.php
@@ -20,15 +20,16 @@
               </span>
         </div>
 
-        <ul class="ccm-header-search-navigation">
-            <li>
-                <a href="<?= $exportURL ?>" class="link-primary">
-                    <i class="fa fa-download"></i> <?= t('Export to CSV') ?>
-                </a>
-            </li>
-            <li><a href="<?= $createURL ?>" class="link-primary"><i class="fa fa-plus"></i> <?= t('New %s',
+        <?php if ($exportURL != null && $createURL != null) { ?>
+            <ul class="ccm-header-search-navigation">
+                <li>
+                    <a href="<?= $exportURL ?>" class="link-primary">
+                        <i class="fa fa-download"></i> <?= t('Export to CSV') ?>
+                    </a>
+                </li>
+                <li><a href="<?= $createURL ?>" class="link-primary"><i class="fa fa-plus"></i> <?= t('New %s',
                         $entity->getEntityDisplayName()) ?></a></li>
-        </ul>
-
+            </ul>
+        <?php } ?>
     </form>
 </div>

--- a/concrete/views/dialogs/express/entry/search.php
+++ b/concrete/views/dialogs/express/entry/search.php
@@ -2,35 +2,39 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
-<div data-search="express_entries" class="ccm-ui">
-    <?php View::element('express/entries/search', array('controller' => $searchController, 'selectMode' => true)) ?>
+<div class="ccm-express-entry-search-dialog">
+  <?php $headerMenu->render(); ?>
+
+  <div data-search="express_entries" class="ccm-ui">
+      <?php View::element('express/entries/search', array('controller' => $searchController, 'selectMode' => true)) ?>
+  </div>
 </div>
 
 <script type="text/javascript">
-    $(function () {
-        $('div[data-search=express_entries]').concreteAjaxSearch({
-            result: <?=$result?>,
-            onUpdateResults: function(concreteSearch) {
-                concreteSearch.$element.on('mouseover', 'tr[data-entity-id]', function(e) {
-                    e.stopPropagation();
-                    $(this).addClass('ccm-search-select-hover');
-                });
-                concreteSearch.$element.on('mouseout', 'tr[data-entity-id]', function(e) {
-                    e.stopPropagation();
-                    $(this).removeClass('ccm-search-select-hover');
-                });
+      $(function () {
+          $('.ccm-express-entry-search-dialog').concreteAjaxSearch({
+              result: <?=$result?>,
+              onUpdateResults: function(concreteSearch) {
+                  concreteSearch.$element.on('mouseover', 'tr[data-entity-id]', function(e) {
+                      e.stopPropagation();
+                      $(this).addClass('ccm-search-select-hover');
+                  });
+                  concreteSearch.$element.on('mouseout', 'tr[data-entity-id]', function(e) {
+                      e.stopPropagation();
+                      $(this).removeClass('ccm-search-select-hover');
+                  });
 
-                concreteSearch.$element.unbind('click.expressEntries');
-                concreteSearch.$element.on('click.expressEntries', 'tr[data-entity-id]', function(e) {
-                    e.stopPropagation();
-                    ConcreteEvent.publish('SelectExpressEntry', {
-                        exEntryID: $(this).attr('data-entity-id'),
-                        event: e
-                    });
-                    return false;
-                });
-            }
+                  concreteSearch.$element.unbind('click.expressEntries');
+                  concreteSearch.$element.on('click.expressEntries', 'tr[data-entity-id]', function(e) {
+                      e.stopPropagation();
+                      ConcreteEvent.publish('SelectExpressEntry', {
+                          exEntryID: $(this).attr('data-entity-id'),
+                          event: e
+                      });
+                      return false;
+                  });
+              }
 
-        });
-    });
+          });
+      });
 </script>

--- a/concrete/views/dialogs/express/entry/search.php
+++ b/concrete/views/dialogs/express/entry/search.php
@@ -11,30 +11,30 @@ defined('C5_EXECUTE') or die("Access Denied.");
 </div>
 
 <script type="text/javascript">
-      $(function () {
-          $('.ccm-express-entry-search-dialog').concreteAjaxSearch({
-              result: <?=$result?>,
-              onUpdateResults: function(concreteSearch) {
-                  concreteSearch.$element.on('mouseover', 'tr[data-entity-id]', function(e) {
-                      e.stopPropagation();
-                      $(this).addClass('ccm-search-select-hover');
-                  });
-                  concreteSearch.$element.on('mouseout', 'tr[data-entity-id]', function(e) {
-                      e.stopPropagation();
-                      $(this).removeClass('ccm-search-select-hover');
-                  });
+    $(function () {
+        $('.ccm-express-entry-search-dialog').concreteAjaxSearch({
+            result: <?=$result?>,
+            onUpdateResults: function(concreteSearch) {
+                concreteSearch.$element.on('mouseover', 'tr[data-entity-id]', function(e) {
+                    e.stopPropagation();
+                    $(this).addClass('ccm-search-select-hover');
+                });
+                concreteSearch.$element.on('mouseout', 'tr[data-entity-id]', function(e) {
+                    e.stopPropagation();
+                    $(this).removeClass('ccm-search-select-hover');
+                });
 
-                  concreteSearch.$element.unbind('click.expressEntries');
-                  concreteSearch.$element.on('click.expressEntries', 'tr[data-entity-id]', function(e) {
-                      e.stopPropagation();
-                      ConcreteEvent.publish('SelectExpressEntry', {
-                          exEntryID: $(this).attr('data-entity-id'),
-                          event: e
-                      });
-                      return false;
-                  });
-              }
+                concreteSearch.$element.unbind('click.expressEntries');
+                concreteSearch.$element.on('click.expressEntries', 'tr[data-entity-id]', function(e) {
+                    e.stopPropagation();
+                    ConcreteEvent.publish('SelectExpressEntry', {
+                        exEntryID: $(this).attr('data-entity-id'),
+                        event: e
+                    });
+                    return false;
+                });
+            }
 
-          });
-      });
+        });
+    });
 </script>


### PR DESCRIPTION
When selecting Express entries in page attributes, there was no way to filter them by search query. This PR adds the default search header to this selector. So now you can search through all entries to find the one you're looking for.