### PR TITLE
Capture the persisted entity for association, make it possible to save events

### DIFF
--- a/concrete/src/Calendar/Event/EventService.php
+++ b/concrete/src/Calendar/Event/EventService.php
@@ -89,7 +89,8 @@ class EventService
             $return->setIsApproved(false);
 
             // Persist the cloned version
-            $return = this->entityManager->persist($return);
+            $this->entityManager->persist($return);
+            $this->entityManager->flush();
 
             // Duplicate attribute Values
             $values = $this->eventCategory->getAttributeValues($recent);

--- a/concrete/src/Calendar/Event/EventService.php
+++ b/concrete/src/Calendar/Event/EventService.php
@@ -88,7 +88,8 @@ class EventService
             $return->setAuthor($u->getUserInfoObject()->getEntityObject());
             $return->setIsApproved(false);
 
-            $this->entityManager->persist($return);
+            // Persist the cloned version
+            $return = this->entityManager->persist($return);
 
             // Duplicate attribute Values
             $values = $this->eventCategory->getAttributeValues($recent);


### PR DESCRIPTION
This fixes an issue wherein an upgraded site would be unable to edit existing events. By capturing the persisted value and using that instead of the original entity we are giving the entity manager a chance to do its magic.
