### PR TITLE
dispatch a additional event when File Sets are deleted.

### DIFF
--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -468,6 +468,9 @@ class Set
 
     public function delete()
     {
+        $fe = new \Concrete\Core\File\Event\FileSet($this);
+        Events::dispatch('on_file_set_delete', $fe);
+
         $db = Database::connection();
         $db->delete('FileSets', array('fsID' => $this->fsID));
         $db->executeQuery('DELETE FROM FileSetSavedSearches WHERE fsID = ?', array($this->fsID));


### PR DESCRIPTION
Due to theyr flexible nature filesets can be a very helpful tool to use in packages.
We use it in our gallery package to define Image Albums for Example.

However, that can lead to orphaned references when Filesets are deleted over the c5 Dashboard. Having a event dispatched enables package developers to hook into it and take apropriate cleanup reactions within their package controller whenever a FileSet is deleted.