### PR TITLE
Feature/theme default page templates by pagetype

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2265,7 +2265,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 $themeTemplates = [];
             } else {
                 foreach($themeTemplates as $key => $template){
-                    $pt = ($this->getPageTypeHandle()) ? $this->getPageTypeHandle() : 'page';
+                    $pt = ($this->getPageTemplateHandle()) ? $this->getPageTemplateHandle() : 'default';
                     if(is_array($template) && $key == $pt){
                         $pageTypeTemplates = $template;
                     }

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2256,14 +2256,23 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $theme = $this->getCollectionThemeObject();
         if ($btHandle && $theme) {
             $areaTemplates = [];
+            $pageTypeTemplates = [];
             if (is_object($a)) {
                 $areaTemplates = $a->getAreaCustomTemplates();
             }
             $themeTemplates = $theme->getThemeDefaultBlockTemplates();
             if (!is_array($themeTemplates)) {
                 $themeTemplates = [];
+            } else {
+                foreach($themeTemplates as $key => $template){
+                    $pt = ($this->getPageTypeHandle()) ? $this->getPageTypeHandle() : 'page';
+                    if(is_array($template) && $key == $pt){
+                        $pageTypeTemplates = $template;
+                    }
+                    unset($themeTemplates[$key]);
+                }
             }
-            $templates = array_merge($themeTemplates, $areaTemplates);
+            $templates = array_merge($pageTypeTemplates, $themeTemplates, $areaTemplates);
             if (count($templates) && isset($templates[$btHandle])) {
                 $template = $templates[$btHandle];
                 $b->updateBlockInformation(['bFilename' => $template]);


### PR DESCRIPTION
The getThemeDefaultBlockTemplates() Method in the Page Theme Controller allows for Theme developers to define specific Block templates that should be used by default with their theme. 
However in many use cases this is not specific enough. We often would like to define a Default Block template per page type and end up defining it separatly for every Area instead, because there is no elegant way to do that on the Theme level.

With this PR this is now possible by returning something like this:
`
[ 
'full' => ['autonav'=>'breadcrumb.php'] ,
'left_sidebar' => ['autonav'=>'navbar.php']
]
`
istead of:
`
['autonav'=>'breadcrumb.php'] 
`
in the Page Theme getThemeDefaultBlockTemplates() Method