### PR TITLE
Inhibit concurrent execution of Update::updateToCurrentVersion()

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1579,4 +1579,10 @@ return [
         'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
         'core_thumbnails' => '\Concrete\Core\Http\Middleware\ThumbnailMiddleware',
     ],
+
+    // Registered mutex keys
+    'mutex' => [
+        'core_system_install',
+        'core_system_upgrade',
+    ],
 ];

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -114,6 +114,7 @@ return [
         'core_database' => '\Concrete\Core\Database\DatabaseServiceProvider',
         'core_form' => '\Concrete\Core\Form\FormServiceProvider',
         'core_session' => '\Concrete\Core\Session\SessionServiceProvider',
+        'core_system' => '\Concrete\Core\System\SystemServiceProvider',
         'core_cookie' => '\Concrete\Core\Cookie\CookieServiceProvider',
         'core_http' => '\Concrete\Core\Http\HttpServiceProvider',
         'core_events' => '\Concrete\Core\Events\EventsServiceProvider',

--- a/concrete/controllers/upgrade.php
+++ b/concrete/controllers/upgrade.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller;
 use Concrete\Core\Updater\Update;
 use View;
 use Concrete\Controller\Backend\UserInterface as BackendUserInterfaceController;
+use Concrete\Core\System\Mutex\MutexInterface;
 use Config;
 
 class Upgrade extends BackendUserInterfaceController
@@ -53,7 +54,9 @@ class Upgrade extends BackendUserInterfaceController
     {
         if ($this->validateAction()) {
             try {
-                Update::updateToCurrentVersion();
+                $this->app->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function() {
+                    Update::updateToCurrentVersion();
+                });
                 $this->set('success', t('Upgrade to <b>%s</b> complete!', APP_VERSION));
             } catch (\Exception $e) {
                 $this->set('error', $e);

--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -17,6 +17,7 @@ use Concrete\Core\Logging\Query\Logger;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Support\Facade\Package;
+use Concrete\Core\System\Mutex\MutexInterface;
 use Concrete\Core\Updater\Update;
 use Concrete\Core\Url\Url;
 use Concrete\Core\Url\UrlImmutable;
@@ -198,7 +199,9 @@ class Application extends Container
         $installed = $config->get('concrete.version_db_installed');
         $core = $config->get('concrete.version_db');
         if ($installed < $core) {
-            Update::updateToCurrentVersion();
+            $this->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function() {
+                Update::updateToCurrentVersion();
+            });
         }
     }
 

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -3,6 +3,8 @@
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\System\Mutex\MutexInterface;
 use Concrete\Core\Updater\Migrations\Configuration;
 use Concrete\Core\Updater\Update;
 use Doctrine\DBAL\Migrations\OutputWriter;
@@ -84,6 +86,9 @@ EOT
                 }
             }
         }
-        Update::updateToCurrentVersion($configuration);
+        $app = Application::getFacadeApplication();
+        $app->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function () use ($configuration) {
+            Update::updateToCurrentVersion($configuration);
+        });
     }
 }

--- a/concrete/src/System/Mutex/FileLockMutex.php
+++ b/concrete/src/System/Mutex/FileLockMutex.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+use Concrete\Core\Application\Application;
+
+class FileLockMutex implements MutexInterface
+{
+    /**
+     * @var string
+     */
+    protected $temporaryDirectory;
+
+    /**
+     * @var array
+     */
+    protected $resources = [];
+
+    public function __construct($temporaryDirectory)
+    {
+        $this->temporaryDirectory = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $temporaryDirectory), '/');
+    }
+
+    public function __destruct()
+    {
+        foreach (array_keys($this->resources) as $key) {
+            $this->release($key);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::isSupported()
+     */
+    public static function isSupported(Application $app)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::acquire()
+     */
+    public function acquire($key)
+    {
+        $success = false;
+        $key = (string) $key;
+        if (isset($this->resources[$key])) {
+            $fd = $this->resources[$key];
+            if (is_resource($fd)) {
+                throw new MutexBusyException($key);
+            }
+        }
+        $filename = $this->keyToFilename($key);
+        @touch($filename);
+        @chmod($filename, 0666);
+        $fd = @fopen($filename, 'r+');
+        if (!is_resource($fd) || @flock($fd, LOCK_EX | LOCK_NB) !== true) {
+            throw new MutexBusyException($key);
+        }
+        $this->resources[$key] = $fd;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::release()
+     */
+    public function release($key)
+    {
+        if (isset($this->resources[$key])) {
+            $fd = $this->resources[$key];
+            unset($this->resources[$key]);
+            @flock($fd, LOCK_UN);
+            @fclose($fd);
+            @unlink($this->keyToFilename($key));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::execute()
+     */
+    public function execute($key, callable $callback)
+    {
+        $this->acquire($key);
+        try {
+            $callback();
+        } finally {
+            $this->release($key);
+        }
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string
+     */
+    protected function keyToFilename($key)
+    {
+        return $this->temporaryDirectory . '/' . md5((string) $key) . '.lock';
+    }
+}

--- a/concrete/src/System/Mutex/FileLockMutex.php
+++ b/concrete/src/System/Mutex/FileLockMutex.php
@@ -117,6 +117,6 @@ class FileLockMutex implements MutexInterface
     {
         $keyIndex = $this->getMutexKeyIndex($key);
 
-        return $this->temporaryDirectory . '/mutex-' . $keyIndex . '.lock';
+        return $this->temporaryDirectory . '/mutex-' . md5(DIR_APPLICATION) . '-' . $keyIndex . '.lock';
     }
 }

--- a/concrete/src/System/Mutex/FileLockMutex.php
+++ b/concrete/src/System/Mutex/FileLockMutex.php
@@ -101,6 +101,6 @@ class FileLockMutex implements MutexInterface
      */
     protected function keyToFilename($key)
     {
-        return $this->temporaryDirectory . '/' . md5((string) $key) . '.lock';
+        return $this->temporaryDirectory . '/' . md5(DIR_BASE . (string) $key) . '.lock';
     }
 }

--- a/concrete/src/System/Mutex/InvalidMutexKeyException.php
+++ b/concrete/src/System/Mutex/InvalidMutexKeyException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when a mutex key is not defined in the app.mutex configuration key.
+ */
+class InvalidMutexKeyException extends RuntimeException
+{
+    /**
+     * The mutex key.
+     *
+     * @var string
+     */
+    protected $mutexKey;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param string $mutexKey The mutex key
+     */
+    public function __construct($mutexKey)
+    {
+        $this->mutexKey = (string) $mutexKey;
+        parent::__construct(t(/*i18n: A mutex is a system object that represents a system to run code; usually this word shouldn't be translated */'The mutex with key "%1$s" is not defined in the "%2$s" configuration key.', $this->mutexKey, 'app.mutex'));
+    }
+
+    /**
+     * Get the mutex key.
+     *
+     * @return string
+     */
+    public function getMutexKey()
+    {
+        return $this->mutexKey;
+    }
+}

--- a/concrete/src/System/Mutex/MutexBusyException.php
+++ b/concrete/src/System/Mutex/MutexBusyException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+use RuntimeException;
+
+class MutexBusyException extends RuntimeException
+{
+    /**
+     * The mutex key.
+     *
+     * @var string
+     */
+    protected $mutexKey;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param string $mutexKey The mutex key
+     */
+    public function __construct($mutexKey)
+    {
+        $this->mutexKey = (string) $mutexKey;
+        parent::__construct(t(/*i18n: A mutex is a system object that represents a system to run code; usually this word shouldn't be translated */'The mutex with key "%s" is busy.', $this->mutexKey));
+    }
+
+    /**
+     * Get the mutex key.
+     *
+     * @return string
+     */
+    public function getMutexKey()
+    {
+        return $this->mutexKey;
+    }
+}

--- a/concrete/src/System/Mutex/MutexInterface.php
+++ b/concrete/src/System/Mutex/MutexInterface.php
@@ -42,11 +42,12 @@ interface MutexInterface
 
     /**
      * Acquire a mutex given its key.
-     * If the mutex is already acquired (for example by another process), a MutexBusyException exception will be thrown.
+     * If the mutex is already acquired (for example by another process), a.
      *
      * @param string $key The identifier of the mutex you want to acquire
      *
-     * @throws MutexBusyException
+     * @throws InvalidMutexKeyException Throws an InvalidMutexKeyException exception if the mutex key is not listed in the app.mutex configuration key
+     * @throws MutexBusyException Throws a MutexBusyException exception if the mutex key is already acquired
      */
     public function acquire($key);
 
@@ -55,18 +56,18 @@ interface MutexInterface
      * If the mutex not already acquired nothing happens.
      * When the current PHP process ends, the mutex will be released automatically.
      *
-     * @param string $key The identifier of the mutex you want to acquire
+     * @param string $key The identifier of the mutex you want to release
      */
     public function release($key);
 
     /**
      * Execute a callable by acquiring and releasing a mutex, so that the callable won't be executed by multiple processes concurrently.
-     * If the mutex is already acquired (for example by another process), a MutexBusyException exception will be thrown.
      *
      * @param string $key The identifier of the mutex
      * @param callable $callback The callback function to be executed
      *
-     * @throws MutexBusyException
+     * @throws InvalidMutexKeyException Throws an InvalidMutexKeyException exception if the mutex key is not listed in the app.mutex configuration key
+     * @throws MutexBusyException Throws a MutexBusyException exception if the mutex key is already acquired
      */
     public function execute($key, callable $callback);
 }

--- a/concrete/src/System/Mutex/MutexInterface.php
+++ b/concrete/src/System/Mutex/MutexInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+use Concrete\Core\Application\Application;
+
+/**
+ * Represent a class that can offer a mutually-exclusive system that allows, for instance, to be sure to run some code just once even in concurrent situations.
+ *
+ * @example
+ * <pre>
+ * try {
+ *    $app->make(MutexInterface::class)->execute('my-mutex', function() {
+ *        // This code won't be executed by two
+ *    });
+ * } catch (MutexBusyException $x) {
+ *     // Another process is already using the 'my-mutex' key
+ * }
+ * </pre>
+ * @example
+ * <pre>
+ * $mutex = $app->make(MutexInterface::class);
+ * try {
+ *    $mutex->acquire('my-mutex');
+ *    // This code won't be executed by two
+ *    $mutex->release('my-mutex');
+ * } catch (MutexBusyException $x) {
+ *     // Another process is already using the 'my-mutex' key
+ * }
+ * </pre>
+ */
+interface MutexInterface
+{
+    /**
+     * Is this mutex available for the current system?
+     *
+     * @param Application $app
+     *
+     * @return bool
+     */
+    public static function isSupported(Application $app);
+
+    /**
+     * Acquire a mutex given its key.
+     * If the mutex is already acquired (for example by another process), a MutexBusyException exception will be thrown.
+     *
+     * @param string $key The identifier of the mutex you want to acquire
+     *
+     * @throws MutexBusyException
+     */
+    public function acquire($key);
+
+    /**
+     * Release a mutex given its key.
+     * If the mutex not already acquired nothing happens.
+     * When the current PHP process ends, the mutex will be released automatically.
+     *
+     * @param string $key The identifier of the mutex you want to acquire
+     */
+    public function release($key);
+
+    /**
+     * Execute a callable by acquiring and releasing a mutex, so that the callable won't be executed by multiple processes concurrently.
+     * If the mutex is already acquired (for example by another process), a MutexBusyException exception will be thrown.
+     *
+     * @param string $key The identifier of the mutex
+     * @param callable $callback The callback function to be executed
+     *
+     * @throws MutexBusyException
+     */
+    public function execute($key, callable $callback);
+}

--- a/concrete/src/System/Mutex/MutexTrait.php
+++ b/concrete/src/System/Mutex/MutexTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+trait MutexTrait
+{
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * Get the index of the mutex as defined in the app.mutex configuration key.
+     *
+     * @param string|mixed $key The mutex key to look for
+     *
+     * @throws InvalidMutexKeyException Throws an InvalidMutexKeyException if $key is not listed in the app.mutex configuration key.
+     *
+     * @return int
+     */
+    protected function getMutexKeyIndex($key)
+    {
+        $configuredMutex = $this->config->get('app.mutex');
+        if (is_array($configuredMutex)) {
+            $index = array_search((string) $key, $configuredMutex, true);
+        } else {
+            $index = false;
+        }
+        if (!is_int($index)) {
+            throw new InvalidMutexKeyException($key);
+        }
+
+        return $index;
+    }
+}

--- a/concrete/src/System/Mutex/SemaphoreMutex.php
+++ b/concrete/src/System/Mutex/SemaphoreMutex.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Concrete\Core\System\Mutex;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Foundation\Environment\FunctionInspector;
+
+class SemaphoreMutex implements MutexInterface
+{
+    /**
+     * @var array
+     */
+    protected $semaphores = [];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::isSupported()
+     */
+    public static function isSupported(Application $app)
+    {
+        $fi = $app->make(FunctionInspector::class);
+
+        return $fi->functionAvailable('sem_get') && $fi->functionAvailable('sem_acquire') && $fi->functionAvailable('sem_release');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::acquire()
+     */
+    public function acquire($key)
+    {
+        $key = (string) $key;
+        if (isset($this->semaphores[$key]) && is_resource($this->semaphores[$key])) {
+            $sem = $this->semaphores[$key];
+        } else {
+            $semKey = $this->keyToInt($key);
+            $sem = sem_get($semKey, 1);
+        }
+        if (@sem_acquire($sem, true) !== true) {
+            throw new MutexBusyException($key);
+        }
+        $this->semaphores[$key] = $sem;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::release()
+     */
+    public function release($key)
+    {
+        $key = (string) $key;
+        if (isset($this->semaphores[$key])) {
+            $sem = $this->semaphores[$key];
+            unset($this->semaphores[$key]);
+            if (is_resource($sem)) {
+                sem_release($sem);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\System\Mutex\MutexInterface::execute()
+     */
+    public function execute($key, callable $callback)
+    {
+        $this->acquire($key);
+        try {
+            $callback();
+        } finally {
+            $this->release($key);
+        }
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return int
+     */
+    protected function keyToInt($key)
+    {
+        // djb2
+        $key = (string) $key;
+        $hash = 5381;
+        $len = strlen($key);
+        for ($i = 0; $i < $len; ++$i) {
+            $hash = (($hash << 5) + $hash + ord($key[$i])) & 0x7FFFFFFF;
+        }
+
+        return $hash;
+    }
+}

--- a/concrete/src/System/Mutex/SemaphoreMutex.php
+++ b/concrete/src/System/Mutex/SemaphoreMutex.php
@@ -19,9 +19,13 @@ class SemaphoreMutex implements MutexInterface
      */
     public static function isSupported(Application $app)
     {
-        $fi = $app->make(FunctionInspector::class);
+        $result = false;
+        if (PHP_VERSION_ID >= 50601) { // we need the $nowait parameter of sem_acquire, available since PHP 5.6.1
+            $fi = $app->make(FunctionInspector::class);
+            $result = $fi->functionAvailable('sem_get') && $fi->functionAvailable('sem_acquire') && $fi->functionAvailable('sem_release');
+        }
 
-        return $fi->functionAvailable('sem_get') && $fi->functionAvailable('sem_acquire') && $fi->functionAvailable('sem_release');
+        return $result;
     }
 
     /**
@@ -84,7 +88,7 @@ class SemaphoreMutex implements MutexInterface
     protected function keyToInt($key)
     {
         // djb2
-        $key = (string) $key;
+        $key = DIR_BASE . (string) $key;
         $hash = 5381;
         $len = strlen($key);
         for ($i = 0; $i < $len; ++$i) {

--- a/concrete/src/System/SystemServiceProvider.php
+++ b/concrete/src/System/SystemServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Concrete\Core\System;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\File\Service\File as FileService;
+use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
+
+class SystemServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(Mutex\MutexInterface::class, function (Application $app) {
+            if (Mutex\SemaphoreMutex::isSupported($app)) {
+                $mutexClass = Mutex\SemaphoreMutex::class;
+            } else {
+                $mutexClass = Mutex\FileLockMutex::class;
+            }
+
+            return $app->make($mutexClass);
+        });
+        $this->app
+            ->when(Mutex\FileLockMutex::class)
+            ->needs('$temporaryDirectory')
+            ->give(function (Application $app) {
+                return $app->make(FileService::class)->getTemporaryDirectory();
+            })
+        ;
+    }
+}

--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -21,7 +21,7 @@ class Update
      *
      * @var string
      */
-    const MUTEX_KEY = 'ccm-mutex-update';
+    const MUTEX_KEY = 'core_system_upgrade';
 
     /**
      * Fetch from the remote marketplace the latest available versions of the core and the packages.

--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -17,6 +17,13 @@ use Throwable;
 class Update
 {
     /**
+     * Keyof the mutex to be used when performing core upgrades.
+     *
+     * @var string
+     */
+    const MUTEX_KEY = 'ccm-mutex-update';
+
+    /**
      * Fetch from the remote marketplace the latest available versions of the core and the packages.
      * These operations are done only the first time or after at least APP_VERSION_LATEST_THRESHOLD seconds since the previous check.
      *

--- a/tests/assets/System/acquire-mutex.php
+++ b/tests/assets/System/acquire-mutex.php
@@ -1,0 +1,28 @@
+<?php
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\System\Mutex\MutexBusyException;
+
+try {
+    $app = Application::getFacadeApplication();
+    $args = $_SERVER['argv'];
+    $mutexKey = array_pop($args);
+    $mutexClass = array_pop($args);
+    $mutex = $app->make($mutexClass);
+    try {
+        $mutex->acquire($mutexKey);
+        echo 'Mutex acquired';
+    } catch (MutexBusyException $x) {
+        echo 'Mutex busy';
+    }
+
+    return 0;
+} catch (Exception $x) {
+    echo $x->getMessage();
+
+    return 1;
+} catch (Throwable $x) {
+    echo $x->getMessage();
+
+    return 1;
+}

--- a/tests/tests/System/MutexTest.php
+++ b/tests/tests/System/MutexTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Tests\Update;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\Core\System\Mutex\FileLockMutex;
+use Concrete\Core\System\Mutex\MutexBusyException;
+use Concrete\Core\System\Mutex\SemaphoreMutex;
+use PHPUnit_Framework_TestCase;
+
+class MutexTest extends PHPUnit_Framework_TestCase
+{
+    public function mutexProvider()
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return [
+            [$app, SemaphoreMutex::class],
+            [$app, FileLockMutex::class],
+        ];
+    }
+
+    /**
+     * @dataProvider mutexProvider
+     *
+     * @param string $mutexClass
+     * @param Application $app
+     */
+    public function testMutex(Application $app, $mutexClass)
+    {
+        $isSupported = $mutexClass . '::isSupported';
+        if (call_user_func($isSupported, $app) !== true) {
+            $this->markTestSkipped($mutexClass . ' mutex is not supported');
+        }
+        $mutex = $app->make($mutexClass);
+        /* @var \Concrete\Core\System\Mutex\MutexInterface $mutex */
+        $key1 = 'ccm-test-system-1-' . mt_rand(0, PHP_INT_MAX);
+        $key2 = 'ccm-test-system-2-' . mt_rand(0, PHP_INT_MAX);
+
+        try {
+            // Let's check that
+            $executed = false;
+            $mutex->execute($key1, function () use (&$executed) { $executed = true; });
+            $this->assertTrue($executed);
+
+            $mutex->acquire($key1);
+            $mutex->acquire($key2);
+            $error = null;
+            try {
+                $mutex->acquire($key1);
+            } catch (MutexBusyException $x) {
+                $error = $x;
+            }
+            $this->assertInstanceOf(MutexBusyException::class, $error);
+
+            $error = null;
+            try {
+                $mutex->execute($key2, function () {});
+            } catch (MutexBusyException $x) {
+                $error = $x;
+            }
+            $this->assertInstanceOf(MutexBusyException::class, $error);
+
+            $mutex->release($key2);
+            foreach ([$key1 => 'Mutex busy', $key2 => 'Mutex acquired'] as $key => $result) {
+                $cmd = escapeshellarg(PHP_BINARY);
+                $cmd .= ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE_CORE . '/bin/concrete5'));
+                $cmd .= ' c5:exec';
+                $cmd .= ' --no-interaction --ansi';
+                $cmd .= ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_TESTS . '/assets/System/acquire-mutex.php'));
+                $cmd .= ' ' . escapeshellarg(get_class($mutex));
+                $cmd .= ' ' . escapeshellarg($key);
+                $cmd .= ' 2>&1';
+                $rc = -1;
+                $output = [];
+                @exec($cmd, $output, $rc);
+                if ($rc !== 0) {
+                    $this->markTestSkipped('Failed to launch PHP to check mutex (' . implode("\n", $output) . ')');
+                }
+                $this->assertSame($result, $output[0]);
+            }
+        } finally {
+            $mutex->release($key2);
+            $mutex->release($key1);
+        }
+    }
+}

--- a/tests/tests/System/MutexTest.php
+++ b/tests/tests/System/MutexTest.php
@@ -7,6 +7,7 @@ use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Concrete\Core\System\Mutex\FileLockMutex;
 use Concrete\Core\System\Mutex\MutexBusyException;
 use Concrete\Core\System\Mutex\SemaphoreMutex;
+use Concrete\Core\Updater\Update;
 use PHPUnit_Framework_TestCase;
 
 class MutexTest extends PHPUnit_Framework_TestCase
@@ -35,8 +36,8 @@ class MutexTest extends PHPUnit_Framework_TestCase
         }
         $mutex = $app->make($mutexClass);
         /* @var \Concrete\Core\System\Mutex\MutexInterface $mutex */
-        $key1 = 'ccm-test-system-1-' . mt_rand(0, PHP_INT_MAX);
-        $key2 = 'ccm-test-system-2-' . mt_rand(0, PHP_INT_MAX);
+        $key1 = 'core_system_install';
+        $key2 = Update::MUTEX_KEY;
 
         try {
             // Let's check that


### PR DESCRIPTION
On high-traffic sites, we may have that `Update::updateToCurrentVersion()` is executed simultaneously more that one time, leading to unexpected results.

What about protecting us from that by using mutex?

I added two mutex implementations here: one based on PHP Semaphores (it requires that PHP is compiled with the ` --enable-sysvsem` option), and another one based on file locks.

I also included a test case to check that these mutex works. I don't think that TravisCI supports Semaphores by default, but I tested with a PHP 7.0 compiled with ` --enable-sysvsem` and test passes.