### PR TITLE
Allow unsetting the "More Details Link"

### DIFF
--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -139,7 +139,7 @@ class Edit extends BackendInterfaceController
 
             $permissions = new \Permissions($calendar);
             if ($permissions->canEditCalendarEventMoreDetailsLocation()) {
-                if ($this->request->request->get('cID')) {
+                if ($this->request->request->get('cID') !== null) {
                     $cID = intval($this->request->request->get('cID'));
                     if ($cID) {
                         $eventPage = \Page::getByID($cID);
@@ -150,6 +150,9 @@ class Edit extends BackendInterfaceController
                                 $eventVersion->setPageObject($eventPage);
                             }
                         }
+                    } else {
+                        // Otherwise unset the page completely
+                        $eventVersion->setPageObject(0);
                     }
                 }
             }


### PR DESCRIPTION
The form passes a `0` if you unset the associated "More Details Link Destination" page. This would get lost in our controller, so I've updated the controller so that it handles it properly.