### PR TITLE
Get theme editor classes when using CKEditor in dashboard single pages and non-pages

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -5,6 +5,7 @@ use Concrete\Core\Site\Config\Liaison as Repository;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Theme\Theme as PageTheme;
 use Concrete\Core\Utility\Service\Identifier;
 use URL;
 use User;
@@ -84,8 +85,20 @@ EOL;
             if ($cp->canViewPage()) {
                 $pt = $c->getCollectionThemeObject();
                 if (is_object($pt)) {
-                    $obj->classes = $pt->getThemeEditorClasses();
+                    if ($pt->getThemeHandle()) {
+                        $obj->classes = $pt->getThemeEditorClasses();
+                    } else {
+                        $siteTheme = $pt::getSiteTheme();
+                        if (is_object($siteTheme)) {
+                            $obj->classes = $siteTheme->getThemeEditorClasses();
+                        }
+                    }
                 }
+            }
+        } else {
+            $siteTheme = PageTheme::getSiteTheme();
+            if (is_object($siteTheme)) {
+                $obj->classes = $siteTheme->getThemeEditorClasses();
             }
         }
 


### PR DESCRIPTION
When using CKEditor in dashboard single pages and non-pages, the Styles drop-down is blank. The `getEditorSnippetsAndClasses()` method expects CKEditor to be used on a non-dashboard page and to have a theme. 

This pull request gets the current site theme when a page has no theme or if CKEditor is used in an element or other non-page.

**Examples of blank CKEditor Styles drop-down:**
- The Add Event modal
    Dashboard > Calendars & Events > View Calendar > Add Event button
    concrete\elements\event\form.php
- Single pages using CKEditor 
    Paste the following code into accessibility.php
    concrete\single_pages\dashboard\system\basics\accessibility.php
    ```
    <div class="form-group">
        <label for="name" class="control-label">
            <?= t('Test'); ?>
        </label>
        <?= Core::make('editor')->outputStandardEditor('test', ''); ?>
    </div>
    ```

**I tested this pull request with:**
- Content block
- Content block in Composer
- Content block in a dashboard page stack and global area
    Dashboard > Stacks & Blocks > Stacks & Global Areas
- CKEditor in Add Event modal    
- CKEditor in a dashboard single page
- CKEditor in a block
