### PR TITLE
Do not automatically upgrade the core in maintenance mode

### DIFF
--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -270,7 +270,9 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
      */
     protected function handleUpdates()
     {
-        $this->app->handleAutomaticUpdates();
+        if (!$this->app->make('config')->get('concrete.maintenance_mode')) {
+            $this->app->handleAutomaticUpdates();
+        }
     }
 
     /**


### PR DESCRIPTION
To upgrade concrete5, we may want to do that via the CLI interface.
BTW, the core currently self-upgrades itself if needed when a web request is fulfilled.

Let's inhibit automatic upgrades via web when the website is in maintenance mode, so that site operators can upgrade it manually.

Ref. https://github.com/concrete5/concrete5/issues/6450#issuecomment-368321469