### PR TITLE
Avoid accessing an undefined variable in attribute/editable_list element

### DIFF
--- a/concrete/elements/attribute/editable_list.php
+++ b/concrete/elements/attribute/editable_list.php
@@ -10,7 +10,7 @@ foreach ($attributes as $ak) {
             'saveAction' => $saveAction,
             'clearAction' => $clearAction,
             'permissionsCallback' => $permissionsCallback,
-            'permissionsArguments' => $permissionsArguments,
+            'permissionsArguments' => isset($permissionsArguments) ? $permissionsArguments : null,
         )
     );
 }


### PR DESCRIPTION
Ref. #4723