### PR TITLE
Add c5:is-installed CLI command

### DIFF
--- a/concrete/src/Console/Application.php
+++ b/concrete/src/Console/Application.php
@@ -23,6 +23,7 @@ class Application extends SymfonyApplication
 
     public function setupDefaultCommands()
     {
+        $this->add(new Command\IsInstalledCommand());
         $this->add(new Command\InfoCommand());
         $this->add(new Command\InstallCommand());
         $this->add(new Command\InstallLanguageCommand());

--- a/concrete/src/Console/Command/IsInstalledCommand.php
+++ b/concrete/src/Console/Command/IsInstalledCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Concrete\Core\Console\Command;
+
+use Concrete\Core\Console\Command;
+use Concrete\Core\Support\Facade\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IsInstalledCommand extends Command
+{
+    const RETURN_CODE_ON_FAILURE = 2;
+
+    protected function configure()
+    {
+        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+
+        $this
+            ->setName('c5:is-installed')
+            ->setDescription('Check if concrete5 is already installed')
+            ->addEnvOption()
+            ->setHelp(<<<EOT
+This command will print out if concrete5 is already installed (unless the --quiet option is specified),
+and set the following return codes
+
+  0 concrete5 is installed
+  1 concrete5 is not installed
+  $errExitCode errors occurred
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+        $isInstalled = $app->isInstalled();
+        if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
+            $output->writeln($isInstalled ? 'concrete5 is installed' : 'concrete5 is not installed');
+        }
+
+        return $isInstalled ? 0 : 1;
+    }
+}


### PR DESCRIPTION
What about adding a new `c5:is-installed` command?
This would allow for instance fancy stuff file adding this to `composer.json`:

```json
{
    "scripts": {
        "pre-update-cmd": "concrete5 c5:is-installed && concrete5 c5:set -g concrete.maintenance_mode true",
        "post-update-cmd": "concrete5 c5:is-installed && concrete5 c5:update --no-interaction >/var/log/concrete5-upgrade.log 2>&1 && concrete5 c5:set -g concrete.maintenance_mode false",

    }
}
```
(PS: the above json is totally untested, but it seems quite interesting)