### PR TITLE
Avoid referencing cvPublishEndDate

### DIFF
--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -94,9 +94,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         }
         $v = array($cID);
 
-        $q = "select cvID, cvIsApproved, cvIsNew, cvHandle, cvName, cvDescription, cvDateCreated, cvDatePublic, " .
-             "pTemplateID, cvAuthorUID, cvApproverUID, cvComments, pThemeID, cvPublishDate, cvPublishEndDate from CollectionVersions " .
-             "where cID = ?";
+        $q = "select * from CollectionVersions where cID = ?";
 
         $now = new \DateTime();
 
@@ -353,15 +351,14 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             $this->pThemeID,
             $this->pTemplateID,
             null,
-            null,
         );
         // important: cvPublishDate used to be the same for the new version as it is for the current , but it made it
         // impossible to create a version that wasn't scheduled once you scheduled a version so I'm turning it off for
         // now - AE
 
        $q = "insert into CollectionVersions (cID, cvID, cvName, cvHandle, cvDescription, cvDatePublic, " .
-            "cvDateCreated, cvComments, cvAuthorUID, cvIsNew, pThemeID, pTemplateID, cvPublishDate, cvPublishEndDate) " .
-            "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            "cvDateCreated, cvComments, cvAuthorUID, cvIsNew, pThemeID, pTemplateID, cvPublishDate) " .
+            "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
        $db->executeQuery($q, $v);
 


### PR DESCRIPTION
That way we can update concrete5 from previous versions.

Without this chamge, I have the following error while updating the core:

```
Refreshing schema for Concrete\Core\Entity\Calendar\CalendarEventVersion...
Refreshing schema for Concrete\Core\Entity\Express\Entity...
Refreshing schema for Concrete\Core\Entity\Express\Form...
Refreshing schema for Concrete\Core\Entity\Package...
Updating database tables found in doctrine xml...
Creating single page at /dashboard/system/mail/addresses...
An exception occurred while executing 'select cvID, cvIsApproved, cvIsNew, cvHandle, cvName, cvDescription, cvDateCreated, cvDatePublic, pTemplateID, cvAuthorUID, cvApproverUID, cvComments, pThemeID, cvPublishDate, cvPublishEndDate from CollectionVersions where cID = ? order by cvID desc' with params ["1"]:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'cvPublishEndDate' in 'field list'
```