### PR TITLE
Avoid breaking the update process

### DIFF
--- a/concrete/controllers/backend/user_interface.php
+++ b/concrete/controllers/backend/user_interface.php
@@ -3,57 +3,94 @@
 namespace Concrete\Controller\Backend;
 
 use Concrete\Core\Controller\Controller;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\View\DialogView;
-use Loader;
+use Exception;
 use Request;
 
 abstract class UserInterface extends Controller
 {
+    /**
+     * The current errors container.
+     *
+     * @var \Concrete\Core\Error\ErrorList\ErrorList
+     */
     protected $error;
+
+    /**
+     * An identifier to be used when checking tokens.
+     *
+     * @var string|null
+     */
     protected $validationToken;
 
     public function __construct()
     {
-        $this->error = \Core::make('helper/validation/error');
+        $this->app = Application::getFacadeApplication();
+        $this->error = $this->app->make('error');
         $this->view = new DialogView($this->viewPath);
         if (preg_match('/Concrete\\\Package\\\(.*)\\\Controller/i', get_class($this), $matches)) {
             $pkgHandle = uncamelcase($matches[1]);
             $this->view->setPackageHandle($pkgHandle);
         }
         $this->view->setController($this);
-        $request = Request::getInstance();
-        $this->request = $request;
+        $this->request = Request::getInstance();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\AbstractController::shouldRunControllerTask()
+     */
     public function shouldRunControllerTask()
     {
         return $this->canAccess();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\Controller::getViewObject()
+     */
     public function getViewObject()
     {
         if ($this->canAccess()) {
             return parent::getViewObject();
         }
-        throw new \Exception(t('Access Denied'));
+        throw new Exception(t('Access Denied'));
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\Controller::action()
+     */
     public function action()
     {
-        $token = (isset($this->validationToken)) ? $this->validationToken : get_class($this);
-        $url = call_user_func_array('parent::action', func_get_args());
-        $url .= '?ccm_token=' . \Core::make('helper/validation/token')->generate($token);
+        $token = isset($this->validationToken) ? $this->validationToken : get_class($this);
+        $url = (string) call_user_func_array('parent::action', func_get_args());
+        $url .= (strpos($url, '?') === false ? '?' : '&') . $this->app->make('token')->getParameter($token);
 
         return $url;
     }
 
+    /**
+     * Can the current page be accessed?
+     *
+     * @return bool
+     */
     abstract protected function canAccess();
 
+    /**
+     * Check whether the token is valid and if the current page be accessed.
+     *
+     * @return bool
+     */
     protected function validateAction()
     {
         $token = (isset($this->validationToken)) ? $this->validationToken : get_class($this);
-        if (!Loader::helper('validation/token')->validate($token)) {
-            $this->error->add(\Core::make('helper/validation/token')->getErrorMessage());
+        if (!$this->app->make('token')->validate($token)) {
+            $this->error->add($this->app->make('token')->getErrorMessage());
 
             return false;
         }

--- a/concrete/controllers/backend/user_interface.php
+++ b/concrete/controllers/backend/user_interface.php
@@ -1,21 +1,16 @@
 <?php
+
 namespace Concrete\Controller\Backend;
 
 use Concrete\Core\Controller\Controller;
 use Concrete\Core\View\DialogView;
-use Request;
 use Loader;
+use Request;
 
 abstract class UserInterface extends Controller
 {
-    abstract protected function canAccess();
     protected $error;
     protected $validationToken;
-
-    public function shouldRunControllerTask()
-    {
-        return $this->canAccess();
-    }
 
     public function __construct()
     {
@@ -30,6 +25,11 @@ abstract class UserInterface extends Controller
         $this->request = $request;
     }
 
+    public function shouldRunControllerTask()
+    {
+        return $this->canAccess();
+    }
+
     public function getViewObject()
     {
         if ($this->canAccess()) {
@@ -37,6 +37,17 @@ abstract class UserInterface extends Controller
         }
         throw new \Exception(t('Access Denied'));
     }
+
+    public function action()
+    {
+        $token = (isset($this->validationToken)) ? $this->validationToken : get_class($this);
+        $url = call_user_func_array('parent::action', func_get_args());
+        $url .= '?ccm_token=' . \Core::make('helper/validation/token')->generate($token);
+
+        return $url;
+    }
+
+    abstract protected function canAccess();
 
     protected function validateAction()
     {
@@ -51,14 +62,5 @@ abstract class UserInterface extends Controller
         }
 
         return true;
-    }
-
-    public function action()
-    {
-        $token = (isset($this->validationToken)) ? $this->validationToken : get_class($this);
-        $url = call_user_func_array('parent::action', func_get_args());
-        $url .= '?ccm_token=' . \Core::make('helper/validation/token')->generate($token);
-
-        return $url;
     }
 }

--- a/concrete/controllers/upgrade.php
+++ b/concrete/controllers/upgrade.php
@@ -3,24 +3,36 @@
 namespace Concrete\Controller;
 
 use Concrete\Controller\Backend\UserInterface as BackendUserInterfaceController;
+use Concrete\Core\Cache\Cache;
+use Concrete\Core\Permission\Checker;
 use Concrete\Core\System\Mutex\MutexInterface;
 use Concrete\Core\Updater\Update;
-use Config;
+use Exception;
 use View;
 
 class Upgrade extends BackendUserInterfaceController
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Controller\Backend\UserInterface::canAccess()
+     */
     public function canAccess()
     {
-        if (!Config::get('concrete.updates.enable_permissions_protection')) {
+        if (!$this->app->make('config')->get('concrete.updates.enable_permissions_protection')) {
             return true; // we have turned this off temporarily which means anyone even non-logged-in users can run update.
         }
 
-        $p = new \Permissions();
+        $p = new Checker();
 
         return $p->canUpgrade();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\AbstractController::on_start()
+     */
     public function on_start()
     {
         parent::on_start();
@@ -28,24 +40,25 @@ class Upgrade extends BackendUserInterfaceController
         $this->view = new View('/frontend/upgrade');
         $this->setTheme('concrete');
 
-        $this->siteVersion = \Config::get('concrete.version_installed');
+        $this->siteVersion = $this->app->make('config')->get('concrete.version_installed');
         $this->checkSecurity();
-        \Cache::disableAll();
+        Cache::disableAll();
     }
 
     public function checkSecurity()
     {
-        $fh = \Loader::helper('file');
+        $fh = $this->app->make('helper/file');
         $updates = $fh->getDirectoryContents(DIR_CORE_UPDATES);
         foreach ($updates as $upd) {
-            if (is_dir(DIR_CORE_UPDATES . '/' . $upd) && is_writable(DIR_CORE_UPDATES . '/' . $upd)) {
-                if (file_exists(DIR_CORE_UPDATES . '/' . $upd . '/' . DISPATCHER_FILENAME) && is_writable(
-                        DIR_CORE_UPDATES . '/' . $upd . '/' . DISPATCHER_FILENAME)
-                ) {
-                    unlink(DIR_CORE_UPDATES . '/' . $upd . '/' . DISPATCHER_FILENAME);
+            $updFullPath = DIR_CORE_UPDATES . '/' . $upd;
+            if (is_dir($updFullPath) && is_writable($updFullPath)) {
+                $dispatcher = $updFullPath . '/' . DISPATCHER_FILENAME;
+                if (file_exists($dispatcher) && is_writable($dispatcher)) {
+                    unlink($dispatcher);
                 }
-                if (!file_exists(DIR_CORE_UPDATES . '/' . $upd . '/index.html')) {
-                    touch(DIR_CORE_UPDATES . '/' . $upd . '/index.html');
+                $index = $updFullPath . '/index.html';
+                if (!file_exists($index)) {
+                    touch($index);
                 }
             }
         }
@@ -59,7 +72,7 @@ class Upgrade extends BackendUserInterfaceController
                     Update::updateToCurrentVersion();
                 });
                 $this->set('success', t('Upgrade to <b>%s</b> complete!', APP_VERSION));
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->set('error', $e);
             }
         }
@@ -77,13 +90,10 @@ class Upgrade extends BackendUserInterfaceController
             if (version_compare($sav, APP_VERSION, '>')) {
                 $message = t('Upgrading from <b>%s</b>', $sav) . '<br/>';
                 $message .= t('Upgrading to <b>%s</b>', APP_VERSION) . '<br/><br/>';
-                $message .= t(
-                    'Your current website uses a version of concrete5 greater than this one. You cannot upgrade.');
+                $message .= t('Your current website uses a version of concrete5 greater than this one. You cannot upgrade.');
             } else {
                 if (version_compare($sav, APP_VERSION, '=')) {
-                    $message = t(
-                        'Your site is already up to date! The current version of concrete5 is <b>%s</b>.',
-                        APP_VERSION);
+                    $message = t('Your site is already up to date! The current version of concrete5 is <b>%s</b>.', APP_VERSION);
                 } else {
                     $message = '';
                     $message .= t('Upgrading from <b>%s</b>', $sav) . '<br/>';

--- a/concrete/controllers/upgrade.php
+++ b/concrete/controllers/upgrade.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace Concrete\Controller;
 
-use Concrete\Core\Updater\Update;
-use View;
 use Concrete\Controller\Backend\UserInterface as BackendUserInterfaceController;
 use Concrete\Core\System\Mutex\MutexInterface;
+use Concrete\Core\Updater\Update;
 use Config;
+use View;
 
 class Upgrade extends BackendUserInterfaceController
 {
@@ -54,7 +55,7 @@ class Upgrade extends BackendUserInterfaceController
     {
         if ($this->validateAction()) {
             try {
-                $this->app->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function() {
+                $this->app->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function () {
                     Update::updateToCurrentVersion();
                 });
                 $this->set('success', t('Upgrade to <b>%s</b> complete!', APP_VERSION));

--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Application;
 
 use Concrete\Core\Cache\CacheClearer;
@@ -193,13 +194,19 @@ class Application extends Container
         return false;
     }
 
+    /**
+     * Check if the core needs to be updated, and if so, updates it.
+     *
+     * @throws \Concrete\Core\System\Mutex\MutexBusyException throws a MutexBusyException exception if there upgrade process is already running
+     * @throws \Concrete\Core\Updater\Migrations\MigrationIncompleteException throws a MigrationIncompleteException exception if there's still some migration pending
+     */
     public function handleAutomaticUpdates()
     {
         $config = $this['config'];
         $installed = $config->get('concrete.version_db_installed');
         $core = $config->get('concrete.version_db');
         if ($installed < $core) {
-            $this->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function() {
+            $this->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function () {
                 Update::updateToCurrentVersion();
             });
         }
@@ -415,7 +422,7 @@ class Application extends Container
      *
      * @return mixed
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function build($concrete, array $parameters = [])
     {

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -6,12 +6,14 @@ use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\Response;
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Http\ServerInterface;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Routing\RouterInterface;
 use Concrete\Core\Site\Service as SiteService;
 use Concrete\Core\System\Mutex\MutexBusyException;
+use Concrete\Core\Updater\Migrations\MigrationIncompleteException;
 use Concrete\Core\Updater\Update;
 use Concrete\Core\Url\Resolver\CanonicalUrlResolver;
 use Concrete\Core\Url\Resolver\UrlResolverInterface;
@@ -281,6 +283,12 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
                     throw $x;
                 }
                 $config->set('concrete.maintenance_mode', true);
+            }
+            catch (MigrationIncompleteException $x) {
+                $request = Request::getInstance();
+                $requestUri = $request->getUri();
+                $rf = $this->app->make(ResponseFactoryInterface::class);
+                return $rf->redirect($requestUri, Response::HTTP_FOUND);
             }
         }
     }

--- a/concrete/src/Updater/Migrations/LongRunningMigrationInterface.php
+++ b/concrete/src/Updater/Migrations/LongRunningMigrationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations;
+
+/**
+ * Interface that migrations that take long time to be executed should implement.
+ */
+interface LongRunningMigrationInterface
+{
+}

--- a/concrete/src/Updater/Migrations/MigrationIncompleteException.php
+++ b/concrete/src/Updater/Migrations/MigrationIncompleteException.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when the migration.
+ */
+class MigrationIncompleteException extends RuntimeException
+{
+    /**
+     * The number of applied migrations.
+     *
+     * @var int
+     */
+    protected $performedMigrations;
+    /**
+     * The number of remaining migrations.
+     *
+     * @var int
+     */
+    protected $remainingMigrations;
+
+    /**
+     * @param int $performedMigrations the number of applied migrations
+     * @param int $remainingMigrations the number of remaining migrations
+     */
+    public function __construct($performedMigrations, $remainingMigrations)
+    {
+        $this->performedMigrations = (int) $performedMigrations;
+        $this->remainingMigrations = (int) $remainingMigrations;
+        parent::__construct(t(/*i18n: %1$s and %2$s are numbers */'The upgrade process is incomplete (migrations performed: %1$s, migrations remaining: %2$s). Please execute the upgrade process again.'), $this->performedMigrations, $this->remainingMigrations);
+    }
+
+    /**
+     * Get the number of applied migrations.
+     *
+     * @return int
+     */
+    public function getPerformedMigrations()
+    {
+        return $this->performedMigrations;
+    }
+
+    /**
+     * Get the number of remaining migrations.
+     *
+     * @return int
+     */
+    public function getRemainingMigrations()
+    {
+        return $this->remainingMigrations;
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
@@ -9,11 +9,12 @@ use Concrete\Core\Permission\Category;
 use Concrete\Core\Permission\Duration;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 use Concrete\Core\User\Group\Group;
 use Doctrine\DBAL\Schema\Schema;
 
-class Version20150504000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20150504000000 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
 {
     private $updateSectionPlurals = false;
     private $updateMultilingualTranslations = false;

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -25,9 +25,10 @@ use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete\Core\Tree\TreeType;
 use Concrete\Core\Tree\Type\ExpressEntryResults;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\Routine\AddPageDraftsBooleanTrait;
 
-class Version20160725000000 extends AbstractMigration
+class Version20160725000000 extends AbstractMigration implements LongRunningMigrationInterface
 {
     use AddPageDraftsBooleanTrait;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
@@ -5,6 +5,7 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Express\EntryList;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
@@ -17,7 +18,7 @@ use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
  * After refreshing all columns we go though all entities and re-fill the search indexes so that any values that are
  * longer than 255 chars will now be indexed properly.
  */
-class Version20170316000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20170316000000 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
@@ -3,9 +3,10 @@
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20170412000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20170412000000 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
 {
     /**
      * {@inheritdoc}

--- a/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
@@ -19,9 +19,10 @@ use Concrete\Core\Entity\Calendar\CalendarRelatedEvent;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20171110032423 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20171110032423 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
The automatic upgrade process via web interface suffers the following problems:

1. if a visitor quits the browser while the upgrade is in progress, the PHP execution could halt.
2. the update process may require long time, because of many migrations need to be executed or because a migration requires long time to be executed, and the PHP execution may reach its maximum time limit.

To solve 1.  we can call [`ignore_user_abort`](http://php.net/manual/en/function.ignore-user-abort.php).

To solve 2:
- Let's try to increase the PHP execution time limit with `set_time_limit`
- If `set_time_limit` fails (or can't be executed), let's ask the client to reload the requested page when:
  - we executed 10 migrations
  - or we executed some migrations and the next migration to be executed will require long time
  - or we executed a migration that required long time
