### PR TITLE
Simpler mutex configuration

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1582,7 +1582,7 @@ return [
 
     // Registered mutex keys
     'mutex' => [
-        'core_system_install',
-        'core_system_upgrade',
+        'core_system_install' => true,
+        'core_system_upgrade' => true,
     ],
 ];

--- a/concrete/src/System/Mutex/MutexTrait.php
+++ b/concrete/src/System/Mutex/MutexTrait.php
@@ -22,7 +22,7 @@ trait MutexTrait
     {
         $configuredMutex = $this->config->get('app.mutex');
         if (is_array($configuredMutex)) {
-            $index = array_search((string) $key, $configuredMutex, true);
+            $index = array_search((string) $key, array_keys($configuredMutex), true);
         } else {
             $index = false;
         }

--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -17,7 +17,7 @@ use Throwable;
 class Update
 {
     /**
-     * Keyof the mutex to be used when performing core upgrades.
+     * Key of the mutex to be used when performing core upgrades.
      *
      * @var string
      */


### PR DESCRIPTION
Having the list of registered mutex keys stored as a plain array makes 3rd party packages hard to use it.
Indeed, to add a new mutex key, we should (a) copy the entire `app.mutes` array the application config, or add a specific numeric key to the application config.

Switching to a key-value approach allows simply adding new keys to the mutex array.