### PR TITLE
Consider text/plain images as SVG images

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1325,6 +1325,7 @@ class Version implements ObjectInterface
             switch ($mimetype) {
                 case 'image/svg+xml':
                 case 'image/svg-xml':
+                case 'text/plain':
                     if ($imageLibrary instanceof \Imagine\Gd\Imagine) {
                         try {
                             $imageLibrary = $app->make('image/imagick');


### PR DESCRIPTION
When loading an image, we check if it is an SVG and, if so, we'll try to use Imagick instead of GD to load it (because GD can't load SVG images).
BTW, I've seen that the system may detect that SVG images have a `text/plain` content type. Let's consider this case.