### PR TITLE
Don't show system-wide PHPUnit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_script:
     fi
   - travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST # Run once to install magento's composer merger
   - travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST # Run twice to install merged dependencies
-  - phpunit --version
 
 script:
   # Run PHPUnit if we're not checking code style, otherwise run phpcs


### PR DESCRIPTION
We install and use PHPUnit via composer: it's useless ([and may lead to problems](https://travis-ci.org/concrete5/concrete5/jobs/349332932#L332)) showing the version of the preinstalled PHPUnit