### PR TITLE
youtube block start time options

### DIFF
--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -37,6 +37,7 @@ class Controller extends BlockController
     {
         $url = parse_url($this->videoURL);
         $pathParts = explode('/', rtrim($url['path'], '/'));
+        parse_str($url['query'], $params);
         $videoID = end($pathParts);
         $playListID = '';
 
@@ -55,8 +56,39 @@ class Controller extends BlockController
             $this->set('playlist', $videoID);
         }
 
+        if ($this->startTimeEnabled && !empty($this->startTime)) {
+            $this->set('startTime', $this->convertStringToSeconds($this->startTime));
+        }
+        elseif ($params['t']) {
+            $this->set('startTime', $this->convertStringToSeconds($params['t']));
+        }
+
         $this->set('videoID', $videoID);
         $this->set('playListID', $playListID);
+    }
+
+    public function convertStringToSeconds($string)
+    {
+        if (preg_match_all('/(\d+)(h|m|s)/i', $string, $matches)) {
+            $h = (($key = array_search('h', $matches[2])) !== false) ? (int)$matches[1][$key] : 0;
+            $m = (($key = array_search('m', $matches[2])) !== false) ? (int)$matches[1][$key] : 0;
+            $s = (($key = array_search('s', $matches[2])) !== false) ? (int)$matches[1][$key] : 0;
+            $seconds = ($h * 3600) + ($m * 60) + $s;
+        }
+        else {
+            $pieces = array_reverse(explode(':', $string));
+            $seconds = 0;
+            $multipliers = [1, 60, 3600];
+            foreach ($multipliers as $key => $multiplier) {
+                if (array_key_exists($key, $pieces)) {
+                    $seconds += (int)$pieces[$key] * $multiplier;
+                }
+            }
+        }
+        if ($seconds > 0) {
+            return $seconds;
+        }
+        return false;
     }
 
     public function save($data)
@@ -65,11 +97,14 @@ class Controller extends BlockController
         $args['videoURL'] = isset($data['videoURL']) ? trim($data['videoURL']) : '';
         $args['vHeight'] = isset($data['vHeight']) ? trim($data['vHeight']) : '';
         $args['vWidth'] = isset($data['vWidth']) ? trim($data['vWidth']) : '';
+        $args['startTime'] = isset($data['startTime']) ? trim($data['startTime']) : '';
 
         $args['rel'] = $data['rel'] ? 1 : 0;
         $args['showinfo'] = $data['showinfo'] ? 1 : 0;
         $args['autoplay'] = $data['autoplay'] ? 1 : 0;
         $args['loopEnd'] = $data['loopEnd'] ? 1 : 0;
+        $args['startTimeEnabled'] = $data['startTimeEnabled'] ? 1 : 0;
+
         $args['modestbranding'] = $data['modestbranding'] ? 1 : 0;
         $args['iv_load_policy'] = $data['iv_load_policy'] ? 3 : 1;
         $args['color'] = $data['color'];

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -49,6 +49,7 @@ class Controller extends BlockController
                 $videoID = '';
             } else {
                 $videoID = (isset($query['v'])) ? $query['v'] : $videoID;
+                $videoID = strtok($videoID, '?');
             }
         }
 
@@ -56,11 +57,11 @@ class Controller extends BlockController
             $this->set('playlist', $videoID);
         }
 
-        if ($this->startTimeEnabled && !empty($this->startTime)) {
-            $this->set('startTime', $this->convertStringToSeconds($this->startTime));
+        if ($this->startTimeEnabled == 1 && ($this->startTime === '0' || $this->startTime)) {
+            $this->set('startSeconds', $this->convertStringToSeconds($this->startTime));
         }
         elseif ($params['t']) {
-            $this->set('startTime', $this->convertStringToSeconds($params['t']));
+            $this->set('startSeconds', $this->convertStringToSeconds($params['t']));
         }
 
         $this->set('videoID', $videoID);
@@ -85,7 +86,7 @@ class Controller extends BlockController
                 }
             }
         }
-        if ($seconds > 0) {
+        if ($seconds === 0 || $seconds > 0) {
             return $seconds;
         }
         return false;

--- a/concrete/blocks/youtube/db.xml
+++ b/concrete/blocks/youtube/db.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema
-  xmlns="http://www.concrete5.org/doctrine-xml/0.5"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+        xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
 
   <table name="btYouTube">
     <field name="bID" type="integer">
@@ -13,6 +13,8 @@
     <field name="vHeight" type="string" size="255"/>
     <field name="vWidth" type="string" size="255"/>
     <field name="sizing" type="string" size="10"/>
+    <field name="startTimeEnabled" type="boolean" />
+    <field name="startTime" type="string" size="10" />
     <field name="autoplay" type="boolean">
       <default value="0"/>
       <notnull/>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -69,10 +69,10 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             <div class="col-xs-6">
                 <div class="form-group">
                     <div class="checkbox">
-                    <label>
-                        <?php echo $form->checkbox('showinfo', 1, (isset($showinfo) ? $showinfo : true)); ?>
-                        <?php echo t("Show video information")?>
-                    </label>
+                        <label>
+                            <?php echo $form->checkbox('showinfo', 1, (isset($showinfo) ? $showinfo : true)); ?>
+                            <?php echo t("Show video information")?>
+                        </label>
                     </div>
                     <div class="checkbox">
                         <label>
@@ -128,6 +128,15 @@ echo Core::make('helper/concrete/ui')->tabs(array(
                     <?php echo $form->checkbox('loopEnd', 1, $loopEnd); ?>
                     <?php echo t("Loop video") ?>
                 </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <?php echo $form->checkbox('startTimeEnabled', 1, $startTimeEnabled); ?>
+                    <?php echo t("Start video at:") ?>
+                </label>
+            </div>
+            <div class="form-group">
+                <?php echo $form->text('startTime', $startTime);?>
             </div>
 
         </div>

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -64,26 +64,30 @@ if (isset($showinfo) && $showinfo) {
     $params[] = 'showinfo=0';
 }
 
+if (!empty($startTime)) {
+    $params[] = 'start=' . $startTime;
+}
+
 $paramstring = '?' . implode('&', $params);
 
 if (Page::getCurrentPage()->isEditMode()) {
     $loc = Localization::getInstance();
     $loc->pushActiveContext(Localization::CONTEXT_UI);
     ?>
-	<div class="ccm-edit-mode-disabled-item youtubeBlock <?php echo $responsiveClass; ?>" <?php echo $sizeDisabled; ?>>
-		<div><?= t('YouTube Video disabled in edit mode.'); ?></div>
-	</div>
+    <div class="ccm-edit-mode-disabled-item youtubeBlock <?php echo $responsiveClass; ?>" <?php echo $sizeDisabled; ?>>
+        <div><?= t('YouTube Video disabled in edit mode.'); ?></div>
+    </div>
     <?php
     $loc->popActiveContext();
 } else {
     ?>
-	<div id="youtube<?= $bID;
+    <div id="youtube<?= $bID;
     ?>" class="youtubeBlock <?php echo $responsiveClass;
     ?>">
-		<iframe class="youtube-player" <?php echo $sizeargs;
-    ?> src="//www.youtube.com/embed/<?= $videoID;
-    ?><?= $paramstring;
-    ?>" frameborder="0" allowfullscreen></iframe>
-	</div>
-<?php
+        <iframe class="youtube-player" <?php echo $sizeargs;
+        ?> src="//www.youtube.com/embed/<?= $videoID;
+        ?><?= $paramstring;
+        ?>" frameborder="0" allowfullscreen></iframe>
+    </div>
+    <?php
 } ?>

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -64,8 +64,8 @@ if (isset($showinfo) && $showinfo) {
     $params[] = 'showinfo=0';
 }
 
-if (!empty($startTime)) {
-    $params[] = 'start=' . $startTime;
+if (!empty($startSeconds)) {
+    $params[] = 'start=' . $startSeconds;
 }
 
 $paramstring = '?' . implode('&', $params);


### PR DESCRIPTION
Thought I'd try to help out while posting an issue of my own :) My IDE has made a few tabbing changes, hope that's ok.

YouTube block changes for https://github.com/concrete5/concrete5/issues/6452

The block will respect the t parameter in the url.

I've also added a way of doing this through the block settings, which will take priority over what's in the url. Works with formats `1:20:30` (`h:m:s`) and `1h20m30s` (or just `20m30s`, or `30s`)

![image](https://user-images.githubusercontent.com/30590452/37060852-7295d1e6-2189-11e8-8e9e-7f38dac36ea5.png)