### PR TITLE
Show different message when public profile option isn't changed

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -33,8 +33,7 @@ class Profiles extends DashboardSitePageController
 
             if (!$isProfileOptionChanged) {
                 $this->flash('success', t('Public profiles settings have been updated.'));
-                $this->view();
-                return;
+                $this->redirect('/dashboard/system/registration/profiles');
             }
 
             // $message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));

--- a/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -22,7 +22,7 @@ class Profiles extends DashboardSitePageController
         if ($this->isPost()) {
             $config = $this->getSite()->getConfigRepository();
 
-            $isProfileOptionChanged = $config->get('user.profiles_enabled') === $this->post('public_profiles') ? true : false;
+            $isProfileOptionChanged = (bool) $config->get('user.profiles_enabled') !== (bool) $this->post('public_profiles');
 
             $config->save('user.profiles_enabled', ($this->post('public_profiles') ? true : false));
             $config->save('user.gravatar.enabled', ($this->post('gravatar_fallback') ? true : false));
@@ -30,9 +30,10 @@ class Profiles extends DashboardSitePageController
             $config->save('user.gravatar.image_set', $this->app->make('helper/security')->sanitizeString($this->post('gravatar_image_set')));
             $config->save('user.display_account_menu', (bool) $this->post('display_account_menu', false));
 
-            if (!$isProfileOptionChanged) {
-                $this->redirect('/dashboard/system/registration/profiles/profiles_updated');
 
+            if (!$isProfileOptionChanged) {
+                $this->flash('success', t('Public profiles settings have been updated.'));
+                $this->view();
                 return;
             }
 
@@ -54,12 +55,6 @@ class Profiles extends DashboardSitePageController
                 $this->redirect('/dashboard/system/registration/profiles/profiles_disabled');
             }
         }
-    }
-
-    public function profiles_updated()
-    {
-        $this->set('message', t('Public profiles settings have been updated.'));
-        $this->view();
     }
 
     public function profiles_enabled()

--- a/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -3,7 +3,6 @@ namespace Concrete\Controller\SinglePage\Dashboard\System\Registration;
 
 use Concrete\Core\Page\Controller\DashboardSitePageController;
 use Concrete\Core\Page\Single;
-use Loader;
 
 class Profiles extends DashboardSitePageController
 {
@@ -27,8 +26,8 @@ class Profiles extends DashboardSitePageController
 
             $config->save('user.profiles_enabled', ($this->post('public_profiles') ? true : false));
             $config->save('user.gravatar.enabled', ($this->post('gravatar_fallback') ? true : false));
-            $config->save('user.gravatar.max_level', Loader::helper('security')->sanitizeString($this->post('gravatar_max_level')));
-            $config->save('user.gravatar.image_set', Loader::helper('security')->sanitizeString($this->post('gravatar_image_set')));
+            $config->save('user.gravatar.max_level', $this->app->make('helper/security')->sanitizeString($this->post('gravatar_max_level')));
+            $config->save('user.gravatar.image_set', $this->app->make('helper/security')->sanitizeString($this->post('gravatar_image_set')));
             $config->save('user.display_account_menu', (bool) $this->post('display_account_menu', false));
 
             if (!$isProfileOptionChanged) {
@@ -80,7 +79,6 @@ class Profiles extends DashboardSitePageController
         if ($message) {
             $this->set('message', $message);
         }
-        $this->token = Loader::helper('validation/token');
 
         $config = $this->getSite()->getConfigRepository();
 

--- a/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -27,12 +27,18 @@ class Profiles extends DashboardSitePageController
 
             $config = $this->getSite()->getConfigRepository();
 
+            $isProfileOptionChanged = $config->get('user.profiles_enabled') === $this->post('public_profiles') ? true : false;
+
             $config->save('user.profiles_enabled', ($this->post('public_profiles') ? true : false));
             $config->save('user.gravatar.enabled', ($this->post('gravatar_fallback') ? true : false));
             $config->save('user.gravatar.max_level', Loader::helper('security')->sanitizeString($this->post('gravatar_max_level')));
             $config->save('user.gravatar.image_set', Loader::helper('security')->sanitizeString($this->post('gravatar_image_set')));
             $config->save('user.display_account_menu', (bool) $this->post('display_account_menu', false));
 
+            if (!$isProfileOptionChanged) {
+                $this->redirect('/dashboard/system/registration/profiles/profiles_updated');
+                return;
+            }
 
             // $message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));
             if ($this->post('public_profiles')) {
@@ -54,6 +60,12 @@ class Profiles extends DashboardSitePageController
                 $this->redirect('/dashboard/system/registration/profiles/profiles_disabled');
             }
         }
+    }
+
+    public function profiles_updated()
+    {
+        $this->set('message', t('Public profiles settings have been updated.'));
+        $this->view();
     }
 
     public function profiles_enabled()

--- a/concrete/controllers/single_page/dashboard/system/registration/profiles.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/profiles.php
@@ -1,19 +1,16 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Registration;
 
-use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
 use Concrete\Core\Page\Single;
-use Config;
 use Loader;
 
 class Profiles extends DashboardSitePageController
 {
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     public function update_profiles()
     {
-
         /** @var Token $token */
         $token = \Core::make('token');
 
@@ -24,7 +21,6 @@ class Profiles extends DashboardSitePageController
         }
 
         if ($this->isPost()) {
-
             $config = $this->getSite()->getConfigRepository();
 
             $isProfileOptionChanged = $config->get('user.profiles_enabled') === $this->post('public_profiles') ? true : false;
@@ -37,12 +33,12 @@ class Profiles extends DashboardSitePageController
 
             if (!$isProfileOptionChanged) {
                 $this->redirect('/dashboard/system/registration/profiles/profiles_updated');
+
                 return;
             }
 
             // $message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));
             if ($this->post('public_profiles')) {
-
                 Single::add('/members');
                 $c = Single::add('/members/profile');
                 Single::add('/members/directory');
@@ -50,9 +46,8 @@ class Profiles extends DashboardSitePageController
 
                 $this->redirect('/dashboard/system/registration/profiles/profiles_enabled');
             } else {
-
-                foreach($this->app->make('site')->getList() as $site) {
-                    foreach(['/members/directory', '/members/profile', '/members'] as $path) {
+                foreach ($this->app->make('site')->getList() as $site) {
+                    foreach (['/members/directory', '/members/profile', '/members'] as $path) {
                         $c = \Page::getByPath($path, 'RECENT', $site);
                         $c->delete();
                     }
@@ -92,9 +87,9 @@ class Profiles extends DashboardSitePageController
         $this->set('public_profiles', $config->get('user.profiles_enabled'));
         $this->set('gravatar_fallback', $config->get('user.gravatar.enabled'));
         $this->set('gravatar_max_level', $config->get('user.gravatar.max_level'));
-        $this->set('gravatar_level_options', array('g' => 'G', 'pg' => 'PG', 'r' => 'R', 'x' => 'X'));
+        $this->set('gravatar_level_options', ['g' => 'G', 'pg' => 'PG', 'r' => 'R', 'x' => 'X']);
         $this->set('gravatar_image_set', $config->get('user.gravatar.image_set'));
-        $this->set('gravatar_set_options', array('404' => '404', 'mm' => 'mm', 'identicon' => 'identicon', 'monsterid' => 'monsterid', 'wavatar' => "wavatar"));
+        $this->set('gravatar_set_options', ['404' => '404', 'mm' => 'mm', 'identicon' => 'identicon', 'monsterid' => 'monsterid', 'wavatar' => "wavatar"]);
         $this->set('display_account_menu', $config->get('user.display_account_menu'));
     }
 }


### PR DESCRIPTION
When I change gravatar settings from `dashboard/system/registration/profiles` it shows `Public profiles have been enabled/disalbed` which is confusing.
Let's show `Public profiles settings have been updated.` when public profile option isn't changed.