### PR TITLE
Fix Class "Query" does not exist

### DIFF
--- a/concrete/src/Entity/Search/SavedSearch.php
+++ b/concrete/src/Entity/Search/SavedSearch.php
@@ -10,7 +10,7 @@ abstract class SavedSearch
 {
 
 
-    /** @ORM\Embedded(class = "Query") */
+    /** @ORM\Embedded(class = "\Concrete\Core\Entity\Search\Query") */
     protected $query = null;
 
     /**


### PR DESCRIPTION
Fix "Class PackageClass\Property\Search\Query does not exist" does not exist from custom SavedSearch