### PR TITLE
Fix unsetting the selected page for an event version

### DIFF
--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -152,7 +152,7 @@ class Edit extends BackendInterfaceController
                         }
                     } else {
                         // Otherwise unset the page completely
-                        $eventVersion->setPageObject(0);
+                        $eventVersion->setPageID(0);
                     }
                 }
             }


### PR DESCRIPTION
We were calling `$version->setPageObject(0)` when this method only accepts instances of `Page`. Instead let's call `$version->setPageID(0)` to unset.
