### PR TITLE
Fix cPath index not defined on PagePath entity

### DIFF
--- a/concrete/src/Entity/Page/PagePath.php
+++ b/concrete/src/Entity/Page/PagePath.php
@@ -10,7 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
  *     name="PagePaths",
  *     indexes={
  *     @ORM\Index(name="ppIsCanonical", columns={"ppIsCanonical"}),
- *     @ORM\Index(name="cID", columns={"cID"})
+ *     @ORM\Index(name="cID", columns={"cID"}),
+ *     @ORM\Index(name="cPath", columns={"cPath"})
  *     }
  * )
  */


### PR DESCRIPTION
The index declaration was missing on the PagePath entity. 

This would cause the cPath index on the PagePaths table to be removed when running `concrete5 orm:schema-tool:update --force`, which we rely pretty heavily on for our libraries.