### PR TITLE
Improve CLI install

### DIFF
--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -101,9 +101,8 @@ EOT
         if ($this->getPreconditionsPassed($app, $output) !== true) {
             throw new Exception('One or more precondition failed!');
         }
-
+        $config = $app->make('config');
         $options = $this->getFinalOptions($input);
-
         $installer = $this->configuredInstaller;
         if ($installer === null) {
             $installer = $this->buildInstaller($options);

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -311,7 +311,10 @@ EOT
         // If the default value is callable, it's probably actually the mutator
         if (is_callable($default)) {
             $mutator = $default;
-            $default = null;
+            $default = array_shift($row);
+            if (is_callable($default)) {
+                $default = $default($input);
+            }
         } elseif ($row) { // Otherwise if there's still items, the mutator is last.
             $mutator = array_shift($row);
         }
@@ -578,11 +581,11 @@ EOT
             [
                 'site-locale',
                 function (Question $question, InputInterface $input, InputOption $option) {
-                    $newDefault = $input->getOption('language');
-                    $input->setOption('site-locale', $newDefault);
-
                     return $question;
                 },
+                function (InputInterface $input) {
+                    return $input->getOption('site-locale') ?: $input->getOption('language') ?: Localization::BASE_LOCALE;
+                }
             ],
             // Test the site locale
             function (InputInterface $input, OutputInterface $output) use ($checkLocale) {

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -72,7 +72,7 @@ class InstallCommand extends Command
             ->addOption('starting-point', null, InputOption::VALUE_REQUIRED, 'Starting point to use', 'elemental_blank')
             ->addOption('admin-email', null, InputOption::VALUE_REQUIRED, 'Email of the admin user of the install', 'admin@example.com')
             ->addOption('admin-password', null, InputOption::VALUE_REQUIRED, 'Password of the admin user of the install')
-            ->addOption('demo-username', null, InputOption::VALUE_REQUIRED, 'Additional user username', 'demo')
+            ->addOption('demo-username', null, InputOption::VALUE_REQUIRED, 'Additional user username')
             ->addOption('demo-password', null, InputOption::VALUE_REQUIRED, 'Additional user password')
             ->addOption('demo-email', null, InputOption::VALUE_REQUIRED, 'Additional user email', 'demo@example.com')
             ->addOption('language', null, InputOption::VALUE_REQUIRED, 'The default concrete5 interface language (eg en_US)')
@@ -402,6 +402,10 @@ EOT
             // If we still have a firstKey set, that means we've hit the first key. Unset so that we don't test again
             if ($firstKey) {
                 $firstKey = null;
+            }
+
+            if (in_array($question[0], ['demo-password', 'demo-email'], true) && '' === (string) $input->getOption('demo-username')) {
+                continue;
             }
 
             yield $question[0] => $this->getQuestion($question, $input);

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -134,7 +134,7 @@ EOT
                             'server' => $options['db-server'],
                             'database' => $options['db-database'],
                             'username' => $options['db-username'],
-                            'password' => $options['db-password'],
+                            'password' => (string) $options['db-password'],
                             'charset' => 'utf8',
                         ],
                     ],


### PR DESCRIPTION
99% of times, we use the same value for the `--language` and `--site-locale` options: so let's make the default value of `--site-locale` the same as `--language` when installing in an interactive way.

Furthermore, let's allow users to edit the options at the end of the cycle.

Sample session (note the default value of *The default site locale*, and the final two lines:

```
$ ./concrete5 c5:install -i
Checking required preconditions:
- PHP 5.5.9... passed (you are running PHP version 7.0.28-0ubuntu0.16.04.1).
- MySQL PDO Extension Enabled... passed.
- JSON Extension Enabled... passed.
- DOM Extension Enabled... passed.
- ASP Style Tags Disabled... passed.
- Fileinfo Extension Enabled... passed.
- Image Manipulation Available... passed.
- XML Support... passed.
- Writable Files and Configuration Directories... passed.
- Internationalization Support... passed.
- PHP Comments Preserved... passed.
- Tokenizer Extension Enabled... passed.
- Memory limit 64.00 MB.... passed.
Checking optional preconditions:
- Remote File Importing... passed.
- Zip Support... passed.
Location of database server? [127.0.0.1]: 10.0.88.07
Database name?: concrete5
Database username?: root
Database password?:
The system time zone, compatible with the database one? [Europe/Paris]: Europe/Rome
Name of the site? [concrete5 Site]:
Canonical URL?:
Alternative canonical URL?:
Starting point to use? [elemental_blank]:
  [0] elemental_blank
  [1] elemental_full
 >
Email of the admin user of the install? [admin@example.com]:
Password of the admin user of the install?:
Additional user username? [demo]:
Additional user email? [demo@example.com]:
Additional user password?:
The default concrete5 interface language (eg en_US)? [en_US]: it_IT
The default site locale (eg en_US)? [it_IT]:
Use configuration file for installation? [none]:
+---------------------------+-------------------+
| Question                  | Value             |
+---------------------------+-------------------+
| env                       |                   |
| db-server                 | 127.0.0.1         |
| db-username               | root              |
| db-password               |                   |
| db-database               | concrete5         |
| timezone                  | Europe/Rome       |
| site                      | concrete5 Site    |
| canonical-url             |                   |
| canonical-url-alternative |                   |
| starting-point            | elemental_blank   |
| admin-email               | admin@example.com |
| admin-password            | HIDDEN            |
| demo-username             | demo              |
| demo-password             | HIDDEN            |
| demo-email                | demo@example.com  |
| language                  | it_IT             |
| site-locale               | it_IT             |
| config                    | none              |
+---------------------------+-------------------+
Would you like to install with these settings? [ Yes / No / Retry ]: r
Location of database server? [10.0.88.07]:
```

Fix #6510 