### PR TITLE
Allow layout presets to optionally have no container element defined

### DIFF
--- a/concrete/src/Area/Layout/Preset/Formatter/ThemeFormatter.php
+++ b/concrete/src/Area/Layout/Preset/Formatter/ThemeFormatter.php
@@ -30,7 +30,7 @@ class ThemeFormatter implements FormatterInterface
         }
 
         if (!isset($element)) {
-            $element = new Element('div');
+            $element = '';
         }
 
         return $element;


### PR DESCRIPTION
Some manual grids and grid systems control row column count using things like flexbox or nth-child selectors. Currently, layout presets always add a container element, this prevents these types of column control approaches.

An example is if you have multiple rows of 3 columns. At smaller screen widths your only option is going to 1 column and stacking vertically, if you switch to 2 columns the columns will be unevenly distributed. Without the container element, you could switch to 2 columns as a screen gets more narrow and then one.

In the below examples, the black line is the container element added in the layout preset and the red is the container element in your theme HTML.

**Example: 3 layout presets of 3 columns with container element**

![container-three_column](https://user-images.githubusercontent.com/10898145/37860372-dd21b548-2ef9-11e8-9bf3-f5d8f053d38b.png)

**Example: 3 layout presets of 3 columns with container element - adjusted to 2 columns at smaller screen size**

![container-two_column](https://user-images.githubusercontent.com/10898145/37860373-dd2f27e6-2ef9-11e8-901d-9bee02da4e78.png)

**Example: 3 layout presets of 3 columns without container element**

![no_container-three_column](https://user-images.githubusercontent.com/10898145/37860370-dd034978-2ef9-11e8-9f98-e95c41d5939a.png)

**Example: 3 layout presets of 3 columns without container element - adjusted to 2 columns at smaller screen size**

![no_container-two_column](https://user-images.githubusercontent.com/10898145/37860371-dd1029a4-2ef9-11e8-84b0-5585eaf9161f.png)

## Current:

**Example: layout preset with container element defined**
layout preset
```
[
    'handle' => 'my_preset',
    'name' => 'My Preset',
    'container' => '<div class="my-container"></div>',
    'columns' => [
        '<div class="grid-class-6"></div>',
        '<div class="grid-class-6 "></div>',
    ],
]
```
HTML output
```
<div class="my-container">
    <div class="grid-class-6"></div>
    <div class="grid-class-6"></div>
</div>
```
**Example: layout preset without container element defined**
layout preset
```
[
    'handle' => 'my_preset',
    'name' => 'My Preset',
    'container' => '',
    'columns' => [
        '<div class="grid-class-6"></div>',
        '<div class="grid-class-6 "></div>',
    ],
]
```
HTML output
```
<div>
    <div class="grid-class-6"></div>
    <div class="grid-class-6"></div>
</div>
```
If a layout preset container element is not defined, an empty `div` is used as the container element.
https://github.com/concrete5/concrete5/blob/bb8f19f45e225bc6e9543c59e5653ca0a05b2ed4/concrete/src/Area/Layout/Preset/Formatter/ThemeFormatter.php#L32-L34

## Changes:

**Example: layout preset without container element defined**
layout preset
```
[
    'handle' => 'my_preset',
    'name' => 'My Preset',
    'container' => '',
    'columns' => [
        '<div class="grid-class-6"></div>',
        '<div class="grid-class-6 "></div>',
    ],
]
```
output
```
<div class="grid-class-6"></div>
<div class="grid-class-6"></div>
```
If a layout preset container element is not defined, the column HTML will output to the page without a `div`.
