### PR TITLE
Use the user entity to delete all user attribute values

### DIFF
--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -217,7 +217,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
         // can get all the details of the user being deleted.
         $this->getDirector()->dispatch('on_user_deleted', new UserInfoEvent($this));
 
-        $attributes = $this->attributeCategory->getAttributeValues($this);
+        $attributes = $this->attributeCategory->getAttributeValues($this->getEntityObject());
         foreach ($attributes as $attribute) {
             $this->attributeCategory->deleteValue($attribute);
         }


### PR DESCRIPTION
Fix #6283

The target on the user column in the table **UserAttributeValues** is not the `UserInfo` class but the `Concrete\Core\Entity\User\User` entity, so we should use the `getEntityObject()` method to pass the correct object.
(Note: this method is also used in the `Concrete\Core\Export\Item\User` class to get all user attributes)