### PR TITLE
Add aria attributes and title to Social Links block links and icons

### DIFF
--- a/concrete/blocks/social_links/view.php
+++ b/concrete/blocks/social_links/view.php
@@ -5,7 +5,10 @@
     <?php foreach($links as $link) {
         $service = $link->getServiceObject();
         ?>
-        <li><a target="_blank" href="<?php echo h($link->getURL()); ?>"><?php echo $service->getServiceIconHTML(); ?></a></li>
+        <li>
+            <a target="_blank" href="<?php echo h($link->getURL()); ?>"
+                aria-label="<?php echo $service->getDisplayName(); ?>"><?php echo $service->getServiceIconHTML(); ?></a>
+        </li>
     <?php } ?>
     </ul>
 </div>

--- a/concrete/src/Sharing/SocialNetwork/Service.php
+++ b/concrete/src/Sharing/SocialNetwork/Service.php
@@ -41,7 +41,7 @@ class Service
         if ($this->customHTML) {
             return $this->customHTML;
         } else {
-            return '<i class="fa fa-' . $this->getIcon() . '"></i>';
+            return '<i class="fa fa-' . $this->getIcon() . '" aria-hidden="true" title="' . $this->getDisplayName() . '"></i>';
         }
     }
 


### PR DESCRIPTION
https://github.com/concrete5/concrete5/issues/6565

This pull request makes the Social Links block links more accessible.

## Current

**link**

![accessibility_link-current](https://user-images.githubusercontent.com/10898145/38462360-16b1637e-3ab4-11e8-802c-2a6eb289938e.png)

**icon**

![accessibility_icon-current](https://user-images.githubusercontent.com/10898145/38462362-1be7835a-3ab4-11e8-88e1-6027cdc86b75.png)

## Changes

**link**

![accessibility_link-changes](https://user-images.githubusercontent.com/10898145/38462364-202dbac4-3ab4-11e8-8166-cc8a68aa1373.png)

**icon**

![accessibility_icon-changes](https://user-images.githubusercontent.com/10898145/38462367-2ccd2a94-3ab4-11e8-9089-c685edf2fca2.png)
