### PR TITLE
Improvements to contrast ratios of front-end ending controls

### DIFF
--- a/concrete/css/build/core/app/page-areas.less
+++ b/concrete/css/build/core/app/page-areas.less
@@ -408,7 +408,7 @@ ul.ccm-edit-mode-inline-commands:hover {
       a, span {
         text-decoration: none !important;
         padding: 3px 12px !important;
-        color: #999;
+        color: #595959;
         display: block;
       }
       a:hover {
@@ -483,7 +483,7 @@ div.ccm-area[data-total-blocks="0"] {
     padding: 18px;
     font-size: 14px;
     line-height: 14px;
-    color: #bbb;
+    color: #767676;
   }
 }
 

--- a/concrete/css/build/core/app/page-areas.less
+++ b/concrete/css/build/core/app/page-areas.less
@@ -414,7 +414,7 @@ ul.ccm-edit-mode-inline-commands:hover {
       a:hover {
         color: #000;
         background-image: none !important;
-        background-color: transparent !important;
+        background-color: #f3f3f3 !important;
       }
 
       font-family: @baseFontFamily !important;

--- a/concrete/css/build/core/app/panels.less
+++ b/concrete/css/build/core/app/panels.less
@@ -251,7 +251,7 @@ div#ccm-panel-dashboard {
   background-color: #dde2e7;
   color: #5d6a78;
   header {
-    color: #97aabc;
+    color: #daeaf9;
     background-color: #414d59;
 
     aside a {
@@ -263,15 +263,15 @@ div#ccm-panel-dashboard {
     li {
       &.nav-selected {
         > a {
-          color: #0c253e;
+          font-weight: 500;
         }
       }
 
       a {
-        color: #4674a1;
+        color: #2d4a67;
 
         &:hover {
-          color: #0c253e;
+          color: #000000;
         }
       }
     }
@@ -327,12 +327,12 @@ div#ccm-panel-dashboard {
       }
 
       span {
-        color: #97aabc;
+        color: #d4eaff;
         background-color: #414d59;
         .box-shadow(inset 10px 1px 10px rgba(0, 0, 0, 0.12));
 
         &:after {
-          border-color: #97aabc transparent;
+          border-color: #d4eaff transparent;
         }
 
         &:hover {
@@ -432,7 +432,7 @@ div#ccm-panel-add-clipboard-block-list {
 
         > div.block-name {
           background: #1c1e21;
-          color: #737c8e;
+          color: #acb9d2;
         }
 
         > div.block-handle {
@@ -525,7 +525,7 @@ div#ccm-panel-page, div#ccm-panel-compose-page {
 
     li {
       a {
-        color: #737c8e;
+        color: #acb9d2;
       }
 
       a:hover {
@@ -1055,7 +1055,7 @@ div.ccm-panel-header-accordion-dropdown-visible {
 
     .list-group-item {
       background-color: #171c22;
-      color: #7f8d90;
+      color: #9baaad;
       border: 1px solid #0c1117;
       border-left: 0px;
       border-right: 0px;
@@ -1068,10 +1068,10 @@ div.ccm-panel-header-accordion-dropdown-visible {
       }
 
       &.list-group-item-collapse {
-        color: #5b5c5f;
+        color: #9baaad;
 
         span:after {
-          border-color: #5b5c5f transparent transparent transparent;
+          border-color: #9baaad transparent transparent transparent;
         }
 
       }
@@ -1087,7 +1087,7 @@ div.ccm-panel-header-accordion-dropdown-visible {
       a.list-group-item-collapse {
         span {
           &:after {
-            border-color: transparent transparent #2e2e2e transparent;
+            border-color: transparent transparent #9baaad transparent;
           }
         }
       }
@@ -1314,7 +1314,7 @@ div.ccm-panel-header-search {
     position: absolute;
     top: 22px;
     left: 40px;
-    color: #111;
+    color: #b8bbc4;
   }
 
   input {
@@ -1347,11 +1347,11 @@ div.ccm-panel-header-accordion {
     }
 
     span {
-      color: #999;
+      color: #adadad;
       background-color: #202226;
 
       &:after {
-        border-color: #999 transparent;
+        border-color: #adadad transparent;
       }
 
       &:hover {

--- a/concrete/css/build/core/app/panels/add-block.less
+++ b/concrete/css/build/core/app/panels/add-block.less
@@ -7,8 +7,8 @@ div#ccm-panel-add-block {
     div.ccm-panel-header-search {
       input {
         background-color: #333539;
-        color: #b8bbc4;
-        .placeholder(#777);
+        color: #ffffff;
+        .placeholder(#b8bbc4);
       }
     }
 
@@ -21,8 +21,17 @@ div#ccm-panel-add-block {
 			line-height: 13px;
 			padding: 0px;
 			border-top: 1px solid #474645;
-			padding-top: 5px;
+			padding-top: 15px;
+			padding-bottom: 5px;
 			color: #2aa9dd;
+
+		}
+
+		&:first-child{
+			header{
+				border-top: none;
+				padding-top: 0;
+			}
 		}
 
 		ul {

--- a/concrete/css/build/core/app/panels/attributes.less
+++ b/concrete/css/build/core/app/panels/attributes.less
@@ -21,15 +21,15 @@
     div.ccm-panel-header-search {
       input {
         background-color: #333539;
-        color: #b8bbc4;
-        .placeholder(#555555);
+        color: #FFFFFF;
+        .placeholder(#b8bbc4);
       }
     }
     ul {
       padding-left: 0px;
       li {
         a {
-          color: #79868d;
+          color: #a9b6ce;
           background-color: #272a2e;
           &:hover {
             background-color: #191b1f;

--- a/concrete/css/build/core/app/panels/design.less
+++ b/concrete/css/build/core/app/panels/design.less
@@ -51,7 +51,7 @@ div#ccm-panel-page-design-page-templates {
       position: absolute;
       top: 12px;
       right: 30px;
-      .opacity(0.8);
+      filter: brightness(200%);
     }
   }
 }
@@ -132,7 +132,7 @@ div#ccm-panel-page-design-themes {
 
             a {
               padding: 8px 0px 8px 0px;
-              color: #6c99f8;
+              color: #e5ebf5;
               cursor: pointer;
               text-decoration: none;
               display: block;
@@ -175,7 +175,7 @@ div#ccm-panel-page-design-themes {
       background-color: #202225;
       margin: 0px;
       padding: 18px 30px 18px 30px;
-      color: #737c8e;
+      color: #acb9d2;
       font-weight: bold;
       position: relative;
 
@@ -216,7 +216,7 @@ div#ccm-panel-page-design-themes {
         }
         position: relative;
         padding: 20px 30px;
-        color: #737c8e;
+        color: #acb9d2;
         border-bottom: 1px solid #1f2022;
 
         span.ccm-style-customizer-display-swatch-wrapper {

--- a/concrete/css/build/core/app/panels/devices.less
+++ b/concrete/css/build/core/app/panels/devices.less
@@ -116,7 +116,7 @@ div.ccm-menu-device-set {
         text-decoration: none;
       }
 
-      color: #79868d !important;
+      color: #a9b6ce !important;
       background-color: #272a2e;
       display: block;
       padding: 10px 20px 10px 20px;

--- a/concrete/css/build/core/app/panels/sitemap.less
+++ b/concrete/css/build/core/app/panels/sitemap.less
@@ -10,7 +10,8 @@ div#ccm-panel-sitemap {
     border-bottom: 1px solid #c0dcf2;
     font-size: 15px;
     padding-bottom: 5px;
-    font-weight: 300;
+    font-weight: 500;
+    color: #545454
   }
 
   ul.ccm-panel-sitemap-list {
@@ -24,7 +25,7 @@ div#ccm-panel-sitemap {
       padding-left: 0px;
 
       a {
-        color: #7097b4;
+        color: #405565;
         display: block;
         font-size: 13px;
         line-height: 16px;

--- a/concrete/css/build/core/app/search.less
+++ b/concrete/css/build/core/app/search.less
@@ -244,7 +244,7 @@ table.ccm-search-results-table {
       }
 
       background-color: #e7e7e7;
-      color: #999;
+      color: #4b4b4b;
       font-weight: normal;
 
       &.ccm-results-list-active-sort-desc a,
@@ -296,7 +296,7 @@ table.ccm-search-results-table {
       }
 
       a {
-        color: #999;
+        color: #4b4b4b;
         display: block;
 
         &:active, &:focus {
@@ -367,7 +367,7 @@ table.ccm-search-results-table {
 
       padding: 15px 0px 15px 15px;
 
-      color: #999;
+      color: #595959;
       background-color: #fff;
 
       &.ccm-search-results-name {

--- a/concrete/css/build/core/app/tabs.less
+++ b/concrete/css/build/core/app/tabs.less
@@ -31,7 +31,7 @@ div.ccm-ui {
       &:hover,
       &:focus {
         outline: none;
-        color: #999;
+        color: #595959;
         border-width: 0px !important;
       }
     }

--- a/concrete/css/build/core/app/toolbar.less
+++ b/concrete/css/build/core/app/toolbar.less
@@ -66,7 +66,7 @@ div#ccm-toolbar {
         text-align: center;
         position: relative;
         font-size: 14px;
-        color: #999;
+        color: #595858;
         border-right: 1px solid #ccc;
         border-left: 1px solid #ccc;
         margin-left: -1px; /* we have to do this tomfoolery because of user-added menus */

--- a/concrete/css/build/core/sitemap.less
+++ b/concrete/css/build/core/sitemap.less
@@ -16,6 +16,10 @@ div.ccm-ui {
 
         }
 
+        .fancytree-title {
+            color: #595959;
+        }
+
     }
 
     div.ccm-sitemap-tree-selector-wrapper {


### PR DESCRIPTION
This adjusts the contrast ratio of text labels and controls to be >= 7 - this then meets WCAG 2.0 level AAA.

The tone of colors have not been changed, only the brightness, to achieve the >7 ratio, as to not change the overall look-and-feel of the interface.

Where a font weight has been adjusted, it is only when there isn't enough visual difference between an active and non-active state (the dashboard panel in particular).

While there may be further minor items throughout the interface that would benefit from contrast improvements, this initial review would then allow concrete5 to pass in terms of WCAG's contrast requirements.  Fortunately there weren't too many items to adjust, with the majority of dashboard pages being totally fine. But some of the most commonly used controls in concrete5 didn't even pass the AA contrast rules, hence this pull request.

Additionally, a small adjustment has been made to the left hand blocks panel, to remove the unnecessary first dividing line, as well as a tiny bit of extra padding on the group titles for balance.

By the way, Chrome has a built in contrast checker in its style inspector, very handy.
