### PR TITLE
allow external links to be displayed in page list

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -132,7 +132,7 @@ class Controller extends BlockController
             $this->cPID = $c->getCollectionParentID();
         }
 
-        if ($this->displayFeaturedOnly == 1) {
+        if (1 == $this->displayFeaturedOnly) {
             $cak = CollectionAttributeKey::getByHandle('is_featured');
             if (is_object($cak)) {
                 $this->list->filterByIsFeatured(1);
@@ -175,12 +175,12 @@ class Controller extends BlockController
 
         $this->list->filterByExcludePageList(false);
 
-        if (intval($this->cParentID) != 0) {
+        if (0 != intval($this->cParentID)) {
             $cParentID = ($this->cThis) ? $this->cID : (($this->cThisParent) ? $this->cPID : $this->cParentID);
             if ($this->includeAllDescendents) {
-                $this->list->filterByPath(Page::getByID($cParentID)->getCollectionPath());
-            } else {
                 $this->list->filterByParentID($cParentID);
+            } else {
+                $this->list->filterByPath(Page::getByID($cParentID)->getCollectionPath());
             }
         }
 
@@ -249,7 +249,7 @@ class Controller extends BlockController
         $bID = $b->getBlockID();
         $this->set('bID', $bID);
         $c = Page::getCurrentPage();
-        if ((!$this->cThis) && (!$this->cThisParent) && ($this->cParentID != 0)) {
+        if ((!$this->cThis) && (!$this->cThisParent) && (0 != $this->cParentID)) {
             $isOtherPage = true;
             $this->set('isOtherPage', true);
         }
@@ -272,7 +272,7 @@ class Controller extends BlockController
         $attributeKeys = [];
         $keys = CollectionKey::getList();
         foreach ($keys as $ak) {
-            if ($ak->getAttributeTypeHandle() == 'topics') {
+            if ('topics' == $ak->getAttributeTypeHandle()) {
                 $attributeKeys[] = $ak;
             }
         }
@@ -315,7 +315,7 @@ class Controller extends BlockController
             }
             $dh = Core::make('helper/date');
             /* @var $dh \Concrete\Core\Localization\Service\Date */
-            if ($timezone !== 'system') {
+            if ('system' !== $timezone) {
                 $start = $dh->toDB($start, $timezone);
                 $end = $dh->toDB($end, $timezone);
             }
@@ -323,7 +323,7 @@ class Controller extends BlockController
             $this->list->filterByPublicDate($end, '<=');
 
             $seo = Core::make('helper/seo');
-            $date = ucfirst(\Punic\Calendar::getMonthName($month, 'wide', '', true).' '.$year);
+            $date = ucfirst(\Punic\Calendar::getMonthName($month, 'wide', '', true) . ' ' . $year);
             $seo->addTitleSegment($date);
         }
         $this->view();
@@ -354,10 +354,10 @@ class Controller extends BlockController
 
     public function getPassThruActionAndParameters($parameters)
     {
-        if ($parameters[0] == 'topic') {
+        if ('topic' == $parameters[0]) {
             $method = 'action_filter_by_topic';
             $parameters = array_slice($parameters, 1);
-        } elseif ($parameters[0] == 'tag') {
+        } elseif ('tag' == $parameters[0]) {
             $method = 'action_filter_by_tag';
             $parameters = array_slice($parameters, 1);
         } elseif (Core::make('helper/validation/numbers')->integer($parameters[0])) {
@@ -417,7 +417,7 @@ class Controller extends BlockController
         $args['num'] = ($args['num'] > 0) ? $args['num'] : 0;
         $args['cThis'] = ($args['cParentID'] == $this->cID) ? '1' : '0';
         $args['cThisParent'] = ($args['cParentID'] == $this->cPID) ? '1' : '0';
-        $args['cParentID'] = ($args['cParentID'] == 'OTHER') ? $args['cParentIDValue'] : $args['cParentID'];
+        $args['cParentID'] = ('OTHER' == $args['cParentID']) ? $args['cParentIDValue'] : $args['cParentID'];
         if (!$args['cParentID']) {
             $args['cParentID'] = 0;
         }
@@ -426,8 +426,8 @@ class Controller extends BlockController
         $args['includeDate'] = ($args['includeDate']) ? '1' : '0';
         $args['truncateSummaries'] = ($args['truncateSummaries']) ? '1' : '0';
         $args['displayFeaturedOnly'] = ($args['displayFeaturedOnly']) ? '1' : '0';
-        $args['filterByRelated'] = ($args['topicFilter'] == 'related') ? '1' : '0';
-        $args['filterByCustomTopic'] = ($args['topicFilter'] == 'custom') ? '1' : '0';
+        $args['filterByRelated'] = ('related' == $args['topicFilter']) ? '1' : '0';
+        $args['filterByCustomTopic'] = ('custom' == $args['topicFilter']) ? '1' : '0';
         $args['displayThumbnail'] = ($args['displayThumbnail']) ? '1' : '0';
         $args['displayAliases'] = ($args['displayAliases']) ? '1' : '0';
         $args['truncateChars'] = intval($args['truncateChars']);
@@ -467,7 +467,7 @@ class Controller extends BlockController
         } elseif (isset($this->pfID) && $this->pfID && !$args['rss']) {
             // let's make sure this isn't in use elsewhere.
             $cnt = $db->fetchColumn('select count(pfID) from btPageList where pfID = ?', [$this->pfID]);
-            if ($cnt == 1) { // this is the last one, so we delete
+            if (1 == $cnt) { // this is the last one, so we delete
                 $pf = Feed::getByID($this->pfID);
                 if (is_object($pf)) {
                     $pf->delete();
@@ -476,14 +476,14 @@ class Controller extends BlockController
             $args['pfID'] = 0;
         }
 
-        if ($args['filterDateOption'] != 'between') {
+        if ('between' != $args['filterDateOption']) {
             $args['filterDateStart'] = null;
             $args['filterDateEnd'] = null;
         }
 
-        if ($args['filterDateOption'] == 'past') {
+        if ('past' == $args['filterDateOption']) {
             $args['filterDateDays'] = $args['filterDatePast'];
-        } elseif ($args['filterDateOption'] == 'future') {
+        } elseif ('future' == $args['filterDateOption']) {
             $args['filterDateDays'] = $args['filterDateFuture'];
         } else {
             $args['filterDateDays'] = null;
@@ -499,7 +499,7 @@ class Controller extends BlockController
         if (isset($this->pageListTitle) && $this->pageListTitle) {
             return false;
         }
-        if (count($pages) == 0) {
+        if (0 == count($pages)) {
             if ($this->noResultsMessage) {
                 return false;
             } else {
@@ -518,7 +518,7 @@ class Controller extends BlockController
 
     public function cacheBlockOutput()
     {
-        if ($this->btCacheBlockOutput === null) {
+        if (null === $this->btCacheBlockOutput) {
             if (!$this->enableExternalFiltering && !$this->paginate) {
                 $this->btCacheBlockOutput = true;
             } else {

--- a/concrete/controllers/dialog/page/add_external.php
+++ b/concrete/controllers/dialog/page/add_external.php
@@ -2,6 +2,7 @@
 namespace Concrete\Controller\Dialog\Page;
 
 use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
+use Concrete\Core\Page\Type\Type;
 use URL;
 use Concrete\Core\Page\EditResponse;
 
@@ -16,6 +17,17 @@ class AddExternal extends BackendInterfacePageController
 
     public function view()
     {
+        $typesSelect = [];
+        if (is_object($tree)) {
+            $type = $tree->getSiteType();
+            $typeList = Type::getList(false, $type);
+            foreach ($typeList as $_pagetype) {
+                $typesSelect[$_pagetype->getPageTypeID()] = $_pagetype->getPageTypeDisplayName();
+            }
+        }
+        $tree = $this->page->getSiteTreeObject();
+
+        $this->set('types', $typesSelect);
     }
 
     public function submit()
@@ -25,7 +37,8 @@ class AddExternal extends BackendInterfacePageController
             $this->page->addCollectionAliasExternal(
                 $request->request->get('name'),
                 $request->request->get('link'),
-                $request->request->get('openInNewWindow')
+                $request->request->get('openInNewWindow'),
+                $request->request->get('ptID')
             );
 
             $r = new EditResponse();

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -16,7 +16,6 @@ use Concrete\Core\Page\Type\Composer\Control\BlockControl;
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl;
 use Concrete\Core\Page\Type\Type;
 use Concrete\Core\Permission\AssignableObjectInterface;
-use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Support\Facade\Route;
 use Concrete\Core\Permission\Access\Entity\PageOwnerEntity;
 use Database;
@@ -37,9 +36,7 @@ use PageType;
 use PageTheme;
 use Concrete\Core\Localization\Locale\Service as LocaleService;
 use Concrete\Core\Permission\Key\PageKey as PagePermissionKey;
-use Concrete\Core\Permission\Access\Access as PermissionAccess;
 use Concrete\Core\Package\PackageList;
-use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\GroupCombinationEntity as GroupCombinationPermissionAccessEntity;
 use Concrete\Core\Permission\Access\Entity\UserEntity as UserPermissionAccessEntity;
@@ -71,6 +68,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public $siteTree;
 
     use AssignableObjectTrait;
+
     /**
      * @param string $path /path/to/page
      * @param string $version ACTIVE or RECENT
@@ -113,7 +111,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $class = get_called_class();
         if ($cID && $version) {
-            $c = CacheLocal::getEntry('page', $cID.'/'.$version.'/'.$class);
+            $c = CacheLocal::getEntry('page', $cID . '/' . $version . '/' . $class);
             if ($c instanceof $class) {
                 return $c;
             }
@@ -125,7 +123,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         // must use cID instead of c->getCollectionID() because cID may be the pointer to another page
         if ($cID && $version) {
-            CacheLocal::set('page', $cID.'/'.$version.'/'.$class, $c);
+            CacheLocal::set('page', $cID . '/' . $version . '/' . $class, $c);
         }
 
         return $c;
@@ -146,10 +144,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         //$q2 = "select cParentID, cPointerID, cPath, Pages.cID from Pages left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
 
         $v = [$cInfo];
-        $r = $db->executeQuery($q0.$where, $v);
+        $r = $db->executeQuery($q0 . $where, $v);
         $row = $r->fetchRow();
         if ($row['cPointerID'] > 0) {
-            $q1 = $q0.'where Pages.cID = ?';
+            $q1 = $q0 . 'where Pages.cID = ?';
             $cPointerOriginalID = $row['cID'];
             $v = [$row['cPointerID']];
             $cParentIDOverride = $row['cParentID'];
@@ -184,7 +182,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $this->loadError(COLLECTION_NOT_FOUND);
         }
 
-        if ($cvID != false && !$this->isError()) {
+        if (false != $cvID && !$this->isError()) {
             $this->loadVersionObject($cvID);
         }
 
@@ -232,19 +230,19 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             if ($this->getPageTypeID() > 0) {
                 $pt = $this->getPageTypeObject();
                 $ptHandle = $pt->getPageTypeHandle();
-                $r = $env->getRecord(DIRNAME_CONTROLLERS.'/'.DIRNAME_PAGE_TYPES.'/'.$ptHandle.'.php', $pt->getPackageHandle());
+                $r = $env->getRecord(DIRNAME_CONTROLLERS . '/' . DIRNAME_PAGE_TYPES . '/' . $ptHandle . '.php', $pt->getPackageHandle());
                 $prefix = $r->override ? true : $pt->getPackageHandle();
-                $class = core_class('Controller\\PageType\\'.camelcase($ptHandle), $prefix);
+                $class = core_class('Controller\\PageType\\' . camelcase($ptHandle), $prefix);
             } elseif ($this->isGeneratedCollection()) {
                 $file = $this->getCollectionFilename();
-                if (strpos($file, '/'.FILENAME_COLLECTION_VIEW) !== false) {
-                    $path = substr($file, 0, strpos($file, '/'.FILENAME_COLLECTION_VIEW));
+                if (false !== strpos($file, '/' . FILENAME_COLLECTION_VIEW)) {
+                    $path = substr($file, 0, strpos($file, '/' . FILENAME_COLLECTION_VIEW));
                 } else {
                     $path = substr($file, 0, strpos($file, '.php'));
                 }
-                $r = $env->getRecord(DIRNAME_CONTROLLERS.'/'.DIRNAME_PAGE_CONTROLLERS.$path.'.php', $this->getPackageHandle());
+                $r = $env->getRecord(DIRNAME_CONTROLLERS . '/' . DIRNAME_PAGE_CONTROLLERS . $path . '.php', $this->getPackageHandle());
                 $prefix = $r->override ? true : $this->getPackageHandle();
-                $class = core_class('Controller\\SinglePage\\'.str_replace('/', '\\', camelcase($path, true)), $prefix);
+                $class = core_class('Controller\\SinglePage\\' . str_replace('/', '\\', camelcase($path, true)), $prefix);
             }
 
             if (isset($class) && class_exists($class)) {
@@ -277,10 +275,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function isEditMode()
     {
-        if ($this->getCollectionPath() == STACKS_LISTING_PAGE_PATH) {
+        if (STACKS_LISTING_PAGE_PATH == $this->getCollectionPath()) {
             return true;
         }
-        if ($this->getPageTypeHandle() == STACKS_PAGE_TYPE) {
+        if (STACKS_PAGE_TYPE == $this->getPageTypeHandle()) {
             return true;
         }
 
@@ -318,7 +316,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function isArrangeMode()
     {
-        return $this->isCheckedOutByMe() && isset($_REQUEST['btask']) && $_REQUEST['btask'] === 'arrange';
+        return $this->isCheckedOutByMe() && isset($_REQUEST['btask']) && 'arrange' === $_REQUEST['btask'];
     }
 
     /**
@@ -340,7 +338,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public function isAdminArea()
     {
         if ($this->isGeneratedCollection()) {
-            $pos = strpos($this->getCollectionFilename(), '/'.DIRNAME_DASHBOARD);
+            $pos = strpos($this->getCollectionFilename(), '/' . DIRNAME_DASHBOARD);
 
             return $pos > -1;
         }
@@ -359,14 +357,14 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         if (is_object($c)) {
             return $c;
         }
-        if ($request->getPath() != '') {
+        if ('' != $request->getPath()) {
             $path = $request->getPath();
             $db = Database::connection();
             $cID = false;
             $ppIsCanonical = false;
             $site = \Core::make('site')->getSite();
             $treeIDs = [0];
-            foreach($site->getLocales() as $locale) {
+            foreach ($site->getLocales() as $locale) {
                 $tree = $locale->getSiteTree();
                 if (is_object($tree)) {
                     $treeIDs[] = $tree->getSiteTreeID();
@@ -434,8 +432,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $update_values[] = $key;
         }
 
-        $update_query .= ' '.implode(' ', $when_statements).' END WHERE bID in ('.
-            implode(',', array_pad([], count($block_order), '?')).') AND cID = ? AND cvID = ?';
+        $update_query .= ' ' . implode(' ', $when_statements) . ' END WHERE bID in (' .
+            implode(',', array_pad([], count($block_order), '?')) . ') AND cID = ? AND cvID = ?';
         $values = array_merge($update_values, $block_order);
         $values = array_merge($values, [$this->getCollectionID(), $this->getVersionID()]);
 
@@ -461,12 +459,12 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         if ($r) {
             $row = $r->fetchRow();
             // If cCheckedOutDatetimeLastEdit is present, get the time span in seconds since it's last edit.
-            if (! empty($row['cCheckedOutDatetimeLastEdit'])) {
+            if (!empty($row['cCheckedOutDatetimeLastEdit'])) {
                 $dh = Core::make('helper/date');
                 $timeSinceCheckout = ($dh->getOverridableNow(true) - strtotime($row['cCheckedOutDatetimeLastEdit']));
             }
 
-            if ($row['cIsCheckedOut'] == 0) {
+            if (0 == $row['cIsCheckedOut']) {
                 return false;
             } else {
                 if (isset($timeSinceCheckout) && $timeSinceCheckout > CHECKOUT_TIMEOUT) {
@@ -528,27 +526,27 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     public function setPermissionsToOverride()
     {
-        if ($this->cInheritPermissionsFrom != 'OVERRIDE') {
+        if ('OVERRIDE' != $this->cInheritPermissionsFrom) {
             $this->setPermissionsToManualOverride();
         }
     }
 
     public function setChildPermissionsToOverride()
     {
-        foreach($this->getCollectionChildren() as $child) {
+        foreach ($this->getCollectionChildren() as $child) {
             $child->setPermissionsToManualOverride();
         }
     }
 
     public function removePermissions($userOrGroup, $permissions = [])
     {
-        if ($this->cInheritPermissionsFrom != 'OVERRIDE') {
+        if ('OVERRIDE' != $this->cInheritPermissionsFrom) {
             return;
         }
 
         if (is_array($userOrGroup)) {
             $pe = GroupCombinationPermissionAccessEntity::getOrCreate($userOrGroup);
-            // group combination
+        // group combination
         } elseif ($userOrGroup instanceof User || $userOrGroup instanceof \Concrete\Core\User\UserInfo) {
             $pe = UserPermissionAccessEntity::getOrCreate($userOrGroup);
         } else {
@@ -576,7 +574,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $db = Database::connection();
         $site = $site ? $site : \Core::make('site')->getSite();
         $cParentID = $db->fetchColumn('select p.cID from PagePaths pp inner join Pages p on pp.cID = p.cID inner join SiteLocales sl on p.siteTreeID = sl.siteTreeID where cPath = ? and sl.siteID = ?', [Config::get('concrete.paths.drafts'), $site->getSiteID()]);
-        return Page::getByID($cParentID);
+
+        return self::getByID($cParentID);
     }
 
     public static function getDrafts(Site $site)
@@ -607,11 +606,11 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     private static function translatePermissionsXMLToKeys($node)
     {
         $pkHandles = [];
-        if ($node['canRead'] == '1') {
+        if ('1' == $node['canRead']) {
             $pkHandles[] = 'view_page';
             $pkHandles[] = 'view_page_in_sitemap';
         }
-        if ($node['canWrite'] == '1') {
+        if ('1' == $node['canWrite']) {
             $pkHandles[] = 'view_page_versions';
             $pkHandles[] = 'edit_page_properties';
             $pkHandles[] = 'edit_page_contents';
@@ -621,7 +620,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $pkHandles[] = 'preview_page_as_user';
             $pkHandles[] = 'add_subpage';
         }
-        if ($node['canAdmin'] == '1') {
+        if ('1' == $node['canAdmin']) {
             $pkHandles[] = 'edit_page_speed_settings';
             $pkHandles[] = 'edit_page_permissions';
             $pkHandles[] = 'edit_page_theme';
@@ -725,7 +724,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         PageStatistics::incrementParents($newCID);
 
         $q2 = 'insert into PagePaths (cID, cPath, ppIsCanonical, ppGeneratedFromURLSlugs) values (?, ?, ?, ?)';
-        $v2 = [$newCID, $cPath.'/'.$handle, 1, 1];
+        $v2 = [$newCID, $cPath . '/' . $handle, 1, 1];
         $db->executeQuery($q2, $v2);
 
         return $newCID;
@@ -740,7 +739,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function updateCollectionAliasExternal($cName, $cLink, $newWindow = 0)
     {
-        if ($this->cPointerExternalLink != '') {
+        if ('' != $this->cPointerExternalLink) {
             $db = Database::connection();
             $this->markModified();
             if ($newWindow) {
@@ -762,7 +761,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      *
      * @return int $newCID
      */
-    public function addCollectionAliasExternal($cName, $cLink, $newWindow = 0)
+    public function addCollectionAliasExternal($cName, $cLink, $newWindow = 0, $ptID)
     {
         $db = Database::connection();
         $dt = Core::make('helper/text');
@@ -795,8 +794,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         $siteTreeID = \Core::make('site')->getSite()->getSiteTreeID();
 
-        $v = [$newCID, $siteTreeID, $cParentID, $uID, $cInheritPermissionsFrom, (int) $cInheritPermissionsFromCID, $cLink, $newWindow];
-        $q = 'insert into Pages (cID, siteTreeID, cParentID, uID, cInheritPermissionsFrom, cInheritPermissionsFromCID, cPointerExternalLink, cPointerExternalLinkNewWindow) values (?, ?, ?, ?, ?, ?, ?, ?)';
+        $v = [$newCID, $siteTreeID, $cParentID, $uID, $cInheritPermissionsFrom, (int) $cInheritPermissionsFromCID, $cLink,
+            $newWindow, $ptID, ];
+        $q = 'insert into Pages (cID, siteTreeID, cParentID, uID, cInheritPermissionsFrom, cInheritPermissionsFromCID, cPointerExternalLink, 
+cPointerExternalLinkNewWindow,ptID) values (?, ?, ?, ?, ?, ?, ?, ?,?)';
         $r = $db->prepare($q);
 
         $r->execute($v);
@@ -844,21 +845,21 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         if ($this->isGeneratedCollection()) {
             if ($this->getPackageID() > 0) {
-                if (is_dir(DIR_PACKAGES.'/'.$this->getPackageHandle())) {
+                if (is_dir(DIR_PACKAGES . '/' . $this->getPackageHandle())) {
                     $dirp = DIR_PACKAGES;
                     $url = \Core::getApplicationURL();
                 } else {
                     $dirp = DIR_PACKAGES_CORE;
                     $url = ASSETS_URL;
                 }
-                $file = $dirp.'/'.$this->getPackageHandle().'/'.DIRNAME_PAGES.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON;
+                $file = $dirp . '/' . $this->getPackageHandle() . '/' . DIRNAME_PAGES . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON;
                 if (file_exists($file)) {
-                    $icon = $url.'/'.DIRNAME_PACKAGES.'/'.$this->getPackageHandle().'/'.DIRNAME_PAGES.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON;
+                    $icon = $url . '/' . DIRNAME_PACKAGES . '/' . $this->getPackageHandle() . '/' . DIRNAME_PAGES . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON;
                 }
-            } elseif (file_exists(DIR_FILES_CONTENT.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON)) {
-                $icon = \Core::getApplicationURL().'/'.DIRNAME_PAGES.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON;
-            } elseif (file_exists(DIR_FILES_CONTENT_REQUIRED.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON)) {
-                $icon = ASSETS_URL.'/'.DIRNAME_PAGES.$this->getCollectionPath().'/'.FILENAME_PAGE_ICON;
+            } elseif (file_exists(DIR_FILES_CONTENT . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON)) {
+                $icon = \Core::getApplicationURL() . '/' . DIRNAME_PAGES . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON;
+            } elseif (file_exists(DIR_FILES_CONTENT_REQUIRED . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON)) {
+                $icon = ASSETS_URL . '/' . DIRNAME_PAGES . $this->getCollectionPath() . '/' . FILENAME_PAGE_ICON;
             }
         } else {
         }
@@ -876,7 +877,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $cIDRedir = $this->getCollectionPointerID();
         $cPointerExternalLink = $this->getCollectionPointerExternalLink();
 
-        if ($cPointerExternalLink != '') {
+        if ('' != $cPointerExternalLink) {
             $this->delete();
         } elseif ($cIDRedir > 0) {
             $db = Database::connection();
@@ -1028,8 +1029,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $p->addAttribute('user', $ui->getUserName());
         $p->addAttribute('description', Core::make('helper/text')->entities($this->getCollectionDescription()));
         $p->addAttribute('package', $this->getPackageHandle());
-        if ($this->getCollectionParentID() == 0) {
-            if ($this->getSiteTreeID() == 0) {
+        if (0 == $this->getCollectionParentID()) {
+            if (0 == $this->getSiteTreeID()) {
                 $p->addAttribute('global', 'true');
             } else {
                 $p->addAttribute('root', 'true');
@@ -1098,7 +1099,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $em = \ORM::entityManager();
         $path = new \Concrete\Core\Entity\Page\PagePath();
-        $path->setPagePath('/'.trim($cPath, '/'));
+        $path->setPagePath('/' . trim($cPath, '/'));
         $path->setPageObject($this);
         $em->persist($path);
         if ($commit) {
@@ -1183,7 +1184,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @see \Concrete\Core\Site\Tree\TreeInterface::getSiteTreeObject()
      */
@@ -1193,6 +1194,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $em = \ORM::entityManager();
             $this->siteTree = $em->find('\Concrete\Core\Entity\Site\Tree', $this->getSiteTreeID());
         }
+
         return $this->siteTree;
     }
 
@@ -1463,7 +1465,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function isAlias()
     {
-        return $this->getCollectionPointerID() > 0 || $this->cPointerExternalLink != null;
+        return $this->getCollectionPointerID() > 0 || null != $this->cPointerExternalLink;
     }
 
     /**
@@ -1473,7 +1475,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function isExternalLink()
     {
-        return $this->cPointerExternalLink != null;
+        return null != $this->cPointerExternalLink;
     }
 
     /**
@@ -1843,7 +1845,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $preset = $selectedPreset->getPresetHandle();
         }
         $sccRecordID = 0;
-        if ($customCssRecord !== null) {
+        if (null !== $customCssRecord) {
             $sccRecordID = $customCssRecord->getRecordID();
         }
         $db->insert(
@@ -1880,10 +1882,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         $classes = ['ccm-page'];
         if (is_object($pt)) {
-            $classes[] = 'page-type-'.str_replace('_', '-', $pt->getPageTypeHandle());
+            $classes[] = 'page-type-' . str_replace('_', '-', $pt->getPageTypeHandle());
         }
         if (is_object($ptm)) {
-            $classes[] = 'page-template-'.str_replace('_', '-', $ptm->getPageTemplateHandle());
+            $classes[] = 'page-template-' . str_replace('_', '-', $ptm->getPageTemplateHandle());
         }
 
         return implode(' ', $classes);
@@ -1896,8 +1898,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $style = $this->getCustomStyleObject();
             $scl = is_object($style) ? $style->getValueList() : null;
 
-            $theme->setStylesheetCachePath(Config::get('concrete.cache.directory').'/pages/'.$this->getCollectionID());
-            $theme->setStylesheetCacheRelativePath(REL_DIR_FILES_CACHE.'/pages/'.$this->getCollectionID());
+            $theme->setStylesheetCachePath(Config::get('concrete.cache.directory') . '/pages/' . $this->getCollectionID());
+            $theme->setStylesheetCacheRelativePath(REL_DIR_FILES_CACHE . '/pages/' . $this->getCollectionID());
             $sheets = $theme->getThemeCustomizableStyleSheets();
             foreach ($sheets as $sheet) {
                 if (is_object($scl)) {
@@ -1972,7 +1974,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
         $txt = Core::make('helper/text');
         $isHomePage = $this->isHomePage();
-        if (!isset($data['cHandle']) && ($this->getCollectionHandle() != '')) {
+        if (!isset($data['cHandle']) && ('' != $this->getCollectionHandle())) {
             // No passed cHandle, and there is an existing handle.
             $cHandle = $this->getCollectionHandle();
         } elseif (!$isHomePage && !Core::make('helper/validation/strings')->notempty($data['cHandle'])) {
@@ -2023,7 +2025,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                     // now, we go back and we alias blocks from the new master collection onto the page.
                     foreach ($newMCBlocks as $b) {
                         $bt = $b->getBlockTypeObject();
-                        if ($bt->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
+                        if (BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY == $bt->getBlockTypeHandle()) {
                             continue;
                         }
                         if ($bt->isCopiedWhenPropagated()) {
@@ -2115,7 +2117,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     public function setPermissionsToManualOverride()
     {
-        if ($this->cInheritPermissionsFrom != 'OVERRIDE') {
+        if ('OVERRIDE' != $this->cInheritPermissionsFrom) {
             $db = Database::connection();
             $this->acquirePagePermissions($this->getPermissionsCollectionID());
             $this->acquireAreaPermissions($this->getPermissionsCollectionID());
@@ -2243,7 +2245,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $b = parent::addBlock($bt, $a, $data);
         $btHandle = $bt->getBlockTypeHandle();
-        if ($b->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
+        if (BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY == $b->getBlockTypeHandle()) {
             $bi = $b->getInstance();
             $output = $bi->getComposerOutputControlObject();
             $control = FormLayoutSetControl::getByID($output->getPageTypeComposerFormLayoutSetControlID());
@@ -2278,15 +2280,16 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $em = \Database::connection()->getEntityManager();
         $r = $em->getRepository('Concrete\Core\Entity\Page\Relation\SiblingRelation');
         $relation = $r->findOneBy(['cID' => $this->getCollectionID()]);
-        $relations = array();
+        $relations = [];
         if (is_object($relation)) {
             $allRelations = $r->findBy(['mpRelationID' => $relation->getPageRelationID()]);
-            foreach($allRelations as $relation) {
+            foreach ($allRelations as $relation) {
                 if ($relation->getPageID() != $this->getCollectionID() && $relation->getPageObject()->getSiteTreeObject() instanceof SiteTree) {
                     $relations[] = $relation;
                 }
             }
         }
+
         return $relations;
     }
 
@@ -2388,7 +2391,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         if ($r) {
             while ($row = $r->fetchRow()) {
                 // This is a terrible hack.
-                if ($row['ptHandle'] === STACKS_PAGE_TYPE) {
+                if (STACKS_PAGE_TYPE === $row['ptHandle']) {
                     $tc = Stack::getByID($row['cID']);
                 } else {
                     $tc = self::getByID($row['cID']);
@@ -2424,7 +2427,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             );
             if ($nameCount > 0) {
                 ++$index;
-                $newCollectionName = $this->getCollectionName().' '.$index;
+                $newCollectionName = $this->getCollectionName() . ' ' . $index;
             }
         }
 
@@ -2466,7 +2469,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $nc2 = self::getByID($newCID);
 
             // now with any specific permissions - but only if this collection is set to override
-            if ($this->getCollectionInheritance() == 'OVERRIDE') {
+            if ('OVERRIDE' == $this->getCollectionInheritance()) {
                 $nc2->acquirePagePermissions($this->getPermissionsCollectionID());
                 $nc2->acquireAreaPermissions($this->getPermissionsCollectionID());
                 // make sure we update the proper permissions pointer to the new page ID
@@ -2474,7 +2477,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 $v = [(int) $newCID, $newCID];
                 $db->executeQuery($q, $v);
                 $nc2->cInheritPermissionsFromCID = $newCID;
-            } elseif ($this->getCollectionInheritance() == 'PARENT') {
+            } elseif ('PARENT' == $this->getCollectionInheritance()) {
                 // we need to clear out any lingering permissions groups (just in case), and set this collection to inherit from the parent
                 $npID = $nc->getPermissionsCollectionID();
                 $q = 'update Pages set cInheritPermissionsFromCID = ? where cID = ?';
@@ -2486,7 +2489,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             if ($index > 1) {
                 $args['cName'] = $newCollectionName;
                 if ($nc2->getCollectionHandle()) {
-                    $args['cHandle'] = $nc2->getCollectionHandle().'-'.$index;
+                    $args['cHandle'] = $nc2->getCollectionHandle() . '-' . $index;
                 }
             }
             $nc2->update($args);
@@ -2585,7 +2588,6 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     public function moveToTrash()
     {
-
         // run any internal event we have for page trashing
         $pe = new Event($this);
         Events::dispatch('on_page_move_to_trash', $pe);
@@ -2655,9 +2657,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     /**
      * Get the ID of the home page.
      *
-     * @param Page|int $page The page (or its ID) for which you want the home (if not specified, we'll use the default locale site tree).
+     * @param Page|int $page the page (or its ID) for which you want the home (if not specified, we'll use the default locale site tree)
      *
-     * @return int|null Returns NULL if $page is null (or it doesn't have a SiteTree associated) and if there's no default locale.
+     * @return int|null returns NULL if $page is null (or it doesn't have a SiteTree associated) and if there's no default locale
      */
     public static function getHomePageID($page = null)
     {
@@ -2665,17 +2667,17 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             if (!$page instanceof self) {
                 $page = self::getByID($page);
             }
-            if ($page instanceof Page) {
+            if ($page instanceof self) {
                 $siteTree = $page->getSiteTreeObject();
-                if ($siteTree !== null) {
+                if (null !== $siteTree) {
                     return $siteTree->getSiteHomePageID();
                 }
             }
         }
         $locale = Application::getFacadeApplication()->make(LocaleService::class)->getDefaultLocale();
-        if ($locale !== null) {
+        if (null !== $locale) {
             $siteTree = $locale->getSiteTreeObject();
-            if ($siteTree != null) {
+            if (null != $siteTree) {
                 return $siteTree->getSiteHomePageID();
             }
         }
@@ -2688,7 +2690,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $path = new PagePath();
         $path->setPagePathIsAutoGenerated(true);
         //if (!$this->isHomePage()) {
-            $path->setPagePath($this->computeCanonicalPagePath());
+        $path->setPagePath($this->computeCanonicalPagePath());
         //}
 
         return $path;
@@ -2709,38 +2711,38 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $newPath = '';
         //if ($this->cParentID > 0) {
-            /**
-             * @var Connection
-             */
-            $db = \Database::connection();
-            /* @var $em \Doctrine\ORM\EntityManager */
-            $pathObject = $this->getCollectionPathObject();
-            if (is_object($pathObject) && !$pathObject->isPagePathAutoGenerated()) {
-                $pathString = $pathObject->getPagePath();
-            } else {
-                $pathString = $this->computeCanonicalPagePath();
-            }
-            if (!$pathString) {
-                return ''; // We are allowed to pass in a blank path in the event of the home page being scanned.
-            }
-            // ensure that the path is unique
-            $suffix = 0;
-            $cID = ($this->getCollectionPointerOriginalID() > 0) ? $this->getCollectionPointerOriginalID() : $this->cID;
-            $pagePathSeparator = Config::get('concrete.seo.page_path_separator');
-            while (true) {
-                $newPath = ($suffix === 0) ? $pathString : $pathString.$pagePathSeparator.$suffix;
-                $result = $db->fetchColumn('select p.cID from PagePaths pp inner join Pages p on pp.cID = p.cID where pp.cPath = ? and pp.cID <> ? and p.siteTreeID = ?',
+        /**
+         * @var Connection
+         */
+        $db = \Database::connection();
+        /* @var $em \Doctrine\ORM\EntityManager */
+        $pathObject = $this->getCollectionPathObject();
+        if (is_object($pathObject) && !$pathObject->isPagePathAutoGenerated()) {
+            $pathString = $pathObject->getPagePath();
+        } else {
+            $pathString = $this->computeCanonicalPagePath();
+        }
+        if (!$pathString) {
+            return ''; // We are allowed to pass in a blank path in the event of the home page being scanned.
+        }
+        // ensure that the path is unique
+        $suffix = 0;
+        $cID = ($this->getCollectionPointerOriginalID() > 0) ? $this->getCollectionPointerOriginalID() : $this->cID;
+        $pagePathSeparator = Config::get('concrete.seo.page_path_separator');
+        while (true) {
+            $newPath = (0 === $suffix) ? $pathString : $pathString . $pagePathSeparator . $suffix;
+            $result = $db->fetchColumn('select p.cID from PagePaths pp inner join Pages p on pp.cID = p.cID where pp.cPath = ? and pp.cID <> ? and p.siteTreeID = ?',
                     [
                         $newPath,
                         $cID,
                         $this->getSiteTreeID(),
                     ]
                 );
-                if (empty($result)) {
-                    break;
-                }
-                ++$suffix;
+            if (empty($result)) {
+                break;
             }
+            ++$suffix;
+        }
         //}
 
         return $newPath;
@@ -2752,24 +2754,24 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public function rescanCollectionPath()
     {
         //if ($this->cParentID > 0) {
-            $newPath = $this->generatePagePath();
+        $newPath = $this->generatePagePath();
 
-            $pathObject = $this->getCollectionPathObject();
-            $ppIsAutoGenerated = true;
-            if (is_object($pathObject) && !$pathObject->isPagePathAutoGenerated()) {
-                $ppIsAutoGenerated = false;
-            }
-            $this->setCanonicalPagePath($newPath, $ppIsAutoGenerated);
-            $this->rescanSystemPageStatus();
-            $this->cPath = $newPath;
-            $this->refreshCache();
+        $pathObject = $this->getCollectionPathObject();
+        $ppIsAutoGenerated = true;
+        if (is_object($pathObject) && !$pathObject->isPagePathAutoGenerated()) {
+            $ppIsAutoGenerated = false;
+        }
+        $this->setCanonicalPagePath($newPath, $ppIsAutoGenerated);
+        $this->rescanSystemPageStatus();
+        $this->cPath = $newPath;
+        $this->refreshCache();
 
-            $children = $this->getCollectionChildren();
-            if (count($children) > 0) {
-                foreach ($children as $child) {
-                    $child->rescanCollectionPath();
-                }
+        $children = $this->getCollectionChildren();
+        if (count($children) > 0) {
+            foreach ($children as $child) {
+                $child->rescanCollectionPath();
             }
+        }
         //}
     }
 
@@ -2793,7 +2795,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $stringValidator = Core::make('helper/validation/strings');
         if ($stringValidator->notempty($this->getCollectionHandle())) {
             $path .= $this->getCollectionHandle();
-        } else if (!$this->isHomePage()) {
+        } elseif (!$this->isHomePage()) {
             $path .= $cID;
         } else {
             $path = ''; // This is computing the path for the home page, which has no handle, and so shouldn't have a segment.
@@ -2842,18 +2844,18 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $this->updateDisplayOrder($max);
     }
 
-    public function movePageDisplayOrderToSibling(Page $c, $position = 'before')
+    public function movePageDisplayOrderToSibling(self $c, $position = 'before')
     {
         // first, we get a list of IDs.
         $pageIDs = [];
         $db = Database::connection();
         $r = $db->executeQuery('select cID from Pages where cParentID = ? and cID <> ? order by cDisplayOrder asc', [$this->getCollectionParentID(), $this->getCollectionID()]);
         while ($row = $r->FetchRow()) {
-            if ($row['cID'] == $c->getCollectionID() && $position == 'before') {
+            if ($row['cID'] == $c->getCollectionID() && 'before' == $position) {
                 $pageIDs[] = $this->cID;
             }
             $pageIDs[] = $row['cID'];
-            if ($row['cID'] == $c->getCollectionID() && $position == 'after') {
+            if ($row['cID'] == $c->getCollectionID() && 'after' == $position) {
                 $pageIDs[] = $this->cID;
             }
         }
@@ -2876,19 +2878,19 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $db = Database::connection();
         $cID = $this->getCollectionID();
         if (!$this->isHomePage()) {
-            if ($this->getSiteTreeID() == 0) {
+            if (0 == $this->getSiteTreeID()) {
                 $systemPage = true;
             } else {
                 $cID = ($this->getCollectionPointerOriginalID() > 0) ? $this->getCollectionPointerOriginalID() : $this->getCollectionID();
                 $db = Database::connection();
-                $path = $db->fetchColumn('select cPath from PagePaths where cID = ? and ppIsCanonical = 1', array($cID));
+                $path = $db->fetchColumn('select cPath from PagePaths where cID = ? and ppIsCanonical = 1', [$cID]);
                 if ($path) {
                     // Grab the top level parent
                     $fragments = explode('/', $path);
                     $topPath = '/' . $fragments[1];
                     $c = \Page::getByPath($topPath);
                     if (is_object($c) && !$c->isError()) {
-                        if ($c->getCollectionParentID() == 0 && !$c->isHomePage()) {
+                        if (0 == $c->getCollectionParentID() && !$c->isHomePage()) {
                             $systemPage = true;
                         }
                     }
@@ -2897,17 +2899,17 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
 
         if ($systemPage) {
-            $db->executeQuery('update Pages set cIsSystemPage = 1 where cID = ?', array($cID));
+            $db->executeQuery('update Pages set cIsSystemPage = 1 where cID = ?', [$cID]);
             $this->cIsSystemPage = true;
         } else {
-            $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', array($cID));
+            $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', [$cID]);
             $this->cIsSystemPage = false;
         }
     }
 
     public function isInTrash()
     {
-        return $this->getCollectionPath() != Config::get('concrete.paths.trash') && strpos($this->getCollectionPath(), Config::get('concrete.paths.trash')) === 0;
+        return $this->getCollectionPath() != Config::get('concrete.paths.trash') && 0 === strpos($this->getCollectionPath(), Config::get('concrete.paths.trash'));
     }
 
     public function moveToRoot()
@@ -2999,7 +3001,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $mc = self::getByID($masterCID, 'ACTIVE');
         $nc = self::getByID($newCID, 'RECENT');
         $attributes = CollectionKey::getAttributeValues($mc);
-        foreach($attributes as $attribute) {
+        foreach ($attributes as $attribute) {
             $value = $attribute->getValueObject();
             if ($value) {
                 $value = clone $value;
@@ -3111,7 +3113,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $masterCIDBlocks = null;
         $masterCID = null;
         if ($pt instanceof \Concrete\Core\Page\Type\Type) {
-            if ($pt->getPageTypeHandle() == STACKS_PAGE_TYPE) {
+            if (STACKS_PAGE_TYPE == $pt->getPageTypeHandle()) {
                 $data['cvIsNew'] = 0;
             }
             if ($pt->getPackageID() > 0) {
@@ -3263,16 +3265,16 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     public function getCollectionFullPageCachingLifetimeValue()
     {
-        if ($this->cCacheFullPageContentOverrideLifetime == 'default') {
+        if ('default' == $this->cCacheFullPageContentOverrideLifetime) {
             $lifetime = Config::get('concrete.cache.lifetime');
-        } elseif ($this->cCacheFullPageContentOverrideLifetime == 'custom') {
+        } elseif ('custom' == $this->cCacheFullPageContentOverrideLifetime) {
             $lifetime = $this->cCacheFullPageContentLifetimeCustom * 60;
-        } elseif ($this->cCacheFullPageContentOverrideLifetime == 'forever') {
+        } elseif ('forever' == $this->cCacheFullPageContentOverrideLifetime) {
             $lifetime = 31536000; // 1 year
         } else {
-            if (Config::get('concrete.cache.full_page_lifetime') == 'custom') {
+            if ('custom' == Config::get('concrete.cache.full_page_lifetime')) {
                 $lifetime = Config::get('concrete.cache.full_page_lifetime_value') * 60;
-            } elseif (Config::get('concrete.cache.full_page_lifetime') == 'forever') {
+            } elseif ('forever' == Config::get('concrete.cache.full_page_lifetime')) {
                 $lifetime = 31536000; // 1 year
             } else {
                 $lifetime = Config::get('concrete.cache.lifetime');
@@ -3290,7 +3292,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public static function addStatic($data, TreeInterface $parent = null)
     {
         $db = Database::connection();
-        if ($parent instanceof Page) {
+        if ($parent instanceof self) {
             $cParentID = $parent->getCollectionID();
             $parent->rescanChildrenDisplayOrder();
             $cDisplayOrder = $parent->getNextSubPageDisplayOrder();
@@ -3358,7 +3360,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public function getTotalPageViews($date = null)
     {
         $db = Database::connection();
-        if ($date != null) {
+        if (null != $date) {
             return $db->fetchColumn('select count(pstID) from PageStatistics where date = ? AND cID = ?', [$date, $this->getCollectionID()]);
         } else {
             return $db->fetchColumn('select count(pstID) from PageStatistics where cID = ?', [$this->getCollectionID()]);
@@ -3392,8 +3394,8 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $db = Database::connection();
         $limitString = '';
-        if ($limit != false) {
-            $limitString = 'limit '.$limit;
+        if (false != $limit) {
+            $limitString = 'limit ' . $limit;
         }
 
         if (is_object($this) && $this instanceof self) {

--- a/concrete/views/dialogs/page/add_external.php
+++ b/concrete/views/dialogs/page/add_external.php
@@ -1,29 +1,39 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 <div class="ccm-ui">
 
-    <form class="form-stacked" data-dialog-form="add-external-link" method="post" action="<?=$controller->action('submit')?>">
+    <form class="form-stacked" data-dialog-form="add-external-link" method="post" action="<?=$controller->action('submit'); ?>">
 
         <div class="form-group">
-            <label class="control-label"><?=t('Name')?></label>
-            <input type="text" name="name" value="<?=h($name)?>" class="form-control" autofocus />
+            <label class="control-label"><?=t('Name'); ?></label>
+            <input type="text" name="name" value="<?=h($name); ?>" class="form-control" autofocus />
         </div>
 
         <div class="form-group">
-            <label class="control-label"><?=t('URL')?></label>
-            <input type="text" name="link" value="<?=h($link)?>" class="form-control" />
+            <label class="control-label"><?=t('URL'); ?></label>
+            <input type="text" name="link" value="<?=h($link); ?>" class="form-control" />
+        </div>
+
+        <div class="form-group">
+            <label class="control-label"><?=t('Page Type'); ?></label>
+            <select name="ptID" class="form-control" >
+                <?php foreach ($types as $key => $select) : ?>
+                    <option value="<?php echo $key; ?>"><?php echo $select; ?></option>
+                <?php endforeach; ?>
+            </select>
+
         </div>
 
         <div class="form-group">
             <div class="checkbox">
                 <label><input type="checkbox" <?php if ($openInNewWindow) {
-    ?>checked<?php 
+    ?>checked<?php
 } ?> name="openInNewWindow" value="1"  />
-                    <?=t('Open Link in New Window')?></label>
+                    <?=t('Open Link in New Window'); ?></label>
         </div>
 
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
-            <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?=t('Add')?></button>
+            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel'); ?></button>
+            <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?=t('Add');?></button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
fix for https://github.com/concrete5/concrete5/issues/6553

allow external links to be displayed in page list. Amended the following; 

FROM: 

     if ($this->includeAllDescendents) {
                $this->list->filterByPath(Page::getByID($cParentID)->getCollectionPath());

            } else {
                $this->list->filterByParentID($cParentID);
     }

TO:

     if ($this->includeAllDescendents) {
                $this->list->filterByParentID($cParentID);
            } else {
                $this->list->filterByPath(Page::getByID($cParentID)->getCollectionPath());
     }


Also required the page in question to be assigned to the correct page type. I.e external link created under blog and page list is filtering on blog entry. then external link should be assigned to that page type too. Hopefully this is an appropriate solution. 