### PR TITLE
Add on_block_before_render event

### DIFF
--- a/concrete/src/Block/Events/BlockBeforeRender.php
+++ b/concrete/src/Block/Events/BlockBeforeRender.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Concrete\Core\Block\Events;
+
+class BlockBeforeRender extends BlockEvent
+{
+    /**
+     * @return \Concrete\Core\Block\Block
+     */
+    public function getBlock()
+    {
+        return $this->getSubject();
+    }
+
+    public function preventRendering()
+    {
+        $this->setArgument('render', false);
+    }
+
+    /**
+     * Return true if the block should be rendered.
+     *
+     * @return bool
+     */
+    public function proceed()
+    {
+        // By default the block is rendered
+        if (!$this->hasArgument('render')) {
+            return true;
+        }
+
+        return $this->getArgument('render');
+    }
+}

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -1,7 +1,9 @@
 <?php
 namespace Concrete\Core\Block\View;
 
+use Concrete\Core\Block\Events\BlockBeforeRender;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\View\AbstractView;
 use Config;
 use Area;
@@ -251,6 +253,23 @@ class BlockView extends AbstractView
 
     public function renderViewContents($scopeItems)
     {
+        $shouldRender = function() {
+            $app = Application::getFacadeApplication();
+
+            // If you hook into this event and use `preventRendering()`
+            // you can prevent the block from being displayed.
+            $event = new BlockBeforeRender($this->block);
+            $app->make('director')->dispatch('on_block_before_render', $event);
+
+            return $event->proceed();
+        };
+
+        if (!$shouldRender()) {
+            return;
+        }
+
+        unset($shouldRender);
+
         extract($scopeItems);
         if (!$this->outputContent) {
             ob_start();

--- a/tests/tests/Block/BlockViewTest.php
+++ b/tests/tests/Block/BlockViewTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use Concrete\Core\Block\Block;
+use Concrete\Core\Block\View\BlockView;
+use Concrete\Core\Entity\Block\BlockType\BlockType;
+use Concrete\Core\Support\Facade\Facade;
+use PHPUnit_Framework_TestCase;
+
+class BlockViewTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \Concrete\Core\Application\Application */
+    protected $app;
+
+    public function setUp()
+    {
+        $this->app = Facade::getFacadeApplication();
+    }
+
+    public function testPreventRendering()
+    {
+        /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $director */
+        $director = $this->app->make('director');
+        $block = $this->getMockBlock('autonav');
+
+        $listener = function ($event) {
+            /** @var \Concrete\Core\Block\Events\BlockBeforeRender $event */
+            $event->preventRendering();
+
+            return $event;
+        };
+
+        $director->addListener('on_block_before_render', $listener);
+
+        $view = new BlockView($block);
+
+        ob_start();
+        $view->renderViewContents([]);
+        $this->assertEquals('', ob_get_flush());
+
+        $director->removeListener('on_block_before_render', $listener);
+    }
+
+    protected function getMockBlock($handle, $bFilename = null)
+    {
+        $blockType = $this->getMockBuilder(BlockType::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $blockType->expects($this->any())
+            ->method('getBlockTypeHandle')
+            ->will($this->returnValue($handle));
+
+        $controller = 'Concrete\\Block\\' . camelcase($handle) . '\\Controller';
+        $controller = $this->getMockBuilder($controller)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $block = $this->getMockBuilder(Block::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $block->expects($this->any())
+            ->method('getBlockTypeHandle')
+            ->will($this->returnValue($handle));
+        $block->expects($this->any())
+            ->method('getInstance')
+            ->will($this->returnValue($controller));
+        $block->expects($this->any())
+            ->method('getBlockTypeObject')
+            ->will($this->returnValue($blockType));
+        $block->expects($this->any())
+            ->method('getBlockFilename')
+            ->will($this->returnValue($bFilename));
+
+        return $block;
+    }
+}


### PR DESCRIPTION
This will trigger an event when the block is about to be rendered*. Hooking into this event makes it possible to prevent it from displaying. 

## Example code to prevent displaying

```php
Events::addListener('on_block_before_render', function ($event) {
    $event->preventRendering();

    return $event;
});
```

## Output

![afbeelding](https://user-images.githubusercontent.com/1431100/38501842-3666e0f8-3c0e-11e8-93b4-5f2802a77d78.png)

---

*) for naming convention see also https://github.com/concrete5/concrete5/issues/6574