### PR TITLE
Better ADA compliance form field labels

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -740,7 +740,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
         return SelectSettings::class;
     }
 
-    public function getLabelID()
+    public function getControlID()
     {
         return $this->field('atSelectOptionValue');
     }

--- a/concrete/authentication/concrete/forgot_password.php
+++ b/concrete/authentication/concrete/forgot_password.php
@@ -9,7 +9,8 @@
 			<?= t('Enter your email address below. We will send you instructions to reset your password.') ?>
 		</div>
 		<div class="form-group">
-			<input name="uEmail" type="email" placeholder="<?= t('Email Address') ?>" class="form-control" />
+			<label class="control-label" for="uEmail"><?= t('Email Address') ?></label>
+			<input name="uEmail" type="email" id="uEmail" class="form-control" />
 		</div>
 		<button name="resetPassword" class="btn btn-primary btn-block"><?= t('Reset and Email Password') ?></button>
 	</form>

--- a/concrete/authentication/concrete/form.php
+++ b/concrete/authentication/concrete/form.php
@@ -6,13 +6,13 @@ $form = Core::make('helper/form');
 <form method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()) ?>">
 
 	<div class="form-group">
-		<label class="control-label"><?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('Username')?></label>
-		<input name="uName" class="form-control" autofocus="autofocus" />
+		<label class="control-label" for="uName"><?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('Username')?></label>
+		<input name="uName" id="uName" class="form-control" autofocus="autofocus" />
 	</div>
 
 	<div class="form-group">
-		<label class="control-label"><?=t('Password')?></label>
-		<input name="uPassword" class="form-control" type="password" />
+		<label class="control-label" for="uPassword"><?=t('Password')?></label>
+		<input name="uPassword" id="uPassword" class="form-control" type="password" />
 	</div>
 
 	<div class="checkbox">

--- a/concrete/controllers/panel/detail/page/attributes.php
+++ b/concrete/controllers/panel/detail/page/attributes.php
@@ -48,6 +48,7 @@ class Attributes extends BackendInterfacePageController
         $html = ob_get_contents();
         ob_end_clean();
         $obj = new stdClass();
+        $obj->controlID = $ak->getController()->getControlID();
         $obj->akID = $ak->getAttributeKeyID();
         $obj->label = $ak->getAttributeKeyDisplayName();
         $obj->content = $html;

--- a/concrete/elements/express/form/form/association/select.php
+++ b/concrete/elements/express/form/form/association/select.php
@@ -2,14 +2,14 @@
 
 <div class="form-group">
     <?php if ($view->supportsLabel()) { ?>
-        <label class="control-label"><?=$label?></label>
+        <label class="control-label" for="<?=$view->getControlID()?>"><?=$label?></label>
     <?php } ?>
 
     <?php
     if (!empty($entities)) {
         $selectedEntity = $selectedEntities[0];
         ?>
-        <select class="form-control" name="express_association_<?=$control->getId()?>">
+        <select class="form-control" id="<?=$view->getControlID()?>" name="express_association_<?=$control->getId()?>">
             <option value=""><?=t('** Choose %s', $control->getControlLabel())?></option>
             <?php
             foreach ($entities as $entity) {

--- a/concrete/elements/form/bootstrap3.php
+++ b/concrete/elements/form/bootstrap3.php
@@ -4,7 +4,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <div class="form-group">
     <?php if ($view->supportsLabel()) { ?>
-        <label class="control-label"><?=$view->getLabel()?></label>
+        <label class="control-label" for="<?=$view->getControlID()?>"><?=$view->getLabel()?></label>
     <?php } ?>
 
     <?php if ($view->isRequired()) { ?>

--- a/concrete/elements/form/composer.php
+++ b/concrete/elements/form/composer.php
@@ -4,7 +4,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <div class="form-group">
     <?php if ($view->supportsLabel()) { ?>
-        <label class="control-label"><?=$view->getLabel()?></label>
+        <label class="control-label" for="<?=$view->getControlID()?>"><?=$view->getLabel()?></label>
     <?php } ?>
 
     <?php if ($context->isRequired()) : ?>

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -421,8 +421,18 @@ class Controller extends AbstractController implements AttributeInterface
     }
 
     /**
+     * Get the ID to use for label elements. Not applicable in form views that do
+     * not contain <label>
+     * @return string
+     */
+    public function getControlID()
+    {
+        return $this->field('value');
+    }
+
+    /**
      * Get the ID to use for label elements.
-     *
+     * @deprecated
      * @return string
      */
     public function getLabelID()
@@ -431,6 +441,8 @@ class Controller extends AbstractController implements AttributeInterface
     }
 
     /**
+     * @deprecated . This should be handled by the templates including <label> tags and using
+     * getControlID() within them.
      * @param string|bool $customText
      */
     public function label($customText = false)

--- a/concrete/src/Attribute/Form/Control/View/View.php
+++ b/concrete/src/Attribute/Form/Control/View/View.php
@@ -37,6 +37,11 @@ class View extends BaseFormView
         $this->addScopeItem('key', $key);
     }
 
+    public function getControlID()
+    {
+        return $this->key->getController()->getControlID();
+    }
+
     public function createTemplateLocator()
     {
         $locator = new TemplateLocator();

--- a/concrete/src/Entity/Attribute/Key/Key.php
+++ b/concrete/src/Entity/Attribute/Key/Key.php
@@ -30,6 +30,8 @@ class Key implements AttributeKeyInterface, ExportableInterface, ControlInterfac
 {
     use PackageTrait;
 
+    protected $controller;
+
     protected $settings;
 
     /**
@@ -215,9 +217,11 @@ class Key implements AttributeKeyInterface, ExportableInterface, ControlInterfac
 
     public function getController()
     {
-        $controller = $this->type->getController();
-        $controller->setAttributeKey($this);
-        return $controller;
+        if (!isset($this->controller)) {
+            $this->controller = $this->type->getController();
+            $this->controller->setAttributeKey($this);
+        }
+        return $this->controller;
     }
 
     public function getAttributeKeyCategoryHandle()

--- a/concrete/src/Express/Form/Control/View/AssociationView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationView.php
@@ -16,6 +16,11 @@ class AssociationView extends View
     protected $allEntities = [];
     protected $selectedEntities = [];
 
+    public function getControlID()
+    {
+        return 'express_association_' . $this->control->getID();
+    }
+
     public function __construct(ContextInterface $context, Control $control)
     {
         parent::__construct($context, $control);

--- a/concrete/src/Express/Form/Control/View/AttributeKeyFormView.php
+++ b/concrete/src/Express/Form/Control/View/AttributeKeyFormView.php
@@ -33,6 +33,11 @@ class AttributeKeyFormView extends BaseFormView
         }
     }
 
+    public function getControlID()
+    {
+        return $this->key->getController()->getControlID();
+    }
+
     public function createTemplateLocator()
     {
         return $this->view->createTemplateLocator();

--- a/concrete/src/Express/Form/Control/View/TextView.php
+++ b/concrete/src/Express/Form/Control/View/TextView.php
@@ -9,6 +9,10 @@ use Concrete\Core\Form\Context\ContextInterface;
 class TextView extends View
 {
 
+    public function getControlID()
+    {
+        return false;
+    }
 
     public function createTemplateLocator()
     {

--- a/concrete/src/Form/Control/FormViewInterface.php
+++ b/concrete/src/Form/Control/FormViewInterface.php
@@ -7,4 +7,5 @@ interface FormViewInterface extends ViewInterface
     function getLabel();
     function setLabel($label);
     function supportsLabel();
+    function getControlID();
 }

--- a/concrete/views/panels/details/page/attributes.php
+++ b/concrete/views/panels/details/page/attributes.php
@@ -5,7 +5,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 <script type="text/template" class="attribute">
 	<div class="form-group <% if (pending) { %>ccm-page-attribute-adding<% } %>" data-attribute-key-id="<%=akID%>">
 		<a href="javascript:void(0)" data-remove-attribute-key="<%=akID%>"><i class="fa fa-minus-circle"></i></a>
-		<label class="control-label"><%=label%></label>
+		<label class="control-label" for="<%=controlID%>"><%=label%></label>
 		<div>
 			<%=content%>
 		</div>


### PR DESCRIPTION
1. Adds for="" attributes to login forms and forgot password forms.
2. Adds for="" attributes to all attributes that use <label>'s in the standard way (text attributes, select attributes using the select tag, telephone, URL, number, etc...) 
3. Adds for="" attributes to Express form association controls.