### PR TITLE
Add on_block_duplicate event

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1648,6 +1648,11 @@ class Block extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
                 );
         }
 
+        $event = $app->make(\Concrete\Core\Block\Events\BlockDuplicate::class, ['subject' => $nb]);
+        $event->setOldBlock($this);
+
+        $app->make('director')->dispatch('on_block_duplicate', $event);
+
         return $nb;
     }
 

--- a/concrete/src/Block/Events/BlockDuplicate.php
+++ b/concrete/src/Block/Events/BlockDuplicate.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Concrete\Core\Block\Events;
+
+class BlockDuplicate extends BlockEvent
+{
+    /**
+     * @return \Concrete\Core\Block\Block
+     */
+    public function getNewBlock()
+    {
+        return $this->getSubject();
+    }
+
+    /**
+     * @return \Concrete\Core\Block\Block
+     */
+    public function getOldBlock()
+    {
+        return $this->getArgument('oldBlock');
+    }
+
+    public function setOldBlock($block)
+    {
+        $this->setArgument('oldBlock', $block);
+    }
+}


### PR DESCRIPTION
This will trigger an event when a block is duplicated.

Example code to listen to this event

```php
Events::addListener('on_block_duplicate', function ($event) {
    /** @var \Concrete\Core\Block\Events\BlockDuplicate $event */
    $oldBlock = $event->getOldBlock();
    $newBlock = $event->getNewBlock();
});
```
