### PR TITLE
Remove 'More Details' link from package upgrade page

### DIFF
--- a/concrete/js/build/core/app/remote-marketplace.js
+++ b/concrete/js/build/core/app/remote-marketplace.js
@@ -3,12 +3,6 @@
     'use strict';
 
     var ConcreteMarketplace = {
-
-        updatesShowMore: function(obj) {
-            $(obj).parent().hide();
-            $(obj).parent().parent().find('.ccm-marketplace-update-changelog').css('max-height', 'none');
-        },
-
         getMoreInformation: function(mpID)
         {
             jQuery.fn.dialog.showLoader();

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -79,9 +79,6 @@ if (!$tp->canInstallPackages()) {
 								<h6><?=t('Version History')?></h6>
 								<?=$versionHistory?>
 							</div>
-							<div class="ccm-marketplace-item-information-more">
-								<a href="javascript:void(0)" onclick="ConcreteMarketplace.updatesShowMore(this)"><?=t('More Details')?></a>
-							</div>
 						<?php 
 }
     ?>
@@ -121,9 +118,6 @@ if (!$tp->canInstallPackages()) {
 							<div class="ccm-marketplace-update-changelog">
 								<h6><?=t('Version History')?></h6>
 								<?=$versionHistory?>
-							</div>
-							<div class="ccm-marketplace-item-information-more">
-								<a href="javascript:void(0)" onclick="ConcreteMarketplace.updatesShowMore(this)"><?=t('More Details')?></a>
 							</div>
 						<?php 
 }


### PR DESCRIPTION
I noticed that the link "More Details" doesn't do anything. There is [no `max-height`](https://github.com/concrete5/concrete5/search?utf8=%E2%9C%93&q=ccm-marketplace-update-changelog&type=) set to the `ccm-marketplace-update-changelog` wrapping div.

This PR removes the links and the corresponding JavaScript.

---

The yellow link will be removed:

![afbeelding](https://user-images.githubusercontent.com/1431100/38565566-f1862b68-3ce1-11e8-9d9d-c27d31c010f5.png)
