### PR TITLE
Add IPv6 user to test instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,9 @@ You need to create a MySQL account with login `travis` and an empty password, an
 
 ```sql
 CREATE USER 'travis'@'localhost' IDENTIFIED BY '';
+CREATE USER 'travis'@'::1' IDENTIFIED BY '';
 GRANT ALL ON concrete5_tests.* TO 'travis'@'localhost' WITH GRANT OPTION;
+GRANT ALL ON concrete5_tests.* TO 'travis'@'::1' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 ```
 


### PR DESCRIPTION
Adding an additional user for the `::1` hostname, solved running the tests for me on Windows. This PR updates the instructions in the README.

```
$ composer test
> phpunit
Doctrine\DBAL\Driver\PDOException: SQLSTATE[HY000] [1045] Access denied for user 'travis'@'::1' (using password: NO) in file C:\dev\c5\concrete\vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\PDOConnection.php on line 47
```