### PR TITLE
Add instructions to run a single test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -63,6 +63,11 @@ Expected output is something like
 	Tests: 1366, Assertions: 3413, Skipped: 6, Incomplete: 6.
 
 
+To run a single tests, you can run for example
+```bash
+composer test -- --filter testCoreBlockView
+```
+
 # Write Tests!
 
 Send us tests via pull request:


### PR DESCRIPTION
Running all tests takes ages and it's not immediately clear how one could run a single test. This PR adds an example of how to run a single test.

```bash
composer test -- --filter testCoreBlockView
```