### PR TITLE
Fix booting package object in test class

### DIFF
--- a/tests/tests/Block/BlockViewTemplateTest.php
+++ b/tests/tests/Block/BlockViewTemplateTest.php
@@ -89,7 +89,7 @@ class BlockViewTemplateTest extends PHPUnit_Framework_TestCase
 
     protected function getMockPackageList($handles = [])
     {
-        // First, we create the package list we're going to use. It's going to have three mock packages in it
+        // First, we create the package list we're going to use.
         $packages = [];
         foreach ($handles as $pkgHandle) {
             $pkg = $this->getMockBuilder(Package::class)

--- a/tests/tests/Block/BlockViewTemplateTest.php
+++ b/tests/tests/Block/BlockViewTemplateTest.php
@@ -92,8 +92,14 @@ class BlockViewTemplateTest extends PHPUnit_Framework_TestCase
         // First, we create the package list we're going to use. It's going to have three mock packages in it
         $packages = [];
         foreach ($handles as $pkgHandle) {
-            $pkg = new Package();
-            $pkg->setPackageHandle($pkgHandle);
+            $pkg = $this->getMockBuilder(Package::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $pkg->expects($this->any())
+                ->method('getPackageHandle')
+                ->willReturn($pkgHandle);
+
             $packages[] = $pkg;
         }
         $packageList = $this->getMockBuilder(PackageList::class)


### PR DESCRIPTION
We can't use `$pkg = new Package();`, because the Application parameter is required. 

This PR uses mocks of the Package object instead.

