### PR TITLE
Change merge order of CKEditor config options to enable overrides

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -151,7 +151,7 @@ EOL;
 
         $customConfigOptions = $this->config->get('editor.ckeditor4.custom_config_options');
         if ($customConfigOptions) {
-            $options = array_merge($customConfigOptions, $options);
+            $options = array_merge($options, $customConfigOptions);
         }
 
         $options = json_encode($options);


### PR DESCRIPTION
In 8.3 @MrKarlDilkington  added some configuration options to the Ckeditor that allow us to customize it's behaviour.
However, the order in wich the options are merged prevents us from overriding options already set in
\concrete\src\Editor\CkeditorEditor.php - This PR changes merge order to enable us to override those settings in config.

## Why is this necessary?
The way "allowedContent" config options is set to true in the core completely disables all Advanced Content Filtering features of CKEditor.
We would like to make use of these features in order to filter content that is pasted from MS Word and other external sources.
This allows us to override the option in config and add more sophisticated content/ paste filtering.
