### PR TITLE
Avoid the need of a fixed dictionary for the mutex system

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1579,10 +1579,4 @@ return [
         'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
         'core_thumbnails' => '\Concrete\Core\Http\Middleware\ThumbnailMiddleware',
     ],
-
-    // Registered mutex keys
-    'mutex' => [
-        'core_system_install' => true,
-        'core_system_upgrade' => true,
-    ],
 ];

--- a/concrete/src/System/Mutex/InvalidMutexKeyException.php
+++ b/concrete/src/System/Mutex/InvalidMutexKeyException.php
@@ -5,32 +5,32 @@ namespace Concrete\Core\System\Mutex;
 use RuntimeException;
 
 /**
- * Exception thrown when a mutex key is not defined in the app.mutex configuration key.
+ * Exception thrown when a mutex key is not valid.
  */
 class InvalidMutexKeyException extends RuntimeException
 {
     /**
      * The mutex key.
      *
-     * @var string
+     * @var mixed
      */
     protected $mutexKey;
 
     /**
      * Initialize the instance.
      *
-     * @param string $mutexKey The mutex key
+     * @param mixed $mutexKey The invalid mutex key
      */
     public function __construct($mutexKey)
     {
         $this->mutexKey = (string) $mutexKey;
-        parent::__construct(t(/*i18n: A mutex is a system object that represents a system to run code; usually this word shouldn't be translated */'The mutex with key "%1$s" is not defined in the "%2$s" configuration key.', $this->mutexKey, 'app.mutex'));
+        parent::__construct(t(/*i18n: A mutex is a system object that represents a system to run code; usually this word shouldn't be translated */'The mutex with key "%s" is not valid.', $this->mutexKey));
     }
 
     /**
-     * Get the mutex key.
+     * Get the invalid mutex key.
      *
-     * @return string
+     * @return mixed
      */
     public function getMutexKey()
     {

--- a/concrete/src/System/SystemServiceProvider.php
+++ b/concrete/src/System/SystemServiceProvider.php
@@ -20,6 +20,13 @@ class SystemServiceProvider extends ServiceProvider
             return $app->make($mutexClass);
         });
         $this->app
+            ->when(Mutex\SemaphoreMutex::class)
+            ->needs('$temporaryDirectory')
+            ->give(function (Application $app) {
+                return $app->make(FileService::class)->getTemporaryDirectory();
+            })
+        ;
+        $this->app
             ->when(Mutex\FileLockMutex::class)
             ->needs('$temporaryDirectory')
             ->give(function (Application $app) {


### PR DESCRIPTION
Having a fixed dictionary for mutex keys can limit what we can do with mutexes.

Let's avoid this limit.