### PR TITLE
allow page controllers to return searchable content

### DIFF
--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -345,4 +345,12 @@ class PageController extends Controller
     {
         return false;
     }
+
+    /**
+     * Override this method to send content created by the page controller to the indexer
+     */
+    public function getSearchableContent()
+    {
+        return;
+    }
 }

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -231,6 +231,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $env = Environment::get();
             if ($this->getPageTypeID() > 0) {
                 $pt = $this->getPageTypeObject();
+                // return null if page type doesn't exist anymore
+                if (!$pt) {
+                    return;
+                }
                 $ptHandle = $pt->getPageTypeHandle();
                 $r = $env->getRecord(DIRNAME_CONTROLLERS.'/'.DIRNAME_PAGE_TYPES.'/'.$ptHandle.'.php', $pt->getPackageHandle());
                 $prefix = $r->override ? true : $pt->getPackageHandle();

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -153,6 +153,25 @@ class IndexedSearch
             }
         }
 
+        // add content defined by a page type controller
+        $pageControllerTypeObject = $c->getPageTypeObject();
+
+        // getting the page controller frequently fails, for example if there's an inconsistent page type,
+        // let's just ignore those exceptions to not break the indexer for existing projects.
+        if ($pageControllerTypeObject) {
+            $pageController = $c->getPageController();
+
+            $searchableContent = $pageController->getSearchableContent();
+
+            if (strlen(trim($searchableContent))) {
+                $text .= $th->decodeEntities(
+                        strip_tags(str_ireplace($tagsToSpaces, ' ', $searchableContent)),
+                        ENT_QUOTES,
+                        APP_CHARSET
+                    ) . ' ';
+            }
+        }
+
         return $text;
     }
 

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -154,13 +154,7 @@ class IndexedSearch
         }
 
         // add content defined by a page type controller
-        $pageControllerTypeObject = $c->getPageTypeObject();
-
-        // getting the page controller frequently fails, for example if there's an inconsistent page type,
-        // let's just ignore those exceptions to not break the indexer for existing projects.
-        if ($pageControllerTypeObject) {
-            $pageController = $c->getPageController();
-
+        if ($pageController = $c->getPageController()) {
             $searchableContent = $pageController->getSearchableContent();
 
             if (strlen(trim($searchableContent))) {

--- a/tests/tests/Attribute/CollectionAttributeTest.php
+++ b/tests/tests/Attribute/CollectionAttributeTest.php
@@ -31,6 +31,7 @@ class CollectionAttributeTest extends AttributeTestCase
             'CollectionAttributeValues',
             'Pages',
             'PageSearchIndex',
+            'PageTypes',
             'CollectionSearchIndexAttributes',
             'CollectionVersions',
             'CollectionVersionBlocks',


### PR DESCRIPTION
I've had to add a check for `getPageTypeObject`. When I tested this change a received a lot of exception when calling `$c->getPageController()` due to a null object.
