### PR TITLE
Check is object to avoid error on search express entities

### DIFF
--- a/concrete/src/Express/Search/Column/AssociationColumn.php
+++ b/concrete/src/Express/Search/Column/AssociationColumn.php
@@ -18,12 +18,16 @@ class AssociationColumn extends Column
 
     public function getColumnKey()
     {
-        return 'association_' . $this->association->getId();
+        if (is_object($this->association)) {
+            return 'association_' . $this->association->getId();
+        }
     }
 
     public function getColumnName()
     {
-        return $this->association->getTargetEntity()->getName();
+        if (is_object($this->association)) {
+            return $this->association->getTargetEntity()->getName();
+        }
     }
 
     public function getAssociation()


### PR DESCRIPTION
Please check `$this->association` is the object like `getColumnValue` method. It may be null when the class is wakeup