### PR TITLE
Backup before update warning message

### DIFF
--- a/concrete/single_pages/dashboard/system/update/update.php
+++ b/concrete/single_pages/dashboard/system/update/update.php
@@ -13,9 +13,10 @@ if ($canUpgrade) {
         </a>
     </div>
 
-
-   <?php if (is_object($update)) {
-    ?>
+   <?php if (is_object($update)) { ?>
+        <div class="alert alert-warning">
+            <p><?= t('Before updating, it is highly recommended to make a full site backup. A full site backup consists of site files and site database export. Please consult your hosting provider for guidance on backup processes.'); ?></p>
+        </div>
 
         <div class="ccm-dashboard-update-details-wrapper">
 


### PR DESCRIPTION
It appears to be fairly common that users apply version updates on production sites without making a backup first. A warning may help remind them that backups should be done before all updates.

**Current:**

![backup_warning-current](https://user-images.githubusercontent.com/10898145/39105755-9fceea3c-4685-11e8-8d54-9a9dcade1c06.png)

![backup_warning2-current](https://user-images.githubusercontent.com/10898145/39106287-b2fd6acc-4688-11e8-9dd3-6e402de35cee.png)

**Changes:**

![backup_warning-current](https://user-images.githubusercontent.com/10898145/39105755-9fceea3c-4685-11e8-8d54-9a9dcade1c06.png)

![backup_warning_1-changes](https://user-images.githubusercontent.com/10898145/39105758-a251371a-4685-11e8-9f9e-40cda585d29b.png)



