### PR TITLE
Test concrete5 on Windows with the latest PHP 7.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,5 @@
+version: "Build {build}"
+
 environment:
   matrix:
     - PHP_VERSION: '7.1'
@@ -75,6 +77,7 @@ install:
               Write-Output -InputObject 'Installing PhpManager PowerShell module'
               Install-Module -Name PhpManager -Repository PSGallery -Scope AllUsers -Force
           }
+          Set-PhpDownloadCache -Path C:\tools\downloads
           Install-Php -Version $Env:PHP_VERSION -Architecture $Env:PHP_ARCHITECTURE -ThreadSafe $false -Path $phpInstallPath -TimeZone UTC -AddToPath System -InitialPhpIni Production -InstallVC -Force
           Set-PhpIniKey -Key date.timezone -Value UTC
           Set-PhpIniKey -Key zend.assertions -Value 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,16 +82,7 @@ install:
           Set-PhpIniKey -Key date.timezone -Value UTC
           Set-PhpIniKey -Key zend.assertions -Value 1
           Set-PhpIniKey -Key assert.exception -Value On
-          Enable-PhpExtension -Extension mbstring
-          Enable-PhpExtension -Extension bz2
-          Enable-PhpExtension -Extension mysqli
-          Enable-PhpExtension -Extension curl
-          Enable-PhpExtension -Extension gd
-          Enable-PhpExtension -Extension intl
-          Enable-PhpExtension -Extension pdo_mysql
-          Enable-PhpExtension -Extension xsl
-          Enable-PhpExtension -Extension fileinfo
-          Enable-PhpExtension -Extension openssl
+          Enable-PhpExtension -Extension mbstring,bz2,mysqli,curl,gd,intl,pdo_mysql,xsl,fileinfo,openssl
           New-Item -ItemType File -Path "$phpInstallPath\php-installed.txt" | Out-Null
       }
   - composer install --no-progress --no-suggest --optimize-autoloader --no-ansi --no-interaction %PREFER_LOWEST%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,115 +1,96 @@
 environment:
   matrix:
-    - PLATFORM: x86
-      PHP_VERSION: '7.1.15'
-      VC_VERSION: '14'
+    - PHP_VERSION: '7.1'
+      PHP_ARCHITECTURE: x86
       PREFER_LOWEST: 
 
 matrix:
   fast_finish: true
 
-init:
-  - set PATH=C:\tools;C:\tools\php-%PHP_VERSION%;C:\Program Files\MySQL\MySQL Server 5.7\bin;C:\tools\gettext\bin;%PATH%
-  - set MYSQL_PWD=Password12!
-
 clone_depth: 50
 
 cache:
   - C:\tools\downloads -> .appveyor.yml
+  - '%ProgramFiles%\WindowsPowerShell\Modules\VcRedist -> .appveyor.yml'
+  - '%ProgramFiles%\WindowsPowerShell\Modules\PhpManager -> .appveyor.yml'
   - '%LOCALAPPDATA%\Composer\files'
 
 services:
   - mysql
 
+init:
+  - set PATH=C:\Program Files\MySQL\MySQL Server 5.7\bin;%PATH%
+  - set MYSQL_PWD=Password12!
+
 install:
   - ps: |
-      $ProgressPreference = "SilentlyContinue"
-      $ErrorActionPreference = "Stop"
-      [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-      If(-Not(Test-Path -Path "C:\tools")) {
-          Write-Host "Creating tools directory"
-          New-Item -ItemType Directory -Path "C:\tools" | Out-Null
+      # Setup a sane environment
+      $ProgressPreference = 'SilentlyContinue'
+      $ErrorActionPreference = 'Stop'
+      $ConfirmPreference = 'None'
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 + [Net.SecurityProtocolType]::Tls11 + [Net.SecurityProtocolType]::Tls
+      # Setup the directory structure
+      If (-Not(Test-Path -PathType Container -Path C:\tools)) {
+          Write-Output -InputObject 'Creating tools directory'
+          New-Item -ItemType Directory -Path C:\tools | Out-Null
       }
-      If(-Not(Test-Path -Path "C:\tools\downloads")) {
-          Write-Host "Creating download directory"
-          New-Item -ItemType Directory -Path "C:\tools\downloads" | Out-Null
+      If (-Not(Test-Path -PathType Container -Path C:\tools\downloads)) {
+          Write-Output -InputObject 'Creating download directory'
+          New-Item -ItemType Directory -Path 'C:\tools\downloads' | Out-Null
       }
-      Set-Location -Path C:\tools\downloads
-      $PHP_ZIP = "php-" + $env:PHP_VERSION + "-Win32-VC" + $env:VC_VERSION + "-" + $env:PLATFORM + ".zip"
-      If(-Not(Test-Path $PHP_ZIP)) {
-          Try {
-              Write-Host "Downloading PHP (release)"
-              Invoke-WebRequest $("http://windows.php.net/downloads/releases/" + $PHP_ZIP) -OutFile $PHP_ZIP
-          } Catch {
-              Try {
-                  Write-Host "Downloading PHP (archived)"
-                  Invoke-WebRequest $("http://windows.php.net/downloads/releases/archives/" + $PHP_ZIP) -OutFile $PHP_ZIP
-              } Catch {
-                  Write-Host "Downloading PHP (QA)"
-                  Invoke-WebRequest $("http://windows.php.net/downloads/releases/qa/" + $PHP_ZIP) -OutFile $PHP_ZIP
-              }
+      # Setup gettext & iconv
+      If (-Not(Test-Path -PathType Leaf -Path C:\tools\gettext\bin\msgen.exe)) {
+          If (-Not(Test-Path -PathType Container -Path C:\tools\gettext)) {
+              Write-Output -InputObject 'Creating gettext directory'
+              New-Item -ItemType Directory -Path C:\tools\gettext | Out-Null
           }
-      }
-      $GETTEXT_ZIP = "gettext0.19.8.1-iconv1.15-shared-32.zip"
-      If(-Not(Test-Path $GETTEXT_ZIP)) {
-          Write-Host "Downloading gettext"
-          Invoke-WebRequest $("https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.15/" + $GETTEXT_ZIP) -OutFile $GETTEXT_ZIP
-      }
-      If(-Not(Test-Path "composer.phar")) {
-          Write-Host "Downloading composer"
-          Invoke-WebRequest "https://getcomposer.org/download/1.6.3/composer.phar" -OutFile "composer.phar"
-      }
-      Set-Location -Path "C:\tools"
-      If(-Not(Test-Path -Path $("php-" + $env:PHP_VERSION))) {
-          Write-Host "Creating PHP directory"
-          New-Item -ItemType Directory -Path $("php-" + $env:PHP_VERSION) | Out-Null
-      }
-      Set-Location -Path $("php-" + $env:PHP_VERSION)
-      If(-Not(Test-Path -Path "php.exe")) {
-          Write-Host "Extracting PHP"
-          (7z.exe x -bd -y -- $("..\downloads\" + $PHP_ZIP)) | Out-Null
-          If(-Not($?)) {
-              throw "7z failed!"
+          If (-Not(Test-Path -PathType Leaf -Path C:\tools\downloads\gettext-iconv.zip)) {
+              Write-Output -InputObject 'Downloading gettext & iconv'
+              Invoke-WebRequest -Uri https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.15/gettext0.19.8.1-iconv1.15-shared-32.zip -OutFile C:\tools\downloads\gettext-iconv.zip
           }
+          Write-Output -InputObject 'Extracting gettext & iconv'
+          Expand-Archive -Path C:\tools\downloads\gettext-iconv.zip -DestinationPath C:\tools\gettext -Force
       }
-      If(-Not(Test-Path -Path "php-installed.txt")) {
-          Write-Host "Creating php.ini"
-          Copy-Item -Path "php.ini-development" -Destination "php.ini"
-          Add-Content -Path "php.ini" -Value "date.timezone=""UTC"""
-          Add-Content -Path "php.ini" -Value "extension_dir=ext"
-          Add-Content -Path "php.ini" -Value "extension=php_mbstring.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_bz2.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_mysqli.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_curl.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_gd2.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_intl.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_pdo_mysql.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_xsl.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_fileinfo.dll"
-          Add-Content -Path "php.ini" -Value "extension=php_openssl"
-          Add-Content -Path "php.ini" -Value "zend.assertions=1"
-          Add-Content -Path "php.ini" -Value "assert.exception=On"
-          New-Item -ItemType File "php-installed.txt" | Out-Null
+      $Env:Path = 'C:\tools\gettext\bin;' + $Env:Path
+      # Setup composer
+      If (-Not(Test-Path -PathType Leaf -Path C:\tools\downloads\composer.phar)) {
+          Write-Output -InputObject 'Downloading composer'
+          Invoke-WebRequest -Uri https://getcomposer.org/download/1.6.4/composer.phar -OutFile C:\tools\downloads\composer.phar
       }
-      Set-Location -Path "C:\tools"
-      If(-Not(Test-Path -Path "composer.bat")) {
-          Write-Host "Creating composer.bat"
-          Add-Content -Path "composer.bat" -Value "@php C:\tools\downloads\composer.phar %*"
+      If (-Not(Test-Path -PathType Leaf -Path C:\tools\composer.bat)) {
+          Write-Output -InputObject 'Creating composer.bat'
+          Add-Content -Path C:\tools\composer.bat -Value '@php C:\tools\downloads\composer.phar %*'
       }
-      If(-Not(Test-Path -Path "gettext")) {
-          Write-Host "Creating gettext directory"
-          New-Item -ItemType Directory -Path "gettext" | Out-Null
-      }
-      Set-Location -Path "C:\tools\gettext"
-      If(-Not(Test-Path -Path "bin\msgen.exe ")) {
-          Write-Host "Extracting gettext"
-          (7z.exe x -bd -y -- $("..\downloads\" + $GETTEXT_ZIP)) | Out-Null
-          If(-Not($?)) {
-              throw "7z failed!"
+      $Env:Path = 'C:\tools;' + $Env:Path
+      # Setup PHP
+      $phpInstallPath = 'C:\tools\php-' + $Env:PHP_VERSION
+      If (Test-Path -PathType Leaf -Path "$phpInstallPath\php-installed.txt") {
+          $Env:Path = $phpInstallPath + $Env:Path
+      } Else {
+          If (-Not(Get-Module -Name VcRedist) -and -Not(Get-Module -ListAvailable | Where-Object { $_.Name -eq 'VcRedist' })) {
+              Write-Output -InputObject 'Installing VcRedist PowerShell module'
+              Install-Module -Name VcRedist -Repository PSGallery -Scope AllUsers -Force
           }
+          If (-Not(Get-Module -Name PhpManager) -and -Not(Get-Module -ListAvailable | Where-Object { $_.Name -eq 'PhpManager' })) {
+              Write-Output -InputObject 'Installing PhpManager PowerShell module'
+              Install-Module -Name PhpManager -Repository PSGallery -Scope AllUsers -Force
+          }
+          Install-Php -Version $Env:PHP_VERSION -Architecture $Env:PHP_ARCHITECTURE -ThreadSafe $false -Path $phpInstallPath -TimeZone UTC -AddToPath System -InitialPhpIni Production -InstallVC -Force
+          Set-PhpIniKey -Key date.timezone -Value UTC
+          Set-PhpIniKey -Key zend.assertions -Value 1
+          Set-PhpIniKey -Key assert.exception -Value On
+          Enable-PhpExtension -Extension mbstring
+          Enable-PhpExtension -Extension bz2
+          Enable-PhpExtension -Extension mysqli
+          Enable-PhpExtension -Extension curl
+          Enable-PhpExtension -Extension gd
+          Enable-PhpExtension -Extension intl
+          Enable-PhpExtension -Extension pdo_mysql
+          Enable-PhpExtension -Extension xsl
+          Enable-PhpExtension -Extension fileinfo
+          Enable-PhpExtension -Extension openssl
+          New-Item -ItemType File -Path "$phpInstallPath\php-installed.txt" | Out-Null
       }
-      Set-Location -Path $env:APPVEYOR_BUILD_FOLDER
-  - cd /D "%APPVEYOR_BUILD_FOLDER%"
   - composer install --no-progress --no-suggest --optimize-autoloader --no-ansi --no-interaction %PREFER_LOWEST%
 
 build: off


### PR DESCRIPTION
Let's use the [PhpManager](https://www.powershellgallery.com/packages/PhpManager) PowerShell package to install and configure PHP in AppVeyor.