### PR TITLE
Add alt attribute to generic thumbnail icons to increase accessibility

### DIFF
--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -408,7 +408,14 @@ class Type
             $url = AL_ICON_DEFAULT;
         }
         if ($fullImageTag == true) {
-            return sprintf('<img src="%s" width="%s" height="%s" class="img-responsive ccm-generic-thumbnail">', $url, $type->getWidth(), $type->getHeight());
+            return sprintf(
+                '<img src="%s" width="%s" height="%s" class="img-responsive ccm-generic-thumbnail" alt="%s %s">',
+                $url,
+                $type->getWidth(),
+                $type->getHeight(),
+                strtoupper($this->getExtension()),
+                tc('GenericThumbnailIcon', 'file icon')
+            );
         } else {
             return $url;
         }


### PR DESCRIPTION
https://github.com/concrete5/concrete5/issues/6618

**Current:**

![generic_thumbnail_icon_alt-current](https://user-images.githubusercontent.com/10898145/39541949-2e44c228-4e15-11e8-89f7-a9c4b7dec6e1.png)

**Changes:**

![generic_thumbnail_icon_alt-changes](https://user-images.githubusercontent.com/10898145/39541955-3163a442-4e15-11e8-9c68-65628f1e4009.png)
