### PR TITLE
Escape element selector for adding file selector

### DIFF
--- a/concrete/src/Application/Service/FileManager.php
+++ b/concrete/src/Application/Service/FileManager.php
@@ -60,7 +60,7 @@ class FileManager
 		<div class="ccm-file-selector" data-file-selector="{$id}"></div>
 		<script type="text/javascript">
 		$(function() {
-			$('[data-file-selector={$id}]').concreteFileSelector({$args});
+			$('[data-file-selector="{$id}"]').concreteFileSelector({$args});
 		});
 		</script>
 EOL;


### PR DESCRIPTION
When trying to create a file selector for an element with a name containing special characters like `form[articles[0]]` the following error was thrown:
`Error: Syntax error, unrecognized expression: [data-file-selector=event_form[articles][0][image]]`

By escaping the name part in the jQuery selector this is fixed.