### PR TITLE
Add missing folder icon in Document Library block

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -858,12 +858,10 @@ class Controller extends BlockController
         switch ($key) {
             case 'thumbnail':
             case 'image':
-                $url = $this->app->make('url/canonical');
-                $path = $url->getPath();
-                $path .= '/' . DIRNAME_PACKAGES . '/document_library/images/folder.png';
-                $url = $url->setPath($path);
-
-                return sprintf('<img src="%s" class="img-responsive" />', $url);
+                return sprintf(
+                    '<i class="fa fa-folder ccm-block-document-library-icon-folder" aria-hidden="true"></i><span class="sr-only">%s</span>',
+                    t('folder icon')
+                );
             case 'title':
                 $view = new BlockView($this->getBlockObject());
                 /** @var UrlImmutable $action */

--- a/concrete/blocks/document_library/view.css
+++ b/concrete/blocks/document_library/view.css
@@ -121,3 +121,8 @@ a.ccm-block-document-library-icon {
     color: #999;
     text-decoration: none;
 }
+
+.ccm-block-document-library-table .ccm-block-document-library-icon-folder {
+    font-size: 45px;
+    padding: 0 9px;
+}


### PR DESCRIPTION
This pull request replaces code that references a package asset. The Document Library block requires Font Awesome, so the package folder.png image is replaced with a Font Awesome font icon.

**Current:**

![document_library_file_icon_generic_thumbnail-current](https://user-images.githubusercontent.com/10898145/39668091-6d24b488-5092-11e8-853b-fa89a5306ce9.png)

![document_library_file_icon_thumbnail-current](https://user-images.githubusercontent.com/10898145/39668092-73be7126-5092-11e8-9392-949d2ddb938a.png)

**Changes:**

![document_library_file_icon_generic_thumbnail-changes](https://user-images.githubusercontent.com/10898145/39668094-78dbf3fe-5092-11e8-8873-2d275b19778c.png)

![document_library_file_icon_thumbnail-changes](https://user-images.githubusercontent.com/10898145/39668096-7ae6fb4e-5092-11e8-882e-4071bc49f09f.png)



