### PR TITLE
Mark migration 20180328215345 as repeatable

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20180328215345.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180328215345.php
@@ -4,18 +4,17 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Page\Page;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
-use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20180328215345 extends AbstractMigration
+class Version20180328215345 extends AbstractMigration implements RepeatableMigrationInterface
 {
-
     public function upgradeDatabase()
     {
         $c = Page::getByPath('/page_not_found');
         if ($c && !$c->isError()) {
             $db = $this->connection;
             $db->executeQuery('update Pages set siteTreeID = ? where cID = ?', [
-                0, $c->getCollectionID()
+                0, $c->getCollectionID(),
             ]);
         }
     }


### PR DESCRIPTION
There's no problem if migration 20180328215345 is excuted more than once, so let's mark it as repeatable.

This is very important, otherwise the `--rerun` option of the `c5:update` command won't be able to execute this migration and all the migrations that precede it: `--rerun` will only let users execute migrations *after* this 20180328215345.