### PR TITLE
Test that migrations are marked as repeatable

### DIFF
--- a/tests/tests/Update/RepeatableMigrationsTest.php
+++ b/tests/tests/Update/RepeatableMigrationsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Concrete\Tests\Update;
+
+use Concrete\Core\Updater\Migrations\Configuration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\Version;
+
+class RepeatableMigrationsTest extends ConcreteDatabaseTestCase
+{
+    protected $allowedNotRepeatableMigrations = [
+        \Concrete\Core\Updater\Migrations\Migrations\Version20160725000000::class,
+    ];
+
+    public function testRepeatableMigrations()
+    {
+        $configuration = new Configuration();
+        $versions = $configuration->getMigrations();
+        $migrationInstances = array_map(function (Version $version) { return $version->getMigration(); }, $versions);
+        $notRepeatableMigrationInstances = array_filter($migrationInstances, function (AbstractMigration $migration) {
+            return !$migration instanceof RepeatableMigrationInterface;
+        });
+        $notRepeatableMigrationClassNames = array_map('get_class', $notRepeatableMigrationInstances);
+        $wrongMigrations = array_diff($notRepeatableMigrationClassNames, $this->allowedNotRepeatableMigrations);
+        $this->assertEmpty(
+            $wrongMigrations,
+            sprintf(
+                "These migrations should implement the \%s interface (if they are repeatable)\n" .
+                "or they should be listed in the \$allowedNotRepeatableMigrations variable of the file %s (if they are not repeatable):\n- ",
+                RepeatableMigrationInterface::class,
+                substr(__FILE__, strlen(DIR_TESTS) + 1)
+            ) . implode("\n- ", $wrongMigrations)
+        );
+    }
+}


### PR DESCRIPTION
When we create a new migration, 99% of times it is repeatable, so let's add a test case to check this.

This new test case checks that all migrations are marked as repeatable, except the ones explicitly listed in the `$allowedNotRepeatableMigrations` property of this new  `RepeatableMigrationsTest` test.

This new test case helps a lot avoiding problems like these:
- #6382
- https://github.com/concrete5/concrete5/pull/6475#pullrequestreview-99785254
- https://github.com/concrete5/concrete5/pull/6539#pullrequestreview-108195062
- #6636

Marking migrations as repeatable is very important, because the `--rerun` option of the `c5:update` command can re-execute migrations only if they are repeatable, and all the next migrations are repeatable.
For instance, if we have migrations M1, M2, M3, M4, M5, and M3 is not marked as repeatable, the `--rerun` option will let you rerun only re-execute migrations M4 and M5.

PS: this PR **should** fail, since #6636 is not merged yet.