### PR TITLE
Fix rerunning migrations

### DIFF
--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -209,10 +209,17 @@ class Update
             }
             if ($isRerunning && $migration->isMigrated()) {
                 $migration->markNotMigrated();
+                $migrated = false;
                 try {
                     $migration->execute('up');
+                    $migrated = true;
                 } finally {
-                    $migration->markMigrated();
+                    if (!$migrated) {
+                        try {
+                            $migration->markMigrated();
+                        } catch (Exception $x) {
+                        }
+                    }
                 }
             } else {
                 $migration->execute('up');


### PR DESCRIPTION
`migration->execute('up')` already marks a migrations as migrated, so our `markMigrated` call leads to the following error:

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '<MigrationVersion>' for key 'PRIMARY'
```

So, let's call `markMigrated` only if `migration->execute('up')` fails.