### PR TITLE
Fix JavaScript warnings

### DIFF
--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -314,7 +314,7 @@
             // re-trigger a file search
             my.$element.find('div[data-header=file-manager] form').trigger('submit');
         }
-    }
+    };
 
     ConcreteFileManager.prototype._launchUploadCompleteDialog = function(files) {
         var my = this;

--- a/concrete/js/build/core/file-manager/selector.js
+++ b/concrete/js/build/core/file-manager/selector.js
@@ -1,5 +1,5 @@
 /* jshint unused:vars, undef:true, browser:true, jquery:true */
-/* global _, ccmi18n_filemanager, CCM_IMAGE_PATH, ConcreteFileManager, ConcreteFileMenu */
+/* global _, ccmi18n_filemanager, CCM_IMAGE_PATH, ConcreteFileManager, ConcreteFileMenu, ConcreteEvent */
 
 ;(function(global, $) {
     'use strict';


### PR DESCRIPTION
There are a couple JavaScript warnings: let's fix them.

BTW there's still a reference to an undefined variable at https://github.com/concrete5/concrete5/blob/18b605ddc1d69be461f3cdd0b85ed9f3ab826f58/concrete/js/build/core/layouts.js#L302

Should thst line be
```javascript
for (i = this.columns; i < $columns.length; i++) {
```
instead of
```javascript
for (i = columns; i < $columns.length; i++) {
```
?