### PR TITLE
Fixes issue when a file with multiple versions is the cursor 

### DIFF
--- a/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
+++ b/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
@@ -29,7 +29,8 @@ class FileVersionDateAddedColumn extends Column implements PagerColumnInterface
         $query = $itemList->getQueryObject();
         $sort = $this->getColumnSortDirection() == 'desc' ? '<' : '>';
         $where = sprintf('(fv.fvDateAdded, f.fID) %s (:sortDate, :sortID)', $sort);
-        $query->setParameter('sortDate', $mixed->getDateAdded()->format('Y-m-d H:i:s'));
+        $fv = $mixed->getApprovedVersion();
+        $query->setParameter('sortDate', $fv->getDateAdded()->format('Y-m-d H:i:s'));
         $query->setParameter('sortID', $mixed->getFileID());
         $query->andWhere($where);
     }


### PR DESCRIPTION
If a non super user is using the file manager with sorting by date modified and, the cursor, the file at the bottom of the list has multiple versions then currently concrete5 will get the original date added for the file not the latest date modified of the approved version.

This is because we get the file entity cursor object from the file list and then call getDateAdded() on it. This causes the cursor to be at a wrong place.

An example is if a file that has a date modified of 21st February 2018 and a date added of 1st January 2017 is at the bottom of the list or used as a cursor on 
`concrete5.site/ccm/system/search/files/basic?`
Then all the files on the next page will be older/newer (depending on sort) of 1st January 2017 not 21st February 2018. This can lead to loops ( since there is more than 1 file version with a newer date) or files not appearing when searching.

Since it is harder to replicate this in the file manager, it is best advised to use `ccm/system/search/files/basic?searchSubmit=1&ccm_order_by=fv.fvDateAdded&ccm_order_by_direction=asc&ccm_cursor=MODIFIED_FILE_ID`