### PR TITLE
Use UserMessageException when there are problems in block backend

### DIFF
--- a/concrete/controllers/backend/user_interface/block.php
+++ b/concrete/controllers/backend/user_interface/block.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Controller\Backend\UserInterface;
 
-use Exception;
+use Concrete\Core\Error\UserMessageException;
 use Page as ConcretePage;
 use Permissions;
 
@@ -38,7 +38,7 @@ abstract class Block extends Page
         }
         $a = \Area::get($this->page, $arHandle);
         if (!is_object($a)) {
-            throw new \Exception('Invalid Area');
+            throw new UserMessageException('Invalid Area');
         }
         $this->area = $a;
         if (!$a->isGlobalArea()) {
@@ -52,7 +52,7 @@ abstract class Block extends Page
             $this->set('isGlobalArea', true);
         }
         if (!$b) {
-            throw new Exception(t('Access Denied'));
+            throw new UserMessageException(t('Access Denied'));
         }
         $this->block = $b;
         $this->permissions = new \Permissions($b);
@@ -65,7 +65,7 @@ abstract class Block extends Page
         if ($this->permissions->canViewEditInterface() && $this->canAccess()) {
             return \Concrete\Core\Controller\Controller::getViewObject();
         }
-        throw new Exception(t('Access Denied'));
+        throw new UserMessageException(t('Access Denied'));
     }
 
     protected function getBlockToEdit()


### PR DESCRIPTION
In order to avoid data disclosure, generic exceptions may not be shown to the site users (it depends on the `concrete.debug.display_errors` configuration key).

When we want that a specific error message is shown to the user, we should throw `Concrete\Core\Error\UserMessageException` exceptions (see [here](https://github.com/concrete5/concrete5/blob/650c92f5ed90543c7e991781185befc5a1fd43e4/concrete/src/Error/Handler/ErrorHandler.php#L28) for http errors and [here](https://github.com/concrete5/concrete5/blob/650c92f5ed90543c7e991781185befc5a1fd43e4/concrete/src/Error/Handler/JsonErrorHandler.php#L20) for json errors).