### PR TITLE
Fix #6647

### DIFF
--- a/concrete/single_pages/dashboard/calendar/event_list.php
+++ b/concrete/single_pages/dashboard/calendar/event_list.php
@@ -16,7 +16,7 @@ $topic_id = Request::getInstance()->get('topic_id');
     <div class="input-group">
         <?=$form->text('query', array('placeholder' => t('Keywords')))?>
 
-            <div class="input-group-btn">
+            <div class="input-group-btn" style="z-index: 501;">
 
                 <?php if (isset($topics) && is_array($topics)) { ?>
 


### PR DESCRIPTION
This pull request addresses issue https://github.com/concrete5/concrete5/issues/6647.

The parent of the categories button and drop-down (.btn-group) has a z-index of 2. The event list item highlight (div#ccm-menu-click-proxy) has a z-index of 500.

This appears to be a one-off situation, so an inline style was used.
