### PR TITLE
Support Flexbox Grid Framework

### DIFF
--- a/concrete/src/Page/Theme/GridFramework/GridFramework.php
+++ b/concrete/src/Page/Theme/GridFramework/GridFramework.php
@@ -159,4 +159,9 @@ abstract class GridFramework
     {
         return false;
     }
+
+    public function isFlex()
+    {
+        return false;
+    }
 }

--- a/concrete/src/Page/Theme/GridFramework/Manager.php
+++ b/concrete/src/Page/Theme/GridFramework/Manager.php
@@ -3,8 +3,10 @@ namespace Concrete\Core\Page\Theme\GridFramework;
 
 use Concrete\Core\Page\Theme\GridFramework\Type\Bootstrap2;
 use Concrete\Core\Page\Theme\GridFramework\Type\Bootstrap3;
+use Concrete\Core\Page\Theme\GridFramework\Type\Bootstrap4;
 use Concrete\Core\Page\Theme\GridFramework\Type\NineSixty;
 use Concrete\Core\Page\Theme\GridFramework\Type\Foundation;
+use Concrete\Core\Page\Theme\GridFramework\Type\Foundation6;
 use Concrete\Core\Support\Manager as CoreManager;
 
 class Manager extends CoreManager
@@ -24,8 +26,18 @@ class Manager extends CoreManager
         return new Bootstrap3();
     }
 
+    protected function createBootstrap4Driver()
+    {
+        return new Bootstrap4();
+    }
+
     protected function createFoundationDriver()
     {
         return new Foundation();
+    }
+
+    protected function createFoundation6Driver()
+    {
+        return new Foundation6();
     }
 }

--- a/concrete/src/Page/Theme/GridFramework/Type/Bootstrap4.php
+++ b/concrete/src/Page/Theme/GridFramework/Type/Bootstrap4.php
@@ -1,0 +1,110 @@
+<?php
+namespace Concrete\Core\Page\Theme\GridFramework\Type;
+
+use Concrete\Core\Entity\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Theme\GridFramework\GridFramework;
+
+class Bootstrap4 extends GridFramework
+{
+    public function getPageThemeGridFrameworkName()
+    {
+        return t('Bootstrap 4');
+    }
+
+    public function supportsNesting()
+    {
+        return true;
+    }
+
+    public function isFlex()
+    {
+        return true;
+    }
+
+    public function getPageThemeGridFrameworkRowStartHTML()
+    {
+        return '<div class="row">';
+    }
+
+    public function getPageThemeGridFrameworkRowEndHTML()
+    {
+        return '</div>';
+    }
+
+    public function getPageThemeGridFrameworkContainerStartHTML()
+    {
+        return '<div class="container">';
+    }
+
+    public function getPageThemeGridFrameworkContainerEndHTML()
+    {
+        return '</div>';
+    }
+
+    public function getPageThemeGridFrameworkColumnClasses()
+    {
+        return [
+            'col-sm-1',
+            'col-sm-2',
+            'col-sm-3',
+            'col-sm-4',
+            'col-sm-5',
+            'col-sm-6',
+            'col-sm-7',
+            'col-sm-8',
+            'col-sm-9',
+            'col-sm-10',
+            'col-sm-11',
+            'col-sm-12',
+        ];
+    }
+
+    public function getPageThemeGridFrameworkColumnOffsetClasses()
+    {
+        return [
+            'col-sm-offset-1',
+            'col-sm-offset-2',
+            'col-sm-offset-3',
+            'col-sm-offset-4',
+            'col-sm-offset-5',
+            'col-sm-offset-6',
+            'col-sm-offset-7',
+            'col-sm-offset-8',
+            'col-sm-offset-9',
+            'col-sm-offset-10',
+            'col-sm-offset-11',
+            'col-sm-offset-12',
+        ];
+    }
+
+    public function getPageThemeGridFrameworkColumnAdditionalClasses()
+    {
+        return '';
+    }
+
+    public function getPageThemeGridFrameworkColumnOffsetAdditionalClasses()
+    {
+        return '';
+    }
+
+    public function getPageThemeGridFrameworkHideOnExtraSmallDeviceClass()
+    {
+        return 'hidden-xs';
+    }
+
+    public function getPageThemeGridFrameworkHideOnSmallDeviceClass()
+    {
+        return 'hidden-sm';
+    }
+
+    public function getPageThemeGridFrameworkHideOnMediumDeviceClass()
+    {
+        return 'hidden-md';
+    }
+
+    public function getPageThemeGridFrameworkHideOnLargeDeviceClass()
+    {
+        return 'hidden-lg';
+    }
+}

--- a/concrete/src/Page/Theme/GridFramework/Type/Foundation6.php
+++ b/concrete/src/Page/Theme/GridFramework/Type/Foundation6.php
@@ -1,0 +1,105 @@
+<?php
+namespace Concrete\Core\Page\Theme\GridFramework\Type;
+
+use Concrete\Core\Entity\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Theme\GridFramework\GridFramework;
+
+class Foundation6 extends GridFramework
+{
+    public function getPageThemeGridFrameworkName()
+    {
+        return t('Foundation 6');
+    }
+
+    public function supportsNesting()
+    {
+        return true;
+    }
+
+    public function isFlex()
+    {
+        return true;
+    }
+
+    public function getPageThemeGridFrameworkRowStartHTML()
+    {
+        return '<div class="grid-x grid-margin-x">';
+    }
+
+    public function getPageThemeGridFrameworkRowEndHTML()
+    {
+        return '</div>';
+    }
+
+    public function getPageThemeGridFrameworkContainerStartHTML()
+    {
+        return '<div class="grid-container">';
+    }
+
+    public function getPageThemeGridFrameworkContainerEndHTML()
+    {
+        return '</div>';
+    }
+
+    public function getPageThemeGridFrameworkColumnClasses()
+    {
+        return [
+            'small-1',
+            'small-2',
+            'small-3',
+            'small-4',
+            'small-5',
+            'small-6',
+            'small-7',
+            'small-8',
+            'small-9',
+            'small-10',
+            'small-11',
+            'small-12',
+        ];
+    }
+
+    public function getPageThemeGridFrameworkColumnOffsetClasses()
+    {
+        return [
+            'small-offset-1',
+            'small-offset-2',
+            'small-offset-3',
+            'small-offset-4',
+            'small-offset-5',
+            'small-offset-6',
+            'small-offset-7',
+            'small-offset-8',
+            'small-offset-9',
+            'small-offset-10',
+            'small-offset-11',
+            'small-offset-12',
+        ];
+    }
+
+    public function getPageThemeGridFrameworkColumnAdditionalClasses()
+    {
+        return 'cell';
+    }
+
+    public function getPageThemeGridFrameworkColumnOffsetAdditionalClasses()
+    {
+        return '';
+    }
+
+    public function getPageThemeGridFrameworkHideOnSmallDeviceClass()
+    {
+        return 'hide-for-small-only';
+    }
+
+    public function getPageThemeGridFrameworkHideOnMediumDeviceClass()
+    {
+        return 'hide-for-medium-only';
+    }
+
+    public function getPageThemeGridFrameworkHideOnLargeDeviceClass()
+    {
+        return 'hide-for-large-only';
+    }
+}


### PR DESCRIPTION
**Please do not merge this pull request yet. It is work in progress now.**

Modern CSS Grid Frameworks like Bootstrap4 or Foundation6 uses [CSS Flexible Box Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout). However, concrete5 doesn't support these frameworks yet.

I tried to add Bootstrap4 and Foundation6 frameworks (see files changed tab), but these frameworks breaks concrete5 editing layout interface.

Here is a screencapture:

![kapture 2018-05-19 at 10 57 01](https://user-images.githubusercontent.com/514294/40264000-2f98ba96-5b56-11e8-91c2-40d54e9b0bda.gif)

If you want to try, please use these themes.

* [Minimum Bootstrap4 Theme](https://gist.github.com/hissy/902c3ae9a528519f0d3a7b82ce9e9ec3)
* [Minimum Foundation6 Theme](https://gist.github.com/hissy/46d8e2a3dad847a64fa6d9bec32f6ea8)

IMO, we should update the editing layout interface completely.
Please write your opinion or suggestion. Thanks!