### PR TITLE
Fix #6659

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -58,7 +58,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         $this->renameProblematicTables();
         $this->updateDoctrineXmlTables();
         $this->prepareProblematicEntityTables();
-        $this->installEntities(['Concrete\Core\Entity\File\File', 'Concrete\Core\Entity\File\Version']);
+        $this->installEntities(['Concrete\Core\Entity\File\File', 'Concrete\Core\Entity\File\Version', 'Concrete\Core\Entity\File\Image\Thumbnail\Type\Type']);
         $this->installOtherEntities();
         $this->installSite();
         $this->importAttributeTypes();


### PR DESCRIPTION
In order to fix #6659 we need to refresh the schema of the `FileImageThumbnailTypes` database table before creating the `FileImageThumbnailTypeFileSets` table.