### PR TITLE
Let FileFolderManager filter by file extensions, improve FileManager service

### DIFF
--- a/concrete/src/Application/Service/FileManager.php
+++ b/concrete/src/Application/Service/FileManager.php
@@ -1,193 +1,238 @@
 <?php
+
 namespace Concrete\Core\Application\Service;
 
-use View;
-use Core;
+use Concrete\Core\Entity\File\File as FileEntity;
 use Concrete\Core\File\Type\Type as FileType;
-use File;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\View\View;
+use Doctrine\ORM\EntityManagerInterface;
 
 class FileManager
 {
     /**
-     * Sets up a file field for use with a block.
+     * Sets up a form field to let users pick a file.
      *
-     * @param string $id The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $bf
+     * @param string $inputID The ID of the form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args An array with additional arguments. Supported array keys are:
+     * <ul>
+     *     <li><code>'filters'</code><br />
+     *         A list of file filters. Every array item must have a 'field' key (with the name of the field as the value), and another field that's specific of the field.<br />
+     *         For a list of valid field identifiers, see the definition of the loadDataFromRequest method of the classes that implement \ Concrete\Core\Search\Field\FieldInterface (usually it's the requestVariables property).
+     *     </li>
+     * </ul>A list of arrays. Each array item must have a 'field' key whose value is the name of the field, and
      *
      * @return string $html
+     *
+     * @example <code><pre>
+     * $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+     * $filemanager = $app->make(\Concrete\Core\Application\Service\FileManager::class);
+     * echo $filemanager->file(
+     *     'myId',
+     *     'myName',
+     *     t('Choose File'),
+     *     $preselectedFile,
+     *     [
+     *         'filters' => [
+     *             [
+     *                 'field' => 'type',
+     *                 'type' => \Concrete\Core\File\Type\Type::T_IMAGE,
+     *             ],
+     *             [
+     *                 'field' => 'extension',
+     *                 'extension' => ['.png', '.jpg'],
+     *             ],
+     *         ],
+     *     ]
+     * )
+     * </pre></code>
      */
-    public function file($id, $postname, $chooseText, $bf = null, $filterArgs = [])
+    public function file($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $fileID = 0;
-        $v = View::getInstance();
-        $v->requireAsset('core/file-manager');
+        $app = Application::getFacadeApplication();
 
-        /*
-         * If $_POST[$postname] is a valid File ID
-         * use that file
-         * If not try to use the $bf parameter passed in
-         */
-        $vh = Core::make('helper/validation/numbers');
-        if (isset($_POST[$postname]) && $vh->integer($_POST[$postname])) {
-            $postFile = File::getByID($_POST[$postname]);
-            if (is_object($postFile) && $postFile->getFileID() > 0) {
-                $bf = $postFile;
+        $view = View::getInstance();
+        $request = $app->make(Request::class);
+        $vh = $app->make('helper/validation/numbers');
+
+        $view->requireAsset('core/file-manager');
+        $fileSelectorArguments = [
+            'inputName' => (string) $inputName,
+            'fID' => null,
+            'filters' => [],
+        ];
+        if ($vh->integer($request->request->get($inputName))) {
+            $file = $app->make(EntityManagerInterface::class)->find(FileEntity::class, $request->request->get($inputName));
+            if ($file !== null) {
+                $fileSelectorArguments['fID'] = $file->getFileID();
             }
+        } elseif ($vh->integer($request->request->get($preselectedFile))) {
+            $fileSelectorArguments['fID'] = (int) $preselectedFile;
+        } elseif (is_object($preselectedFile)) {
+            $fileSelectorArguments['fID'] = (int) $preselectedFile->getFileID();
+        }
+        if ($fileSelectorArguments['fID'] === null && (string) $chooseText !== '') {
+            $fileSelectorArguments['chooseText'] = (string) $chooseText;
         }
 
-        if (is_object($bf) && $bf->getFileID() > 0) {
-            $fileID = $bf->getFileID();
+        if (isset($args['filters']) && is_array($args['filters'])) {
+            $fileSelectorArguments['filters'] = $args['filters'];
         }
 
-        $filters = '[]';
-        if (isset($filterArgs['filters']) && $filterArgs['filters']) {
-            $filters = json_encode($filterArgs['filters']);
-        }
-
-        if (!empty($chooseText)) {
-            $chooseText = json_encode($chooseText);
-            $chooseText = "'chooseText': $chooseText";
-        }
-        if ($fileID) {
-            $args = "{'inputName': '{$postname}', 'fID': {$fileID}, 'filters': $filters }";
-        } else {
-            $args = "{'inputName': '{$postname}', 'filters': $filters, $chooseText }";
-        }
-
+        $fileSelectorArgumentsJson = json_encode($fileSelectorArguments);
         $html = <<<EOL
-		<div class="ccm-file-selector" data-file-selector="{$id}"></div>
-		<script type="text/javascript">
-		$(function() {
-			$('[data-file-selector="{$id}"]').concreteFileSelector({$args});
-		});
-		</script>
+<div class="ccm-file-selector" data-file-selector="{$inputID}"></div>
+<script type="text/javascript">
+$(function() {
+    $('[data-file-selector="{$inputID}"]').concreteFileSelector({$fileSelectorArgumentsJson});
+});
+</script>
 EOL;
-        /*
-         * $html = '<div id="' . $id . '-fm-selected" class="ccm-file-selected-wrapper">'; $html .= '<div class="ccm-file-manager-select" id="' . $id . '-fm-display" ccm-file-manager-field="' . $id . '" style="display: ' . $resetDisplay . '">'; $html .= '<a href="javascript:void(0)" onclick="ccm_chooseAsset=false; ccm_alLaunchSelectorFileManager(\'' . $id . '\')">' . $chooseText . '</a>'; $html .= '</div><input id="' . $id . '-fm-value" type="hidden" name="' . $postname . '" value="' . $fileID . '" />'; $html .= '<script type="text/javascript">$(function() { if (is_object($bf) && (!$bf->isError()) && $bf->getFileID() > 0) { $html .= '<script type="text/javascript">$(function() { ccm_triggerSelectFile(' . $fileID . ', \'' . $id . '\'); });</script>'; }
-         */
 
         return $html;
     }
 
     /**
-     * Sets up an image to be chosen for use with a block.
+     * Sets up a form field to let users pick an image file.
      *
-     * @param string $id The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID The ID of the form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function image($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function image($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_IMAGE]];
-        $args = array_merge($args, $additionalArgs);
-
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+        return $this->fileOfType(FileType::T_IMAGE, $inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 
     /**
-     * Sets up a video to be chosen for use with a block.
+     * Sets up a form field to let users pick a video file.
      *
-     * @param string $id  The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID The ID of the form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function video($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function video($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_VIDEO]];
-        $args = array_merge($args, $additionalArgs);
-
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+        return $this->fileOfType(FileType::T_VIDEO, $inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 
     /**
-     * Sets up a text file to be chosen for use with a block.
+     * Sets up a form field to let users pick a text file.
      *
-     * @param string $id The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID The ID of your form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function text($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function text($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_TEXT]];
-        $args = array_merge($args, $additionalArgs);
-
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+        return $this->fileOfType(FileType::T_TEXT, $inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 
     /**
-     * Sets up audio to be chosen for use with a block.
+     * Sets up a form field to let users pick an audio file.
      *
-     * @param string $id The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID The ID of your form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function audio($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function audio($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_AUDIO]];
-        $args = array_merge($args, $additionalArgs);
-
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+        return $this->fileOfType(FileType::T_AUDIO, $inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 
     /**
-     * Sets up a document to be chosen for use with a block.
+     * Sets up a form field to let users pick a document file.
      *
-     * @param string $id  The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID  The ID of your form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function doc($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function doc($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_DOCUMENT]];
-        $args = array_merge($args, $additionalArgs);
-
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+        return $this->fileOfType(FileType::T_DOCUMENT, $inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 
     /**
-     * Sets up an application to be chosen for use with a block.
+     * Sets up a form field to let users pick a application file.
      *
-     * @param string $id The ID of your form field
-     * @param string $postname The name of your database column into which you'd like to save the file ID
-     * @param string $chooseText
-     * @param \File $fileInstanceBlock
-     * @param array $additionalArgs
+     * @param string $inputID The ID of your form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
      *
      * @return string $html
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
      */
-    public function app($id, $postname, $chooseText, $fileInstanceBlock = null, $additionalArgs = [])
+    public function app($inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
     {
-        $args = [];
-        $args['filters'] = [['field' => 'type', 'type' => FileType::T_APPLICATION]];
-        $args = array_merge($args, $additionalArgs);
+        return $this->fileOfType(FileType::T_APPLICATION, $inputID, $inputName, $chooseText, $preselectedFile, $args);
+    }
 
-        return $this->file($id, $postname, $chooseText, $fileInstanceBlock, $args);
+    /**
+     * Sets up a form field to let users pick a file of a specific type.
+     *
+     * @param int $type One of the \Concrete\Core\File\Type\Type::T_... constants.
+     * @param string $inputID The ID of your form field
+     * @param string $inputName The name of the form field (the selected file ID will be posted with this name)
+     * @param string $chooseText The text to be used to tell users "Choose a File"
+     * @param \Concrete\Core\Entity\File\File|\Concrete\Core\Entity\File\Version|int|null $preselectedFile the pre-selected file (or its ID)
+     * @param array $args See the $args description of the <code>file</code> method
+     *
+     * @return string
+     *
+     * @see \Concrete\Core\Application\Service\FileManager::file()
+     */
+    private function fileOfType($type, $inputID, $inputName, $chooseText, $preselectedFile = null, $args = [])
+    {
+        if (!isset($args['filters']) || !is_array($args['filters'])) {
+            $args['filters'] = [];
+        }
+        $args['filters'] = array_merge(
+            [
+                [
+                    'field' => 'type',
+                    'type' => (int) $type,
+                ],
+            ],
+            $args['filters']
+        );
+
+        return $this->file($inputID, $inputName, $chooseText, $preselectedFile, $args);
     }
 }

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -146,10 +146,26 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->filter('fvType', $type);
     }
 
+    /**
+     * Filter the files by their extension.
+     *
+     * @param string|string[] $extension One or more file extensions (with or without leading dot).
+     */
     public function filterByExtension($extension)
     {
-        $this->query->andWhere('fv.fvExtension = :fvExtension');
-        $this->query->setParameter('fvExtension', $extension);
+        $extensions = is_array($extension) ? $extension : [$extension];
+        if (count($extensions) > 0) {
+            $expr = $this->query->expr();
+            $or = $expr->orX();
+            foreach ($extensions as $extension) {
+                $extension = ltrim((string) $extension, '.');
+                $or->add($expr->eq('fv.fvExtension', $this->query->createNamedParameter($extension)));
+                if ($extension === '') {
+                    $or->add($expr->isNull('fv.fvExtension'));
+                }
+            }
+            $this->query->andWhere($or);
+        }
     }
 
     /**

--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -153,6 +153,28 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         $this->query->setParameter('fvType', $type);
     }
 
+    /**
+     * Filter the files by their extension.
+     *
+     * @param string|string[] $extension One or more file extensions (with or without leading dot).
+     */
+    public function filterByExtension($extension)
+    {
+        $extensions = is_array($extension) ? $extension : [$extension];
+        if (count($extensions) > 0) {
+            $expr = $this->query->expr();
+            $or = $expr->orX();
+            foreach ($extensions as $extension) {
+                $extension = ltrim((string) $extension, '.');
+                $or->add($expr->eq('fv.fvExtension', $this->query->createNamedParameter($extension)));
+                if ($extension === '') {
+                    $or->add($expr->isNull('fv.fvExtension'));
+                }
+            }
+            $this->query->andWhere($or);
+        }
+    }
+
     public function deliverQueryObject()
     {
         if (!isset($this->parent)) {

--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -1,31 +1,34 @@
 <?php
+
 namespace Concrete\Core\File;
 
-use Concrete\Core\Permission\Access\Access as PermissionAccess;
+use Closure;
 use Concrete\Core\Permission\Access\Entity\FileUploaderEntity;
+use Concrete\Core\Permission\Checker as Permissions;
 use Concrete\Core\Permission\Key\FileFolderKey;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Concrete\Core\Search\ItemList\Pager\Manager\FolderItemListPagerManager;
 use Concrete\Core\Search\ItemList\Pager\PagerProviderInterface;
 use Concrete\Core\Search\ItemList\Pager\QueryString\VariableFactory;
-use Concrete\Core\Search\Pagination\PagerPagination;
-use Concrete\Core\Search\Pagination\Pagination;
 use Concrete\Core\Search\Pagination\PaginationProviderInterface;
-use Concrete\Core\Search\Pagination\PermissionablePagination;
-use Concrete\Core\Search\PermissionableListItemInterface;
 use Concrete\Core\Search\StickyRequest;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete\Core\User\User;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
-use Closure;
-use Concrete\Core\Permission\Checker as Permissions;
 
 class FolderItemList extends AttributedItemList implements PagerProviderInterface, PaginationProviderInterface
 {
     protected $parent;
     protected $searchSubFolders = false;
     protected $permissionsChecker;
+
+    protected $autoSortColumns = [
+        'folderItemName',
+        'folderItemModified',
+        'folderItemType',
+        'folderItemSize',
+    ];
 
     public function __construct(StickyRequest $req = null)
     {
@@ -35,13 +38,6 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         }
         parent::__construct($req);
     }
-
-    protected $autoSortColumns = [
-        'folderItemName',
-        'folderItemModified',
-        'folderItemType',
-        'folderItemSize',
-    ];
 
     public function enableSubFolderSearch()
     {
@@ -64,11 +60,6 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
     public function getPagerManager()
     {
         return new FolderItemListPagerManager($this);
-    }
-
-    protected function getAttributeKeyClassName()
-    {
-        return '\\Concrete\\Core\\Attribute\\Key\\FileKey';
     }
 
     public function setPermissionsChecker(Closure $checker = null)
@@ -115,6 +106,7 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
             $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct n.treeNodeID)')->setMaxResults(1);
         });
+
         return $adapter;
     }
 
@@ -141,7 +133,6 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         return $fp->canViewTreeNode();
     }
 
-
     public function filterByParentFolder(FileFolder $folder)
     {
         $this->parent = $folder;
@@ -156,7 +147,7 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
     /**
      * Filter the files by their extension.
      *
-     * @param string|string[] $extension One or more file extensions (with or without leading dot).
+     * @param string|string[] $extension one or more file extensions (with or without leading dot)
      */
     public function filterByExtension($extension)
     {
@@ -185,8 +176,8 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
         if ($this->searchSubFolders) {
             // determine how many subfolders are within the parent folder.
             $subFolders = $this->parent->getHierarchicalNodesOfType('file_folder', 1, false, true);
-            $subFolderIds = array();
-            foreach($subFolders as $subFolder) {
+            $subFolderIds = [];
+            foreach ($subFolders as $subFolder) {
                 $subFolderIds[] = $subFolder['treeNodeID'];
             }
             $this->query->andWhere(
@@ -209,7 +200,7 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
             $pk = FileFolderKey::getByHandle('search_file_folder');
             if (is_object($pk)) {
                 $pk->setPermissionObject($this->parent);
-                /** @var PermissionAccess $pa */
+                /** @var \Concrete\Core\Permission\Access\Access $pa */
                 $pa = $pk->getPermissionAccessObject();
                 // Check whether or not current user can search files in the current folder
                 if (is_object($pa) && $pa->validate()) {
@@ -217,11 +208,11 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
                     $accessEntitiesWithoutFileUploader = [];
                     $accessEntities = $u->getUserAccessEntityObjects();
                     foreach ($accessEntities as $accessEntity) {
-                        if (! $accessEntity instanceof FileUploaderEntity) {
+                        if (!$accessEntity instanceof FileUploaderEntity) {
                             $accessEntitiesWithoutFileUploader[] = $accessEntity;
                         }
                     }
-                    /**
+                    /*
                      * For performance reason, if the current user can not search files without "File Uploader" entity,
                      * we filter only files that uploaded by the current user or permission overridden.
                      */
@@ -246,5 +237,10 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
     public function sortByNodeType()
     {
         $this->sortBy('folderItemType', 'asc');
+    }
+
+    protected function getAttributeKeyClassName()
+    {
+        return '\\Concrete\\Core\\Attribute\\Key\\FileKey';
     }
 }

--- a/concrete/src/File/Search/Field/FileFolderManager.php
+++ b/concrete/src/File/Search/Field/FileFolderManager.php
@@ -23,6 +23,7 @@ class FileFolderManager extends FieldManager
         $this->fileCategory = $fileCategory;
         $this->addGroup('', [
             new TypeField(),
+            new ExtensionField(),
         ]);
     }
 

--- a/concrete/src/File/Search/Field/FileFolderManager.php
+++ b/concrete/src/File/Search/Field/FileFolderManager.php
@@ -1,21 +1,14 @@
 <?php
+
 namespace Concrete\Core\File\Search\Field;
 
 use Concrete\Core\Attribute\Category\FileCategory;
-use Concrete\Core\File\Search\Field\Field\AddedToPageField;
-use Concrete\Core\File\Search\Field\Field\DateAddedField;
 use Concrete\Core\File\Search\Field\Field\ExtensionField;
-use Concrete\Core\File\Search\Field\Field\FileSetField;
-use Concrete\Core\File\Search\Field\Field\KeywordsField;
-use Concrete\Core\File\Search\Field\Field\SizeField;
 use Concrete\Core\File\Search\Field\Field\TypeField;
-use Concrete\Core\Search\Field\AttributeKeyField;
 use Concrete\Core\Search\Field\Manager as FieldManager;
-use Doctrine\ORM\EntityManagerInterface;
 
 class FileFolderManager extends FieldManager
 {
-
     protected $fileCategory;
 
     public function __construct(FileCategory $fileCategory)
@@ -26,6 +19,4 @@ class FileFolderManager extends FieldManager
             new ExtensionField(),
         ]);
     }
-
-
 }


### PR DESCRIPTION
It seems that the new `FileFolderManager` only supports filtering by file type: it's very useful if it supported filtering by file extension.

Furthermore, the use of filters in the FileManager is very little documented: let's improve its PHPDoc (and rename a few parameters... `$bf` doesn't tell me much :wink:)