### PR TITLE
Tracker may be null in block types

### DIFF
--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -115,7 +115,7 @@ class Controller extends BlockController implements FileTrackableInterface
             $args['content'] = LinkAbstractor::translateTo($args['content']);
         }
         parent::save($args);
-        $this->tracker->track($this);
+        $this->getTracker()->track($this);
     }
 
     /**
@@ -124,7 +124,7 @@ class Controller extends BlockController implements FileTrackableInterface
     public function delete()
     {
         parent::delete();
-        $this->tracker->forget($this);
+        $this->getTracker()->forget($this);
     }
 
     public function getUsedFiles()
@@ -144,5 +144,17 @@ class Controller extends BlockController implements FileTrackableInterface
     public function getUsedCollection()
     {
         return $this->getCollectionObject();
+    }
+
+    /**
+     * @return \Concrete\Core\Statistics\UsageTracker\AggregateTracker
+     */
+    protected function getTracker()
+    {
+        if ($this->tracker === null) {
+            $this->tracker = $this->app->make(AggregateTracker::class);
+        }
+
+        return $this->tracker;
     }
 }

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Block\Content;
 
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PictureRoutine;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
@@ -19,9 +19,10 @@ use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
  */
 class Controller extends BlockController implements FileTrackableInterface
 {
+    public $content;
     protected $btTable = 'btContentLocal';
-    protected $btInterfaceWidth = "600";
-    protected $btInterfaceHeight = "465";
+    protected $btInterfaceWidth = 600;
+    protected $btInterfaceHeight = 465;
     protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
@@ -30,27 +31,25 @@ class Controller extends BlockController implements FileTrackableInterface
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
-    public $content;
-
     /**
-     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker
+     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null
      */
     protected $tracker;
 
+    public function __construct($obj = null, AggregateTracker $tracker = null)
+    {
+        parent::__construct($obj);
+        $this->tracker = $tracker;
+    }
+
     public function getBlockTypeDescription()
     {
-        return t("HTML/WYSIWYG Editor Content.");
+        return t('HTML/WYSIWYG Editor Content.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Content");
-    }
-
-    public function __construct($obj=null, AggregateTracker $tracker=null)
-    {
-        parent::__construct($obj);
-        $this->tracker = $tracker;
+        return t('Content');
     }
 
     public function getContent()
@@ -92,7 +91,7 @@ class Controller extends BlockController implements FileTrackableInterface
     {
         $content = $blockNode->data->record->content;
         $content = LinkAbstractor::import($content);
-        $args = array('content' => $content);
+        $args = ['content' => $content];
 
         return $args;
     }
@@ -120,7 +119,7 @@ class Controller extends BlockController implements FileTrackableInterface
     }
 
     /**
-     * Tell the tracker to forget us when we are deleted
+     * Tell the tracker to forget us when we are deleted.
      */
     public function delete()
     {
@@ -133,9 +132,9 @@ class Controller extends BlockController implements FileTrackableInterface
         $files = [];
         $matches = [];
         if (preg_match_all('/\<concrete-picture[^>]*?fID\s*=\s*[\'"]([^\'"]*?)[\'"]/i', $this->content, $matches)) {
-            list(,$ids) = $matches;
+            list(, $ids) = $matches;
             foreach ($ids as $id) {
-                $files[] = intval($id);
+                $files[] = (int) $id;
             }
         }
 
@@ -146,5 +145,4 @@ class Controller extends BlockController implements FileTrackableInterface
     {
         return $this->getCollectionObject();
     }
-
 }

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Block\Image;
 
-use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Error\Error;
 use Concrete\Core\File\File;
@@ -25,7 +25,9 @@ class Controller extends BlockController implements FileTrackableInterface
         'image',
     ];
 
-    /** @var AggregateTracker */
+    /**
+     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null
+     */
     protected $tracker;
 
     public function __construct($blockType = null, AggregateTracker $tracker = null)
@@ -328,6 +330,8 @@ class Controller extends BlockController implements FileTrackableInterface
     }
 
     /**
+     * @param array $args
+     *
      * @return Error
      */
     public function validate($args)
@@ -343,7 +347,7 @@ class Controller extends BlockController implements FileTrackableInterface
             $e->add(t('Please select an image.'));
         }
 
-        if (isset($args['cropImage']) && (intval($args['maxWidth']) <= 0 || (intval($args['maxHeight']) <= 0)) && !$svg) {
+        if (isset($args['cropImage']) && ((int) $args['maxWidth'] <= 0 || ((int) $args['maxHeight'] <= 0)) && !$svg) {
             $e->add(t('Cropping an image requires setting a max width and max height.'));
         }
 
@@ -385,8 +389,8 @@ class Controller extends BlockController implements FileTrackableInterface
         $args['fOnstateID'] = $args['fOnstateID'] != '' ? $args['fOnstateID'] : 0;
         $args['fileLinkID'] = $args['fileLinkID'] != '' ? $args['fileLinkID'] : 0;
         $args['cropImage'] = isset($args['cropImage']) ? 1 : 0;
-        $args['maxWidth'] = intval($args['maxWidth']) > 0 ? intval($args['maxWidth']) : 0;
-        $args['maxHeight'] = intval($args['maxHeight']) > 0 ? intval($args['maxHeight']) : 0;
+        $args['maxWidth'] = (int) $args['maxWidth'] > 0 ? (int) $args['maxWidth'] : 0;
+        $args['maxHeight'] = (int) $args['maxHeight'] > 0 ? (int) $args['maxHeight'] : 0;
 
         if (!$args['constrainImage']) {
             $args['cropImage'] = 0;
@@ -394,7 +398,7 @@ class Controller extends BlockController implements FileTrackableInterface
             $args['maxHeight'] = 0;
         }
 
-        switch (intval($args['linkType'])) {
+        switch ((int) $args['linkType']) {
             case 1:
                 $args['externalLink'] = '';
                 $args['fileLinkID'] = 0;

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -363,7 +363,7 @@ class Controller extends BlockController implements FileTrackableInterface
      */
     public function delete()
     {
-        $this->tracker->forget($this);
+        $this->getTracker()->forget($this);
         parent::delete();
     }
 
@@ -426,7 +426,7 @@ class Controller extends BlockController implements FileTrackableInterface
         unset($args['linkType']);
 
         parent::save($args);
-        $this->tracker->track($this);
+        $this->getTracker()->track($this);
     }
 
     public function getUsedFiles()
@@ -437,5 +437,17 @@ class Controller extends BlockController implements FileTrackableInterface
     public function getUsedCollection()
     {
         return $this->getCollectionObject();
+    }
+
+    /**
+     * @return \Concrete\Core\Statistics\UsageTracker\AggregateTracker
+     */
+    protected function getTracker()
+    {
+        if ($this->tracker === null) {
+            $this->tracker = $this->app->make(AggregateTracker::class);
+        }
+
+        return $this->tracker;
     }
 }

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -1,38 +1,39 @@
 <?php
+
 namespace Concrete\Block\ImageSlider;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Core;
 use Database;
 use Page;
-use Concrete\Core\Editor\LinkAbstractor;
-use Core;
 
 class Controller extends BlockController implements FileTrackableInterface
 {
     protected $btTable = 'btImageSlider';
-    protected $btExportTables = array('btImageSlider', 'btImageSliderEntries');
-    protected $btInterfaceWidth = "600";
+    protected $btExportTables = ['btImageSlider', 'btImageSliderEntries'];
+    protected $btInterfaceWidth = 600;
+    protected $btInterfaceHeight = 550;
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "550";
     protected $btCacheBlockRecord = true;
-    protected $btExportFileColumns = array('fID');
+    protected $btExportFileColumns = ['fID'];
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btIgnorePageThemeGridFrameworkContainer = true;
 
     /**
-     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker
+     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null
      */
     protected $tracker;
 
     /**
      * Instantiates the block controller.
      *
-     * @param BlockType|null $obj
-     * @param \Concrete\Core\Statistics\UsageTracker\AggregateTracker $tracker
+     * @param \Concrete\Core\Block\BlockType\BlockType|null $obj
+     * @param \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null $tracker
      */
     public function __construct($obj = null, AggregateTracker $tracker = null)
     {
@@ -42,24 +43,24 @@ class Controller extends BlockController implements FileTrackableInterface
 
     public function getBlockTypeDescription()
     {
-        return t("Display your images and captions in an attractive slideshow format.");
+        return t('Display your images and captions in an attractive slideshow format.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Image Slider");
+        return t('Image Slider');
     }
 
     public function getSearchableContent()
     {
         $content = '';
         $db = Database::get();
-        $v = array($this->bID);
+        $v = [$this->bID];
         $q = 'select * from btImageSliderEntries where bID = ?';
         $r = $db->query($q, $v);
         foreach ($r as $row) {
-            $content .= $row['title'].' ';
-            $content .= $row['description'].' ';
+            $content .= $row['title'] . ' ';
+            $content .= $row['description'] . ' ';
         }
 
         return $content;
@@ -76,7 +77,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $this->requireAsset('core/file-manager');
         $this->requireAsset('core/sitemap');
         $db = Database::get();
-        $query = $db->GetAll('SELECT * from btImageSliderEntries WHERE bID = ? ORDER BY sortOrder', array($this->bID));
+        $query = $db->GetAll('SELECT * from btImageSliderEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
         $this->set('rows', $query);
     }
 
@@ -102,9 +103,9 @@ class Controller extends BlockController implements FileTrackableInterface
     public function getEntries()
     {
         $db = Database::get();
-        $r = $db->GetAll('SELECT * from btImageSliderEntries WHERE bID = ? ORDER BY sortOrder', array($this->bID));
+        $r = $db->GetAll('SELECT * from btImageSliderEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
         // in view mode, linkURL takes us to where we need to go whether it's on our site or elsewhere
-        $rows = array();
+        $rows = [];
         foreach ($r as $q) {
             if (!$q['linkURL'] && $q['internalLinkCID']) {
                 $c = Page::getByID($q['internalLinkCID'], 'ACTIVE');
@@ -127,12 +128,12 @@ class Controller extends BlockController implements FileTrackableInterface
     {
         parent::duplicate($newBID);
         $db = Database::get();
-        $v = array($this->bID);
+        $v = [$this->bID];
         $q = 'select * from btImageSliderEntries where bID = ?';
         $r = $db->query($q, $v);
         while ($row = $r->FetchRow()) {
             $db->execute('INSERT INTO btImageSliderEntries (bID, fID, linkURL, title, description, sortOrder, internalLinkCID) values(?,?,?,?,?,?,?)',
-                array(
+                [
                     $newBID,
                     $row['fID'],
                     $row['linkURL'],
@@ -140,7 +141,7 @@ class Controller extends BlockController implements FileTrackableInterface
                     $row['description'],
                     $row['sortOrder'],
                     $row['internalLinkCID'],
-                )
+                ]
             );
         }
     }
@@ -148,7 +149,7 @@ class Controller extends BlockController implements FileTrackableInterface
     public function delete()
     {
         $db = Database::get();
-        $db->delete('btImageSliderEntries', array('bID' => $this->bID));
+        $db->delete('btImageSliderEntries', ['bID' => $this->bID]);
         parent::delete();
 
         $this->tracker->forget($this);
@@ -157,8 +158,8 @@ class Controller extends BlockController implements FileTrackableInterface
     public function validate($args)
     {
         $error = Core::make('helper/validation/error');
-        $timeout = intval($args['timeout']);
-        $speed = intval($args['speed']);
+        $timeout = (int) $args['timeout'];
+        $speed = (int) $args['speed'];
 
         if (!$timeout) {
             $error->add(t('Slide Duration must be greater than 0.'));
@@ -177,18 +178,18 @@ class Controller extends BlockController implements FileTrackableInterface
 
     public function save($args)
     {
-        $args += array(
+        $args += [
             'timeout' => 4000,
             'speed' => 500,
-        );
-        $args['timeout'] = intval($args['timeout']);
-        $args['speed'] = intval($args['speed']);
+        ];
+        $args['timeout'] = (int) $args['timeout'];
+        $args['speed'] = (int) $args['speed'];
         $args['noAnimate'] = isset($args['noAnimate']) ? 1 : 0;
         $args['pause'] = isset($args['pause']) ? 1 : 0;
-        $args['maxWidth'] = isset($args['maxWidth']) ? intval($args['maxWidth']) : 0;
+        $args['maxWidth'] = isset($args['maxWidth']) ? (int) $args['maxWidth'] : 0;
 
         $db = Database::get();
-        $db->execute('DELETE from btImageSliderEntries WHERE bID = ?', array($this->bID));
+        $db->execute('DELETE from btImageSliderEntries WHERE bID = ?', [$this->bID]);
         parent::save($args);
         if (isset($args['sortOrder'])) {
             $count = count($args['sortOrder']);
@@ -197,7 +198,7 @@ class Controller extends BlockController implements FileTrackableInterface
             while ($i < $count) {
                 $linkURL = $args['linkURL'][$i];
                 $internalLinkCID = $args['internalLinkCID'][$i];
-                switch (intval($args['linkType'][$i])) {
+                switch ((int) $args['linkType'][$i]) {
                     case 1:
                         $linkURL = '';
                         break;
@@ -215,15 +216,15 @@ class Controller extends BlockController implements FileTrackableInterface
                 }
 
                 $db->execute('INSERT INTO btImageSliderEntries (bID, fID, title, description, sortOrder, linkURL, internalLinkCID) values(?, ?, ?, ?,?,?,?)',
-                    array(
+                    [
                         $this->bID,
-                        intval($args['fID'][$i]),
+                        (int) $args['fID'][$i],
                         $args['title'][$i],
                         $args['description'][$i],
                         $args['sortOrder'][$i],
                         $linkURL,
                         $internalLinkCID,
-                    )
+                    ]
                 );
                 ++$i;
             }
@@ -234,7 +235,7 @@ class Controller extends BlockController implements FileTrackableInterface
 
     public function getUsedFiles()
     {
-        return array_map(function($entry) {
+        return array_map(function ($entry) {
             return $entry['fID'];
         }, $this->getEntries());
     }
@@ -243,5 +244,4 @@ class Controller extends BlockController implements FileTrackableInterface
     {
         return $this->getCollectionObject();
     }
-
 }

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -151,8 +151,7 @@ class Controller extends BlockController implements FileTrackableInterface
         $db = Database::get();
         $db->delete('btImageSliderEntries', ['bID' => $this->bID]);
         parent::delete();
-
-        $this->tracker->forget($this);
+        $this->getTracker()->forget($this);
     }
 
     public function validate($args)
@@ -229,8 +228,7 @@ class Controller extends BlockController implements FileTrackableInterface
                 ++$i;
             }
         }
-
-        $this->tracker->track($this);
+        $this->getTracker()->track($this);
     }
 
     public function getUsedFiles()
@@ -243,5 +241,17 @@ class Controller extends BlockController implements FileTrackableInterface
     public function getUsedCollection()
     {
         return $this->getCollectionObject();
+    }
+
+    /**
+     * @return \Concrete\Core\Statistics\UsageTracker\AggregateTracker
+     */
+    protected function getTracker()
+    {
+        if ($this->tracker === null) {
+            $this->tracker = $this->app->make(AggregateTracker::class);
+        }
+
+        return $this->tracker;
     }
 }


### PR DESCRIPTION
When someone extends a block type, the $tracker property may not be set if they override the controller constructor. This leads to this error:
```
Error thrown with message "Call to a member function track() on null"
```
Let's avoid this BC issue.