### PR TITLE
Add a migration to refresh the image block type

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.4.0RC4',
     'version_installed' => '8.4.0RC4',
-    'version_db' => '20180518153531', // the key of the latest database migration
+    'version_db' => '20180524000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Updater/Migrations/Migrations/Version20180524000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180524000000.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20180524000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshBlockType('image');
+    }
+}


### PR DESCRIPTION
Commit 01cada6eea10c9def51a09ae3e03bdbf77419b5f changed the schema of the `btContentImage` database table, but we didn't have a migration for it.
Thus, for upgraded concrete5 instances we may have:
```sh
$ ./concrete/bin/concrete5/c5:compare-schema
concrete5 found at C:\Dev\Web\concrete5\concrete5.git
1 query found
1: ALTER TABLE btContentImage CHANGE openLinkInNewWindow openLinkInNewWindow TINYINT(1) DEFAULT '0' NOT NULL
```

Let's fix this database difference.