### PR TITLE
Add Node::getChildNodeByName and Node::getChildNodeByPath

### DIFF
--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -465,7 +465,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $rows = $db->fetchAll('select treeNodeID from TreeNodes where treeNodeParentID = ?', [$treeNodeParentID]);
             foreach ($rows as $row) {
                 $nodeIDs[] = $row['treeNodeID'];
-                $walk($nodeID);
+                $walk($row['treeNodeID']);
             }
         };
         $walk($this->treeNodeID);
@@ -563,7 +563,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
     /**
      * Add a new node.
      *
-     * @param Node|null|false $parent The parent node.
+     * @param Node|null|false $parent the parent node
      *
      * @return Node
      */

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -153,6 +153,55 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
         return $this->childNodes;
     }
 
+    /**
+     * Get the first child node that has a specific name.
+     *
+     * @param string $name The name of the child node
+     * @param bool $create Should the child node be created if it does not exist?
+     *
+     * @return static|null return NULL if no child node has the specified name and $create is false
+     */
+    public function getChildNodeByName($name, $create = false)
+    {
+        $result = null;
+        $this->populateDirectChildrenOnly();
+        foreach ($this->getChildNodes() as $childNode) {
+            if ($childNode->getTreeNodeName() === $name) {
+                $result = $childNode;
+                break;
+            }
+        }
+        if ($result === null && $create) {
+            $result = self::add($this);
+            $result->setTreeNodeName($name);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get a descendent node given its path.
+     *
+     * @param array $names The names of the child nodes (1st item: child name, 2nd item: grand-child name, ...)
+     * @param bool $create Should the descendent node be created if it does not exist?
+     *
+     * @return static|null return NULL if the descendent node has not been found and $create is false
+     */
+    public function getChildNodeByPath(array $names, $create = false)
+    {
+        if (count($names) === 0) {
+            $result = $this;
+        } else {
+            $childName = array_shift($names);
+            $result = $this->getChildNodeByName($childName, $create);
+            if ($result !== null) {
+                $result = $result->getChildNodeByPath($names, $create);
+            }
+        }
+
+        return $result;
+    }
+
     public function overrideParentTreeNodePermissions()
     {
         return $this->treeNodeOverridePermissions;

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -560,6 +560,13 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
         }
     }
 
+    /**
+     * Add a new node.
+     *
+     * @param Node|null|false $parent The parent node.
+     *
+     * @return Node
+     */
     public static function add($parent = false)
     {
         $db = Database::connection();
@@ -573,6 +580,8 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $inheritPermissionsFromTreeNodeID = $parent->getTreeNodePermissionsNodeID();
             $treeNodeDisplayOrder = (int) $db->fetchColumn('select count(treeNodeDisplayOrder) from TreeNodes where treeNodeParentID = ?', [$treeNodeParentID]);
             $parent->updateDateModified();
+        } else {
+            $parent = null;
         }
 
         $treeNodeTypeHandle = uncamelcase(strrchr(get_called_class(), '\\'));
@@ -598,6 +607,10 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
 
         if (!$inheritPermissionsFromTreeNodeID) {
             $node->setTreeNodePermissionsToOverride();
+        }
+
+        if ($parent !== null && $parent->childNodesLoaded) {
+            $parent->childNodes[] = $node;
         }
 
         return $node;

--- a/concrete/src/Tree/Node/Type/Category.php
+++ b/concrete/src/Tree/Node/Type/Category.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Concrete\Core\Tree\Node\Type;
 
 use Concrete\Core\Tree\Node\Node as TreeNode;
 use Concrete\Core\Tree\Node\Type\Formatter\CategoryListFormatter;
 use Concrete\Core\Tree\Node\Type\Menu\CategoryMenu;
-use Loader;
 
 class Category extends TreeNode
 {
@@ -22,6 +22,7 @@ class Category extends TreeNode
     {
         return '\\Concrete\\Core\\Permission\\Assignment\\CategoryTreeNodeAssignment';
     }
+
     public function getPermissionObjectKeyCategoryHandle()
     {
         return 'category_tree_node';


### PR DESCRIPTION
Here's what we discussed in #6672, with a handy addition: the ability to add a node if it's not found (plus [this](https://github.com/concrete5/concrete5/commit/243983d934ad2a707db80ec9677e7472c17805f9) and [this](https://github.com/concrete5/concrete5/commit/c78fddfa5a89468d8f246bb8f3706bb4e52dea83) fixes).

PS: fix #6672