### PR TITLE
Avoid accessing an undefined var in Job::executeJob

### DIFF
--- a/concrete/src/Job/Job.php
+++ b/concrete/src/Job/Job.php
@@ -344,6 +344,7 @@ abstract class Job extends ConcreteObject
             if (strlen($resultMsg) == 0) {
                 $resultMsg = t('The Job was run successfully.');
             }
+            $error = static::JOB_SUCCESS;
         } catch (\Exception $e) {
             $resultMsg = $e->getMessage();
             $error = static::JOB_ERROR_EXCEPTION_GENERAL;


### PR DESCRIPTION
Ref. #4723