### PR TITLE
Add Thumbnail Type events

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1500,6 +1500,10 @@ class Version implements ObjectInterface
             ]
         );
 
+        $app['director']->dispatch('on_thumbnail_generate',
+            new \Concrete\Core\File\Event\ThumbnailGenerate($thumbnailPath, $type)
+        );
+
         if ($type->getHandle() == $config->get('concrete.icons.file_manager_listing.handle') && !$this->fvHasListingThumbnail) {
             $this->fvHasListingThumbnail = true;
             $this->save();

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1689,6 +1689,10 @@ class Version implements ObjectInterface
         try {
             if ($fsl->has($path)) {
                 $fsl->delete($path);
+
+                $app['director']->dispatch('on_thumbnail_delete',
+                    new \Concrete\Core\File\Event\ThumbnailDelete($path, $type)
+                );
             }
         } catch (FileNotFoundException $e) {
         }

--- a/concrete/src/File/Event/ThumbnailDelete.php
+++ b/concrete/src/File/Event/ThumbnailDelete.php
@@ -7,6 +7,8 @@ use Symfony\Component\EventDispatcher\Event as AbstractEvent;
 class ThumbnailDelete extends AbstractEvent
 {
     /**
+     * E.g. /thumbnails/medium_2x/9915/2801/7337/png-24.jpg
+     *
      * @var string
      */
     private $path;
@@ -17,7 +19,7 @@ class ThumbnailDelete extends AbstractEvent
     protected $type;
 
     /**
-     * @param string $path Absolute path to the thumbnail
+     * @param string $path Path to the thumbnail
      * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $type
      */
     public function __construct($path, $type)

--- a/concrete/src/File/Event/ThumbnailDelete.php
+++ b/concrete/src/File/Event/ThumbnailDelete.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Concrete\Core\File\Event;
+
+use Symfony\Component\EventDispatcher\Event as AbstractEvent;
+
+class ThumbnailDelete extends AbstractEvent
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var \Concrete\Core\File\Image\Thumbnail\Type\Version
+     */
+    protected $type;
+
+    /**
+     * @param string $path Absolute path to the thumbnail
+     * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $type
+     */
+    public function __construct($path, $type)
+    {
+        $this->path = $path;
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return \Concrete\Core\File\Image\Thumbnail\Type\Version
+     */
+    public function getThumbnailType()
+    {
+        return $this->type;
+    }
+}

--- a/concrete/src/File/Event/ThumbnailGenerate.php
+++ b/concrete/src/File/Event/ThumbnailGenerate.php
@@ -7,6 +7,8 @@ use Symfony\Component\EventDispatcher\Event as AbstractEvent;
 class ThumbnailGenerate extends AbstractEvent
 {
     /**
+     * E.g. /thumbnails/medium_2x/9915/2801/7337/png-24.jpg
+     *
      * @var string
      */
     private $path;
@@ -17,7 +19,7 @@ class ThumbnailGenerate extends AbstractEvent
     protected $type;
 
     /**
-     * @param string $path Absolute path to the thumbnail
+     * @param string $path Path to the thumbnail
      * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $type
      */
     public function __construct($path, $type)

--- a/concrete/src/File/Event/ThumbnailGenerate.php
+++ b/concrete/src/File/Event/ThumbnailGenerate.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Concrete\Core\File\Event;
+
+use Symfony\Component\EventDispatcher\Event as AbstractEvent;
+
+class ThumbnailGenerate extends AbstractEvent
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var \Concrete\Core\File\Image\Thumbnail\Type\Version
+     */
+    protected $type;
+
+    /**
+     * @param string $path Absolute path to the thumbnail
+     * @param \Concrete\Core\File\Image\Thumbnail\Type\Version $type
+     */
+    public function __construct($path, $type)
+    {
+        $this->path = $path;
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return \Concrete\Core\File\Image\Thumbnail\Type\Version
+     */
+    public function getThumbnailType()
+    {
+        return $this->type;
+    }
+}


### PR DESCRIPTION
It'd be handy if an event is fired when thumbnails are deleted or regenerated. 

- [x] on_thumbnail_delete
- [x] on_thumbnail_generate

Related issue: https://github.com/concrete5/concrete5/issues/6695

---

When hooking into the events and logging the path:
![afbeelding](https://user-images.githubusercontent.com/1431100/40885215-93d64f8e-6711-11e8-8f7d-261a5d024ada.png)
(I added and removed a file)