### PR TITLE
Fix migration of address attribute type settings

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -547,15 +547,18 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
                     if (!$count) {
                         $rowA = $this->connection->fetchAssoc('select * from _atAddressSettings where akID = ?', [$akID]);
                         if ($rowA['akID']) {
-                            $countries = $this->connection->fetchAll('select * from _atAddressCustomCountries where akID = ?', [$akID]);
-                            if (!$countries) {
-                                $countries = [];
+                            $countries = [];
+                            foreach ($this->connection->fetchAll('select * from _atAddressCustomCountries where akID = ?', [$akID]) as $customCountryRow) {
+                                if ($customCountryRow['country']) {
+                                    $countries[] = $customCountryRow['country'];
+                                }
                             }
                             $this->connection->insert('atAddressSettings', [
                                 'akHasCustomCountries' => $rowA['akHasCustomCountries'],
                                 'akDefaultCountry' => $rowA['akDefaultCountry'],
                                 'customCountries' => json_encode($countries),
                                 'akID' => $akID,
+                                'akGeolocateCountry' => 0,
                             ]);
                         }
                     }


### PR DESCRIPTION
When migrating address attribute types from concrete5 5.7.x to 8, we currently have 2 problems:

- the list of allowed countries is malformed
- we have an SQL error because we are inserting a row without specifying the (required) value for the `akGeolocateCountry` field.

Let's fix them.