### PR TITLE
Mark static Pile methods as static

### DIFF
--- a/concrete/controllers/panel/add.php
+++ b/concrete/controllers/panel/add.php
@@ -33,7 +33,7 @@ class Add extends BackendInterfacePageController
             $tab = $session->get('panels_page_add_block_tab');
         }
 
-        $sp = (new Pile())->getDefault();
+        $sp = Pile::getDefault();
         $contents = $sp->getPileContentObjects('date_desc');
 
         $stacks = new StackList();

--- a/concrete/src/Page/Stack/Pile/Pile.php
+++ b/concrete/src/Page/Stack/Pile/Pile.php
@@ -78,7 +78,7 @@ class Pile extends ConcreteObject
      *
      * @return Pile
      */
-    public function create($name)
+    public static function create($name)
     {
         $db = Loader::db();
         $u = new User();
@@ -97,7 +97,7 @@ class Pile extends ConcreteObject
      *
      * @return Pile
      */
-    public function get($pID)
+    public static function get($pID)
     {
         $db = Loader::db();
         $v = array($pID);
@@ -120,7 +120,7 @@ class Pile extends ConcreteObject
      *
      * @return Pile
      */
-    public function getOrCreate($name)
+    public static function getOrCreate($name)
     {
         $db = Loader::db();
         $u = new User();
@@ -178,7 +178,7 @@ class Pile extends ConcreteObject
     /**
      * @return Pile
      */
-    public function getDefault()
+    public static function getDefault()
     {
         $db = Loader::db();
         // checks to see if we're registered, or if we're a visitor. Either way, we get a pile entry
@@ -203,7 +203,7 @@ class Pile extends ConcreteObject
     /**
      * @return Pile
      */
-    public function createDefaultPile()
+    public static function createDefaultPile()
     {
         $db = Loader::db();
         // for the sake of data integrity, we're going to ensure that a general pile does not exist
@@ -233,7 +233,7 @@ class Pile extends ConcreteObject
     /**
      * @return array
      */
-    public function getMyPiles()
+    public static function getMyPiles()
     {
         $db = Loader::db();
 


### PR DESCRIPTION
These methods are called statically ([example 1](https://github.com/concrete5/concrete5/blob/e4d73c2f758083d3fa5d40585fdef2a50055fad0/concrete/src/Page/Stack/Pile/PileContent.php#L110), [example 2](https://github.com/concrete5/concrete5/blob/e4d73c2f758083d3fa5d40585fdef2a50055fad0/concrete/tools/pile_manager.php#L47)), so let's mark them as static.

Sure, we should switch to a better approach (services, factories, entities, ...), but let's fix these warnings for the moment.

Ref. #4723