### PR TITLE
Remove typo in PostLoginLocation PHPDoc

### DIFF
--- a/concrete/src/User/PostLoginLocation.php
+++ b/concrete/src/User/PostLoginLocation.php
@@ -131,7 +131,7 @@ class PostLoginLocation
     }
 
     /**
-     * Get the default post-login URLgetDefaultPostLoginUrl.
+     * Get the default post-login URL.
      *
      * @return string Empty string if unavailable
      */


### PR DESCRIPTION
Remove spurious text introduced in https://github.com/concrete5/concrete5/commit/74b6cbe53c9d4d5ffff7da2562ea4cdc439a2fde#diff-5d6eedbcae8cb3ad2b5a549e128fe347R134