### PR TITLE
Fix #6733

### DIFF
--- a/concrete/src/Config/FileLoader.php
+++ b/concrete/src/Config/FileLoader.php
@@ -153,6 +153,22 @@ class FileLoader implements LoaderInterface {
     }
 
     /**
+     * @param string $namespace
+     * @return string[]
+     */
+    private function getNamespaceDefaultPaths($namespace)
+    {
+        $result = [];
+        if ((string) $namespace !== '') {
+            $result = [
+                "{$this->defaultPath}/generated_overrides/{$namespace}",
+                "{$this->defaultPath}/{$namespace}",
+            ];
+        }
+        return $result;
+    }
+
+    /**
      * Merge the items in the given file into the items.
      *
      * @param  array   $items
@@ -295,9 +311,11 @@ class FileLoader implements LoaderInterface {
      */
     public function clearNamespace($namespace)
     {
-        $path = $this->getPath($namespace);
-        if ($path !== $this->getPath(null) && $this->files->isDirectory($namespace)) {
-            $this->files->deleteDirectory($path);
+        $paths = $this->getNamespaceDefaultPaths($namespace);
+        foreach ($paths as $path) {
+            if ($this->files->isDirectory($path)) {
+                $this->files->deleteDirectory($path);
+            }
         }
     }
 

--- a/concrete/src/Config/FileLoader.php
+++ b/concrete/src/Config/FileLoader.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Concrete\Core\Config;
 
 use Illuminate\Filesystem\Filesystem;
 
-class FileLoader implements LoaderInterface {
-
+class FileLoader implements LoaderInterface
+{
     /**
      * The filesystem instance.
      *
@@ -24,72 +25,26 @@ class FileLoader implements LoaderInterface {
      *
      * @var array
      */
-    protected $hints = array();
+    protected $hints = [];
 
     /**
      * A cache of whether namespaces and groups exists.
      *
      * @var array
      */
-    protected $exists = array();
+    protected $exists = [];
 
     /**
      * Create a new file configuration loader.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $defaultPath
-     * @return void
      */
     public function __construct(Filesystem $files)
     {
         $this->files = $files;
         $this->defaultPath = DIR_CONFIG_SITE;
         $this->addNamespace('core', DIR_BASE_CORE . '/config');
-    }
-
-    /**
-     * Load the given configuration group.
-     *
-     * @param  string  $environment
-     * @param  string  $group
-     * @param  string  $namespace
-     * @return array
-     */
-    protected function defaultLoad($environment, $group, $namespace = null)
-    {
-        $items = array();
-
-        // First we'll get the root configuration path for the environment which is
-        // where all of the configuration files live for that namespace, as well
-        // as any environment folders with their specific configuration items.
-        $path = $this->getPath($namespace);
-
-        if (is_null($path))
-        {
-            return $items;
-        }
-
-        // First we'll get the main configuration file for the groups. Once we have
-        // that we can check for any environment specific files, which will get
-        // merged on top of the main arrays to make the environments cascade.
-        $file = "{$path}/{$group}.php";
-
-        if ($this->files->exists($file))
-        {
-            $items = $this->getRequire($file);
-        }
-
-        // Finally we're ready to check for the environment specific configuration
-        // file which will be merged on top of the main arrays so that they get
-        // precedence over them if we are currently in an environments setup.
-        $file = "{$path}/{$environment}/{$group}.php";
-
-        if ($this->files->exists($file))
-        {
-            $items = $this->mergeEnvironment($items, $file);
-        }
-
-        return $items;
     }
 
     /**
@@ -114,33 +69,35 @@ class FileLoader implements LoaderInterface {
      */
     public function load($environment, $group, $namespace = null)
     {
-        $items = array();
+        $items = [];
 
         // First we'll get the root configuration path for the environment which is
         // where all of the configuration files live for that namespace, as well
         // as any environment folders with their specific configuration items.
         $path = $this->getPath($namespace);
 
-        if (is_null($path)) {
+        if ($path === null) {
             return $items;
         }
 
-        $paths = array();
+        $paths = [];
         if ($namespace === null || $namespace == '') {
             // No namespace, let's load up the concrete config first.
             $items = $this->defaultLoad($environment, $group, 'core');
 
-            $paths = array(
+            $paths = [
                 "{$path}/generated_overrides/{$group}.php",
                 "{$path}/{$group}.php",
-                "{$path}/{$environment}.{$group}.php", );
+                "{$path}/{$environment}.{$group}.php",
+            ];
         } else {
-            $paths = array(
+            $paths = [
                 "{$path}/{$group}.php",
                 "{$path}/{$environment}.{$group}.php",
                 "{$this->defaultPath}/generated_overrides/{$namespace}/{$group}.php",
                 "{$this->defaultPath}/{$namespace}/{$group}.php",
-                "{$this->defaultPath}/{$namespace}/{$environment}.{$group}.php", );
+                "{$this->defaultPath}/{$namespace}/{$environment}.{$group}.php",
+            ];
         }
 
         foreach ($paths as $file) {
@@ -153,49 +110,21 @@ class FileLoader implements LoaderInterface {
     }
 
     /**
-     * @param string $namespace
-     * @return string[]
-     */
-    private function getNamespaceDefaultPaths($namespace)
-    {
-        $result = [];
-        if ((string) $namespace !== '') {
-            $result = [
-                "{$this->defaultPath}/generated_overrides/{$namespace}",
-                "{$this->defaultPath}/{$namespace}",
-            ];
-        }
-        return $result;
-    }
-
-    /**
-     * Merge the items in the given file into the items.
-     *
-     * @param  array   $items
-     * @param  string  $file
-     * @return array
-     */
-    protected function mergeEnvironment(array $items, $file)
-    {
-        return array_replace_recursive($items, $this->getRequire($file));
-    }
-
-    /**
      * Determine if the given group exists.
      *
      * @param  string  $group
      * @param  string  $namespace
+     *
      * @return bool
      */
     public function exists($group, $namespace = null)
     {
-        $key = $group.$namespace;
+        $key = $group . $namespace;
 
         // We'll first check to see if we have determined if this namespace and
         // group combination have been checked before. If they have, we will
         // just return the cached result so we don't have to hit the disk.
-        if (isset($this->exists[$key]))
-        {
+        if (isset($this->exists[$key])) {
             return $this->exists[$key];
         }
 
@@ -204,8 +133,7 @@ class FileLoader implements LoaderInterface {
         // To check if a group exists, we will simply get the path based on the
         // namespace, and then check to see if this files exists within that
         // namespace. False is returned if no path exists for a namespace.
-        if (is_null($path))
-        {
+        if ($path === null) {
             return $this->exists[$key] = false;
         }
 
@@ -226,6 +154,7 @@ class FileLoader implements LoaderInterface {
      * @param  string  $package
      * @param  string  $group
      * @param  array   $items
+     *
      * @return array
      */
     public function cascadePackage($env, $package, $group, $items)
@@ -235,8 +164,7 @@ class FileLoader implements LoaderInterface {
         // options so that we will easily "cascade" a package's configurations.
         $file = "packages/{$package}/{$group}.php";
 
-        if ($this->files->exists($path = $this->defaultPath.'/'.$file))
-        {
+        if ($this->files->exists($path = $this->defaultPath . '/' . $file)) {
             $items = array_merge(
                 $items, $this->getRequire($path)
             );
@@ -247,8 +175,7 @@ class FileLoader implements LoaderInterface {
         // the contents and merge them on top of this array of options we have.
         $path = $this->getPackagePath($env, $package, $group);
 
-        if ($this->files->exists($path))
-        {
+        if ($this->files->exists($path)) {
             $items = array_merge(
                 $items, $this->getRequire($path)
             );
@@ -258,45 +185,10 @@ class FileLoader implements LoaderInterface {
     }
 
     /**
-     * Get the package path for an environment and group.
-     *
-     * @param  string  $env
-     * @param  string  $package
-     * @param  string  $group
-     * @return string
-     */
-    protected function getPackagePath($env, $package, $group)
-    {
-        $file = "packages/{$package}/{$env}/{$group}.php";
-
-        return $this->defaultPath.'/'.$file;
-    }
-
-    /**
-     * Get the configuration path for a namespace.
-     *
-     * @param  string  $namespace
-     * @return string
-     */
-    protected function getPath($namespace)
-    {
-        if (is_null($namespace)) {
-            return $this->defaultPath;
-        }
-
-        if (isset($this->hints[$namespace])) {
-            return $this->hints[$namespace];
-        }
-
-        return "{$this->defaultPath}/{$namespace}";
-    }
-
-    /**
      * Add a new namespace to the loader.
      *
      * @param  string  $namespace
      * @param  string  $hint
-     * @return void
      */
     public function addNamespace($namespace, $hint)
     {
@@ -304,10 +196,9 @@ class FileLoader implements LoaderInterface {
     }
 
     /**
-     * Clear groups in a namespace
+     * Clear groups in a namespace.
      *
      * @param $namespace
-     * @return void
      */
     public function clearNamespace($namespace)
     {
@@ -331,17 +222,6 @@ class FileLoader implements LoaderInterface {
     }
 
     /**
-     * Get a file's contents by requiring it.
-     *
-     * @param  string  $path
-     * @return mixed
-     */
-    protected function getRequire($path)
-    {
-        return $this->files->getRequire($path);
-    }
-
-    /**
      * Get the Filesystem instance.
      *
      * @return \Illuminate\Filesystem\Filesystem
@@ -351,4 +231,125 @@ class FileLoader implements LoaderInterface {
         return $this->files;
     }
 
+    /**
+     * Load the given configuration group.
+     *
+     * @param  string  $environment
+     * @param  string  $group
+     * @param  string  $namespace
+     *
+     * @return array
+     */
+    protected function defaultLoad($environment, $group, $namespace = null)
+    {
+        $items = [];
+
+        // First we'll get the root configuration path for the environment which is
+        // where all of the configuration files live for that namespace, as well
+        // as any environment folders with their specific configuration items.
+        $path = $this->getPath($namespace);
+
+        if ($path === null) {
+            return $items;
+        }
+
+        // First we'll get the main configuration file for the groups. Once we have
+        // that we can check for any environment specific files, which will get
+        // merged on top of the main arrays to make the environments cascade.
+        $file = "{$path}/{$group}.php";
+
+        if ($this->files->exists($file)) {
+            $items = $this->getRequire($file);
+        }
+
+        // Finally we're ready to check for the environment specific configuration
+        // file which will be merged on top of the main arrays so that they get
+        // precedence over them if we are currently in an environments setup.
+        $file = "{$path}/{$environment}/{$group}.php";
+
+        if ($this->files->exists($file)) {
+            $items = $this->mergeEnvironment($items, $file);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Merge the items in the given file into the items.
+     *
+     * @param  array   $items
+     * @param  string  $file
+     *
+     * @return array
+     */
+    protected function mergeEnvironment(array $items, $file)
+    {
+        return array_replace_recursive($items, $this->getRequire($file));
+    }
+
+    /**
+     * Get the package path for an environment and group.
+     *
+     * @param  string  $env
+     * @param  string  $package
+     * @param  string  $group
+     *
+     * @return string
+     */
+    protected function getPackagePath($env, $package, $group)
+    {
+        $file = "packages/{$package}/{$env}/{$group}.php";
+
+        return $this->defaultPath . '/' . $file;
+    }
+
+    /**
+     * Get the configuration path for a namespace.
+     *
+     * @param  string  $namespace
+     *
+     * @return string
+     */
+    protected function getPath($namespace)
+    {
+        if ($namespace === null) {
+            return $this->defaultPath;
+        }
+
+        if (isset($this->hints[$namespace])) {
+            return $this->hints[$namespace];
+        }
+
+        return "{$this->defaultPath}/{$namespace}";
+    }
+
+    /**
+     * Get a file's contents by requiring it.
+     *
+     * @param  string  $path
+     *
+     * @return mixed
+     */
+    protected function getRequire($path)
+    {
+        return $this->files->getRequire($path);
+    }
+
+    /**
+     * @param string $namespace
+     *
+     * @return string[]
+     */
+    private function getNamespaceDefaultPaths($namespace)
+    {
+        $result = [];
+        if ((string) $namespace !== '') {
+            $result = [
+                "{$this->defaultPath}/generated_overrides/{$namespace}",
+                "{$this->defaultPath}/{$namespace}",
+            ];
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
#6733  is caused by this method: https://github.com/concrete5/concrete5/blob/075722d57546e5408b79bfa0affda882e393a768/concrete/src/Config/FileLoader.php#L296-L302

As you can see, there are two bugs in it:
1. `$this->files->isDirectory($namespace)` is wrong, since it tests if a namespace (for instance, a package handle) is a directory. This doesn't make sense.
2.  `$this->getPath($namespace)` returns the `/packages/<handle>/config` directory: we must not delete it.

What we should delete are only the directories under the `/application/config` directory.

PS: this *could* also be related to #6666 