### PR TITLE
Avoid accessing undefined var in Block/Menu constructor

### DIFF
--- a/concrete/src/Block/Menu/Menu.php
+++ b/concrete/src/Block/Menu/Menu.php
@@ -87,6 +87,8 @@ class Menu extends ContextMenu
             if ($btOriginal->supportsInlineEdit()) {
                 $editInline = true;
             }
+        } else {
+            $_bo = null;
         }
 
 


### PR DESCRIPTION
Ref. #4723