### PR TITLE
Add FileFolder::getChildFolderByName and FileFolder::getChildFolderByPath

### DIFF
--- a/concrete/src/File/Filesystem.php
+++ b/concrete/src/File/Filesystem.php
@@ -16,6 +16,8 @@ class Filesystem
 {
     /**
      * Creates everything necessary to store files in folders.
+     *
+     * @return \Concrete\Core\Tree\Type\FileManager
      */
     public function create()
     {
@@ -56,6 +58,13 @@ class Filesystem
         $pt->assignPermissionAccess($pa);
     }
 
+    /**
+     * Get a folder given its ID.
+     *
+     * @param mixed $folderID
+     *
+     * @return \Concrete\Core\Tree\Node\Type\FileFolder|null
+     */
     public function getFolder($folderID)
     {
         $node = Node::getByID($folderID);
@@ -64,14 +73,27 @@ class Filesystem
         }
     }
 
+    /**
+     * Get the root folder.
+     *
+     * @return \Concrete\Core\Tree\Node\Type\FileFolder|null
+     */
     public function getRootFolder()
     {
         $tree = FileManager::get();
-        if (is_object($tree)) {
+        if ($tree !== null) {
             return $tree->getRootTreeNodeObject();
         }
     }
 
+    /**
+     * Create a new folder.
+     *
+     * @param FileFolder $folder The parent folder
+     * @param string $name The name of the new folder
+     *
+     * @return \Concrete\Core\Tree\Node\Type\FileFolder
+     */
     public function addFolder(FileFolder $folder, $name)
     {
         return $folder->add($name, $folder);

--- a/concrete/src/File/Filesystem.php
+++ b/concrete/src/File/Filesystem.php
@@ -1,13 +1,10 @@
 <?php
+
 namespace Concrete\Core\File;
 
-use Concrete\Core\File\Search\ColumnSet\DefaultSet;
-use Concrete\Core\File\Search\ColumnSet\FolderSet;
-use Concrete\Core\File\Search\Result\Result;
 use Concrete\Core\Permission\Access\Access;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
 use Concrete\Core\Permission\Key\CategoryTreeNodeKey;
-use Concrete\Core\File\FolderItemList;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\NodeType;
 use Concrete\Core\Tree\Node\Type\FileFolder;
@@ -79,5 +76,4 @@ class Filesystem
     {
         return $folder->add($name, $folder);
     }
-
 }

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -416,7 +416,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $rows = $db->fetchAll('select treeNodeID from TreeNodes where treeNodeParentID = ?', [$treeNodeParentID]);
             foreach ($rows as $row) {
                 $nodeIDs[] = $row['treeNodeID'];
-                $walk($nodeID);
+                $walk($row['treeNodeID']);
             }
         };
         $walk($this->treeNodeID);
@@ -514,7 +514,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
     /**
      * Add a new node.
      *
-     * @param Node|null|false $parent The parent node.
+     * @param Node|null|false $parent the parent node
      *
      * @return Node
      */

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -511,6 +511,13 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
         }
     }
 
+    /**
+     * Add a new node.
+     *
+     * @param Node|null|false $parent The parent node.
+     *
+     * @return Node
+     */
     public static function add($parent = false)
     {
         $db = Database::connection();
@@ -524,6 +531,8 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $inheritPermissionsFromTreeNodeID = $parent->getTreeNodePermissionsNodeID();
             $treeNodeDisplayOrder = (int) $db->fetchColumn('select count(treeNodeDisplayOrder) from TreeNodes where treeNodeParentID = ?', [$treeNodeParentID]);
             $parent->updateDateModified();
+        } else {
+            $parent = null;
         }
 
         $treeNodeTypeHandle = uncamelcase(strrchr(get_called_class(), '\\'));
@@ -549,6 +558,10 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
 
         if (!$inheritPermissionsFromTreeNodeID) {
             $node->setTreeNodePermissionsToOverride();
+        }
+
+        if ($parent !== null && $parent->childNodesLoaded) {
+            $parent->childNodes[] = $node;
         }
 
         return $node;

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -770,7 +770,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $children = $db->fetchAll('select treeNodeID, treeNodeTypeID, treeNodeParentID, treeNodeDisplayOrder from TreeNodes where treeNodeTypeID = ? and treeNodeParentID = ? order by treeNodeDisplayOrder asc', [$treeNodeTypeID, $nodeRow['treeNodeID']]);
             $numChildren = count($children);
         } else {
-            $numChildren = (int) $db->fetchColumn('select count(*) from TreeNodes where treeNodeTypeID = ? and treeNodeParentID = ? order by treeNodeDisplayOrder asc', [$treeNodeTypeID, $nodeRow['treeNodeID']]);
+            $numChildren = (int) $db->fetchColumn('select count(*) from TreeNodes where treeNodeTypeID = ? and treeNodeParentID = ?', [$treeNodeTypeID, $nodeRow['treeNodeID']]);
         }
 
         if ($includeThisNode) {

--- a/concrete/src/Tree/Node/Type/Category.php
+++ b/concrete/src/Tree/Node/Type/Category.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Concrete\Core\Tree\Node\Type;
 
 use Concrete\Core\Tree\Node\Node as TreeNode;
 use Concrete\Core\Tree\Node\Type\Formatter\CategoryListFormatter;
 use Concrete\Core\Tree\Node\Type\Menu\CategoryMenu;
-use Loader;
 
 class Category extends TreeNode
 {
@@ -22,6 +22,7 @@ class Category extends TreeNode
     {
         return '\\Concrete\\Core\\Permission\\Assignment\\CategoryTreeNodeAssignment';
     }
+
     public function getPermissionObjectKeyCategoryHandle()
     {
         return 'category_tree_node';

--- a/concrete/src/Tree/Node/Type/FileFolder.php
+++ b/concrete/src/Tree/Node/Type/FileFolder.php
@@ -62,7 +62,7 @@ class FileFolder extends Category
         $sort = false;
         $list = new FolderItemList();
         $list->filterByParentFolder($this);
-        if (is_object($u)) {
+        if ($u !== null) {
             if (($column = $request->get($list->getQuerySortColumnParameter())) && ($direction = $request->get($list->getQuerySortDirectionParameter()))) {
                 if (is_object($available->getColumnByKey($column)) && ($direction == 'asc' || $direction == 'desc')) {
                     $sort = [$column, $direction];

--- a/concrete/src/Tree/Node/Type/FileFolder.php
+++ b/concrete/src/Tree/Node/Type/FileFolder.php
@@ -102,6 +102,7 @@ class FileFolder extends Category
             $childNodesData = $this->getHierarchicalNodesOfType($typeHandle, 1, true, false, 1);
             $childNodes = array_map(function ($item) { return $item['treeNodeObject']; }, $childNodesData);
         }
+        $result = null;
         foreach ($childNodes as $childNode) {
             if ($childNode->getTreeNodeTypeHandle() === $typeHandle && $childNode->getTreeNodeName() === $name) {
                 $result = $childNode;

--- a/concrete/src/Tree/Node/Type/FileFolder.php
+++ b/concrete/src/Tree/Node/Type/FileFolder.php
@@ -4,17 +4,13 @@ namespace Concrete\Core\Tree\Node\Type;
 use Concrete\Core\File\FolderItemList;
 use Concrete\Core\File\Search\ColumnSet\FolderSet;
 use Concrete\Core\Tree\Node\Node as TreeNode;
-use Concrete\Core\Tree\Node\Type\Formatter\CategoryListFormatter;
-use Concrete\Core\Tree\Node\Type\Menu\CategoryMenu;
 use Concrete\Core\Tree\Node\Type\Menu\FileFolderMenu;
 use Concrete\Core\User\User;
 use Gettext\Translations;
-use Loader;
 use Symfony\Component\HttpFoundation\Request;
 
 class FileFolder extends Category
 {
-
     public function getPermissionResponseClassName()
     {
         return '\\Concrete\\Core\\Permission\\Response\\FileFolderResponse';
@@ -24,6 +20,7 @@ class FileFolder extends Category
     {
         return '\\Concrete\\Core\\Permission\\Assignment\\FileFolderAssignment';
     }
+
     public function getPermissionObjectKeyCategoryHandle()
     {
         return 'file_folder';
@@ -46,6 +43,7 @@ class FileFolder extends Category
             $node->isFolder = true;
             $node->resultsThumbnailImg = $this->getListFormatter()->getIconElement();
         }
+
         return $node;
     }
 
@@ -54,6 +52,7 @@ class FileFolder extends Category
         if ($this->getTreeNodeParentID() == 0) {
             return t('File Manager');
         }
+
         return parent::getTreeNodeName();
     }
 
@@ -66,7 +65,7 @@ class FileFolder extends Category
         if (is_object($u)) {
             if (($column = $request->get($list->getQuerySortColumnParameter())) && ($direction = $request->get($list->getQuerySortDirectionParameter()))) {
                 if (is_object($available->getColumnByKey($column)) && ($direction == 'asc' || $direction == 'desc')) {
-                    $sort = array($column, $direction);
+                    $sort = [$column, $direction];
                     $u->saveConfig(sprintf('file_manager.sort.%s', $this->getTreeNodeID()), json_encode($sort));
                 }
             } else {
@@ -82,6 +81,7 @@ class FileFolder extends Category
                 }
             }
         }
+
         return $list;
     }
 
@@ -89,5 +89,4 @@ class FileFolder extends Category
     {
         return false;
     }
-
 }

--- a/concrete/src/Tree/Type/FileManager.php
+++ b/concrete/src/Tree/Type/FileManager.php
@@ -1,18 +1,16 @@
 <?php
+
 namespace Concrete\Core\Tree\Type;
 
-use Concrete\Core\Permission\Access\Access;
-use Concrete\Core\Permission\Access\Entity\GroupEntity;
-use Concrete\Core\Permission\Key\CategoryTreeNodeKey;
-use Concrete\Core\Tree\Node\Type\Category;
 use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete\Core\Tree\Tree;
-use Concrete\Core\User\Group\Group as ConcreteGroup;
 use Database;
 
 class FileManager extends Tree
 {
-    /** Returns the standard name for this tree
+    /**
+     * Returns the standard name for this tree.
+     *
      * @return string
      */
     public function getTreeName()
@@ -20,7 +18,9 @@ class FileManager extends Tree
         return 'File Manager';
     }
 
-    /** Returns the display name for this tree (localized and escaped accordingly to $format)
+    /**
+     * Returns the display name for this tree (localized and escaped accordingly to $format).
+     *
      * @param  string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
      *
      * @return string
@@ -37,6 +37,11 @@ class FileManager extends Tree
         }
     }
 
+    /**
+     * Get the FileManager instance.
+     *
+     * @return FileManager|null
+     */
     public static function get()
     {
         $db = Database::connection();
@@ -47,10 +52,6 @@ class FileManager extends Tree
     }
 
     public function exportDetails(\SimpleXMLElement $sx)
-    {
-    }
-
-    protected function deleteDetails()
     {
     }
 
@@ -67,8 +68,11 @@ class FileManager extends Tree
         return $tree;
     }
 
-    protected function loadDetails()
+    protected function deleteDetails()
     {
     }
 
+    protected function loadDetails()
+    {
+    }
 }

--- a/concrete/src/Tree/Type/FileManager.php
+++ b/concrete/src/Tree/Type/FileManager.php
@@ -45,10 +45,9 @@ class FileManager extends Tree
     public static function get()
     {
         $db = Database::connection();
-        $treeTypeID = $db->GetOne('select treeTypeID from TreeTypes where treeTypeHandle = ?', array('file_manager'));
-        $treeID = $db->GetOne('select treeID from Trees where treeTypeID = ?', array($treeTypeID));
+        $treeID = $db->fetchColumn('select Trees.treeID from TreeTypes inner join Trees on TreeTypes.treeTypeID = Trees.treeTypeID where TreeTypes.treeTypeHandle = ?', ['file_manager']);
 
-        return Tree::getByID($treeID);
+        return $treeID ? Tree::getByID($treeID) : null;
     }
 
     public function exportDetails(\SimpleXMLElement $sx)

--- a/tests/tests/File/FilesystemTest.php
+++ b/tests/tests/File/FilesystemTest.php
@@ -7,6 +7,9 @@ use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 
 class FilesystemTest extends ConcreteDatabaseTestCase
 {
+    /**
+     * @var \Concrete\Core\File\Filesystem
+     */
     protected $filesystem;
 
     protected $tables = [

--- a/tests/tests/File/FilesystemTest.php
+++ b/tests/tests/File/FilesystemTest.php
@@ -41,4 +41,52 @@ class FilesystemTest extends ConcreteDatabaseTestCase
         $this->assertEquals(1, $folder->getTreeNodeParentID());
         $this->assertEquals('Test Sub Folder', $folder->getTreeNodeDisplayName());
     }
+
+    public function testGetFolderByName()
+    {
+        $rootFolder = $this->filesystem->getRootFolder();
+        $uniqueID = microtime(true) . '-' - mt_rand();
+        // Create these folders:
+        // |- Folder 1
+        // |   |- Folder 1.1
+        // |- Folder 2
+        // |   |- Folder 1.2
+        $folder_1 = $this->filesystem->addFolder($rootFolder, "Folder 1 {$uniqueID}");
+        $folder_1_1 = $this->filesystem->addFolder($folder_1, "Folder 1.1 {$uniqueID}");
+        $folder_2 = $this->filesystem->addFolder($rootFolder, "Folder 2 {$uniqueID}");
+        $folder_2_1 = $this->filesystem->addFolder($folder_2, "Folder 2.1 {$uniqueID}");
+        // Folder A should not be found
+        $folderA = $rootFolder->getNodeByName("Folder A {$uniqueID}");
+        $this->assertNull($folderA);
+        // Add two Folder A:
+        // |- Folder 1
+        // |   |- Folder 1.1
+        // |       |- Folder A
+        // |- Folder 2
+        // |   |- Folder 1.2
+        // |       |- Folder A
+        $folderA_1_1 = $this->filesystem->addFolder($folder_1_1, "Folder A {$uniqueID}");
+        $folderA_2_1 = $this->filesystem->addFolder($folder_2_1, "Folder A {$uniqueID}");
+        // Now Folder A can be one of the two Folder A created (we don't know which one)
+        $folderA = $rootFolder->getNodeByName("Folder A {$uniqueID}");
+        $this->assertNotNull($folderA);
+        $this->assertContains($folderA->getTreeNodeID(), [$folderA_1_1->getTreeNodeID(), $folderA_2_1->getTreeNodeID()]);
+        // Let's look for Folder A child of 1 -> 1.1
+        $folderA = $rootFolder->getChildFolderByPath(["Folder 1 {$uniqueID}", "Folder 1.1 {$uniqueID}", "Folder A {$uniqueID}"]);
+        $this->assertNotNull($folderA);
+        $this->assertSame($folderA->getTreeNodeID(), $folderA_1_1->getTreeNodeID());
+        // Let's look for Folder A child of 2 -> 2.1
+        $folderA = $rootFolder->getChildFolderByPath(["Folder 2 {$uniqueID}", "Folder 2.1 {$uniqueID}", "Folder A {$uniqueID}"]);
+        $this->assertNotNull($folderA);
+        $this->assertSame($folderA->getTreeNodeID(), $folderA_2_1->getTreeNodeID());
+        // Let getChildFolderByPath create folders that don't exist yet
+        foreach ([false, true] as $create) {
+            $folderB = $rootFolder->getChildFolderByPath(["Folder 3 {$uniqueID}", "Folder 3.1 {$uniqueID}", "Folder B {$uniqueID}"], $create);
+            if ($create === false) {
+                $this->assertNull($folderB);
+            } else {
+                $this->assertNotNull($folderB);
+            }
+        }
+    }
 }

--- a/tests/tests/File/FilesystemTest.php
+++ b/tests/tests/File/FilesystemTest.php
@@ -48,7 +48,7 @@ class FilesystemTest extends ConcreteDatabaseTestCase
     public function testGetFolderByName()
     {
         $rootFolder = $this->filesystem->getRootFolder();
-        $uniqueID = microtime(true) . '-' - mt_rand();
+        $uniqueID = microtime(true) . '-' . mt_rand();
         // Create these folders:
         // |- Folder 1
         // |   |- Folder 1.1


### PR DESCRIPTION
Here's what we discussed in #6672, with a handy addition: the ability to create folders if they don't exist (plus some phpdocs and [this](https://github.com/concrete5/concrete5/commit/1dcee2fe1cc162acfe13e3697bd020947d8fe285#diff-479422cef7f180fc48e597c997a644ecR564) and [this](https://github.com/concrete5/concrete5/commit/50e92a45043e3668f7eccab5c39cbc831e517764) bug fixes).

One question about [this line](https://github.com/concrete5/concrete5/commit/8c63a1d317d1703ffd63f4a4d1d14aad1f5f501a#diff-65eeada9ffd75ac1f9142813fa390018R112): it works, but is it ok or should we use the `addFolder` method of `Filesystem`?

PS: fix #6672