### PR TITLE
Add support of MySQL 8 keywords

### DIFF
--- a/concrete/src/Database/Driver/PDOMySqlConcrete5/Driver.php
+++ b/concrete/src/Database/Driver/PDOMySqlConcrete5/Driver.php
@@ -10,7 +10,7 @@ use Concrete\Core\Database\Connection\PDOConnection;
  */
 class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver
 {
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         $conn = new PDOConnection(
             $this->_constructPdoDsn($params),
@@ -27,7 +27,7 @@ class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver
      *
      * @param array $params
      *
-     * @return string The DSN.
+     * @return string the DSN
      */
     private function _constructPdoDsn(array $params)
     {

--- a/concrete/src/Database/Driver/PDOMySqlConcrete5/Driver.php
+++ b/concrete/src/Database/Driver/PDOMySqlConcrete5/Driver.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Database\Driver\PDOMySqlConcrete5;
 
 use Concrete\Core\Database\Connection\PDOConnection;
+use Concrete\Core\Database\Platforms\MySQL80Platform;
 
 /**
  * PDO MySql driver.
@@ -20,6 +21,24 @@ class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver
         );
 
         return $conn;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\DBAL\Driver\AbstractMySQLDriver::createDatabasePlatformForVersion()
+     */
+    public function createDatabasePlatformForVersion($version)
+    {
+        if (false === stripos($version, 'mariadb')) {
+            if (preg_match('/^(\d+)/', $version, $match)) {
+                if ((int) $match[1] >= 8) {
+                    return new MySQL80Platform();
+                }
+            }
+        }
+
+        return parent::createDatabasePlatformForVersion($version);
     }
 
     /**

--- a/concrete/src/Database/Platforms/Keywords/MySQL80Keywords.php
+++ b/concrete/src/Database/Platforms/Keywords/MySQL80Keywords.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Concrete\Core\Database\Platforms\Keywords;
+
+use Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords;
+
+/**
+ * Backport of https://github.com/doctrine/dbal/pull/3128.
+ */
+class MySQL80Keywords extends MySQL57Keywords
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords::getName()
+     */
+    public function getName()
+    {
+        return 'MySQL80';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords::getKeywords()
+     */
+    protected function getKeywords()
+    {
+        $keywords = parent::getKeywords();
+
+        $keywords = array_merge($keywords, [
+            'ADMIN',
+            'CUBE',
+            'CUME_DIST',
+            'DENSE_RANK',
+            'EMPTY',
+            'EXCEPT',
+            'FIRST_VALUE',
+            'FUNCTION',
+            'GROUPING',
+            'GROUPS',
+            'JSON_TABLE',
+            'LAG',
+            'LAST_VALUE',
+            'LEAD',
+            'NTH_VALUE',
+            'NTILE',
+            'OF',
+            'OVER',
+            'PERCENT_RANK',
+            'PERSIST',
+            'PERSIST_ONLY',
+            'RANK',
+            'RECURSIVE',
+            'ROW',
+            'ROWS',
+            'ROW_NUMBER',
+            'SYSTEM',
+            'WINDOW',
+        ]);
+
+        return $keywords;
+    }
+}

--- a/concrete/src/Database/Platforms/MySQL80Platform.php
+++ b/concrete/src/Database/Platforms/MySQL80Platform.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Core\Database\Platforms;
+
+use Concrete\Core\Database\Platforms\Keywords\MySQL80Keywords;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+
+/**
+ * Backport of https://github.com/doctrine/dbal/pull/3128.
+ */
+class MySQL80Platform extends MySQL57Platform
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\DBAL\Platforms\MySQL57Platform::getReservedKeywordsClass()
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return MySQL80Keywords::class;
+    }
+}


### PR DESCRIPTION
#6622 is not enough to close #6156: we need to tell Doctrine the actual list of MySQL reserved keywords.

Since https://github.com/doctrine/dbal/pull/3128 won't be backported, we have to implement our own MySQL 8 reserved keyword list.

Fix #6156