### PR TITLE
Fix handling of JavascriptLocalizedAsset URL & path

### DIFF
--- a/concrete/src/Asset/JavascriptLocalizedAsset.php
+++ b/concrete/src/Asset/JavascriptLocalizedAsset.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Concrete\Core\Asset;
 
-use URL;
 use Localization;
+use URL;
 
 class JavascriptLocalizedAsset extends JavascriptAsset
 {
@@ -24,14 +25,15 @@ class JavascriptLocalizedAsset extends JavascriptAsset
         return 'javascript';
     }
 
-    public function getAssetURL()
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Asset\Asset::mapAssetLocation()
+     */
+    public function mapAssetLocation($path)
     {
-        $url = parent::getAssetURL();
-        try {
-            return URL::to($url)->getRelativeUrl();
-        } catch(\Exception $e) {
-            return DIR_REL . '/' . DISPATCHER_FILENAME . $url;
-        }
+        $url = URL::to('/' . ltrim($path, '/'))->getRelativeUrl();
+        $this->setAssetURL($url);
     }
 
     /**
@@ -39,7 +41,7 @@ class JavascriptLocalizedAsset extends JavascriptAsset
      */
     public function getAssetHashKey()
     {
-        return $this->assetURL.'::'.Localization::activeLocale().'::'.sha1($this->getAssetContents());
+        return $this->assetURL . '::' . Localization::activeLocale() . '::' . sha1($this->getAssetContents());
     }
 
     public function isAssetLocal()
@@ -52,6 +54,12 @@ class JavascriptLocalizedAsset extends JavascriptAsset
      */
     public function getAssetContents()
     {
-        return parent::getAssetContentsByRoute($this->assetURL);
+        $assetRoute = $this->getAssetURL();
+        $prefix = '/' . DISPATCHER_FILENAME . '/';
+        if (strpos($assetRoute, $prefix) === 0) {
+            $assetRoute = substr($assetRoute, strlen($prefix) - 1);
+        }
+
+        return parent::getAssetContentsByRoute($assetRoute);
     }
 }


### PR DESCRIPTION
If we register a JavascriptLocalizedAsset without specifying a leading `/` for the filename, the asset gets loaded when `concrete.cache.assets` is false, but it doesn't get loaded if its true.

That's because of an unnecessarily convoluted and buggy algorithm to resolve the assets (which furthermore may not work if pretty URLs are not enabled).

Let's simplify this approach, making it simpler and more robust.