### PR TITLE
Fix CKEditor configuration preview

### DIFF
--- a/concrete/controllers/dialog/editor/settings/preview.php
+++ b/concrete/controllers/dialog/editor/settings/preview.php
@@ -52,11 +52,20 @@ class Preview extends BackendUserInterface
         $this->set('previewHtml', is_string($previewHtml) ? $previewHtml : '');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Controller\Backend\UserInterface::canAccess()
+     */
     protected function canAccess()
     {
+        $result = false;
         $page = Page::getByPath('/dashboard/system/basics/editor');
-        $checker = new Checker($page);
+        if ($page && !$page->isError()) {
+            $checker = new Checker($page);
+            $result = $checker->canViewPage();
+        }
 
-        return $checker->canView();
+        return $result;
     }
 }


### PR DESCRIPTION
Fix a bug introduced in #6720 which prevents users from viewing the editor preview in the `/dashboard/system/basics/editor` page (it only worked for `admin`).