### PR TITLE
Use correct locale ID in Multilingual/Service/Detector::getPreferredSection

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -66,11 +66,11 @@ class Detector
             $config = $site->getConfigRepository();
             if ($config->get('multilingual.use_browser_detected_locale')) {
                 $home = false;
-                $locales = \Punic\Misc::getBrowserLocales();
-                foreach (array_keys($locales) as $locale) {
-                    $home = Section::getByLocaleOrLanguage($locale);
+                $browserLocales = \Punic\Misc::getBrowserLocales();
+                foreach (array_keys($browserLocales) as $browserLocale) {
+                    $home = Section::getByLocaleOrLanguage($browserLocale);
                     if ($home) {
-                        $result = [$locale, $home];
+                        $result = [$home->getLocale(), $home];
                         break;
                     }
                 }


### PR DESCRIPTION
When we detect the browser locale, we can for example resolve the `it` language code specified by the browser to the `it_IT` multilingual section.
In this case, we store in the `multilingual_default_locale` session key `it` instead of `it_IT`, which is wrong: we should store the actual multilingual section ID, otherwise [this line](https://github.com/concrete5/concrete5/blob/8.4.0/concrete/src/Multilingual/Service/Detector.php#L43) will fail.

Let's fix this.