### PR TITLE
Use UI localization context in concrete5 toolbar & account menu

### DIFF
--- a/concrete/elements/footer_required.php
+++ b/concrete/elements/footer_required.php
@@ -1,4 +1,5 @@
 <?php
+use Concrete\Core\Localization\Localization;
 use Concrete\Core\Support\Facade\Application;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -11,10 +12,16 @@ $app = Application::getFacadeApplication();
 $c = Page::getCurrentPage();
 $site = $app->make('site')->getSite();
 $config = $site->getConfigRepository();
+$localization = Localization::getInstance();
 
 if (is_object($c)) {
     $cp = new Permissions($c);
-    View::element('page_controls_footer', ['cp' => $cp, 'c' => $c]);
+    $localization->pushActiveContext(Localization::CONTEXT_UI);
+    try {
+        View::element('page_controls_footer', ['cp' => $cp, 'c' => $c]);
+    } finally {
+        $localization->popActiveContext();
+    }
 }
 
 if (empty($disableTrackingCode)) {
@@ -29,6 +36,11 @@ if (!isset($display_account_menu)) {
 if ($display_account_menu) {
     $dh = $app->make('helper/concrete/dashboard');
     if (!$dh->inDashboard($c)) {
-        View::element('account/menu');
+        $localization->pushActiveContext(Localization::CONTEXT_UI);
+        try {
+            View::element('account/menu');
+        } finally {
+            $localization->popActiveContext();
+        }
     }
 }


### PR DESCRIPTION
Let's assume that I'm a user that specified English when I logged in, and that I'm viewing a page in Chinese.
I'd expect the concrete5 toolbar and the account menu to be in English (sadly I really can't understand Chinese).

BTW ATM the interface is in Chinese:

![immagine](https://user-images.githubusercontent.com/928116/41284209-ed2101aa-6e38-11e8-9c9c-f8fed1cc7407.png)

With this fix, the interface will be in English:

![immagine](https://user-images.githubusercontent.com/928116/41284230-f8a60ec6-6e38-11e8-915e-4a86d1ad48a5.png)
