### PR TITLE
Pass user to finishAuthentication in AuthenticationTypeController completeAuthentication

### DIFF
--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -36,7 +36,7 @@ abstract class AuthenticationTypeController extends Controller implements Authen
     {
         $c = Page::getByPath('/login');
         $controller = $c->getPageController();
-        return $controller->finishAuthentication($this->getAuthenticationType());
+        return $controller->finishAuthentication($this->getAuthenticationType(), $u);
     }
 
     /**


### PR DESCRIPTION
In https://github.com/concrete5/concrete5/pull/6673 the signature of the Login controller method `finishAuthentication` changed.

Most calls were updated, but this call in `AuthenticationTypeController` was missed.

When login in with a third-party authentication type like Twitter the following message appears:

![screenshot 2018-06-13 11 36 08](https://user-images.githubusercontent.com/13346/41343343-98f952dc-6efe-11e8-8fdd-b25384533592.png)

```
Too few arguments to function Concrete\Controller\SinglePage\Login::finishAuthentication(), 1 passed in /Users/fabian/Workspace/concrete5/concrete/src/Authentication/AuthenticationTypeController.php on line 39 and exactly 2 expected
```

The user is already passed to the `completeAuthentication` method, so we can simply forward that argument.