### PR TITLE
Don't call t() in BrokenPackage constructor

### DIFF
--- a/concrete/src/Package/BrokenPackage.php
+++ b/concrete/src/Package/BrokenPackage.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace Concrete\Core\Package;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Error\UserMessageException;
 
 class BrokenPackage extends Package
 {
@@ -9,14 +11,34 @@ class BrokenPackage extends Package
     {
         $this->pkgHandle = $pkgHandle;
         $this->pkgVersion = '0.0';
-        $this->pkgName = t('Unknown Package');
-        $this->pkgDescription = t('Broken package (handle %s).', $pkgHandle);
+        $this->pkgName = 'Unknown Package';
+        $this->pkgDescription = sprintf('Broken package (handle %s).', $pkgHandle);
         parent::__construct($application);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\Package::getPackageName()
+     */
+    public function getPackageName()
+    {
+        return t('Unknown Package');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\Package::getPackageDescription()
+     */
+    public function getPackageDescription()
+    {
+        return t('Broken package (handle %s).', $this->getPackageHandle());
     }
 
     public function install()
     {
-        throw new \Exception($this->getInstallErrorMessage());
+        throw new UserMessageException($this->getInstallErrorMessage());
     }
 
     public function getInstallErrorMessage()


### PR DESCRIPTION
1. `t()` is called
2. the localization system initialize itself:
   1. it loads the core language files
   2. it loads the package language files, which implies listing all the packages marked as installed in the database and creating an instance of package controller of each
   3. If there's a problem instantiating a package controller, we create an instance of BrokenPackage
   4. In the constructor of the BrokenPackage controller we currently have `t()` calls.
   5. since the localization system is not yet loaded, go to point 2. until PHP runs out of memory.

Solution: don't call `t()` in BrokenPackage constructor

PS: this problem does not occur for `en_US`, since no language file is loaded for that locale.