### PR TITLE
Reduce concurrency problems in FileSystemStashDriver::storeData

### DIFF
--- a/concrete/src/Cache/Driver/FileSystemStashDriver.php
+++ b/concrete/src/Cache/Driver/FileSystemStashDriver.php
@@ -28,9 +28,12 @@ class FileSystemStashDriver extends FileSystem
         }
 
         if (!file_exists($path)) {
-            if (!is_dir(dirname($path))) {
-                if (!@mkdir(dirname($path), $this->dirPermissions, true)) {
-                    return false;
+            $dirname = dirname($path);
+            if (!is_dir($dirname)) {
+                if (!@mkdir($dirname, $this->dirPermissions, true)) {
+                    if (!is_dir($dirname)) {
+                        return false;
+                    }
                 }
             }
 


### PR DESCRIPTION
If two concurrent processes are running [these lines](https://github.com/concrete5/concrete5/blob/66a0c288b8b6b990a1a3f1030fd0999d370e48c3/concrete/src/Cache/Driver/FileSystemStashDriver.php#L31-L34), the first process will succeed, but the second one may return false because it tried to create the directory that has been already created by the other process.
So, let's try to see if the directory exists even if mkdir failed.