### PR TITLE
Add a link to Slack in the install page

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -593,6 +593,7 @@ return [
             'developer' => 'http://documentation.concrete5.org/developers',
             'user' => 'http://documentation.concrete5.org/editors',
             'forum' => 'http://www.concrete5.org/community/forums',
+            'slack' => 'https://www.concrete5.org/slack',
         ],
         'paths' => [
             'menu_help_service' => '/tools/get_remote_help_list/',

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -737,6 +737,17 @@ switch ($installStep) {
 
                         <div class="media">
                             <div class="media-left" style="padding-right: 1em">
+                                <i class="fa fa-slack fa-2x"></i>
+                            </div>
+                            <div class="media-body">
+                                <h4 class="media-heading"><?= t('Slack') ?></h4>
+                                <?= t('In the <a href="%s" target="_blank">concrete5 Slack channels</a> you can get in touch with a lot of concrete5 lovers and developers.',
+                                    Config::get('concrete.urls.help.slack')) ?>
+                            </div>
+                        </div>
+
+                        <div class="media">
+                            <div class="media-left" style="padding-right: 1em">
                                 <i class="fa fa-book fa-2x"></i>
                             </div>
                             <div class="media-body">


### PR DESCRIPTION
What about adding a link to the concrete5 Slack channels in the install screen?

![immagine](https://user-images.githubusercontent.com/928116/41520659-1594328e-72cf-11e8-9f97-5489ce35e961.png)
