### PR TITLE
Add UsernameValidator

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.4.1a2',
     'version_installed' => '8.4.1a2',
-    'version_db' => '20180615000000', // the key of the latest database migration
+    'version_db' => '20180621000000', // the key of the latest database migration
 
     /*
      * Installation status
@@ -740,7 +740,10 @@ return [
         'username' => [
             'maximum' => 64,
             'minimum' => 3,
-            'allow_spaces' => false,
+            'allowed_characters' => [
+                'boundary' => 'A-Za-z0-9',
+                'middle' => 'A-Za-z0-9_\.',
+            ],
         ],
         'password' => [
             'maximum' => 128,

--- a/concrete/controllers/single_page/account/edit_profile.php
+++ b/concrete/controllers/single_page/account/edit_profile.php
@@ -13,6 +13,7 @@ use Loader;
 use User;
 use UserAttributeKey;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\User\Validation\UsernameValidator;
 
 class EditProfile extends AccountPageController
 {
@@ -74,18 +75,17 @@ class EditProfile extends AccountPageController
     {
         $this->view();
         $ui = $this->get('profile');
+        /* @var \Concrete\Core\User\UserInfo $ui */
 
-        /** @var Application $app */
         $app = $this->app;
 
-        /** @var Strings $vsh */
         $vsh = $app->make('helper/validation/strings');
 
-        /** @var Validation $cvh */
         $cvh = $app->make('helper/concrete/validation');
 
-        /** @var Token $valt */
         $valt = $app->make('token');
+
+        $usernameValidator = $app->make(UsernameValidator::class);
 
         $data = $this->post();
 
@@ -107,11 +107,7 @@ class EditProfile extends AccountPageController
          * Username validation
          */
         if ($username = $this->post('uName')) {
-            if (!$cvh->username($username)) {
-                $this->error->add(t('Invalid username provided.'));
-            } elseif (!$cvh->isUniqueUsername($username)) {
-                $this->error->add(t("The username '%s' is already in use. Please choose another.", $username));
-            }
+            $this->error->add($usernameValidator->describeError($usernameValidator->check($username, $ui->getUserID())));
         }
 
         // password

--- a/concrete/controllers/single_page/account/edit_profile.php
+++ b/concrete/controllers/single_page/account/edit_profile.php
@@ -1,19 +1,16 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Account;
 
-use Concrete\Core\Error\UserMessageException;
-use Concrete\Core\Page\Controller\AccountPageController;
-use Concrete\Core\Validation\ResponseInterface;
-use Config;
-use UserInfo;
-use Exception;
 use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Authentication\AuthenticationTypeFailureException;
-use Loader;
-use User;
-use UserAttributeKey;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Controller\AccountPageController;
 use Concrete\Core\User\Validation\UsernameValidator;
+use Config;
+use Exception;
+use UserAttributeKey;
 
 class EditProfile extends AccountPageController
 {
@@ -24,7 +21,7 @@ class EditProfile extends AccountPageController
             throw new UserMessageException(t('You must be logged in to access this page.'));
         }
 
-        $locales = array();
+        $locales = [];
         $languages = Localization::getAvailableInterfaceLanguages();
         if (count($languages) > 0) {
             array_unshift($languages, Localization::BASE_LOCALE);
@@ -34,7 +31,7 @@ class EditProfile extends AccountPageController
                 $locales[$lang] = \Punic\Language::getName($lang, $lang);
             }
             asort($locales);
-            $locales = array_merge(array('' => tc('Default locale', '** Default')), $locales);
+            $locales = array_merge(['' => tc('Default locale', '** Default')], $locales);
         }
         $this->set('locales', $locales);
     }
@@ -54,7 +51,7 @@ class EditProfile extends AccountPageController
         }
         if ($method != 'callback') {
             if (!is_array($at->controller->apiMethods) || !in_array($method, $at->controller->apiMethods)) {
-                throw new UserMessageException("Invalid method.");
+                throw new UserMessageException('Invalid method.');
             }
         }
         try {
@@ -103,9 +100,7 @@ class EditProfile extends AccountPageController
             }
         }
 
-        /**
-         * Username validation
-         */
+        // Username validation
         if ($username = $this->post('uName')) {
             $this->error->add($usernameValidator->describeError($usernameValidator->check($username, $ui->getUserID())));
         }
@@ -132,9 +127,6 @@ class EditProfile extends AccountPageController
             $controller = $uak->getController();
             $validator = $controller->getValidator();
             $response = $validator->validateSaveValueRequest($controller, $this->request, $uak->isAttributeKeyRequiredOnProfile());
-            /**
-             * @var $response ResponseInterface
-             */
             if (!$response->isValid()) {
                 $error = $response->getErrorObject();
                 $this->error->add($error);
@@ -149,7 +141,7 @@ class EditProfile extends AccountPageController
 
             $ui->saveUserAttributesForm($aks);
             $ui->update($data);
-            $this->redirect("/account/edit_profile", "save_complete");
+            $this->redirect('/account/edit_profile', 'save_complete');
         }
     }
 }

--- a/concrete/controllers/single_page/dashboard/users/add.php
+++ b/concrete/controllers/single_page/dashboard/users/add.php
@@ -1,25 +1,24 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Users;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\User\Validation\UsernameValidator;
-use Concrete\Core\Validation\ResponseInterface;
 use Config;
+use Group;
+use GroupList;
 use Imagine\Image\Box;
 use Loader;
-use UserInfo;
+use Localization;
 use PermissionKey;
 use Permissions;
 use UserAttributeKey;
-use Group;
-use Localization;
-use GroupList;
+use UserInfo;
 
 class Add extends DashboardPageController
 {
     public function view()
     {
-        $loc = Localization::getInstance();
         $locales = Localization::getAvailableInterfaceLanguageDescriptions();
         $attribs = UserAttributeKey::getRegistrationList();
         $assignment = PermissionKey::getByHandle('edit_user_properties')->getMyAssignment();
@@ -47,7 +46,7 @@ class Add extends DashboardPageController
         $usernameValidator = $this->app->make(UsernameValidator::class);
 
         $username = trim($_POST['uName']);
-        $username = preg_replace("/\s+/", " ", $username);
+        $username = preg_replace("/\s+/", ' ', $username);
         $_POST['uName'] = $username;
 
         $password = $_POST['uPassword'];
@@ -74,9 +73,6 @@ class Add extends DashboardPageController
             $response = $validator->validateSaveValueRequest(
                 $controller, $this->request, $uak->isAttributeKeyRequiredOnRegister()
             );
-            /**
-             * @var $response ResponseInterface
-             */
             if (!$response->isValid()) {
                 $error = $response->getErrorObject();
                 $this->error->add($error);
@@ -85,10 +81,9 @@ class Add extends DashboardPageController
 
         if (!$this->error->has()) {
             // do the registration
-            $data = array('uName' => $username, 'uPassword' => $password, 'uEmail' => $_POST['uEmail'], 'uDefaultLanguage' => $_POST['uDefaultLanguage']);
+            $data = ['uName' => $username, 'uPassword' => $password, 'uEmail' => $_POST['uEmail'], 'uDefaultLanguage' => $_POST['uDefaultLanguage']];
             $uo = UserInfo::add($data);
             if (is_object($uo)) {
-                $av = Loader::helper('concrete/avatar');
                 if ($assignment->allowEditAvatar()) {
                     if (is_uploaded_file($_FILES['uAvatar']['tmp_name'])) {
                         $image = \Image::open($_FILES['uAvatar']['tmp_name']);
@@ -100,7 +95,7 @@ class Add extends DashboardPageController
                     }
                 }
 
-                $saveAttributes = array();
+                $saveAttributes = [];
                 foreach ($aks as $uak) {
                     if (in_array($uak->getAttributeKeyID(), $assignment->getAttributesAllowedArray())) {
                         $saveAttributes[] = $uak;
@@ -111,7 +106,7 @@ class Add extends DashboardPageController
                     $uo->saveUserAttributesForm($saveAttributes);
                 }
 
-                $gIDs = array();
+                $gIDs = [];
                 if (is_array($_POST['gID'])) {
                     foreach ($_POST['gID'] as $gID) {
                         $gx = Group::getByID($gID);

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -7,6 +7,7 @@ use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Csv\Export\UserExporter;
 use Concrete\Core\User\EditResponse as UserEditResponse;
+use Concrete\Core\User\Validation\UsernameValidator;
 use Concrete\Core\Workflow\Progress\UserProgress as UserWorkflowProgress;
 use Imagine\Image\Box;
 use Exception;
@@ -22,6 +23,9 @@ use UserInfo;
 
 class Search extends DashboardPageController
 {
+    /**
+     * @var \Concrete\Core\User\UserInfo|false
+     */
     protected $user = false;
 
     public function update_avatar($uID = false)
@@ -246,49 +250,13 @@ class Search extends DashboardPageController
     public function update_username($uID = false)
     {
         $this->setupUser($uID);
-        if ($this->canEditUserName) {
-            $config = $this->app->make('config');
+        if ($this->user &&  $this->canEditUserName) {
+            $usernameValidator = $this->app->make(UsernameValidator::class);
             $username = $this->post('value');
             if (!$this->app->make('helper/validation/token')->validate()) {
                 $this->error->add($this->app->make('helper/validation/token')->getErrorMessage());
             }
-            if (strlen($username) < $config->get('concrete.user.username.minimum')) {
-                $this->error->add(
-                    t(
-                        'A username must be at least %s characters long.',
-                        $config->get('concrete.user.username.minimum')
-                    )
-                );
-            }
-
-            if (strlen($username) > $config->get('concrete.user.username.maximum')) {
-                $this->error->add(
-                    t(
-                        'A username cannot be more than %s characters long.',
-                        $config->get('concrete.user.username.maximum')
-                    )
-                );
-            }
-
-            if (strlen($username) >= $config->get('concrete.user.username.minimum') && !$this->app->make('helper/concrete/validation')->username($username)) {
-                if ($config->get('concrete.user.username.allow_spaces')) {
-                    $this->error->add(
-                        t(
-                            'A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'
-                        )
-                    );
-                } else {
-                    $this->error->add(
-                        t(
-                            'A username may only contain letters, numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'
-                        )
-                    );
-                }
-            }
-            $uo = $this->user->getUserObject();
-            if (strcasecmp($uo->getUserName(), $username) && !$this->app->make('helper/concrete/validation')->isUniqueUsername($username)) {
-                $this->error->add(t("The username '%s' already exists. Please choose another", $username));
-            }
+            $this->error->add($usernameValidator->describeError($usernameValidator->check($username, $this->user->getUserID())));
 
             $sr = new UserEditResponse();
             $sr->setUser($this->user);

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -5,6 +5,7 @@ use Concrete\Core\Attribute\Context\FrontendFormContext;
 use Concrete\Core\Attribute\Form\Renderer;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Page\Controller\PageController;
+use Concrete\Core\User\Validation\UsernameValidator;
 use Concrete\Core\Validation\ResponseInterface;
 use Config;
 use Loader;
@@ -83,34 +84,8 @@ class Register extends PageController
             }
 
             if ($this->displayUserName) {
-                if (strlen($username) < $config->get('concrete.user.username.minimum')) {
-                    $e->add(t(
-                        'A username must be at least %s characters long.',
-                        $config->get('concrete.user.username.minimum')
-                    ));
-                }
-
-                if (strlen($username) > $config->get('concrete.user.username.maximum')) {
-                    $e->add(t(
-                        'A username cannot be more than %s characters long.',
-                        $config->get('concrete.user.username.maximum')
-                    ));
-                }
-
-                if (strlen($username) >= $config->get('concrete.user.username.minimum') && strlen($username) <= $config->get('concrete.user.username.maximum') && !$valc->username($username)) {
-                    if ($config->get('concrete.user.username.allow_spaces')) {
-                        $e->add(t('A username may only contain letters, numbers, spaces (not at the beginning/end), dots (not at the beginning/end), underscores (not at the beginning/end).'));
-                    } else {
-                        $e->add(t('A username may only contain letters, numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'));
-                    }
-                }
-                if (!$valc->isUniqueUsername($username)) {
-                    $e->add(t('The username %s already exists. Please choose another', $username));
-                }
-            }
-
-            if ($username == USER_SUPER) {
-                $e->add(t('Invalid Username'));
+                $usernameValidator = $this->app->make(UsernameValidator::class);
+                $e->add($usernameValidator->describeError($usernameValidator->check($username)));
             }
 
             \Core::make('validator/password')->isValid($password, $e);

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\SinglePage;
 
 use Concrete\Core\Attribute\Context\FrontendFormContext;
@@ -6,7 +7,6 @@ use Concrete\Core\Attribute\Form\Renderer;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\User\Validation\UsernameValidator;
-use Concrete\Core\Validation\ResponseInterface;
 use Config;
 use Loader;
 use User;
@@ -107,9 +107,6 @@ class Register extends PageController
                     $this->request,
                     $uak->isAttributeKeyRequiredOnRegister()
                 );
-                /**
-                 * @var ResponseInterface
-                 */
                 if (!$response->isValid()) {
                     $error = $response->getErrorObject();
                     $e->add($error);

--- a/concrete/src/Application/Service/Validation.php
+++ b/concrete/src/Application/Service/Validation.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace Concrete\Core\Application\Service;
 
-use Loader;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\Validation\UsernameValidator;
+use Loader;
 
 class Validation
 {
     /**
      * @deprecated Use \Core::make(\Concrete\Core\User\Validation\UsernameValidator::class)->check()
      *
-     * @param string $username
+     * @param string $uName
      *
      * @return bool
      */
@@ -25,15 +26,16 @@ class Validation
     /**
      * Checks whether a passed email address is unique.
      *
-     * @return bool
      *
      * @param string $uEmail
+     *
+     * @return bool
      */
     public function isUniqueEmail($uEmail)
     {
         $db = Loader::db();
-        $q = "select uID from Users where uEmail = ?";
-        $r = $db->getOne($q, array($uEmail));
+        $q = 'select uID from Users where uEmail = ?';
+        $r = $db->getOne($q, [$uEmail]);
         if ($r) {
             return false;
         } else {

--- a/concrete/src/Application/Service/Validation.php
+++ b/concrete/src/Application/Service/Validation.php
@@ -2,27 +2,24 @@
 namespace Concrete\Core\Application\Service;
 
 use Loader;
-use Config;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\Validation\UsernameValidator;
 
 class Validation
 {
     /**
-     * Checks whether a passed username is unique or if a user of this name already exists.
+     * @deprecated Use \Core::make(\Concrete\Core\User\Validation\UsernameValidator::class)->check()
      *
-     * @param string $uName
+     * @param string $username
      *
      * @return bool
      */
     public function isUniqueUsername($uName)
     {
-        $db = Loader::db();
-        $q = "select uID from Users where uName = ?";
-        $r = $db->getOne($q, array($uName));
-        if ($r) {
-            return false;
-        } else {
-            return true;
-        }
+        $app = Application::getFacadeApplication();
+        $validator = $app->make(UsernameValidator::class);
+
+        return ($validator->checkUnique($uName) & $validator::E_IN_USE) === 0;
     }
 
     /**
@@ -59,8 +56,7 @@ class Validation
     }
 
     /**
-     * Returns true if this is a valid username.
-     * Valid usernames can only contain letters, numbers, dots (only in the middle), underscores (only in the middle) and optionally single spaces.
+     * @deprecated Use \Core::make(\Concrete\Core\User\Validation\UsernameValidator::class)->check()
      *
      * @param string $username
      *
@@ -68,29 +64,9 @@ class Validation
      */
     public function username($username)
     {
-        $username = trim($username);
-        if (strlen($username) < Config::get('concrete.user.username.minimum')) {
-            return false;
-        }
-        if (strlen($username) > Config::get('concrete.user.username.maximum')) {
-            return false;
-        }
-        $rxBoundary = '[A-Za-z0-9]';
-        if (Config::get('concrete.user.username.allow_spaces')) {
-            $rxMiddle = '[A-Za-z0-9_. ]';
-        } else {
-            $rxMiddle = '[A-Za-z0-9_.]';
-        }
-        if (strlen($username) < 3) {
-            if (!preg_match('/^' . $rxBoundary . '+$/', $username)) {
-                return false;
-            }
-        } else {
-            if (!preg_match('/^' . $rxBoundary . $rxMiddle . '+' . $rxBoundary . '$/', $username)) {
-                return false;
-            }
-        }
+        $app = Application::getFacadeApplication();
+        $validator = $app->make(UsernameValidator::class);
 
-        return true;
+        return ($validator->checkLength($username) | $validator->checkCharacters($username)) === $validator::E_OK;
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180621000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180621000000.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20180621000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $config = $this->app->make('config');
+        if ($config->get('concrete.user.username.allow_spaces') && !$config->get('concrete.user.username.allow_spaces_migrated')) {
+            $rxMiddle = $config->get('concrete.user.username.allowed_characters.middle');
+            if (strpos($rxMiddle, ' ') === false) {
+                $rxMiddle .= ' ';
+                $config->set('concrete.user.username.allowed_characters.middle', $rxMiddle);
+                $config->save('concrete.user.username.allowed_characters.middle', $rxMiddle);
+            }
+            $config->set('concrete.user.username.allow_spaces_migrated', true);
+            $config->save('concrete.user.username.allow_spaces_migrated', true);
+        }
+    }
+}

--- a/concrete/src/User/Validation/UsernameValidator.php
+++ b/concrete/src/User/Validation/UsernameValidator.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace Concrete\Core\User\Validation;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Database\Connection\Connection;
+use Exception;
+
+class UsernameValidator
+{
+    /**
+     * Validation flag: everything is ok.
+     *
+     * @var int
+     */
+    const E_OK = 0b00000000; // 0
+
+    /**
+     * Validation flag: not a string (or string is empty).
+     *
+     * @var int
+     */
+    const E_INVALID_STRING = 0b00000001; // 1
+
+    /**
+     * Validation flag: username is too short.
+     *
+     * @var int
+     */
+    const E_TOO_SHORT = 0b10; // 2
+
+    /**
+     * Validation flag: username is too long.
+     *
+     * @var int
+     */
+    const E_TOO_LONG = 0b100; // 4
+
+    /**
+     * Validation flag: username contains invalid characters.
+     *
+     * @var int
+     */
+    const E_INVALID_CHARACTERS = 0b1000; // 8
+
+    /**
+     * Validation flag: username already in use.
+     *
+     * @var int
+     */
+    const E_IN_USE = 0b10000; // 16
+
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    protected $app;
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $connection;
+
+    /**
+     * Minimum username length (null: none, false: not yet initialized).
+     *
+     * @var int|null|false
+     */
+    private $minimumLength = false;
+
+    /**
+     * Maximum username length (null: none, false: not yet initialized).
+     *
+     * @var int|null|false
+     */
+    private $maximumLength = false;
+
+    /**
+     * Characters allowed at the beginning/end of usernames, with regular expressions syntax (null: not yet initialized).
+     *
+     * @var string|null
+     */
+    private $allowedCharactersBoundary = null;
+
+    /**
+     * Characters allowed in the middle of usernames, with regular expressions syntax (null: not yet initialized).
+     *
+     * @var string|null
+     */
+    private $allowedCharactersMiddle = null;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Application\Application $app
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     */
+    public function __construct(Application $app, Repository $config, Connection $connection)
+    {
+        $this->app = $app;
+        $this->config = $config;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Get the minimum username length.
+     *
+     * @return int|null
+     */
+    public function getMinimumLength()
+    {
+        if ($this->minimumLength === false) {
+            $this->setMinimumLength($this->config->get('concrete.user.username.minimum'));
+        }
+
+        return $this->minimumLength;
+    }
+
+    /**
+     * Set the minimum username length.
+     *
+     * @param int|null $minimumLength
+     *
+     * @return $this
+     */
+    public function setMinimumLength($minimumLength)
+    {
+        $this->minimumLength = empty($minimumLength) ? null : (int) $minimumLength;
+
+        return $this;
+    }
+
+    /**
+     * Get the maximum username length.
+     *
+     * @return int|null
+     */
+    public function getMaximumLength()
+    {
+        if ($this->maximumLength === false) {
+            $this->setMaximumLength($this->config->get('concrete.user.username.maximum'));
+        }
+
+        return $this->maximumLength;
+    }
+
+    /**
+     * Set the maximum username length.
+     *
+     * @param int|null $maximumLength
+     *
+     * @return $this
+     */
+    public function setMaximumLength($maximumLength)
+    {
+        $this->maximumLength = empty($maximumLength) ? null : (int) $maximumLength;
+
+        return $this;
+    }
+
+    /**
+     * Get the characters allowed at the beginning/end of usernames, with regular expressions syntax.
+     *
+     * @return string
+     *
+     * @example 'A-Za-z0-9'
+     */
+    public function getAllowedCharactersBoundary()
+    {
+        if ($this->allowedCharactersBoundary === null) {
+            $this->setAllowedCharactersBoundary($this->config->get('concrete.user.username.allowed_characters.boundary'));
+        }
+
+        return $this->allowedCharactersBoundary;
+    }
+
+    /**
+     * Set the characters allowed at the beginning/end of usernames, with regular expressions syntax.
+     *
+     * @param string $allowedCharacters
+     *
+     * @return $this
+     *
+     * @example 'A-Za-z0-9'
+     */
+    public function setAllowedCharactersBoundary($allowedCharacters)
+    {
+        $this->allowedCharactersBoundary = (string) $allowedCharacters;
+
+        return $this;
+    }
+
+    /**
+     * Get the characters allowed in the middle of usernames, with regular expressions syntax.
+     *
+     * @return string
+     *
+     * @example 'A-Za-z0-9_\.'
+     */
+    public function getAllowedCharactersMiddle()
+    {
+        if ($this->allowedCharactersMiddle === null) {
+            $this->setAllowedCharactersMiddle($this->config->get('concrete.user.username.allowed_characters.middle'));
+        }
+
+        return $this->allowedCharactersMiddle;
+    }
+
+    /**
+     * Set the characters allowed in the middle of usernames, with regular expressions syntax.
+     *
+     * @param string $allowedCharacters
+     *
+     * @return $this
+     *
+     * @example 'A-Za-z0-9_\.'
+     */
+    public function setAllowedCharactersMiddle($allowedCharacters)
+    {
+        $this->allowedCharactersMiddle = (string) $allowedCharacters;
+
+        return $this;
+    }
+
+    /**
+     * Check if a username is valid.
+     *
+     * @param string|mixed $username the username to be ckecked
+     * @param int|null $userID the ID of the user whose the username is/will be associated to
+     *
+     * @return int One or more of the UsernameValidator::E_... flags
+     */
+    public function check($username, $userID = null)
+    {
+        $result = static::E_OK;
+
+        $username = $this->normalizeString($username);
+        if ($username === '') {
+            $result |= static::E_INVALID_STRING;
+        } else {
+            $result |= $this->checkLength($username);
+            $result |= $this->checkCharacters($username);
+            if ($result === static::E_OK) {
+                $result |= $this->checkUnique($username, $userID);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a username has the allowed length.
+     *
+     * @param string $username
+     *
+     * @return int One or more of the UsernameValidator::E_... flags
+     */
+    public function checkLength($username)
+    {
+        $username = $this->normalizeString($username);
+        if ($username === '') {
+            $result |= static::E_INVALID_STRING;
+        } else {
+            $result = static::E_OK;
+            $usernameLength = mb_strlen($username);
+            $minLength = $this->getMinimumLength();
+            if ($minLength !== null && $usernameLength < $minLength) {
+                $result |= static::E_TOO_SHORT;
+            }
+            $maxLength = $this->getMaximumLength();
+            if ($maxLength !== null && $usernameLength > $maxLength) {
+                $result |= static::E_TOO_LONG;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a username contains only the allowed characters.
+     *
+     * @param string $username
+     *
+     * @return int One or more of the UsernameValidator::E_... flags
+     */
+    public function checkCharacters($username)
+    {
+        $username = $this->normalizeString($username);
+        if ($username === '') {
+            $result |= static::E_INVALID_STRING;
+        } else {
+            $result = static::E_OK;
+            $rx = $this->getValidCharactersRegularExpression();
+            $match = preg_match($rx, $username);
+            if ($match === false) {
+                throw new Exception(t('The list of valid username characters is not valid.'));
+            }
+            $result = $match ? static::E_OK : static::E_INVALID_CHARACTERS;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a username is already in use.
+     *
+     * @param string $username
+     * @param int|null $userID the ID of the user whose the username is/will be associated to
+     *
+     * @return int One or more of the UsernameValidator::E_... flags
+     */
+    public function checkUnique($username, $userID = null)
+    {
+        $username = $this->normalizeString($username);
+        if ($username === '') {
+            $result = static::E_INVALID_STRING;
+        } else {
+            $qb = $this->connection->createQueryBuilder();
+            $qb
+            ->select('u.uID')
+            ->from('Users', 'u')
+            ->where($qb->expr()->eq('u.uName', $qb->createNamedParameter($username)))
+            ;
+            if (!empty($userID)) {
+                $qb->andWhere($qb->expr()->neq('u.uID', $qb->createNamedParameter($userID)));
+            }
+            $result = $qb->execute()->fetchColumn() === false ? static::E_OK : static::E_IN_USE;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Describe the errors returned by the check functions.
+     *
+     * @param int $flags One or more of the UsernameValidator::E_... flags
+     *
+     * @return \Concrete\Core\Error\ErrorList\ErrorList
+     */
+    public function describeError($flags)
+    {
+        $result = $this->app->make('error');
+        $flags = (int) $flags;
+        if ($flags & static::E_INVALID_STRING) {
+            $result->add(t('The username is empty.'));
+        }
+        if ($flags & static::E_TOO_SHORT) {
+            $result->add(t('A username must be at least %s characters long.', $this->getMinimumLength()));
+        }
+        if ($flags & static::E_TOO_LONG) {
+            $result->add(t('A username cannot be more than %s characters long.', $this->getMaximumLength()));
+        }
+        if ($flags & static::E_INVALID_CHARACTERS) {
+            $boundary = $this->getAllowedCharactersBoundary();
+            $middle = $this->getAllowedCharactersMiddle();
+            if ($boundary === $middle) {
+                $result->add(t('A username can only contains these characters: %s', $middle));
+            } else {
+                $result->add(t('A username can only contains the characters "%1$s" and can only start/end with "%2$s".', $middle, $boundary));
+            }
+        }
+        if ($flags & static::E_IN_USE) {
+            $result->add(t('The username is already used by another account.'));
+        }
+        if ($flags !== 0 && !$result->has()) {
+            $result->add(t('The username is not valid.'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a username is a non empty string.
+     *
+     * @param string|mixed $username
+     *
+     * @return string returns an empty string of $username is not a string, $username otherwise
+     */
+    protected function normalizeString($username)
+    {
+        return is_string($username) ? $username : '';
+    }
+
+    /**
+     * Get the regular expression to be used to check the username.
+     *
+     * @return string
+     *
+     * @example '/^[A-Za-z0-9]([A-Za-z0-9 ]*[A-Za-z0-9])?/
+     */
+    protected function getValidCharactersRegularExpression()
+    {
+        $boundary = '[' . $this->getAllowedCharactersBoundary() . ']';
+        $middle = '[' . $this->getAllowedCharactersMiddle() . ']';
+
+        return "/^{$boundary}({$middle}*{$boundary})?$/";
+    }
+}

--- a/tests/assets/User/UsernameValidator.xml
+++ b/tests/assets/User/UsernameValidator.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<database name="phpunitTesting">
+		<table_data name="Users">
+			<row>
+				<field name="uID">1</field>
+				<field name="uName">admin</field>
+				<field name="uEmail">master@example.com</field>
+				<field name="uPassword"></field>
+				<field name="uIsActive">1</field>
+				<field name="uIsFullRecord">1</field>
+				<field name="uDateAdded">2018-06-21 16:31:48</field>
+				<field name="uLastPasswordChange">2018-06-21 16:31:48</field>
+				<field name="uHasAvatar">0</field>
+				<field name="uIsPasswordReset">0</field>
+			</row>
+		</table_data>
+	</database>
+</mysqldump>

--- a/tests/tests/User/UsernameValidatorTest.php
+++ b/tests/tests/User/UsernameValidatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Concrete\Tests\User;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\Validation\UsernameValidator;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+
+class UsernameValidatorTest extends ConcreteDatabaseTestCase
+{
+    protected $fixtures = [
+        'UsernameValidator',
+    ];
+
+    /**
+     * @var \Concrete\Core\User\Validation\UsernameValidator
+     */
+    private static $defaultInstance;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->metadatas[] = \Concrete\Core\Entity\User\User::class;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        $app = Application::getFacadeApplication();
+        self::$defaultInstance = $app->make(UsernameValidator::class);
+    }
+
+    public function usernameValidatorTestProvider()
+    {
+        return [
+            [null, UsernameValidator::E_INVALID_STRING],
+            ['', UsernameValidator::E_INVALID_STRING],
+            [$this, UsernameValidator::E_INVALID_STRING],
+            ['this.is.good', 0],
+            ['s', UsernameValidator::E_TOO_SHORT],
+            [str_repeat('x', 9999), UsernameValidator::E_TOO_LONG],
+            ['invalid<chars>', UsernameValidator::E_INVALID_CHARACTERS],
+            ['<', UsernameValidator::E_TOO_SHORT | UsernameValidator::E_INVALID_CHARACTERS],
+            [str_repeat('>', 9999), UsernameValidator::E_TOO_LONG | UsernameValidator::E_INVALID_CHARACTERS],
+            ['admin', UsernameValidator::E_IN_USE],
+            ['admin', UsernameValidator::E_IN_USE, 2],
+            ['admin', UsernameValidator::E_OK, 1],
+        ];
+    }
+
+    /**
+     * @dataProvider usernameValidatorTestProvider
+     *
+     * @param string $username
+     * @param int $expectedFlags
+     * @param null|mixed $uID
+     */
+    public function testUsernameValidator($username, $expectedFlags, $uID = null)
+    {
+        $flags = static::$defaultInstance->check($username, $uID);
+        $this->assertSame($expectedFlags, $flags);
+        $errorDescriptions = static::$defaultInstance->describeError($flags);
+        if ($expectedFlags === UsernameValidator::E_OK) {
+            $this->assertFalse($errorDescriptions->has());
+        } else {
+            $this->assertTrue($errorDescriptions->has());
+        }
+    }
+}


### PR DESCRIPTION
We have a lot of duplicated code to check if a username is valid.
That's because
- the current validators only returns true/false (so we can't show users an appropriate message like "The username is too short)
- the code has been implemented here and there in very different times

So, what about adding a centralized and more powerful validator?

### Pros:
- it can be overridden with a subclass
- the valid username characters are now in a configuration setting.
- every check can be performed separately
- every check is now in a common class

### Cons:

There's a BC break: before we had the `concrete.user.username.allow_spaces` configuration key that allowed having a space in the middle of a username, now we have `concrete.user.username.allowed_characters.boundary` to describe the chars that can occur at the beginning/end of a username and `concrete.user.username.allowed_characters.middle` to describe the chars that can occur in the middle of a username.
There's a migration that adds spaces to `concrete.user.username.allowed_characters.middle` if `concrete.user.username.allow_spaces` is true, but 4rd party tools relying on `concrete.user.username.allow_spaces` may have problems.
BTW it's not a great BC problem: this may occur only if people customize `concrete.user.username.allowed_characters.middle`.