### PR TITLE
Avoid accessing undefined var in footer element

### DIFF
--- a/concrete/themes/dashboard/elements/footer.php
+++ b/concrete/themes/dashboard/elements/footer.php
@@ -1,5 +1,5 @@
 <?php
-if ($showPrivacyPolicyNotice) { ?>
+if (!empty($showPrivacyPolicyNotice)) { ?>
 <div class="ccm-dashboard-privacy-policy">
     <div class="ccm-dashboard-privacy-policy-inner">
         <div class="container-fluid">


### PR DESCRIPTION
I noticed that sometimes `$showPrivacyPolicyNotice` is not defined...

Ref. #4723