### PR TITLE
Actually add translatable strings extracted from config files to Translations instance

### DIFF
--- a/concrete/src/Multilingual/Service/Extractor.php
+++ b/concrete/src/Multilingual/Service/Extractor.php
@@ -36,7 +36,7 @@ class Extractor
         $themesPresetsParser = new C5TLParserThemePresets();
         $configFilesParser = new C5TLParserConfigFiles();
 
-        $configFilesParser->parseDirectory(DIR_BASE, '');
+        $configFilesParser->parseDirectory(DIR_BASE, '', $translations);
 
         $processApplication = [
             DIRNAME_BLOCKS => [$phpParser, $blockTemplatesParser],


### PR DESCRIPTION
In the multilingual Extractor, we extract translatable strings from configuration files.
BTW those strings are not added to the list of extracted strings.