### PR TITLE
Faster routes resolution

### DIFF
--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Concrete\Core\Http;
 
 use Concrete\Core\Application\Application;
 use Concrete\Core\Routing\DispatcherRouteCallback;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Routing\RouterInterface;
+use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\User\User;
 use Concrete\Core\View\View;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -13,7 +15,6 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
-use Concrete\Core\Session\SessionValidator;
 
 class DefaultDispatcher implements DispatcherInterface
 {

--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -141,22 +141,29 @@ class DefaultDispatcher implements DispatcherInterface
      */
     private function filterRouteCollectionForPath(RouteCollection $routes, $path)
     {
-        $routes = clone $routes;
+        $result = new RouteCollection();
+        foreach ($routes->getResources() as $resource) {
+            $result->addResource($resource);
+        }
         foreach ($routes->all() as $name => $route) {
             $routePath = $route->getPath();
             $p = strpos($routePath, '{');
+            $skip = false;
             if ($p === false) {
                 if ($routePath !== $path) {
-                    $routes->remove($name);
+                    $skip = true;
                 }
             } elseif ($p > 0) {
                 $routeFixedPath = substr($routePath, 0, $p);
                 if (strpos($path, $routeFixedPath) !== 0) {
-                    $routes->remove($name);
+                    $skip = true;
                 }
+            }
+            if ($skip === false) {
+                $result->add($name, $route);
             }
         }
 
-        return $routes;
+        return $result;
     }
 }


### PR DESCRIPTION
As discussed in #3336

TL;DR: We currently have ~300 registered routes in a bare concrete5 installation. For every request we compile all of them, and implementing a cache is very hard because routes may be dinamically added by packages. This PR strips out from the routes that won't match the request for sure.


