### PR TITLE
Throw email delivery exceptions even when $resetData is true

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -674,13 +674,16 @@ class Service
             $l->close();
         }
 
+        if ($sendError !== null && $this->isThrowOnFailure()) {
+            if ($resetData) {
+                $this->reset();
+            }
+            throw $sendError;
+        }
+
         // clear data if applicable
         if ($resetData) {
             $this->reset();
-        }
-
-        if ($sendError !== null && $this->isThrowOnFailure()) {
-            throw $sendError;
         }
 
         return $sendError === null;


### PR DESCRIPTION
When we instruct the mail service to throw exceptions on delivery failures, and when we pass `true` for the `$resetData` parameter of the `sendMail` method, exceptions are not thrown.

Let's fix this.