### PR TITLE
Add 'on_block_output' event

### DIFF
--- a/concrete/src/Block/Events/BlockOutput.php
+++ b/concrete/src/Block/Events/BlockOutput.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Concrete\Core\Block\Events;
+
+class BlockOutput extends BlockEvent
+{
+    /**
+     * @return \Concrete\Core\Block\Block
+     */
+    public function getBlock()
+    {
+        return $this->getSubject();
+    }
+
+    /**
+     * @param string $contents
+     */
+    public function setContents($contents)
+    {
+        $this->setArgument('contents', $contents);
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        return $this->getArgument('contents');
+    }
+}

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Block\View;
 
 use Concrete\Core\Block\Events\BlockBeforeRender;
+use Concrete\Core\Block\Events\BlockOutput;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\View\AbstractView;
@@ -290,6 +291,7 @@ class BlockView extends AbstractView
         $this->controller->registerViewAssets($this->outputContent);
 
         $this->onBeforeGetContents();
+        $this->fireOnBlockOutputEvent();
         echo $this->outputContent;
         $this->onAfterGetContents();
 
@@ -478,5 +480,24 @@ class BlockView extends AbstractView
         $v = View::getInstance();
 
         return $v->getThemePath();
+    }
+
+    /**
+     * Fire an event just before the block is outputted on the page
+     *
+     * Custom code can modify the block contents before
+     * the block contents are 'echoed' out on the page.
+     *
+     * @since 8.4.1
+     */
+    private function fireOnBlockOutputEvent()
+    {
+        $event = new BlockOutput($this->block);
+        $event->setContents($this->outputContent);
+
+        $app = Application::getFacadeApplication();
+        $app->make('director')->dispatch('on_block_output', $event);
+
+        $this->outputContent = $event->getContents();
     }
 }


### PR DESCRIPTION
Fire an event just before a block is outputted / echoed on a page. This allows custom code / add-ons to modify the block's contents on runtime.

---

### Example code to hook into the event:
```php
$dispatcher->addListener('on_block_output', function ($event) {
    $event->setContents('Block ID:' . $event->getBlock()->getBlockID());
});
```

### Example screenshot / output when using the hook above:
![afbeelding](https://user-images.githubusercontent.com/1431100/42019045-46da0066-7ab4-11e8-93db-549479a6a6d3.png)
