### PR TITLE
Add an option to consider warnings as errors

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -336,6 +336,7 @@ const COLLECTION_PRIVATE = 40;
 const BLOCK_NOT_AVAILABLE = 50;
 
 /* -- Debugging and Logging -- */
+defined('DEFAULT_ERROR_REPORTING') or define('DEFAULT_ERROR_REPORTING', E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
 const DEBUG_DISPLAY_PRODUCTION = 0;
 const DEBUG_DISPLAY_ERRORS = 1;
 const DEBUG_DISPLAY_ERRORS_SQL = 2; // not used
@@ -347,7 +348,7 @@ const LOG_TYPE_EXCEPTIONS = 'exceptions';
  * concrete5 depends on some more forgiving error handling.
  * ----------------------------------------------------------------------------
  */
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+error_reporting(DEFAULT_ERROR_REPORTING);
 
 /*
  * ----------------------------------------------------------------------------

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -51,6 +51,13 @@ return [
          * @var string (message|debug)
          */
         'detail' => 'message',
+
+        /*
+         * Error reporting level
+         *
+         * @var int|null
+         */
+        'error_reporting' => null,
     ],
 
     /*

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -757,7 +757,7 @@ return [
         'deactivation' => [
             'enable_login_threshold_deactivation' => false,
             'login' => [
-                'threshold' => 120 // in days
+                'threshold' => 120, // in days
             ],
             'message' => 'This user is inactive. Please contact us regarding this account.',
         ],

--- a/concrete/controllers/single_page/dashboard/system/environment/debug.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/debug.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Environment;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -17,14 +18,14 @@ class Debug extends DashboardPageController
 
     public function update_debug()
     {
-        if ($this->token->validate("update_debug")) {
+        if ($this->token->validate('update_debug')) {
             if ($this->isPost()) {
                 Config::save('concrete.debug.detail', $this->post('debug_detail'));
                 Config::save('concrete.debug.display_errors', (bool) $this->post('debug_enabled'));
                 $this->redirect('/dashboard/system/environment/debug', 'debug_saved');
             }
         } else {
-            $this->set('error', array($this->token->getErrorMessage()));
+            $this->set('error', [$this->token->getErrorMessage()]);
         }
     }
 

--- a/concrete/controllers/single_page/dashboard/system/environment/debug.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/debug.php
@@ -9,37 +9,33 @@ class Debug extends DashboardPageController
 {
     public function view()
     {
-        $enabled = Config::get('concrete.debug.display_errors');
-        $detail = Config::get('concrete.debug.detail');
-
-        $this->set('debug_enabled', $enabled);
-        $this->set('debug_detail', $detail);
+        $config = $this->app->make('config');
+        $this->set('debug_enabled', (bool) $config->get('concrete.debug.display_errors'));
+        $this->set('debug_detail', $config->get('concrete.debug.detail'));
     }
 
     public function update_debug()
     {
         if ($this->token->validate('update_debug')) {
-            if ($this->isPost()) {
-                Config::save('concrete.debug.detail', $this->post('debug_detail'));
-                Config::save('concrete.debug.display_errors', (bool) $this->post('debug_enabled'));
-                $this->redirect('/dashboard/system/environment/debug', 'debug_saved');
+            if ($this->request->isPost()) {
+                $post = $this->request->request;
+                $config = $this->app->make('config');
+                $config->save('concrete.debug.display_errors', (bool) $post->get('debug_enabled'));
+                $config->save('concrete.debug.detail', $post->get('debug_detail'));
+                $this->flash('success', t('Debug configuration saved.'));
+                $this->redirect($this->action(''));
             }
         } else {
-            $this->set('error', [$this->token->getErrorMessage()]);
+            $this->error->add($this->token->getErrorMessage());
         }
-    }
-
-    public function debug_saved()
-    {
-        $this->set('message', t('Debug configuration saved.'));
-        $this->view();
     }
 
     public function debug_example()
     {
-        \Config::set('concrete.log.errors', false);
-        \Config::set('concrete.debug.display_errors', true);
-        \Config::set('concrete.debug.detail', 'debug');
+        $config = $this->app->make('config');
+        $config->set('concrete.log.errors', false);
+        $config->set('concrete.debug.display_errors', true);
+        $config->set('concrete.debug.detail', 'debug');
 
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
 
@@ -48,9 +44,10 @@ class Debug extends DashboardPageController
 
     public function message_example()
     {
-        \Config::set('concrete.log.errors', false);
-        \Config::set('concrete.debug.display_errors', true);
-        \Config::set('concrete.debug.detail', 'message');
+        $config = $this->app->make('config');
+        $config->set('concrete.log.errors', false);
+        $config->set('concrete.debug.display_errors', true);
+        $config->set('concrete.debug.detail', 'message');
 
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
 
@@ -59,8 +56,10 @@ class Debug extends DashboardPageController
 
     public function disabled_example()
     {
-        \Config::set('concrete.log.errors', false);
-        \Config::set('concrete.debug.display_errors', false);
+        $config = $this->app->make('config');
+        $config->set('concrete.log.errors', false);
+        $config->set('concrete.debug.display_errors', false);
+
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
 
         throw new ExampleException('Sample Disabled Output!');

--- a/concrete/controllers/single_page/dashboard/system/environment/debug.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/debug.php
@@ -41,6 +41,9 @@ class Debug extends DashboardPageController
 
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
 
+        error_reporting($this->request->query->get('warnings_as_errors') ? -1 : DEFAULT_ERROR_REPORTING);
+        $this->will_throw_a_warning_because = $this->is_not_a_defined_property;
+
         throw new ExampleException('Sample Debug Output!');
     }
 
@@ -53,6 +56,9 @@ class Debug extends DashboardPageController
 
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
 
+        error_reporting($this->request->query->get('warnings_as_errors') ? -1 : DEFAULT_ERROR_REPORTING);
+        $this->will_throw_a_warning_because = $this->is_not_a_defined_property;
+
         throw new ExampleException('Sample Message Output!');
     }
 
@@ -63,6 +69,9 @@ class Debug extends DashboardPageController
         $config->set('concrete.debug.display_errors', false);
 
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
+
+        error_reporting($this->request->query->get('warnings_as_errors') ? -1 : DEFAULT_ERROR_REPORTING);
+        $this->will_throw_a_warning_because = $this->is_not_a_defined_property;
 
         throw new ExampleException('Sample Disabled Output!');
     }

--- a/concrete/controllers/single_page/dashboard/system/environment/debug.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/debug.php
@@ -3,7 +3,7 @@
 namespace Concrete\Controller\SinglePage\Dashboard\System\Environment;
 
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Config;
+use Exception;
 
 class Debug extends DashboardPageController
 {
@@ -12,6 +12,7 @@ class Debug extends DashboardPageController
         $config = $this->app->make('config');
         $this->set('debug_enabled', (bool) $config->get('concrete.debug.display_errors'));
         $this->set('debug_detail', $config->get('concrete.debug.detail'));
+        $this->set('warnings_as_errors', (string) $config->get('concrete.debug.error_reporting') !== '');
     }
 
     public function update_debug()
@@ -22,6 +23,7 @@ class Debug extends DashboardPageController
                 $config = $this->app->make('config');
                 $config->save('concrete.debug.display_errors', (bool) $post->get('debug_enabled'));
                 $config->save('concrete.debug.detail', $post->get('debug_detail'));
+                $config->save('concrete.debug.error_reporting', $post->get('warnings_as_errors') ? -1 : null);
                 $this->flash('success', t('Debug configuration saved.'));
                 $this->redirect($this->action(''));
             }
@@ -66,6 +68,6 @@ class Debug extends DashboardPageController
     }
 }
 
-class ExampleException extends \Exception
+class ExampleException extends Exception
 {
 }

--- a/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/concrete/single_pages/dashboard/system/environment/debug.php
@@ -80,10 +80,12 @@ defined('C5_EXECUTE') or die('Access Denied.');
 <script>
 $(document).ready(function() {
 
-var iframe = $('iframe#sample'),
-    enabled = $('input[name=debug_enabled]'),
-    detail = $('input[name=debug_detail]'),
-    inputs = $('input:not([data-dont-update])');
+var form = $('#debug-form'),
+    iframe = $('iframe#sample'),
+    enabled = form.find('input[name=debug_enabled]'),
+    detail = form.find('input[name=debug_detail]'),
+    warningsAsErrors = form.find('input[name=warnings_as_errors]'),
+    inputs = form.find('input');
 
 inputs
     .on('change', function () {
@@ -93,6 +95,7 @@ inputs
         } else {
             url = enabled.data('sample');
         }
+        url += (url.indexOf('?') < 0 ? '?' : '&') + 'warnings_as_errors=' + (warningsAsErrors.is(':checked') ? 1 : 0);
         iframe.show().attr('src', url);
     })
     .trigger('change')

--- a/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/concrete/single_pages/dashboard/system/environment/debug.php
@@ -10,6 +10,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var string $debug_detail */
 /* @var bool $debug_enabled */
 /* @var bool $show_warnings */
+/* @var bool $warnings_as_errors */
 ?>
 <form method="post" id="debug-form" action="<?= $view->action('update_debug') ?>">
     <?= $token->output('update_debug') ?>
@@ -46,6 +47,23 @@ defined('C5_EXECUTE') or die('Access Denied.');
         </div>
     </div>
 
+    <div class="form-group">
+        <?= $form->label('', t('Error Level')) ?>
+        <div class="checkbox">
+            <label>
+                <?= $form->checkbox('warnings_as_errors', 1, $warnings_as_errors, ['data-dont-update' => '1']) ?>
+                <?= t('Consider warnings as errors') ?>
+                <span class="help-block">
+                    <span class="text-danger">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        <?= t('This option should only be enabled by developers: it could brick your site.') ?><br />
+                        <?= t('In this case you\'ll have to manually delete the %s configuration key.', '<code>concrete.debug.error_reporting</code>') ?>
+                    </span>
+                </span>
+            </label>
+        </div>
+    </div>
+
     <fieldset>
         <legend><?= t('Example') ?></legend>
         <iframe id="sample" style="display:none;width:100%;height:600px;border:0"></iframe>
@@ -65,7 +83,7 @@ $(document).ready(function() {
 var iframe = $('iframe#sample'),
     enabled = $('input[name=debug_enabled]'),
     detail = $('input[name=debug_detail]'),
-    inputs = $('input');
+    inputs = $('input:not([data-dont-update])');
 
 inputs
     .on('change', function () {
@@ -79,6 +97,13 @@ inputs
     })
     .trigger('change')
 ;
+
+$('#warnings_as_errors').on('click', function(e) {
+    if (this.checked && !window.confirm(<?= json_encode(t('Are you sure?')) ?>)) {
+        e.preventDefault();
+        return false;
+    }
+});
 
 });
 </script>

--- a/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/concrete/single_pages/dashboard/system/environment/debug.php
@@ -1,90 +1,84 @@
 <?php
+
 defined('C5_EXECUTE') or die('Access Denied.');
-$view = View::getInstance();
+
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Core\Html\Service\Html $html */
+/* @var Concrete\Core\Application\Service\UserInterface $interface */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var string $debug_detail */
+/* @var bool $debug_enabled */
+/* @var bool $show_warnings */
 ?>
+<form method="post" id="debug-form" action="<?= $view->action('update_debug') ?>">
+    <?= $token->output('update_debug') ?>
 
-<form method="post" id="debug-form"
-      action="<?php echo $view->url('/dashboard/system/environment/debug', 'update_debug') ?>">
-    <?php echo $this->controller->token->output('update_debug') ?>
-
-    <fieldset>
-        <legend><?= t('Display Errors') ?></legend>
-        <div class="form-group">
-
-            <div class="checkbox">
-                <label>
-                    <input data-sample='<?= $view->action('disabled_example') ?>' type="checkbox" name="debug_enabled"
-                           value="1" <?= $debug_enabled ? 'checked' : '' ?> />
-                    <span><?php echo t('Output error information to site users') ?></span>
-                    <span class="help-block"><?= t('Disable to show a generic error message') ?></span>
-                </label>
-            </div>
-
+    <div class="form-group">
+        <?= $form->label('', t('Display Errors')) ?>
+        <div class="checkbox">
+            <label>
+                <?= $form->checkbox('debug_enabled', 1, $debug_enabled, ['data-sample' => $view->action('disabled_example')]) ?>
+                <?= t('Output error information to site users') ?>
+                <span class="help-block"><?= t('Disable to show a generic error message') ?></span>
+            </label>
         </div>
-    </fieldset>
+    </div>
 
-    <fieldset>
-        <legend><?= t('Error detail') ?></legend>
-        <div class="form-group">
-
-            <div class="radio">
-                <label>
-                    <input data-sample='<?= $view->action('message_example') ?>' type="radio" name="debug_detail"
-                           value="message" <?= $debug_detail != 'debug' ? 'checked' : '' ?> />
-                    <span><?php echo t('Show the error message but nothing else') ?></span>
-                </label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input data-sample='<?= $view->action('debug_example') ?>' type="radio" name="debug_detail"
-                           value="debug" <?= $debug_detail == 'debug' ? 'checked' : '' ?> />
-                    <span><?php echo t('Show the debug error output') ?></span>
-
-                    <p class="help-block">
-                        <span class='text-danger'>
-                            <?php echo t('May disclose sensitive information, use only for development.') ?>
-                        </span>
-                    </p>
-                </label>
-            </div>
-
+    <div class="form-group">
+        <?= $form->label('', t('Error Detail')) ?>
+        <div class="radio">
+            <label>
+                <?= $form->radio('debug_detail', 'message', $debug_detail, ['data-sample' => $view->action('message_example')]) ?>
+                <?= t('Show the error message but nothing else') ?>
+            </label>
         </div>
-    </fieldset>
+        <div class="radio">
+            <label>
+                <?= $form->radio('debug_detail', 'debug', $debug_detail, ['data-sample' => $view->action('debug_example')]) ?>
+                <?= t('Show the debug error output') ?>
+                <span class="help-block">
+                    <span class="text-danger">
+                        <?= t('May disclose sensitive information, use only for development.') ?>
+                    </span>
+                </span>
+            </label>
+        </div>
+    </div>
 
     <fieldset>
         <legend><?= t('Example') ?></legend>
-        <iframe class="sample" style="display:none"></iframe>
+        <iframe id="sample" style="display:none;width:100%;height:600px;border:0"></iframe>
     </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <?php
-            echo $interface->submit(t('Save'), 'debug-form', 'right', 'btn-primary');
-            ?>
+            <?= $interface->submit(t('Save'), 'debug-form', 'right', 'btn-primary') ?>
         </div>
     </div>
 
 </form>
 
 <script>
-    (function () {
-        var iframe = $('.sample'),
-            enabled = $('input[name=debug_enabled]'),
-            detail = $('input[name=debug_detail]'),
-            inputs = $('input');
+$(document).ready(function() {
 
-        inputs.change(function () {
-            var url;
-            if (enabled.is(':checked')) {
-                url = detail.filter(':checked').data('sample');
-            } else {
-                url = enabled.data('sample');
-            }
-            iframe.css({
-                width: '100%',
-                height: 600,
-                border: 'none'
-            }).show().attr('src', url);
-        }).change();
-    }());
+var iframe = $('iframe#sample'),
+    enabled = $('input[name=debug_enabled]'),
+    detail = $('input[name=debug_detail]'),
+    inputs = $('input');
+
+inputs
+    .on('change', function () {
+        var url;
+        if (enabled.is(':checked')) {
+            url = detail.filter(':checked').data('sample');
+        } else {
+            url = enabled.data('sample');
+        }
+        iframe.show().attr('src', url);
+    })
+    .trigger('change')
+;
+
+});
 </script>

--- a/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/concrete/single_pages/dashboard/system/environment/debug.php
@@ -101,8 +101,8 @@ inputs
     .trigger('change')
 ;
 
-$('#warnings_as_errors').on('click', function(e) {
-    if (this.checked && !window.confirm(<?= json_encode(t('Are you sure?')) ?>)) {
+form.on('submit', function(e) {
+    if (warningsAsErrors.is(':checked') && !window.confirm(<?= json_encode(t('Are you sure you want to consider warnings as errors?') . "\n" . t('This option should only be enabled by developers: it could brick your site.')) ?>)) {
         e.preventDefault();
         return false;
     }

--- a/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/concrete/single_pages/dashboard/system/environment/debug.php
@@ -1,4 +1,5 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 $view = View::getInstance();
 ?>
 

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -317,7 +317,7 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
          * to consider 3rd party libraries (like Symfony for instance) which use
          * those superglobals.
          */
-        if(isset($_POST['__ccm_consider_request_as_xhr']) && $_POST['__ccm_consider_request_as_xhr'] === '1') {
+        if (isset($_POST['__ccm_consider_request_as_xhr']) && $_POST['__ccm_consider_request_as_xhr'] === '1') {
             unset($_POST['__ccm_consider_request_as_xhr']);
             unset($_REQUEST['__ccm_consider_request_as_xhr']);
             $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -61,6 +61,13 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
 
         /*
          * ----------------------------------------------------------------------------
+         * Set configured error reporting
+         * ----------------------------------------------------------------------------
+         */
+        $this->setupErrorReporting($config);
+
+        /*
+         * ----------------------------------------------------------------------------
          * Enable Localization
          * ----------------------------------------------------------------------------
          */
@@ -187,6 +194,19 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
         $config = $app->make('config');
 
         return $config;
+    }
+
+    /**
+     * Setup the configured error reporting.
+     *
+     * @param Repository $config
+     */
+    private function setupErrorReporting(Repository $config)
+    {
+        $error_reporting = $config->get('concrete.debug.error_reporting');
+        if ((string) $error_reporting !== '') {
+            error_reporting((int) $error_reporting);
+        }
     }
 
     /**


### PR DESCRIPTION
Now that concrete5 doesn't throw many warnings (see all the fixes addressing #4723), what about adding an option for developers to consider PHP warnings as errors?

![immagine](https://user-images.githubusercontent.com/928116/42048091-70ee6984-7b02-11e8-972c-bff988b587e2.png)

Sure, they could add `error_reporting(-1);` to `/application/bootstrap/start.php`, but it's a manual operation that:
- developers may not think about it
- developers may not be aware of it
- it requires more time than checking an option

I really want this option, and I'd really prefer that any concrete5 core/package developer turns it on: that way we may grant a better and more stable product.

Example of a warning:

![immagine](https://user-images.githubusercontent.com/928116/42048105-803a3d5a-7b02-11e8-972c-c65b4b9c6fe2.png)
