### PR TITLE
Avoid warning in Securimage::check when no captcha token is received

### DIFF
--- a/concrete/src/Captcha/SecurimageController.php
+++ b/concrete/src/Captcha/SecurimageController.php
@@ -257,8 +257,12 @@ class SecurimageController extends AbstractController implements CaptchaWithPict
         } else {
             $inputName = static::DEFAULT_INPUT_NAME;
         }
+        $checkCode = $this->request->get($inputName);
+        if (!is_string($checkCode)) {
+            $checkCode = '';
+        }
 
-        return $this->securimage->check($this->request->get($inputName));
+        return $this->securimage->check($checkCode);
     }
 
     /**


### PR DESCRIPTION
I have these warnings in my logs:
```
The $code parameter passed to Securimage::check() must be a string, NULL given
```

This is [caused by Securimage](https://github.com/dapphp/securimage/blob/3.6.7/securimage.php#L1278) when someone tries to do something harmful with the website. Let's avoid this warning.