### PR TITLE
Add $subject to form email templates to make it easier to customize

### DIFF
--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -596,7 +596,9 @@ class Controller extends BlockController
                 $mh->addParameter('questionSetId', $this->questionSetId);
                 $mh->addParameter('questionAnswerPairs', $questionAnswerPairs);
                 $mh->load('block_form_submission');
-                $mh->setSubject(t('%s Form Submission', $this->surveyName));
+                if (empty($mh->getSubject())) {
+                    $mh->setSubject(t('%s Form Submission', $this->surveyName));
+                }
                 //echo $mh->body.'<br>';
                 @$mh->sendMail();
             }

--- a/concrete/mail/block_express_form_submission.php
+++ b/concrete/mail/block_express_form_submission.php
@@ -4,6 +4,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 $formDisplayUrl = URL::to('/dashboard/reports/forms', 'view', $entity->getEntityResultsNodeId());
 
+$subject = t('Website Form Submission – %s', $formName);
+
 $submittedData = '';
 foreach($attributes as $value) {
     $submittedData .= $value->getAttributeKey()->getAttributeKeyDisplayName('text') . ":\r\n";

--- a/concrete/mail/block_form_submission.php
+++ b/concrete/mail/block_form_submission.php
@@ -2,6 +2,8 @@
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
+$subject = t('%s Form Submission', $formName);
+
 $submittedData = '';
 foreach ($questionAnswerPairs as $questionAnswerPair) {
     $submittedData .= $questionAnswerPair['question']."\r\n".$questionAnswerPair['answerDisplay']."\r\n"."\r\n";

--- a/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
+++ b/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
@@ -81,7 +81,9 @@ class FormBlockSubmissionEmailNotification extends AbstractFormBlockSubmissionNo
             $mh->addParameter('formName', $this->getFormName($entry));
             $mh->addParameter('attributes', $this->getAttributeValues($entry));
             $mh->load('block_express_form_submission');
-            $mh->setSubject(t('Website Form Submission – %s', $this->getFormName($entry)));
+            if (empty($mh->getSubject())) {
+                $mh->setSubject(t('Website Form Submission – %s', $this->getFormName($entry)));
+            }
             $mh->sendMail();
         }
 


### PR DESCRIPTION
I've added $subject variable to email template so that it'll be easier to customize the email template for both Legacy Form and Express Form blocks.

To support backward compatibility, I've added an extra step to insert subject if the email templates didn't set subject.