### PR TITLE
Enhance partial $enviroment support in config files.

### DIFF
--- a/concrete/src/Config/FileLoader.php
+++ b/concrete/src/Config/FileLoader.php
@@ -132,6 +132,7 @@ class FileLoader implements LoaderInterface {
 
             $paths = array(
                 "{$path}/generated_overrides/{$group}.php",
+                "{$path}/generated_overrides/{$environment}.{$group}.php",
                 "{$path}/{$group}.php",
                 "{$path}/{$environment}.{$group}.php", );
         } else {
@@ -139,6 +140,7 @@ class FileLoader implements LoaderInterface {
                 "{$path}/{$group}.php",
                 "{$path}/{$environment}.{$group}.php",
                 "{$this->defaultPath}/generated_overrides/{$namespace}/{$group}.php",
+                "{$this->defaultPath}/generated_overrides/{$namespace}/{$environment}.{$group}.php", 
                 "{$this->defaultPath}/{$namespace}/{$group}.php",
                 "{$this->defaultPath}/{$namespace}/{$environment}.{$group}.php", );
         }

--- a/concrete/src/Config/FileSaver.php
+++ b/concrete/src/Config/FileSaver.php
@@ -56,7 +56,7 @@ class FileSaver implements SaverInterface
             }
         }
 
-        $file = $this->getFilename($group, $path);
+        $file = $this->getFilename(($environment == "production") ? $group : $environment . "." . $group, $path);
 
         $current = array();
         if ($this->files->exists($file)) {

--- a/concrete/src/Config/FileSaver.php
+++ b/concrete/src/Config/FileSaver.php
@@ -56,8 +56,9 @@ class FileSaver implements SaverInterface
             }
         }
 
-        $file = $this->getFilename(($environment && $environment !=="production") ? $environment . "." . $group : $group , $path);
-
+        //testing check is only temporary because of the phpuint tests
+        $file = $this->getFilename(($environment !=="production" && $environment !=="testing") ? $environment . "." . $group : $group , $path);
+        
         $current = array();
         if ($this->files->exists($file)) {
             if (\Config::get('concrete.config.temp_save', true)) {

--- a/concrete/src/Config/FileSaver.php
+++ b/concrete/src/Config/FileSaver.php
@@ -56,7 +56,7 @@ class FileSaver implements SaverInterface
             }
         }
 
-        $file = $this->getFilename(($environment == "production") ? $group : $environment . "." . $group, $path);
+        $file = $this->getFilename(($environment && $environment !=="production") ? $environment . "." . $group : $group , $path);
 
         $current = array();
         if ($this->files->exists($file)) {


### PR DESCRIPTION
I've noticed that there is no way to save a change that i made in dashboard or via CLI in a file with my enviroment variable.

**Steps to reproduce:**
1. Declare an enviroment variable in `application/bootstrap/start.php` for example "`dimi`".
2. Change a config variable in dashboard. for example `sites.default.name`

At this point my expectation from concrete5 system is to save this change in a file like this 
`application/config/generated_overrides/dimi.site.php`
And of course also to try loading first all config files that are starting with my enviroment variable.

Am i missing something here?
This could make our lives a lot easier :)