### PR TITLE
Fix CKEditor options override

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -86,11 +86,11 @@ class CkeditorEditor implements EditorInterface
     /**
      * Generate the Javascript code that initialize the plugin.
      *
-     * @param array $options a list of custom options that override the default one
+     * @param array $dynamicOptions a list of custom options that override the default ones
      *
      * @return string
      */
-    public function getEditorInitJSFunction($options = [])
+    public function getEditorInitJSFunction($dynamicOptions = [])
     {
         $pluginManager = $this->getPluginManager();
 
@@ -104,35 +104,36 @@ class CkeditorEditor implements EditorInterface
         $plugins = $pluginManager->getSelectedPlugins();
         $snippetsAndClasses = $this->getEditorSnippetsAndClasses();
 
-        $options = array_merge(
-            $options,
-            [
-                'plugins' => implode(',', $plugins),
-                'stylesSet' => 'concrete5styles',
-                'filebrowserBrowseUrl' => 'a',
-                'uploadUrl' => (string) URL::to('/ccm/system/file/upload'),
-                'language' => $this->getLanguageOption(),
-                'customConfig' => '',
-                'allowedContent' => true,
-                'baseFloatZIndex' => 1990, /* Must come below modal variable in variables.less */
-                'image2_captionedClass' => 'content-editor-image-captioned',
-                'image2_alignClasses' => [
-                    'content-editor-image-left',
-                    'content-editor-image-center',
-                    'content-editor-image-right',
-                ],
-                'toolbarGroups' => $this->config->get('editor.ckeditor4.toolbar_groups'),
-                'snippets' => $snippetsAndClasses->snippets,
-                'classes' => $snippetsAndClasses->classes,
-            ]
-        );
-
-        $customConfigOptions = $this->config->get('editor.ckeditor4.custom_config_options');
-        if ($customConfigOptions) {
-            $options = array_merge($options, $customConfigOptions);
+        if (!is_array($dynamicOptions)) {
+            $dynamicOptions = [];
         }
 
-        $options = json_encode($options);
+        $defaultOptions = [
+            'plugins' => implode(',', $plugins),
+            'stylesSet' => 'concrete5styles',
+            'filebrowserBrowseUrl' => 'a',
+            'uploadUrl' => (string) URL::to('/ccm/system/file/upload'),
+            'language' => $this->getLanguageOption(),
+            'customConfig' => '',
+            'allowedContent' => true,
+            'baseFloatZIndex' => 1990, /* Must come below modal variable in variables.less */
+            'image2_captionedClass' => 'content-editor-image-captioned',
+            'image2_alignClasses' => [
+                'content-editor-image-left',
+                'content-editor-image-center',
+                'content-editor-image-right',
+            ],
+            'toolbarGroups' => $this->config->get('editor.ckeditor4.toolbar_groups'),
+            'snippets' => $snippetsAndClasses->snippets,
+            'classes' => $snippetsAndClasses->classes,
+        ];
+
+        $customOptions = $this->config->get('editor.ckeditor4.custom_config_options');
+        if (!is_array($customOptions)) {
+            $customOptions = [];
+        }
+
+        $options = json_encode($dynamicOptions + $customOptions + $defaultOptions);
         $removeEmptyIcon = '$removeEmpty[\'i\']';
 
         $jsfunc = <<<EOL


### PR DESCRIPTION
When building CKEditor options, we have up to 3 option sets:
- the default options, defined in the `getEditorInitJSFunction` method (let's call them `$defaultOptions`)
- dynamically-defined options, passed to the `getEditorInitJSFunction` as an argument (let's call them `$dynamicOptions`)
- custom options defined in the `editor.ckeditor4.toolbar_groups` configuration key (let's call them `$customOptions`)

At the moment, the final option list is built with a code this:
```php
$options = array_merge(
    array_merge(
        $dynamicOptions,
        $defaultOptions,
    ),
    $customConfigOptions
);
```

which can be written as

```php
$options = $customConfigOptions + $defaultOptions + $dynamicOptions;
```

that means that the precedence order (from hight to low) is
1. `$customConfigOptions`
1. `$defaultOptions`
1. `$dynamicOptions`

IMHO it should be
1. `$dynamicOptions`
1. `$customOptions`
1. `$defaultOptions`

that is,
```php
$options = $dynamicOptions + $customOptions + $defaultOptions;
```
