### PR TITLE
Let CookieJar work with Request cookies and new cookies

### DIFF
--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -189,7 +189,7 @@ class CookieJar
      */
     public function getNewCookies()
     {
-        return $this->cookies;
+        return $this->getCookies();
     }
 
     /**

--- a/concrete/src/Http/Middleware/CookieMiddleware.php
+++ b/concrete/src/Http/Middleware/CookieMiddleware.php
@@ -41,7 +41,7 @@ class CookieMiddleware implements MiddlewareInterface
             $response->headers->clearCookie($cookie, DIR_REL . '/');
         }
 
-        $cookies = $this->cookies->getCookies();
+        $cookies = $this->cookies->getNewCookies();
         foreach ($cookies as $cookie) {
             $response->headers->setCookie($cookie);
         }

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Concrete\Tests\Error;
+
+use Concrete\Core\Cookie\CookieJar;
+use Concrete\Core\Http\Request;
+use PHPUnit_Framework_TestCase;
+
+class CookieTest extends PHPUnit_Framework_TestCase
+{
+    public function testCookiesFromRequest()
+    {
+        $jar = new CookieJar($this->getSampleRequest([]));
+        $this->assertFalse($jar->has('test'));
+        $jar = new CookieJar($this->getSampleRequest(['test' => 'RequestCookieValue']));
+        $this->assertTrue($jar->has('test'));
+        $this->assertSame('RequestCookieValue', $jar->get('test'));
+    }
+
+    public function testOverridingCookies()
+    {
+        $jar = new CookieJar($this->getSampleRequest(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2']));
+
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(0, $jar->getNewCookies());
+
+        $jar->clear('test1');
+        $this->assertFalse($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame(['test1'], $jar->getClearedCookies());
+        $this->assertCount(0, $jar->getNewCookies());
+
+        $jar->set('test1', 'NewCookieValue1');
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(1, $jar->getNewCookies());
+
+        $jar->set('test3', 'NewCookieValue3');
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertTrue($jar->has('test3'));
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(2, $jar->getNewCookies());
+
+        $jar->clear('test1');
+        $jar->clear('test4');
+        $this->assertFalse($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
+        $this->assertSame(['test1', 'test4'], $jar->getClearedCookies());
+        $this->assertCount(1, $jar->getNewCookies());
+    }
+
+    /**
+     * @param array $cookies
+     *
+     * @return \Concrete\Core\Http\Request
+     */
+    protected function getSampleRequest(array $cookies)
+    {
+        return Request::create('https://www.example.com/', 'GET', [], $cookies);
+    }
+}


### PR DESCRIPTION
Currently `CookieJar` has the following limitations:

- it's not possible to list all the cookies (the ones from request and the newly added ones): the `getCookies` method only returns the newly added cookies
- if we call the the `clear` method to "remove" a cookie, `has` still returns true, and `get` still returns the original cookie
- if we add a new cookie, `has` returns false and `get` returns `null`
- if we override a request cookie with a new cookie, `get` still returns the value of the original request cookie
- newly added cookies can't be removed with the `clear` method
- we don't have tests

Let's fix all these issues.