### PR TITLE
Update return type of Page::getBy* methods

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -78,7 +78,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      * @param string $path /path/to/page
      * @param string $version ACTIVE or RECENT
      *
-     * @return Page
+     * @return \Concrete\Core\Page\Page
      */
     public static function getByPath($path, $version = 'RECENT', TreeInterface $tree = null)
     {
@@ -116,7 +116,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      * @param int $cID Collection ID of a page
      * @param string $version ACTIVE or RECENT
      *
-     * @return Page
+     * @return \Concrete\Core\Page\Page
      */
     public static function getByID($cID, $version = 'RECENT')
     {


### PR DESCRIPTION
I grow tired of writing

```php
/** @var \Concrete\Core\Page\Page $page **/
$page = Page::getByID(1);
```

Can we use the FQN instead of the alias?