### PR TITLE
Forward $pageTitle to dashboard header element

### DIFF
--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -44,7 +44,7 @@ $large_font = (bool) $config->get('concrete.accessibility.toolbar_large_font');
 <html<?= $hideDashboardPanel ? '' : ' class="ccm-panel-open ccm-panel-right"'; ?>>
 <head>
     <link rel="stylesheet" type="text/css" href="<?=$this->getThemePath()?>/main.css" />
-    <?php View::element('header_required', ['disableTrackingCode' => true]); ?>
+    <?php View::element('header_required', ['disableTrackingCode' => true, 'pageTitle' => isset($pageTitle) ? $pageTitle : null]); ?>
     <link href='https://fonts.googleapis.com/css?family=Roboto:900' rel='stylesheet' type='text/css'>
 </head>
 <body <?php if (isset($bodyClass)) { ?>class="<?=$bodyClass?>"<?php } ?>>


### PR DESCRIPTION
In the dashboard pages we can override the page title placed in the `<h1>` tag by using a `$pageTitle` variable.
BTW the `<title>` element doesn't reflect this setting: let's do that.