### PR TITLE
Use Symfony Request to determine the request method

### DIFF
--- a/concrete/src/Http/RequestBase.php
+++ b/concrete/src/Http/RequestBase.php
@@ -209,6 +209,8 @@ class RequestBase extends SymfonyRequest
      */
     public static function isPost()
     {
-        return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'POST';
+        $req = static::getInstance();
+
+        return $req->getMethod() === 'POST';
     }
 }


### PR DESCRIPTION
Symphony `Request` has a [more complete approach](https://github.com/symfony/http-foundation/blob/v3.4.8/Request.php#L1347-L1362) that [our `isPost`](https://github.com/concrete5/concrete5/blob/051ee246c4c27599a21ece098b16686835e12170/concrete/src/Http/RequestBase.php#L212) method: let's use it.