### PR TITLE
Highlight existing localized stacks

### DIFF
--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -96,17 +96,21 @@ class Stacks extends DashboardPageController
                 $localeCrumbs[] = array(
                     'id' => $neutralStack->getCollectionID(),
                     'active' => $locale === '',
-                    'name' => h(tc('Locale', 'default')),
+                    'name' => '<strong>'.h(tc('Locale', 'default')).'</strong>',
                     'url' => \URL::to('/dashboard/blocks/stacks', 'view_details', $neutralStack->getCollectionID()),
                 );
                 $mif = $this->app->make('multilingual/interface/flag');
                 /* @var \Concrete\Core\Multilingual\Service\UserInterface\Flag $mif */
                 foreach ($sections as $sectionLocale => $section) {
                     /* @var Section $section */
+                    $localizedStackName = $mif->getSectionFlagIcon($section).' '.h($section->getLanguageText());
+                    if ($neutralStack->getLocalizedStack($section) !== null) {
+                        $localizedStackName = '<strong>' . $localizedStackName . '</strong>';
+                    }
                     $localeCrumbs[] = array(
                         'id' => $neutralStack->getCollectionID().'@'.$sectionLocale,
                         'active' => $locale === $sectionLocale,
-                        'name' => $mif->getSectionFlagIcon($section).' '.h($section->getLanguageText()).' <span class="text-muted">'.h($sectionLocale).'</span>',
+                        'name' => $localizedStackName .' <span class="text-muted">'.h($sectionLocale).'</span>',
                         'url' => \URL::to('/dashboard/blocks/stacks', 'view_details', $neutralStack->getCollectionID().rawurlencode('@'.$sectionLocale)),
                     );
                 }


### PR DESCRIPTION
I'm getting crazy to check if a stack exists for a specific language:

![immagine](https://user-images.githubusercontent.com/928116/42579344-6c4d42f8-8528-11e8-9833-edfcee9679c1.png)

With this edit, it's pretty clear which languages have a specific stack version:

![immagine](https://user-images.githubusercontent.com/928116/42579379-7f87e300-8528-11e8-891d-0f2954ca09ef.png)
