### PR TITLE
Fix default definition of tracking codes

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -863,21 +863,6 @@ return [
      * ------------------------------------------------------------------------
      */
     'seo' => [
-        'tracking' => [
-            /*
-             * User defined tracking code
-             *
-             * @var string
-             */
-            'code' => '',
-
-            /*
-             * Tracking code position
-             *
-             * @var string (top|bottom)
-             */
-            'code_position' => 'bottom',
-        ],
         'exclude_words' => 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, ' .
             'since, than, the, this, that, to, up, via, with',
 

--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -148,6 +148,12 @@ return [
                         'ccm_token',
                     ],
                 ],
+                'tracking' => [
+                    'code' => [
+                        'header' => '',
+                        'footer' => '',
+                    ],
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
Tracking codes has been moved from global configuration to site-specific configuration.
Let's reflect it in the default configuration files.