### PR TITLE
Avoid calling setBlockAreaObject on NULL in block backend userinterface controller

### DIFF
--- a/concrete/controllers/backend/user_interface/block.php
+++ b/concrete/controllers/backend/user_interface/block.php
@@ -42,14 +42,16 @@ abstract class Block extends Page
         }
         $this->area = $a;
         if (!$a->isGlobalArea()) {
-            $b = \Block::getByID($bID, $this->page, $a);
             $this->set('isGlobalArea', false);
+            $b = \Block::getByID($bID, $this->page, $a);
         } else {
+            $this->set('isGlobalArea', true);
             $stack = \Stack::getByName($arHandle);
             $sc = ConcretePage::getByID($stack->getCollectionID(), 'RECENT');
             $b = \Block::getByID($bID, $sc, STACKS_AREA_NAME);
-            $b->setBlockAreaObject($a); // set the original area object
-            $this->set('isGlobalArea', true);
+            if ($b) {
+                $b->setBlockAreaObject($a); // set the original area object
+            }
         }
         if (!$b) {
             throw new UserMessageException(t('Access Denied'));


### PR DESCRIPTION
This fixes the following error:

```
Call to a member function setBlockAreaObject() on a non-object
File: concrete/controllers/backend/user_interface/block.php
Line: 51
```

I don't know when it happens, maybe when a block is removed from a stack but in the concrete5 cache it's still there...