### PR TITLE
Adds a recursive function to find the root area for theme classes

### DIFF
--- a/concrete/controllers/dialog/area/design.php
+++ b/concrete/controllers/dialog/area/design.php
@@ -22,6 +22,23 @@ class Design extends BackendPageController
         return $this->permissions->canEditAreaDesign();
     }
 
+    /**
+     * Recursive function to find the root area of an
+     * area/subarea and return the handle of that area.
+     *
+     * @param $a
+     * @return mixed
+     */
+    public function getRootAreaHandle($a) {
+        if ($a instanceof \Concrete\Core\Area\SubArea) {
+            $paID = $a->getAreaParentID();
+            $paHandle = \Concrete\Core\Area\Area::getAreaHandleFromID($paID);
+            return $this->getRootAreaHandle(\Concrete\Core\Area\Area::getOrCreate($this->page, $paHandle));
+        } else {
+            return $a->getAreaHandle();
+        }
+    }
+
     public function reset()
     {
         $a = $this->area;

--- a/concrete/views/dialogs/area/design.php
+++ b/concrete/views/dialogs/area/design.php
@@ -11,12 +11,7 @@ $areaClasses = $pt->getThemeAreaClasses();
 $customClasses = array();
 
 // Use the area handle as the key to map against area classes
-$areaHandle = $a->getAreaHandle();
-
-// If its a SubArea, find the parent handle and use that
-if ($a instanceof \Concrete\Core\Area\SubArea) {
-    $areaHandle = \Concrete\Core\Area\Area::getAreaHandleFromID($a->getAreaParentID());
-}
+$areaHandle = $this->controller->getRootAreaHandle($a);
 
 if (isset($areaClasses[$areaHandle])) {
     $customClasses = $areaClasses[$areaHandle];


### PR DESCRIPTION
Noticed that theme area classes on an area are only inherited by layouts within at the first level. Changed the subarea check to a recursive function to get the theme area classes from the root area.