### PR TITLE
CookieJar refactoring v2

### DIFF
--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -39,6 +39,16 @@ class CookieJar
     }
 
     /**
+     * Get the object containing the response cookies.
+     *
+     * @return \Concrete\Core\Cookie\ResponseCookieJar
+     */
+    public function getResponseCookiesJar()
+    {
+        return $this->responseCookiesJar;
+    }
+
+    /**
      * Does a cookie exist in the request or response cookies?
      *
      * @param string $name
@@ -90,7 +100,7 @@ class CookieJar
             }
         }
         foreach ($this->responseCookiesJar->getCookies() as $cookie) {
-            if ($cookie->isCleared()) {
+            if ($cookie->getExpiresTime() !== 0 && $cookie->isCleared()) {
                 unset($result[$cookie->getName()]);
             } else {
                 $result[$cookie->getName()] = $cookie->getValue();

--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -90,7 +90,11 @@ class CookieJar
             }
         }
         foreach ($this->responseCookiesJar->getCookies() as $cookie) {
-            $result[$cookie->getName()] = $cookie->getValue();
+            if ($cookie->isCleared()) {
+                unset($result[$cookie->getName()]);
+            } else {
+                $result[$cookie->getName()] = $cookie->getValue();
+            }
         }
 
         return $result;

--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -24,18 +24,18 @@ class CookieJar
      *
      * @var \Concrete\Core\Cookie\ResponseCookieJar
      */
-    protected $responseCookieJar;
+    protected $responseCookies;
 
     /**
      * Initialize the instance.
      *
      * @param Request $request the object containing the request cookies
-     * @param ResponseCookieJar $responseCookieJar the object containing the response cookies
+     * @param ResponseCookieJar $responseCookies the object containing the response cookies
      */
-    public function __construct(Request $request, ResponseCookieJar $responseCookieJar)
+    public function __construct(Request $request, ResponseCookieJar $responseCookies)
     {
         $this->setRequest($request);
-        $this->responseCookieJar = $responseCookieJar;
+        $this->responseCookies = $responseCookies;
     }
 
     /**
@@ -43,9 +43,9 @@ class CookieJar
      *
      * @return \Concrete\Core\Cookie\ResponseCookieJar
      */
-    public function getResponseCookiesJar()
+    public function getResponseCookies()
     {
-        return $this->responseCookieJar;
+        return $this->responseCookies;
     }
 
     /**
@@ -57,11 +57,11 @@ class CookieJar
      */
     public function has($name)
     {
-        if (in_array($name, $this->responseCookieJar->getClearedCookies(), true)) {
+        if (in_array($name, $this->responseCookies->getClearedCookies(), true)) {
             return false;
         }
 
-        return $this->request->cookies->has($name) || $this->responseCookieJar->hasCookie($name);
+        return $this->request->cookies->has($name) || $this->responseCookies->hasCookie($name);
     }
 
     /**
@@ -74,11 +74,11 @@ class CookieJar
      */
     public function get($name, $default = null)
     {
-        $responseCookie = $this->responseCookieJar->getCookieByName($name);
+        $responseCookie = $this->responseCookies->getCookieByName($name);
         if ($responseCookie !== null) {
             return $responseCookie->getValue();
         }
-        if (in_array($name, $this->responseCookieJar->getClearedCookies(), true)) {
+        if (in_array($name, $this->responseCookies->getClearedCookies(), true)) {
             return $default;
         }
 
@@ -93,13 +93,13 @@ class CookieJar
     public function getAll()
     {
         $result = [];
-        $clearedRequestCookies = $this->responseCookieJar->getClearedCookies();
+        $clearedRequestCookies = $this->responseCookies->getClearedCookies();
         foreach ($this->request->cookies->all() as $name => $value) {
             if (!in_array($name, $clearedRequestCookies, true)) {
                 $result[$name] = $value;
             }
         }
-        foreach ($this->responseCookieJar->getCookies() as $cookie) {
+        foreach ($this->responseCookies->getCookies() as $cookie) {
             if ($cookie->getExpiresTime() !== 0 && $cookie->isCleared()) {
                 unset($result[$cookie->getName()]);
             } else {
@@ -121,7 +121,7 @@ class CookieJar
     }
 
     /**
-     * @deprecated Use $app->make(ResponseCookieJar::class)->addCookie()
+     * @deprecated Use ->getResponseCookies()->addCookie() or $app->make(ResponseCookieJar::class)->addCookie()
      *
      * @param string $name
      * @param string|null $value
@@ -135,37 +135,37 @@ class CookieJar
      */
     public function set($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true)
     {
-        return $this->responseCookieJar->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+        return $this->responseCookies->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
     }
 
     /**
-     * @deprecated Use $app->make(ResponseCookieJar::class)->addCookieObject()
+     * @deprecated Use ->getResponseCookies()->addCookieObject() or $app->make(ResponseCookieJar::class)->addCookieObject()
      *
      * @param \Symfony\Component\HttpFoundation\Cookie $cookie
      */
     public function add($cookie)
     {
-        $this->responseCookieJar->addCookieObject($cookie);
+        $this->responseCookies->addCookieObject($cookie);
     }
 
     /**
-     * @deprecated use $app->make(ResponseCookieJar::class)->clear()
+     * @deprecated Use ->getResponseCookies()->clear() or $app->make(ResponseCookieJar::class)->clear()
      *
      * @param string $name
      */
     public function clear($name)
     {
-        $this->responseCookieJar->clear($name);
+        $this->responseCookies->clear($name);
     }
 
     /**
-     * @deprecated use $app->make(ResponseCookieJar::class)->getCookies()
+     * @deprecated Use ->getResponseCookies()->getCookies() or $app->make(ResponseCookieJar::class)->getCookies()
      *
      * @return \Symfony\Component\HttpFoundation\Cookie[]
      */
     public function getCookies()
     {
-        return $this->responseCookieJar->getCookies();
+        return $this->responseCookies->getCookies();
     }
 
     /**

--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -1,113 +1,166 @@
 <?php
+
 namespace Concrete\Core\Cookie;
 
 use Concrete\Core\Http\Request;
-use Symfony\Component\HttpFoundation\Cookie as CookieObject;
 
+/**
+ * A class that holds operations performed on both request and response cookies.
+ *
+ * To work only on request cookies, use the Request class.
+ * To work only on response cookies, use the ResponseCookieJar class.
+ */
 class CookieJar
 {
-    protected $cookies = array();
-    protected $clearedCookies = array();
+    /**
+     * The object containing the request cookies.
+     *
+     * @var \Concrete\Core\Http\Request
+     */
     protected $request;
 
     /**
-     * Adds a CookieObject to the cookie pantry.
+     * The object containing the response cookies.
      *
-     * @param string $name The cookie name
-     * @param string|null $value The value of the cookie
-     * @param int $expire The number of seconds until the cookie expires
-     * @param string $path The path for the cookie
-     * @param null|string $domain The domain the cookie is available to
-     * @param bool $secure whether the cookie should only be transmitted over a HTTPS connection from the client
-     * @param bool $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
-     *
-     * @return \Symfony\Component\HttpFoundation\Cookie
+     * @var \Concrete\Core\Cookie\ResponseCookieJar
      */
-    public function set(
-        $name,
-        $value = null,
-        $expire = 0,
-        $path = '/',
-        $domain = null,
-        $secure = false,
-        $httpOnly = true
-    ) {
-        $cookie = new CookieObject($name, $value, $expire, $path, $domain, $secure, $httpOnly);
-        $this->add($cookie);
-
-        return $cookie;
-    }
+    protected $responseCookiesJar;
 
     /**
-     * Adds a CookieObject to the array of cookies for the object.
+     * Initialize the instance.
      *
-     * @param CookieObject $cookie
+     * @param Request $request the object containing the request cookies
+     * @param ResponseCookieJar $responseCookiesJar the object containing the response cookies
      */
-    public function add($cookie)
+    public function __construct(Request $request, ResponseCookieJar $responseCookiesJar)
     {
-        $this->cookies[] = $cookie;
+        $this->setRequest($request);
+        $this->responseCookiesJar = $responseCookiesJar;
     }
 
     /**
-     * Used to determine if the cookie key exists in the pantry.
+     * Does a cookie exist in the request or response cookies?
      *
-     * @param string $cookie
+     * @param string $name
      *
      * @return bool
      */
-    public function has($cookie)
+    public function has($name)
     {
-        return $this->getRequest()->cookies->has($cookie);
-    }
+        if (in_array($name, $this->responseCookiesJar->getClearedCookies(), true)) {
+            return false;
+        }
 
-    public function clear($cookie)
-    {
-        $this->clearedCookies[] = $cookie;
+        return $this->request->cookies->has($name) || $this->responseCookiesJar->hasCookie($name);
     }
 
     /**
-     * @param string $name    The key the cookie is stored under
-     * @param mixed  $default A value to return if the cookie isn't set
+     * Get the value of a cookie (from response or from request) given its name.
+     *
+     * @param string $name The key the cookie
+     * @param mixed $default The value to return if the cookie isn't set
      *
      * @return mixed
      */
     public function get($name, $default = null)
     {
-        if (!$this->has($name)) {
+        $responseCookie = $this->responseCookiesJar->getCookieByName($name);
+        if ($responseCookie !== null) {
+            return $responseCookie->getValue();
+        }
+        if (in_array($name, $this->responseCookiesJar->getClearedCookies(), true)) {
             return $default;
         }
 
-        return $this->getRequest()->cookies->get($name);
+        return $this->getRequest()->cookies->get($name, $default);
     }
 
     /**
-     * @return CookieObject[]
+     * Get a list of cookie names and values (both from response and from request).
+     *
+     * @return array array keys are the cookie names, array values are the cookie values
      */
-    public function getCookies()
+    public function getAll()
     {
-        return $this->cookies;
-    }
+        $result = [];
+        $clearedRequestCookies = $this->responseCookiesJar->getClearedCookies();
+        foreach ($this->request->cookies->all() as $name => $value) {
+            if (!in_array($name, $clearedRequestCookies, true)) {
+                $result[$name] = $value;
+            }
+        }
+        foreach ($this->responseCookiesJar->getCookies() as $cookie) {
+            $result[$cookie->getName()] = $cookie->getValue();
+        }
 
-    public function getClearedCookies()
-    {
-        return $this->clearedCookies;
+        return $result;
     }
 
     /**
-     * Set a request for this cookie jar
-     * @param \Concrete\Core\Cookie\Request $request
+     * Set the request for this cookie jar.
+     *
+     * @param \Concrete\Core\Http\Request $request
      */
     public function setRequest(Request $request)
     {
         $this->request = $request;
     }
 
+    /**
+     * @deprecated Use $app->make(ResponseCookieJar::class)->addCookie()
+     *
+     * @param string $name
+     * @param string|null $value
+     * @param int $expire
+     * @param string $path
+     * @param null|string $domain
+     * @param bool $secure
+     * @param bool $httpOnly
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function set($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true)
+    {
+        return $this->responseCookiesJar->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+    }
+
+    /**
+     * @deprecated Use $app->make(ResponseCookieJar::class)->addCookieObject()
+     *
+     * @param \Symfony\Component\HttpFoundation\Cookie $cookie
+     */
+    public function add($cookie)
+    {
+        $this->responseCookiesJar->addCookieObject($cookie);
+    }
+
+    /**
+     * @deprecated use $app->make(ResponseCookieJar::class)->clear()
+     *
+     * @param string $name
+     */
+    public function clear($name)
+    {
+        $this->responseCookiesJar->clear($name);
+    }
+
+    /**
+     * @deprecated use $app->make(ResponseCookieJar::class)->getCookies()
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie[]
+     */
+    public function getCookies()
+    {
+        return $this->responseCookiesJar->getCookies();
+    }
+
+    /**
+     * Get the request for this cookie jar.
+     *
+     * @return \Concrete\Core\Http\Request
+     */
     protected function getRequest()
     {
-        if (!$this->request) {
-            $this->request = \Request::getInstance();
-        }
-
         return $this->request;
     }
 }

--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -24,18 +24,18 @@ class CookieJar
      *
      * @var \Concrete\Core\Cookie\ResponseCookieJar
      */
-    protected $responseCookiesJar;
+    protected $responseCookieJar;
 
     /**
      * Initialize the instance.
      *
      * @param Request $request the object containing the request cookies
-     * @param ResponseCookieJar $responseCookiesJar the object containing the response cookies
+     * @param ResponseCookieJar $responseCookieJar the object containing the response cookies
      */
-    public function __construct(Request $request, ResponseCookieJar $responseCookiesJar)
+    public function __construct(Request $request, ResponseCookieJar $responseCookieJar)
     {
         $this->setRequest($request);
-        $this->responseCookiesJar = $responseCookiesJar;
+        $this->responseCookieJar = $responseCookieJar;
     }
 
     /**
@@ -45,7 +45,7 @@ class CookieJar
      */
     public function getResponseCookiesJar()
     {
-        return $this->responseCookiesJar;
+        return $this->responseCookieJar;
     }
 
     /**
@@ -57,11 +57,11 @@ class CookieJar
      */
     public function has($name)
     {
-        if (in_array($name, $this->responseCookiesJar->getClearedCookies(), true)) {
+        if (in_array($name, $this->responseCookieJar->getClearedCookies(), true)) {
             return false;
         }
 
-        return $this->request->cookies->has($name) || $this->responseCookiesJar->hasCookie($name);
+        return $this->request->cookies->has($name) || $this->responseCookieJar->hasCookie($name);
     }
 
     /**
@@ -74,11 +74,11 @@ class CookieJar
      */
     public function get($name, $default = null)
     {
-        $responseCookie = $this->responseCookiesJar->getCookieByName($name);
+        $responseCookie = $this->responseCookieJar->getCookieByName($name);
         if ($responseCookie !== null) {
             return $responseCookie->getValue();
         }
-        if (in_array($name, $this->responseCookiesJar->getClearedCookies(), true)) {
+        if (in_array($name, $this->responseCookieJar->getClearedCookies(), true)) {
             return $default;
         }
 
@@ -93,13 +93,13 @@ class CookieJar
     public function getAll()
     {
         $result = [];
-        $clearedRequestCookies = $this->responseCookiesJar->getClearedCookies();
+        $clearedRequestCookies = $this->responseCookieJar->getClearedCookies();
         foreach ($this->request->cookies->all() as $name => $value) {
             if (!in_array($name, $clearedRequestCookies, true)) {
                 $result[$name] = $value;
             }
         }
-        foreach ($this->responseCookiesJar->getCookies() as $cookie) {
+        foreach ($this->responseCookieJar->getCookies() as $cookie) {
             if ($cookie->getExpiresTime() !== 0 && $cookie->isCleared()) {
                 unset($result[$cookie->getName()]);
             } else {
@@ -135,7 +135,7 @@ class CookieJar
      */
     public function set($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true)
     {
-        return $this->responseCookiesJar->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+        return $this->responseCookieJar->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
     }
 
     /**
@@ -145,7 +145,7 @@ class CookieJar
      */
     public function add($cookie)
     {
-        $this->responseCookiesJar->addCookieObject($cookie);
+        $this->responseCookieJar->addCookieObject($cookie);
     }
 
     /**
@@ -155,7 +155,7 @@ class CookieJar
      */
     public function clear($name)
     {
-        $this->responseCookiesJar->clear($name);
+        $this->responseCookieJar->clear($name);
     }
 
     /**
@@ -165,7 +165,7 @@ class CookieJar
      */
     public function getCookies()
     {
-        return $this->responseCookiesJar->getCookies();
+        return $this->responseCookieJar->getCookies();
     }
 
     /**

--- a/concrete/src/Cookie/CookieServiceProvider.php
+++ b/concrete/src/Cookie/CookieServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Cookie;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
@@ -7,7 +8,8 @@ class CookieServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('\Concrete\Core\Cookie\CookieJar');
-        $this->app->bind('cookie', '\Concrete\Core\Cookie\CookieJar');
+        $this->app->singleton(ResponseCookieJar::class);
+        $this->app->singleton(CookieJar::class);
+        $this->app->alias(CookieJar::class, 'cookie');
     }
 }

--- a/concrete/src/Cookie/ResponseCookieJar.php
+++ b/concrete/src/Cookie/ResponseCookieJar.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Concrete\Core\Cookie;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+class ResponseCookieJar
+{
+    /**
+     * The list of new cookies to be added to the response.
+     *
+     * @var \Symfony\Component\HttpFoundation\Cookie[]
+     */
+    protected $cookies = [];
+
+    /**
+     * The names of the request cookies to be cleared out in response.
+     *
+     * @var string[]
+     */
+    protected $clearedCookies = [];
+
+    /**
+     * Adds a Cookie object to the cookie pantry.
+     *
+     * @param string $name The cookie name
+     * @param string|null $value The value of the cookie
+     * @param int $expire The number of seconds until the cookie expires
+     * @param string $path The path for the cookie
+     * @param null|string $domain The domain the cookie is available to
+     * @param bool $secure whether the cookie should only be transmitted over a HTTPS connection from the client
+     * @param bool $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function addCookie($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true)
+    {
+        $cookie = new Cookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+        $this->addCookieObject($cookie);
+
+        return $cookie;
+    }
+
+    /**
+     * Adds a Cookie object to the array of cookies for the object.
+     *
+     * @param \Symfony\Component\HttpFoundation\Cookie $cookie
+     *
+     * @return $this
+     */
+    public function addCookieObject(Cookie $cookie)
+    {
+        $name = $cookie->getName();
+        $isNew = true;
+        foreach ($this->cookies as $index => $value) {
+            if ($value->getName() === $name) {
+                $this->cookies[$index] = $cookie;
+                $isNew = false;
+            }
+        }
+        if ($isNew) {
+            $index = array_search($name, $this->clearedCookies, true);
+            if ($index !== false) {
+                unset($this->clearedCookies[$index]);
+                $this->clearedCookies = array_values($this->clearedCookies);
+            }
+            $this->cookies[] = $cookie;
+        }
+
+        return $this;
+    }
+
+    /**
+     * The list of new cookies to be added to the response.
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie[]
+     */
+    public function getCookies()
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Get the response cookie given its name.
+     *
+     * @param string $name The key the cookie is stored under
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie|null
+     */
+    public function getCookieByName($name)
+    {
+        foreach ($this->cookies as $cookie) {
+            if ($cookie->getName() === $name) {
+                return $cookie;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * There's a cookie with the specific name in the response cookies?
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasCookie($name)
+    {
+        return $this->getCookieByName($name) !== null;
+    }
+
+    /**
+     * The names of the request cookies to be cleared out in response.
+     *
+     * @return string[]
+     */
+    public function getClearedCookies()
+    {
+        return $this->clearedCookies;
+    }
+
+    /**
+     * Clear a cookie.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function clear($name)
+    {
+        if (!in_array($name, $this->clearedCookies, true)) {
+            $this->clearedCookies[] = $name;
+            foreach ($this->cookies as $index => $value) {
+                if ($value->getName() === $name) {
+                    unset($this->cookies[$index]);
+                }
+            }
+            $this->cookies = array_values($this->cookies);
+        }
+    }
+}

--- a/concrete/src/Http/Middleware/CookieMiddleware.php
+++ b/concrete/src/Http/Middleware/CookieMiddleware.php
@@ -2,51 +2,50 @@
 
 namespace Concrete\Core\Http\Middleware;
 
-use Concrete\Core\Cookie\CookieJar;
+use Concrete\Core\Cookie\ResponseCookieJar;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Middleware for adding and deleting cookies to an http response
+ * Middleware for adding and deleting cookies to an http response.
+ *
  * @package Concrete\Core\Http
  */
 class CookieMiddleware implements MiddlewareInterface
 {
+    /**
+     * @var \Concrete\Core\Cookie\ResponseCookieJar
+     */
+    private $responseCookies;
 
     /**
-     * @var \Concrete\Core\Cookie\CookieJar
+     * @param \Concrete\Core\Cookie\ResponseCookieJar $responseCookiess
      */
-    private $cookies;
-
-    public function __construct(CookieJar $cookies)
+    public function __construct(ResponseCookieJar $responseCookiess)
     {
-        $this->cookies = $cookies;
+        $this->responseCookiess = $responseCookiess;
     }
 
     /**
-     * Add or remove cookies from the
-     * @param Request $request
-     * @param \Concrete\Core\Http\Middleware\DelegateInterface $frame
-     * @return Response
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Http\Middleware\MiddlewareInterface::process()
      */
     public function process(Request $request, DelegateInterface $frame)
     {
         $this->cookies->setRequest($request);
 
-        /** @var Response $response */
         $response = $frame->next($request);
 
-        $cleared = $this->cookies->getClearedCookies();
+        $cleared = $this->responseCookies->getClearedCookies();
         foreach ($cleared as $cookie) {
             $response->headers->clearCookie($cookie, DIR_REL . '/');
         }
 
-        $cookies = $this->cookies->getCookies();
+        $cookies = $this->responseCookies->getCookies();
         foreach ($cookies as $cookie) {
             $response->headers->setCookie($cookie);
         }
 
         return $response;
     }
-
 }

--- a/concrete/src/Http/Middleware/CookieMiddleware.php
+++ b/concrete/src/Http/Middleware/CookieMiddleware.php
@@ -15,14 +15,14 @@ class CookieMiddleware implements MiddlewareInterface
     /**
      * @var \Concrete\Core\Cookie\ResponseCookieJar
      */
-    private $responseCookies;
+    private $responseCookieJar;
 
     /**
-     * @param \Concrete\Core\Cookie\ResponseCookieJar $responseCookiess
+     * @param \Concrete\Core\Cookie\ResponseCookieJar $responseCookieJar
      */
-    public function __construct(ResponseCookieJar $responseCookiess)
+    public function __construct(ResponseCookieJar $responseCookieJar)
     {
-        $this->responseCookiess = $responseCookiess;
+        $this->responseCookieJar = $responseCookieJar;
     }
 
     /**
@@ -32,16 +32,14 @@ class CookieMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, DelegateInterface $frame)
     {
-        $this->cookies->setRequest($request);
-
         $response = $frame->next($request);
 
-        $cleared = $this->responseCookies->getClearedCookies();
+        $cleared = $this->responseCookieJar->getClearedCookies();
         foreach ($cleared as $cookie) {
             $response->headers->clearCookie($cookie, DIR_REL . '/');
         }
 
-        $cookies = $this->responseCookies->getCookies();
+        $cookies = $this->responseCookieJar->getCookies();
         foreach ($cookies as $cookie) {
             $response->headers->setCookie($cookie);
         }

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Concrete\Tests\Error;
+
+use Concrete\Core\Cookie\CookieJar;
+use Concrete\Core\Cookie\ResponseCookieJar;
+use Concrete\Core\Http\Request;
+use PHPUnit_Framework_TestCase;
+
+class CookieTest extends PHPUnit_Framework_TestCase
+{
+    public function testCookiesFromRequest()
+    {
+        $jar = new CookieJar($this->getSampleRequest([]), new ResponseCookieJar());
+        $this->assertFalse($jar->has('test'));
+        $jar = new CookieJar($this->getSampleRequest(['test' => 'RequestCookieValue']), new ResponseCookieJar());
+        $this->assertTrue($jar->has('test'));
+        $this->assertSame('RequestCookieValue', $jar->get('test'));
+    }
+
+    public function testOverridingCookies()
+    {
+        $jar = new CookieJar($this->getSampleRequest(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2']), new ResponseCookieJar());
+
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(0, $jar->getNewCookies());
+
+        $jar->clear('test1');
+        $this->assertFalse($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame(['test1'], $jar->getClearedCookies());
+        $this->assertCount(0, $jar->getNewCookies());
+
+        $jar->set('test1', 'NewCookieValue1');
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(1, $jar->getNewCookies());
+
+        $jar->set('test3', 'NewCookieValue3');
+        $this->assertTrue($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertTrue($jar->has('test3'));
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
+        $this->assertSame([], $jar->getClearedCookies());
+        $this->assertCount(2, $jar->getNewCookies());
+
+        $jar->clear('test1');
+        $jar->clear('test4');
+        $this->assertFalse($jar->has('test1'));
+        $this->assertTrue($jar->has('test2'));
+        $this->assertSame(['test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
+        $this->assertSame(['test1', 'test4'], $jar->getClearedCookies());
+        $this->assertCount(1, $jar->getNewCookies());
+    }
+
+    /**
+     * @param array $cookies
+     *
+     * @return \Concrete\Core\Http\Request
+     */
+    protected function getSampleRequest(array $cookies)
+    {
+        return Request::create('https://www.example.com/', 'GET', [], $cookies);
+    }
+}

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -24,39 +24,39 @@ class CookieTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
-        $this->assertSame(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
-        $this->assertSame([], $jar->getClearedCookies());
-        $this->assertCount(0, $jar->getNewCookies());
+        $this->assertSame(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAll());
+        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
+        $this->assertCount(0, $jar->getResponseCookiesJar()->getCookies());
 
         $jar->clear('test1');
         $this->assertFalse($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
-        $this->assertSame(['test2' => 'RequestCookieValue2'], $jar->getAllCookies());
-        $this->assertSame(['test1'], $jar->getClearedCookies());
-        $this->assertCount(0, $jar->getNewCookies());
+        $this->assertSame(['test2' => 'RequestCookieValue2'], $jar->getAll());
+        $this->assertSame(['test1'], $jar->getResponseCookiesJar()->getClearedCookies());
+        $this->assertCount(0, $jar->getResponseCookiesJar()->getCookies());
 
         $jar->set('test1', 'NewCookieValue1');
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
-        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAllCookies());
-        $this->assertSame([], $jar->getClearedCookies());
-        $this->assertCount(1, $jar->getNewCookies());
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAll());
+        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
+        $this->assertCount(1, $jar->getResponseCookiesJar()->getCookies());
 
         $jar->set('test3', 'NewCookieValue3');
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertTrue($jar->has('test3'));
-        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
-        $this->assertSame([], $jar->getClearedCookies());
-        $this->assertCount(2, $jar->getNewCookies());
+        $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAll());
+        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
+        $this->assertCount(2, $jar->getResponseCookiesJar()->getCookies());
 
         $jar->clear('test1');
         $jar->clear('test4');
         $this->assertFalse($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
-        $this->assertSame(['test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAllCookies());
-        $this->assertSame(['test1', 'test4'], $jar->getClearedCookies());
-        $this->assertCount(1, $jar->getNewCookies());
+        $this->assertSame(['test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAll());
+        $this->assertSame(['test1', 'test4'], $jar->getResponseCookiesJar()->getClearedCookies());
+        $this->assertCount(1, $jar->getResponseCookiesJar()->getCookies());
     }
 
     /**

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -25,38 +25,38 @@ class CookieTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertSame(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAll());
-        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
-        $this->assertCount(0, $jar->getResponseCookiesJar()->getCookies());
+        $this->assertSame([], $jar->getResponseCookies()->getClearedCookies());
+        $this->assertCount(0, $jar->getResponseCookies()->getCookies());
 
         $jar->clear('test1');
         $this->assertFalse($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertSame(['test2' => 'RequestCookieValue2'], $jar->getAll());
-        $this->assertSame(['test1'], $jar->getResponseCookiesJar()->getClearedCookies());
-        $this->assertCount(0, $jar->getResponseCookiesJar()->getCookies());
+        $this->assertSame(['test1'], $jar->getResponseCookies()->getClearedCookies());
+        $this->assertCount(0, $jar->getResponseCookies()->getCookies());
 
         $jar->set('test1', 'NewCookieValue1');
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2'], $jar->getAll());
-        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
-        $this->assertCount(1, $jar->getResponseCookiesJar()->getCookies());
+        $this->assertSame([], $jar->getResponseCookies()->getClearedCookies());
+        $this->assertCount(1, $jar->getResponseCookies()->getCookies());
 
         $jar->set('test3', 'NewCookieValue3');
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertTrue($jar->has('test3'));
         $this->assertSame(['test1' => 'NewCookieValue1', 'test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAll());
-        $this->assertSame([], $jar->getResponseCookiesJar()->getClearedCookies());
-        $this->assertCount(2, $jar->getResponseCookiesJar()->getCookies());
+        $this->assertSame([], $jar->getResponseCookies()->getClearedCookies());
+        $this->assertCount(2, $jar->getResponseCookies()->getCookies());
 
         $jar->clear('test1');
         $jar->clear('test4');
         $this->assertFalse($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));
         $this->assertSame(['test2' => 'RequestCookieValue2', 'test3' => 'NewCookieValue3'], $jar->getAll());
-        $this->assertSame(['test1', 'test4'], $jar->getResponseCookiesJar()->getClearedCookies());
-        $this->assertCount(1, $jar->getResponseCookiesJar()->getCookies());
+        $this->assertSame(['test1', 'test4'], $jar->getResponseCookies()->getClearedCookies());
+        $this->assertCount(1, $jar->getResponseCookies()->getCookies());
     }
 
     /**


### PR DESCRIPTION
#6864 was bad because CookieJar did too many things, having too many responsibilities.

Here's the (backward compatible) approach of this pull request:
- response cookies are handled by the new `ResponseCookieJar`
- we don't need a `RequestCookieJar`: it's already there in Symfony (see `$request->cookies`)
- `CookieJar` now is a simpler class that can be used for simple operations that involve both request and response cookies

For backward compatibility (we have to consider existing code that uses `$app->make('cookies')` or the `CookieJar` class with DI), I kept these methods (but I deprecated them) that work with response cookies:
- `set` ⇒ use `ResponseCookieJar::addCookie`
- `add` ⇒ use `ResponseCookieJar::addCookieObject`
- `clear` ⇒ use `ResponseCookieJar::clear`
- `getCookies` ⇒ use `ResponseCookieJar::getCookies`