### PR TITLE
Add public properties to next_previous block controller

### DIFF
--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -19,6 +19,46 @@ class Controller extends BlockController
 
     protected $btWrapperClass = 'ccm-ui';
 
+    /**
+     * The label to go to the previous page.
+     *
+     * @var string
+     */
+    public $previousLabel;
+
+    /**
+     * The label to go to the next page.
+     *
+     * @var string
+     */
+    public $nextLabel;
+
+    /**
+     * The label of the parent page.
+     *
+     * @var string
+     */
+    public $parentLabel;
+
+    /**
+     * Whether the navigation should be looped.
+     *
+     * 0 = don't loop
+     * 1 = loop (default)
+     *
+     * @var int
+     */
+    public $loopSequence;
+
+    /**
+     * How to order the sibling pages.
+     *
+     * @example E.g. <code>display_asc</code>
+     *
+     * @var string
+     */
+    public $orderBy;
+
     public function getBlockTypeDescription()
     {
         return t('Navigate through sibling pages.');


### PR DESCRIPTION
Hardcoding a `next_previous` block in a template without specifying all the block properties causes PHP warnings.

Because it's not ideal to write
```php
$bt = BlockType::getByHandle('next_previous');
$bt->controller->loopSequence = 1;
$bt->controller->orderBy = 'display_asc';
$bt->controller->nextLabel = '';
$bt->controller->previousLabel = '';
$bt->controller->parentLabel = '';
$bt->render();
```

just to prevent some 'undefined variables' warnings, it's probably better to add these block properties to the controller. In that case they are always defined.