### PR TITLE
Fix for #6840

### DIFF
--- a/concrete/controllers/dialog/user/bulk/delete.php
+++ b/concrete/controllers/dialog/user/bulk/delete.php
@@ -106,6 +106,7 @@ class Delete extends BackendInterfaceController
 
         $sh = Core::make('helper/security');
         if (is_array($this->request('item'))) {
+            $this->users = [];
             foreach ($this->request('item') as $uID) {
                 $ui = UserInfo::getByID($sh->sanitizeInt($uID));
                 if (is_object($ui) && !$ui->isError()) {


### PR DESCRIPTION
#6840 is caused by double $ui objects in $this->users array in `concrete/controllers/dialog/user/bulk/delete.php:91`.