### PR TITLE
Fix migration of data in atPageSelector table

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20180621222449.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180621222449.php
@@ -2,32 +2,31 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
-use Doctrine\DBAL\Schema\Schema;
-
 
 class Version20180621222449 extends AbstractMigration implements RepeatableMigrationInterface
 {
-
     public function upgradeDatabase()
     {
         $db = $this->connection;
         if ($db->tableExists('atPageSelector')) {
             // This is the name of the page selector attribute table in some implementations of the page selector attribute
             // We need to take this data and place it into atNumber.
-            $r = $db->executeQuery('select * from atPageSelector');
-            while ($row = $r->fetch()) {
-                $db->transactional(function($db) use ($row) {
-                    /** @var $db Connection */
-                    $avID = $db->fetchColumn('select avID from atNumber where avID = ?', [$row['avID']]);
-                    if (!$avID) {
-                        $db->insert('atNumber', ['avID' => $row['avID'], 'value' => $row['value']]);
-                    }
-                });
-            }
+            $db->query(<<<EOT
+insert into atNumber (avID, value)
+    select
+        atPageSelector.avID, atPageSelector.value
+    from
+        atPageSelector
+    inner join
+        AttributeValues on atPageSelector.avID = AttributeValues.avID
+    left join
+        atNumber on atPageSelector.avID = atNumber.avID
+    where
+        atNumber.avID is null
+EOT
+            );
         }
     }
-
 }


### PR DESCRIPTION
This should fix the following error:
```
Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException
thrown with message
"An exception occurred while executing
'INSERT INTO atNumber (avID, value) VALUES (?, ?)'
with params ["462", "0"]:SQLSTATE[23000]:
Integrity constraint violation:
1452 Cannot add or update a child row:
a foreign key constraint fails (`c1c5minenu`.`atNumber`, CONSTRAINT `FK_41BA30B5A2A82A5D` FOREIGN KEY (`avID`) REFERENCES `AttributeValues` (`avID`) ON DELETE CASCADE)"
```