### PR TITLE
Fix for installing new blocks in 8.4.1

### DIFF
--- a/concrete/single_pages/dashboard/blocks/types/view.php
+++ b/concrete/single_pages/dashboard/blocks/types/view.php
@@ -91,7 +91,7 @@ if ($controller->getAction() == 'inspect') {
             foreach ($availableBlockTypes as $bt) {
                 $btIcon = $ci->getBlockTypeIconURL($bt);
                 ?>
-                <li><span><img src="<?= $btIcon ?>" /> <?= t($bt->getBlockTypeName()) ?>
+                <li><span class="clearfix"><img src="<?= $btIcon ?>" /> <?= t($bt->getBlockTypeName()) ?>
                     <a href="<?= $urlResolver->resolve(['/dashboard/blocks/types', 'install', $bt->getBlockTypeHandle()]) ?>" class="btn pull-right btn-sm btn-default"><?= t('Install') ?></a>
                 </span></li>
                 <?php

--- a/concrete/single_pages/dashboard/blocks/types/view.php
+++ b/concrete/single_pages/dashboard/blocks/types/view.php
@@ -92,7 +92,7 @@ if ($controller->getAction() == 'inspect') {
                 $btIcon = $ci->getBlockTypeIconURL($bt);
                 ?>
                 <li><span><img src="<?= $btIcon ?>" /> <?= t($bt->getBlockTypeName()) ?>
-                    <a href="<?= $urlResolver->resolve('/dashboard/blocks/types', 'install', $bt->getBlockTypeHandle()) ?>" class="btn pull-right btn-sm btn-default"><?= t('Install') ?></a>
+                    <a href="<?= $urlResolver->resolve(['/dashboard/blocks/types', 'install', $bt->getBlockTypeHandle()]) ?>" class="btn pull-right btn-sm btn-default"><?= t('Install') ?></a>
                 </span></li>
                 <?php
             }


### PR DESCRIPTION
This is a fix for the following error:

`Argument 1 passed to Concrete\Core\Url\Resolver\Manager\ResolverManager::resolve() must be of the type array, string given, called in B:\wamp64\www\dimger\concrete\single_pages\dashboard\blocks\types\view.php on line 95`