### PR TITLE
Fix infinite redirection visiting existing dirs when seo.trailing_slash is false

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -331,7 +331,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $site = $this->app['site']->getSite();
 
         $response = $cms->handleCanonicalURLRedirection($request, $site);
-        if (!$response) {
+        if (!$response && $collection->getCollectionPath() !== '/page_not_found') {
             $response = $cms->handleURLSlashes($request, $site);
         }
         if (isset($response)) {

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -331,6 +331,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $site = $this->app['site']->getSite();
 
         $response = $cms->handleCanonicalURLRedirection($request, $site);
+        // Don't handle final URL slashes if it's a page not found to avoid infinite redirections
         if (!$response && $collection->getCollectionPath() !== '/page_not_found') {
             $response = $cms->handleURLSlashes($request, $site);
         }


### PR DESCRIPTION
Condition:
1. using Apache with [`.htaccess` set by concrete5](https://github.com/concrete5/concrete5/blob/8.4.1/concrete/src/Service/Configuration/HTTP/ApacheGenerator.php#L43-L50)
1. users visits an existing directory (eg `/concrete/images`)

Execution:
1. the browser visits `/concrete/images`
1. Apache sees that `/concrete/images` is not a file and it's not a folder containing `index.php`/`index.html`, and it sends the request to `index.php` but with `/concrete/images/` as request path  
    Here's the mod_rewrite log:
    ```
    strip per-dir prefix: /var/www/concrete/images -> concrete/images
    applying pattern '.' to uri 'concrete/images'
    RewriteCond: input='/var/www/concrete/images' pattern='!-f' => matched
    RewriteCond: input='/var/www/concrete/images/index.html' pattern='!-f' => matched
    RewriteCond: input='/var/www/concrete/images/index.php' pattern='!-f' => matched
    rewrite 'concrete/images' -> 'index.php'
    add per-dir prefix: index.php -> /var/www/index.php
    trying to replace prefix /var/www/ with /
    strip matching prefix: /var/www/index.php -> index.php
    add subst prefix: index.php -> /index.php
    internal redirect with /index.php [INTERNAL REDIRECT]
    strip per-dir prefix: /var/www/concrete/images/ -> concrete/images/
    applying pattern '.' to uri 'concrete/images/'
    RewriteCond: input='/var/www/concrete/images/' pattern='!-f' => matched
    RewriteCond: input='/var/www/concrete/images//index.html' pattern='!-f' => matched
    RewriteCond: input='/var/www/concrete/images//index.php' pattern='!-f' => matched
    rewrite 'concrete/images/' -> 'index.php'
    add per-dir prefix: index.php -> /var/www/index.php
    trying to replace prefix /var/www/ with /
    strip matching prefix: /var/www/index.php -> index.php
    add subst prefix: index.php -> /index.php
    internal redirect with /index.php [INTERNAL REDIRECT]
    strip per-dir prefix: /var/www/index.php -> index.php
    applying pattern '.' to uri 'index.php'
    RewriteCond: input='/var/www/index.php' pattern='!-f' => not-matched
    pass through /var/www/index.php
    ```
1. the response factory sees that the request URL does not end with a slash, so it build a redirect response to `/concrete/images`
1. go to point 1 until the browsers stops the request because of too many redirects