### PR TITLE
Fixed issue with function causing URL's to break

### DIFF
--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -355,8 +355,7 @@ class PageController extends Controller
         $task = substr($requestPath, strlen($this->c->getCollectionPath()));
         if(is_string($task)) {
             if (strpos($task, '/') !== false) {
-                $replaceCount = 1;
-                $task = str_replace('/', '', $task, $replaceCount);
+                $task = ltrim($task, '/');
                 $task = str_replace('-/', '', $task);
                 $taskparts = explode('/', $task);
 


### PR DESCRIPTION
Fixed issue with function removing all "/" instead of just the first one which was causing all routing to break
