### PR TITLE
Add a tooltip that makes it clear that there are unpublished changes in events

### DIFF
--- a/concrete/css/build/core/app/utilities.less
+++ b/concrete/css/build/core/app/utilities.less
@@ -29,3 +29,31 @@
 .spacer-row-10 {
   height: (@padding-large-vertical * 10);
 }
+
+// Classes to easily set z-index
+.z-indexable {
+  &.z-0 {
+    z-index: 0
+  }
+  &.z-1 {
+    z-index: 1
+  }
+  &.z-2 {
+    z-index: 2
+  }
+  &.z-10 {
+    z-index: 10
+  }
+  &.z-100 {
+    z-index: 100
+  }
+  &.z-250 {
+    z-index: 250
+  }
+  &.z-500 {
+    z-index: 500
+  }
+  &.z-1000 {
+    z-index: 1000
+  }
+}

--- a/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
+++ b/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
@@ -64,7 +64,11 @@ class LinkFormatter implements LinkFormatterInterface
         $page = $occurrence->getEvent()->getPageObject();
         $href = 'javascript:void(0)';
         if (!$occurrence->getVersion()->isApproved()) {
-            $value .= '<i class="fa fa-exclamation-circle"></i>';
+            // Output a tooltip with text that makes it clear that there are unpublished changes
+            $value .= sprintf(
+                '<i class="fa fa-exclamation-circle z-indexable z-1000" data-toggle="tooltip" data-placement="bottom" title="%s"></i>',
+                t('This event has unpublished versions.')
+            );
         }
         $background = $this->getEventOccurrenceBackgroundColor($occurrence);
         $text = $this->getEventOccurrenceTextColor($occurrence);


### PR DESCRIPTION
This makes the exclamation point on calendar event listings a tooltip that makes it obvious that there are unpublished changes