### PR TITLE
Allow disabling the Welcome page

### DIFF
--- a/concrete/controllers/single_page/dashboard/welcome.php
+++ b/concrete/controllers/single_page/dashboard/welcome.php
@@ -3,11 +3,21 @@ namespace Concrete\Controller\SinglePage\Dashboard;
 
 use Concrete\Controller\Panel\Page\CheckIn;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Routing\Redirect;
 
 class Welcome extends DashboardPageController
 {
     public function view()
     {
+        /** @var \Concrete\Core\Config\Repository\Repository $config */
+        $config = $this->app->make('config');
+
+        // If the welcome page is disabled, the user is redirected to "Waiting for me" page.
+        // The welcome page can be disabled to prevent connections to concrete5.org.
+        if ($config->get('concrete.external.disable_welcome_page', false) === true) {
+            return Redirect::to('/dashboard/welcome/me');
+        }
+
         $this->setThemeViewTemplate('desktop.php');
     }
 }

--- a/concrete/controllers/single_page/dashboard/welcome.php
+++ b/concrete/controllers/single_page/dashboard/welcome.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard;
 
-use Concrete\Controller\Panel\Page\CheckIn;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Routing\Redirect;
 


### PR DESCRIPTION
The reason for this PR is:
- External news is retrieved, regardless of config setting (https://github.com/concrete5/concrete5/issues/6933).
- An RSS feed is loaded, and can't be disabled easily.
- The latest C5 version is retrieved, which can't be disabled easily.
- Featured add-ons, tutorials, etc. are loaded, which can't be disabled easily.

To increase **privacy** for a website owner, I'd propose to make it possible to disable the Welcome page. Because deleting is not possible, I chose for a redirect to the child page "Waiting for Me".

The controller now checks for the `concrete.external.disable_welcome_page` setting. By default it's `false`. If it's `true` the user is redirected to the "Waiting for Me" page.

I'm open for alternative ideas / suggestions...