### PR TITLE
Use https for updates services

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -477,8 +477,8 @@ return [
         'enable_permissions_protection' => true,
         'check_threshold' => 172800,
         'services' => [
-            'get_available_updates' => 'http://www.concrete5.org/tools/update_core',
-            'inspect_update' => 'http://www.concrete5.org/tools/inspect_update',
+            'get_available_updates' => 'https://www.concrete5.org/tools/update_core',
+            'inspect_update' => 'https://www.concrete5.org/tools/inspect_update',
         ],
     ],
     'paths' => [


### PR DESCRIPTION
It seems the URLs also work with https. How about making https default?

https://www.concrete5.org/tools/update_core
https://www.concrete5.org/tools/inspect_update