### PR TITLE
Use https for translate.concrete5.org/api

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -582,7 +582,7 @@ return [
         // Community Translation instance offering concrete5 translations
         'community_translation' => [
             // API entry point of the Community Translation instance
-            'entry_point' => 'http://translate.concrete5.org/api',
+            'entry_point' => 'https://translate.concrete5.org/api',
             // API Token to be used for the Community Translation instance
             'api_token' => '',
             // Languages below this translation progress won't be considered


### PR DESCRIPTION
It seems 'http://translate.concrete5.org/api' is also used to send an API token to. Can we switch over to https, @mlocati?

https://github.com/concrete5/concrete5/blob/36d42d8f52a820e018037073872342458c4e71cc/concrete/src/Localization/Translation/Remote/CommunityStoreTranslationProvider.php#L355-L369