### PR TITLE
Fixing the error of generate sitemap xml job

### DIFF
--- a/concrete/src/Page/Sitemap/SitemapWriter.php
+++ b/concrete/src/Page/Sitemap/SitemapWriter.php
@@ -370,7 +370,7 @@ class SitemapWriter
             $this->temporaryDirectory = $temporaryDirectory;
         }
 
-        return $result;
+        return $this->temporaryDirectory;
     }
 
     /**


### PR DESCRIPTION
When we run  generate sitemap xml job getTemporaryDirectory() function return null value on first call (or if $result was null)
