### PR TITLE
Remove the last '/' from url

### DIFF
--- a/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -7,7 +7,7 @@ $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
 $valt = $app->make('helper/validation/token');
 
 if ($this->controller->getTask() == 'translate_po') {
-    $url = Url::createFromUrl($this->controller->action('save_translation'));
+    $url = Url::createFromUrl($this->controller->action('save_translation'), false);
     $url = $url->setQuery([
         'ccm_token' => $app->make('token')->generate('translate/save'),
     ]);


### PR DESCRIPTION

BUG  SEEN : "Translate Site Interface" (when adding translation  for words)

BUG DESCRIPTION : Early the url is like this `"/index.php/dashboard/system/multilingual/translate_interface/save_translation/?ccm_token=1533208169%3Ae04faade91fe2a8eeeb2c6aa51589a64"`, when we send the request  it automaticly redirect to `"/index.php/dashboard/system/multilingual/translate_interface/save_translation?ccm_token=1533208169%3Ae04faade91fe2a8eeeb2c6aa51589a64"` and we lost the post data(show errors).

This commit will fix that issue