### PR TITLE
Port league csv's injection protection

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -78,7 +78,7 @@
     "ocramius/proxy-manager": "^1.0",
     "paragonie/random_compat": "^2.0",
     "league/flysystem-cached-adapter": "~1.0.3",
-    "league/csv": "~8.0",
+    "league/csv": "~8.2",
     "symfony/console": "^3.2"
   },
   "extra": {

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist;
 
+use Concrete\Core\Csv\WriterFactory;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -168,7 +169,10 @@ class Range extends DashboardPageController
 
         return StreamedResponse::create(
             function () use ($app, $type, $ranges) {
-                $writer = $app->build(IPRangesCsvWriter::class, ['writer' => Writer::createFromPath('php://output', 'w'), 'type' => $type]);
+                $writer = $app->build(IPRangesCsvWriter::class, [
+                    'writer' => $app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
+                    'type' => $type
+                ]);
                 $writer->insertHeaders();
                 $writer->insertRanges($ranges);
             },

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -5,6 +5,7 @@ namespace Concrete\Controller\SinglePage\Dashboard\Users;
 use Concrete\Controller\Element\Search\Users\Header;
 use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Csv\Export\UserExporter;
+use Concrete\Core\Csv\WriterFactory;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\User\EditResponse as UserEditResponse;
@@ -494,7 +495,7 @@ class Search extends DashboardPageController
                 $writer = $app->build(
                     UserExporter::class,
                     [
-                        'writer' => Writer::createFromPath('php://output', 'w'),
+                        'writer' => $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
                     ]
                 );
 

--- a/concrete/src/Csv/EscapeFormula.php
+++ b/concrete/src/Csv/EscapeFormula.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Concrete\Core\Csv;
+
+/**
+ * This file was ported from League CSV to be compatible with PHP 5.5.9 minimum
+ *
+ * League.Csv (https://csv.thephpleague.com).
+ *
+ * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ * @license https://github.com/thephpleague/csv/blob/master/LICENSE (MIT License)
+ * @version 9.1.5
+ * @link    https://github.com/thephpleague/csv
+ */
+use \InvalidArgumentException;
+
+/**
+ * A League CSV formatter to tackle CSV Formula Injection.
+ *
+ * @see http://georgemauer.net/2017/10/07/csv-injection.html
+ *
+ * @package League.csv
+ * @since   9.1.0
+ * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ */
+class EscapeFormula
+{
+    /**
+     * Spreadsheet formula starting character.
+     */
+    const FORMULA_STARTING_CHARS = '=-+@';
+
+    /**
+     * Effective Spreadsheet formula starting characters.
+     *
+     * @var array
+     */
+    protected $special_chars = [];
+
+    /**
+     * Escape character to escape each CSV formula field.
+     *
+     * @var string
+     */
+    protected $escape;
+
+    /**
+     * New instance.
+     *
+     * @param string   $escape        escape character to escape each CSV formula field
+     * @param string[] $special_chars additional spreadsheet formula starting characters
+     *
+     */
+    public function __construct($escape = "\t", array $special_chars = [])
+    {
+        $this->escape = $escape;
+        if ([] !== $special_chars) {
+            $special_chars = $this->filterSpecialCharacters($special_chars);
+        }
+        $chars = array_merge(str_split(self::FORMULA_STARTING_CHARS), $special_chars);
+        $chars = array_unique($chars);
+        $this->special_chars = array_fill_keys($chars, 1);
+    }
+
+    /**
+     * Filter submitted special characters.
+     *
+     * @param string[] $characters
+     *
+     * @throws InvalidArgumentException if the string is not a single character
+     *
+     * @return string[]
+     */
+    protected function filterSpecialCharacters(array $characters)
+    {
+        foreach ($characters as $str) {
+            if (1 != strlen($str)) {
+                throw new InvalidArgumentException(sprintf('The submitted string %s must be a single character', $str));
+            }
+        }
+        return $characters;
+    }
+
+    /**
+     * Returns the list of character the instance will escape.
+     *
+     * @return string[]
+     */
+    public function getSpecialCharacters()
+    {
+        return array_keys($this->special_chars);
+    }
+
+    /**
+     * Returns the escape character.
+     *
+     * @return string
+     */
+    public function getEscape()
+    {
+        return $this->escape;
+    }
+
+    /**
+     * League CSV formatter hook.
+     *
+     * @see escapeRecord
+     */
+    public function __invoke(array $record)
+    {
+        return $this->escapeRecord($record);
+    }
+
+    /**
+     * Escape a CSV record.
+     *
+     * @return array
+     */
+    public function escapeRecord(array $record)
+    {
+        return array_map([$this, 'escapeField'], $record);
+    }
+
+    /**
+     * Escape a CSV cell.
+     *
+     * @return string
+     */
+    protected function escapeField($cell)
+    {
+        if (!$this->isStringable($cell)) {
+            return $cell;
+        }
+        $str_cell = (string) $cell;
+        if (isset($str_cell[0], $this->special_chars[$str_cell[0]])) {
+            return $this->escape.$str_cell;
+        }
+        return $cell;
+    }
+
+    /**
+     * Tell whether the submitted value is stringable.
+     *
+     * @return bool
+     */
+    protected function isStringable($value)
+    {
+        return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
+    }
+}

--- a/concrete/src/Csv/WriterFactory.php
+++ b/concrete/src/Csv/WriterFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Concrete\Core\Csv;
+
+use Concrete\Core\Application\Application;
+use League\Csv\Writer;
+
+/**
+ * Get an instance of a CSV Writer
+ */
+class WriterFactory
+{
+
+    protected $writerClass;
+    protected $formatter;
+
+    public function __construct(EscapeFormula $formatter, $writerClass = Writer::class)
+    {
+        $this->formatter = $formatter;
+        $this->writerClass = $writerClass;
+    }
+
+    /**
+     * Create a CSV writer from a string
+     *
+     * @see Writer::createFromString
+     * @param string $string
+     * @return Writer
+     */
+    public function createFromString($string)
+    {
+        $class = $this->writerClass;
+        return $this->prepare($class::createFromString($string));
+    }
+
+    /**
+     * Create a CSV writer from a file object
+     *
+     * @see Writer::createFromFileObject
+     * @param SplFileObject $fileObject
+     * @return Writer
+     */
+    public function createFromFileObject(SplFileObject $fileObject)
+    {
+        $class = $this->writerClass;
+        return $this->prepare($class::createFromFileObject($fileObject));
+    }
+
+    /**
+     * Create a CSV writer from a stream
+     *
+     * @see Writer::createFromStream
+     * @param resource $stream
+     * @return Writer
+     */
+    public function createFromStream($stream)
+    {
+        $class = $this->writerClass;
+        return $this->prepare($class::createFromStream($stream));
+    }
+
+    /**
+     * Create a CSV writer from a string
+     *
+     * @see Writer::createFromPath
+     * @param string $path
+     * @param string $open_mode
+     * @return Writer
+     */
+    public function createFromPath($path, $open_mode = 'r+')
+    {
+        $class = $this->writerClass;
+        return $this->prepare($class::createFromPath($path, $open_mode));
+    }
+
+    /**
+     * Add extra details to a writer
+     *
+     * @param \League\Csv\Writer $writer
+     * @return Writer
+     */
+    protected function prepare(Writer $writer)
+    {
+        return $writer->addFormatter($this->formatter);
+    }
+}

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Page\Controller;
 
+use Concrete\Core\Csv\WriterFactory;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Express\Entry\Notifier\NotificationInterface;
@@ -108,7 +109,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
         return StreamedResponse::create(function() use ($entity, $me) {
             $entryList = new EntryList($entity);
 
-            $writer = new CsvWriter(Writer::createFromPath('php://output', 'w'), new Date());
+            $writer = new CsvWriter($this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'), new Date());
             $writer->insertHeaders($entity);
             $writer->insertEntryList($entryList);
         }, 200, $headers);

--- a/tests/tests/Csv/InjectionPreventionTest.php
+++ b/tests/tests/Csv/InjectionPreventionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Csv;
+
+use Concrete\Core\Csv\EscapeFormula;
+use Concrete\Core\Csv\WriterFactory;
+use League\Csv\Writer;
+
+class InjectionPreventionTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $input = [
+        ['=5+5'],
+        ['-5+5'],
+        ['+5+5'],
+        ['@5+5'],
+        ['%5+5'],
+        ['&5+5'],
+        ['5+5'],
+        ['*5+5'],
+        ['/5+5'],
+    ];
+
+    public function testCsvEscape()
+    {
+        $escaper = new EscapeFormula();
+
+        $this->assertSame(array_map($escaper, $this->input), [
+            ["\t=5+5"], // Escaped
+            ["\t-5+5"], // Escaped
+            ["\t+5+5"], // Escaped
+            ["\t@5+5"], // Escaped
+            ['%5+5'],   // Not Escaped
+            ['&5+5'],   // Not Escaped
+            ['5+5'],    // Not Escaped
+            ['*5+5'],   // Not Escaped
+            ['/5+5'],   // Not Escaped
+        ]);
+    }
+
+    public function testLeagueCsvUsage()
+    {
+        $escaper = new EscapeFormula();
+
+        $stream = tmpfile();
+        $writer = Writer::createFromStream($stream);
+        $writer->addFormatter($escaper);
+
+        // Write all the input items to the stream
+        array_map([$writer, 'insertOne'], $this->input);
+
+        rewind($stream);
+        while ($row = fgets($stream)) {
+            $result[] = [trim($row, PHP_EOL)];
+        }
+
+        $this->assertSame([
+            ["\"\t=5+5\""], // Escaped
+            ["\"\t-5+5\""], // Escaped
+            ["\"\t+5+5\""], // Escaped
+            ["\"\t@5+5\""], // Escaped
+            ['%5+5'],   // Not Escaped
+            ['&5+5'],   // Not Escaped
+            ['5+5'],    // Not Escaped
+            ['*5+5'],   // Not Escaped
+            ['/5+5'],   // Not Escaped
+        ], $result);
+    }
+
+    public function testWriterFactory()
+    {
+        $factory = \Core::make(WriterFactory::class);
+
+        $writer = $factory->createFromString('');
+        $writer->insertAll($this->input);
+
+        $stream = $writer->getIterator();
+        $stream->rewind();
+
+        $result = iterator_to_array($stream);
+        $this->assertEquals([
+            ["\t=5+5"], // Escaped
+            ["\t-5+5"], // Escaped
+            ["\t+5+5"], // Escaped
+            ["\t@5+5"], // Escaped
+            ['%5+5'],   // Not Escaped
+            ['&5+5'],   // Not Escaped
+            ['5+5'],    // Not Escaped
+            ['*5+5'],   // Not Escaped
+            ['/5+5'],   // Not Escaped
+        ], $result);
+    }
+
+}


### PR DESCRIPTION
This PR has two ways you could add protection from CSVi:

1. If you're create your own write
    * Apply an `EscapeFormula` object as a "Formatter" with `$writer->addFormatter(new EscapeFormula())`
2. If you're just using old `Writer::createFrom...` methods, we have a replacement factory
   * Create a writer with `$writerFactory->createFrom(String|Stream|Path|FileObject)(...)

Either way you'll end up with a writer that has reasonable protection from common CSVi attacks. 