### PR TITLE
Tags block - support mixed case tag names when setting selected tag class

### DIFF
--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -1,29 +1,29 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <?php if (isset($options) && count($options) > 0) { ?>
-<div class="ccm-block-tags-wrapper">
-    <?php if ($title) { ?>
-    <div class="ccm-block-tags-header">
-        <h5><?=$title?></h5>
-    </div>
-    <?php } ?>
+    <div class="ccm-block-tags-wrapper">
+        <?php if ($title) { ?>
+            <div class="ccm-block-tags-header">
+                <h5><?=$title?></h5>
+            </div>
+        <?php } ?>
 
-    <?php foreach ($options as $option) { ?>
-        <?php if (isset($target) && $target) { ?>
-            <a href="<?=$controller->getTagLink($option) ?>">
-                <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-                <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
-                <?php } else { ?>
-                <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
-                <?php } ?>
-            </a>
-        <?php } else { ?>
-            <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-            <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+        <?php foreach ($options as $option) { ?>
+            <?php if (isset($target) && $target) { ?>
+                <a href="<?=$controller->getTagLink($option) ?>">
+                    <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
+                        <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <?php } else { ?>
+                        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <?php } ?>
+                </a>
             <?php } else { ?>
-            <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
+                    <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php } else { ?>
+                    <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php } ?>
             <?php } ?>
         <?php } ?>
-    <?php } ?>
-</div>
+    </div>
 <?php } ?>

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -11,14 +11,14 @@
     <?php foreach ($options as $option) { ?>
         <?php if (isset($target) && $target) { ?>
             <a href="<?=$controller->getTagLink($option) ?>">
-                <?php if (isset($selectedTag) && $option->getSelectAttributeOptionValue() == $selectedTag) { ?>
+                <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
                 <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
                 <?php } else { ?>
                 <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
                 <?php } ?>
             </a>
         <?php } else { ?>
-            <?php if (isset($selectedTag) && $option->getSelectAttributeOptionValue() == $selectedTag) { ?>
+            <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
             <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
             <?php } else { ?>
             <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>


### PR DESCRIPTION
This pull request fixes an issue with mixed case tag names and when the `ccm-block-tags-tag-selected` class is assigned to the current selected tag name. The tag name in the URL will always be lowercase and the selected tag name compared with it should also be lowercase.

The following is an example of the "Artist editions" tag name before and after the fix. In the changes screenshot, the `ccm-block-tags-tag-selected` class is applied to the current selected tag name.

**Current:**

![image](https://user-images.githubusercontent.com/10898145/43664441-f4619c9c-973a-11e8-867a-a86111013150.png)

**Changes:**

![image](https://user-images.githubusercontent.com/10898145/43664453-f9686478-973a-11e8-9da9-6516ad052a6f.png)
