### PR TITLE
Fix Page::movePageDisplayOrderToSibling() when working with aliases

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2847,17 +2847,18 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     public function movePageDisplayOrderToSibling(Page $c, $position = 'before')
     {
-        // first, we get a list of IDs.
+        $myCID = $this->getCollectionPointerOriginalID() ?: $this->getCollectionID();
+        $relatedCID = $c->getCollectionPointerOriginalID() ?: $c->getCollectionID();
         $pageIDs = [];
         $db = Database::connection();
-        $r = $db->executeQuery('select cID from Pages where cParentID = ? and cID <> ? order by cDisplayOrder asc', [$this->getCollectionParentID(), $this->getCollectionID()]);
-        while ($row = $r->FetchRow()) {
-            if ($row['cID'] == $c->getCollectionID() && $position == 'before') {
-                $pageIDs[] = $this->cID;
+        $r = $db->executeQuery('select cID from Pages where cParentID = ? and cID <> ? order by cDisplayOrder asc', [$this->getCollectionParentID(), $myCID]);
+        while (($cID = $r->fetchColumn()) !== false) {
+            if ($cID == $relatedCID && $position == 'before') {
+                $pageIDs[] = $myCID;
             }
-            $pageIDs[] = $row['cID'];
-            if ($row['cID'] == $c->getCollectionID() && $position == 'after') {
-                $pageIDs[] = $this->cID;
+            $pageIDs[] = $cID;
+            if ($cID == $relatedCID && $position == 'after') {
+                $pageIDs[] = $myCID;
             }
         }
         $displayOrder = 0;


### PR DESCRIPTION
When working with aliases, we have to use `cPointerOriginalID` instead of `cID` to build the display order.