### PR TITLE
Mark Connection::replace as NOT deprecated

### DIFF
--- a/concrete/src/Database/Connection/Connection.php
+++ b/concrete/src/Database/Connection/Connection.php
@@ -244,15 +244,14 @@ class Connection extends \Doctrine\DBAL\Connection
     }
 
     /**
-     * @deprecated
-     * Alias to old ADODB Replace() method
+     * Insert or update a row in a database table.
      *
-     * @param string $table
-     * @param array $fieldArray
-     * @param string|string[] $keyCol
-     * @param bool $autoQuote
+     * @param string $table the name of the database table
+     * @param array $fieldArray array keys are the field names, array values are the field values
+     * @param string|string[] $keyCol the names of the primary key fields
+     * @param bool $autoQuote set to true to quote the field values
      */
-    public function Replace($table, $fieldArray, $keyCol, $autoQuote = true)
+    public function replace($table, $fieldArray, $keyCol, $autoQuote = true)
     {
         $qb = $this->createQueryBuilder();
         $qb->select('count(*)')->from($table, 't');


### PR DESCRIPTION
The Connection::Replace method is currently marked as deprecated. BTW a simple alternative to it does not exist.

So, what about making it NOT deprecated?

Furthermore, since all the new use camelCase instead of PascalCase, I renamed it from `Replace` to `replace` (which shouldn't have BC issues since method names are case insensitive).