### PR TITLE
Avoid deprecated methods in Collection

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -485,7 +485,7 @@ class Collection extends ConcreteObject implements TrackableInterface
      * Return the attribute value object with the handle $akHandle of the currently loaded version (if it's loaded).
      *
      * @param string|\Concrete\Core\Attribute\Key\CollectionKey $akHandle the attribute key (or its handle)
-     * @param mixed $createIfNotExists
+     * @param bool $createIfNotExists
      *
      * @return \Concrete\Core\Entity\Attribute\Value\PageValue|null
      */
@@ -910,10 +910,9 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Add a new block to a specific area of the currently loaded collection version.
      *
-     * @param \Concrete\Core\Entity\Block\BlockType\BlockType $blockType the type of block to be added
+     * @param \Concrete\Core\Entity\Block\BlockType\BlockType $bt the type of block to be added
      * @param string|\Concrete\Core\Area\Area $a the area instance (or its handle) to which the block should be added to
      * @param array $data The data of the block. This data depends on the specific block type. Common values are: 'uID' to specify the ID of the author (if not specified: we'll use the current user), 'bName' to specify the block name.
-     * @param mixed $bt
      *
      * @return \Concrete\Core\Block\Block
      */
@@ -1047,7 +1046,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     }
 
     /**
-     * Mark this collection as newly modified.
+     * Mark this collection as modified right now.
      */
     public function markModified()
     {

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -237,7 +237,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         if (isset($data['cvIsNew'])) {
             $insert['cvIsNew'] = $data['cvIsNew'] ? 1 : 0;
         } else {
-            $insert['cvIsNew'] = $cvIsApproved ? 0 : 1;
+            $insert['cvIsNew'] = $insert['cvIsApproved'] ? 0 : 1;
         }
         $db->insert('CollectionVersions', $insert);
 

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -91,7 +91,7 @@ class Collection extends ConcreteObject implements TrackableInterface
      * Get a collection by ID.
      *
      * @param int $cID The collection ID
-     * @param string|int|false $version the collection version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, a falsy value to not load the collection version, or an integer to retrieve a specific version ID)
+     * @param string|int|false $version the collection version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, 'SCHEDULED' for the currently scheduled version, a falsy value to not load the collection version, or an integer to retrieve a specific version ID)
      *
      * @return \Concrete\Core\Page\Collection\Collection If the collection is not found, you'll get an empty Collection instance
      */
@@ -343,7 +343,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Load a specific collection version (you can retrieve it with the getVersionObject() method).
      *
-     * @param string|int $cvID the collection version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, or an integer to retrieve a specific version ID)
+     * @param string|int $cvID the collection version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, 'SCHEDULED' for the currently scheduled version, or an integer to retrieve a specific version ID)
      */
     public function loadVersionObject($cvID = 'ACTIVE')
     {

--- a/tests/helpers/Page/PageTestCase.php
+++ b/tests/helpers/Page/PageTestCase.php
@@ -38,6 +38,7 @@ abstract class PageTestCase extends ConcreteDatabaseTestCase
         'AttributeKeyCategories',
         'PageTypeComposerOutputBlocks',
         'PageTypeComposerFormLayoutSets',
+        'BlockPermissionAssignments',
     ]; // so brutal
 
     protected $metadatas = [


### PR DESCRIPTION
I rewrote the code by replacing calls to deprecated methods.

I also:
1. removed [this line](https://github.com/concrete5/concrete5/blob/8.4.2/concrete/src/Page/Collection/Collection.php#L697) and [this line](https://github.com/concrete5/concrete5/blob/8.4.2/concrete/src/Page/Collection/Collection.php#L756) since it doesn't seem to be used in the code (just assigned)
2. fixed the result of `reindexPendingPages` ([this line was missing](https://github.com/mlocati/concrete5/commit/c13a75e671e43fd5ddd1c7069985734ccca10362#diff-6871966227e19cfe2b1c686222ced28dR163)).

PS: I double checked every change.