### PR TITLE
Fix package installer not checking dependencies on other packages

### DIFF
--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -751,7 +751,7 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        if (empty($errors)) {
+        if (!$errors->has()) {
             // Step 3 - test minimum application version requirement
             $applicationVersionRequired = $this->getApplicationVersionRequired();
             if (version_compare(APP_VERSION, $applicationVersionRequired, '<')) {


### PR DESCRIPTION
Fix for an issue where the package installer never checks for dependencies on other packages because `empty($errors)` would always be true (it's checking an ErrorList object not an array).