### PR TITLE
Avoid errors in editing express entry detail block

### DIFF
--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -155,6 +155,7 @@ class Controller extends BlockController
             $entities[$entity->getID()] = $entity->getEntityDisplayName();
         }
         $this->set('entities', $entities);
+        $attributeKeys = [];
         $keys = CollectionKey::getList();
         foreach ($keys as $ak) {
             if ($ak->getAttributeTypeHandle() == 'express') {


### PR DESCRIPTION
Error detail

file: "/path/to/concrete5/concrete/blocks/express_entry_detail/edit.php"
line: 36
message: "count(): Parameter must be an array or an object that implements Countable"

How to reproduce: Delete all "express" page attributes