### PR TITLE
Fix/express association form view element

### DIFF
--- a/concrete/elements/express/form/form/association/view.php
+++ b/concrete/elements/express/form/form/association/view.php
@@ -10,12 +10,14 @@
     }
     if (count($entities)) {
         ?>
+        <ul>
         <?php foreach ($entities as $entity) {
     ?>
-            <div><a href="<?=URL::to('/dashboard/express/entries', 'view_entry', $entity->getID())?>"><?=$formatter->getEntryDisplayName($control, $entity)?></a></div>
+            <li><a href="<?=URL::to('/dashboard/express/entries', 'view_entry', $entity->getID())?>"><?=$formatter->getEntryDisplayName($control, $entity)?></a></li>
         <?php 
 }
         ?>
+        </ul>
     <?php 
     } ?>
 </div>

--- a/concrete/elements/express/form/form/association/view.php
+++ b/concrete/elements/express/form/form/association/view.php
@@ -5,6 +5,9 @@
     <label class="control-label"><?=$label?></label>
     </div>
     <?php
+    if (isset($selectedEntities) && is_array($selectedEntities)) {
+        $entities = $selectedEntities;
+    }
     if (count($entities)) {
         ?>
         <?php foreach ($entities as $entity) {


### PR DESCRIPTION
See this image:

![screencapture-concrete5-test-index-php-dashboard-express-entries-create_entry-82beff0a-9cb0-11e8-ab0f-a8667f39691c-2018-08-12-18_13_31](https://user-images.githubusercontent.com/514294/44000499-bf6fe4e4-9e5b-11e8-9a75-467ef3c1c9ad.png)

I'm creating a new entry for Channel.
The "Channel" entity has an association with "Episode."
All episodes are listed in the form.
This is weird, there are no selected entries because I'm creating a new entry!

I believe this is correct fix for this issue, but I'm expecting a review from core team. Thanks!