### PR TITLE
Send JSON error responses when browser supports '*/*' content type

### DIFF
--- a/concrete/src/Error/Handler/JsonErrorHandler.php
+++ b/concrete/src/Error/Handler/JsonErrorHandler.php
@@ -64,7 +64,7 @@ class JsonErrorHandler extends Handler
         ];
 
         if (Misc::canSendHeaders()) {
-            if (isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) {
+            if (isset($_SERVER['HTTP_ACCEPT']) && preg_match('%^(application|\*)/(json|\*)$%', $_SERVER['HTTP_ACCEPT'])) {
                 header('Content-Type: application/json; charset=' . APP_CHARSET, true);
             } else {
                 header('Content-Type: text/plain; charset=' . APP_CHARSET, true);


### PR DESCRIPTION
Our JsonError handler only sends `application/json` content types if the browser explicity says it supports it, BTW some browser may say that it support *any* content type: let's consider this case.