### PR TITLE
Add support to site-wide page searches

### DIFF
--- a/concrete/elements/pages/search_header.php
+++ b/concrete/elements/pages/search_header.php
@@ -18,8 +18,8 @@
         $site = Core::make('site')->getActiveSiteForEditing();
         $locales = $site->getLocales();
         if (count($locales) > 1) {
-            $selector = new \Concrete\Core\Form\Service\Widget\SiteLocaleSelector();
-            print $selector->selectLocale('localeID', $site);
+            $selector = new Concrete\Core\Form\Service\Widget\SiteLocaleSelector();
+            print $selector->selectLocale('localeID', $site, null, ['allowNull' => true, 'noLocaleText' => t('Any Locale')]);
         } ?>
 
         <button class="btn btn-info" type="submit"><i class="fa fa-search"></i></button>

--- a/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
+++ b/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
@@ -1,37 +1,54 @@
 <?php
+
 namespace Concrete\Core\Form\Service\Widget;
 
 use Concrete\Core\Entity\Site\Locale;
 use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Multilingual\Service\UserInterface\Flag;
+use Concrete\Core\Utility\Service\Identifier;
+use View;
 
 class SiteLocaleSelector
 {
     /**
      * Creates form fields and JavaScript page chooser for choosing a locale.
+     *
+     * @param string $fieldName
+     * @param \Concrete\Core\Entity\Site\Site $site
+     * @param \Concrete\Core\Entity\Site\Locale|null $selectedLocale
+     * @param array $options Supported options are:
+     *     bool $allowNull Set to a non falsy value to allow users to choose "no" locale [default: false]
+     *     string $noLocaleText The string to represent "no locale" [default: t('No Locale')]
+     *
+     * @return string
      */
-    public function selectLocale($fieldName, Site $site, Locale $selectedLocale = null)
+    public function selectLocale($fieldName, Site $site, Locale $selectedLocale = null, array $options = [])
     {
-        $v = \View::getInstance();
+        $v = View::getInstance();
         $v->requireAsset('core/app');
 
-        if (!$selectedLocale) {
+        $allowNull = !empty($options['allowNull']);
+        $nullText = isset($options['noLocaleText']) ? $options['noLocaleText'] : t('No Locale');
+
+        if ($selectedLocale === null && !$allowNull) {
             $selectedLocale = $site->getDefaultLocale();
         }
 
-        $localeID = $selectedLocale->getLocaleID();
+        $localeID = $selectedLocale ? $selectedLocale->getLocaleID() : '';
 
-        $identifier = new \Concrete\Core\Utility\Service\Identifier();
-        $identifier = $identifier->getString(32);
-        $flag = Flag::getLocaleFlagIcon($selectedLocale);
-        $label = $selectedLocale->getLanguageText();
+        $identifier = (new Identifier())->getString(32);
 
-        $locales = $site->getLocales();
+        $flag = $selectedLocale ? Flag::getLocaleFlagIcon($selectedLocale) : '';
+
+        $label = $selectedLocale ? $selectedLocale->getLanguageText() : $nullText;
+
         $localeHTML = '';
-        foreach ($locales as $locale) {
-            $locales = $site->getLocales();
+        if ($allowNull) {
+            $localeHTML .= '<li><a href="#"' . ($selectedLocale === null ? ' data-locale="default"' : '') . ' data-select-locale="">' . $nullText . '</li>';
+        }
+        foreach ($site->getLocales() as $locale) {
             $localeHTML .= '<li><a href="#" ';
-            if ($selectedLocale->getLocaleID() == $locale->getLocaleID()) {
+            if ($selectedLocale && $selectedLocale->getLocaleID() == $locale->getLocaleID()) {
                 $localeHTML .= 'data-locale="default"';
             }
             $localeHTML .= 'data-select-locale="' . $locale->getLocaleID() . '">';
@@ -68,5 +85,4 @@ EOL;
 
         return $html;
     }
-
 }


### PR DESCRIPTION
We often need to search pages across all the language sections of the website.

So, what about these changes?

- let `PageList` filter by all the languages of a site, if pass to `setSiteTreeObject()` a `Site` object instead of a `SiteTree` object
- Add an option to `SiteLocaleSelector` to select "any locale"
- Add support to "any locale" to the `page_search` element