### PR TITLE
Let ItemList correctly detect columns in select when checking order by columns

### DIFF
--- a/concrete/src/Search/ItemList/Database/ItemList.php
+++ b/concrete/src/Search/ItemList/Database/ItemList.php
@@ -108,7 +108,8 @@ abstract class ItemList extends AbstractItemList
 
     protected function ensureSelected($field)
     {
-        $rx = '/\b' . preg_quote($field, '/') . '\b/i';
+        $quoter = $this->query->getConnection()->getDatabasePlatform()->getIdentifierQuoteCharacter();
+        $rx = '/\b' . preg_quote($field, '/') . preg_quote($quoter, '/') . '?\s*$/i';
         $selects = $this->query->getQueryPart('select');
         $add = true;
         foreach ($selects as $select) {


### PR DESCRIPTION
When using the Document Library block, we have this SQL error:

Exception Occurred: /concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:115 An exception occurred while executing ’SELECT distinct n.treeNodeID, if(nt.treeNodeTypeHandle=‘file’, fv.fvTitle, n.treeNodeName) as folderItemName, if(nt.treeNodeTypeHandle=‘file’, fv.fvDateAdded, n.dateModified) as folderItemModified, case when nt.treeNodeTypeHandle=‘search_preset’ then 1 when nt.treeNodeTypeHandle=‘file_folder’ then 2 else (10 + fvType) end as folderItemType, fv.fvSize as folderItemSize FROM TreeNodes n INNER JOIN TreeNodeTypes nt ON nt.treeNodeTypeID = n.treeNodeTypeID LEFT JOIN TreeFileNodes tf ON tf.treeNodeID = n.treeNodeID LEFT JOIN FileVersions fv ON tf.fID = fv.fID and fv.fvIsApproved = 1 LEFT JOIN FileSearchIndexAttributes fis ON fv.fID = fis.fID WHERE n.treeNodeParentID = ? ORDER BY fv.fvTitle asc LIMIT 20 OFFSET 0' with params [“2513”]:

That's because we are ordering for fv.fvTitle, and the ItemList thinks it's already in the select fields (see `if(nt.treeNodeTypeHandle=‘file’, fv.fvTitle, n.treeNodeName) as folderItemName`), but it's not the case.

Let's fix this.