### PR TITLE
[WIP] Keep owning entry is selected after adding a new owned by entry

### DIFF
--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -303,7 +303,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
                 if ($entry === null) {
                     // create
                     $entry = $manager->addEntry($entity);
-                    $manager->saveEntryAttributesForm($form, $entry);
+                    $entry = $manager->saveEntryAttributesForm($form, $entry);
                     $notifier->sendNotifications($notifications, $entry, ProcessorInterface::REQUEST_TYPE_ADD);
 
                     $this->flash(
@@ -313,7 +313,11 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
                         . '<a class="btn btn-default" href="' . \URL::to(\Page::getCurrentPage(), 'view_entry', $entry->getID()) . '">' . t('View Record Here') . '</a>',
                         true
                     );
-                    $this->redirect(\URL::to(\Page::getCurrentPage(), 'create_entry', $entity->getID()));
+                    if (is_object($entry->getOwnedByEntry())) {
+                        $this->redirect(\URL::to(\Page::getCurrentPage(), 'create_entry', $entity->getID(), $entry->getOwnedByEntry()->getID()));
+                    } else {
+                        $this->redirect(\URL::to(\Page::getCurrentPage(), 'create_entry', $entity->getID()));
+                    }
                 } else {
                     // update
                     $manager->saveEntryAttributesForm($form, $entry);


### PR DESCRIPTION
*Do not merge this pull request. It doesn't work correctly yet.*

I think my change is correct, but it doesn't work. `$entry->getOwnedByEntry()` returns `null`. Does anyone know why?

*What I want to do*

We can add an "owned by" entry from owning entry.

![view_entries1](https://user-images.githubusercontent.com/514294/44297237-2c6a5780-a309-11e8-8117-de9caab16706.png)

Owning entry is already selected when you are adding a new one.

![view_entries2](https://user-images.githubusercontent.com/514294/44297246-42781800-a309-11e8-93d6-39853153403c.png)

However, it isn't selected after submitting a form. I'd like to keep owning entry is selected.

![view_entries3](https://user-images.githubusercontent.com/514294/44297252-56237e80-a309-11e8-8ae3-e3c1b9e69640.png)

