### PR TITLE
Don't define ConcreteSearchFieldSelector as global

### DIFF
--- a/concrete/js/build/core/app/search/field-selector.js
+++ b/concrete/js/build/core/app/search/field-selector.js
@@ -1,5 +1,4 @@
 /* jshint unused:vars, undef:true, browser:true, jquery:true */
-/* global ConcreteSearchFieldSelector */
 
 ;(function(global, $) {
     'use strict';


### PR DESCRIPTION
`ConcreteSearchFieldSelector` is *defined in* field-selector.js, it's not *used by* field-selector.js