### PR TITLE
Fix #6886

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0a1',
     'version_installed' => '8.5.0a1',
-    'version_db' => '20180813220933', // the key of the latest database migration
+    'version_db' => '20180820000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/controllers/backend/express/entry.php
+++ b/concrete/controllers/backend/express/entry.php
@@ -2,6 +2,8 @@
 namespace Concrete\Controller\Backend\Express;
 
 use Concrete\Core\Controller\AbstractController;
+use Concrete\Core\Entity\Express\Entity;
+use Concrete\Core\Express\EntryList;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -18,17 +20,31 @@ class Entry extends AbstractController
 
     protected function getRequestEntries()
     {
+        $vals = $this->app->make('helper/validation/strings');
         $entries = array();
-        if (is_array($_REQUEST['exEntryID'])) {
-            $entryIDs = $_REQUEST['exEntryID'];
-        } else {
-            $entryIDs[] = $_REQUEST['exEntryID'];
+        $entryIDs = array();
+        if (isset($_REQUEST['exEntryID'])) {
+            if (is_array($_REQUEST['exEntryID'])) {
+                $entryIDs = $_REQUEST['exEntryID'];
+            } else {
+                $entryIDs[] = $_REQUEST['exEntryID'];
+            }
         }
-        $r = $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entry');
-        foreach ($entryIDs as $entryID) {
-            $entry = $r->findOneById($entryID);
-            if (is_object($entry)) {
-                $entries[] = $entry;
+        if (count($entryIDs) > 0) {
+            $r = $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entry');
+            foreach ($entryIDs as $entryID) {
+                $entry = $r->findOneById($entryID);
+                if (is_object($entry)) {
+                    $entries[] = $entry;
+                }
+            }
+        } elseif ($_REQUEST['exEntityID'] && $vals->min($_REQUEST['keyword'], 2)) {
+            $r = $this->entityManager->getRepository(Entity::class);
+            $entity = $r->find($_REQUEST['exEntityID']);
+            if (is_object($entity)) {
+                $list = new EntryList($entity);
+                $list->filterByKeywords($_REQUEST['keyword']);
+                $entries = $list->getResults();
             }
         }
 

--- a/concrete/controllers/backend/express/entry.php
+++ b/concrete/controllers/backend/express/entry.php
@@ -4,6 +4,8 @@ namespace Concrete\Controller\Backend\Express;
 use Concrete\Core\Controller\AbstractController;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Express\EntryList;
+use Concrete\Core\Legacy\Pagination;
+use Concrete\Core\Search\Pagination\PaginationFactory;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -44,7 +46,9 @@ class Entry extends AbstractController
             if (is_object($entity)) {
                 $list = new EntryList($entity);
                 $list->filterByKeywords($_REQUEST['keyword']);
-                $entries = $list->getResults();
+                $factory = new PaginationFactory($this->getRequest());
+                $pagination = $factory->createPaginationObject($list, PaginationFactory::PERMISSIONED_PAGINATION_STYLE_PAGER);
+                $entries = $pagination->getCurrentPageResults();
             }
         }
 

--- a/concrete/elements/dashboard/express/control/options/association.php
+++ b/concrete/elements/dashboard/express/control/options/association.php
@@ -7,4 +7,15 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <?=$form->text('label_mask', $control->getAssociationEntityLabelMask())?>
 </div>
 
+<div class="form-group">
+    <?=$form->label('mode', t('Input Format'))?>
+    <?php
+    $options = [
+        \Concrete\Core\Entity\Express\Control\AssociationControl::TYPE_HTML_INPUT => t('HTML Input'),
+        \Concrete\Core\Entity\Express\Control\AssociationControl::TYPE_ENTRY_SELECTOR => t('Entry Selector'),
+    ];
+    ?>
+    <?= $form->select('mode', $options, $control->getEntrySelectorMode()); ?>
+</div>
+
 <div class="alert alert-info"><?=t('Example: %first_name% %last_name%')?></div>

--- a/concrete/elements/express/form/form/association/entry_selector.php
+++ b/concrete/elements/express/form/form/association/entry_selector.php
@@ -1,0 +1,17 @@
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php $entrySelector = \Concrete\Core\Support\Facade\Application::getFacadeApplication()->make('form/express/entry_selector'); ?>
+<div class="form-group">
+    <?php if ($view->supportsLabel()) {
+    ?>
+        <label class="control-label" for="<?=$view->getControlID(); ?>"><?=$label; ?></label>
+    <?php
+} ?>
+
+    <?php
+    $selectedEntity = null;
+    if (!empty($selectedEntities)) {
+        $selectedEntity = $selectedEntities[0];
+    }
+    echo $entrySelector->selectEntry($control->getAssociation()->getTargetEntity(), 'express_association_' . $control->getId(), $selectedEntity);
+    ?>
+</div>

--- a/concrete/elements/express/form/form/association/entry_selector_multiple.php
+++ b/concrete/elements/express/form/form/association/entry_selector_multiple.php
@@ -1,0 +1,56 @@
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+\View::getInstance()->requireAsset('selectize');
+$options = [];
+$selectedIDs = [];
+if (isset($selectedEntities)) {
+    foreach ($selectedEntities as $selectedEntity) {
+        $options[] = [
+            'exEntryID' => $selectedEntity->getID(),
+            'label' => $selectedEntity->getLabel(),
+        ];
+        $selectedIDs[] = $selectedEntity->getID();
+    }
+}
+?>
+<div class="form-group">
+    <?php if ($view->supportsLabel()) {
+    ?>
+        <label class="control-label" for="<?=$view->getControlID(); ?>"><?=$label; ?></label>
+    <?php
+} ?>
+    <input type="hidden" data-select-and-add="<?= $control->getId(); ?>" style="width: 100%" name="express_association_<?= $control->getId(); ?>" value="" />
+</div>
+
+<script type="text/javascript">
+    $(function() {
+        $('input[data-select-and-add=<?= $control->getId(); ?>]').selectize({
+            plugins: ['remove_button'],
+            valueField: 'exEntryID',
+            labelField: 'label',
+            searchField: 'label',
+            create: false,
+            delimiter: ',',
+            maxItems: 500,
+            options: <?= json_encode($options); ?>,
+            items: <?= json_encode($selectedIDs); ?>,
+            load: function(query, callback) {
+                if (!query.length) return callback();
+                $.ajax({
+                    url: "<?= \URL::to('/ccm/system/express/entry/get_json'); ?>",
+                    data: {
+                        'exEntityID': '<?= $control->getAssociation()->getTargetEntity()->getID(); ?>',
+                        'keyword': query
+                    },
+                    dataType: 'json',
+                    error: function() {
+                        callback();
+                    },
+                    success: function(res) {
+                        callback(res.entries.slice(0, 10));
+                    }
+                });
+            }
+        });
+    });
+</script>

--- a/concrete/src/Entity/Express/Control/AssociationControl.php
+++ b/concrete/src/Entity/Express/Control/AssociationControl.php
@@ -14,6 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class AssociationControl extends Control
 {
+    const TYPE_HTML_INPUT = 0;
+    const TYPE_ENTRY_SELECTOR = 5;
+
     /**
      * @var \Concrete\Core\Entity\Express\Association
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Express\Association", inversedBy="controls")
@@ -24,6 +27,19 @@ class AssociationControl extends Control
      * @ORM\Column(type="string", nullable=true)
      */
     protected $association_entity_label_mask;
+
+    /**
+     * The association selector mode (one of the self::TYPE_... constants).
+     *
+     * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
+     * @var integer
+     */
+    protected $entry_selector_mode;
+
+    public function __construct()
+    {
+        $this->entry_selector_mode = self::TYPE_HTML_INPUT;
+    }
 
     /**
      * @return mixed
@@ -47,6 +63,22 @@ class AssociationControl extends Control
     public function setAssociationEntityLabelMask($association_entity_label_mask)
     {
         $this->association_entity_label_mask = $association_entity_label_mask;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEntrySelectorMode()
+    {
+        return $this->entry_selector_mode;
+    }
+
+    /**
+     * @param int $entry_selector_mode
+     */
+    public function setEntrySelectorMode($entry_selector_mode)
+    {
+        $this->entry_selector_mode = $entry_selector_mode;
     }
 
     /**

--- a/concrete/src/Entity/Express/Control/AssociationControl.php
+++ b/concrete/src/Entity/Express/Control/AssociationControl.php
@@ -1,8 +1,6 @@
 <?php
 namespace Concrete\Core\Entity\Express\Control;
 
-use Concrete\Core\Entity\Express\Entry;
-use Concrete\Core\Express\Form\Control\View\AssociationView;
 use Concrete\Core\Form\Context\ContextInterface;
 use Concrete\Core\Express\Form\Control\Type\SaveHandler\AssociationControlSaveHandler;
 use Concrete\Core\Form\Context\Registry\ControlRegistry;
@@ -32,7 +30,8 @@ class AssociationControl extends Control
      * The association selector mode (one of the self::TYPE_... constants).
      *
      * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
-     * @var integer
+     *
+     * @var int
      */
     protected $entry_selector_mode;
 
@@ -52,8 +51,9 @@ class AssociationControl extends Control
     public function getControlView(ContextInterface $context)
     {
         $registry = \Core::make(ControlRegistry::class);
+
         return $registry->getControlView($context, 'express_control_association', [
-            $this
+            $this,
         ]);
     }
 
@@ -116,7 +116,4 @@ class AssociationControl extends Control
     {
         return new \Concrete\Core\Export\Item\Express\Control\AssociationControl();
     }
-
-
-
 }

--- a/concrete/src/Express/Form/Control/SaveHandler/ManyAssociationSaveHandler.php
+++ b/concrete/src/Express/Form/Control/SaveHandler/ManyAssociationSaveHandler.php
@@ -6,6 +6,7 @@ use Concrete\Core\Entity\Express\Control\Control;
 use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Express\Association\Applier;
 use Concrete\Core\Express\ObjectManager;
+use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,6 +25,10 @@ abstract class ManyAssociationSaveHandler implements SaveHandlerInterface
     {
         $r = $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entry');
         $entryIDs = $request->request->get('express_association_' . $control->getId());
+        $vals = Application::getFacadeApplication()->make('helper/validation/strings');
+        if (!is_array($entryIDs) && $vals->notempty($entryIDs)) {
+            $entryIDs = explode(',', $entryIDs);
+        }
         $associatedEntries = array();
         if (is_array($entryIDs)) {
             foreach($entryIDs as $entryID) {

--- a/concrete/src/Express/Form/Control/SaveHandler/ManyAssociationSaveHandler.php
+++ b/concrete/src/Express/Form/Control/SaveHandler/ManyAssociationSaveHandler.php
@@ -1,11 +1,8 @@
 <?php
 namespace Concrete\Core\Express\Form\Control\SaveHandler;
 
-use Concrete\Core\Entity\Express\Control\AssociationControl;
 use Concrete\Core\Entity\Express\Control\Control;
-use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Express\Association\Applier;
-use Concrete\Core\Express\ObjectManager;
 use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,9 +26,9 @@ abstract class ManyAssociationSaveHandler implements SaveHandlerInterface
         if (!is_array($entryIDs) && $vals->notempty($entryIDs)) {
             $entryIDs = explode(',', $entryIDs);
         }
-        $associatedEntries = array();
+        $associatedEntries = [];
         if (is_array($entryIDs)) {
-            foreach($entryIDs as $entryID) {
+            foreach ($entryIDs as $entryID) {
                 $associatedEntry = $r->findOneById($entryID);
                 $target = $control->getAssociation()->getTargetEntity();
                 if (is_object($associatedEntry) && $associatedEntry->getEntity()->getID() == $target->getID()) {
@@ -39,8 +36,7 @@ abstract class ManyAssociationSaveHandler implements SaveHandlerInterface
                 }
             }
         }
+
         return $associatedEntries;
     }
-
-
 }

--- a/concrete/src/Express/Form/Control/Type/SaveHandler/AssociationControlSaveHandler.php
+++ b/concrete/src/Express/Form/Control/Type/SaveHandler/AssociationControlSaveHandler.php
@@ -10,6 +10,7 @@ class AssociationControlSaveHandler extends ControlSaveHandler
     {
         $control = parent::saveFromRequest($control, $request);
         $control->setAssociationEntityLabelMask($request->request('label_mask'));
+        $control->setEntrySelectorMode($request->request('mode'));
 
         return $control;
     }

--- a/concrete/src/Express/Form/Control/View/AssociationFormView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationFormView.php
@@ -25,12 +25,21 @@ class AssociationFormView extends AssociationView
      */
     protected function getFormFieldElement(AssociationControl $control)
     {
+        $mode = $control->getEntrySelectorMode();
         $class = get_class($control->getAssociation());
         $class = strtolower(str_replace(array('Concrete\\Core\\Entity\\Express\\', 'Association'), '', $class));
         if (substr($class, -4) == 'many') {
-            return 'select_multiple';
+            if($mode == AssociationControl::TYPE_ENTRY_SELECTOR) {
+                return 'entry_selector_multiple';
+            } else {
+                return 'select_multiple';
+            }
         } else {
-            return 'select';
+            if($mode == AssociationControl::TYPE_ENTRY_SELECTOR) {
+                return 'entry_selector';
+            } else {
+                return 'select';
+            }
         }
     }
 

--- a/concrete/src/Express/Form/Control/View/AssociationFormView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationFormView.php
@@ -3,13 +3,11 @@ namespace Concrete\Core\Express\Form\Control\View;
 
 use Concrete\Core\Entity\Express\Control\AssociationControl;
 use Concrete\Core\Entity\Express\Control\Control;
-use Concrete\Core\Express\EntryList;
 use Concrete\Core\Express\Form\Context\ContextInterface;
 use Concrete\Core\Filesystem\TemplateLocator;
 
 class AssociationFormView extends AssociationView
 {
-
     protected $association;
 
     public function __construct(ContextInterface $context, Control $control)
@@ -21,21 +19,22 @@ class AssociationFormView extends AssociationView
 
     /**
      * @param AssociationControl $control
+     *
      * @return string
      */
     protected function getFormFieldElement(AssociationControl $control)
     {
         $mode = $control->getEntrySelectorMode();
         $class = get_class($control->getAssociation());
-        $class = strtolower(str_replace(array('Concrete\\Core\\Entity\\Express\\', 'Association'), '', $class));
-        if (substr($class, -4) == 'many') {
-            if($mode == AssociationControl::TYPE_ENTRY_SELECTOR) {
+        $class = strtolower(str_replace(['Concrete\\Core\\Entity\\Express\\', 'Association'], '', $class));
+        if ('many' == substr($class, -4)) {
+            if (AssociationControl::TYPE_ENTRY_SELECTOR == $mode) {
                 return 'entry_selector_multiple';
             } else {
                 return 'select_multiple';
             }
         } else {
-            if($mode == AssociationControl::TYPE_ENTRY_SELECTOR) {
+            if (AssociationControl::TYPE_ENTRY_SELECTOR == $mode) {
                 return 'entry_selector';
             } else {
                 return 'select';
@@ -56,9 +55,7 @@ class AssociationFormView extends AssociationView
             }
         }
         $locator = new TemplateLocator('association/' . $element);
+
         return $locator;
     }
-
-
-
 }

--- a/concrete/src/Express/Form/Control/View/AssociationView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationView.php
@@ -10,7 +10,6 @@ use Concrete\Core\Filesystem\TemplateLocator;
 
 class AssociationView extends View
 {
-
     protected $association;
     protected $entry;
     protected $allEntities = [];
@@ -27,14 +26,14 @@ class AssociationView extends View
         $this->entry = $context->getEntry();
         $this->association = $this->control->getAssociation();
         $entity = $this->association->getTargetEntity();
-        if ($control->getEntrySelectorMode() != AssociationControl::TYPE_ENTRY_SELECTOR) {
+        if (AssociationControl::TYPE_ENTRY_SELECTOR != $control->getEntrySelectorMode()) {
             $list = new EntryList($entity);
             $this->allEntities = $list->getResults();
         }
 
         if (is_object($this->entry)) {
             $related = $this->entry->getAssociations();
-            foreach($related as $relatedAssociation) {
+            foreach ($related as $relatedAssociation) {
                 if ($relatedAssociation->getAssociation()->getID() == $this->association->getID()) {
                     $this->selectedEntities = $relatedAssociation->getSelectedEntries();
                 }
@@ -42,7 +41,7 @@ class AssociationView extends View
         } else {
             $form = $context->getForm();
             if ($form instanceof OwnedEntityForm) {
-                $this->selectedEntities = array($form->getOwningEntry());
+                $this->selectedEntities = [$form->getOwningEntry()];
             }
         }
 
@@ -54,9 +53,7 @@ class AssociationView extends View
     public function createTemplateLocator()
     {
         $locator = new TemplateLocator('association');
+
         return $locator;
     }
-
-
-
 }

--- a/concrete/src/Express/Form/Control/View/AssociationView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationView.php
@@ -27,8 +27,10 @@ class AssociationView extends View
         $this->entry = $context->getEntry();
         $this->association = $this->control->getAssociation();
         $entity = $this->association->getTargetEntity();
-        $list = new EntryList($entity);
-        $this->allEntities = $list->getResults();
+        if ($control->getEntrySelectorMode() != AssociationControl::TYPE_ENTRY_SELECTOR) {
+            $list = new EntryList($entity);
+            $this->allEntities = $list->getResults();
+        }
 
         if (is_object($this->entry)) {
             $related = $this->entry->getAssociations();

--- a/concrete/src/Updater/Migrations/Migrations/Version20180820000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180820000000.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20180820000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            'Concrete\Core\Entity\Express\Control\AssociationControl',
+        ]);
+    }
+}


### PR DESCRIPTION
* Added "mode" option for Express Association Control form
* If you chose "Entity Selector" option, you can select an entry by "Express Entry Selector" interface for ToOneAssociation, entries by "selectize" interface for ToManuAssociation
* Let's avoid loading all entries when you select Entity Selector. If the entity has a large number of entries, it takes large memory spaces.