### PR TITLE
 Let localized stacks inherit permissions from locale home 

### DIFF
--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -217,11 +217,11 @@ class Stack extends Page implements ExportableInterface
     }
 
     /**
-     * @param |\Concrete\Core\Page\Collection $nc
-     * @param bool $preserveUserID
-     * @param \Concrete\Core\Entity\Site\Site $site
+     * {@inheritdoc}
      *
-     * @return Stack
+     * @see \Concrete\Core\Page\Page::duplicate()
+     * 
+     * @return static
      */
     public function duplicate($nc = null, $preserveUserID = false, TreeInterface $site = null)
     {


### PR DESCRIPTION
Let's assume that we have a Stack that inherit permissions from the default homepage.
When we create a localized version of that stack, it should inherit permissions from the homepage of its language.