### PR TITLE
Do not back to entry list if there’s an error on adding/editing an express entry

### DIFF
--- a/concrete/src/Express/Form/Control/View/AssociationFormView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationFormView.php
@@ -3,9 +3,13 @@ namespace Concrete\Core\Express\Form\Control\View;
 
 use Concrete\Core\Entity\Express\Control\AssociationControl;
 use Concrete\Core\Entity\Express\Control\Control;
+use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Express\EntryList;
 use Concrete\Core\Express\Form\Context\ContextInterface;
 use Concrete\Core\Filesystem\TemplateLocator;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
 
 class AssociationFormView extends AssociationView
 {
@@ -15,6 +19,31 @@ class AssociationFormView extends AssociationView
     public function __construct(ContextInterface $context, Control $control)
     {
         parent::__construct($context, $control);
+        
+        $app = Application::getFacadeApplication();
+        $request = Request::getInstance();
+        $requestedEntryIDs = $request->request->get('express_association_' . $control->getId());
+        $vals = $app->make('helper/validation/strings');
+        if (!is_array($requestedEntryIDs) && $vals->notempty($requestedEntryIDs)) {
+            $requestedEntryIDs = explode(',', $requestedEntryIDs);
+        }
+
+        $requestedEntries = [];
+        if (is_array($requestedEntryIDs)) {
+            $r = $app->make(EntityManagerInterface::class)->getRepository(Entry::class);
+            foreach ($requestedEntryIDs as $requestedEntryID) {
+                $requestedEntry = $r->findOneById($requestedEntryID);
+                $target = $control->getAssociation()->getTargetEntity();
+                if (is_object($requestedEntry) && $requestedEntry->getEntity()->getID() == $target->getID()) {
+                    $requestedEntries[] = $requestedEntry;
+                }
+            }
+        }
+
+        if (count($requestedEntries)) {
+            $this->selectedEntities = $requestedEntries;
+        }
+
         $this->addScopeItem('entities', $this->allEntities);
         $this->addScopeItem('selectedEntities', $this->selectedEntities);
     }

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -322,6 +322,14 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
                     $this->redirect($this->getBackURL($entity));
                 }
             }
+
+            if ($entry === null) {
+                if (method_exists($this, 'create_entry')) {
+                    $this->create_entry($id);
+                }
+            } else {
+                $this->edit_entry($entry->getID());
+            }
         } else {
             throw new \Exception(t('Invalid form.'));
         }


### PR DESCRIPTION
## Issue detail

You'll get an error when you get some validation errors on adding/editing an express entry.
To reproduce this error, you have to set required to some form controls and keep empty when you are adding/editing an entry.

## Error detail

```
Whoops\Exception\ErrorException thrown with message "count(): Parameter must be an array or an object that implements Countable"

Stacktrace:
#26 Whoops\Exception\ErrorException in /path/to/concrete5/concrete/single_pages/dashboard/express/entries.php:9
#25 Whoops\Run:handleError in /path/to/concrete5/concrete/single_pages/dashboard/express/entries.php:9
#24 include in /path/to/concrete5/concrete/src/View/View.php:233
#23 Concrete\Core\View\View:renderInnerContents in /path/to/concrete5/concrete/src/View/View.php:211
#22 Concrete\Core\View\View:renderViewContents in /path/to/concrete5/concrete/src/View/AbstractView.php:151
#21 Concrete\Core\View\AbstractView:render in /path/to/concrete5/concrete/src/Http/ResponseFactory.php:148
#20 Concrete\Core\Http\ResponseFactory:view in /path/to/concrete5/concrete/src/Http/ResponseFactory.php:215
#19 Concrete\Core\Http\ResponseFactory:controller in /path/to/concrete5/concrete/src/Http/ResponseFactory.php:393
#18 Concrete\Core\Http\ResponseFactory:collection in /path/to/concrete5/concrete/src/Routing/DispatcherRouteCallback.php:34
#17 Concrete\Core\Routing\DispatcherRouteCallback:execute in /path/to/concrete5/concrete/src/Http/DefaultDispatcher.php:130
#16 Concrete\Core\Http\DefaultDispatcher:handleDispatch in /path/to/concrete5/concrete/src/Http/DefaultDispatcher.php:57
#15 Concrete\Core\Http\DefaultDispatcher:dispatch in /path/to/concrete5/concrete/src/Http/Middleware/DispatcherDelegate.php:39
#14 Concrete\Core\Http\Middleware\DispatcherDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/ThumbnailMiddleware.php:71
#13 Concrete\Core\Http\Middleware\ThumbnailMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#12 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/FrameOptionsMiddleware.php:39
#11 Concrete\Core\Http\Middleware\FrameOptionsMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#10 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/CookieMiddleware.php:35
#9 Concrete\Core\Http\Middleware\CookieMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#8 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/ApplicationMiddleware.php:29
#7 Concrete\Core\Http\Middleware\ApplicationMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:38
#6 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareStack.php:86
#5 Concrete\Core\Http\Middleware\MiddlewareStack:process in /path/to/concrete5/concrete/src/Http/DefaultServer.php:85
#4 Concrete\Core\Http\DefaultServer:handleRequest in /path/to/concrete5/concrete/src/Foundation/Runtime/Run/DefaultRunner.php:119
#3 Concrete\Core\Foundation\Runtime\Run\DefaultRunner:run in /path/to/concrete5/concrete/src/Foundation/Runtime/DefaultRuntime.php:102
#2 Concrete\Core\Foundation\Runtime\DefaultRuntime:run in /path/to/concrete5/concrete/dispatcher.php:36
#1 require in /path/to/concrete5/index.php:3
```

## Screenshot

After applied this pull request

![view_entries](https://user-images.githubusercontent.com/514294/44454274-0957e480-a636-11e8-9ba3-1c1f58423048.png)
