### PR TITLE
Improve user search controller

### DIFF
--- a/concrete/controllers/search/users.php
+++ b/concrete/controllers/search/users.php
@@ -1,22 +1,24 @@
 <?php
+
 namespace Concrete\Controller\Search;
 
+use Concrete\Controller\Dialog\User\AdvancedSearch;
+use Concrete\Core\Entity\Search\SavedUserSearch;
 use Concrete\Core\Search\Field\Field\KeywordsField;
-use Concrete\Core\User\Group\GroupList;
+use Doctrine\ORM\EntityManagerInterface;
 
 class Users extends Standard
 {
-
     protected function getAdvancedSearchDialogController()
     {
-        return $this->app->make('\Concrete\Controller\Dialog\User\AdvancedSearch');
+        return $this->app->make(AdvancedSearch::class);
     }
 
     protected function getSavedSearchPreset($presetID)
     {
-        $em = \Database::connection()->getEntityManager();
-        $preset = $em->find('Concrete\Core\Entity\Search\SavedUserSearch', $presetID);
-        return $preset;
+        $em = $this->app->make(EntityManagerInterface::class);
+
+        return $em->find(SavedUserSearch::class, $presetID);
     }
 
     protected function getBasicSearchFieldsFromRequest()
@@ -26,17 +28,14 @@ class Users extends Standard
         if ($keywords) {
             $fields[] = new KeywordsField($keywords);
         }
+
         return $fields;
     }
 
     protected function canAccess()
     {
         $dh = $this->app->make('helper/concrete/user');
-        if ($dh->canAccessUserSearchInterface()) {
-            return true;
-        }
-        return false;
+
+        return $dh->canAccessUserSearchInterface();
     }
-
-
 }

--- a/concrete/controllers/search/users.php
+++ b/concrete/controllers/search/users.php
@@ -9,11 +9,19 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class Users extends Standard
 {
+    /**
+     * @return \Concrete\Controller\Dialog\Search\AdvancedSearch
+     */
     protected function getAdvancedSearchDialogController()
     {
         return $this->app->make(AdvancedSearch::class);
     }
 
+    /**
+     * @param int $presetID
+     *
+     * @return \Concrete\Core\Entity\Search\SavedUserSearch|null
+     */
     protected function getSavedSearchPreset($presetID)
     {
         $em = $this->app->make(EntityManagerInterface::class);
@@ -21,6 +29,9 @@ class Users extends Standard
         return $em->find(SavedUserSearch::class, $presetID);
     }
 
+    /**
+     * @return KeywordsField[]
+     */
     protected function getBasicSearchFieldsFromRequest()
     {
         $fields = parent::getBasicSearchFieldsFromRequest();
@@ -32,6 +43,9 @@ class Users extends Standard
         return $fields;
     }
 
+    /**
+     * @return bool
+     */
     protected function canAccess()
     {
         $dh = $this->app->make('helper/concrete/user');


### PR DESCRIPTION
Using `getEntityManager` on the Connection object is deprecated, so I replaced that by booting an instance of the EntityManager instead.