### PR TITLE
Sitemap external link icon: from fa-sign-out to fa-external-link

### DIFF
--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -206,7 +206,7 @@ class Sitemap
                 $cAlias = 'POINTER';
                 $cID = $c->getCollectionPointerOriginalID();
             } else {
-                $cIconClass = 'fa fa-sign-out';
+                $cIconClass = 'fa fa-external-link';
                 $cAlias = 'LINK';
             }
         }


### PR DESCRIPTION
What about using `fa-external-link` instead of `fa-sign-out` for external links in the sitemap? I think it's more clear.

Before:
![immagine](https://user-images.githubusercontent.com/928116/44508518-e0c00100-a6ae-11e8-9b86-e61f60447108.png)

After:
![immagine](https://user-images.githubusercontent.com/928116/44508498-d271e500-a6ae-11e8-83d3-7fe062ef896b.png)
