### PR TITLE
Improve Express Form block view

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -797,6 +797,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                     $this->set('expressForm', $form);
                 }
                 if ($this->displayCaptcha) {
+                    $this->set('captcha', $this->app->make('helper/validation/captcha'));
                     $this->requireAsset('css', 'core/frontend/captcha');
                 }
                 $this->requireAsset('css', 'core/frontend/errors');

--- a/concrete/blocks/express_form/view.php
+++ b/concrete/blocks/express_form/view.php
@@ -7,6 +7,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /** @var string|null $success */
 /** @var string $bID */
 /** @var \Concrete\Core\Error\ErrorList\ErrorList|null $error */
+/** @var \Concrete\Core\Captcha\CaptchaInterface|null $captcha */
 /** @var string $displayCaptcha "0" or "1" */
 /** @var string $submitLabel */
 ?>
@@ -33,7 +34,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
             $renderer->render();
 
             if ($displayCaptcha) {
-                $captcha = \Core::make('helper/validation/captcha');
                 ?>
                 <div class="form-group captcha">
                     <?php

--- a/concrete/blocks/express_form/view.php
+++ b/concrete/blocks/express_form/view.php
@@ -1,4 +1,15 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/** @var \Concrete\Core\Block\View\BlockView $view */
+/** @var \Concrete\Core\Express\Form\Renderer|null $renderer */
+/** @var string|null $success */
+/** @var string $bID */
+/** @var \Concrete\Core\Error\ErrorList\ErrorList|null $error */
+/** @var string $displayCaptcha "0" or "1" */
+/** @var string $submitLabel */
+?>
 <div class="ccm-block-express-form">
     <?php if (isset($renderer)) { ?>
         <div class="ccm-form">

--- a/concrete/blocks/express_form/view.php
+++ b/concrete/blocks/express_form/view.php
@@ -30,7 +30,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
             <form enctype="multipart/form-data" class="form-stacked" method="post" action="<?=$view->action('submit')?>#form<?=$bID?>">
             <?php
-            print $renderer->render();
+            $renderer->render();
 
             if ($displayCaptcha) {
                 $captcha = \Core::make('helper/validation/captcha');

--- a/concrete/blocks/express_form/view.php
+++ b/concrete/blocks/express_form/view.php
@@ -28,35 +28,30 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 </div>
             <?php } ?>
 
-
             <form enctype="multipart/form-data" class="form-stacked" method="post" action="<?=$view->action('submit')?>#form<?=$bID?>">
-            <?php
-            $renderer->render();
+                <?php
+                $renderer->render();
 
-            if ($displayCaptcha) {
-                ?>
-                <div class="form-group captcha">
-                    <?php
-                    $captchaLabel = $captcha->label();
-                    if (!empty($captchaLabel)) {
-                        ?>
-                        <label class="control-label"><?php echo $captchaLabel;
-                            ?></label>
-                        <?php
-
-                    }
+                if ($displayCaptcha) {
                     ?>
-                    <div><?php  $captcha->display(); ?></div>
-                    <div><?php  $captcha->showInput(); ?></div>
+                    <div class="form-group captcha">
+                        <?php
+                        $captchaLabel = $captcha->label();
+                        if (!empty($captchaLabel)) {
+                            ?>
+                            <label class="control-label"><?php echo $captchaLabel; ?></label>
+                            <?php
+                        }
+                        ?>
+                        <div><?php $captcha->display(); ?></div>
+                        <div><?php $captcha->showInput(); ?></div>
+                    </div>
+                <?php } ?>
+
+                <div class="form-actions">
+                    <button type="submit" name="Submit" class="btn btn-primary"><?=t($submitLabel)?></button>
                 </div>
-            <?php } ?>
-
-            <div class="form-actions">
-                <button type="submit" name="Submit" class="btn btn-primary"><?=t($submitLabel)?></button>
-            </div>
-
             </form>
-
         </div>
     <?php } else { ?>
         <p><?=t('This form is unavailable.')?></p>


### PR DESCRIPTION
PR:
- Add phpdocs to help IDE with variables in the view.
- Make sure captcha object is injected via the controller instead of instantiated in the view.
- Fix indentation / newline issues.
- Do not `print` the renderer, as it always returns `void`.

Ref https://github.com/concrete5/concrete5/issues/4723