### PR TITLE
Improve Content block view

### DIFF
--- a/concrete/blocks/content/view.php
+++ b/concrete/blocks/content/view.php
@@ -2,7 +2,9 @@
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-$c = Page::getCurrentPage();
+/** @var string $content */
+/** @var \Concrete\Core\Page\Page|null $c */
+
 if (!$content && is_object($c) && $c->isEditMode()) {
     ?>
     <div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div>

--- a/concrete/blocks/content/view.php
+++ b/concrete/blocks/content/view.php
@@ -1,10 +1,12 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-    $c = Page::getCurrentPage();
-    if (!$content && is_object($c) && $c->isEditMode()) {
-        ?>
-		<div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div> 
-	<?php 
-    } else {
-        echo $content;
-    }
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+$c = Page::getCurrentPage();
+if (!$content && is_object($c) && $c->isEditMode()) {
+    ?>
+    <div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div>
+    <?php
+} else {
+    echo $content;
+}


### PR DESCRIPTION
PR:
- Remove `$c = Page::getCurrentPage()`; The Page object is always passed to the view.
- Fix identation / code style
- Add phpdocs

Ref https://github.com/concrete5/concrete5/issues/4723