### PR TITLE
Fix/express association form view owned element

### DIFF
--- a/concrete/elements/express/form/form/association/select.php
+++ b/concrete/elements/express/form/form/association/select.php
@@ -6,19 +6,19 @@
     <?php } ?>
 
     <?php
-    if (!empty($entities)) {
-        $selectedEntity = $selectedEntities[0];
+    if (!empty($allEntries)) {
+        $selectedEntry = $selectedEntries[0];
         ?>
         <select class="form-control" id="<?=$view->getControlID()?>" name="express_association_<?=$control->getId()?>">
             <option value=""><?=t('** Choose %s', $control->getControlLabel())?></option>
             <?php
-            foreach ($entities as $entity) {
+            foreach ($allEntries as $entry) {
                 ?>
                 <option
-                    value="<?=$entity->getId()?>"
-                    <?php if (is_object($selectedEntity) && $selectedEntity->getID() == $entity->getID()) { ?>selected<?php } ?>
+                    value="<?=$entry->getId()?>"
+                    <?php if (is_object($selectedEntry) && $selectedEntry->getID() == $entry->getID()) { ?>selected<?php } ?>
                 >
-                    <?=$formatter->getEntryDisplayName($control, $entity)?>
+                    <?=$formatter->getEntryDisplayName($control, $entry)?>
                 </option>
                 <?php
             }
@@ -26,6 +26,6 @@
         </select>
     <?php
     } else {
-        ?><p><?=t('No entity found.')?></p><?php
+        ?><p><?=t('No available entries found.')?></p><?php
     } ?>
 </div>

--- a/concrete/elements/express/form/form/association/select_multiple.php
+++ b/concrete/elements/express/form/form/association/select_multiple.php
@@ -5,32 +5,32 @@
         <label class="control-label"><?=$label?></label>
     <?php } ?>
     <?php
-    if (!empty($entities)) {
-        foreach ($entities as $entity) {
+    if (!empty($allEntries)) {
+        foreach ($allEntries as $entry) {
             ?>
             <div class="checkbox">
                 <label>
                     <input
                         type="checkbox"
                         <?php
-                        if (isset($selectedEntities)) {
-                            foreach($selectedEntities as $selectedEntity) {
-                                if ($selectedEntity->getID() == $entity->getID()) {
+                        if (isset($selectedEntries)) {
+                            foreach($selectedEntries as $selectedEntry) {
+                                if ($selectedEntry->getID() == $entry->getID()) {
                                     print 'checked';
                                 }
                             }
                         }
                         ?>
                         name="express_association_<?=$control->getId()?>[]"
-                        value="<?=$entity->getId()?>"
+                        value="<?=$entry->getId()?>"
                     >
-                    <?=$formatter->getEntryDisplayName($control, $entity)?>
+                    <?=$formatter->getEntryDisplayName($control, $entry)?>
                 </label>
             </div>
             <?php
         }
     } else {
-        ?><p><?=t('No entity found.')?></p><?php
+        ?><p><?=t('No available entries found.')?></p><?php
     }
     ?>
 </div>

--- a/concrete/elements/express/form/form/association/select_multiple_reorder.php
+++ b/concrete/elements/express/form/form/association/select_multiple_reorder.php
@@ -5,9 +5,9 @@
         <label class="control-label"><?=$label?></label>
     <?php } ?>
     <?php
-    if (!empty($selectedEntities) && count($selectedEntities)) { ?>
+    if (!empty($selectedEntries) && count($selectedEntries)) { ?>
         <ul class="item-select-list" data-sortable-list="items">
-            <?php foreach($selectedEntities as $entry) { ?>
+            <?php foreach($selectedEntries as $entry) { ?>
                 <li>
                     <input type="hidden" name="express_association_<?=$control->getID()?>[]" value="<?=$entry->getID()?>">
                     <?=$formatter->getEntryDisplayName($control, $entry)?>
@@ -17,6 +17,8 @@
             <?php } ?>
         </ul>
         <?php
+    } else {
+        ?><p><?=t('No available entries found.')?></p><?php
     }
     ?>
 </div>

--- a/concrete/elements/express/form/form/association/view.php
+++ b/concrete/elements/express/form/form/association/view.php
@@ -5,11 +5,11 @@
     <label class="control-label"><?=$label?></label>
     </div>
     <?php
-    if (count($entities)) {
+    if (count($selectedEntries)) {
         ?>
-        <?php foreach ($entities as $entity) {
+        <?php foreach ($selectedEntriesies as $entry) {
     ?>
-            <div><a href="<?=URL::to('/dashboard/express/entries', 'view_entry', $entity->getID())?>"><?=$formatter->getEntryDisplayName($control, $entity)?></a></div>
+            <div><a href="<?=URL::to('/dashboard/express/entries', 'view_entry', $entry->getID())?>"><?=$formatter->getEntryDisplayName($control, $entry)?></a></div>
         <?php 
 }
         ?>

--- a/concrete/src/Express/Form/Control/View/AssociationFormView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationFormView.php
@@ -15,8 +15,12 @@ class AssociationFormView extends AssociationView
     public function __construct(ContextInterface $context, Control $control)
     {
         parent::__construct($context, $control);
-        $this->addScopeItem('entities', $this->allEntities);
-        $this->addScopeItem('selectedEntities', $this->selectedEntities);
+        $this->addScopeItem('allEntries', $this->allEntries);
+        $this->addScopeItem('selectedEntries', $this->selectedEntries);
+
+        // @deprecated – use allEntries and selectedEntries instead
+        $this->addScopeItem('entities', $this->allEntries);
+        $this->addScopeItem('selectedEntities', $this->selectedEntries);
     }
 
     /**

--- a/concrete/src/Express/Form/Control/View/AssociationView.php
+++ b/concrete/src/Express/Form/Control/View/AssociationView.php
@@ -13,8 +13,8 @@ class AssociationView extends View
 
     protected $association;
     protected $entry;
-    protected $allEntities = [];
-    protected $selectedEntities = [];
+    protected $allEntries = [];
+    protected $selectedEntries = [];
 
     public function getControlID()
     {
@@ -28,25 +28,29 @@ class AssociationView extends View
         $this->association = $this->control->getAssociation();
         $entity = $this->association->getTargetEntity();
         $list = new EntryList($entity);
-        $this->allEntities = $list->getResults();
+        $this->allEntries = $list->getResults();
 
         if (is_object($this->entry)) {
             $related = $this->entry->getAssociations();
             foreach($related as $relatedAssociation) {
                 if ($relatedAssociation->getAssociation()->getID() == $this->association->getID()) {
-                    $this->selectedEntities = $relatedAssociation->getSelectedEntries();
+                    $this->selectedEntries = $relatedAssociation->getSelectedEntries();
                 }
             }
         } else {
             $form = $context->getForm();
             if ($form instanceof OwnedEntityForm) {
-                $this->selectedEntities = array($form->getOwningEntry());
+                $this->selectedEntries = array($form->getOwningEntry());
             }
         }
 
-        $this->addScopeItem('entities', $this->selectedEntities);
+        $this->addScopeItem('selectedEntries', $this->selectedEntries);
         $this->addScopeItem('control', $control);
         $this->addScopeItem('formatter', $this->association->getFormatter());
+
+        // @deprecated - use selectedEntries instead
+        $this->addScopeItem('entities', $this->selectedEntries);
+
     }
 
     public function createTemplateLocator()


### PR DESCRIPTION
This supersedes the issue described in this pull request:

https://github.com/concrete5/concrete5/pull/6969

I believe the issue stems from the fact that we use 'entities' and 'selectedEntities' in different ways in association view vs association forms. However, the association form view controller will sometimes render using the association view template.

Let's simplify this: Let's keep the 'entities' and 'selectedEntities' and deprecate them, and instead always pass in 'selectedEntries'. On form views we'll also pass in 'allEntries' so we can construct forms. This way any view – be it for the viewing element or the form element - will have access to 'selectedEntries'. This should fix the issue described above and make code cleaner.