### PR TITLE
Fixing tests 

### DIFF
--- a/concrete/src/Routing/RouteGroupBuilder.php
+++ b/concrete/src/Routing/RouteGroupBuilder.php
@@ -159,7 +159,7 @@ class RouteGroupBuilder
     protected function processNamespace(Route $route)
     {
         if ($this->namespace) {
-            if (is_string($route->getAction())) {
+            if (is_string($route->getAction()) && !(strpos($route->getAction(), '\\') === 0)) {
                 $controller = [$this->namespace, trim($route->getAction(), '\\')];
                 $route->setAction(implode('\\', $controller));
             }

--- a/concrete/src/Routing/SystemRouteList.php
+++ b/concrete/src/Routing/SystemRouteList.php
@@ -34,7 +34,7 @@ class SystemRouteList implements RouteListInterface
         $router->buildGroup()->setNamespace('Concrete\Controller\Backend')->setPrefix('/ccm/system/file')
             ->routes('actions/files.php');
 
-        $router->buildGroup()->setNamespace('Concrete\Controller\Dialog')->setPrefix('/ccm/system/dialogs/conversation')
+        $router->buildGroup()->setNamespace('Concrete\Controller\Dialog\Conversation')->setPrefix('/ccm/system/dialogs/conversation')
             ->routes('dialogs/conversations.php');
 
         $router->buildGroup()->setNamespace('Concrete\Controller\Dialog\Type')

--- a/tests/tests/Core/Routing/RouterTest.php
+++ b/tests/tests/Core/Routing/RouterTest.php
@@ -242,7 +242,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $routes = $router->getRoutes();
         $this->assertEquals(6, count($routes));
-        $route = $router->getRoutes()->get('ccm_api_v1_system_status');
+        $route = $router->getRoutes()->get('ccm_api_v1_system_status_get');
         $middlewares = $route->getMiddlewares();
         $scope = $route->getOption('oauth_scopes');
 
@@ -250,7 +250,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/ccm/api/v1/system/status/', $route->getPath());
         $this->assertEquals('api', $scope);
 
-        $route = $router->getRoutes()->get('ccm_api_v1_products_add');
+        $route = $router->getRoutes()->get('ccm_api_v1_products_add_post');
         $middlewares = $route->getMiddlewares();
         $scope = $route->getOption('oauth_scopes');
         $methods = $route->getMethods();
@@ -261,7 +261,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('POST', $methods[0]);
         $this->assertEquals('api,products', $scope);
 
-        $route = $router->getRoutes()->get('ccm_api_v1_users');
+        $route = $router->getRoutes()->get('ccm_api_v1_users_get');
         $scope = $route->getOption('oauth_scopes');
         $middlewares = $route->getMiddlewares();
         $this->assertCount(3, $middlewares);

--- a/tests/tests/Core/Routing/RouterTest.php
+++ b/tests/tests/Core/Routing/RouterTest.php
@@ -73,7 +73,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $route = $router->all('/my/method', 'Something\Controller')->getRoute();
         $this->assertCount(7, $route->getMethods());
 
-        $route = $router->getRoutes()->get('my_method');
+        $route = $router->getRoutes()->get('my_method_all');
         $this->assertInstanceOf(Route::class, $route);
 
         $route = $router->head('/something/special', 'Something\Controller')
@@ -140,7 +140,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(MatchedRoute::class, $route);
         $route = $route->getRoute();
         $this->assertInstanceOf(Route::class, $route);
-        $this->assertEquals('something_hello_world', $route->getName());
+        $this->assertEquals('something_hello_world_get', $route->getName());
         $action = $router->resolveAction($route);
         $response = $action->execute($request, $route, []);
         $this->assertEquals('oh hai', $response->getContent());
@@ -172,9 +172,9 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(4, $routes);
 
         // Test prefix and name.
-        $this->assertEquals('/api/v1/hello-world/', $routes->get('api_v1_hello_world')->getPath());
-        $this->assertEquals('/a-fun-test/', $routes->get('a_fun_test')->getPath());
-        $this->assertEquals('/api/v1/status/', $routes->get('api_v1_status')->getPath());
+        $this->assertEquals('/api/v1/hello-world/', $routes->get('api_v1_hello_world_get')->getPath());
+        $this->assertEquals('/a-fun-test/', $routes->get('a_fun_test_post')->getPath());
+        $this->assertEquals('/api/v1/status/', $routes->get('api_v1_status_get')->getPath());
         $this->assertEquals('/api/v1/user/{:user}/', $routes->get('user_details')->getPath());
 
         // Test everything
@@ -192,7 +192,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 return $groupRouter;
             });
 
-        $route = $router->getRoutes()->get('ccm_system_user_remove_group');
+        $route = $router->getRoutes()->get('ccm_system_user_remove_group_post');
         $middlewares = $route->getMiddlewares();
         $this->assertCount(2, $middlewares);
         $this->assertEquals('Concrete\Tests\Core\Routing\AnotherMiddleware', $middlewares[1]->getMiddleware());

--- a/tests/tests/Routing/CheckRoutesTest.php
+++ b/tests/tests/Routing/CheckRoutesTest.php
@@ -10,42 +10,52 @@ class CheckRoutesTest extends PHPUnit_Framework_TestCase
 {
     public function routeDestinationProvider()
     {
-        return [];
         
         $app = ApplicationFacade::getFacadeApplication();
-        $config = $app->make('config');
-        $routes = $config->get('app.routes');
+        /** @var $router  \Concrete\Core\Routing\Router */
+        $router = $app->make('router');
+        $routes = $router->getRoutes();
         $result = [];
-        foreach ($routes as $path => $data) {
-            if (is_array($data) && isset($data[0]) && is_string($data[0]) && $data[0] !== '') {
-                $result[] = [$app, $path, $data[0]];
+        /**
+         * @var  $route \Concrete\Core\Routing\Route
+         */
+        foreach ($routes as $route) {
+            $data = $route->getAction();
+            $path = $route->getPath();
+            if (!empty($data) && is_string($data)) {
+                $result[] = [$app, $path, $data];
             }
         }
+
 
         return $result;
     }
 
-/** Issue with dataproviders that return nothing
- * on phpunit old versions
+/** @dataProvider routeDestinationProvider
+ *
+ * @param $app Application
+ * @param $path string
+ * @param $callable mixed
  */
-    public function testRouteDestination()
+    public function testRouteDestination(Application $app, $path, $callable)
     {
-        $this->markTestSkipped('Skipping until we can rewrite for new router.');
+
         $checked = false;
         if (preg_match('/^([^:]+)::([^:]+)$/', $callable, $m)) {
             $class = $m[1];
             $method = $m[2];
             if ($method === '__construct') {
-                $this->assertTrue(class_exists($m[1], true), "Invalid route for path $path: $callable");
+                $this->assertTrue(class_exists($m[1], true), "No class! Invalid route for path $path : $callable");
                 $checked = true;
             } elseif (interface_exists($class, true)) {
-                $this->assertTrue(method_exists($class, $method), "Invalid route for path $path: $callable");
-                $this->assertTrue($app->bound($class), "Invalid route for path $path: $callable");
+                $this->assertTrue(method_exists($class, $method), "No Method! Invalid route for path $path : $callable");
                 $checked = true;
+            } elseif ($app->isAlias($class)) {
+                $this->assertTrue(method_exists($class, $method), 'bound but no method!');
             }
         }
         if ($checked === false) {
-            $this->assertTrue(is_callable($callable), "Invalid route for path $path: $callable");
+            $this->assertTrue(is_callable($callable), "Not callable! Invalid route for path $path : $callable");
         }
     }
 }

--- a/tests/tests/Routing/CheckRoutesTest.php
+++ b/tests/tests/Routing/CheckRoutesTest.php
@@ -25,14 +25,10 @@ class CheckRoutesTest extends PHPUnit_Framework_TestCase
         return $result;
     }
 
-    /**
-     * @dataProvider routeDestinationProvider
-     *
-     * @param Application $app
-     * @param mixed $path
-     * @param mixed $callable
-     */
-    public function testRouteDestination(Application $app, $path, $callable)
+/** Issue with dataproviders that return nothing
+ * on phpunit old versions
+ */
+    public function testRouteDestination()
     {
         $this->markTestSkipped('Skipping until we can rewrite for new router.');
         $checked = false;

--- a/tests/tests/Routing/CheckRoutesTest.php
+++ b/tests/tests/Routing/CheckRoutesTest.php
@@ -51,7 +51,7 @@ class CheckRoutesTest extends PHPUnit_Framework_TestCase
                 $this->assertTrue(method_exists($class, $method), "No Method! Invalid route for path $path : $callable");
                 $checked = true;
             } elseif ($app->isAlias($class)) {
-                $this->assertTrue(method_exists($class, $method), 'bound but no method!');
+                $this->assertTrue(method_exists($class, $method), "Alias but no method! Invalid route for path $path : $callable");
             }
         }
         if ($checked === false) {


### PR DESCRIPTION
So I've fixed all of the tests and I've written a new test for checking the routes. (without the new test - https://travis-ci.org/deek87/concrete5/builds/424294629 )

As you can see there are a few classes missing. Im assuming @aembler may have forgot to merge them in when migrating the new routing system.

Ive also made the routeGroupBuilder ignore namespace if you use \ in front of a classname

The following classes don't exist in concrete5

 ```
/ccm/system/page/copy_all/ : Concrete\Controller\Backend\Page\CopyAll::fillQueue

 /ccm/system/page/sitemap_delete_forever/ : Concrete\Controller\Backend\Page\SitemapDeleteForever::fillQueue

 /ccm/system/dialogs/page/bulk/delete/ : Concrete\Controller\Dialog\Page\Bulk\Delete::view

 /ccm/system/dialogs/page/bulk/delete/submit/ : Concrete\Controller\Dialog\Page\Bulk\Delete::submit

/ccm/system/queue/monitor/{queue}/{token}/ : \Concrete\Controller\Backend\Queue::monitor

```