### PR TITLE
Image Slider block - remove old CSS and JS assets code

### DIFF
--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -92,12 +92,6 @@ class Controller extends BlockController implements FileTrackableInterface
 
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('responsive-slides');
-
-        $al->register('javascript', 'responsiveslides', 'blocks/image_slider/responsiveslides.js');
-        $this->requireAsset('javascript', 'blocks/image_slider/responsiveslides');
-
-        $al->register('css', 'responsiveslides', 'blocks/image_slider/responsiveslides.css');
-        $this->requireAsset('css', 'blocks/image_slider/responsiveslides');
     }
 
     public function getEntries()


### PR DESCRIPTION
Reported in Slack #bug_team
https://concrete5.slack.com/archives/C6P2PL03A/p1535546677000100

The Image Slider block ResponsiveSlides.js assets were moved into app.php. 
https://github.com/concrete5/concrete5/blob/develop/concrete/config/app.php#L410-L412
https://github.com/concrete5/concrete5/blob/develop/concrete/config/app.php#L721-L726