### PR TITLE
Fix getAssetContentsByRoute

### DIFF
--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -506,8 +506,12 @@ abstract class Asset implements AssetInterface
                 }
             }
             if ($matched !== null) {
+                if (isset($matched['_route'])) {
+                    $controller = $routes->get($matched['_route'])->getAction();
+                } else {
+                    $controller = $matched['_controller'];
+                }
                 $callable = null;
-                $controller = $matched['_controller'];
                 if (is_string($controller)) {
                     $chunks = explode('::', $controller, 2);
                     if (count($chunks) === 2) {


### PR DESCRIPTION
It seems that `UrlMatcher` now returns an array with only one key (`_route`) containing the name of the found route.