### PR TITLE
Fix DatabaseTest::testInvalidConnection

### DIFF
--- a/concrete/src/Database/Connection/ConnectionFactory.php
+++ b/concrete/src/Database/Connection/ConnectionFactory.php
@@ -19,6 +19,11 @@ class ConnectionFactory
         $this->driver_manager = $driver_manager;
     }
 
+    /**
+     * @param \ArrayAccess|array $config
+     *
+     * @return \Concrete\Core\Database\Connection\Connection|\Doctrine\DBAL\Connection
+     */
     public function createConnection($config)
     {
         $driver = $this->driver_manager->driver(array_get($config, 'driver', ''));

--- a/tests/tests/Database/DatabaseTest.php
+++ b/tests/tests/Database/DatabaseTest.php
@@ -23,6 +23,10 @@ class DatabaseTest extends ConcreteDatabaseTestCase
         parent::setUp();
     }
 
+    /**
+     * @expectedException \Doctrine\DBAL\Driver\PDOException
+     * @expectedExceptionMessage getaddrinfo failed
+     */
     public function testInvalidConnection()
     {
         $connection = Database::getFactory()->createConnection(
@@ -32,14 +36,7 @@ class DatabaseTest extends ConcreteDatabaseTestCase
                 'password' => md5(mt_rand()),
                 'host' => 'DB_SERVER',
             ]);
-
-        try {
-            $errorCode = $connection->errorCode();
-        } catch (PDOException $e) {
-            return;
-        }
-
-        $this->fail('Invalid PDO exception not raised on failed connection.');
+        $connection->errorCode();
     }
 
     public function testValidConnection()


### PR DESCRIPTION
Commit 34efff59e3fecd33dbea3e3e31a16d7b9e86fa9c implies that the connection is opened as soon as the connection instance is created.
Let's update the DatabaseTest::testInvalidConnection accordingly.