### PR TITLE
Fix BlockController::getActionURL when a custom action is already executed

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -517,6 +517,14 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         return [$method, $parameters];
     }
 
+    /**
+     * Creates a URL that can be posted or navigated to that, when done so, will automatically run the corresponding method inside the block's controller.
+     * It can also be used to perform system operations, accordingly to the current action.
+     *
+     * @param mixed $task,... The arguments to build the URL (variable number of arguments).
+     *
+     * @return \Concrete\Core\Url\UrlImmutable|null Return NULL in case of problems
+     */
     public function getActionURL($task)
     {
         try {
@@ -528,7 +536,8 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                     $b = $this->block;
                 }
 
-                if ($this->getAction() == 'view') {
+                $action = $this->getAction();
+                if ($action === 'view' || strpos($action, 'action_') === 0) {
                     $c = Page::getCurrentPage();
                     if (is_object($b) && is_object($c)) {
                         $arguments = func_get_args();
@@ -559,7 +568,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 return call_user_func_array(array('\URL', 'to'), $arguments);
 
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
         }
 
     }

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -90,14 +90,9 @@ class BlockView extends AbstractView
     }
 
     /**
-     * Creates a URL that can be posted or navigated to that, when done so, will automatically run the corresponding method inside the block's controller.
-     * <code>
-     *     <a href="<?=$view->action('get_results')?>">Get the results</a>
-     * </code>.
+     * @deprecated In views, use $controller->getActionURL() using the same arguments.
      *
-     * @param string $task
-     *
-     * @return string $url
+     * @return \Concrete\Core\Url\UrlImmutable|null
      */
     public function action($task)
     {


### PR DESCRIPTION
If we call a custom block action (for example `action_my_custom_method`), the action of block controller is not `view` but `action_my_custom_method`.

Let's fix this issue.