### PR TITLE
CSV export: reset loaded doctrine entities every now and then

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -498,7 +498,7 @@ class Search extends DashboardPageController
                         'writer' => $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
                     ]
                 );
-
+                $writer->setUnloadDoctrineEveryTick(50);
                 $writer->insertHeaders();
                 $writer->insertList($result->getItemListObject());
             },


### PR DESCRIPTION
This should greatly reduce the memory usage, in particular in case of many user attributes.