### PR TITLE
Improve installation detection by allowing {$env}.database.php

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -226,21 +226,66 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
      */
     private function initializeEnvironmentDetection(Application $app)
     {
-        $db_config = [];
-        if (file_exists(DIR_CONFIG_SITE . '/database.php')) {
-            $db_config = include DIR_CONFIG_SITE . '/database.php';
-        }
         $environment = $app->environment();
-        $app->detectEnvironment(function () use ($db_config, $environment, $app) {
-            try {
-                $installed = $app->isInstalled();
+        $app->detectEnvironment(function () use ($environment, $app) {
+            $forceInstalled = \defined('CONCRETE5_INSTALLED') ? CONCRETE5_INSTALLED : getenv('CONCRETE5_INSTALLED');
 
-                return $installed;
+            // Allow overriding installation detection
+            if ($forceInstalled && strtolower($forceInstalled) !== 'auto') {
+                return filter_var($forceInstalled, FILTER_VALIDATE_BOOLEAN) ? $environment : 'install';
+            }
+
+            // Check if config has loaded, if so use that
+            try {
+                return $app->isInstalled() ? $environment : 'install';
             } catch (\Exception $e) {
             }
 
-            return isset($db_config['default-connection']) ? $environment : 'install';
+            // If we have well formed database details defined, we're probably installed
+            if ($this->validateDatabaseDetails($environment)) {
+                return $environment;
+            }
+
+            return 'install';
         });
+    }
+
+    /**
+     * Check whether an environment has well formed database credentials defined
+     *
+     * @param $environment
+     * @return mixed
+     */
+    private function validateDatabaseDetails($environment)
+    {
+        $db_config = [];
+        $configFile = DIR_CONFIG_SITE . '/database.php';
+        $environmentConfig = DIR_CONFIG_SITE . "/{$environment}.database.php";
+
+        // If the database.php file exists, load it first
+        if (file_exists($configFile)) {
+            $db_config = include DIR_CONFIG_SITE . '/database.php';
+        }
+
+        // If there's an environment specific database file, load that too
+        if (file_exists($environmentConfig)) {
+            $db_config = array_merge($db_config, include $environmentConfig);
+        }
+
+        // Make sure the default connection is set
+        $defaultConnection = array_get($db_config, 'default-connection');
+
+        // Make sure we have all the stuff we expect
+        $connection = array_get($db_config, "connections.{$defaultConnection}");
+
+        // Make sure we have all the keys we are expecting
+        if ($defaultConnection && $connection &&
+            array_get($connection, 'database') &&
+            array_get($connection, 'username') &&
+            array_get($connection, 'server')
+        ) {
+            return $environment;
+        }
     }
 
     /**


### PR DESCRIPTION
Previously we detected whether concrete5 was installed in the following order:
1. Check with the application object to see if it's installed, this will fail unless config is already loaded which is not the case most the time (also this was broken)
2. Load `/public/application/config/database.php` directly and verify that a 'default_connection' key is set

This works well, but it's pretty hard to work with if you're doing automated deploys:

A bad pattern is this:

- *Dev A* has installed c5 locally and is working on a project that is tracked with git
- *Dev B* joins the project and pulls the repository, they see a `public/application/config/database.php` file with *Dev A*'s credentials
- *Dev B* must delete database.php in order to install
- *Dev B* must ignore the changes in database.php whenever committing changes to git (this sucks)

A better pattern is:

- *Dev A* has installed c5 locally and is working on a project that is tracked with git
- *Dev A* has added `public/application/config/database.php` to gitignore
- *Dev B* joins the project and pulls the repository, they don't see any database.php 
- *Dev B* installs locally without needing to change anything
- *Dev B* can commit all changes, since database.php isn't tracked by git


But this leads to trouble with the current way of tracking whether c5 is installed. If you're using an automated deploy and [composer based concrete5](https://github.com/concrete5/composer), you'll find yourself in this situation:

- `public/application/config/database.php` is not tracked by git
- `public/application/config/live.database.php` exists and totally is tracked. It has `getenv(...)` calls to get the db credentials and a .env file to manage them across deploy

Now when you go to deploy, the steps are:

- Deploy the code to the new release directory
- Symlink in `/public/application/files/` and `/public/application/config/generated_overrides`
- **Create a fake `/public/application/config/database.php` file so that things are marked as installed**
- Generated database proxies
- restart php-fpm and clear cache

This pull request addresses the need to create a fake database.php. Instead with composer based concrete5 it'd be enough to have a `{$environment}.database.php` file and the `.env` file filled in.

A good example would be pulling the current composer based concrete5 repo and filling in the .env details. Even if you have a `live.database.php` and you've set `CONCRETE5_ENV='live'` in your .env file, you still have to make a stub database.php file for concrete5 to think the thing is installed.


----


After this PR we do the following:

- Check a new environment variable / constant `CONCRETE5_INSTALLED`. If it's defined, it becomes the source of truth for whether c5 is installed or not. If set to 'auto' it acts as if it weren't defined
- See if the application object is ready to tell us if it's installed. If it is, use it as the source of truth
- If a `database.php` exists, load it
- If a `{$CONCRETE5_ENV}.database.php` file exists, merge it in
- if we have a database, user, and server defined for the default connection, we are installed
