### PR TITLE
Fix alternative canonical URL in package StartingPoint

### DIFF
--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -501,8 +501,8 @@ class StartingPointPackage extends BasePackage
             $siteConfig->save('seo.canonical_url', $installConfiguration['canonical-url']);
         }
         unset($installConfiguration['canonical-url']);
-        if (isset($site_install['canonical-url-alternative']) && $site_install['canonical-url-alternative']) {
-            $siteConfig->save('seo.canonical_url_alternative', $site_install['canonical-url-alternative']);
+        if (isset($installConfiguration['canonical-url-alternative']) && $installConfiguration['canonical-url-alternative']) {
+            $siteConfig->save('seo.canonical_url_alternative', $installConfiguration['canonical-url-alternative']);
         }
         unset($installConfiguration['canonical-url-alternative']);
         


### PR DESCRIPTION
The `$site_install` variable doesn't exist in this scope. 

https://github.com/concrete5/concrete5/blob/b404d9f54f4eb6b72990c8f0530bfdd8dd5a6a98/concrete/src/Package/StartingPointPackage.php#L485-L507