### PR TITLE
Fix typo in 'successfully'

### DIFF
--- a/concrete/src/Console/Command/RefreshEntitiesCommand.php
+++ b/concrete/src/Console/Command/RefreshEntitiesCommand.php
@@ -25,7 +25,7 @@ class RefreshEntitiesCommand extends Command
             ->setHelp(<<<EOT
 This command will refresh the Doctrine database entities and set the following return codes
 
-  0 operation completed succesfully
+  0 operation completed successfully
   {$errExitCode} errors occurred
 EOT
             )


### PR DESCRIPTION
`./concrete/bin/concrete5 c5:entities:refresh --help`

![afbeelding](https://user-images.githubusercontent.com/1431100/45633466-1be00500-baa0-11e8-9dcd-2405dfc40118.png)
