### PR TITLE
Fix warnings about double definition of properties in OAuth classes

### DIFF
--- a/concrete/src/Entity/OAuth/AccessToken.php
+++ b/concrete/src/Entity/OAuth/AccessToken.php
@@ -2,13 +2,11 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
+use Doctrine\ORM\Mapping as ORM;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
-use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
-use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="AccessTokenRepository")
@@ -18,7 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class AccessToken implements AccessTokenEntityInterface
 {
-    use AccessTokenTrait, EntityTrait;
+    use AccessTokenTrait;
 
     /**
      * @ORM\Id @ORM\Column(type="guid")
@@ -43,16 +41,36 @@ class AccessToken implements AccessTokenEntityInterface
     protected $scopes = [];
 
     /**
-     * @var ScopeEntityInterface[]
+     * @var \League\OAuth2\Server\Entities\ScopeEntityInterface[]
      * @ORM\ManyToOne(targetEntity="Client")
      * @ORM\JoinColumn(name="client", referencedColumnName="identifier")
      */
     protected $client;
 
     /**
-     * Associate a scope with the token.
+     * {@inheritdoc}
      *
-     * @param ScopeEntityInterface $scope
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getIdentifier()
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setIdentifier()
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\TokenInterface::addScope()
      */
     public function addScope(ScopeEntityInterface $scope)
     {
@@ -60,9 +78,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Return an array of scopes associated with the token.
+     * {@inheritdoc}
      *
-     * @return ScopeEntityInterface[]
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getScopes()
      */
     public function getScopes()
     {
@@ -70,9 +88,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Get the token's expiry date time.
+     * {@inheritdoc}
      *
-     * @return \DateTime
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getExpiryDateTime()
      */
     public function getExpiryDateTime()
     {
@@ -80,9 +98,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Set the date time when the token expires.
+     * {@inheritdoc}
      *
-     * @param \DateTime $dateTime
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setExpiryDateTime()
      */
     public function setExpiryDateTime(\DateTime $dateTime)
     {
@@ -90,9 +108,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Set the identifier of the user associated with the token.
+     * {@inheritdoc}
      *
-     * @param string|int $identifier The identifier of the user
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setUserIdentifier()
      */
     public function setUserIdentifier($identifier)
     {
@@ -100,9 +118,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Get the token user's identifier.
+     * {@inheritdoc}
      *
-     * @return string|int
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getUserIdentifier()
      */
     public function getUserIdentifier()
     {
@@ -110,9 +128,9 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Get the client that the token was issued to.
+     * {@inheritdoc}
      *
-     * @return ClientEntityInterface
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getClient()
      */
     public function getClient()
     {
@@ -120,13 +138,12 @@ class AccessToken implements AccessTokenEntityInterface
     }
 
     /**
-     * Set the client that the token was issued to.
+     * {@inheritdoc}
      *
-     * @param ClientEntityInterface $client
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setClient()
      */
     public function setClient(ClientEntityInterface $client)
     {
         $this->client = $client;
     }
-
 }

--- a/concrete/src/Entity/OAuth/AuthCode.php
+++ b/concrete/src/Entity/OAuth/AuthCode.php
@@ -2,13 +2,11 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
+use Doctrine\ORM\Mapping as ORM;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
-use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
-use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="AuthCodeRepository")
@@ -18,8 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class AuthCode implements AuthCodeEntityInterface
 {
-
-    use EntityTrait, AuthCodeTrait;
+    use AuthCodeTrait;
 
     /**
      * @ORM\Id @ORM\Column(type="guid")
@@ -51,9 +48,29 @@ class AuthCode implements AuthCodeEntityInterface
     protected $client;
 
     /**
-     * Associate a scope with the token.
+     * {@inheritdoc}
      *
-     * @param ScopeEntityInterface $scope
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getIdentifier()
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setIdentifier()
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\TokenInterface::addScope()
      */
     public function addScope(ScopeEntityInterface $scope)
     {
@@ -61,9 +78,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Return an array of scopes associated with the token.
+     * {@inheritdoc}
      *
-     * @return ScopeEntityInterface[]
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getScopes()
      */
     public function getScopes()
     {
@@ -71,9 +88,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Get the token's expiry date time.
+     * {@inheritdoc}
      *
-     * @return \DateTime
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getExpiryDateTime()
      */
     public function getExpiryDateTime()
     {
@@ -81,9 +98,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Set the date time when the token expires.
+     * {@inheritdoc}
      *
-     * @param \DateTime $dateTime
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setExpiryDateTime()
      */
     public function setExpiryDateTime(\DateTime $dateTime)
     {
@@ -91,9 +108,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Set the identifier of the user associated with the token.
+     * {@inheritdoc}
      *
-     * @param string|int $identifier The identifier of the user
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setUserIdentifier()
      */
     public function setUserIdentifier($identifier)
     {
@@ -101,9 +118,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Get the token user's identifier.
+     * {@inheritdoc}
      *
-     * @return string|int
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getUserIdentifier()
      */
     public function getUserIdentifier()
     {
@@ -111,9 +128,9 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Get the client that the token was issued to.
+     * {@inheritdoc}
      *
-     * @return ClientEntityInterface
+     * @see \League\OAuth2\Server\Entities\TokenInterface::getClient()
      */
     public function getClient()
     {
@@ -121,13 +138,12 @@ class AuthCode implements AuthCodeEntityInterface
     }
 
     /**
-     * Set the client that the token was issued to.
+     * {@inheritdoc}
      *
-     * @param ClientEntityInterface $client
+     * @see \League\OAuth2\Server\Entities\TokenInterface::setClient()
      */
     public function setClient(ClientEntityInterface $client)
     {
         $this->client = $client;
     }
-
 }

--- a/concrete/src/Entity/OAuth/Client.php
+++ b/concrete/src/Entity/OAuth/Client.php
@@ -2,10 +2,8 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
-use League\OAuth2\Server\Entities\ClientEntityInterface;
-use League\OAuth2\Server\Entities\Traits\ClientTrait;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use Doctrine\ORM\Mapping as ORM;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
 
 /**
  * @ORM\Entity(repositoryClass="ClientRepository")
@@ -16,9 +14,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Client implements ClientEntityInterface
 {
-
-    use EntityTrait, ClientTrait;
-
     /**
      * @ORM\Id @ORM\Column(type="guid")
      * @ORM\GeneratedValue(strategy="UUID")
@@ -50,6 +45,38 @@ class Client implements ClientEntityInterface
     protected $clientSecret;
 
     /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\ClientEntityInterface::getIdentifier()
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the client's identifier.
+     *
+     * @param string $identifier
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\ClientEntityInterface::getName()
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the client's name.
+     *
      * @param string $name
      */
     public function setName($name)
@@ -90,6 +117,18 @@ class Client implements ClientEntityInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\ClientEntityInterface::getRedirectUri()
+     */
+    public function getRedirectUri()
+    {
+        return $this->redirectUri;
+    }
+
+    /**
+     * Set the registered redirect URI (as a string), or an indexed array of redirect URIs.
+     *
      * @param string|string[] $redirectUri
      */
     public function setRedirectUri($redirectUri)

--- a/concrete/src/Entity/OAuth/RefreshToken.php
+++ b/concrete/src/Entity/OAuth/RefreshToken.php
@@ -2,10 +2,9 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
-use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
-use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
 use Doctrine\ORM\Mapping as ORM;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 
 /**
  * @ORM\Entity(repositoryClass="RefreshTokenRepository")
@@ -15,9 +14,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class RefreshToken implements RefreshTokenEntityInterface
 {
-
-    use RefreshTokenTrait, EntityTrait;
-
     /**
      * @ORM\Id @ORM\Column(type="guid")
      * @ORM\GeneratedValue(strategy="UUID")
@@ -31,9 +27,69 @@ class RefreshToken implements RefreshTokenEntityInterface
     protected $expiryDateTime;
 
     /**
-     * @var AccessTokenEntityInterface
+     * @var \League\OAuth2\Server\Entities\AccessTokenEntityInterface
      * @ORM\OneToOne(targetEntity="AccessToken")
      * @ORM\JoinColumn(name="client", referencedColumnName="identifier")
      */
     protected $accessToken;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::getIdentifier()
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::setIdentifier()
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::setAccessToken()
+     */
+    public function setAccessToken(AccessTokenEntityInterface $accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::getAccessToken()
+     */
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::getExpiryDateTime()
+     */
+    public function getExpiryDateTime()
+    {
+        return $this->expiryDateTime;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::setExpiryDateTime()
+     */
+    public function setExpiryDateTime(\DateTime $dateTime)
+    {
+        $this->expiryDateTime = $dateTime;
+    }
 }

--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -2,9 +2,8 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
-use League\OAuth2\Server\Entities\ScopeEntityInterface;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use Doctrine\ORM\Mapping as ORM;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
 
 /**
  * @ORM\Entity(repositoryClass="ScopeRepository")
@@ -14,9 +13,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Scope implements ScopeEntityInterface
 {
-
-    use EntityTrait;
-
     /**
      * @var string
      * @ORM\Id @ORM\Column(type="string")
@@ -34,7 +30,27 @@ class Scope implements ScopeEntityInterface
     protected $tokens;
 
     /**
-     * Serialize into a string
+     * {@inheritdoc}
+     *
+     * @see \League\OAuth2\Server\Entities\ScopeEntityInterface::getIdentifier()
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
      */
     public function jsonSerialize()
     {


### PR DESCRIPTION
After #7011, I have seen these warnings:

- `Concrete\Core\Entity\OAuth\AccessToken`  
  and
  `League\OAuth2\Server\Entities\Traits\EntityTrait`
  define the same property ($identifier) in the composition of
  `Concrete\Core\Entity\OAuth\AccessToken`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\AuthCode`  
  and
  `League\OAuth2\Server\Entities\Traits\EntityTrait`
  define the same property ($identifier) in the composition of
  `Concrete\Core\Entity\OAuth\AuthCode`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\Client`  
  and
  `League\OAuth2\Server\Entities\Traits\EntityTrait`
  define the same property ($identifier) in the composition of
  `Concrete\Core\Entity\OAuth\Client`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\Client`  
  and
  `League\OAuth2\Server\Entities\Traits\ClientTrait`
  define the same property ($name) in the composition of
  `Concrete\Core\Entity\OAuth\Client`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\Client`  
  and
  `League\OAuth2\Server\Entities\Traits\ClientTrait`
  define the same property ($redirectUri) in the composition of
  `Concrete\Core\Entity\OAuth\Client`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\RefreshToken`  
  and
  `League\OAuth2\Server\Entities\Traits\RefreshTokenTrait`
  define the same property ($accessToken) in the composition of
  `Concrete\Core\Entity\OAuth\RefreshToken`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\RefreshToken`  
  and
  `League\OAuth2\Server\Entities\Traits\RefreshTokenTrait`
  define the same property ($expiryDateTime) in the composition of
  `Concrete\Core\Entity\OAuth\RefreshToken`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\RefreshToken`  
  and
  `League\OAuth2\Server\Entities\Traits\EntityTrait`
  define the same property ($identifier) in the composition of
  `Concrete\Core\Entity\OAuth\RefreshToken`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
- `Concrete\Core\Entity\OAuth\Scope``  
  and
  `League\OAuth2\Server\Entities\Traits\EntityTrait`
  define the same property ($identifier) in the composition of
  `Concrete\Core\Entity\OAuth\Scope`  
  This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed

The reason of these warnings is that the League traits define the same properties as the concrete5 classes.
IMHO the only solution is to move the code of the traits to the concrete5 classes...