### PR TITLE
Fix stack access with advanced permissions - Take 2

### DIFF
--- a/concrete/blocks/core_stack_display/view.php
+++ b/concrete/blocks/core_stack_display/view.php
@@ -1,17 +1,24 @@
 <?php
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Permission\Checker;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
+/* @var int $stID */
+
 $c = Page::getCurrentPage();
-$cp = new Permissions($c);
+$cp = new Checker($c);
 if ($cp->canViewPageVersions()) {
     $stack = Stack::getByID($stID);
 } else {
     $stack = Stack::getByID($stID, 'ACTIVE');
 }
 if ($stack) {
-    $ax = Area::get($stack, STACKS_AREA_NAME);
-    $axp = new Permissions($ax);
+    $axp = new Checker($stack);
     if ($axp->canRead()) {
+        $ax = Area::get($stack, STACKS_AREA_NAME);
         $ax->disableControls();
         $ax->display($stack);
     }

--- a/concrete/controllers/page_types/core_stack.php
+++ b/concrete/controllers/page_types/core_stack.php
@@ -22,7 +22,7 @@ class CoreStack extends PageTypeController
 
     public function on_start()
     {
-        $stacksPage = Page::getByPath('/dashboard/blocks/stacks');
+        $stacksPage = Page::getByPath(STACKS_LISTING_PAGE_PATH);
         $stacksPerms = new Permissions($stacksPage);
 
         // Make sure we can view the stacks page

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -83,7 +83,7 @@ if (isset($neutralStack)) {
             <div class="container-fluid">
                 <ul class="nav navbar-nav small">
                     <?php
-                    if ($areaPermissions->canAddBlockToArea()) {
+                    if ($cpc->canEditPageContents()) {
                         ?>
                         <li class="dropdown">
                             <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -106,7 +106,6 @@ if (isset($neutralStack)) {
                     if ($cpc->canEditPagePermissions() && Config::get('concrete.permissions.model') == 'advanced') {
                         ?>
                         <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?=URL::to('/ccm/system/panels/details/page/permissions?cID=' . $stackToEdit->getCollectionID())?>"><?=t('Permissions')?></a></li>
-                        <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?= URL::to('/ccm/system/dialogs/area/edit/permissions') ?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Permissions')?></a></li>
                         <?php
                     }
                     if (!$isGlobalArea && $cpc->canMoveOrCopyPage()) {

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -89,6 +89,7 @@ if (isset($neutralStack)) {
                             <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>
                             <ul class="dropdown-menu">
                                 <li><a class="dialog-launch" dialog-modal="false" dialog-width="550" dialog-height="380" dialog-title="<?=t('Add')?>" href="<?=URL::to('/ccm/system/dialogs/page/add_block_list')?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Add Block')?></a></li>
+                                <li><a class="dialog-launch" dialog-modal="false" dialog-width="550" dialog-height="380" dialog-title="<?=t('Paste From Clipboard')?>" href="<?=URL::to('/ccm/system/dialogs/page/clipboard')?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Paste From Clipboard')?></a></li>
                             </ul>
                         </li>
                         <?php

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -83,7 +83,7 @@ if (isset($neutralStack)) {
             <div class="container-fluid">
                 <ul class="nav navbar-nav small">
                     <?php
-                    if ($cpc->canEditPageContents()) {
+                    if ($cpc->canEditPageContents() && $areaPermissions->canAddBlocks()) {
                         ?>
                         <li class="dropdown">
                             <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -31,22 +31,32 @@ if (isset($neutralStack)) {
     <?php
     if ($stackToEdit === null) {
         ?>
-        <form method="post" action="<?=$view->action('add_localized_stack')?>">
-            <?=$token->output('add_localized_stack')?>
-            <?=$form->hidden('stackID', $neutralStack->getCollectionID());?>
-            <?=$form->hidden('locale', $localeCode);?>
-            <div class="alert alert-info">
-                <p>
-                    <?=t(/*i18n: %1$s is a language name, %2$s is a language code*/'This stack is not defined for %1$s (%2$s): the default version will be used.', $localeName, $localeCode); ?>
-                </p>
-                <p>
-                    <button class="btn btn-primary" type="submit"><?=$isGlobalArea ? t('Create localized global area version') : t('Create localized stack version')?></button><br />
-                </p>
-            </div>
-        </form>
+        <div class="alert alert-info">
+            <p>
+                <?=t(/*i18n: %1$s is a language name, %2$s is a language code*/'This stack is not defined for %1$s (%2$s): the default version will be used.', $localeName, $localeCode); ?>
+            </p>
+            <?php
+            $cpc = new Permissions($neutralStack);
+            if ($cpc->canAddSubpage()) {
+                ?>
+                <form method="post" action="<?=$view->action('add_localized_stack')?>">
+                    <?=$token->output('add_localized_stack')?>
+                    <?=$form->hidden('stackID', $neutralStack->getCollectionID());?>
+                    <?=$form->hidden('locale', $localeCode);?>
+                    <p>
+                        <button class="btn btn-primary" type="submit"><?=$isGlobalArea ? t('Create localized global area version') : t('Create localized stack version')?></button><br />
+                    </p>
+                </form>                    
+                <?php
+            }
+            ?>
+        </div>
         <?php
     } else {
+        $a = Area::get($stackToEdit, STACKS_AREA_NAME);
         $cpc = new Permissions($stackToEdit);
+        $cpcNeutral = $stackToEdit === $neutralStack ? $cpc : new Permissions($neutralStack);
+        $areaPermissions = new Permissions($a);
         $showApprovalButton = false;
         $hasPendingPageApproval = false;
         $workflowList = PageWorkflowProgress::getList($stackToEdit);
@@ -72,31 +82,43 @@ if (isset($neutralStack)) {
         <nav class="navbar navbar-default">
             <div class="container-fluid">
                 <ul class="nav navbar-nav small">
-                    <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>
-                        <ul class="dropdown-menu">
-                            <li><a class="dialog-launch" dialog-modal="false" dialog-width="550" dialog-height="380" dialog-title="<?=t('Add')?>" href="<?=URL::to('/ccm/system/dialogs/page/add_block_list')?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Add Block')?></a></li>
-                            <li><a class="dialog-launch" dialog-modal="false" dialog-width="550" dialog-height="380" dialog-title="<?=t('Paste From Clipboard')?>" href="<?=URL::to('/ccm/system/dialogs/page/clipboard')?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Paste From Clipboard')?></a></li>
-                        </ul>
-                    </li>
-                    <li><a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackVersions" dialog-title="<?=t('Version History')?>" href="<?=URL::to('/ccm/system/panels/page/versions')?>?cID=<?=$stackToEdit->getCollectionID()?>"><?=t('Version History')?></a></li>
-                    <?php if (!$isGlobalArea && $cpc->canEditPageProperties()) { ?>
-                        <li><a href="<?=$view->action('rename', $neutralStack->getCollectionID())?>"><?=t('Rename')?></a></li>
-                    <?php } ?>
-                    <?php if ($cpc->canEditPagePermissions() && Config::get('concrete.permissions.model') == 'advanced') { ?>
-                        <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?= URL::to('/ccm/system/dialogs/area/edit/permissions') ?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Permissions')?></a></li>
-                    <?php } ?>
-                    <?php if (!$isGlobalArea && $cpc->canMoveOrCopyPage()) { ?>
-                        <li><a href="<?=$view->action('duplicate', $neutralStack->getCollectionID())?>" style="margin-right: 4px;"><?=t('Duplicate')?></a></li>
-                    <?php } ?>
-                    <?php if (!$isGlobalArea) { ?>
-                    <li>
-                        <a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackUsage" dialog-title="<?=t('Usage')?>" href="<?= $view->action('usage', $stackToEdit->getCollectionID()) ?>">
-                   <?=t('Stack Usage')?>
-                    </a>
-                    </li>
-                    <?php } ?>
                     <?php
+                    if ($areaPermissions->canAddBlockToArea()) {
+                        ?>
+                        <li class="dropdown">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>
+                            <ul class="dropdown-menu">
+                                <li><a class="dialog-launch" dialog-modal="false" dialog-width="550" dialog-height="380" dialog-title="<?=t('Add')?>" href="<?=URL::to('/ccm/system/dialogs/page/add_block_list')?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Add Block')?></a></li>
+                            </ul>
+                        </li>
+                        <?php
+                    }
+                    if ($cpc->canViewPageVersions()) {
+                        ?>
+                        <li><a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackVersions" dialog-title="<?=t('Version History')?>" href="<?=URL::to('/ccm/system/panels/page/versions')?>?cID=<?=$stackToEdit->getCollectionID()?>"><?=t('Version History')?></a></li>
+                        <?php
+                    }
+                    if (!$isGlobalArea && $cpcNeutral->canEditPageProperties()) {
+                        ?>
+                        <li><a href="<?=$view->action('rename', $neutralStack->getCollectionID())?>"><?=t('Rename')?></a></li>
+                        <?php
+                    }
+                    if ($cpc->canEditPagePermissions() && Config::get('concrete.permissions.model') == 'advanced') {
+                        ?>
+                        <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?=URL::to('/ccm/system/panels/details/page/permissions?cID=' . $stackToEdit->getCollectionID())?>"><?=t('Permissions')?></a></li>
+                        <li><a dialog-width="580" class="dialog-launch" dialog-append-buttons="true" dialog-height="420" dialog-title="<?=t('Stack Permissions')?>" id="stackPermissions" href="<?= URL::to('/ccm/system/dialogs/area/edit/permissions') ?>?cID=<?=$stackToEdit->getCollectionID()?>&arHandle=<?=STACKS_AREA_NAME?>"><?=t('Permissions')?></a></li>
+                        <?php
+                    }
+                    if (!$isGlobalArea && $cpc->canMoveOrCopyPage()) {
+                        ?>
+                        <li><a href="<?=$view->action('duplicate', $neutralStack->getCollectionID())?>" style="margin-right: 4px;"><?=t('Duplicate')?></a></li>
+                        <?php
+                    }
+                    if (!$isGlobalArea) {
+                        ?>
+                        <li><a dialog-width="640" dialog-height="340" class="dialog-launch" id="stackUsage" dialog-title="<?=t('Usage')?>" href="<?= $view->action('usage', $stackToEdit->getCollectionID()) ?>"><?=t('Stack Usage')?></a></li>
+                        <?php
+                    }
                     if ($cpc->canDeletePage()) {
                         if ($isGlobalArea) {
                             if ($stackToEdit !== $neutralStack) {
@@ -120,7 +142,7 @@ if (isset($neutralStack)) {
                 </ul>
                 <?php if ($showApprovalButton) { ?>
                     <ul class="nav navbar-nav navbar-right">
-                        <li id="ccm-stack-list-approve-button" class="navbar-form" <?php if ($vo->isApproved()) { ?> style="display: none;" <?php } ?>>
+                        <li id="ccm-stack-list-approve-button" class="navbar-form"<?= $vo->isApproved() ? ' style="display: none;"' : '' ?>>
                             <button class="btn btn-success" onclick="window.location.href='<?=URL::to('/dashboard/blocks/stacks', 'approve_stack', $stackToEdit->getCollectionID(), $token->generate('approve_stack'))?>'"><?=$publishTitle?></button>
                         </li>
                     </ul>
@@ -130,7 +152,6 @@ if (isset($neutralStack)) {
 
         <div id="ccm-stack-container">
             <?php
-            $a = Area::get($stackToEdit, STACKS_AREA_NAME);
             $a->forceControlsToDisplay();
             View::element('block_area_header', array('a' => $a));
             foreach ($blocks as $b) {

--- a/concrete/src/Block/Menu/Menu.php
+++ b/concrete/src/Block/Menu/Menu.php
@@ -125,7 +125,7 @@ class Menu extends ContextMenu
             if (is_object($stack)) {
                 $sp = new \Permissions($stack);
                 if ($sp->canWrite()) {
-                    $this->addItem(new LinkItem(\URL::to('/dashboard/blocks/stacks', 'view_details', $stack->getCollectionID()), t('Manage Stack Contents')));
+                    $this->addItem(new LinkItem(\URL::to(STACKS_LISTING_PAGE_PATH, 'view_details', $stack->getCollectionID()), t('Manage Stack Contents')));
                 }
             }
         } else if ($p->canEditBlock() && $b->isEditable()) {

--- a/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -29,6 +29,8 @@ class AreaAssignment extends Assignment
      */
     protected $inheritedPermissions = [
         'view_area' => 'view_page',
+        'add_block_to_area' => 'edit_page_contents',
+        'add_stack_to_area' => 'edit_page_contents',
         'edit_area_contents' => 'edit_page_contents',
         'add_layout_to_area' => 'edit_page_contents',
         'edit_area_design' => 'edit_page_contents',

--- a/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -29,8 +29,6 @@ class AreaAssignment extends Assignment
      */
     protected $inheritedPermissions = [
         'view_area' => 'view_page',
-        'add_block_to_area' => 'edit_page_contents',
-        'add_stack_to_area' => 'edit_page_contents',
         'edit_area_contents' => 'edit_page_contents',
         'add_layout_to_area' => 'edit_page_contents',
         'edit_area_design' => 'edit_page_contents',

--- a/concrete/src/Permission/Key/AddBlockBlockTypeKey.php
+++ b/concrete/src/Permission/Key/AddBlockBlockTypeKey.php
@@ -30,18 +30,20 @@ class AddBlockBlockTypeKey extends BlockTypeKey
                 $allBTIDs = $db->GetCol('select btID from BlockTypes where btIsInternal = 0');
             }
             foreach ($list as $l) {
-                if ($l->getBlockTypesAllowedPermission() == 'N') {
-                    $btIDs = array();
-                }
-                if ($l->getBlockTypesAllowedPermission() == 'C') {
-                    if ($l->getAccessType() == PermissionKey::ACCESS_TYPE_EXCLUDE) {
-                        $btIDs = array_values(array_diff($btIDs, $l->getBlockTypesAllowedArray()));
-                    } else {
-                        $btIDs = array_unique(array_merge($btIDs, $l->getBlockTypesAllowedArray()));
-                    }
-                }
-                if ($l->getBlockTypesAllowedPermission() == 'A') {
-                    $btIDs = $allBTIDs;
+                switch ($l->getBlockTypesAllowedPermission()) {
+                    case 'N':
+                        $btIDs = array();
+                        break;
+                    case 'C':
+                        if ($l->getAccessType() == PermissionKey::ACCESS_TYPE_EXCLUDE) {
+                            $btIDs = array_values(array_diff($btIDs, $l->getBlockTypesAllowedArray()));
+                        } else {
+                            $btIDs = array_unique(array_merge($btIDs, $l->getBlockTypesAllowedArray()));
+                        }
+                        break;
+                    case 'A':
+                        $btIDs = $allBTIDs;
+                        break;
                 }
             }
         }

--- a/concrete/src/Permission/Response/PageResponse.php
+++ b/concrete/src/Permission/Response/PageResponse.php
@@ -10,6 +10,7 @@ use Block;
 use Config;
 use Session;
 use TaskPermission;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Key\PageKey as PagePermissionKey;
 use Concrete\Core\Permission\Key\AreaKey as AreaPermissionKey;
 use Concrete\Core\Permission\Key\BlockKey as BlockPermissionKey;
@@ -164,9 +165,13 @@ class PageResponse extends Response
             $this->canMoveOrCopyPage()
         ) {
             return true;
-        } else {
-            return false;
         }
+        $c = Page::getCurrentPage();
+        if ($c && $c->getCollectionPath() == STACKS_LISTING_PAGE_PATH) {
+            return true;
+        }
+
+        return false;
     }
 
     public function testForErrors()

--- a/concrete/src/Workflow/Request/DeletePageRequest.php
+++ b/concrete/src/Workflow/Request/DeletePageRequest.php
@@ -65,7 +65,7 @@ class DeletePageRequest extends PageRequest
             $c = Stack::getByID($this->getRequestedPageID());
             $c->delete();
             $wpr = new WorkflowProgressResponse();
-            $wpr->setWorkflowProgressResponseURL(URL::to('/dashboard/blocks/stacks', 'stack_deleted'));
+            $wpr->setWorkflowProgressResponseURL(URL::to(STACKS_LISTING_PAGE_PATH, 'stack_deleted'));
 
             return $wpr;
         }

--- a/concrete/views/panels/details/page/permissions/advanced.php
+++ b/concrete/views/panels/details/page/permissions/advanced.php
@@ -1,56 +1,78 @@
 <?php
+
+use Concrete\Core\Page\Stack\Stack;
+
 defined('C5_EXECUTE') or die('Access Denied.');
+
+/* @var Concrete\Core\Page\Page $c */
 ?>
 <section class="ccm-ui">
     <header><?=t('Page Permissions')?></header>
 
     <?php
+    $stack = null;
+    if ($c->getPageTypeHandle() === STACKS_PAGE_TYPE) {
+        $stack = $c instanceof Stack ? $c : Stack::getByID($c->getCollectionID());
+    }
     $cpc = $c->getPermissionsCollectionObject();
     if ($c->getCollectionInheritance() == 'PARENT') {
-        ?>
-        <?php if ($c->isPageDraft()) {
+        if ($c->isPageDraft()) {
             ?>
-            <div class="alert alert-info"><?=t('This page inherits its permissions from the drafts area, as well as its edit page type drafts permission.');
-                ?></div>
+            <div class="alert alert-info">
+                <?php
+                if ($stack) {
+                    if ($stack->getStackType() === Stack::ST_TYPE_GLOBAL_AREA) {
+                        echo t('This global area inherits its permissions from the drafts area, as well as its edit page type drafts permission.');
+                    } else {
+                        echo t('This stack inherits its permissions from the drafts area, as well as its edit page type drafts permission.');
+                    }
+                } else {
+                    echo t('This page inherits its permissions from the drafts area, as well as its edit page type drafts permission.');
+                }
+                ?>
+            </div>
             <?php
         } else {
             ?>
-            <div class="alert alert-info"><?=t('This page inherits its permissions from:');
-                ?> <a target="_blank" href="<?=URL::to($cpc)?>"><?=$cpc->getCollectionName()?></a></div>
+            <div class="alert alert-info">
+                <?php
+                if ($stack) {
+                    if ($stack->getStackType() === Stack::ST_TYPE_GLOBAL_AREA) {
+                        echo t('This global area inherits its permissions from:');
+                    } else {
+                        echo t('This stack inherits its permissions from:');
+                    }
+                } else {
+                    echo t('This page inherits its permissions from:');
+                }
+                ?>
+                <a target="_blank" href="<?=URL::to($cpc)?>"><?=$cpc->getCollectionName()?></a>
+            </div>
             <?php
         }
-        ?>
-        <?php
-    } ?>
-
-
+    }
+    ?>
     <div>
         <div class="form-group">
             <label class="control-label" for="ccm-page-permissions-inherit"><?=t('Assign Permissions')?></label>
             <select id="ccm-page-permissions-inherit" class="form-control">
-                <?php if ($c->getCollectionID() > 1) {
-                    ?><option value="PARENT" <?php if ($c->getCollectionInheritance() == 'PARENT') {
-                        ?> selected<?php
-
-                    }
-                    ?>><?=t('By Area of Site (Hierarchy)')?></option><?php
-
-                } ?>
-                <?php if ($c->getMasterCollectionID() > 1) {
-                    ?><option value="TEMPLATE"  <?php if ($c->getCollectionInheritance() == 'TEMPLATE') {
-                        ?> selected<?php
-
-                    }
-                    ?>><?=t('From Page Type Defaults')?></option><?php
-
-                } ?>
-                <option value="OVERRIDE" <?php if ($c->getCollectionInheritance() == 'OVERRIDE') {
-                    ?> selected<?php
-
-                } ?>><?=t('Manually')?></option>
+                <?php
+                if ($c->getCollectionID() > 1) {
+                    ?>
+                    <option value="PARENT"<?= $c->getCollectionInheritance() === 'PARENT' ? ' selected="selected"' : ''?>><?=t('By Area of Site (Hierarchy)')?></option>
+                    <?php
+                }
+                if ($c->getMasterCollectionID() > 1) {
+                    ?>
+                    <option value="TEMPLATE"<?= $c->getCollectionInheritance() === 'TEMPLATE' ? ' selected="selected"' : ''?>><?=t('From Page Type Defaults')?></option>
+                    <?php
+                }
+                ?>
+                <option value="OVERRIDE"<?= $c->getCollectionInheritance() === 'OVERRIDE' ? ' selected="selected"' : ''?>><?=t('Manually')?></option>
             </select>
         </div>
-        <?php if (!$c->isMasterCollection()) {
+        <?php
+        if (!$c->isMasterCollection()) {
             ?>
             <div class="form-group">
                 <label class="control-label" for="ccm-page-permissions-subpages-override-template-permissions"><?=t('Subpage Permissions')?></label>

--- a/concrete/views/panels/page/versions.php
+++ b/concrete/views/panels/page/versions.php
@@ -280,7 +280,7 @@ $(function() {
 		if (checkboxes.length > 1) {
 			$('button[data-version-action=compare]').removeClass('disabled');
 		}
-		if (checkboxes.length > 0  && notChecked.length > 0 && !checkboxes.filter('[data-version-active=true]').length) {
+		if (checkboxes.length > 0  && notChecked.length > 0 && !checkboxes.filter('[data-version-active=true]').length && $('#ccm-panel-page-versions tbody [data-version-menu-task=delete]').length) {
 			$('button[data-version-action=delete]').removeClass('disabled');
 		}
 


### PR DESCRIPTION
This *pool* :wink: request is an alternative to #7029.
Here I'm trying to implement what @aembler [suggested](https://github.com/concrete5/concrete5/issues/7006#issuecomment-420037381).

*WARNING* it's not yet done, I'm currently facing a big issue, as described below.

Let's assume that we configure the stack with the following *page* permissions:  
  
![immagine](https://user-images.githubusercontent.com/928116/45767438-73b27380-bc3a-11e8-8361-5f8ffad99091.png)


- if we don't specify [these lines](https://github.com/concrete5/concrete5/commit/2b0e45c81a327b4a4b7fedb0c1b78afae4c3ffaa#diff-4d8968f8965dab8c74fe27f9b5a6bb39R18), the resulting area permissions are the following ones (the user can't add blocks to the stack):  
   
   ![immagine](https://user-images.githubusercontent.com/928116/45767468-888f0700-bc3a-11e8-9d4d-642f46677983.png)
- if we specify [these lines](https://github.com/concrete5/concrete5/commit/2b0e45c81a327b4a4b7fedb0c1b78afae4c3ffaa#diff-4d8968f8965dab8c74fe27f9b5a6bb39R18), the resulting area permissions are the following ones (the user can add blocks to the stack):  
  
  ![immagine](https://user-images.githubusercontent.com/928116/45767674-1d920000-bc3b-11e8-865a-438df0d696d7.png)  
   
   *BUT*, since the permission "can add block to page" is not implemented, we have this error [here](https://github.com/mlocati/concrete5/blob/2b0e45c81a327b4a4b7fedb0c1b78afae4c3ffaa/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php#L90):  
   ```
   Call to undefined method
   Concrete\Core\Permission\Access\ListItem\PageListItem::getBlockTypesAllowedPermission()
   ```  
   
   ...which I really don't know how to solve 😢 
