### PR TITLE
Update User.php

### DIFF
--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -89,7 +89,7 @@ class User extends ConcreteObject
 
         $aeu = $config->get('concrete.misc.access_entity_updated');
         if ($aeu && $aeu > $session->get('accessEntitiesUpdated')) {
-            self::refreshUserGroups();
+            $this->refreshUserGroups();
         }
 
         $invalidate = $app->make('Concrete\Core\Session\SessionValidatorInterface')->handleSessionValidation($session);


### PR DESCRIPTION
refreshUserGroups() shouldn't be called statically

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!