### PR TITLE
[Fix] #7065 - Fixed accidentally deleting all FileSets when deleting a user

### DIFF
--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -233,16 +233,18 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
         $this->connection->executeQuery('DELETE FROM PermissionAccessEntityUsers WHERE uID = ?', [(int) $this->getUserID()]);
         $this->connection->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID = ?', [(int) $this->getUserID()]);
 
-        // Delete private file sets from this user
-        foreach (\Concrete\Core\File\Set\Set::getMySets($this) as $set) {
-            $set->delete();
-        }
-
         // Public file sets should be detached from the user
         $this->connection->executeQuery('UPDATE FileSets SET uID = 0 WHERE uID = ? AND fsType = ?', [
             (int) $this->getUserID(),
             \Concrete\Core\File\Set\Set::TYPE_PUBLIC,
         ]);
+
+        // Delete private file sets from this user
+        foreach (\Concrete\Core\File\Set\Set::getOwnedSets($this) as $set) {
+            $set->delete();
+        }
+
+
 
         $this->connection->executeQuery('UPDATE Blocks set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);
         $this->connection->executeQuery('UPDATE Pages set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);


### PR DESCRIPTION
Also added a new static function to get only Owned Sets

The issue is called by calling getMySets which gets all available sets rather than your owned sets.

Ive updated the doc blocks and added a new function to cover only owned sets, I also changed the order so publicly available sets created by that user would not be deleted.