### PR TITLE
Create collection handle when aliasing the homepage

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -728,7 +728,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $u = new User();
         $uID = $u->getUserID();
 
-        $handle = $this->getCollectionHandle();
+        $handle = (string) $this->getCollectionHandle();
+        if ($handle === '') {
+            $handle = Core::make('helper/text')->handle($this->getCollectionName());
+        }
         $cDisplayOrder = $c->getNextSubPageDisplayOrder();
 
         $_cParentID = $c->getCollectionID();
@@ -741,7 +744,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $cPath = $db->fetchColumn($q, $v);
 
         $data = [
-            'handle' => $this->getCollectionHandle(),
+            'handle' => $handle,
             'name' => $this->getCollectionName(),
         ];
         $cobj = parent::addCollection($data);


### PR DESCRIPTION
When we create an alias of the homepage, we need to create a handle for the page because home pages doesn't have any and the resulting alias URL will be the same as the one of its parent page:

![immagine](https://user-images.githubusercontent.com/928116/45892537-b5712480-bdc8-11e8-90f1-30eb5a1269f0.png)
