### PR TITLE
Simplify Page::populatePage

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -155,8 +155,6 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     {
         $db = Database::connection();
 
-        $this->loadError(false);
-
         $q0 = 'select Pages.cID, Pages.pkgID, Pages.siteTreeID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsDraft, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Pages.ptID, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ';
         //$q2 = "select cParentID, cPointerID, cPath, Pages.cID from Pages left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
 
@@ -181,6 +179,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 $this->cDisplayOrder = $originalRow['cDisplayOrder'];
             }
             $this->isMasterCollection = $row['cIsTemplate'];
+            $this->loadError(false);
         } else {
             // there was no record of this particular collection in the database
             $this->loadError(COLLECTION_NOT_FOUND);

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -160,20 +160,14 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $q0 = 'select Pages.cID, Pages.pkgID, Pages.siteTreeID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsDraft, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Pages.ptID, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ';
         //$q2 = "select cParentID, cPointerID, cPath, Pages.cID from Pages left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
 
-        $v = [$cInfo];
-        $r = $db->executeQuery($q0.$where, $v);
+        $r = $db->executeQuery($q0 . $where, [$cInfo]);
         $row = $r->fetchRow();
         if ($row['cPointerID'] > 0) {
-            $q1 = $q0.'where Pages.cID = ?';
-            $cPointerOriginalID = $row['cID'];
-            $v = [$row['cPointerID']];
-            $cParentIDOverride = $row['cParentID'];
-            $cPathOverride = $row['cPath'];
-            $cIsActiveOverride = $row['cIsActive'];
-            $cPointerID = $row['cPointerID'];
-            $cDisplayOrderOverride = $row['cDisplayOrder'];
-            $r = $db->executeQuery($q1, $v);
+            $originalRow = $row;
+            $r = $db->executeQuery($q0 . 'where Pages.cID = ?', [$row['cPointerID']]);
             $row = $r->fetchRow();
+        } else {
+            $originalRow = null;
         }
 
         if ($r) {
@@ -181,13 +175,13 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 foreach ($row as $key => $value) {
                     $this->{$key} = $value;
                 }
-                if (isset($cParentIDOverride)) {
-                    $this->cPointerID = $cPointerID;
-                    $this->cIsActive = $cIsActiveOverride;
-                    $this->cPointerOriginalID = $cPointerOriginalID;
-                    $this->cPath = $cPathOverride;
-                    $this->cParentID = $cParentIDOverride;
-                    $this->cDisplayOrder = $cDisplayOrderOverride;
+                if ($originalRow !== null) {
+                    $this->cPointerID = $originalRow['cPointerID'];
+                    $this->cIsActive = $originalRow['cIsActive'];
+                    $this->cPointerOriginalID = $originalRow['cID'];
+                    $this->cPath = $originalRow['cPath'];
+                    $this->cParentID = $originalRow['cParentID'];
+                    $this->cDisplayOrder = $originalRow['cDisplayOrder'];
                 }
                 $this->isMasterCollection = $row['cIsTemplate'];
             } else {

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -180,13 +180,12 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             }
             $this->isMasterCollection = $row['cIsTemplate'];
             $this->loadError(false);
+            if ($cvID != false) {
+                $this->loadVersionObject($cvID);
+            }
         } else {
             // there was no record of this particular collection in the database
             $this->loadError(COLLECTION_NOT_FOUND);
-        }
-
-        if ($cvID != false && !$this->isError()) {
-            $this->loadVersionObject($cvID);
         }
     }
 

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -160,44 +160,35 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         $q0 = 'select Pages.cID, Pages.pkgID, Pages.siteTreeID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsDraft, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Pages.ptID, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ';
         //$q2 = "select cParentID, cPointerID, cPath, Pages.cID from Pages left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
 
-        $r = $db->executeQuery($q0 . $where, [$cInfo]);
-        $row = $r->fetchRow();
-        if ($row['cPointerID'] > 0) {
+        $row = $db->fetchAssoc($q0 . $where, [$cInfo]);
+        if ($row !== false && $row['cPointerID'] > 0) {
             $originalRow = $row;
-            $r = $db->executeQuery($q0 . 'where Pages.cID = ?', [$row['cPointerID']]);
-            $row = $r->fetchRow();
+            $row = $db->fetchAssoc($q0 . 'where Pages.cID = ?', [$row['cPointerID']]);
         } else {
             $originalRow = null;
         }
 
-        if ($r) {
-            if ($row) {
-                foreach ($row as $key => $value) {
-                    $this->{$key} = $value;
-                }
-                if ($originalRow !== null) {
-                    $this->cPointerID = $originalRow['cPointerID'];
-                    $this->cIsActive = $originalRow['cIsActive'];
-                    $this->cPointerOriginalID = $originalRow['cID'];
-                    $this->cPath = $originalRow['cPath'];
-                    $this->cParentID = $originalRow['cParentID'];
-                    $this->cDisplayOrder = $originalRow['cDisplayOrder'];
-                }
-                $this->isMasterCollection = $row['cIsTemplate'];
-            } else {
-                // there was no record of this particular collection in the database
-                $this->loadError(COLLECTION_NOT_FOUND);
+        if ($row !== false) {
+            foreach ($row as $key => $value) {
+                $this->{$key} = $value;
             }
-            $r->free();
+            if ($originalRow !== null) {
+                $this->cPointerID = $originalRow['cPointerID'];
+                $this->cIsActive = $originalRow['cIsActive'];
+                $this->cPointerOriginalID = $originalRow['cID'];
+                $this->cPath = $originalRow['cPath'];
+                $this->cParentID = $originalRow['cParentID'];
+                $this->cDisplayOrder = $originalRow['cDisplayOrder'];
+            }
+            $this->isMasterCollection = $row['cIsTemplate'];
         } else {
+            // there was no record of this particular collection in the database
             $this->loadError(COLLECTION_NOT_FOUND);
         }
 
         if ($cvID != false && !$this->isError()) {
             $this->loadVersionObject($cvID);
         }
-
-        unset($r);
     }
 
     public function getPermissionResponseClassName()


### PR DESCRIPTION
- (5a57d38762b036d25f396a7919938049d7552f5b) in case of page aliases, let's just use the `$row` variable containing the alias data, there's no need to extract the wanted fields one by one
- (e5016043ac089a67ca187c96f45670abd2f61203) the result of `executeQuery` for select queries is always a `Statement` object, there's no need to check if it's not falsy (in case of errors, Doctrine throws exceptions, doesn't return falsy values)
- (e5016043ac089a67ca187c96f45670abd2f61203) we can use `fetchAssoc` instead of `executeQuery` + `fetchRow`, which returns `false` if no row is found