### PR TITLE
allow resizing for SVG images on image block.

### DIFF
--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -351,8 +351,8 @@ class Controller extends BlockController implements FileTrackableInterface
             $e->add(t('Cropping an image requires setting a max width and max height.'));
         }
 
-        if ($svg && isset($args['constrainImage'])) {
-            $e->add(t('SVG images cannot be size constrained.'));
+        if ($svg && isset($args['cropImage'])) {
+            $e->add(t('SVG images cannot be cropped.'));
         }
 
         return $e;

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -5,6 +5,12 @@ if (is_object($f) && $f->getFileID()) {
     if ($f->getTypeObject()->isSVG()) {
         $tag = new \HtmlObject\Image();
         $tag->src($f->getRelativePath());
+         if ($maxWidth > 0) {
+            $tag->width($maxWidth);
+        }
+        if ($maxHeight > 0) {
+            $tag->height($maxHeight);
+        }
         $tag->addClass('ccm-svg');
     } elseif ($maxWidth > 0 || $maxHeight > 0) {
         $im = $app->make('helper/image');


### PR DESCRIPTION
In my opinion this option should not be excluded from image Block. Imagine a concrete5-template with a logo Area in which the user wants to add an SVG Logo with image Block. Why he can't have the option to resize this SVG image?