### PR TITLE
Avoid displaying an empty message when forcing exit edit mode

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -417,7 +417,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
         if ($pageInUseBySomeoneElse) {
             $buttons = array();
             if ($canApprovePageVersions) {
-                $buttons[] = '<a onclick="$.get(\'' . REL_DIR_FILES_TOOLS_REQUIRED . '/dashboard/sitemap_check_in?cID=' . $c->getCollectionID() . $token . '\', function() { window.location.reload(); })" href="javascript:void(0)" class="dialog-launch btn btn-xs btn-default">' . t('Force Exit Edit Mode') . '</a>';
+                $buttons[] = '<a onclick="$.get(\'' . REL_DIR_FILES_TOOLS_REQUIRED . '/dashboard/sitemap_check_in?cID=' . $c->getCollectionID() . $token . '\', function() { window.location.reload(); })" href="javascript:void(0)" class="btn btn-xs btn-default">' . t('Force Exit Edit Mode') . '</a>';
             }
 
             echo $cih->notify(array(


### PR DESCRIPTION
When we hit the "Force Exit Edit Mode" button, an empty dialog, users see an empty dialog (the Italian "dice" means "says"):

![immagine](https://user-images.githubusercontent.com/928116/45922096-3e6c8680-bec3-11e8-847e-a3dcbeb5a884.png)

Let's avoid that.