### PR TITLE
Translate checkbox labels

### DIFF
--- a/concrete/attributes/boolean/controller.php
+++ b/concrete/attributes/boolean/controller.php
@@ -65,7 +65,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
             return $this->akCheckboxLabel;
         }
 
-        return $this->attributeKey->getAttributeKeyName();
+        return $this->attributeKey->getAttributeKeyDisplayName();
     }
 
     public function exportKey($akey)


### PR DESCRIPTION
For example, in the registration page in Italian we currently have this:

> ![immagine](https://user-images.githubusercontent.com/928116/45961163-28bfa400-c01e-11e8-814e-c1c2bada5eef.png)

as you can see, there are mixed Italian (correct) and English (wrong) texts.

With this fix, we'll have:

> ![immagine](https://user-images.githubusercontent.com/928116/45961194-3ecd6480-c01e-11e8-9d9a-7a4aabba51c3.png)
