### PR TITLE
Allow filtering blocks in the add_block_list dialog used in Stacks

### DIFF
--- a/concrete/views/dialogs/page/add_block_list.php
+++ b/concrete/views/dialogs/page/add_block_list.php
@@ -11,50 +11,83 @@ defined('C5_EXECUTE') or die('Access Denied.');
 $id = str_replace('.', '_', uniqid('ccm-add-block-lists-', true));
 ?>
 <div id="<?= $id ?>">
+    <div class="input-group">
+        <span class="input-group-addon">
+            <i class="fa fa-search"></i>
+        </span>
+        <input type="search" class="form-control" autofocus="autofocus" />
+    </div>
+    <br />
     <?php
     foreach ($blockTypesForSets as $setName => $blockTypes) {
         ?>
-        <div class="ccm-ui ccm-add-block-list">
-            <section>
-                <legend><?= $setName ?></legend>
-                <ul class="item-select-list">
-                    <?php
-                    foreach ($blockTypes as $bt) {
-                        $btIcon = $ci->getBlockTypeIconURL($bt);
-                        ?>
-                        <li>
-                            <a
-                                data-cID="<?= $c->getCollectionID() ?>"
-                                data-block-type-handle="<?= $bt->getBlockTypeHandle() ?>"
-                                data-block-type-name="<?= h(t($bt->getBlockTypeName())) ?>"
-                                data-block-type-description="<?= h(t($bt->getBlockTypeDescription())) ?>"
-                                data-dialog-title="<?= t('Add %s', t($bt->getBlockTypeName())) ?>"
-                                data-dialog-width="<?= $bt->getBlockTypeInterfaceWidth() ?>"
-                                data-dialog-height="<?= $bt->getBlockTypeInterfaceHeight() ?>"
-                                data-has-add-template="<?= $bt->hasAddTemplate() ?>"
-                                data-supports-inline-add="<?= $bt->supportsInlineAdd() ?>"
-                                data-btID="<?= $bt->getBlockTypeID() ?>"
-                                title="<?= t($bt->getBlockTypeName()) ?>"
-                                href="javascript:void(0)"
-                            ><img src="<?=$btIcon?>" /> <?=t($bt->getBlockTypeName())?></a>
-                        </li>
-                        <?php
-                    }
+        <section>
+            <legend><?= $setName ?></legend>
+            <ul class="item-select-list">
+                <?php
+                foreach ($blockTypes as $bt) {
+                    $btIcon = $ci->getBlockTypeIconURL($bt);
                     ?>
-                </ul>
-            </section>
-            <?php
+                    <li>
+                        <a
+                            data-cID="<?= $c->getCollectionID() ?>"
+                            data-block-type-handle="<?= $bt->getBlockTypeHandle() ?>"
+                            data-block-type-name="<?= h(t($bt->getBlockTypeName())) ?>"
+                            data-block-type-description="<?= h(t($bt->getBlockTypeDescription())) ?>"
+                            data-dialog-title="<?= t('Add %s', t($bt->getBlockTypeName())) ?>"
+                            data-dialog-width="<?= $bt->getBlockTypeInterfaceWidth() ?>"
+                            data-dialog-height="<?= $bt->getBlockTypeInterfaceHeight() ?>"
+                            data-has-add-template="<?= $bt->hasAddTemplate() ?>"
+                            data-supports-inline-add="<?= $bt->supportsInlineAdd() ?>"
+                            data-btID="<?= $bt->getBlockTypeID() ?>"
+                            title="<?= h(t($bt->getBlockTypeDescription())) ?>"
+                            href="javascript:void(0)"
+                        ><img src="<?=$btIcon?>" /> <?=t($bt->getBlockTypeName())?></a>
+                    </li>
+                    <?php
+                }
+                ?>
+            </ul>
+        </section>
+        <?php
         }
         ?>
     </div>
 </div>
 <script>
     $(function() {
-        $('#<?= $id ?> a').on('click', function() {
+        var $list = $('#<?= $id ?>'),
+            $search = $list.find('input[type="search"]');
+
+        $search.on('keydown keypress keyup change blur', function() {
+            var search = $.trim($search.val()).toLowerCase();
+            $list.find('section').each(function() {
+                var $section = $(this),
+                    someDisplayed = false;
+                $section.find('li a').each(function() {
+                    var $a = $(this),
+                        $li = $a.closest('li');
+                    if (search === '' || ($a.data('block-type-name') || '').toLowerCase().indexOf(search) >= 0 || ($a.data('block-type-description') || '').toLowerCase().indexOf(search) >= 0) {
+                        $li.show();
+                        someDisplayed = true;
+                    } else {
+                        $li.hide();
+                    }
+                });
+                $section.toggle(someDisplayed);
+            });
+        });
+
+        $list.find('a').on('click', function() {
             ConcreteEvent.publish('AddBlockListAddBlock', {
                 $launcher: $(this)
             });
             return false;
         });
+
+        setTimeout(function() {
+            $search.focus();
+        }, 250);
+
     });
 </script>

--- a/concrete/views/dialogs/page/add_block_list.php
+++ b/concrete/views/dialogs/page/add_block_list.php
@@ -22,6 +22,8 @@ foreach ($blockTypesForSets as $setName => $blockTypes) {
                         <a
                             data-cID="<?= $c->getCollectionID() ?>"
                             data-block-type-handle="<?= $bt->getBlockTypeHandle() ?>"
+                            data-block-type-name="<?= h(t($bt->getBlockTypeName())) ?>"
+                            data-block-type-description="<?= h(t($bt->getBlockTypeDescription())) ?>"
                             data-dialog-title="<?= t('Add %s', t($bt->getBlockTypeName())) ?>"
                             data-dialog-width="<?= $bt->getBlockTypeInterfaceWidth() ?>"
                             data-dialog-height="<?= $bt->getBlockTypeInterfaceHeight() ?>"

--- a/concrete/views/dialogs/page/add_block_list.php
+++ b/concrete/views/dialogs/page/add_block_list.php
@@ -8,44 +8,49 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var Concrete\Core\Entity\Block\BlockType\BlockType[] $blockTypesForSets */
 
-foreach ($blockTypesForSets as $setName => $blockTypes) {
-    ?>
-    <div class="ccm-ui" id="ccm-add-block-list">
-        <section>
-            <legend><?= $setName ?></legend>
-            <ul class="item-select-list">
-                <?php
-                foreach ($blockTypes as $bt) {
-                    $btIcon = $ci->getBlockTypeIconURL($bt);
-                    ?>
-                    <li>
-                        <a
-                            data-cID="<?= $c->getCollectionID() ?>"
-                            data-block-type-handle="<?= $bt->getBlockTypeHandle() ?>"
-                            data-block-type-name="<?= h(t($bt->getBlockTypeName())) ?>"
-                            data-block-type-description="<?= h(t($bt->getBlockTypeDescription())) ?>"
-                            data-dialog-title="<?= t('Add %s', t($bt->getBlockTypeName())) ?>"
-                            data-dialog-width="<?= $bt->getBlockTypeInterfaceWidth() ?>"
-                            data-dialog-height="<?= $bt->getBlockTypeInterfaceHeight() ?>"
-                            data-has-add-template="<?= $bt->hasAddTemplate() ?>"
-                            data-supports-inline-add="<?= $bt->supportsInlineAdd() ?>"
-                            data-btID="<?= $bt->getBlockTypeID() ?>"
-                            title="<?= t($bt->getBlockTypeName()) ?>"
-                            href="javascript:void(0)"
-                        ><img src="<?=$btIcon?>" /> <?=t($bt->getBlockTypeName())?></a>
-                    </li>
+$id = str_replace('.', '_', uniqid('ccm-add-block-lists-', true));
+?>
+<div id="<?= $id ?>">
+    <?php
+    foreach ($blockTypesForSets as $setName => $blockTypes) {
+        ?>
+        <div class="ccm-ui ccm-add-block-list">
+            <section>
+                <legend><?= $setName ?></legend>
+                <ul class="item-select-list">
                     <?php
-                }
-                ?>
-            </ul>
-        </section>
-        <?php
-    }
-    ?>
+                    foreach ($blockTypes as $bt) {
+                        $btIcon = $ci->getBlockTypeIconURL($bt);
+                        ?>
+                        <li>
+                            <a
+                                data-cID="<?= $c->getCollectionID() ?>"
+                                data-block-type-handle="<?= $bt->getBlockTypeHandle() ?>"
+                                data-block-type-name="<?= h(t($bt->getBlockTypeName())) ?>"
+                                data-block-type-description="<?= h(t($bt->getBlockTypeDescription())) ?>"
+                                data-dialog-title="<?= t('Add %s', t($bt->getBlockTypeName())) ?>"
+                                data-dialog-width="<?= $bt->getBlockTypeInterfaceWidth() ?>"
+                                data-dialog-height="<?= $bt->getBlockTypeInterfaceHeight() ?>"
+                                data-has-add-template="<?= $bt->hasAddTemplate() ?>"
+                                data-supports-inline-add="<?= $bt->supportsInlineAdd() ?>"
+                                data-btID="<?= $bt->getBlockTypeID() ?>"
+                                title="<?= t($bt->getBlockTypeName()) ?>"
+                                href="javascript:void(0)"
+                            ><img src="<?=$btIcon?>" /> <?=t($bt->getBlockTypeName())?></a>
+                        </li>
+                        <?php
+                    }
+                    ?>
+                </ul>
+            </section>
+            <?php
+        }
+        ?>
+    </div>
 </div>
 <script>
     $(function() {
-        $('#ccm-add-block-list').on('click', 'a', function() {
+        $('#<?= $id ?> a').on('click', function() {
             ConcreteEvent.publish('AddBlockListAddBlock', {
                 $launcher: $(this)
             });


### PR DESCRIPTION
When adding new blocks to a stack, we are presented a full list of blocks, without the possibility to quickly filter it.

What about this?

![filter-add-block-stacks](https://user-images.githubusercontent.com/928116/45963748-2b24fc80-c024-11e8-9903-32551da939f0.gif)

PS: this `/views/dialogs/page/add_block_list.php` view is not the one used when adding blocks to pages, which is `/views/panels/add.php`