### PR TITLE
Implement OAuth2 Authorization Grant and an authentication type to hook into it

### DIFF
--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -170,6 +170,7 @@ class Controller extends GenericOauth2TypeController
      */
     private function setData()
     {
+        $data = $this->config->get('auth.external_concrete5', '');
         $authUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_auth']);
         $attachUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_attach']);
         $baseUrl = $this->urlResolver->resolve(['/']);
@@ -177,6 +178,7 @@ class Controller extends GenericOauth2TypeController
         $path->remove('index.php');
         $name = trim((string) array_get($data, 'name', t('External concrete5')));
 
+        $this->set('data', $data);
         $this->set('authUrl', $authUrl);
         $this->set('attachUrl', $attachUrl);
         $this->set('baseUrl', $baseUrl);

--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -6,6 +6,7 @@ use Concrete\Core\Authentication\Type\ExternalConcrete5\ServiceFactory;
 use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\User\Group\GroupList;
 use League\Url\Url;
 
 class Controller extends GenericOauth2TypeController
@@ -17,34 +18,54 @@ class Controller extends GenericOauth2TypeController
     /** @var \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface */
     protected $urlResolver;
 
+    /** @var \Concrete\Core\Config\Repository\Repository */
+    protected $config;
+
     public function __construct(
         \Concrete\Core\Authentication\AuthenticationType $type = null,
         ServiceFactory $factory,
-        ResolverManagerInterface $urlResolver)
+        ResolverManagerInterface $urlResolver,
+        Repository $config)
     {
         parent::__construct($type);
         $this->factory = $factory;
         $this->urlResolver = $urlResolver;
+        $this->config = $config;
     }
 
+    /**
+     * Get the ID of the group to enter upon registration
+     * This method grabs the registration group ID out of the auth config group
+     *
+     * @return int
+     */
     public function registrationGroupID()
     {
-        $config = $this->app->make(Repository::class);
-        return $config->get('auth.external_concrete5.registration.group');
+        return (int) $this->config->get('auth.external_concrete5.registration.group');
     }
 
+    /**
+     * Determine whether this type supports automatically registering users
+     * This method grabs this configuration from the auth config group
+     *
+     * @return bool
+     */
     public function supportsRegistration()
     {
-        $config = $this->app->make(Repository::class);
-        return $config->get('auth.external_concrete5.registration.enabled', false);
+        return (bool) $this->config->get('auth.external_concrete5.registration.enabled', false);
     }
 
+    /**
+     * Build and return this authentication type's icon HTML
+     *
+     * @return string
+     */
     public function getAuthenticationTypeIconHTML()
     {
-        return '<div class="ccm-concrete-authentication-type-svg" ' .
-            'data-src="/concrete/images/authentication/community/concrete.svg">' .
-            file_get_contents(DIR_BASE_CORE . '/images/authentication/community/concrete.svg') .
-            '</div>';
+        $svgData = file_get_contents(DIR_BASE_CORE . '/images/authentication/community/concrete.svg');
+        $publicSrc = '/concrete/images/authentication/community/concrete.svg';
+
+        return "<div class='ccm-concrete-authentication-type-svg' data-src='{$publicSrc}'>{$svgData}</div>";
     }
 
     public function getHandle()
@@ -53,7 +74,10 @@ class Controller extends GenericOauth2TypeController
     }
 
     /**
-     * @return \Concrete\Core\Api\OAuth\Service\ExternalConcrete5
+     * Get the service object associated with this authentication type
+     * This method uses the oauth/factory/service object to create our service if one is not set
+     *
+     * @return \Concrete\Core\Authentication\Type\ExternalConcrete5\ExternalConcrete5Service
      */
     public function getService()
     {
@@ -66,39 +90,57 @@ class Controller extends GenericOauth2TypeController
         return $this->service;
     }
 
+    /**
+     * Save data for this authentication type
+     * This method is called when the type_form.php submits. It stores client details and configuration for connecting
+     *
+     * @param array|\Traversable $args
+     */
     public function saveAuthenticationType($args)
     {
-        $passedUrl = $args['url'];
-        try {
-            $url = Url::createFromUrl($passedUrl);
+        $passedUrl = trim($args['url']);
 
-            if (!(string)$url->getScheme() || !(string)$url->getHost()) {
-                throw new \InvalidArgumentException('No scheme or host provided.');
+        if ($passedUrl) {
+            try {
+                $url = Url::createFromUrl($passedUrl);
+
+                if (!(string)$url->getScheme() || !(string)$url->getHost()) {
+                    throw new \InvalidArgumentException('No scheme or host provided.');
+                }
+
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException('Invalid URL.');
             }
-
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('Invalid URL.');
         }
 
         $config = $this->app->make(Repository::class);
         $config->save('auth.external_concrete5.url', $args['url']);
         $config->save('auth.external_concrete5.appid', $args['apikey']);
         $config->save('auth.external_concrete5.secret', $args['apisecret']);
-        $config->save('auth.external_concrete5.registration.enabled', (bool)$args['registration_enabled']);
+        $config->save('auth.external_concrete5.registration.enabled', (bool) $args['registration_enabled']);
         $config->save('auth.external_concrete5.registration.group', intval($args['registration_group'], 10));
     }
 
+    /**
+     * Controller method for type_form
+     * This method is called just before rendering type_form.php, use it to set data for that template
+     */
     public function edit()
     {
         $config = $this->app->make(Repository::class);
         $this->set('form', $this->app->make('helper/form'));
         $this->set('data', $config->get('auth.external_concrete5', ''));
+        $this->set('redirectUri', $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/callback']));
 
-        $list = new \GroupList();
+        $list = $this->app->make(GroupList::class);
         $list->includeAllGroups();
         $this->set('groups', $list->getResults());
     }
 
+    /**
+     * Controller method for form
+     * This method is called just before form.php is rendered, use it to set data for that template
+     */
     public function form()
     {
         $authUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_auth']);

--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Concrete\Authentication\ExternalConcrete5;
+
+use Concrete\Core\Authentication\Type\ExternalConcrete5\ServiceFactory;
+use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use League\Url\Url;
+
+class Controller extends GenericOauth2TypeController
+{
+
+    /** @var \Concrete\Core\Authentication\Type\ExternalConcrete5\ServiceFactory */
+    protected $factory;
+
+    /** @var \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface */
+    protected $urlResolver;
+
+    public function __construct(
+        \Concrete\Core\Authentication\AuthenticationType $type = null,
+        ServiceFactory $factory,
+        ResolverManagerInterface $urlResolver)
+    {
+        parent::__construct($type);
+        $this->factory = $factory;
+        $this->urlResolver = $urlResolver;
+    }
+
+    public function registrationGroupID()
+    {
+        $config = $this->app->make(Repository::class);
+        return $config->get('auth.external_concrete5.registration.group');
+    }
+
+    public function supportsRegistration()
+    {
+        $config = $this->app->make(Repository::class);
+        return $config->get('auth.external_concrete5.registration.enabled', false);
+    }
+
+    public function getAuthenticationTypeIconHTML()
+    {
+        return '<div class="ccm-concrete-authentication-type-svg" ' .
+            'data-src="/concrete/images/authentication/community/concrete.svg">' .
+            file_get_contents(DIR_BASE_CORE . '/images/authentication/community/concrete.svg') .
+            '</div>';
+    }
+
+    public function getHandle()
+    {
+        return 'external_concrete5';
+    }
+
+    /**
+     * @return \Concrete\Core\Api\OAuth\Service\ExternalConcrete5
+     */
+    public function getService()
+    {
+        if (!$this->service) {
+            /** @var \OAuth\ServiceFactory $serviceFactory */
+            $serviceFactory = $this->app->make('oauth/factory/service');
+            $this->service = $this->factory->createService($serviceFactory);
+        }
+
+        return $this->service;
+    }
+
+    public function saveAuthenticationType($args)
+    {
+        $passedUrl = $args['url'];
+        try {
+            $url = Url::createFromUrl($passedUrl);
+
+            if (!(string)$url->getScheme() || !(string)$url->getHost()) {
+                throw new \InvalidArgumentException('No scheme or host provided.');
+            }
+
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException('Invalid URL.');
+        }
+
+        $config = $this->app->make(Repository::class);
+        $config->save('auth.external_concrete5.url', $args['url']);
+        $config->save('auth.external_concrete5.appid', $args['apikey']);
+        $config->save('auth.external_concrete5.secret', $args['apisecret']);
+        $config->save('auth.external_concrete5.registration.enabled', (bool)$args['registration_enabled']);
+        $config->save('auth.external_concrete5.registration.group', intval($args['registration_group'], 10));
+    }
+
+    public function edit()
+    {
+        $config = $this->app->make(Repository::class);
+        $this->set('form', $this->app->make('helper/form'));
+        $this->set('data', $config->get('auth.external_concrete5', ''));
+
+        $list = new \GroupList();
+        $list->includeAllGroups();
+        $this->set('groups', $list->getResults());
+    }
+
+    public function form()
+    {
+        $authUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_auth']);
+        $attachUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_attach']);
+        $baseUrl = $this->urlResolver->resolve(['/']);
+        $path = $baseUrl->getPath();
+        $path->remove('index.php');
+
+        $this->set('authUrl', $authUrl);
+        $this->set('attachUrl', $attachUrl);
+        $this->set('baseUrl', $baseUrl);
+        $this->set('assetBase', $baseUrl->setPath($path));
+    }
+}

--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -7,6 +7,7 @@ use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\User\Group\GroupList;
+use Concrete\Core\User\User;
 use League\Url\Url;
 
 class Controller extends GenericOauth2TypeController
@@ -143,15 +144,44 @@ class Controller extends GenericOauth2TypeController
      */
     public function form()
     {
+        $this->setData();
+    }
+
+    /**
+     * Controller method for the hook template
+     * This method is called before hook.php is rendered, use it to set data for that template
+     */
+    public function hook()
+    {
+        $this->setData();
+    }
+
+    /**
+     * Controller method for the hooked template
+     * This method gets called before hooked.php is rendered, use it to set data for that template
+     */
+    public function hooked()
+    {
+        $this->setData();
+    }
+
+    /**
+     * Method for setting general data for all views
+     */
+    private function setData()
+    {
         $authUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_auth']);
         $attachUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/attempt_attach']);
         $baseUrl = $this->urlResolver->resolve(['/']);
         $path = $baseUrl->getPath();
         $path->remove('index.php');
+        $name = trim((string) array_get($data, 'name', t('External concrete5')));
 
         $this->set('authUrl', $authUrl);
         $this->set('attachUrl', $attachUrl);
         $this->set('baseUrl', $baseUrl);
         $this->set('assetBase', $baseUrl->setPath($path));
+        $this->set('name', $name);
+        $this->set('user', $this->app->make(User::class));
     }
 }

--- a/concrete/authentication/external_concrete5/form.php
+++ b/concrete/authentication/external_concrete5/form.php
@@ -1,0 +1,107 @@
+<?php defined('C5_EXECUTE') or die('Access denied.');
+
+$name = trim((string) array_get($data, 'name', t('External concrete5')));
+$leadingVowel = $name ? in_array(strtolower($name[0]), ['a', 'e', 'i', 'o', 'u'], true) : false;
+
+if (isset($error)) {
+    ?>
+    <div class="alert alert-danger"><?= $error ?></div>
+    <?php
+
+}
+if (isset($message)) {
+    ?>
+    <div class="alert alert-success"><?= $message ?></div>
+<?php
+
+}
+
+$user = new User();
+
+if ($user->isLoggedIn()) {
+    ?>
+    <div class="form-group">
+        <span>
+            <?= $leadingVowel ? t('Attach an %s account', $name) : t('Attach a %s account', $name) ?>
+        </span>
+        <hr>
+    </div>
+    <div class="form-group">
+        <a href="<?= $attachUrl ?>" class="btn btn-success btn-login btn-attach btn-block">
+            <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
+            <?= $leadingVowel ? t('Attach an %s account', $name) : t('Attach a %s account', $name) ?>
+        </a>
+    </div>
+    <?php
+
+} else {
+    ?>
+    <div class="form-group">
+        <span>
+            <?= $leadingVowel ? t('Sign in with an %s account', $name) : t('Sign in with a %s account', $name) ?>
+        </span>
+        <hr class="ccm-authentication-type-external-concrete5">
+    </div>
+    <div class="form-group">
+        <a href="<?= $authUrl ?>" class="btn btn-success btn-login btn-block">
+            <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
+            <?= t('Log in with ' . $name) ?>
+        </a>
+    </div>
+    <?php
+
+}
+?>
+<style>
+    .ccm-ui .btn-community {
+        border-width: 0px;
+        background: rgb(31,186,232);
+        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
+        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
+    }
+
+    .ccm-concrete-authentication-type-svg > svg {
+      width: 16px;
+    }
+
+    img.concrete5-icon {
+        width: 20px;
+        margin-right:5px;
+    }
+</style>
+<script>
+    (function() {
+        var svg = $('.ccm-concrete-authentication-type-svg > svg');
+
+        if (svg) {
+            var img = new Image();
+            img.onerror = function() {
+                svg.parent().replaceWith('<i class="fa fa-user"></i>');
+            };
+            img.src = svg.parent().data('src');
+            $(function() {
+
+                if (svg.closest('li').hasClass('active')) {
+                    var color = $('ul.auth-types li.active').css('color');
+                    svg.attr('fill', color);
+                } else {
+                    svg.attr('fill', 'rgb(155,155,155)');
+                }
+                Concrete.event.bind('AuthenticationTypeSelected', function(e, handle) {
+                    if (handle === 'community') {
+                        var color = $('ul.auth-types li.active').css('color');
+                        svg.attr('fill', color);
+                    } else {
+                        svg.attr('fill', 'rgb(155,155,155)');
+                    }
+                });
+
+            });
+        }
+    }());
+</script>

--- a/concrete/authentication/external_concrete5/form.php
+++ b/concrete/authentication/external_concrete5/form.php
@@ -33,7 +33,7 @@ if ($user->getUserID() && $user->checkLogin()) {
     ?>
     <div class="form-group">
         <span>
-            <?= t('Sign in with you %s account', h($name)) ?>
+            <?= t('Sign in with your %s account', h($name)) ?>
         </span>
         <hr class="ccm-authentication-type-external-concrete5">
     </div>

--- a/concrete/authentication/external_concrete5/form.php
+++ b/concrete/authentication/external_concrete5/form.php
@@ -1,8 +1,5 @@
 <?php defined('C5_EXECUTE') or die('Access denied.');
 
-$name = trim((string) array_get($data, 'name', t('External concrete5')));
-$leadingVowel = $name ? in_array(strtolower($name[0]), ['a', 'e', 'i', 'o', 'u'], true) : false;
-
 if (isset($error)) {
     ?>
     <div class="alert alert-danger"><?= $error ?></div>
@@ -16,20 +13,18 @@ if (isset($message)) {
 
 }
 
-$user = new User();
-
-if ($user->isLoggedIn()) {
+if ($user->getUserID() && $user->checkLogin()) {
     ?>
     <div class="form-group">
         <span>
-            <?= $leadingVowel ? t('Attach an %s account', $name) : t('Attach a %s account', $name) ?>
+            <?= t('Attach your %s account', h($name)) ?>
         </span>
         <hr>
     </div>
     <div class="form-group">
         <a href="<?= $attachUrl ?>" class="btn btn-success btn-login btn-attach btn-block">
             <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= $leadingVowel ? t('Attach an %s account', $name) : t('Attach a %s account', $name) ?>
+            <?= t('Attach your %s account', h($name)) ?>
         </a>
     </div>
     <?php
@@ -38,14 +33,14 @@ if ($user->isLoggedIn()) {
     ?>
     <div class="form-group">
         <span>
-            <?= $leadingVowel ? t('Sign in with an %s account', $name) : t('Sign in with a %s account', $name) ?>
+            <?= t('Sign in with you %s account', h($name)) ?>
         </span>
         <hr class="ccm-authentication-type-external-concrete5">
     </div>
     <div class="form-group">
         <a href="<?= $authUrl ?>" class="btn btn-success btn-login btn-block">
             <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= t('Log in with ' . $name) ?>
+            <?= t('Log in with %s', h($name)) ?>
         </a>
     </div>
     <?php

--- a/concrete/authentication/external_concrete5/hook.php
+++ b/concrete/authentication/external_concrete5/hook.php
@@ -2,14 +2,14 @@
 
 <div class="form-group">
         <span>
-            <?= t('Attach a community account') ?>
+            <?= t('Attach your %s account', h($name)) ?>
         </span>
     <hr>
 </div>
 <div class="form-group">
-    <a href="<?= \URL::to('/ccm/system/authentication/oauth2/external_concrete5/attempt_attach'); ?>" class="btn btn-primary btn-community">
-        <img src="<?= \Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
-        <?= t('Attach a concrete5.org account') ?>
+    <a href="<?= $attachUrl ?>" class="btn btn-primary btn-success btn-external-concrete5">
+        <img src="<?= $assetUrl ?>/concrete/images/logo.svg" class="concrete5-icon" />
+        <?= t('Attach your %s account', h($name)) ?>
     </a>
 </div>
 

--- a/concrete/authentication/external_concrete5/hook.php
+++ b/concrete/authentication/external_concrete5/hook.php
@@ -1,0 +1,33 @@
+<?php defined('C5_EXECUTE') or die('Access denied.'); ?>
+
+<div class="form-group">
+        <span>
+            <?= t('Attach a community account') ?>
+        </span>
+    <hr>
+</div>
+<div class="form-group">
+    <a href="<?= \URL::to('/ccm/system/authentication/oauth2/external_concrete5/attempt_attach'); ?>" class="btn btn-primary btn-community">
+        <img src="<?= \Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
+        <?= t('Attach a concrete5.org account') ?>
+    </a>
+</div>
+
+<style>
+    .ccm-ui .btn-community {
+        border-width: 0px;
+        background: rgb(31,186,232);
+        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
+        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
+    }
+
+    img.concrete5-icon {
+        width: 20px;
+        margin-right:5px;
+    }
+</style>

--- a/concrete/authentication/external_concrete5/hooked.php
+++ b/concrete/authentication/external_concrete5/hooked.php
@@ -1,30 +1,4 @@
-<?php defined('C5_EXECUTE') or die('Access denied.');
-
-/* @var Concrete\Authentication\Community\Controller $controller */
-$url = $controller->getConcrete5ProfileURL(new User())
-?>
+<?php defined('C5_EXECUTE') or die('Access denied.') ?>
 <div class="form-group">
-    <a href="<?= h($url) ?>" class="btn btn-primary btn-community">
-        <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
-        <?= t('View your concrete5 account') ?>
-    </a>
+    <?= t('You\'ve already attached a %s account', $name) ?>
 </div>
-
-<style>
-    .ccm-ui .btn-community {
-        border-width: 0px;
-        background: rgb(31,186,232);
-        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
-        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
-    }
-
-    img.concrete5-icon {
-        width: 20px;
-        margin-right:5px;
-    }
-</style>

--- a/concrete/authentication/external_concrete5/hooked.php
+++ b/concrete/authentication/external_concrete5/hooked.php
@@ -1,4 +1,4 @@
 <?php defined('C5_EXECUTE') or die('Access denied.') ?>
 <div class="form-group">
-    <?= t('You\'ve already attached a %s account', $name) ?>
+    <?= t('You\'ve already attached your %s account', $name) ?>
 </div>

--- a/concrete/authentication/external_concrete5/hooked.php
+++ b/concrete/authentication/external_concrete5/hooked.php
@@ -1,0 +1,30 @@
+<?php defined('C5_EXECUTE') or die('Access denied.');
+
+/* @var Concrete\Authentication\Community\Controller $controller */
+$url = $controller->getConcrete5ProfileURL(new User())
+?>
+<div class="form-group">
+    <a href="<?= h($url) ?>" class="btn btn-primary btn-community">
+        <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon" />
+        <?= t('View your concrete5 account') ?>
+    </a>
+</div>
+
+<style>
+    .ccm-ui .btn-community {
+        border-width: 0px;
+        background: rgb(31,186,232);
+        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
+        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
+    }
+
+    img.concrete5-icon {
+        width: 20px;
+        margin-right:5px;
+    }
+</style>

--- a/concrete/authentication/external_concrete5/type_form.php
+++ b/concrete/authentication/external_concrete5/type_form.php
@@ -1,0 +1,72 @@
+<?php defined('C5_EXECUTE') or die('Access denied.'); ?>
+<div class='form-group'>
+    <?=$form->label('url', t('External concrete5 URL'))?>
+    <?=$form->text('url', $data['url'])?>
+</div>
+<div class='form-group'>
+    <?=$form->label('apikey', t('App ID'))?>
+    <?=$form->text('apikey', $data['appid'])?>
+</div>
+<div class='form-group'>
+    <?=$form->label('apisecret', t('App Secret'))?>
+    <div class="input-group">
+        <?=$form->password('apisecret', $data['secret'], array('autocomplete' => 'off'))?>
+        <span class="input-group-btn">
+        <button id="showsecret" class="btn btn-warning" type="button"><?php echo t('Show secret key')?></button>
+      </span>
+    </div>
+</div>
+<div class='form-group'>
+    <div class="input-group">
+        <label type="checkbox">
+            <input type="checkbox" name="registration_enabled" value="1" <?= $data['enabled'] ? 'checked' : '' ?>>
+            <span style="font-weight:normal"><?= t('Allow automatic registration') ?></span>
+        </label>
+      </span>
+    </div>
+</div>
+<div class='form-group registration-group'>
+    <label for="registration_group" class="control-label"><?= t('Group to enter on registration') ?></label>
+    <select name="registration_group" class="form-control">
+        <option value="0"><?= t("None") ?></option>
+        <?php
+        /** @var \Group $group */
+        foreach ($groups as $group) {
+            ?>
+            <option value="<?= $group->getGroupID() ?>" <?= intval($group->getGroupID(), 10) === intval(
+                $data['group'],
+                10) ? 'selected' : '' ?>>
+                <?= $group->getGroupDisplayName(false) ?>
+            </option>
+        <?php
+
+        }
+        ?>
+    </select>
+</div>
+
+<script type="text/javascript">
+
+    (function RegistrationGroup() {
+
+        var input = $('input[name="registration_enabled"]'),
+            group_div = $('div.registration-group');
+
+        input.change(function () {
+            input.get(0).checked && group_div.show() || group_div.hide();
+        }).change();
+
+    }());
+
+    var button = $('#showsecret');
+    button.click(function() {
+        var apisecret = $('#apisecret');
+        if(apisecret.attr('type') == 'password') {
+            apisecret.attr('type', 'text');
+            button.html('<?php echo addslashes(t('Hide secret key'))?>');
+        } else {
+            apisecret.attr('type', 'password');
+            button.html('<?php echo addslashes(t('Show secret key'))?>');
+        }
+    });
+</script>

--- a/concrete/authentication/external_concrete5/type_form.php
+++ b/concrete/authentication/external_concrete5/type_form.php
@@ -1,4 +1,8 @@
 <?php defined('C5_EXECUTE') or die('Access denied.'); ?>
+<div class="alert alert-info">
+    <p><?php echo t('Set the "Redirect URI" to: %s', ' <code>'.$redirectUri.'</code>'); ?></p>
+</div>
+
 <div class='form-group'>
     <?=$form->label('url', t('External concrete5 URL'))?>
     <?=$form->text('url', $data['url'])?>

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1170,9 +1170,7 @@ return [
     ],
 
     'api' => [
-
         'scopes' => [
-
             'system',
             'site',
             'account'

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -140,6 +140,7 @@ return [
         'core_oauth' => '\Concrete\Core\Authentication\Type\OAuth\ServiceProvider',
         'core_auth_community' => '\Concrete\Core\Authentication\Type\Community\ServiceProvider',
         'core_auth_google' => '\Concrete\Core\Authentication\Type\Google\ServiceProvider',
+        'core_auth_external_concrete5' => '\Concrete\Core\Authentication\Type\ExternalConcrete5\ServiceProvider',
 
         // Validator
         'core_validator' => '\Concrete\Core\Validator\ValidatorServiceProvider',
@@ -1173,7 +1174,8 @@ return [
         'scopes' => [
 
             'system',
-            'site'
+            'site',
+            'account'
         ]
     ],
 

--- a/concrete/controllers/single_page/dashboard/system/api/integrations.php
+++ b/concrete/controllers/single_page/dashboard/system/api/integrations.php
@@ -1,13 +1,12 @@
 <?php
 namespace Concrete\Controller\SinglePage\Dashboard\System\Api;
 
+use Concrete\Core\Api\OAuth\Client\ClientFactory;
 use Concrete\Core\Entity\OAuth\Client;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Permission\Checker;
-use Concrete\Core\User\UserInfoRepository;
-use Concrete\Core\Utility\Service\Identifier;
 use Concrete\Core\Utility\Service\Validation\Strings;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\Url\Url;
 
 class Integrations extends DashboardPageController
 {
@@ -26,6 +25,22 @@ class Integrations extends DashboardPageController
         $validator = $this->app->make(Strings::class);
         if (!$validator->notempty($this->request->request->get('name'))) {
             $this->error->add(t('You must specify a name for this integration'));
+        }
+
+        $redirect = $this->request->request->get('redirect');
+        if (!$validator->notempty($redirect)) {
+            $this->error->add(t('You must specify a redirect url for this integration'));
+        }
+
+        try {
+            $uri = Url::createFromUrl($redirect);
+
+            // Do some simple validation
+            if (!$uri->getHost() || !$uri->getScheme()) {
+                throw new \RuntimeException('Invalid URI');
+            }
+        } catch (\Exception $e) {
+            $this->error->add(t('That doesn\'t look like a valid URL.'));
         }
     }
 
@@ -57,12 +72,15 @@ class Integrations extends DashboardPageController
             $this->error->add($this->token->getErrorMessage());
         }
         if (!$this->error->has()) {
+            /** @var Client $client */
             $client = $this->get('client');
             $client->setName($this->request->request->get('name'));
+            $client->setRedirectUri($this->request->request->get('redirect'));
+
             $this->entityManager->persist($client);
             $this->entityManager->flush();
             $this->flash('success', t('Integration saved successfully.'));
-            return $this->redirect('/dashboard/system/api/settings');
+            return $this->redirect('/dashboard/system/api/integrations/', 'view_client', $client->getIdentifier());
         }
     }
 
@@ -73,6 +91,7 @@ class Integrations extends DashboardPageController
             $this->error->add($this->token->getErrorMessage());
         }
         if (!$this->error->has()) {
+            /** @var Client $client */
             $client = $this->get('client');
             $this->entityManager->remove($client);
             $this->entityManager->flush();
@@ -81,8 +100,18 @@ class Integrations extends DashboardPageController
         }
     }
 
-
-
+    /**
+     * Request handler to create new client objects
+     *
+     * This method:
+     * 1. Makes sure a name exists
+     * 2. Validates the request token `create`
+     * 3. Returns if any errors exist
+     * 4. Uses a ClientFactory to create a new client object
+     * 5. Uses password_hash on the client secret before storing to the database
+     * 6. Stores the secret to a session flash bag
+     * 7. Redirects to the view_client action
+     */
     public function create()
     {
         $this->add();
@@ -90,19 +119,30 @@ class Integrations extends DashboardPageController
         if (!$this->token->validate('create')) {
             $this->error->add($this->token->getErrorMessage());
         }
-        if (!$this->error->has()) {
-            $identifier = new Identifier();
-            $key = $identifier->getString(32);
-            $secret = bin2hex(random_bytes(32));
-            $client = new Client();
-            $client->setClientKey($key);
-            $client->setClientSecret($secret);
-            $client->setRedirectUri('');
-            $client->setName($this->request->request->get('name'));
-            $this->entityManager->persist($client);
-            $this->entityManager->flush();
-            $this->flash('success', t('Integration saved successfully.'));
-            return $this->redirect('/dashboard/system/api/integrations/', 'view_client', $client->getIdentifier());
+
+        if ($this->error->has()) {
+            return;
         }
+
+        $factory = $this->app->make(ClientFactory::class);
+        $credentials = $factory->generateCredentials();
+
+        // Create a new client while hashing the new secret
+        $client = $factory->createClient(
+            $this->request->request->get('name'),
+            $this->request->request->get('redirect'),
+            [],
+            $credentials->getKey(),
+            password_hash($credentials->getSecret(), PASSWORD_DEFAULT)
+        );
+
+        // Persist the new client to the database
+        $this->entityManager->persist($client);
+        $this->entityManager->flush();
+        $this->flash('success', t('Integration saved successfully.'));
+        $this->flash('clientSecret', $credentials->getSecret());
+
+        return $this->redirect('/dashboard/system/api/integrations/', 'view_client', $client->getIdentifier());
     }
+
 }

--- a/concrete/routes/api/account.php
+++ b/concrete/routes/api/account.php
@@ -1,0 +1,31 @@
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+
+/**
+ * @var $router \Concrete\Core\Routing\Router
+ * @var $app \Concrete\Core\Application\Application
+ */
+
+use Concrete\Core\System\Info;
+
+$router->all('/account/info', function() use ($app) {
+    $request = $app->make(\Concrete\Core\Http\Request::class);
+    $loggedInUser = $request->attributes->get('oauth_user_id');
+
+    if (!$loggedInUser) {
+        throw new \RuntimeException('Invalid user associated with request');
+    }
+
+    $userRepository = $app->make(\Concrete\Core\User\UserInfoRepository::class);
+    $user = $userRepository->getByID($loggedInUser);
+
+    return new \League\Fractal\Resource\Item($user, function(\Concrete\Core\User\UserInfo $user) {
+        return [
+            'email' => $user->getUserEmail(),
+            'firstName' => $user->getAttributeValue('first_name'),
+            'lastName' => $user->getAttribute('last_name'),
+            'id' => $user->getUserID(),
+            'username' => $user->getUserName()
+        ];
+    });
+});

--- a/concrete/routes/api/oauth2.php
+++ b/concrete/routes/api/oauth2.php
@@ -10,3 +10,4 @@ use Concrete\Core\Api\OAuth\Controller as OAuthController;
  */
 
 $router->post('/oauth/2.0/token', [OAuthController::class, 'token']);
+$router->all('/oauth/2.0/authorize', [OAuthController::class, 'authorize']);

--- a/concrete/single_pages/dashboard/system/api/integrations/add.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/add.php
@@ -1,5 +1,9 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-
+<?php
+/**
+ * @var \Concrete\Core\Entity\OAuth\Client $client
+ */
+?>
 
 <form method="post" class="ccm-dashboard-content-form" action="<?=$view->action('create')?>">
     <?=$this->controller->token->output('create')?>
@@ -9,6 +13,14 @@
             <label for="name" class="control-label"><?php echo t('Name'); ?></label>
             <div class="input-group">
                 <?php echo $form->text('name', array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
+            <div class="input-group">
+                <?php echo $form->text('redirect', array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/api/integrations/edit.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/edit.php
@@ -1,5 +1,9 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-
+<?php
+/**
+ * @var \Concrete\Core\Entity\OAuth\Client $client
+ */
+?>
 
 <form method="post" class="ccm-dashboard-content-form" action="<?=$view->action('update', $client->getIdentifier())?>">
     <?=$this->controller->token->output('update')?>
@@ -9,6 +13,14 @@
             <label for="name" class="control-label"><?php echo t('Name'); ?></label>
             <div class="input-group">
                 <?php echo $form->text('name', $client->getName(), array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
+            <div class="input-group">
+                <?php echo $form->text('redirect', $client->getRedirectUri(), array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/api/integrations/view_client.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/view_client.php
@@ -3,7 +3,7 @@
 /**
  * @var \Concrete\Core\Entity\OAuth\Client $client
  */
-$clientSecret = !isset($clientSecret) ? $clientSecret : null;
+$clientSecret = isset($clientSecret) ? $clientSecret : null;
 
 // Make sure the client secret matches this client
 if ($clientSecret && !password_verify($clientSecret, $client->getClientSecret())) {

--- a/concrete/single_pages/dashboard/system/api/integrations/view_client.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/view_client.php
@@ -1,4 +1,15 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+/**
+ * @var \Concrete\Core\Entity\OAuth\Client $client
+ */
+$clientSecret = !isset($clientSecret) ? $clientSecret : null;
+
+// Make sure the client secret matches this client
+if ($clientSecret && !password_verify($clientSecret, $client->getClientSecret())) {
+    $clientSecret = null;
+}
+?>
 
 <div class="ccm-dashboard-header-buttons">
     <div class="btn-group">
@@ -17,13 +28,27 @@
     </div>
 
     <div class="form-group">
+        <label class="control-label"><?=t('Redirect URI')?></label>
+        <div><?=$client->getRedirectUri() ?: t('None provided') ?></div>
+    </div>
+
+    <div class="form-group">
         <label class="control-label"><?=t('Client ID')?></label>
         <input type="text" class="form-control" onclick="this.select()" value="<?=$client->getClientKey()?>">
     </div>
 
-    <div class="form-group">
+    <div class="form-group <?= $clientSecret ? 'has-warning' : '' ?>">
         <label class="control-label"><?=t('Client Secret')?></label>
-        <input type="text" class="form-control" onclick="this.select()" value="<?=$client->getClientSecret()?>">
+        <input type="<?= $clientSecret ? 'text' : 'password' ?>" class="form-control" onclick="this.select()" value="<?= $clientSecret ?: str_repeat('*', 96) ?>" <?= $clientSecret ? '' : 'disabled' ?>>
+        <div class="help-block">
+            <?php
+            if ($clientSecret) {
+                echo t('Make sure to copy this API secret, this is the last time it will be displayed.');
+            } else {
+                echo t('This API secret was displayed when this client was first created. It can no longer be displayed.');
+            }
+            ?>
+        </div>
     </div>
 
 </fieldset>

--- a/concrete/src/Api/ApiRouteList.php
+++ b/concrete/src/Api/ApiRouteList.php
@@ -31,5 +31,8 @@ class ApiRouteList implements RouteListInterface
             ->scope('site')
             ->routes('api/site.php');
 
+        $api->buildGroup()
+            ->scope('account')
+            ->routes('api/account.php');
     }
 }

--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -14,6 +14,7 @@ use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 use Concrete\Core\Routing\Router;
 use Doctrine\ORM\EntityManagerInterface;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -133,9 +134,12 @@ class ApiServiceProvider extends ServiceProvider
             $server->setEncryptionKey($this->app->make('config/database')->get('concrete.security.token.encryption'));
 
             $oneHourTTL = new \DateInterval('PT1H');
+            $oneDayTTL = new \DateInterval('P1D');
+
 
             // Enable client_credentials grant type with 1 hour ttl
             $server->enableGrantType($this->app->make(ClientCredentialsGrant::class), $oneHourTTL);
+            $server->enableGrantType($this->app->make(AuthCodeGrant::class, ['authCodeTTL' => $oneDayTTL]), $oneDayTTL);
 
             return $server;
         });

--- a/concrete/src/Api/OAuth/Client/ClientFactory.php
+++ b/concrete/src/Api/OAuth/Client/ClientFactory.php
@@ -1,0 +1,102 @@
+<?php
+namespace Concrete\Core\Api\OAuth\Client;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Entity\OAuth\Client;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\UuidGenerator;
+
+class ClientFactory
+{
+
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private $app;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var \Doctrine\ORM\Id\UuidGenerator
+     */
+    private $generator;
+
+    public function __construct(Application $app, EntityManager $entityManager, UuidGenerator $generator)
+    {
+        $this->app = $app;
+        $this->entityManager = $entityManager;
+        $this->generator = $generator;
+    }
+
+    /**
+     * Create a new OAuth client object and provide it a proper UUID
+     *
+     * @param string $name The client name
+     * @param string $redirect The redirect url
+     * @param string[] $scopes The scopes this client is allowed to interact with
+     * @param string $key The client's api key
+     * @param string $secret This secret should be properly hashed with something like `password_hash`
+     * @return \Concrete\Core\Entity\OAuth\Client
+     */
+    public function createClient($name, $redirect, array $scopes, $key, $secret)
+    {
+        $client = $this->app->make(Client::class);
+        $client->setName($name);
+        $client->setRedirectUri($redirect);
+        // @TODO support scopes
+        //$client->setScopes($scopes);
+        $client->setClientKey($key);
+        $client->setClientSecret($secret);
+
+        // Apply a new UUID to the client
+        $id = $this->generator->generate($this->entityManager, $client);
+        $client->setIdentifier($id);
+
+        return $client;
+    }
+
+    /**
+     * Generate new credentials for use with a client
+     * Note: the secret provided by with these credentials is in plain text and should be hashed before storing to the
+     * database.
+     *
+     * @param int $keyLength
+     * @param int $secretLength
+     * @return \Concrete\Core\Api\OAuth\Client\Credentials
+     * @throws \InvalidArgumentException If an invalid size is passed
+     */
+    public function generateCredentials($keyLength = 64, $secretLength = 96)
+    {
+        // Make sure we have ints
+        $keyLength = (int) $keyLength;
+        $secretLength = (int) $secretLength;
+
+        // Make sure our keys are long enough
+        if ($keyLength < 16 || $secretLength < 16) {
+            throw new \InvalidArgumentException('A key must have a length longer than 16');
+        }
+
+        return $this->app->make(Credentials::class, [
+            $this->generateString($keyLength),
+            $this->generateString($secretLength)
+        ]);
+    }
+
+    /**
+     * Generate a cryptographically secure strig
+     *
+     * @param $length
+     * @return bool|string
+     */
+    protected function generateString($length)
+    {
+        $bytes = ceil($length / 2);
+        $string = bin2hex(random_bytes($bytes));
+
+        return substr($string, 0, $length);
+    }
+
+}

--- a/concrete/src/Api/OAuth/Client/Credentials.php
+++ b/concrete/src/Api/OAuth/Client/Credentials.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Concrete\Core\Api\OAuth\Client;
+
+/**
+ * OAuth Client Credentials
+ * A value object for communicating plain text keys and secrets
+ */
+class Credentials
+{
+
+    /** @var string */
+    private $key;
+
+    /** @var string */
+    private $secret;
+
+    /**
+     * Credentials constructor.
+     * @param string $key
+     * @param string $secret
+     */
+    public function __construct($key, $secret)
+    {
+        $this->key = $key;
+        $this->secret = $secret;
+    }
+
+    /**
+     * Get the associated key
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Get the associated secret
+     * WARNING: This is a secure string and is meant to be kept secret. Be sure to hash this value before storing to a
+     * database.
+     *
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
+    }
+}

--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -34,7 +34,6 @@ final class Controller
     /**
      * Handle authorization
      *
-     * @param \Psr\Http\Message\ServerRequestInterface $request
      * @return \Psr\Http\Message\ResponseInterface
      * @throws \Exception
      */

--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -2,33 +2,63 @@
 
 namespace Concrete\Core\Api\OAuth;
 
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Entity\OAuth\AccessToken;
 use Concrete\Core\Entity\OAuth\AuthCode;
+use Concrete\Core\Entity\OAuth\Client;
 use Concrete\Core\Entity\OAuth\RefreshToken;
+use Concrete\Core\Entity\OAuth\Scope;
+use Concrete\Core\Entity\User\User;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Validation\CSRF\Token;
+use Concrete\Core\View\View;
 use Doctrine\ORM\EntityManagerInterface;
+use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\Response;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 final class Controller
 {
 
+    const STEP_LOGIN = 1;
+    const STEP_AUTHORIZE_CLIENT = 2;
+    const STEP_COMPLETE = 3;
+
     /** @var \League\OAuth2\Server\AuthorizationServer */
     private $oauthServer;
 
-    /** @var \Doctrine\ORM\EntityManagerInterface  */
+    /** @var \Doctrine\ORM\EntityManagerInterface */
     private $entityManager;
 
-    /**
-     * @var ServerRequestInterface
-     */
+    /** @var \Psr\Http\Message\ServerRequestInterface */
     private $request;
 
-    public function __construct(AuthorizationServer $oauthServer, EntityManagerInterface $entityManager, ServerRequestInterface $request)
-    {
+    /** @var \Symfony\Component\HttpFoundation\Session\Session */
+    private $session;
+
+    /** @var \Concrete\Core\Validation\CSRF\Token */
+    private $token;
+
+    /** @var \Concrete\Core\Config\Repository\Repository */
+    private $config;
+
+    public function __construct(
+        AuthorizationServer $oauthServer,
+        EntityManagerInterface $entityManager,
+        ServerRequestInterface $request,
+        Session $session,
+        Token $token,
+        Repository $config
+    ) {
         $this->oauthServer = $oauthServer;
         $this->entityManager = $entityManager;
         $this->request = $request;
+        $this->session = $session;
+        $this->token = $token;
+        $this->config = $config;
     }
 
     /**
@@ -53,6 +83,139 @@ final class Controller
     }
 
     /**
+     * Route handler that deals with authorization
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Concrete\Core\Http\Response
+     */
+    public function authorize()
+    {
+        $response = new Response();
+
+        try {
+            $request = $this->getAuthorizationRequest();
+            $step = $this->determineStep($request);
+
+            // Handle login step
+            if ($step === self::STEP_LOGIN) {
+                return $this->handleLogin($request);
+            }
+
+            // Handle authorize step
+            if ($step === self::STEP_AUTHORIZE_CLIENT) {
+                return $this->handleAuthorizeClient($request);
+            }
+
+            // We've fallen through all the other steps...
+            $this->clearRequest($request);
+            return $this->oauthServer->completeAuthorizationRequest($request, $response);
+        } catch (OAuthServerException $exception) {
+            return $exception->generateHttpResponse($response);
+        } catch (\Exception $exception) {
+            $body = new LazyOpenStream('php://temp', 'r+');
+            $body->write($exception->getMessage());
+            return $response->withStatus(500)->withBody($body);
+        }
+    }
+
+    /**
+     * Handle the login portion of an authorization request
+     * This method renders a view for login that handles either email or username based login
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     * @return \Concrete\Core\Http\Response|\RedirectResponse
+     */
+    public function handleLogin(AuthorizationRequest $request)
+    {
+        $error = new ErrorList();
+        $emailLogin = $this->config->get('concrete.user.registration.email_registration');
+
+        while ($this->request->getMethod() === 'POST') {
+
+            if (!$this->token->validate('oauth_login_' . $request->getClient()->getClientKey())) {
+                $error->add(t('Invalid request token.'));
+                break;
+            }
+
+            $query = $this->request->getParsedBody();
+            $user = array_get($query, 'uName');
+            $password = array_get($query, 'uPassword');
+
+            $userRepository = $this->entityManager->getRepository(User::class);
+
+            /** @var User $user */
+            $user = $userRepository->findOneBy([$emailLogin ? 'uEmail' : 'uName' => $user]);
+
+            // User successfully logged in
+            if ($user && $user->getUserID() && password_verify($password, $user->getUserPassword())) {
+
+                $userInfo = $this->entityManager->find(User::class, $user->getUserID());
+                $request->setUser($userInfo);
+                $this->storeRequest($request);
+
+                return new \RedirectResponse($this->request->getUri());
+            } else {
+                $error->add(t('Invalid username or password.'));
+            }
+
+            break;
+        }
+
+        $contents = $this->createLoginView([
+            'error' => $error,
+            'auth' => $request,
+            'request' => $this->request,
+            'client' => $request->getClient(),
+            'emailLogin' => $emailLogin
+        ]);
+
+        return new \Concrete\Core\Http\Response($contents->render());
+    }
+
+    /**
+     * Handle the scope authorization portion of an authorization request
+     * This method renders a view that outputs a list of scopes and asks the user to verify that they want to give the
+     * client the access that is being requested.
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     * @return \Concrete\Core\Http\Response|\RedirectResponse
+     */
+    public function handleAuthorizeClient(AuthorizationRequest $request)
+    {
+        $error = new ErrorList();
+
+        while ($this->request->getMethod() === 'POST') {
+
+            if (!$this->token->validate('oauth_authorize_' . $request->getClient()->getClientKey())) {
+                $error->add(t('Invalid request token.'));
+                break;
+            }
+
+            $query = $this->request->getParsedBody();
+            $authorized = array_get($query, 'authorize_client');
+
+            // User authorized the request
+            if ($authorized) {
+                $request->setAuthorizationApproved(true);
+                $this->storeRequest($request);
+
+                return new \RedirectResponse($this->request->getUri());
+            }
+
+            break;
+        }
+
+        $contents = $this->createLoginView([
+            'error' => $error,
+            'auth' => $request,
+            'request' => $this->request,
+            'client' => $request->getClient(),
+            'authorize' => true,
+        ]);
+
+        return new \Concrete\Core\Http\Response($contents->render());
+    }
+
+    /**
      * Prune old authentication tokens
      */
     private function pruneTokens()
@@ -60,13 +223,13 @@ final class Controller
         $now = new \DateTime('now');
         $qb = $this->entityManager->createQueryBuilder();
 
-        // Delete all expired access tokens
-        $qb->delete(AccessToken::class, 'token')
+        // Delete all expired refresh tokens
+        $qb->delete(RefreshToken::class, 'token')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
             ->getQuery()->execute([':now' => $now]);
 
-        // Delete all expired refresh tokens
-        $qb->delete(RefreshToken::class, 'token')
+        // Delete all expired access tokens
+        $qb->delete(AccessToken::class, 'token')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
             ->getQuery()->execute([':now' => $now]);
 
@@ -74,6 +237,155 @@ final class Controller
         $qb->delete(AuthCode::class, 'token')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
             ->getQuery()->execute([':now' => $now]);
+    }
+
+    /**
+     * @return \League\OAuth2\Server\RequestTypes\AuthorizationRequest
+     * @throws \League\OAuth2\Server\Exception\OAuthServerException
+     */
+    private function getAuthorizationRequest()
+    {
+        $clientId = array_get($this->request->getQueryParams(), 'client_id');
+        $sessionRequest = $this->restoreRequest($this->session->get("authn_request.$clientId", []));
+
+        if ($sessionRequest) {
+            return $sessionRequest;
+        }
+
+        $request = $this->oauthServer->validateAuthorizationRequest($this->request);
+        $this->storeRequest($request);
+
+        return $request;
+    }
+
+    /**
+     * Store a request against session
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     */
+    private function storeRequest(AuthorizationRequest $request)
+    {
+        $data = [
+            'user' => $request->getUser() ? $request->getUser()->getIdentifier() : null,
+            'client' => $request->getClient()->getIdentifier(),
+            'challenge' => $request->getCodeChallenge(),
+            'challenge_method' => $request->getCodeChallengeMethod(),
+            'grant_type' => $request->getGrantTypeId(),
+            'redirect' => $request->getRedirectUri(),
+            'scopes' => $request->getScopes(),
+            'state' => $request->getState(),
+            'approved' => (bool) $request->isAuthorizationApproved()
+        ];
+
+        /** @var Client $client */
+        $client = $request->getClient();
+        $clientId = $client->getClientKey();
+        $this->session->set("authn_request.$clientId", $data);
+    }
+
+    /**
+     * Restore a real request from the passed data
+     *
+     * @param array $data
+     * @return \League\OAuth2\Server\RequestTypes\AuthorizationRequest|null
+     */
+    private function restoreRequest(array $data)
+    {
+        if (!$data) {
+            return null;
+        }
+
+        // Inflate identifiers into objects
+        $scopeData = (array) array_get($data, 'scopes', []);
+        $scopes = array_filter(array_map([$this, 'inflateType'], $scopeData));
+        $user = $this->inflateType(array_get($data, 'user'), User::class);
+        $client = $this->inflateType(array_get($data, 'client'), Client::class);
+
+        // If some data is malformed or missing, restart this whole process.
+        if (!$user || !$client || count($scopes) !== count($scopeData)) {
+            return null;
+        }
+
+        // Build out the authorization request
+        $request = new AuthorizationRequest();
+        $request->setUser($user);
+        $request->setClient($client);
+        $request->setAuthorizationApproved((bool) array_get($data, 'approved', false));
+        $request->setCodeChallenge(array_get($data, 'challenge', ''));
+        $request->setCodeChallengeMethod(array_get($data, 'challenge_method', ''));
+        $request->setGrantTypeId(array_get($data, 'grant_type'));
+        $request->setState(array_get($data, 'state'));
+        $request->setScopes($scopes);
+        $request->setRedirectUri(array_get($data, 'redirect'));
+
+        return $request;
+    }
+
+    /**
+     * Remove all session data related to this flow
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     */
+    private function clearRequest(AuthorizationRequest $request)
+    {
+        /** @var Client $client */
+        $client = $request->getClient();
+        $clientId = $client->getClientKey();
+        $this->session->remove("authn_request.$clientId");
+    }
+
+    /**
+     * Inflate an identifier into a specific type
+     *
+     * @param int|string|null $identifier
+     * @param string $type
+     * @return object|null The inflated entity
+     */
+    private function inflateType($identifier, $type = Scope::class)
+    {
+        if ($identifier === null) {
+            return null;
+        }
+
+        return $this->entityManager->find($type, $identifier);
+    }
+
+    /**
+     * Figure out what step we should be rendering based on the active authorization request
+     * This method should handle verifying authorization and login
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     * @return int
+     */
+    private function determineStep(AuthorizationRequest $request)
+    {
+        // If the request doesn't have a user attached, we need to login still.
+        if (!$request->getUser()) {
+            return self::STEP_LOGIN;
+        }
+
+        /** @todo Track this authorization in the database and notify the user if the scope requirements change */
+        if (!$request->isAuthorizationApproved()) {
+            return self::STEP_AUTHORIZE_CLIENT;
+        }
+
+        return self::STEP_COMPLETE;
+    }
+
+    /**
+     * Create a new authorize login view with the given data in scope
+     *
+     * @param array $data
+     * @return \Concrete\Core\View\View
+     */
+    private function createLoginView(array $data)
+    {
+        $contents = new View('/oauth/authorize');
+        $contents->setViewTheme('concrete');
+        $contents->setViewTemplate('background_image');
+        $contents->addScopeItems($data);
+
+        return $contents;
     }
 
 }

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
+
+use Concrete\Core\Entity\OAuth\AccessToken;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use OAuth\Common\Http\Exception\TokenResponseException;
+use OAuth\Common\Http\Uri\UriInterface;
+use OAuth\OAuth2\Service\AbstractService;
+use OAuth\OAuth2\Token\StdOAuth2Token;
+use OAuth\OAuth2\Token\TokenInterface;
+
+class ExternalConcrete5Service extends AbstractService
+{
+
+    const SCOPE_SERVICE = 'service';
+    const SCOPE_SITE = 'site';
+    const SCOPE_ACCOUNT = 'account';
+
+    const PATH_AUTHORIZE = '/oauth/2.0/authorize';
+    const PATH_TOKEN = '/oauth/2.0/token';
+
+    /**
+     * Parses the access token response and returns a TokenInterface.
+     *
+     *
+     * @param string $responseBody
+     *
+     * @return TokenInterface
+     *
+     * @throws TokenResponseException
+     */
+    protected function parseAccessTokenResponse($responseBody)
+    {
+        $body = json_decode($responseBody, true);
+
+        if (isset($body['error'])) {
+            throw new TokenResponseException($body['hint']);
+        }
+
+        $token = new StdOAuth2Token();
+        $token->setAccessToken($body['access_token']);
+        $token->setRefreshToken($body['refresh_token']);
+        $token->setLifetime($body['expires_in']);
+
+        return $token;
+    }
+
+    /**
+     * Returns the authorization API endpoint.
+     *
+     * @return UriInterface
+     */
+    public function getAuthorizationEndpoint()
+    {
+        $uri = $this->getBaseApiUri();
+        $uri->setPath(self::PATH_AUTHORIZE);
+
+        return $uri;
+    }
+
+    /**
+     * Returns the access token API endpoint.
+     *
+     * @return UriInterface
+     */
+    public function getAccessTokenEndpoint()
+    {
+        $uri = $this->getBaseApiUri();
+        $uri->setPath(self::PATH_TOKEN);
+
+        return $uri;
+    }
+
+    /**
+     * Return a copy of our base api uri
+     * @return null|\OAuth\Common\Http\Uri\UriInterface
+     */
+    public function getBaseApiUri()
+    {
+        return clone $this->baseApiUri;
+    }
+
+    /**
+     * Declare that we use the bearer header field
+     * @return int
+     */
+    protected function getAuthorizationMethod()
+    {
+        return self::AUTHORIZATION_METHOD_HEADER_BEARER;
+    }
+}

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
@@ -13,11 +13,19 @@ use OAuth\OAuth2\Token\TokenInterface;
 class ExternalConcrete5Service extends AbstractService
 {
 
-    const SCOPE_SERVICE = 'service';
+    /** @var string Scope for system info */
+    const SCOPE_SYSTEM = 'system';
+
+    /** @var string Scope for site tree info */
     const SCOPE_SITE = 'site';
+
+    /** @var string Scope for authenticated user */
     const SCOPE_ACCOUNT = 'account';
 
+    /** @var string Authorization path */
     const PATH_AUTHORIZE = '/oauth/2.0/authorize';
+
+    /** @var string Token path */
     const PATH_TOKEN = '/oauth/2.0/token';
 
     /**
@@ -25,9 +33,7 @@ class ExternalConcrete5Service extends AbstractService
      *
      *
      * @param string $responseBody
-     *
      * @return TokenInterface
-     *
      * @throws TokenResponseException
      */
     protected function parseAccessTokenResponse($responseBody)
@@ -74,7 +80,8 @@ class ExternalConcrete5Service extends AbstractService
 
     /**
      * Return a copy of our base api uri
-     * @return null|\OAuth\Common\Http\Uri\UriInterface
+     *
+     * @return \OAuth\Common\Http\Uri\UriInterface
      */
     public function getBaseApiUri()
     {
@@ -83,6 +90,12 @@ class ExternalConcrete5Service extends AbstractService
 
     /**
      * Declare that we use the bearer header field
+     * We want our headers to be:
+     *     Authorization: Bearer SOMETOKEN
+     *
+     * If we didn't declare this everything would break because they'd be
+     *     Authorization: Bearer OAuth SOMETOKEN
+     *
      * @return int
      */
     protected function getAuthorizationMethod()

--- a/concrete/src/Authentication/Type/ExternalConcrete5/Extractor.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/Extractor.php
@@ -1,0 +1,67 @@
+<?php
+namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
+
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\UserData\Extractor\LazyExtractor;
+
+class Extractor extends LazyExtractor
+{
+    const USER_PATH = '/ccm/api/v1/account/info';
+
+    public function __construct()
+    {
+        parent::__construct(
+            $this->getDefaultLoadersMap(),
+            $this->getNormalizersMap(),
+            $this->getSupports());
+    }
+
+    public function getSupports()
+    {
+        return [
+            self::FIELD_EMAIL,
+            self::FIELD_UNIQUE_ID,
+            self::FIELD_USERNAME,
+        ];
+    }
+    protected function getNormalizersMap()
+    {
+        return [
+            self::FIELD_EMAIL => 'email',
+            self::FIELD_FIRST_NAME => 'firstName',
+            self::FIELD_LAST_NAME => 'lastName',
+            self::FIELD_UNIQUE_ID => 'id',
+            self::FIELD_USERNAME => 'username',
+        ];
+    }
+
+    public function idNormalizer($data)
+    {
+        return isset($data['id']) ? (int) $data['id'] : null;
+    }
+
+    public function emailNormalizer($data)
+    {
+        return array_get($data, 'email', null);
+    }
+
+    public function firstNameNormalizer($data)
+    {
+        return array_get($data, 'first_name', null);
+    }
+
+    public function lastNameNormalizer($data)
+    {
+        return array_get($data, 'last_name', null);
+    }
+
+    public function usernameNormalizer($data)
+    {
+        return array_get($data, 'username', null);
+    }
+
+    public function profileLoader()
+    {
+        return json_decode($this->service->request(self::USER_PATH), true)['data'];
+    }
+}

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
+
+use Concrete\Core\Api\OAuth\Service\ExternalConcrete5;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\Url\Url;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Storage\SymfonySession;
+use OAuth\ServiceFactory as OAuthServiceFactory;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class ServiceFactory
+{
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Session
+     */
+    protected $session;
+
+    /**
+     * @var \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface
+     */
+    protected $urlResolver;
+
+    /**
+     * @var \Concrete\Core\Http\Request
+     */
+    protected $request;
+
+    /**
+     * CommunityServiceFactory constructor.
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     * @param \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $url
+     * @param \Concrete\Core\Http\Request $request
+     */
+    public function __construct(Repository $config, Session $session, ResolverManagerInterface $url, Request $request)
+    {
+        $this->config = $config;
+        $this->session = $session;
+        $this->request = $request;
+        $this->urlResolver = $url;
+    }
+
+    /**
+     * Create a service object given a ServiceFactory object
+     *
+     *
+     * @param \OAuth\ServiceFactory $factory
+     * @return \OAuth\Common\Service\ServiceInterface
+     */
+    public function createService(OAuthServiceFactory $factory)
+    {
+        $appId = $this->config->get('auth.external_concrete5.appid');
+        $appSecret = $this->config->get('auth.external_concrete5.secret');
+
+        // Get the callback url
+        /** @var Url $callbackUrl */
+        $callbackUrl = $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/callback/']);
+        if ($callbackUrl->getHost() == '') {
+            $callbackUrl = $callbackUrl->setHost($this->request->getHost());
+            $callbackUrl = $callbackUrl->setScheme($this->request->getScheme());
+        }
+
+        // Create a credential object with our ID, Secret, and callback url
+        $credentials = new Credentials($appId, $appSecret, (string) $callbackUrl);
+
+        // Create a new session storage object and pass it the active session
+        $storage = new SymfonySession($this->session, false);
+
+        $baseUrl = $this->urlResolver->resolve(['']);
+        $baseApiUrl = new Uri((string) $baseUrl);
+
+        // Create the service using the oauth service factory
+        return $factory->createService('external_concrete5', $credentials, $storage, [ExternalConcrete5Service::SCOPE_ACCOUNT], $baseApiUrl);
+    }
+
+}
+

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
@@ -60,8 +60,11 @@ class ServiceFactory
      */
     public function createService(OAuthServiceFactory $factory)
     {
-        $appId = $this->config->get('auth.external_concrete5.appid');
-        $appSecret = $this->config->get('auth.external_concrete5.secret');
+        $config = $this->config->get('auth.external_concrete5');
+
+        $appId = array_get($config, 'appid');
+        $appSecret = array_get($config, 'secret');
+        $baseUrl = array_get($config, 'url');
 
         // Get the callback url
         /** @var Url $callbackUrl */
@@ -77,11 +80,14 @@ class ServiceFactory
         // Create a new session storage object and pass it the active session
         $storage = new SymfonySession($this->session, false);
 
-        $baseUrl = $this->urlResolver->resolve(['']);
-        $baseApiUrl = new Uri((string) $baseUrl);
+        $baseApiUrl = new Uri($baseUrl);
 
         // Create the service using the oauth service factory
-        return $factory->createService('external_concrete5', $credentials, $storage, [ExternalConcrete5Service::SCOPE_ACCOUNT], $baseApiUrl);
+        return $factory->createService('external_concrete5', $credentials, $storage, [
+            ExternalConcrete5Service::SCOPE_SYSTEM,
+            ExternalConcrete5Service::SCOPE_SITE,
+            ExternalConcrete5Service::SCOPE_ACCOUNT,
+        ], $baseApiUrl);
     }
 
 }

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ServiceProvider.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
+
+use OAuth\ServiceFactory;
+use OAuth\UserData\ExtractorFactory;
+
+class ServiceProvider extends \Concrete\Core\Foundation\Service\Provider
+{
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        // Register our extractor
+        $this->app->extend('oauth/factory/extractor', function(ExtractorFactory $factory) {
+            $factory->addExtractorMapping(ExternalConcrete5Service::class, Extractor::class);
+
+            return $factory;
+        });
+
+        // Register our service
+        $this->app->extend('oauth/factory/service', function(ServiceFactory $factory) {
+            $factory->registerService('external_concrete5', ExternalConcrete5Service::class);
+            return $factory;
+        });
+    }
+}

--- a/concrete/src/Entity/OAuth/AccessToken.php
+++ b/concrete/src/Entity/OAuth/AccessToken.php
@@ -74,7 +74,7 @@ class AccessToken implements AccessTokenEntityInterface
      */
     public function addScope(ScopeEntityInterface $scope)
     {
-        $this->scopes[$scope->getIdentifier()] = $scope;
+        $this->scopes[] = $scope;
     }
 
     /**
@@ -84,7 +84,7 @@ class AccessToken implements AccessTokenEntityInterface
      */
     public function getScopes()
     {
-        return array_values($this->scopes);
+        return $this->scopes;
     }
 
     /**

--- a/concrete/src/Entity/OAuth/AccessTokenRepository.php
+++ b/concrete/src/Entity/OAuth/AccessTokenRepository.php
@@ -54,7 +54,7 @@ class AccessTokenRepository extends EntityRepository implements AccessTokenRepos
     {
         if ($token = $this->find($tokenId)) {
             $this->getEntityManager()->transactional(function(EntityManagerInterface $em) use ($token) {
-                $em->detach($token);
+                $em->remove($token);
             });
         }
     }

--- a/concrete/src/Entity/OAuth/AuthCode.php
+++ b/concrete/src/Entity/OAuth/AuthCode.php
@@ -74,7 +74,7 @@ class AuthCode implements AuthCodeEntityInterface
      */
     public function addScope(ScopeEntityInterface $scope)
     {
-        $this->scopes[$scope->getIdentifier()] = $scope;
+        $this->scopes[] = $scope;
     }
 
     /**
@@ -84,7 +84,7 @@ class AuthCode implements AuthCodeEntityInterface
      */
     public function getScopes()
     {
-        return array_values($this->scopes);
+        return $this->scopes;
     }
 
     /**

--- a/concrete/src/Entity/OAuth/AuthCodeRepository.php
+++ b/concrete/src/Entity/OAuth/AuthCodeRepository.php
@@ -51,7 +51,7 @@ class AuthCodeRepository extends EntityRepository implements AuthCodeRepositoryI
         $this->getEntityManager()->transactional(function(EntityManagerInterface $em) use ($code) {
             $code = $em->merge($code);
             if ($code) {
-                $em->detach($code);
+                $em->remove($code);
             }
         });
     }

--- a/concrete/src/Entity/OAuth/ClientRepository.php
+++ b/concrete/src/Entity/OAuth/ClientRepository.php
@@ -24,10 +24,15 @@ class ClientRepository extends EntityRepository implements ClientRepositoryInter
     public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $mustValidateSecret = true)
     {
         $client = $this->findOneBy(['clientKey' => $clientIdentifier]);
-        if ($client && $mustValidateSecret) {
-            if ($client->getClientSecret() !== $clientSecret) {
-                throw OAuthServerException::invalidClient();
-            }
+
+        // Handle client not found
+        if (!$client) {
+            throw OAuthServerException::invalidClient();
+        }
+
+        // Handle validation
+        if ($mustValidateSecret && !password_verify($clientSecret, $client->getClientSecret())) {
+            throw OAuthServerException::invalidClient();
         }
 
         return $client;

--- a/concrete/src/Entity/OAuth/RefreshToken.php
+++ b/concrete/src/Entity/OAuth/RefreshToken.php
@@ -2,9 +2,9 @@
 
 namespace Concrete\Core\Entity\OAuth;
 
-use Doctrine\ORM\Mapping as ORM;
-use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="RefreshTokenRepository")
@@ -29,7 +29,7 @@ class RefreshToken implements RefreshTokenEntityInterface
     /**
      * @var \League\OAuth2\Server\Entities\AccessTokenEntityInterface
      * @ORM\OneToOne(targetEntity="AccessToken")
-     * @ORM\JoinColumn(name="client", referencedColumnName="identifier")
+     * @ORM\JoinColumn(name="accessToken", referencedColumnName="identifier")
      */
     protected $accessToken;
 

--- a/concrete/src/Entity/OAuth/RefreshTokenRepository.php
+++ b/concrete/src/Entity/OAuth/RefreshTokenRepository.php
@@ -45,7 +45,7 @@ class RefreshTokenRepository extends EntityRepository implements RefreshTokenRep
             $token = $this->find($tokenId);
 
             if ($token) {
-                $em->detach($token);
+                $em->remove($token);
             }
         });
     }

--- a/concrete/src/Entity/OAuth/RefreshTokenRepository.php
+++ b/concrete/src/Entity/OAuth/RefreshTokenRepository.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Entity\OAuth;
 
 use Concrete\Core\Entity\Express\EntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 
@@ -58,6 +59,6 @@ class RefreshTokenRepository extends EntityRepository implements RefreshTokenRep
      */
     public function isRefreshTokenRevoked($tokenId)
     {
-        return (bool) $this->find($tokenId);
+        return $this->find($tokenId) === null;
     }
 }

--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -20,6 +20,12 @@ class Scope implements ScopeEntityInterface
     protected $identifier;
 
     /**
+     * @var string
+     * @ORM\Column(type="string")
+     */
+    protected $description;
+
+    /**
      * @ORM\ManyToMany(targetEntity="AuthCode", mappedBy="scopes")
      */
     protected $codes;
@@ -48,9 +54,26 @@ class Scope implements ScopeEntityInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Serialize this scope into a string.
+     * This method MUST return a string and must match the scope ID that clients will request
      *
-     * @see \JsonSerializable::jsonSerialize()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/concrete/views/oauth/authorize.php
+++ b/concrete/views/oauth/authorize.php
@@ -51,7 +51,7 @@ $image = (date('Ymd') - 1) . '.jpg';
                         ?>
                         <div class="form-group">
                             <label class="control-label"
-                                   for="uName"><?= Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('Username') ?></label>
+                                   for="uName"><?= $emailLogin ? t('Email Address') : t('Username') ?></label>
                             <input name="uName" id="uName" class="form-control" autofocus="autofocus"/>
                         </div>
 

--- a/concrete/views/oauth/authorize.php
+++ b/concrete/views/oauth/authorize.php
@@ -1,0 +1,202 @@
+<?php
+use Concrete\Core\Attribute\Key\Key;
+use Concrete\Core\Http\ResponseAssetGroup;
+
+defined('C5_EXECUTE') or die('Access denied.');
+
+/* @var \Concrete\Core\Error\ErrorList\ErrorList $error */
+/* @var \League\OAuth2\Server\RequestTypes\AuthorizationRequest $auth */
+/* @var \Concrete\Core\Http\Request $request */
+/* @var \Concrete\Core\Entity\OAuth\Client $client */
+
+$r = ResponseAssetGroup::get();
+$r->requireAsset('javascript', 'underscore');
+$r->requireAsset('javascript', 'core/events');
+$r->requireAsset('javascript', 'backstretch');
+
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$form = $app->make(\Concrete\Core\Form\Service\Form::class);
+$token = $app->make(\Concrete\Core\Validation\CSRF\Token::class);
+
+if (isset($authType) && $authType) {
+    $active = $authType;
+    $activeAuths = array($authType);
+} else {
+    $active = null;
+    $activeAuths = AuthenticationType::getList(true, true);
+}
+if (!isset($authTypeElement)) {
+    $authTypeElement = null;
+}
+if (!isset($authTypeParams)) {
+    $authTypeParams = null;
+}
+
+// Always use yesterday's picture
+$image = (date('Ymd') - 1) . '.jpg';
+?>
+
+<div class="login-page">
+    <div class="col-sm-6 col-sm-offset-3">
+        <h1><?= t('Authorize') ?></h1>
+    </div>
+    <div class="col-sm-6 col-sm-offset-3 login-form">
+        <div class="row login-row">
+            <div class="controls col-sm-12 col-xs-12">
+                <h3 class="text-center"><?= t('Sign in to %s', "<strong>{$client->getName()}</strong>") ?></h3>
+
+                <form method="post" action="<?= $request->getUri() ?>">
+                    <?php
+                    if (!$authorize) {
+                        ?>
+                        <div class="form-group">
+                            <label class="control-label"
+                                   for="uName"><?= Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('Username') ?></label>
+                            <input name="uName" id="uName" class="form-control" autofocus="autofocus"/>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="control-label" for="uPassword"><?= t('Password') ?></label>
+                            <input name="uPassword" id="uPassword" class="form-control" type="password"/>
+                        </div>
+
+                        <?php if (isset($locales) && is_array($locales) && count($locales) > 0) {
+                            ?>
+                            <div class="form-group">
+                                <label for="USER_LOCALE" class="control-label"><?= t('Language') ?></label>
+                                <?= $form->select('USER_LOCALE', $locales) ?>
+                            </div>
+                            <?php
+                        } ?>
+
+                        <div class="form-group">
+                            <button class="btn btn-primary"><?= t('Log in') ?></button>
+                        </div>
+
+                        <?php $token->output('oauth_login_' . $client->getClientKey()); ?>
+
+                        <?php if (Config::get('concrete.user.registration.enabled')) {
+                            ?>
+                            <br/>
+                            <hr/>
+                            <a href="<?= URL::to('/register') ?>" class="btn btn-block btn-success" target="_blank">
+                                <?= t('Not a member? Register') ?>
+                            </a>
+                            <?php
+                        } ?>
+
+                        <?php
+                    } else {
+                        ?>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="authorize_client" value="1">
+                                <?= t('Authorize "%s" to use the following scopes:', $client->getName()) ?>
+                            </label>
+                        </div>
+
+                        <div class="scopes">
+                            <ul>
+                                <?php
+                                foreach ($auth->getScopes() as $scope) {
+                                    ?>
+                                    <li><?= $scope->getIdentifier() ?></li>
+                                    <?php
+                                }
+                                ?>
+                            </ul>
+                        </div>
+
+                        <?php $token->output('oauth_authorize_' . $client->getClientKey()); ?>
+
+                        <div class="form-group">
+                            <button class="btn btn-success pull-right"><?= t('Authorize') ?></button>
+                        </div>
+                        <?php
+                    }
+                    ?>
+
+                </form>
+
+            </div>
+        </div>
+    </div>
+    <div style="clear:both"></div>
+
+    <style type="text/css">
+        body {
+            background: url("<?= ASSETS_URL_IMAGES ?>/bg_login.png");
+        }
+        div.login-form hr {
+            margin-top: 10px !important;
+            margin-bottom: 5px !important;
+        }
+
+        ul.auth-types {
+            margin: 20px 0px 0px 0px;
+            padding: 0;
+        }
+
+        ul.auth-types > li > .fa,
+        ul.auth-types > li svg,
+        ul.auth-types > li .ccm-auth-type-icon {
+            position: absolute;
+            top: 2px;
+            left: 0px;
+        }
+
+        ul.auth-types > li {
+            list-style-type: none;
+            cursor: pointer;
+            padding-left: 25px;
+            margin-bottom: 15px;
+            transition: color .25s;
+            position: relative;
+        }
+
+        ul.auth-types > li:hover {
+            color: #cfcfcf;
+        }
+
+        ul.auth-types > li.active {
+            font-weight: bold;
+            cursor: auto;
+        }
+    </style>
+
+    <script type="text/javascript">
+        (function ($) {
+            "use strict";
+
+            var forms = $('div.controls').find('div.authentication-type').hide(),
+                select = $('div.ccm-authentication-type-select > select');
+            var types = $('ul.auth-types > li').each(function () {
+                var me = $(this),
+                    form = forms.filter('[data-handle="' + me.data('handle') + '"]');
+                me.click(function () {
+                    select.val(me.data('handle'));
+                    if (typeof Concrete !== 'undefined') {
+                        Concrete.event.fire('AuthenticationTypeSelected', me.data('handle'));
+                    }
+
+                    if (form.hasClass('active')) return;
+                    types.removeClass('active');
+                    me.addClass('active');
+                    if (forms.filter('.active').length) {
+                        forms.stop().filter('.active').removeClass('active').fadeOut(250, function () {
+                            form.addClass('active').fadeIn(250);
+                        });
+                    } else {
+                        form.addClass('active').show();
+                    }
+                });
+            });
+
+            $(function() {
+                $.backstretch("<?= Config::get('concrete.urls.background_feed') . '/' . $image ?>", {
+                    fade: 500
+                });
+            });
+        })(jQuery);
+    </script>
+</div>

--- a/concrete/views/oauth/authorize.php
+++ b/concrete/views/oauth/authorize.php
@@ -32,8 +32,8 @@ if (!isset($authTypeParams)) {
     $authTypeParams = null;
 }
 
-// Always use yesterday's picture
-$image = (date('Ymd') - 1) . '.jpg';
+// Always use last week's picture
+$image = (date('Ymd') - 7) . '.jpg';
 ?>
 
 <div class="login-page">
@@ -43,7 +43,13 @@ $image = (date('Ymd') - 1) . '.jpg';
     <div class="col-sm-6 col-sm-offset-3 login-form">
         <div class="row login-row">
             <div class="controls col-sm-12 col-xs-12">
-                <h3 class="text-center"><?= t('Sign in to %s', "<strong>{$client->getName()}</strong>") ?></h3>
+                <?php
+                if (!$authorize) {
+                    ?>
+                    <h3 class="text-center"><?= t('Sign in to %s', "<strong>{$client->getName()}</strong>") ?></h3>
+                    <?php
+                }
+                ?>
 
                 <form method="post" action="<?= $request->getUri() ?>">
                     <?php
@@ -88,19 +94,17 @@ $image = (date('Ymd') - 1) . '.jpg';
                         <?php
                     } else {
                         ?>
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" name="authorize_client" value="1">
-                                <?= t('Authorize "%s" to use the following scopes:', $client->getName()) ?>
-                            </label>
-                        </div>
+                        <h3 class="scope-title text-center"><strong><?= h($client->getName()) ?></strong></h3>
+                        <h4 class="scope-description text-center">
+                            <?= t('is requesting access to the following scopes') ?>
+                        </h4>
 
                         <div class="scopes">
                             <ul>
                                 <?php
                                 foreach ($auth->getScopes() as $scope) {
                                     ?>
-                                    <li><?= $scope->getIdentifier() ?></li>
+                                    <li><strong><?= h(ucwords($scope->getIdentifier())) ?></strong>: <?= h($scope->getDescription()) ?></li>
                                     <?php
                                 }
                                 ?>
@@ -108,6 +112,13 @@ $image = (date('Ymd') - 1) . '.jpg';
                         </div>
 
                         <?php $token->output('oauth_authorize_' . $client->getClientKey()); ?>
+
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="authorize_client" value="1" />
+                                <?= t('Authorize %s', '<strong>' . h($client->getName()) . '</strong>') ?>
+                            </label>
+                        </div>
 
                         <div class="form-group">
                             <button class="btn btn-success pull-right"><?= t('Authorize') ?></button>

--- a/tests/tests/Api/OAuth/Client/ClientFactoryTest.php
+++ b/tests/tests/Api/OAuth/Client/ClientFactoryTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Concrete\Tests\Api\OAuth\Client;
+
+use Concrete\Core\Api\OAuth\Client\ClientFactory;
+use Concrete\Core\Application\Application;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\UuidGenerator;
+use Mockery as M;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class ClientFactoryTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+    protected $app;
+    protected $em;
+    protected $uuidGenerator;
+
+    /** @var ClientFactory|\Mockery\Mock */
+    protected $factory;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $this->app = M::mock(Application::class);
+        $this->em = M::mock(EntityManager::class);
+        $this->uuidGenerator = M::mock(UuidGenerator::class);
+
+        $this->factory = new ClientFactory($this->app, $this->em, $this->uuidGenerator);
+
+        // Handle "build"
+        $this->app->shouldReceive('build')->andReturnUsing(function($abstract, $data=[]) {
+            return M::mock($abstract, $data)->makePartial();
+        });
+
+        // Handle "make"
+        $this->app->shouldReceive('make')->andReturnUsing([$this->app, 'build']);
+
+        // Handle UUIDs
+        $this->uuidGenerator->shouldReceive('generate')->andReturn('uu-i-d');
+    }
+
+    /**
+     * @after
+     */
+    public function after()
+    {
+        $this->app = $this->em = $this->uuidGenerator = $this->factory = null;
+    }
+
+    public function testCredentials()
+    {
+        $defaultKeyLength = 64;
+        $defaultSecretLength = 96;
+        $customKeyLength = 17; // Low prime number
+        $customSecretLength = 97; // High prime number
+        $credentials1 = $this->factory->generateCredentials();
+        $credentials2 = $this->factory->generateCredentials();
+        $credentials3 = $this->factory->generateCredentials($customKeyLength, $customSecretLength);
+
+        // Make sure none of the credentials are empty
+        $this->assertNotEmpty($credentials1->getKey(), 'Credentials generated with empty key!');
+        $this->assertNotEmpty($credentials2->getKey(), 'Credentials generated with empty key!');
+        $this->assertNotEmpty($credentials1->getSecret(), 'Credentials generated with empty secret!');
+        $this->assertNotEmpty($credentials2->getSecret(), 'Credentials generated with empty secret!');
+
+        // Make sure the keys aren't the same as the secrets
+        $this->assertNotSame($credentials1->getKey(), $credentials1->getSecret(), 'Credentials generated with equivalent key and secret!');
+        $this->assertNotSame($credentials2->getKey(), $credentials2->getSecret(), 'Credentials generated with equivalent key and secret!');
+
+        // Make sure the two credentials aren't the same at all
+        $this->assertNotSame($credentials1->getKey(), $credentials2->getKey(), 'Credentials generated with the same key twice!');
+        $this->assertNotSame($credentials1->getSecret(), $credentials2->getSecret(), 'Credentials generated with the same secret twice!');
+
+        // Make sure the size is right
+        $this->assertEquals($defaultKeyLength, strlen($credentials1->getKey()), 'Default size key is the wrong size.');
+        $this->assertEquals($defaultSecretLength, strlen($credentials1->getSecret()), 'Custom size secret is the wrong size.');
+        $this->assertEquals($customKeyLength, strlen($credentials3->getKey()), 'Custom size key is the wrong size.');
+        $this->assertEquals($customSecretLength, strlen($credentials3->getSecret()), 'Custom size secret is the wrong size.');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A key must have a length longer than 16
+     */
+    public function testShortKeysException()
+    {
+        $this->factory->generateCredentials(10, 10);
+    }
+
+    /**
+     * @todo Enable scopes when scopes is implemented
+     */
+    public function testCreateClient()
+    {
+        $client = $this->factory->createClient(
+            'Ritas Toaster',
+            'http://example.com',
+            ['test', 'scopes'],
+            'key',
+            'secret'
+        );
+
+        $this->assertSame(
+            [
+                'uu-i-d',
+                'Ritas Toaster',
+                'http://example.com',
+                //['test', 'scopes'],
+                'key',
+                'secret'
+            ],
+            [
+                $client->getIdentifier(),
+                $client->getName(),
+                $client->getRedirectUri(),
+                //$client->getScopes(),
+                $client->getClientKey(),
+                $client->getClientSecret()
+            ]
+        );
+    }
+
+}

--- a/tests/tests/Api/OAuth/Client/ClientFactoryTest.php
+++ b/tests/tests/Api/OAuth/Client/ClientFactoryTest.php
@@ -8,9 +8,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\UuidGenerator;
 use Mockery as M;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class ClientFactoryTest extends TestCase
+class ClientFactoryTest extends PHPUnit_Framework_TestCase
 {
     use MockeryPHPUnitIntegration;
     protected $app;


### PR DESCRIPTION
This pull request:

- Implements Authorization Code grant type fully
- Adds an API scope "account" for getting the authenticated user info
- Adjusts the OAuth entities to be deletable in all cases (I think)
- Adds an authentication type called "External concrete5" that allows you to authenticate using another concrete5 site as your oauth identity provider.

TODO:

- Handle scopes a little better. Today they aren't properly translatable and authorization isn't persisted across sessions.
- More test coverage
- Better oauth authorization login page. Today I just copied the login page and made the background image be from last week so that theres a bit of difference, but it's still not immediately obvious what is happening when you're going through the login flow
- Complete the list of scopes and figure out how we want to split things up. We could go the github route and do `user:read` and `user:write`, but we should do our best to support the base scopes defined by OIDC https://auth0.com/docs/scopes/current/oidc-scopes