### PR TITLE
Upgrade Imagine from 0.7.1 to 1.0.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1959,24 +1959,24 @@
         },
         {
             "name": "imagine/imagine",
-            "version": "v0.7.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "a9a702a946073cbca166718f1b02a1e72d742daa"
+                "reference": "b9e15fac9b79c28cd6b7de3e7e5162e143ae80ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/a9a702a946073cbca166718f1b02a1e72d742daa",
-                "reference": "a9a702a946073cbca166718f1b02a1e72d742daa",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/b9e15fac9b79c28cd6b7de3e7e5162e143ae80ad",
+                "reference": "b9e15fac9b79c28cd6b7de3e7e5162e143ae80ad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "sami/sami": "^3.3",
-                "symfony/phpunit-bridge": "^3.2"
+                "friendsofphp/php-cs-fixer": "2.2.*",
+                "symfony/phpunit-bridge": "^3.2 || ^4.0"
             },
             "suggest": {
                 "ext-gd": "to use the GD implementation",
@@ -1990,8 +1990,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Imagine": "lib/"
+                "psr-4": {
+                    "Imagine\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2013,7 +2013,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2017-05-16T10:31:22+00:00"
+            "time": "2018-09-25T14:50:23+00:00"
         },
         {
             "name": "indigophp/hash-compat",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -43,7 +43,7 @@
     "illuminate/config": "5.2.*",
     "patchwork/utf8": "~1.2.3|~1.3",
     "concrete5/less.php": "2.0.0",
-    "imagine/imagine": "0.7.*",
+    "imagine/imagine": "1.*",
     "natxet/cssmin": "3.*",
     "tedivm/jshrink": "1.*",
     "michelf/php-markdown": "1.*",


### PR DESCRIPTION
There are some breaking changes in Imagine from 0.7.1 to 1.0.0.
These BC are only relevant if someone extends Imagine classes; which is BTW very unlikely since almost all Imagine classes are final. So, it should be safe to upgrade this library.

Fix #3999