### PR TITLE
Fix resizing images on import when only max height is set

### DIFF
--- a/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
+++ b/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
@@ -259,6 +259,7 @@ class ConstrainImageProcessor implements ProcessorInterface
         } elseif ($this->maxHeight !== null) {
             if ($imageSize->getHeight() > $this->maxHeight) {
                 $width = $this->maxHeight * $imageSize->getWidth() / $imageSize->getHeight();
+                $newBox = new Box($width, $this->maxHeight);
             }
         }
         if ($newBox !== null) {


### PR DESCRIPTION
If concrete5 is set to automatically resize images that exceed a maximum height but not a maximum width, the resizing never happens.
Let's fix this.