### PR TITLE
Keep animations when ConstrainImageProcessor resizes animated GIFs

### DIFF
--- a/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
+++ b/concrete/src/File/ImportProcessor/ConstrainImageProcessor.php
@@ -268,6 +268,9 @@ class ConstrainImageProcessor implements ProcessorInterface
             $bitmapFormat = $this->app->make(BitmapFormat::class);
             $thumbnailType = $bitmapFormat->getFormatFromMimeType($mimetype, BitmapFormat::FORMAT_PNG);
             $thumbnailOptions = $bitmapFormat->getFormatImagineSaveOptions($thumbnailType);
+            if ($thumbnailType === BitmapFormat::FORMAT_GIF && $thumbnail->layers()->count() > 1) {
+                $thumbnailOptions['animated'] = true;
+            }
             $version->updateContents($thumbnail->get($thumbnailType, $thumbnailOptions), $this->rescanThumbnails);
         }
     }


### PR DESCRIPTION
This works only if Imagine is configured to use the Imagick driver (the GD driver does not support animated GIFs).