### PR TITLE
Add support to generate animated GIF thumbnails

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0a2',
     'version_installed' => '8.5.0a2',
-    'version_db' => '20180910000000', // the key of the latest database migration
+    'version_db' => '20180926070200', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails.php
@@ -36,9 +36,12 @@ class Thumbnails extends DashboardPageController
                 return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
             }
         }
+        $config = $this->app->make('config');
         $this->set('type', $type);
         $this->set('sizingModes', $this->getSizingModes());
         $this->set('sizingModeHelps', $this->getSizingModeHelps());
+        $imageManipulationLibrary = $config->get('concrete.file_manager.images.manipulation_library');
+        $this->set('manipulationLibrarySupportsAnimations', (string) $imageManipulationLibrary !== '' && $imageManipulationLibrary !== 'gd'); 
         if ($type->getID() && $type->isRequired()) {
             $this->set('allowConditionalThumbnails', false);
         } else {
@@ -142,6 +145,7 @@ class Thumbnails extends DashboardPageController
                 $type->setSizingMode($sizingMode);
             }
             $type->setIsUpscalingEnabled($post->get('ftUpscalingEnabled') ? true : false);
+            $type->setKeepAnimations($post->get('ftKeepAnimations'));
             if ($ftTypeID === 'new' || !$type->isRequired()) {
                 $fileSetOption = $post->get('fileSetOption');
                 if (!in_array($fileSetOption, array_keys($this->getFileSetOptions()), true)) {

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -1,5 +1,8 @@
 <?php
 
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var Concrete\Core\Page\View\PageView $view */
@@ -14,6 +17,7 @@ if (isset($type)) {
     /* @var bool $allowConditionalThumbnails */
     /* @var array $fileSetOptions [if $allowConditionalThumbnails is true] */
     /* @var array $fileSets [if $allowConditionalThumbnails is true] */
+    /* @var bool $manipulationLibrarySupportsAnimations */
     if ($type->getID() !== null && !$type->isRequired()) {
         ?>
         <div class="ccm-dashboard-header-buttons">
@@ -66,6 +70,44 @@ if (isset($type)) {
                 <label>
                     <?= $form->checkbox('ftUpscalingEnabled', '1', $type->isUpscalingEnabled()) ?>
                     <?= t('Allow upscaling images smaller than the thumbnail size') ?>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('ftKeepAnimations', '1', $type->isKeepAnimations()) ?>
+                    <?= t('Create animated thumbnails for animated images') ?>
+                    <?php
+                    if (!$manipulationLibrarySupportsAnimations) {
+                        $optionsPageName = t('Image Options');
+                        $optionsPage = Page::getByPath('/dashboard/system/files/image_uploading');
+                        if ($optionsPage && !$optionsPage->isError()) {
+                            $optionsPageName = h(t($optionsPage->getCollectionName()));
+                            $optionsPagePermissions = new Checker($optionsPage);
+                            if ($optionsPagePermissions->canViewPage()) {
+                                $optionsPageName = '<a href="' . h($optionsPage->getCollectionLink()) . '" target="_blank">' . $optionsPageName . '</a>';
+                            }
+                        }
+                        ?>
+                        <span class="small text-muted" id="ftKeepAnimations-warning" <?= $type->isKeepAnimations() ? '' : ' style="display: none"' ?>>
+                            <br />
+                            <i class="fa fa-exclamation-triangle" aria-hidden="true" style="color: red"></i>
+                            <?= t('This requires that concrete5 is configured to use the ImageMagick manipulation library.') ?>
+                            <br />
+                            <?= t(/*i18n: %s is the name of a page*/ 'You can configure it in the %s page.', $optionsPageName) ?>
+                        </span>
+                        <script>
+                        $(document).ready(function() {
+                            $('#ftKeepAnimations')
+                                .on('change', function() {
+                                    $('#ftKeepAnimations-warning').toggle(this.checked);
+                                })
+                                .trigger('change')
+                            ;
+                        });
+                        </script>
+                        <?php
+                    }
+                    ?>
                 </label>
             </div>
         </div>

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportFileImportantThumbnailTypesRoutine.php
@@ -34,6 +34,7 @@ class ImportFileImportantThumbnailTypesRoutine extends AbstractRoutine
                     $type->setSizingMode((string) $l['sizingMode']);
                 }
                 $type->setIsUpscalingEnabled(isset($l['upscalingEnabled']) && $l['upscalingEnabled']);
+                $type->setKeepAnimations(isset($l['keepAnimations']) && $l['keepAnimations']);
                 if (isset($l['width'])) {
                     $type->setWidth((string) $l['width']);
                 }

--- a/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/Entity/File/Image/Thumbnail/Type/Type.php
@@ -136,6 +136,18 @@ class Type
      */
     protected $ftAssociatedFileSets;
 
+    /**
+     * Should we create animated thumbnails for animated images?
+     *
+     * @ORM\Column(type="boolean")
+     *
+     * @var bool
+     */
+    protected $ftKeepAnimations = false;
+
+    /**
+     * Initialize the instance.
+     */
     public function __construct()
     {
         $this->ftAssociatedFileSets = new ArrayCollection();
@@ -372,6 +384,30 @@ class Type
     }
 
     /**
+     * Should we create animated thumbnails for animated images?
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setKeepAnimations($value)
+    {
+        $this->ftKeepAnimations = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * Should we create animated thumbnails for animated images?
+     *
+     * @return bool
+     */
+    public function isKeepAnimations()
+    {
+        return (bool) $this->ftKeepAnimations;
+    }
+
+    /**
      * Save this instance to the database.
      */
     public function save()
@@ -439,6 +475,6 @@ class Type
             }
         }
 
-        return new Version($handle . $suffix, $handle . $suffix, $this->getName(), $width, $height, $doubled, $this->getSizingMode(), $limitedToFileSets, $filesetIDs, $this->isUpscalingEnabled());
+        return new Version($handle . $suffix, $handle . $suffix, $this->getName(), $width, $height, $doubled, $this->getSizingMode(), $limitedToFileSets, $filesetIDs, $this->isUpscalingEnabled(), $this->isKeepAnimations());
     }
 }

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1486,10 +1486,19 @@ class Version implements ObjectInterface
         $thumbnail = $imageForThumbnail->thumbnail($size, $thumbnailMode);
         unset($imageForThumbnail);
         $thumbnailPath = $type->getFilePath($this);
-        $thumbnailFormat = $app->make(ThumbnailFormatService::class)->getFormatForFile($this);
+        if ($type->isKeepAnimations() && $thumbnail->layers()->count() > 1) {
+            $isAnimation = true;
+            $thumbnailFormat = BitmapFormat::FORMAT_GIF;
+        } else {
+            $thumbnailFormat = $app->make(ThumbnailFormatService::class)->getFormatForFile($this);
+            $isAnimation = false;
+        }
 
         $mimetype = $bitmapFormat->getFormatMimeType($thumbnailFormat);
         $thumbnailOptions = $bitmapFormat->getFormatImagineSaveOptions($thumbnailFormat);
+        if ($isAnimation) {
+            $thumbnailOptions['animated'] = true;
+        }
 
         $filesystem->write(
             $thumbnailPath,

--- a/concrete/src/File/Image/Thumbnail/Type/Type.php
+++ b/concrete/src/File/Image/Thumbnail/Type/Type.php
@@ -82,6 +82,7 @@ class Type
             $linkNode->addAttribute('handle', $link->getHandle());
             $linkNode->addAttribute('sizingMode', $link->getSizingMode());
             $linkNode->addAttribute('upscalingEnabled', $link->isUpscalingEnabled() ? '1' : '0');
+            $linkNode->addAttribute('keepAnimations', $link->isKeepAnimations() ? '1' : '0');
             if ($link->getWidth()) {
                 $linkNode->addAttribute('width', $link->getWidth());
             }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180926070200.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180926070200.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20180926070200 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            Type::class,
+        ]);
+    }
+}


### PR DESCRIPTION
This PR add an option to the thumbnail types to instruct concrete5 to generate animated GIF thumbnails in case of animated GIF images.

In order to have this feature working, Imagine must be configured to use imagick instead of GD.
If concrete5 is not configured so, we'll display a warning:

![immagine](https://user-images.githubusercontent.com/928116/46068990-c0d2a000-c17a-11e8-8e21-7a90cab8e229.png)

Sample session with `file_manager_listing` and `file_manager_detail` set with this option turned on:
![thumbnail-animated-gif](https://user-images.githubusercontent.com/928116/46072147-ea42fa00-c181-11e8-9eb8-357c4c6694a0.gif)
