### PR TITLE
Let OAuth Scopes always have strings in their description

### DIFF
--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -23,7 +23,7 @@ class Scope implements ScopeEntityInterface
      * @var string
      * @ORM\Column(type="string")
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * @ORM\ManyToMany(targetEntity="AuthCode", mappedBy="scopes")
@@ -66,7 +66,7 @@ class Scope implements ScopeEntityInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
     }
 
     /**


### PR DESCRIPTION
It's not possible to install concrete5 right now, because we have this error:

```
[Doctrine\DBAL\Exception\NotNullConstraintViolationException]                                                        
An exception occurred while executing
'INSERT INTO OAuth2Scope (identifier, description) VALUES (?, ?)'
with params  
["system", null]:                                                                                                   
```

Here's the relevant stack trace:

```
Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException()
at
concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:128

Doctrine\DBAL\DBALException::driverExceptionDuringQuery()
at
concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Statement.php:177

Doctrine\DBAL\Statement->execute()
at
concrete/vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php:281

Doctrine\ORM\Persisters\Entity\BasicEntityPersister->executeInserts()
at
concrete/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:1014

Doctrine\ORM\UnitOfWork->executeInserts()
at
concrete/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:378

Doctrine\ORM\UnitOfWork->commit()
at
concrete/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php:356

Doctrine\ORM\EntityManager->flush()
at
concrete/src/Package/StartingPointPackage.php:356

Concrete\Core\Package\StartingPointPackage->install_api()
at
concrete/src/Package/StartingPointPackage.php:184
```

Let's fix this.