### PR TITLE
Show a warning about memory & performance when using animated thumbnails

### DIFF
--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -76,38 +76,42 @@ if (isset($type)) {
                 <label>
                     <?= $form->checkbox('ftKeepAnimations', '1', $type->isKeepAnimations()) ?>
                     <?= t('Create animated thumbnails for animated images') ?>
-                    <?php
-                    if (!$manipulationLibrarySupportsAnimations) {
-                        $optionsPageName = t('Image Options');
-                        $optionsPage = Page::getByPath('/dashboard/system/files/image_uploading');
-                        if ($optionsPage && !$optionsPage->isError()) {
-                            $optionsPageName = h(t($optionsPage->getCollectionName()));
-                            $optionsPagePermissions = new Checker($optionsPage);
-                            if ($optionsPagePermissions->canViewPage()) {
-                                $optionsPageName = '<a href="' . h($optionsPage->getCollectionLink()) . '" target="_blank">' . $optionsPageName . '</a>';
+                    <span class="small text-muted" id="ftKeepAnimations-warning" <?= $type->isKeepAnimations() ? '' : ' style="display: none"' ?>>
+                        <br />
+                        <i class="fa fa-exclamation-triangle" aria-hidden="true" style="color: red"></i>
+                        <?php
+                        if ($manipulationLibrarySupportsAnimations) {
+                            ?>
+                            <?= t('Creating animated thumbnails may require a lot of memory and may require more processing time.') ?>
+                            <?php
+                        } else {
+                            $optionsPageName = t('Image Options');
+                            $optionsPage = Page::getByPath('/dashboard/system/files/image_uploading');
+                            if ($optionsPage && !$optionsPage->isError()) {
+                                $optionsPageName = h(t($optionsPage->getCollectionName()));
+                                $optionsPagePermissions = new Checker($optionsPage);
+                                if ($optionsPagePermissions->canViewPage()) {
+                                    $optionsPageName = '<a href="' . h($optionsPage->getCollectionLink()) . '" target="_blank">' . $optionsPageName . '</a>';
+                                }
                             }
-                        }
-                        ?>
-                        <span class="small text-muted" id="ftKeepAnimations-warning" <?= $type->isKeepAnimations() ? '' : ' style="display: none"' ?>>
-                            <br />
-                            <i class="fa fa-exclamation-triangle" aria-hidden="true" style="color: red"></i>
+                            ?>
                             <?= t('This requires that concrete5 is configured to use the ImageMagick manipulation library.') ?>
                             <br />
                             <?= t(/*i18n: %s is the name of a page*/ 'You can configure it in the %s page.', $optionsPageName) ?>
-                        </span>
-                        <script>
-                        $(document).ready(function() {
-                            $('#ftKeepAnimations')
-                                .on('change', function() {
-                                    $('#ftKeepAnimations-warning').toggle(this.checked);
-                                })
-                                .trigger('change')
-                            ;
-                        });
-                        </script>
-                        <?php
-                    }
-                    ?>
+                            <?php
+                        }
+                        ?>
+                    </span>
+                    <script>
+                    $(document).ready(function() {
+                        $('#ftKeepAnimations')
+                            .on('change', function() {
+                                $('#ftKeepAnimations-warning').toggle(this.checked);
+                            })
+                            .trigger('change')
+                        ;
+                    });
+                    </script>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
As [suggested](https://github.com/concrete5/concrete5/pull/7114#issuecomment-424817221) by @MrKarlDilkington, we should show a warning about memory & performance issues when a thumbnail is set to create animated GIF files.

With this change, we'll show this error message (if Imagine is configured to use ImageMagick):

![immagine](https://user-images.githubusercontent.com/928116/46129648-a6aac780-c237-11e8-85c4-a31c7e4d52f8.png)

If Imagine is configured to use GD, we still show this other warning:

![immagine](https://user-images.githubusercontent.com/928116/46129706-d063ee80-c237-11e8-9a59-9e67272d2fa3.png)
