### PR TITLE
Add dedicated event class for 'on_sitemap_xml_element'

### DIFF
--- a/concrete/src/Page/Sitemap/Event/SitemapXmlElementEvent.php
+++ b/concrete/src/Page/Sitemap/Event/SitemapXmlElementEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Concrete\Core\Page\Sitemap\Event;
+
+use phpDocumentor\Reflection\Types\Parent_;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @since 8.5.0
+ */
+class SitemapXmlElementEvent extends GenericEvent
+{
+    /**
+     * For backward compatibility on < 8.5.0.
+     *
+     * @deprecated Use getElement instead.
+     *
+     * @return array
+     */
+    public function getSubject()
+    {
+        if (isset($this->subject['sitemapPage'])) {
+            return $this->subject;
+        }
+
+        return ['sitemapPage' => $this->getElement()];
+    }
+
+    /**
+     * Get the current XML element.
+     *
+     * @see \Concrete\Core\Page\Sitemap\Element\SitemapPage
+     *
+     * @return \Concrete\Core\Page\Sitemap\Element\SitemapElement
+     */
+    public function getElement()
+    {
+        return $this->getArgument('element');
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Sitemap\Element\SitemapElement $element
+     */
+    public function setElement($element)
+    {
+        $this->setArgument('element', $element);
+    }
+}

--- a/concrete/src/Page/Sitemap/SitemapWriter.php
+++ b/concrete/src/Page/Sitemap/SitemapWriter.php
@@ -6,6 +6,7 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Page\Sitemap\Element\SitemapHeader;
 use Concrete\Core\Page\Sitemap\Element\SitemapPage;
+use Concrete\Core\Page\Sitemap\Event\SitemapXmlElementEvent;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -292,7 +293,9 @@ class SitemapWriter
                     $pulse($element);
                 }
                 if ($dispatchElementReady) {
-                    $this->director->dispatch(static::EVENTNAME_ELEMENTREADY, new GenericEvent(['sitemapPage' => $element]));
+                    $event = new SitemapXmlElementEvent();
+                    $event->setElement($element);
+                    $this->director->dispatch(static::EVENTNAME_ELEMENTREADY, $event);
                 }
                 if ($mode === static::MODE_HIGHMEMORY) {
                     if ($element instanceof SitemapHeader) {


### PR DESCRIPTION
 This PR adds the `SitemapXmlElementEvent` class, which makes it easier to work with than a `GenericEvent` class. Because now we can add documentation blocks, for example.

Also, the former code:
```php
new GenericEvent(['sitemapPage' => $element])
```

causes the `$subject` to be an array, which is not very handy, because then you'd get this kind of code in a listener:

```
$subject = $event->getSubject();

/** @var \Concrete\Core\Page\Sitemap\Element\SitemapPage $element */
$element = $subject['sitemapPage'];
```