### PR TITLE
Display the list of pages where a feed is used

### DIFF
--- a/concrete/controllers/single_page/dashboard/pages/feeds.php
+++ b/concrete/controllers/single_page/dashboard/pages/feeds.php
@@ -5,6 +5,7 @@ use Concrete\Core\Area\Area;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Feed;
+use Concrete\Core\Feed\FeedService;
 use Concrete\Core\Page\Type\Type;
 use Core;
 
@@ -172,6 +173,7 @@ class Feeds extends DashboardPageController
         $this->feed = $feed;
 
         $this->set('feed', $feed);
+        $this->set('feedUsage', $this->app->make(FeedService::class)->getFeedUsage($feed));
         $this->add();
     }
 }

--- a/concrete/single_pages/dashboard/pages/feeds.php
+++ b/concrete/single_pages/dashboard/pages/feeds.php
@@ -43,6 +43,10 @@
         $tokenString = 'edit_feed';
         $button = t('Update');
     }
+    if (!isset($feedUsage)) {
+        $feedUsage = null;
+    }
+    /* @var Concrete\Core\Feed\FeedUsage|null $feedUsage */
     ?>
 
     <div class="ccm-dashboard-header-buttons">
@@ -198,6 +202,38 @@
             <?=$form->label('pfAreaHandleToDisplay', t('Select Area'))?>
             <?=$form->select('pfAreaHandleToDisplay', $areas, $pfAreaHandleToDisplay)?>
         </div>
+
+        <?php
+        if ($feedUsage !== null) {
+            ?>
+            <div class="form-group">
+                <?=$form->label('', t('Feed Usage'))?>
+                <?php
+                $usageEntries = $feedUsage->getUsageEntries();
+                if (empty($usageEntries)) {
+                    ?>
+                    <div><?= t('This feed is not used.') ?></div>
+                    <?php
+                } else {
+                    $previousHeading = false;
+                    foreach ($usageEntries as $usageEntry) {
+                        $heading = $usageEntry->getHeadingText();
+                        if ($heading !== $previousHeading) {
+                            if ($previousHeading !== false) {
+                                echo '</ul>';
+                            }
+                            $previousHeading = $heading; 
+                            echo '<ul>', h($heading);
+                        }
+                        echo '<li>', $usageEntry->toHtml(), '</li>';
+                    }
+                    echo '</ul>';
+                }
+                ?>
+            </div>
+            <?php
+        }
+        ?>
 
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">

--- a/concrete/src/Feed/FeedService.php
+++ b/concrete/src/Feed/FeedService.php
@@ -1,16 +1,40 @@
 <?php
+
 namespace Concrete\Core\Feed;
 
 use Concrete\Core\Cache\Adapter\ZendCacheDriver;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Page\Feed as FeedEntity;
+use PDO;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Zend\Feed\Reader\Reader;
 
 class FeedService
 {
     /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    protected $director;
+
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $connection;
+
+    public function __construct(EventDispatcherInterface $director, Connection $connection)
+    {
+        $this->director = $director;
+        $this->connection = $connection;
+    }
+
+    /**
      * Loads a newsfeed object.
      *
      * @param string $feedurl
      * @param int    $cache - number of seconds to cache the RSS feed data for
+     * @param mixed $url
+     *
      * @return Reader
      */
     public function load($url, $cache = 3600)
@@ -24,5 +48,72 @@ class FeedService
         $feed = Reader::import($url);
 
         return $feed;
+    }
+
+    /**
+     * Get info about the usage of a feed.
+     *
+     * @param \Concrete\Core\Entity\Page\Feed $feed
+     *
+     * @return \Concrete\Core\Feed\FeedUsage
+     */
+    public function getFeedUsage(FeedEntity $feed)
+    {
+        $result = new FeedUsage($feed);
+        $this->populateFeedUsage($result);
+        $this->sortFeedUsage($result);
+
+        return $result;
+    }
+
+    /**
+     * Populate the usage of a feed.
+     *
+     * @param \Concrete\Core\Feed\FeedUsage $feedUsage
+     */
+    protected function populateFeedUsage(FeedUsage $feedUsage)
+    {
+        $this->populatePageListFeedUsage($feedUsage);
+        $this->director->dispatch('populate_feed_usage', new GenericEvent($feedUsage));
+    }
+
+    /**
+     * Populate the usage of a feed: PageList blocks.
+     *
+     * @param \Concrete\Core\Feed\FeedUsage $feedUsage
+     */
+    protected function populatePageListFeedUsage(FeedUsage $feedUsage)
+    {
+        $rs = $this->connection->executeQuery(
+            <<<'EOT'
+select distinct CollectionVersions.cID, CollectionVersions.cvID
+from btPageList
+inner join CollectionVersionBlocks on btPageList.bID = CollectionVersionBlocks.bID
+inner join CollectionVersions on CollectionVersionBlocks.cID = CollectionVersions.cID and CollectionVersionBlocks.cvID = CollectionVersions.cvID
+where btPageList.pfID = ?
+EOT
+            ,
+            [$feedUsage->getFeed()->getID()]
+        );
+        while (($row = $rs->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $entry = PageListFeedUsageEntry::create($row['cID'], $row['cvID']);
+            if ($entry !== null) {
+                $feedUsage->addUsageEntry($entry);
+            }
+        }
+    }
+
+    /**
+     * Sort the usage of a feed.
+     *
+     * @param \Concrete\Core\Feed\FeedUsage $feedUsage
+     */
+    protected function sortFeedUsage(FeedUsage $feedUsage)
+    {
+        $entries = $feedUsage->getUsageEntries();
+        usort($entries, function (FeedUsageEntryInterface $a, FeedUsageEntryInterface $b) {
+            return strcmp(get_class($a), get_class($b));
+        });
+        $feedUsage->setUsageEntries($entries);
     }
 }

--- a/concrete/src/Feed/FeedUsage.php
+++ b/concrete/src/Feed/FeedUsage.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Concrete\Core\Feed;
+
+use Concrete\Core\Entity\Page\Feed as FeedEntity;
+
+class FeedUsage
+{
+    /**
+     * The feed instance.
+     *
+     * @var \Concrete\Core\Entity\Page\Feed
+     */
+    protected $feed;
+
+    /**
+     * The feed usage entries.
+     *
+     * @var \Concrete\Core\Feed\FeedUsageEntryInterface[]
+     */
+    protected $usageEntries = [];
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Entity\Page\Feed $feed the feed instance
+     */
+    public function __construct(FeedEntity $feed)
+    {
+        $this->feed = $feed;
+    }
+
+    /**
+     * Get the feed instance.
+     *
+     * @return \Concrete\Core\Entity\Page\Feed
+     */
+    public function getFeed()
+    {
+        return $this->feed;
+    }
+
+    /**
+     * Add a new usage entry.
+     *
+     * @param FeedUsageEntryInterface $entry
+     *
+     * @return $this
+     */
+    public function addUsageEntry(FeedUsageEntryInterface $entry)
+    {
+        $this->usageEntries[] = $entry;
+
+        return $this;
+    }
+
+    /**
+     * Set the feed usage entries.
+     *
+     * @param \Concrete\Core\Feed\FeedUsageEntryInterface[] $entries
+     *
+     * @return $this
+     */
+    public function setUsageEntries(array $entries)
+    {
+        $this->usageEntries = $entries;
+
+        return $this;
+    }
+
+    /**
+     * Get the feed usage entries.
+     *
+     * @return \Concrete\Core\Feed\FeedUsageEntryInterface[]
+     */
+    public function getUsageEntries()
+    {
+        return $this->usageEntries;
+    }
+}

--- a/concrete/src/Feed/FeedUsageEntryInterface.php
+++ b/concrete/src/Feed/FeedUsageEntryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Feed;
+
+interface FeedUsageEntryInterface
+{
+    /**
+     * Get the heading text to be used before a list of these items.
+     *
+     * @return string
+     */
+    public function getHeadingText();
+
+    /**
+     * Return an HTML representation of this item.
+     *
+     * @return string
+     */
+    public function toHtml();
+}

--- a/concrete/src/Feed/FeedUsageOnPageEntry.php
+++ b/concrete/src/Feed/FeedUsageOnPageEntry.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Concrete\Core\Feed;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Stack\Stack;
+use URL;
+
+abstract class FeedUsageOnPageEntry implements FeedUsageEntryInterface
+{
+    /**
+     * @var \Concrete\Core\Page\Page
+     */
+    protected $page;
+
+    /**
+     * Create a new instance.
+     *
+     * @param int $pageID
+     * @param int $pageVersion
+     *
+     * @return static|null
+     */
+    public static function create($pageID, $pageVersion)
+    {
+        $page = Page::getByID($pageID, $pageVersion);
+        if (!$page || $page->isError()) {
+            return null;
+        }
+        $result = new static();
+        $result->page = $page;
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Feed\FeedUsageEntryInterface::toHtml()
+     */
+    public function toHtml()
+    {
+        $pageVersion = $this->page->getVersionObject();
+        $url = '';
+        $notes = $pageVersion->isApproved() ? t('approved version "%s"', $pageVersion->getVersionComments() ?: $pageVersion->getVersionID()) : t('not approved version "%s"', $pageVersion->getVersionComments() ?: $pageVersion->getVersionID());
+        if ($this->page->getPageTypeHandle() == STACKS_PAGE_TYPE) {
+            $stack = Stack::getByID($this->page->getCollectionID(), $pageVersion->getVersionID());
+            if ($stack->getStackType() === Stack::ST_TYPE_GLOBAL_AREA) {
+                $name = t('Global Area "%s"', t($stack->getStackName()));
+            } else {
+                $name = t('Stack "%s"', t($stack->getStackName()));
+            }
+        } elseif ($this->page->isMasterCollection()) {
+            $name = t('Page Template "%s"', t($this->page->getPageTypeObject()->getPageTypeName()));
+        } else {
+            $name = $this->page->getCollectionName();
+            $url = (string) URL::to($this->page);
+        }
+        $result = '';
+        if ($url !== '') {
+            $result .= '<a href="' . h($url) . '">';
+        }
+        $result .= h($name);
+        if ($url !== '') {
+            $result .= '</a>';
+        }
+        if ($notes !== '') {
+            $result .= ' (' . h($notes) . ')';
+        }
+
+        return $result;
+    }
+}

--- a/concrete/src/Feed/PageListFeedUsageEntry.php
+++ b/concrete/src/Feed/PageListFeedUsageEntry.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Concrete\Core\Feed;
+
+class PageListFeedUsageEntry extends FeedUsageOnPageEntry
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Feed\FeedUsageEntryInterface::getHeadingText()
+     */
+    public function getHeadingText()
+    {
+        return t('The RSS feed is used by blocks of type %s in the following places:', t('Page List'));
+    }
+}


### PR DESCRIPTION
RSS Feeds can be created (and updated) by Page List blocks.
RSS Feeds can also be managed in the `/dashboard/pages/feeds` dashboard page, but it's not clear which feeds are defined manually, which feeds exist only for PageList blocks in old page versions, and which feeds are used by currently approved pages.

What about adding some details in the dashboard page?

Example 1: a RSS Feed defined manually:
![immagine](https://user-images.githubusercontent.com/928116/46160800-ebf4e680-c283-11e8-8e0b-4b868ff2b6b2.png)

Example 2: a RSS Feed defined by Page List blocks:
![immagine](https://user-images.githubusercontent.com/928116/46161743-a685e880-c286-11e8-94a9-956522fe7716.png)

