### PR TITLE
Add back route to rich text editor preview

### DIFF
--- a/concrete/routes/misc.php
+++ b/concrete/routes/misc.php
@@ -28,3 +28,4 @@ $router->all('/tools/required/jobs/run_single', '\Concrete\Controller\Frontend\J
 $router->all('/ccm/system/upgrade/', '\Concrete\Controller\Upgrade::view');
 $router->all('/ccm/system/upgrade/submit', '\Concrete\Controller\Upgrade::submit');
 $router->all('/ccm/system/country-stateprovince-link/get_stateprovinces', '\Concrete\Controller\Frontend\CountryStateprovinceLink::getStateprovinces');
+$router->all('/ccm/system/dialogs/editor/settings/preview', 'Concrete\Controller\Dialog\Editor\Settings\Preview::view');


### PR DESCRIPTION
It seems that the `/ccm/system/dialogs/editor/settings/preview` route introduced in https://github.com/concrete5/concrete5/pull/6720 doesn't exist anymore: let's add it back.