### PR TITLE
Show "Database should be empty" instead of "Database is empty"

### DIFF
--- a/concrete/src/Install/Preconditions/EmptyDatabase.php
+++ b/concrete/src/Install/Preconditions/EmptyDatabase.php
@@ -27,7 +27,7 @@ class EmptyDatabase implements ConnectionOptionsPreconditionInterface
      */
     public function getName()
     {
-        return t('Database is empty');
+        return t('Database should be empty');
     }
 
     /**


### PR DESCRIPTION
Fix #7152