### PR TITLE
Catch exceptions in interactive CLI install

### DIFF
--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -220,7 +220,13 @@ EOT
                 }
 
                 $installer = $this->buildInstaller($this->getFinalOptions($input));
-                switch ($this->checkOptionPreconditions($app, $installer, $input, $output)) {
+                try {
+                    $preconditionsResult = $this->checkOptionPreconditions($app, $installer, $input, $output);
+                } catch (Exception $x) {
+                    $output->writeln('<error>' . $x->getMessage() . '</error>');
+                    $preconditionsResult = self::OPTIONPRECONDITIONS_ERROR;
+                }
+                switch ($preconditionsResult) {
                     case self::OPTIONPRECONDITIONS_ERROR:
                         $confirm = new Question('Errors detected! Would you like to change the above settings? [Y]es / [N]o: ', false);
                         $confirm->setValidator(function ($given) {


### PR DESCRIPTION
If running the CLI install command in an interactive way (`./concrete/bin/concrete5 c5:install -i`), and we enter invalid database connection parameters, the process aborts for an uncaught exception (`SQLSTATE[HY000] [2002] Connection refused`).

What about intercepting exceptions so that users can change the wrong connection parameters?