### PR TITLE
Install: use utf8mb4 in database connection if available

### DIFF
--- a/concrete/src/Install/Installer.php
+++ b/concrete/src/Install/Installer.php
@@ -219,6 +219,9 @@ class Installer
             }
         }
 
+        if ($result !== $connection) {
+            $connection->close();
+        }
         return $result;
     }
 }

--- a/concrete/src/Install/Installer.php
+++ b/concrete/src/Install/Installer.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Install;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Database\DatabaseManager;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Install\Preconditions\PdoMysqlExtension;
@@ -88,12 +89,16 @@ class Installer
         }
         $databaseManager = $this->application->make(DatabaseManager::class);
         try {
-            return $databaseManager->getFactory()->createConnection($databaseConfiguration);
+            $connection = $databaseManager->getFactory()->createConnection($databaseConfiguration);
         } catch (Exception $x) {
             throw new UserMessageException($x->getMessage(), $x->getCode(), $x);
         } catch (Throwable $x) {
             throw new UserMessageException($x->getMessage(), $x->getCode());
         }
+
+        $connection = $this->checkUnicodeCharset($connection, $databaseConfiguration);
+
+        return $connection;
     }
 
     /**
@@ -172,6 +177,45 @@ class Installer
             } else {
                 $result['host'] = $result['server'];
                 unset($result['server']);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     * @param array $configuration
+     *
+     * @return \Concrete\Core\Database\Connection\Connection
+     */
+    private function checkUnicodeCharset(Connection $connection, array $configuration)
+    {
+        $result = $connection;
+        $charset = isset($configuration['charset']) ? (string) $configuration['charset'] : '';
+        if (strcasecmp($charset, 'utf8') === 0) {
+            try {
+                $hasUtf8Mb4 = false;
+                $rs = $connection->executeQuery('SHOW CHARACTER SET');
+                while (($charset = $rs->fetchColumn()) !== false) {
+                    if (strcasecmp($charset, 'utf8mb4') === 0) {
+                        $hasUtf8Mb4 = true;
+                        break;
+                    }
+                }
+                if ($hasUtf8Mb4) {
+                    $configuration = $this->getOptions()->getConfiguration();
+                    $defaultConnectionName = isset($configuration['database']['default-connection']) ? $configuration['database']['default-connection'] : '';
+                    if ($defaultConnectionName) {
+                        $defaultConnectionConfiguration = isset($configuration['database']['connections'][$defaultConnectionName]) ? $configuration['database']['connections'][$defaultConnectionName] : null;
+                        if (is_array($defaultConnectionConfiguration)) {
+                            $configuration['database']['connections'][$defaultConnectionName]['charset'] = 'utf8mb4';
+                            $this->getOptions()->setConfiguration($configuration);
+                            $result = $this->createConnection();
+                        }
+                    }
+                }
+            } catch (Exception $x) {
             }
         }
 


### PR DESCRIPTION
When we install concrete5, we use the `utf8` charset. BTW it'd be much better to use `utf8mb4` because the latter supports the full range of Unicode characters.

The changes in this PR improves the install procedure, by configuring the default connection to use `utf8mb4` (if it's supported by the DBMS).