### PR TITLE
Resolve SitemapHeader via container, to allow overriding

### DIFF
--- a/concrete/src/Page/Sitemap/SitemapGenerator.php
+++ b/concrete/src/Page/Sitemap/SitemapGenerator.php
@@ -139,7 +139,7 @@ class SitemapGenerator
         try {
             Cache::disableAll();
             $multilingualEnabled = $pageListGenerator->isMultilingualEnabled();
-            yield new SitemapHeader($multilingualEnabled);
+            yield $this->app->make(SitemapHeader::class, [$multilingualEnabled]);
             foreach ($pageListGenerator->generatePageList() as $page) {
                 yield $this->createSitemapPage($page, $multilingualEnabled);
             }


### PR DESCRIPTION
Without overriding the **SitemapHeader** class it's not easy to change the XML's **namespaces**.

Overriding the class would be a lot easier if we resolve it via the container.