### PR TITLE
Checkout branch before rebuilding the CSS/JS assets

### DIFF
--- a/.travis/rebuild-assets.sh
+++ b/.travis/rebuild-assets.sh
@@ -46,6 +46,9 @@ To create it:
     exit 0
 fi
 
+printf '%s: checking out %s\n' "${AUTO_COMMIT_NAME_BASE}" "${TRAVIS_BRANCH}"
+git checkout -qf "${TRAVIS_BRANCH}"
+
 printf '%s: building assets\n' "${AUTO_COMMIT_NAME_BASE}"
 cd "${TRAVIS_BUILD_DIR}/build"
 printf -- '- CSS\n'


### PR DESCRIPTION
TravisCI checks out a commit before doing its tests thus we are in the so-called *detached HEAD state*).
We need to checkout the develop branch in order to actullly being able to update it.