### PR TITLE
fix const usage

### DIFF
--- a/concrete/src/File/Importer.php
+++ b/concrete/src/File/Importer.php
@@ -418,7 +418,7 @@ class Importer
     public function importUploadedFile(UploadedFile $uploadedFile = null, $fr = false)
     {
         if ($uploadedFile === null) {
-            $result = E_PHP_NO_FILE;
+            $result = self::E_PHP_NO_FILE;
         } elseif (!$uploadedFile->isValid()) {
             $result = $uploadedFile->getError();
         } else {


### PR DESCRIPTION
one of the constants in Importer.php was missing the self:: in front of it which was causing an issue in PHP 7.2