### PR TITLE
Move slideout method of imageeditor to the right place

### DIFF
--- a/concrete/js/build/core/image-editor/build/actions.js
+++ b/concrete/js/build/core/image-editor/build/actions.js
@@ -174,3 +174,37 @@ im.bind('ChangeNavTab', function (e, data) {
 im.bind('FiltersLoaded', function () {
     im.hideLoader();
 });
+
+im.slideOut = $("<div/>").addClass('slideOut').css({
+  width:0,
+  float:'right',
+  height:'100%',
+  'overflow-x':'hidden',
+  right:im.controlContext.width()-1,
+  position:'absolute',
+  background:'white',
+  'box-shadow':'black -20px 0 20px -25px'
+});
+
+im.slideOutContents = $('<div/>').appendTo(im.slideOut).width(300);
+im.showSlideOut = function(contents,callback) {
+  im.hideSlideOut(function(){
+    im.slideOut.empty();
+    im.slideOutContents = contents.width(300);
+    im.slideOut.append(im.slideOutContents);
+    im.slideOut.addClass('active').addClass('sliding');
+    im.slideOut.stop(1).slideOut(300, function(){
+      im.slideOut.removeClass('sliding');
+      if(typeof callback === 'function') callback();
+    });
+  });
+};
+im.hideSlideOut = function(callback) {
+  im.slideOut.addClass('sliding');
+  im.slideOut.slideIn(300,function(){
+    im.slideOut.css('border-right','0');
+    im.slideOut.removeClass('active').removeClass('sliding');
+    if(typeof callback === 'function') callback();
+  });
+};
+im.controlContext.after(im.slideOut);


### PR DESCRIPTION
the slideout method [was added](https://github.com/concrete5/concrete5/commit/ca283bfe2c1f2c19ebd38c99e3c2f80e60e374db) to `/concrete/js/build/core/image-editor/image-editor.js`, which is generated automatically from the chunks in the [`/concrete/js/build/core/image-editor/build`](https://github.com/concrete5/concrete5/tree/develop/concrete/js/build/core/image-editor/build) folder.
So, it's overwritten when we run the build process.

Let's move it to the correct file.

PS: there's no need to rebuild the assets manually, since the repository is now automatically updated.