### PR TITLE
Detach user from conversation messages and ratings when deleted

### DIFF
--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -233,6 +233,10 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
         $this->connection->executeQuery('DELETE FROM PermissionAccessEntityUsers WHERE uID = ?', [(int) $this->getUserID()]);
         $this->connection->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID = ?', [(int) $this->getUserID()]);
 
+        // Conversation messages and ratings should be detached from the user
+        $this->connection->executeQuery('UPDATE ConversationMessages SET uID = 0, cnvMessageAuthorName = NULL, cnvMessageAuthorEmail = NULL, cnvMessageAuthorWebsite = NULL, cnvMessageSubmitIP = NULL, cnvMessageSubmitUserAgent = NULL WHERE uID = ?', [(int) $this->getUserID()]);
+        $this->connection->executeQuery('UPDATE ConversationMessageRatings SET cnvMessageRatingIP = NULL, uID = 0 WHERE uID = ?', [(int) $this->getUserID()]);
+
         // Public file sets should be detached from the user
         $this->connection->executeQuery('UPDATE FileSets SET uID = 0 WHERE uID = ? AND fsType = ?', [
             (int) $this->getUserID(),


### PR DESCRIPTION
In addition to what @a3020 proposed in #7163, I also added the `UPDATE` on the ConversationMessageRatings table.

Fix #7163