### PR TITLE
Switch to forked repositories to add PHP 7.3 compatibility

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -994,17 +994,32 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.14",
+            "version": "v2.5.15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754"
+                "url": "https://github.com/concrete5-forks/doctrine2.git",
+                "reference": "0e81194de2cd74065d2e30b67c96b963cf5b9f73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
-                "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754",
+                "url": "https://api.github.com/repos/concrete5-forks/doctrine2/zipball/0e81194de2cd74065d2e30b67c96b963cf5b9f73",
+                "reference": "0e81194de2cd74065d2e30b67c96b963cf5b9f73",
                 "shasum": ""
+            },
+            "archive": {
+                "exclude": [
+                    "!vendor",
+                    "tests",
+                    "*phpunit.xml",
+                    ".travis.yml",
+                    "build.xml",
+                    "build.properties",
+                    "composer.phar",
+                    "vendor/satooshi",
+                    "lib/vendor",
+                    "*.swp",
+                    "*coveralls.yml"
+                ]
             },
             "require": {
                 "doctrine/cache": "~1.4",
@@ -1038,11 +1053,19 @@
                     "Doctrine\\ORM\\": "lib/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-0": {
+                    "Doctrine\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
             "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
                 {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
@@ -1050,10 +1073,6 @@
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -1066,7 +1085,10 @@
                 "database",
                 "orm"
             ],
-            "time": "2017-12-17T02:57:51+00:00"
+            "support": {
+                "source": "https://github.com/concrete5-forks/doctrine2/tree/v2.5.15"
+            },
+            "time": "2018-10-09T07:32:34+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -3648,16 +3670,16 @@
         },
         {
             "name": "sunra/php-simple-html-dom-parser",
-            "version": "v1.5.2",
+            "version": "v1.5.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sunra/php-simple-html-dom-parser.git",
-                "reference": "75b9b1cb64502d8f8c04dc11b5906b969af247c6"
+                "url": "https://github.com/concrete5-forks/php-simple-html-dom-parser.git",
+                "reference": "05e66702051da4da19533bba9efca54aaab22dd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sunra/php-simple-html-dom-parser/zipball/75b9b1cb64502d8f8c04dc11b5906b969af247c6",
-                "reference": "75b9b1cb64502d8f8c04dc11b5906b969af247c6",
+                "url": "https://api.github.com/repos/concrete5-forks/php-simple-html-dom-parser/zipball/05e66702051da4da19533bba9efca54aaab22dd5",
+                "reference": "05e66702051da4da19533bba9efca54aaab22dd5",
                 "shasum": ""
             },
             "require": {
@@ -3670,19 +3692,18 @@
                     "Sunra\\PhpSimple\\HtmlDomParser": "Src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
+                    "name": "S.C. Chen",
+                    "homepage": "http://sourceforge.net/projects/simplehtmldom/"
+                },
+                {
                     "name": "Sunra",
                     "email": "sunra@yandex.ru",
                     "homepage": "https://github.com/sunra"
-                },
-                {
-                    "name": "S.C. Chen",
-                    "homepage": "http://sourceforge.net/projects/simplehtmldom/"
                 }
             ],
             "description": "Composer adaptation of: A HTML DOM parser written in PHP5+ let you manipulate HTML in a very easy way! Require PHP 5+. Supports invalid HTML. Find tags on an HTML page with selectors just like jQuery. Extract contents from HTML in a single line.",
@@ -3692,7 +3713,10 @@
                 "html",
                 "parser"
             ],
-            "time": "2016-11-22T22:57:47+00:00"
+            "support": {
+                "source": "https://github.com/concrete5-forks/php-simple-html-dom-parser/tree/v1.5.3"
+            },
+            "time": "2018-10-09T08:28:08+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -5644,16 +5668,16 @@
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "2.7.7",
+            "version": "2.7.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f"
+                "url": "https://github.com/concrete5-forks/zend-stdlib.git",
+                "reference": "952f4da4afe095130a457fa23dd089d97afa3751"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/0e44eb46788f65e09e077eb7f44d2659143bcc1f",
-                "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f",
+                "url": "https://api.github.com/repos/concrete5-forks/zend-stdlib/zipball/952f4da4afe095130a457fa23dd089d97afa3751",
+                "reference": "952f4da4afe095130a457fa23dd089d97afa3751",
                 "shasum": ""
             },
             "require": {
@@ -5690,16 +5714,25 @@
                     "Zend\\Stdlib\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Stdlib\\": "test/",
+                    "ZendBench\\Stdlib\\": "benchmark/"
+                }
+            },
             "license": [
                 "BSD-3-Clause"
             ],
+            "description": " ",
             "homepage": "https://github.com/zendframework/zend-stdlib",
             "keywords": [
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12T21:17:31+00:00"
+            "support": {
+                "source": "https://github.com/concrete5-forks/zend-stdlib/tree/release-2.7.8"
+            },
+            "time": "2018-10-10T06:17:58+00:00"
         },
         {
             "name": "zendframework/zend-uri",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -89,6 +89,20 @@
     "frankkessler/guzzle-oauth2-middleware": "^0.1.1",
     "league/fractal": "^0.17.0"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/concrete5-forks/doctrine2"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/concrete5-forks/php-simple-html-dom-parser"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/concrete5-forks/zend-stdlib"
+    }
+  ],
   "extra": {
     "branch-alias": {
       "dev-develop": "8.x-dev"


### PR DESCRIPTION
Fix #7138

PS: this PR is not yet ready: we [also need](https://github.com/zendframework/zend-stdlib/issues/94#issuecomment-428129035) to fork `zendframework/zend-stdlib`...