### PR TITLE
Make sure parameters are passed as array in getListByPackage

### DIFF
--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -388,7 +388,7 @@ EOT
         $db = $app->make(Connection::class);
 
         $kina = ['-1'];
-        $rs = $db->executeQuery('select pkCategoryID from PermissionKeyCategories where pkgID = ?', $pkg->getPackageID());
+        $rs = $db->executeQuery('select pkCategoryID from PermissionKeyCategories where pkgID = ?', [$pkg->getPackageID()]);
         while (($pkCategoryID = $rs->fetchColumn()) !== false) {
             $kina[] = $pkCategoryID;
         }


### PR DESCRIPTION
Fixes this error:

> Argument 2 passed to Doctrine\DBAL\Connection::executeQuery() must be of the type array, integer given, called in **\public\concrete\src\Permission\Key\Key.php on line 391