### PR TITLE
Fix System\Info constructor for PHP 7.3

### DIFF
--- a/concrete/src/System/Info.php
+++ b/concrete/src/System/Info.php
@@ -179,7 +179,7 @@ class Info
                     switch (count($chunks)) {
                         case 1:
                             if ($chunks[0] === '') {
-                                continue;
+                                continue 2;
                             }
                             $section = $chunks[0];
                             break;


### PR DESCRIPTION
Let's get rid of this error thrown with PHP 7.3:

```
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```