### PR TITLE
Fix in the sitemap_overlay tool

### DIFF
--- a/concrete/tools/sitemap_overlay.php
+++ b/concrete/tools/sitemap_overlay.php
@@ -1,7 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$sh = Loader::helper('concrete/dashboard/sitemap');
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+
+$sh = $app->make('helper/concrete/dashboard/sitemap');
 if (!$sh->canRead()) {
     die(t('Access Denied'));
 }
@@ -9,14 +11,15 @@ if (!$sh->canRead()) {
 $v = View::getInstance();
 $v->requireAsset('core/sitemap');
 
+$overlayID = uniqid();
+
 ?>
 
-<div class="ccm-sitemap-overlay"></div>
-
+<div class="ccm-sitemap-overlay-<?= $overlayID; ?>"></div>
 
 <script type="text/javascript">
     $(function () {
-        $('.ccm-sitemap-overlay').concreteSitemap({
+        $('.ccm-sitemap-overlay-<?= $overlayID; ?>').concreteSitemap({
             onClickNode: function (node) {
                 ConcreteEvent.publish('SitemapSelectPage', {
                     cID: node.data.cID,
@@ -24,7 +27,7 @@ $v->requireAsset('core/sitemap');
                     instance: this
                 });
             },
-            displaySingleLevel: <?= (isset($_REQUEST['display']) && $_REQUEST['display'] === 'flat') ? 'true' : 'false' ?>,
+            displaySingleLevel: <?= (isset($_REQUEST['display']) && $_REQUEST['display'] === 'flat') ? 'true' : 'false'; ?>,
         });
     });
 </script>

--- a/concrete/tools/sitemap_search_selector.php
+++ b/concrete/tools/sitemap_search_selector.php
@@ -1,6 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$sh = Loader::helper('concrete/dashboard/sitemap');
+
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+
+$sh = $app->make('helper/concrete/dashboard/sitemap');
 if (!$sh->canRead()) {
     die(t('Access Denied.') . ' ' . t('You do not have access to the sitemap.'));
 }
@@ -10,10 +13,10 @@ $v->requireAsset('core/sitemap');
 
 /*
 
-$select_mode = Loader::helper('text')->entities($_REQUEST['sitemap_select_mode']);
-$callback = Loader::helper('text')->entities($_REQUEST['callback']);
+$select_mode = $app->make('helper/text')->entities($_REQUEST['sitemap_select_mode']);
+$callback = $app->make('helper/text')->entities($_REQUEST['callback']);
 
-if (Loader::helper('validation/numbers')->integer($_REQUEST['cID']) && $select_mode == 'move_copy_delete') {
+if ($app->make('helper/validation/numbers')->integer($_REQUEST['cID']) && $select_mode == 'move_copy_delete') {
     $cID = '&cID=' . $_REQUEST['cID'];
 } else {
     $cID = '';
@@ -25,72 +28,72 @@ if ($callback) {
 */
 
 ?>
+
 <div class="ccm-ui" id="ccm-sitemap-search-selector">
 
-<?=Loader::helper('concrete/ui')->tabs(array(
-    array('sitemap', t('Full Sitemap')),
-    array('explore', t('Flat View')),
-    array('search', t('Search')),
-));
-?>
+	<?php
+        echo $app->make('helper/concrete/ui')->tabs([
+            ['sitemap', t('Full Sitemap')],
+            ['explore', t('Flat View')],
+            ['search', t('Search')],
+        ]);
+    ?>
 
-<div id="ccm-tab-content-sitemap" class="ccm-tab-content"></div>
+	<div id="ccm-tab-content-sitemap" class="ccm-tab-content"></div>
 
+	<div id="ccm-tab-content-explore" class="ccm-tab-content"></div>
 
-<div id="ccm-tab-content-explore" class="ccm-tab-content"></div>
-
-<div id="ccm-tab-content-search" class="ccm-tab-content"></div>
+	<div id="ccm-tab-content-search" class="ccm-tab-content"></div>
 
 </div>
 
 <script type="text/javascript">
-ccm_sitemapSearchSelectorHideBottom = function() {
-	$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').hide();
-}
-
-ccm_sitemapSearchSelectorShowBottom = function() {
-	$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').show();
-}
-
-
-$(function() {
-	var sst = jQuery.cookie('ccm-sitemap-selector-tab');
-	if (sst != 'explore' && sst != 'search') {
-		sst = 'sitemap';
+	ccm_sitemapSearchSelectorHideBottom = function() {
+		$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').hide();
 	}
-	$('a[data-tab=' + sst + ']').parent().addClass('active');
-	ccm_sitemapSearchSelectorHideBottom();
-	$('a[data-tab=sitemap]').click(function() {
-		jQuery.cookie('ccm-sitemap-selector-tab', 'sitemap', {path: '<?=DIR_REL?>/'});
-		ccm_sitemapSearchSelectorHideBottom();
-		if ($('#ccm-tab-content-sitemap').html() == '') {
-			jQuery.fn.dialog.showLoader();
-			$('#ccm-tab-content-sitemap').load('<?=REL_DIR_FILES_TOOLS_REQUIRED?>/sitemap_overlay', function() {
-				jQuery.fn.dialog.hideLoader();
-			});
-		}
-	});
-	$('a[data-tab=explore]').click(function() {
-		jQuery.cookie('ccm-sitemap-selector-tab', 'explore', {path: '<?=DIR_REL?>/'});
-		ccm_sitemapSearchSelectorHideBottom();
-		if ($('#ccm-tab-content-explore').html() == '') {
-			jQuery.fn.dialog.showLoader();
-			$('#ccm-tab-content-explore').load('<?=REL_DIR_FILES_TOOLS_REQUIRED?>/sitemap_overlay?display=flat', function() {
-				jQuery.fn.dialog.hideLoader();
-			});
-		}
-	});
-	$('a[data-tab=search]').click(function() {
-		jQuery.cookie('ccm-sitemap-selector-tab', 'search', {path: '<?=DIR_REL?>/'});
-		ccm_sitemapSearchSelectorShowBottom();
-		if ($('#ccm-tab-content-search').html() == '') {
-			jQuery.fn.dialog.showLoader();
-			$('#ccm-tab-content-search').load('<?=URL::to('/ccm/system/dialogs/page/search')?>', function() {
-				jQuery.fn.dialog.hideLoader();
-			});
-		}
-	});
 
-	$('#ccm-sitemap-search-selector ul li.active a').click();
-});
+	ccm_sitemapSearchSelectorShowBottom = function() {
+		$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').show();
+	}
+
+	$(function() {
+		var sst = jQuery.cookie('ccm-sitemap-selector-tab');
+		if (sst != 'explore' && sst != 'search') {
+			sst = 'sitemap';
+		}
+		$('a[data-tab=' + sst + ']').parent().addClass('active');
+		ccm_sitemapSearchSelectorHideBottom();
+		$('a[data-tab=sitemap]').click(function() {
+			jQuery.cookie('ccm-sitemap-selector-tab', 'sitemap', {path: '<?= DIR_REL; ?>/'});
+			ccm_sitemapSearchSelectorHideBottom();
+			if ($('#ccm-tab-content-sitemap').html() == '') {
+				jQuery.fn.dialog.showLoader();
+				$('#ccm-tab-content-sitemap').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay', function() {
+					jQuery.fn.dialog.hideLoader();
+				});
+			}
+		});
+		$('a[data-tab=explore]').click(function() {
+			jQuery.cookie('ccm-sitemap-selector-tab', 'explore', {path: '<?=DIR_REL; ?>/'});
+			ccm_sitemapSearchSelectorHideBottom();
+			if ($('#ccm-tab-content-explore').html() == '') {
+				jQuery.fn.dialog.showLoader();
+				$('#ccm-tab-content-explore').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay?display=flat', function() {
+					jQuery.fn.dialog.hideLoader();
+				});
+			}
+		});
+		$('a[data-tab=search]').click(function() {
+			jQuery.cookie('ccm-sitemap-selector-tab', 'search', {path: '<?= DIR_REL; ?>/'});
+			ccm_sitemapSearchSelectorShowBottom();
+			if ($('#ccm-tab-content-search').html() == '') {
+				jQuery.fn.dialog.showLoader();
+				$('#ccm-tab-content-search').load('<?= URL::to('/ccm/system/dialogs/page/search'); ?>', function() {
+					jQuery.fn.dialog.hideLoader();
+				});
+			}
+		});
+
+		$('#ccm-sitemap-search-selector ul li.active a').click();
+	});
 </script>

--- a/concrete/tools/sitemap_search_selector.php
+++ b/concrete/tools/sitemap_search_selector.php
@@ -58,7 +58,7 @@ if ($callback) {
 
     $(function() {
         var sst = jQuery.cookie('ccm-sitemap-selector-tab');
-        if (sst != 'explore' && sst != 'search') {
+        if (sst !== 'explore' && sst !== 'search') {
             sst = 'sitemap';
         }
         $('a[data-tab=' + sst + ']').parent().addClass('active');

--- a/concrete/tools/sitemap_search_selector.php
+++ b/concrete/tools/sitemap_search_selector.php
@@ -31,7 +31,7 @@ if ($callback) {
 
 <div class="ccm-ui" id="ccm-sitemap-search-selector">
 
-	<?php
+    <?php
         echo $app->make('helper/concrete/ui')->tabs([
             ['sitemap', t('Full Sitemap')],
             ['explore', t('Flat View')],
@@ -39,61 +39,61 @@ if ($callback) {
         ]);
     ?>
 
-	<div id="ccm-tab-content-sitemap" class="ccm-tab-content"></div>
+    <div id="ccm-tab-content-sitemap" class="ccm-tab-content"></div>
 
-	<div id="ccm-tab-content-explore" class="ccm-tab-content"></div>
+    <div id="ccm-tab-content-explore" class="ccm-tab-content"></div>
 
-	<div id="ccm-tab-content-search" class="ccm-tab-content"></div>
+    <div id="ccm-tab-content-search" class="ccm-tab-content"></div>
 
 </div>
 
 <script type="text/javascript">
-	ccm_sitemapSearchSelectorHideBottom = function() {
-		$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').hide();
-	}
+    ccm_sitemapSearchSelectorHideBottom = function() {
+        $('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').hide();
+    }
 
-	ccm_sitemapSearchSelectorShowBottom = function() {
-		$('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').show();
-	}
+    ccm_sitemapSearchSelectorShowBottom = function() {
+        $('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').show();
+    }
 
-	$(function() {
-		var sst = jQuery.cookie('ccm-sitemap-selector-tab');
-		if (sst != 'explore' && sst != 'search') {
-			sst = 'sitemap';
-		}
-		$('a[data-tab=' + sst + ']').parent().addClass('active');
-		ccm_sitemapSearchSelectorHideBottom();
-		$('a[data-tab=sitemap]').click(function() {
-			jQuery.cookie('ccm-sitemap-selector-tab', 'sitemap', {path: '<?= DIR_REL; ?>/'});
-			ccm_sitemapSearchSelectorHideBottom();
-			if ($('#ccm-tab-content-sitemap').html() == '') {
-				jQuery.fn.dialog.showLoader();
-				$('#ccm-tab-content-sitemap').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay', function() {
-					jQuery.fn.dialog.hideLoader();
-				});
-			}
-		});
-		$('a[data-tab=explore]').click(function() {
-			jQuery.cookie('ccm-sitemap-selector-tab', 'explore', {path: '<?=DIR_REL; ?>/'});
-			ccm_sitemapSearchSelectorHideBottom();
-			if ($('#ccm-tab-content-explore').html() == '') {
-				jQuery.fn.dialog.showLoader();
-				$('#ccm-tab-content-explore').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay?display=flat', function() {
-					jQuery.fn.dialog.hideLoader();
-				});
-			}
-		});
-		$('a[data-tab=search]').click(function() {
-			jQuery.cookie('ccm-sitemap-selector-tab', 'search', {path: '<?= DIR_REL; ?>/'});
-			ccm_sitemapSearchSelectorShowBottom();
-			if ($('#ccm-tab-content-search').html() == '') {
-				jQuery.fn.dialog.showLoader();
-				$('#ccm-tab-content-search').load('<?= URL::to('/ccm/system/dialogs/page/search'); ?>', function() {
-					jQuery.fn.dialog.hideLoader();
-				});
-			}
-		});
+    $(function() {
+        var sst = jQuery.cookie('ccm-sitemap-selector-tab');
+        if (sst != 'explore' && sst != 'search') {
+            sst = 'sitemap';
+        }
+        $('a[data-tab=' + sst + ']').parent().addClass('active');
+        ccm_sitemapSearchSelectorHideBottom();
+        $('a[data-tab=sitemap]').click(function() {
+            jQuery.cookie('ccm-sitemap-selector-tab', 'sitemap', {path: '<?= DIR_REL; ?>/'});
+            ccm_sitemapSearchSelectorHideBottom();
+            if ($('#ccm-tab-content-sitemap').html() == '') {
+                jQuery.fn.dialog.showLoader();
+                $('#ccm-tab-content-sitemap').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay', function() {
+                    jQuery.fn.dialog.hideLoader();
+                });
+            }
+        });
+        $('a[data-tab=explore]').click(function() {
+            jQuery.cookie('ccm-sitemap-selector-tab', 'explore', {path: '<?=DIR_REL; ?>/'});
+            ccm_sitemapSearchSelectorHideBottom();
+            if ($('#ccm-tab-content-explore').html() == '') {
+                jQuery.fn.dialog.showLoader();
+                $('#ccm-tab-content-explore').load('<?= REL_DIR_FILES_TOOLS_REQUIRED; ?>/sitemap_overlay?display=flat', function() {
+                    jQuery.fn.dialog.hideLoader();
+                });
+            }
+        });
+        $('a[data-tab=search]').click(function() {
+            jQuery.cookie('ccm-sitemap-selector-tab', 'search', {path: '<?= DIR_REL; ?>/'});
+            ccm_sitemapSearchSelectorShowBottom();
+            if ($('#ccm-tab-content-search').html() == '') {
+                jQuery.fn.dialog.showLoader();
+                $('#ccm-tab-content-search').load('<?= URL::to('/ccm/system/dialogs/page/search'); ?>', function() {
+                    jQuery.fn.dialog.hideLoader();
+                });
+            }
+        });
 
-		$('#ccm-sitemap-search-selector ul li.active a').click();
-	});
+        $('#ccm-sitemap-search-selector ul li.active a').click();
+    });
 </script>


### PR DESCRIPTION
This PR fixes two bugs within the `sitemap_overlay` tool :

1. When selecting the **Full Sitemap** tab and switching to **Flat View**, there was an error in the console :

`Uncaught TypeError: Cannot read property 'indexOf' of undefined`


2. When selecting the **Flat View** tab, switching to **Full Sitemap** and switching back to **Flat View**, the sitemap overlay was displayed two times :

<img width="1640" alt="capture d ecran 2018-10-11 a 22 28 54" src="https://user-images.githubusercontent.com/29543909/46832016-41151a00-cda5-11e8-9954-8c804bc13a4b.png">
