### PR TITLE
fix duplicate IDs in cloned blocks

### DIFF
--- a/concrete/blocks/autonav/templates/responsive_header_navigation/view.js
+++ b/concrete/blocks/autonav/templates/responsive_header_navigation/view.js
@@ -5,6 +5,12 @@
     }
     var clonedNavigation = originalNav.clone();
     $(clonedNavigation).removeClass('original');
+    $(clonedNavigation).find("*").each(function(){
+        var t=$(this).attr('id');
+        if (t!==undefined && t !==null &&t !=="") {
+            $(this).attr('id',"cloned-ccm-ro_"+t)
+        }
+    });
     $('.ccm-responsive-overlay').append(clonedNavigation);
     $('.ccm-responsive-menu-launch').click(function(){
         $('.ccm-responsive-menu-launch').toggleClass('responsive-button-close');   // slide out mobile nav


### PR DESCRIPTION
fixes errors (and companion warning) in w3.org validator (and possibly non-standard browsers). These errors show as
>Error: Duplicate ID `_search_input`.
>From line 100, column 17; to line 100, column 130
>          `<input id="_search_input" class="ccm-search-block-text _search_input" value="" size="20" name="query" type="text">` 
>Warning: The first occurrence of ID `_search_input` was here.
>From line 71, column 17; to line 71, column 130
          `<input id="_search_input" class="ccm-search-block-text _search_input" value="" size="20" name="query" type="text">`

replaces element in cloned region as `<input id="cloned-ccm-ro__search_input" class="ccm-search-block-text _search_input" value="" size="20" name="query" type="text">`

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!