### PR TITLE
Remove frameborder attribute on YouTube block and use CSS border for W3C validation

### DIFF
--- a/concrete/blocks/youtube/view.css
+++ b/concrete/blocks/youtube/view.css
@@ -8,6 +8,7 @@
     left: 0;
     width: 100%;
     height: 100%;
+    border: none;
 }
 
 .youtubeBlockResponsive16by9 {

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -87,7 +87,7 @@ if (Page::getCurrentPage()->isEditMode()) {
         <iframe class="youtube-player" <?php echo $sizeargs;
         ?> src="//www.youtube.com/embed/<?= $videoID;
         ?><?= $paramstring;
-        ?>" frameborder="0" allowfullscreen></iframe>
+        ?>" allowfullscreen></iframe>
     </div>
     <?php
 } ?>


### PR DESCRIPTION
We recently came across this error in the W3C validation of the YouTube block, so what about replacing the frameborder attribute with a `border: none;` ?

The error :
<img width="1520" alt="capture d ecran 2018-10-12 a 19 58 08" src="https://user-images.githubusercontent.com/29543909/46886089-189b2780-ce5a-11e8-8bf5-ac26ada864ac.png">
