### PR TITLE
Storage locations improvements

### DIFF
--- a/concrete/controllers/dialog/file/bulk/storage.php
+++ b/concrete/controllers/dialog/file/bulk/storage.php
@@ -6,7 +6,12 @@ use Concrete\Core\File\EditResponse;
 use Concrete\Core\File\File;
 use Concrete\Core\File\Set\Set;
 use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
+use Concrete\Core\Foundation\Queue\QueueService;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\View\View;
 use Permissions;
+use Exception;
+use stdClass;
 
 class Storage extends BackendInterfaceController
 {
@@ -59,42 +64,59 @@ class Storage extends BackendInterfaceController
 
     public function submit()
     {
+        $json = new \Concrete\Core\Application\EditResponse();
+        $err = $this->app->make('error');
+        if ($this->validateAction()) {
+            $post = $this->request->request->all();
+            $fsl = FileStorageLocation::getByID($post['fslID']);
+            if (!is_object($fsl)) {
+                $err->add(t('Please select valid file storage location.'));
+            }
+        }
+        $json->setError($err);
+        return $json->outputJSON();
+    }
+
+    public function doChangeStorageLocation()
+    {
         if ($this->validateAction()) {
             $post = $this->request->request->all();
             $fsl = FileStorageLocation::getByID($post['fslID']);
             if (is_object($fsl)) {
                 $fIDs = $post['fID'];
-                if (is_array($fIDs)) {
-                    foreach ($fIDs as $fID) {
-                        $f = File::getByID($fID);
-                        if (is_object($f)) {
-                            $fp = new Permissions($f);
-                            if ($fp->canEditFilePermissions()) {
-                                try {
-                                    $f->setFileStorageLocation($fsl);
-                                } catch (\Exception $e) {
-                                    $json = new \Concrete\Core\Application\EditResponse();
-                                    $err = \Core::make('error');
-                                    $err->add($e->getMessage());
-                                    $json->setError($err);
-                                    $json->outputJSON();
+                $q = $this->app->make(QueueService::class)->get('change_files_storage_location');
+                if ($this->request->request->get('process')) {
+                    $obj = new stdClass();
+                    $messages = $q->receive(5);
+                    foreach ($messages as $key => $msg) {
+                        $fID = $msg->body;
+                        if ($fID !== false) {
+                            $file = File::getByID($fID);
+                            if (is_object($file)) {
+                                $fp = new Permissions($file);
+                                if ($fp->canEditFilePermissions()) {
+                                    $file->setFileStorageLocation($fsl);
                                 }
                             }
                         }
+                        $q->deleteMessage($msg);
+                    }
+                    $obj->totalItems = $q->count();
+                    $obj->files = $fIDs;
+                    if ($q->count() == 0) {
+                        $q->deleteQueue();
+                    }
+
+                    return $this->app->make(ResponseFactoryInterface::class)->json($obj);
+                } elseif ($q->count() == 0) {
+                    foreach ($fIDs as $fID) {
+                        $q->send($fID);
                     }
                 }
-            } else {
-                $json = new \Concrete\Core\Application\EditResponse();
-                $err = \Core::make('error');
-                $err->add(t('Please select valid file storage location.'));
-                $json->setError($err);
-                $json->outputJSON();
-            }
 
-            $response = new EditResponse();
-            $response->setFiles($this->files);
-            $response->setMessage(t('File storage locations updated successfully.'));
-            $response->outputJSON();
+                $totalItems = $q->count();
+                View::element('progress_bar', ['totalItems' => $totalItems, 'totalItemsSummary' => t2('%d file', '%d files', $totalItems)]);
+            }
         }
     }
 }

--- a/concrete/controllers/dialog/file/bulk/storage.php
+++ b/concrete/controllers/dialog/file/bulk/storage.php
@@ -5,7 +5,7 @@ use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
 use Concrete\Core\File\EditResponse;
 use Concrete\Core\File\File;
 use Concrete\Core\File\Set\Set;
-use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
+use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\Foundation\Queue\QueueService;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\View\View;
@@ -68,7 +68,7 @@ class Storage extends BackendInterfaceController
         $err = $this->app->make('error');
         if ($this->validateAction()) {
             $post = $this->request->request->all();
-            $fsl = FileStorageLocation::getByID($post['fslID']);
+            $fsl = $this->app->make(StorageLocationFactory::class)->fetchByID($post['fslID']);
             if (!is_object($fsl)) {
                 $err->add(t('Please select valid file storage location.'));
             }
@@ -81,7 +81,7 @@ class Storage extends BackendInterfaceController
     {
         if ($this->validateAction()) {
             $post = $this->request->request->all();
-            $fsl = FileStorageLocation::getByID($post['fslID']);
+            $fsl = $this->app->make(StorageLocationFactory::class)->fetchByID($post['fslID']);
             if (is_object($fsl)) {
                 $fIDs = $post['fID'];
                 $q = $this->app->make(QueueService::class)->get('change_files_storage_location');

--- a/concrete/controllers/dialog/file/bulk/storage.php
+++ b/concrete/controllers/dialog/file/bulk/storage.php
@@ -59,7 +59,9 @@ class Storage extends BackendInterfaceController
 
     public function view()
     {
+        $locations = $this->app->make(StorageLocationFactory::class)->fetchList();
         $this->set('files', $this->files);
+        $this->set('locations', $locations);
     }
 
     public function submit()

--- a/concrete/elements/storage_location_types/local.php
+++ b/concrete/elements/storage_location_types/local.php
@@ -1,19 +1,37 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied');
+
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$form = $app->make('helper/form');
+
+$locationHasFiles = false;
+if (is_object($location)) {
+    $locationHasFiles = $location->hasFiles();
+}
 if (is_object($configuration)) {
     $path = $configuration->getRootPath();
     $relativePath = $configuration->getWebRootRelativePath();
 }
 ?>
-<?php $form = Loader::helper('form'); ?>
 <div class="form-group">
-    <label for="path"><?=t('Root Path')?></label>
+    <label for="path"><?= t('Root Path'); ?></label>
     <div class="input-group">
-        <?=$form->text('fslType[path]', $path, array('placeholder' => t('Example: %ssome/path', $_SERVER['DOCUMENT_ROOT'] . '/')))?>
+        <?php
+            $fslTypeOptions = [
+                'placeholder' => t('Example: %ssome/path', $_SERVER['DOCUMENT_ROOT'].'/')
+            ];
+            if ($locationHasFiles) {
+                $fslTypeOptions['readonly'] = true;
+            }
+            echo $form->text('fslType[path]', $path, $fslTypeOptions);
+        ?>
         <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
     </div>
+    <?php if ($locationHasFiles) { ?>
+        <span class="help-block"><?= t('You can not change the root path of this storage location because it contains files.') ?></span>
+    <?php } ?>
 </div>
 <div class="form-group">
-    <label for="path"><?=t('Relative Path')?></label>
-    <?=$form->text('fslType[relativePath]', $relativePath, array('placeholder' => t('Example: %ssome/path', '/')))?>
+    <label for="path"><?= t('Relative Path'); ?></label>
+    <?= $form->text('fslType[relativePath]', $relativePath, ['placeholder' => t('Example: %ssome/path', '/')]); ?>
 </div>

--- a/concrete/routes/dialogs/files.php
+++ b/concrete/routes/dialogs/files.php
@@ -16,6 +16,7 @@ $router->all('/bulk/properties/clear_attribute', 'Bulk\Properties::clearAttribut
 $router->all('/bulk/properties/update_attribute', 'Bulk\Properties::updateAttribute');
 $router->all('/bulk/storage', 'Bulk\Storage::view');
 $router->all('/bulk/storage/submit', 'Bulk\Storage::submit');
+$router->all('/bulk/storage/change_files_storage_location', 'Bulk\Storage::doChangeStorageLocation');
 $router->all('/sets', 'Sets::view');
 $router->all('/sets/submit', 'Sets::submit');
 $router->all('/folder', 'Folder::view');

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -32,7 +32,7 @@ switch ($controller->getTask()) {
                     </form>
                 </div>
             <?php } ?>
-            <?php if ($hasFiles) { ?>
+            <?php if (!$fslIsDefault && $hasFiles) { ?>
                 <div class="alert alert-info">
                     <?= t('You can not delete this storage location because it contains files.'); ?>
                 </div>

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -66,7 +66,7 @@ switch ($controller->getTask()) {
                 }
                 ?>
                 <div class="form-group">
-                    <label><?= t('Default'); ?></label>
+                    <?= $form->label('fslIsDefault', t('Default Location')); ?>
                     <div class="radio">
                         <label>
                             <?= $form->radio('fslIsDefault', 1, $fslIsDefault, $args); ?>

--- a/concrete/single_pages/dashboard/system/files/storage.php
+++ b/concrete/single_pages/dashboard/system/files/storage.php
@@ -21,38 +21,40 @@ switch ($controller->getTask()) {
             /* @var Concrete\Core\Entity\File\StorageLocation\StorageLocation $location */
             $fslName = $location->getName();
             $fslIsDefault = $location->isDefault();
+            $hasFiles = $location->hasFiles();
             $method = 'update';
-            if (!$fslIsDefault && $type->getHandle() != 'default') {
-                ?>
+            if (!$fslIsDefault && $type->getHandle() != 'default' && !$hasFiles) { ?>
                 <div class="ccm-dashboard-header-buttons">
-                    <form method="post" action="<?= $view->action('delete') ?>">
-                        <input type="hidden" name="fslID" value="<?= $location->getID() ?>" />
-                        <?= $token->output('delete') ?>
-                        <button type="button" class="btn btn-danger" data-action="delete-location"><?= t('Delete Location') ?></button>
+                    <form method="post" action="<?= $view->action('delete'); ?>">
+                        <input type="hidden" name="fslID" value="<?= $location->getID(); ?>" />
+                        <?= $token->output('delete'); ?>
+                        <button type="button" class="btn btn-danger" data-action="delete-location"><?= t('Delete Location'); ?></button>
                     </form>
                 </div>
-                <?php
-            }
-        } else {
+            <?php } ?>
+            <?php if ($hasFiles) { ?>
+                <div class="alert alert-info">
+                    <?= t('You can not delete this storage location because it contains files.'); ?>
+                </div>
+            <?php } ?>
+        <?php } else {
             $fslName = '';
             $fslIsDefault = false;
             $method = 'add';
         }
         ?>
-        <form method="post" action="<?= $view->action($method) ?>" id="ccm-attribute-key-form">
-            <?= $token->output($method) ?>
-            <input type="hidden" name="fslTypeID" value="<?= $type->getID() ?>" />
-            <?php
-            if ($location !== null) {
-                ?><input type="hidden" name="fslID" value="<?= $location->getID() ?>" /><?php
-            }
-            ?>
+        <form method="post" action="<?= $view->action($method); ?>" id="ccm-attribute-key-form">
+            <?= $token->output($method); ?>
+            <input type="hidden" name="fslTypeID" value="<?= $type->getID(); ?>" />
+            <?php if ($location !== null) { ?>
+                <input type="hidden" name="fslID" value="<?= $location->getID(); ?>" />
+            <?php } ?>
             <fieldset>
-                <legend><?= t('Basics') ?></legend>
+                <legend><?= t('Basics'); ?></legend>
                 <div class="form-group">
-                    <?= $form->label('fslName', t('Name')) ?>
+                    <?= $form->label('fslName', t('Name')); ?>
                     <div class="input-group">
-                        <?= $form->text('fslName', $fslName) ?>
+                        <?= $form->text('fslName', $fslName); ?>
                         <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
                     </div>
                 </div>
@@ -64,41 +66,35 @@ switch ($controller->getTask()) {
                 }
                 ?>
                 <div class="form-group">
-                    <label><?= t('Default') ?></label>
+                    <label><?= t('Default'); ?></label>
                     <div class="radio">
                         <label>
-                            <?= $form->radio('fslIsDefault', 1, $fslIsDefault, $args) ?>
-                            <?= t('Yes, make this the default storage location for new files.') ?>
+                            <?= $form->radio('fslIsDefault', 1, $fslIsDefault, $args); ?>
+                            <?= t('Yes, make this the default storage location for new files.'); ?>
                         </label>
                     </div>
                     <div class="radio">
                         <label>
-                            <?= $form->radio('fslIsDefault', 0, $fslIsDefault, $args) ?>
-                            <?= t('No, this is not the default storage location.') ?>
+                            <?= $form->radio('fslIsDefault', 0, $fslIsDefault, $args); ?>
+                            <?= t('No, this is not the default storage location.'); ?>
                         </label>
                     </div>
                 </div>
             </fieldset>
-            <?php
-            if ($type->hasOptionsForm()) {
-                ?>
+            <?php if ($type->hasOptionsForm()) { ?>
                 <fieldset>
-                    <legend><?= t('Options %s Storage Type', $type->getName()) ?></legend>
-                    <?php $type->includeOptionsForm($location) ?>
+                    <legend><?= t('Options %s Storage Type', $type->getName()); ?></legend>
+                    <?php $type->includeOptionsForm($location); ?>
                 </fieldset>
-                <?php
-            }
-            ?>
+            <?php } ?>
             <div class="ccm-dashboard-form-actions-wrapper">
                 <div class="ccm-dashboard-form-actions">
-                    <a href="<?= URL::to($c) ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
-                    <?php
-                    if ($location !== null) {
-                        ?><button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button><?php
-                    } else {
-                        ?><button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button><?php
-                    }
-                    ?>
+                    <a href="<?= URL::to($c); ?>" class="btn pull-left btn-default"><?= t('Back'); ?></a>
+                    <?php if ($location !== null) { ?>
+                        <button type="submit" class="btn btn-primary pull-right"><?= t('Save'); ?></button>
+                    <?php } else { ?>
+                        <button type="submit" class="btn btn-primary pull-right"><?= t('Add'); ?></button>
+                    <?php } ?>
                 </div>
             </div>
         </form>
@@ -106,7 +102,7 @@ switch ($controller->getTask()) {
             $(function() {
                 $('button[data-action=delete-location]').on('click', function(e) {
                     e.preventDefault();
-                    if (confirm(<?= json_encode(t('Delete this storage location? All files using it will have their storage location reset to the default.')) ?>)) {
+                    if (confirm(<?= json_encode(t('Delete this storage location? All files using it will have their storage location reset to the default.')); ?>)) {
                         $(this).closest('form').submit();
                     }
                 });
@@ -115,25 +111,24 @@ switch ($controller->getTask()) {
         <?php
         break;
 
-    default:
-        ?>
-        <h3><?= t('Storage Locations') ?></h3>
+    default: ?>
+        <h3><?= t('Storage Locations'); ?></h3>
         <ul class="item-select-list">
-            <?php
-            foreach ($locations as $location) {
-                ?><li><a href="<?= $view->action('edit', $location->getID()) ?>"><i class="fa fa-hdd-o"></i> <?= $location->getDisplayName() ?></a></li><?php
-            }
-            ?>
+            <?php foreach ($locations as $location) { ?>
+                <li>
+                    <a href="<?= $view->action('edit', $location->getID()); ?>"><i class="fa fa-hdd-o"></i> <?= $location->getDisplayName(); ?></a>
+                </li>
+            <?php } ?>
         </ul>
-        <form method="get" action="<?= $view->action('select_type') ?>" id="ccm-file-storage-location-type-form">
+        <form method="get" action="<?= $view->action('select_type'); ?>" id="ccm-file-storage-location-type-form">
             <fieldset>
-                <legend><?= t('Add Location') ?></legend>
-                <label for="atID"><?= t('Choose Type') ?></label>
+                <legend><?= t('Add Location'); ?></legend>
+                <label for="atID"><?= t('Choose Type'); ?></label>
                 <div class="form-inline">
                     <div class="form-group">
-                        <?= $form->select('fslTypeID', $types) ?>
+                        <?= $form->select('fslTypeID', $types); ?>
                     </div>
-                    <button type="submit" class="btn btn-default"><?= t('Go') ?></button>
+                    <button type="submit" class="btn btn-default"><?= t('Go'); ?></button>
                 </div>
             </fieldset>
         </form>

--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -170,11 +170,12 @@ class StorageLocation implements StorageLocationInterface
         $app = Application::getFacadeApplication();
         $db = $app->make('database');
 
+        // let's check if there is any file in this storage location and throw an exception if yes
         $fIDs = $db->fetchAll('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
         foreach ($fIDs as $fID) {
             $file = File::getByID($fID);
             if (is_object($file)) {
-                $file->setFileStorageLocation($default);
+                throw new Exception(t('You can not delete this storage location because it contains files.'));
             }
         }
 

--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -1,13 +1,17 @@
 <?php
+
 namespace Concrete\Core\Entity\File\StorageLocation;
 
 use Concrete\Core\Cache\Level\ExpensiveCache;
+use Concrete\Core\File\File;
 use Concrete\Core\File\StorageLocation\StorageLocationInterface;
 use Concrete\Core\Filesystem\FlysystemCache;
-use Database;
+use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\Mapping as ORM;
+use Exception;
 use League\Flysystem\Cached\CachedAdapter;
 use League\Flysystem\Cached\Storage\Psr6Cache;
+use League\Flysystem\Filesystem;
 
 /**
  * @ORM\Entity
@@ -60,7 +64,7 @@ class StorageLocation implements StorageLocationInterface
     /** Returns the display name for this storage location (localized and escaped accordingly to $format)
      * @param string $format = 'html'
      *                       Escape the result in html format (if $format is 'html').
-     *                       If $format is 'text' or any other value, the display name won't be escaped.
+     *                       If $format is 'text' or any other value, the display name won't be escaped
      *
      * @return string
      */
@@ -141,7 +145,8 @@ class StorageLocation implements StorageLocationInterface
         $cachedAdapter = new FlysystemCache($adapter, $cache);
         $filesystem = new \League\Flysystem\Filesystem($cachedAdapter);
         */
-        $filesystem = new \League\Flysystem\Filesystem($adapter);
+        $filesystem = new Filesystem($adapter);
+
         return $filesystem;
     }
 
@@ -162,11 +167,12 @@ class StorageLocation implements StorageLocationInterface
     public function delete()
     {
         $default = \Concrete\Core\File\StorageLocation\StorageLocation::getDefault();
-        $db = Database::get();
+        $app = Application::getFacadeApplication();
+        $db = $app->make('database');
 
-        $fIDs = $db->GetCol('select fID from Files where fslID = ?', [$this->getID()]);
+        $fIDs = $db->fetchAll('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
         foreach ($fIDs as $fID) {
-            $file = \File::getByID($fID);
+            $file = File::getByID($fID);
             if (is_object($file)) {
                 $file->setFileStorageLocation($default);
             }
@@ -190,5 +196,18 @@ class StorageLocation implements StorageLocationInterface
         }
 
         $em->flush();
+    }
+
+    /**
+     * Check if the storage location contains files
+     *
+     * @return boolean
+     */
+    public function hasFiles()
+    {
+        $app = Application::getFacadeApplication();
+        $db = $app->make('database');
+        $fIDs = $db->fetchAll('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
+        return (!empty($fIDs));
     }
 }

--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -166,8 +166,6 @@ class StorageLocation implements StorageLocationInterface
 
     public function delete()
     {
-        $app = Application::getFacadeApplication();
-        $db = $app->make('database');
 
         // let's check if there is any file in this storage location and throw an exception if yes
         if ($this->hasFiles()) {

--- a/concrete/src/Entity/File/StorageLocation/StorageLocation.php
+++ b/concrete/src/Entity/File/StorageLocation/StorageLocation.php
@@ -166,17 +166,12 @@ class StorageLocation implements StorageLocationInterface
 
     public function delete()
     {
-        $default = \Concrete\Core\File\StorageLocation\StorageLocation::getDefault();
         $app = Application::getFacadeApplication();
         $db = $app->make('database');
 
         // let's check if there is any file in this storage location and throw an exception if yes
-        $fIDs = $db->fetchAll('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
-        foreach ($fIDs as $fID) {
-            $file = File::getByID($fID);
-            if (is_object($file)) {
-                throw new Exception(t('You can not delete this storage location because it contains files.'));
-            }
+        if ($this->hasFiles()) {
+            throw new Exception(t('You can not delete this storage location because it contains files.'));
         }
 
         $em = \ORM::entityManager();
@@ -208,7 +203,7 @@ class StorageLocation implements StorageLocationInterface
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database');
-        $fIDs = $db->fetchAll('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
+        $fIDs = $db->fetchColumn('SELECT fID FROM Files WHERE fslID = ?', [$this->getID()]);
         return (!empty($fIDs));
     }
 }

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -166,11 +166,11 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
      *
      * @param \Concrete\Core\Entity\File\StorageLocation\StorageLocation|int $storageLocation storage location object
      */
-    function filterByStorageLocation($storageLocation) {
+    public function filterByStorageLocation($storageLocation) {
         if ($storageLocation instanceof \Concrete\Core\Entity\File\StorageLocation\StorageLocation) {
             $this->filterByStorageLocationID($storageLocation->getID());
         } elseif (!is_object($storageLocation)) {
-            $this->filterByStorageLocationID($fslID);
+            $this->filterByStorageLocationID($storageLocation);
         } else {
             throw new Exception(t('Invalid file storage location.'));
         }

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\File;
 
+use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList as DatabaseItemList;
 use Concrete\Core\Search\ItemList\Pager\Manager\FileListPagerManager;
 use Concrete\Core\Search\ItemList\Pager\PagerProviderInterface;
@@ -162,10 +163,16 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filter the files by their storage location.
      *
-     * @param int $fslID storage location id
+     * @param int|\Concrete\Core\Entity\File\StorageLocation\StorageLocation $fslID storage location id or object
      */
-    public function filterByStorageLocation($fslID)
+    public function filterByStorageLocationID($fslID)
     {
+        if (is_object($fslID)) {
+            $fsl = $this->app->make(StorageLocationFactory::class)->fetchByID($fslID);
+            if (is_object($fsl)) {
+                $fslID = $fsl->getID();
+            }
+        }
         $this->query->andWhere('f.fslID = :fslID');
         $this->query->setParameter('fslID', $fslID);
     }

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -160,6 +160,17 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
     }
 
     /**
+     * Filter the files by their storage location.
+     *
+     * @param int $fslID storage location id
+     */
+    public function filterByStorageLocation($fslID)
+    {
+        $this->query->andWhere('f.fslID = :fslID');
+        $this->query->setParameter('fslID', $fslID);
+    }
+
+    /**
      * Filters by "keywords" (which searches everything including filenames,
      * title, users who uploaded the file, tags).
      *

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -11,6 +11,7 @@ use Concrete\Core\Search\Pagination\PaginationProviderInterface;
 use Concrete\Core\Search\StickyRequest;
 use FileAttributeKey;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
+use Exception;
 
 class FileList extends DatabaseItemList implements PagerProviderInterface, PaginationProviderInterface
 {
@@ -161,18 +162,28 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
     }
 
     /**
-     * Filter the files by their storage location.
+     * Filter the files by their storage location using a storage location object.
      *
-     * @param int|\Concrete\Core\Entity\File\StorageLocation\StorageLocation $fslID storage location id or object
+     * @param \Concrete\Core\Entity\File\StorageLocation\StorageLocation|int $storageLocation storage location object
+     */
+    function filterByStorageLocation($storageLocation) {
+        if ($storageLocation instanceof \Concrete\Core\Entity\File\StorageLocation\StorageLocation) {
+            $this->filterByStorageLocationID($storageLocation->getID());
+        } elseif (!is_object($storageLocation)) {
+            $this->filterByStorageLocationID($fslID);
+        } else {
+            throw new Exception(t('Invalid file storage location.'));
+        }
+    }
+
+    /**
+     * Filter the files by their storage location using a storage location id.
+     *
+     * @param int $fslID storage location id
      */
     public function filterByStorageLocationID($fslID)
     {
-        if (is_object($fslID)) {
-            $fsl = $this->app->make(StorageLocationFactory::class)->fetchByID($fslID);
-            if (is_object($fsl)) {
-                $fslID = $fsl->getID();
-            }
-        }
+        $fslID = (int) $fslID;
         $this->query->andWhere('f.fslID = :fslID');
         $this->query->setParameter('fslID', $fslID);
     }

--- a/concrete/src/File/Menu.php
+++ b/concrete/src/File/Menu.php
@@ -63,6 +63,12 @@ class Menu extends \Concrete\Core\Application\UserInterface\ContextMenu\Menu
                 \URL::to('/ccm/system/dialogs/file/folder?fID=' . $file->getFileID()),
                 t('Move to Folder'), t('Move to Folder'), '500', '450')
         );
+        if ($fp->canEditFilePermissions()) {
+            $this->addItem(new DialogLinkItem(
+                \URL::to('/ccm/system/dialogs/file/bulk/storage?fID[]=' . $file->getFileID()),
+                t('Storage Location'), t('Storage Location'), '500', '400')
+            );
+        }
         if ($fp->canCopyFile()) {
             $this->addItem(new LinkItem('#', t('Duplicate'), [
                 'data-file-manager-action' => 'duplicate',

--- a/concrete/src/File/Search/Field/Field/StorageLocationField.php
+++ b/concrete/src/File/Search/Field/Field/StorageLocationField.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\Core\File\Search\Field\Field;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\File\FileList;
+use Concrete\Core\File\StorageLocation\StorageLocation;
+use Concrete\Core\Search\Field\AbstractField;
+use Concrete\Core\Search\ItemList\ItemList;
+
+class StorageLocationField extends AbstractField
+{
+    /**
+     * @var array
+     */
+    protected $requestVariables = [
+        'fslID',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return 'fslID';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return t('Storage Location');
+    }
+
+    /**
+     * @param FileList $list
+     * @param $request
+     */
+    public function filterList(ItemList $list)
+    {
+        $storageLocation = $this->data['fslID'];
+        $list->filterByStorageLocation($storageLocation);
+    }
+
+    /**
+     * @return string
+     */
+    public function renderSearchField()
+    {
+        $app = Application::getFacadeApplication();
+        $form = $app->make('helper/form');
+        $locations = StorageLocation::getList();
+        $storageLocations = [];
+        foreach ($locations as $location) {
+            $locationID = $location->getID();
+            $locationName = $location->getDisplayName('text');
+            if (!empty($locationID) && !empty($locationName)) {
+                $storageLocations[$locationID] = $locationName;
+            }
+        }
+
+        return $form->select('fslID', $storageLocations, $this->data['fslID']);
+    }
+}

--- a/concrete/src/File/Search/Field/Field/StorageLocationField.php
+++ b/concrete/src/File/Search/Field/Field/StorageLocationField.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\File\Search\Field\Field;
 
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\File\FileList;
-use Concrete\Core\File\StorageLocation\StorageLocation;
+use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\Search\Field\AbstractField;
 use Concrete\Core\Search\ItemList\ItemList;
 
@@ -50,7 +50,7 @@ class StorageLocationField extends AbstractField
     {
         $app = Application::getFacadeApplication();
         $form = $app->make('helper/form');
-        $locations = StorageLocation::getList();
+        $locations = $app->make(StorageLocationFactory::class)->fetchList();
         $storageLocations = [];
         foreach ($locations as $location) {
             $locationID = $location->getID();

--- a/concrete/src/File/Search/Field/Field/StorageLocationField.php
+++ b/concrete/src/File/Search/Field/Field/StorageLocationField.php
@@ -40,7 +40,7 @@ class StorageLocationField extends AbstractField
     public function filterList(ItemList $list)
     {
         $storageLocation = $this->data['fslID'];
-        $list->filterByStorageLocation($storageLocation);
+        $list->filterByStorageLocationID($storageLocation);
     }
 
     /**

--- a/concrete/src/File/Search/Field/Manager.php
+++ b/concrete/src/File/Search/Field/Manager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\File\Search\Field;
 
 use Concrete\Core\Attribute\Category\FileCategory;
@@ -7,15 +8,18 @@ use Concrete\Core\File\Search\Field\Field\DateAddedField;
 use Concrete\Core\File\Search\Field\Field\ExtensionField;
 use Concrete\Core\File\Search\Field\Field\FileSetField;
 use Concrete\Core\File\Search\Field\Field\SizeField;
+use Concrete\Core\File\Search\Field\Field\StorageLocationField;
 use Concrete\Core\File\Search\Field\Field\TypeField;
 use Concrete\Core\Search\Field\AttributeKeyField;
 use Concrete\Core\Search\Field\Field\KeywordsField;
 use Concrete\Core\Search\Field\Manager as FieldManager;
-use Doctrine\ORM\EntityManagerInterface;
 
 class Manager extends FieldManager
 {
 
+    /**
+     * @var \Concrete\Core\Attribute\Category\FileCategory
+     */
     protected $fileCategory;
 
     public function __construct(FileCategory $fileCategory)
@@ -28,16 +32,14 @@ class Manager extends FieldManager
             new TypeField(),
             new SizeField(),
             new DateAddedField(),
-            new AddedToPageField()
+            new AddedToPageField(),
+            new StorageLocationField()
         ]);
         $attributes = [];
-        foreach($fileCategory->getSearchableList() as $key) {
+        foreach ($fileCategory->getSearchableList() as $key) {
             $field = new AttributeKeyField($key);
             $attributes[] = $field;
         }
         $this->addGroup(t('Custom Attributes'), $attributes);
-
     }
-
-
 }

--- a/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -52,8 +52,14 @@ class LocalConfiguration extends Configuration implements ConfigurationInterface
             return $rel;
         }
 
-        $url = \Core::getApplicationURL(true);
-        $url = $url->setPath($rel);
+        $url = Application::getApplicationURL(true);
+
+        // check if the URL already uses a path that must be kept in the final URL
+        if (!empty($url->getPath())) {
+            $url = $url->setPath(rtrim((string) $url->getPath(), '/') . '/' . ltrim((string) $rel, '/'));
+        } else {
+            $url = $url->setPath($rel);
+        }
 
         return rtrim((string) $url, '/');
     }

--- a/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -52,14 +52,8 @@ class LocalConfiguration extends Configuration implements ConfigurationInterface
             return $rel;
         }
 
-        $url = Application::getApplicationURL(true);
-
-        // check if the URL already uses a path that must be kept in the final URL
-        if (!empty($url->getPath())) {
-            $url = $url->setPath(rtrim((string) $url->getPath(), '/') . '/' . ltrim((string) $rel, '/'));
-        } else {
-            $url = $url->setPath($rel);
-        }
+        $url = \Core::getApplicationURL(true);
+        $url = $url->setPath($rel);
 
         return rtrim((string) $url, '/');
     }

--- a/concrete/views/dialogs/file/bulk/storage.php
+++ b/concrete/views/dialogs/file/bulk/storage.php
@@ -3,19 +3,32 @@
     use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
 
     $locations = FileStorageLocation::getList();
+
+    // let's check the storage locations to see if all the files use the same and check the correct checkbox
+    $usedStorageLocations = [];
+    $currentStorageLocation = null;
+    foreach ($files as $file) {
+        $fileStorageLocationID = $file->getStorageLocationID();
+        if (!in_array($fileStorageLocationID, $usedStorageLocations)) {
+            $usedStorageLocations[] = $fileStorageLocationID;
+        }
+    }
+    if (count($usedStorageLocations) === 1) {
+        $currentStorageLocation = $usedStorageLocations[0];
+    }
 ?>
 
 <form data-dialog-form="bulk-file-storage" method="post" action="<?= $controller->action('submit'); ?>">
 
-    <?php foreach ($files as $f) { ?>
-        <input type="hidden" name="fID[]" value="<?= $f->getFileID(); ?>" />
+    <?php foreach ($files as $file) { ?>
+        <input type="hidden" name="fID[]" value="<?= $file->getFileID(); ?>" />
     <?php } ?>
 
     <div class="ccm-ui">
         <?php foreach ($locations as $fsl) { ?>
             <div class="radio">
                 <label>
-                    <?= $form->radio('fslID', $fsl->getID()); ?> <?= $fsl->getDisplayName(); ?>
+                    <?= $form->radio('fslID', $fsl->getID(), $currentStorageLocation); ?> <?= $fsl->getDisplayName(); ?>
                 </label>
             </div>
         <?php } ?>

--- a/concrete/views/dialogs/file/bulk/storage.php
+++ b/concrete/views/dialogs/file/bulk/storage.php
@@ -1,8 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <?php
-    use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
-
-    $locations = FileStorageLocation::getList();
+if (!empty($files)) {
 
     // let's check the storage locations to see if all the files use the same and check the correct checkbox
     $usedStorageLocations = [];
@@ -15,53 +13,53 @@
     }
     if (count($usedStorageLocations) === 1) {
         $currentStorageLocation = $usedStorageLocations[0];
-    }
-?>
+    } ?>
 
-<form data-dialog-form="bulk-file-storage" method="post" action="<?= $controller->action('submit'); ?>">
+    <form data-dialog-form="bulk-file-storage" method="post" action="<?= $controller->action('submit'); ?>">
 
-    <?php foreach ($files as $file) { ?>
-        <input type="hidden" name="fID[]" value="<?= $file->getFileID(); ?>" />
-    <?php } ?>
-
-    <div class="ccm-ui">
-        <?php foreach ($locations as $fsl) { ?>
-            <div class="radio">
-                <label>
-                    <?= $form->radio('fslID', $fsl->getID(), $currentStorageLocation); ?> <?= $fsl->getDisplayName(); ?>
-                </label>
-            </div>
+        <?php foreach ($files as $file) { ?>
+            <input type="hidden" name="fID[]" value="<?= $file->getFileID(); ?>" />
         <?php } ?>
-    </div>
 
-    <div class="dialog-buttons">
-        <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel'); ?></button>
-        <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?= t('Move Location'); ?></button>
-    </div>
+        <div class="ccm-ui">
+            <?php foreach ($locations as $fsl) { ?>
+                <div class="radio">
+                    <label>
+                        <?= $form->radio('fslID', $fsl->getID(), $currentStorageLocation); ?> <?= $fsl->getDisplayName(); ?>
+                    </label>
+                </div>
+            <?php } ?>
+        </div>
 
-</form>
+        <div class="dialog-buttons">
+            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel'); ?></button>
+            <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?= t('Move Location'); ?></button>
+        </div>
 
-<script type="text/javascript">
-    $(function() {
-        $('form[data-dialog-form=bulk-file-storage]').on('submit', function () {
-            var params = $('form[data-dialog-form=bulk-file-storage]').formToArray(true);
-            $.concreteAjax({
-                url: '<?= $controller->action('submit'); ?>',
-                data: params,
-                success: function(r) {
-                    jQuery.fn.dialog.closeTop();
-                    ccm_triggerProgressiveOperation(
-                        '<?= $controller->action('change_files_storage_location'); ?>',
-                        params,
-                        <?= json_encode(t('Change files storage location')); ?>,
-                        function (result) {
-                            ConcreteEvent.publish('FileManagerBulkFileStorageComplete', {files: result.files});
-                            ConcreteAlert.notify({message: <?= json_encode(t('File storage locations updated successfully.')); ?>});
-                        }
-                    );
-                }
+    </form>
+
+    <script type="text/javascript">
+        $(function() {
+            $('form[data-dialog-form=bulk-file-storage]').on('submit', function () {
+                var params = $('form[data-dialog-form=bulk-file-storage]').formToArray(true);
+                $.concreteAjax({
+                    url: '<?= $controller->action('submit'); ?>',
+                    data: params,
+                    success: function(r) {
+                        jQuery.fn.dialog.closeTop();
+                        ccm_triggerProgressiveOperation(
+                            '<?= $controller->action('change_files_storage_location'); ?>',
+                            params,
+                            <?= json_encode(t('Change files storage location')); ?>,
+                            function (result) {
+                                ConcreteEvent.publish('FileManagerBulkFileStorageComplete', {files: result.files});
+                                ConcreteAlert.notify({message: <?= json_encode(t('File storage locations updated successfully.')); ?>});
+                            }
+                        );
+                    }
+                });
+                return false;
             });
-            return false;
         });
-    });
-</script>
+    </script>
+<?php } ?>

--- a/concrete/views/dialogs/file/bulk/storage.php
+++ b/concrete/views/dialogs/file/bulk/storage.php
@@ -1,37 +1,54 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+    use Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
 
-<form data-dialog-form="bulk-file-storage" method="post" action="<?=$controller->action('submit')?>">
-    <?php foreach ($files as $f) {
-    ?>
-        <input type="hidden" name="fID[]" value="<?=$f->getFileID()?>" />
-    <?php 
-} ?>
+    $locations = FileStorageLocation::getList();
+?>
+
+<form data-dialog-form="bulk-file-storage" method="post" action="<?= $controller->action('submit'); ?>">
+
+    <?php foreach ($files as $f) { ?>
+        <input type="hidden" name="fID[]" value="<?= $f->getFileID(); ?>" />
+    <?php } ?>
 
     <div class="ccm-ui">
-        <?php
-        use \Concrete\Core\File\StorageLocation\StorageLocation as FileStorageLocation;
-
-$locations = FileStorageLocation::getList();
-        foreach ($locations as $fsl) {
-            ?>
-            <div class="radio"><label><?=$form->radio('fslID', $fsl->getID()) ?> <?=$fsl->getDisplayName()?></label></div>
-        <?php 
-        } ?>
+        <?php foreach ($locations as $fsl) { ?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('fslID', $fsl->getID()); ?> <?= $fsl->getDisplayName(); ?>
+                </label>
+            </div>
+        <?php } ?>
     </div>
 
     <div class="dialog-buttons">
-        <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
-        <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?=t('Move Location')?></button>
+        <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel'); ?></button>
+        <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?= t('Move Location'); ?></button>
     </div>
 
 </form>
 
 <script type="text/javascript">
     $(function() {
-        ConcreteEvent.subscribe('AjaxFormSubmitSuccess', function(e, data) {
-            if (data.form == 'bulk-file-storage') {
-                ConcreteEvent.publish('FileManagerBulkFileStorageComplete', {files: data.response.files});
-            }
+        $('form[data-dialog-form=bulk-file-storage]').on('submit', function () {
+            var params = $('form[data-dialog-form=bulk-file-storage]').formToArray(true);
+            $.concreteAjax({
+                url: '<?= $controller->action('submit'); ?>',
+                data: params,
+                success: function(r) {
+                    jQuery.fn.dialog.closeTop();
+                    ccm_triggerProgressiveOperation(
+                        '<?= $controller->action('change_files_storage_location'); ?>',
+                        params,
+                        <?= json_encode(t('Change files storage location')); ?>,
+                        function (result) {
+                            ConcreteEvent.publish('FileManagerBulkFileStorageComplete', {files: result.files});
+                            ConcreteAlert.notify({message: <?= json_encode(t('File storage locations updated successfully.')); ?>});
+                        }
+                    );
+                }
+            });
+            return false;
         });
     });
 </script>

--- a/tests/tests/File/SearchFieldManagerTest.php
+++ b/tests/tests/File/SearchFieldManagerTest.php
@@ -74,7 +74,7 @@ class SearchFieldManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Custom Attributes', $groups[1]->getName());
         $this->assertInstanceOf('Concrete\Core\Search\Field\GroupInterface', $groups[0]);
         $this->assertInstanceOf('Concrete\Core\Search\Field\GroupInterface', $groups[1]);
-        $this->assertEquals(7, count($groups[0]->getFields()));
+        $this->assertEquals(8, count($groups[0]->getFields()));
         $this->assertEquals(2, count($groups[1]->getFields()));
 
         $field1 = $groups[0]->getFields()[5];


### PR DESCRIPTION
This PR :
- Adds a storage location field to the advanced file search
- Adds a `hasFiles()` method to storage locations
- Prevents the deletion of a storage location if there are files in it
- Prevents changing the root path of a local storage location if it contains files
- Adds a progressive operation to change files storage location
- Adds the 'Storage Location' bulk menu item to files

**I didn't try it with a storage location other than the local one, if anyone is available to test that 👍** 

Fix #5517, fix #1611, fix #4107 