### PR TITLE
Add custom Gettext loader to fix plural rules

### DIFF
--- a/concrete/src/Localization/Translator/Adapter/Zend/TranslatorAdapterFactory.php
+++ b/concrete/src/Localization/Translator/Adapter/Zend/TranslatorAdapterFactory.php
@@ -5,6 +5,7 @@ use Concrete\Core\Cache\Adapter\ZendCacheDriver;
 use Concrete\Core\Localization\Translator\Translation\TranslationLoaderRepositoryInterface;
 use Concrete\Core\Localization\Translator\TranslatorAdapterFactoryInterface;
 use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\LoaderPluginManager;
 
 /**
  * Provides a factory method to create translator objects for the Zend
@@ -18,11 +19,17 @@ class TranslatorAdapterFactory implements TranslatorAdapterFactoryInterface
     protected $translationLoaderRepository;
 
     /**
+     * @var \Zend\I18n\Translator\LoaderPluginManager|null
+     */
+    protected $loaderPluginManager;
+
+    /**
      * {@inheritdoc}
      */
-    public function __construct(TranslationLoaderRepositoryInterface $translationLoaderRepository = null)
+    public function __construct(TranslationLoaderRepositoryInterface $translationLoaderRepository = null, LoaderPluginManager $loaderPluginManager = null)
     {
         $this->translationLoaderRepository = $translationLoaderRepository;
+        $this->loaderPluginManager = $loaderPluginManager;
     }
 
     /**
@@ -33,6 +40,9 @@ class TranslatorAdapterFactory implements TranslatorAdapterFactoryInterface
         $cache = new ZendCacheDriver('cache/expensive');
 
         $t = new Translator();
+        if ($this->loaderPluginManager !== null) {
+            $t->setPluginManager($this->loaderPluginManager);
+        }
         $t->setCache($cache);
 
         $adapter = new TranslatorAdapter($t);

--- a/concrete/src/Localization/Translator/Loader/Gettext.php
+++ b/concrete/src/Localization/Translator/Loader/Gettext.php
@@ -75,7 +75,11 @@ class Gettext extends ZendGettext
                 }
                 // Don't translate the message, otherwise we may have an infinite loop (t() -> load translations -> t() -> load translations -> ...)
                 throw new RuntimeException(sprintf(
-                    'The language file %1$s for %2$s has %3$s plural forms instead of %4$s.',
+                    $readNumPlurals === 1 ?
+                        'The language file %1$s for %2$s has %3$s plural form instead of %4$s.'
+                        :
+                        'The language file %1$s for %2$s has %3$s plural forms instead of %4$s.'
+                    ,
                     $filename,
                     $localeInfo->name,
                     $readNumPlurals,

--- a/concrete/src/Localization/Translator/Loader/Gettext.php
+++ b/concrete/src/Localization/Translator/Loader/Gettext.php
@@ -75,8 +75,9 @@ class Gettext extends ZendGettext
                 }
                 // Don't translate the message, otherwise we may have an infinite loop (t() -> load translations -> t() -> load translations -> ...)
                 throw new RuntimeException(sprintf(
-                    'The language file %1$s has %2$s plural forms instead of %3$s.',
+                    'The language file %1$s for %2$s has %3$s plural forms instead of %4$s.',
                     $filename,
+                    $localeInfo->name,
                     $readNumPlurals,
                     $expectedNumPlurals
                 ));

--- a/concrete/src/Localization/Translator/Loader/Gettext.php
+++ b/concrete/src/Localization/Translator/Loader/Gettext.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Core\Localization\Translator\Loader;
+
+use Gettext\Languages\Language;
+use Zend\I18n\Exception\RuntimeException;
+use Zend\I18n\Translator\Loader\Gettext as ZendGettext;
+use Zend\I18n\Translator\Plural\Rule;
+use Zend\I18n\Translator\TextDomain;
+
+class Gettext extends ZendGettext
+{
+    /**
+     * Tthe absolute path of the web root.
+     *
+     * @var string
+     */
+    private $webrootDirectory;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param string $webrootDirectory the absolute path of the web root
+     */
+    public function __construct($webrootDirectory)
+    {
+        $this->webrootDirectory = $webrootDirectory;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Zend\I18n\Translator\Loader\Gettext::load()
+     */
+    public function load($locale, $filename)
+    {
+        $textDomain = parent::load($locale, $filename);
+
+        $localeInfo = Language::getById($locale);
+        if ($localeInfo !== null) {
+            $this->fixPlurals($filename, $textDomain, $localeInfo);
+        }
+
+        return $textDomain;
+    }
+
+    /**
+     * Fix the plural rules of the translations loaded from a file.
+     *
+     * @param string $filename
+     * @param \Zend\I18n\Translator\TextDomain $textDomain
+     * @param \Gettext\Languages\Language $localeInfo
+     *
+     * @throws \Zend\I18n\Exception\RuntimeException when the loaded file has less plural rules than the required ones
+     */
+    private function fixPlurals($filename, TextDomain $textDomain, Language $localeInfo)
+    {
+        $expectedNumPlurals = count($localeInfo->categories);
+        $pluralRule = $textDomain->getPluralRule(false);
+        if ($pluralRule === null) {
+            // Build the plural rules
+            $pluralRule = Rule::fromString("nplurals={$expectedNumPlurals}; plural={$localeInfo->formula};");
+            $textDomain->setPluralRule($pluralRule);
+        } else {
+            $readNumPlurals = $pluralRule->getNumPlurals();
+            if ($expectedNumPlurals < $readNumPlurals) {
+                // Reduce the number of plural rules, in order to consider other systems that use wrong counts (for example, Transifex uses 4 plural rules, but gettext only defines 3)
+                $pluralRule = Rule::fromString("nplurals={$expectedNumPlurals}; plural={$localeInfo->formula};");
+                $textDomain->setPluralRule($pluralRule);
+            } elseif ($expectedNumPlurals > $readNumPlurals) {
+                // The language file defines less plurals than the required ones.
+                $filename = str_replace(DIRECTORY_SEPARATOR, '/', $filename);
+                if (strpos($filename, $this->webrootDirectory . '/') === 0) {
+                    $filename = substr($filename, strlen($this->webrootDirectory));
+                }
+                // Don't translate the message, otherwise we may have an infinite loop (t() -> load translations -> t() -> load translations -> ...)
+                throw new RuntimeException(sprintf(
+                    'The language file %1$s has %2$s plural forms instead of %3$s.',
+                    $filename,
+                    $readNumPlurals,
+                    $expectedNumPlurals
+                ));
+            }
+        }
+
+        return $textDomain;
+    }
+}

--- a/concrete/src/Localization/Translator/TranslatorAdapterRepository.php
+++ b/concrete/src/Localization/Translator/TranslatorAdapterRepository.php
@@ -21,7 +21,7 @@ class TranslatorAdapterRepository implements TranslatorAdapterRepositoryInterfac
     protected $adapters = [];
 
     /**
-     * @param TranslatorFactoryInterface $translatorFactory
+     * @param TranslatorAdapterFactoryInterface $translatorFactory
      */
     public function __construct(TranslatorAdapterFactoryInterface $translatorAdapterFactory)
     {

--- a/concrete/src/Localization/Translator/TranslatorAdapterRepositoryInterface.php
+++ b/concrete/src/Localization/Translator/TranslatorAdapterRepositoryInterface.php
@@ -17,7 +17,7 @@ interface TranslatorAdapterRepositoryInterface
      *
      * @param string $handle
      * @param string $locale
-     * @param TranslatorAdapter $translator
+     * @param TranslatorAdapterInterface $translator
      */
     public function registerTranslatorAdapter($handle, $locale, TranslatorAdapterInterface $translatorAdapter);
 


### PR DESCRIPTION
When the Zend I18N component loads language files with wrong or missing plural rules, concrete5 aborts with this `Zend\I18n\Exception\RuntimeException` exception:

```
Plural rule of merging text domain is not compatible with the current one
```

End users may have a very hard time debugging (and understanding) what's going on.

So, what about fixing automatically the number of plural rules if possible (or showing a better error message if an automatic fix is not possible)?