### PR TITLE
 Switch from concrete5/less.php to wikimedia/less.php 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -90,68 +90,6 @@
             "time": "2018-10-05T16:44:04+00:00"
         },
         {
-            "name": "concrete5/less.php",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/concrete5-forks/less.php.git",
-                "reference": "eebead5849b7dd21f450905007cd65a385b894e3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/concrete5-forks/less.php/zipball/eebead5849b7dd21f450905007cd65a385b894e3",
-                "reference": "eebead5849b7dd21f450905007cd65a385b894e3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8.21"
-            },
-            "bin": [
-                "bin/lessc"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Less": "lib/"
-                },
-                "classmap": [
-                    "lessc.inc.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Agar",
-                    "homepage": "https://github.com/agar"
-                },
-                {
-                    "name": "Martin Jantošovič",
-                    "homepage": "https://github.com/Mordred"
-                },
-                {
-                    "name": "Josh Schmidt",
-                    "homepage": "https://github.com/oyejorge"
-                }
-            ],
-            "description": "Fork of Oyejorge's PHP port of the Javascript version of LESS http://lesscss.org",
-            "homepage": "http://lessphp.gpeasy.com",
-            "keywords": [
-                "css",
-                "less",
-                "less.js",
-                "lesscss",
-                "php",
-                "stylesheet"
-            ],
-            "time": "2017-02-02T17:13:13+00:00"
-        },
-        {
             "name": "concrete5/oauth-user-data",
             "version": "v1.0.1",
             "source": {
@@ -4978,6 +4916,67 @@
             ],
             "description": "Composer plugin to merge multiple composer.json files",
             "time": "2017-04-25T02:31:25+00:00"
+        },
+        {
+            "name": "wikimedia/less.php",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/less.php.git",
+                "reference": "eb783ddc912266f2106fee4684b24f178d7d4d06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/eb783ddc912266f2106fee4684b24f178d7d4d06",
+                "reference": "eb783ddc912266f2106fee4684b24f178d7d4d06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.24"
+            },
+            "bin": [
+                "bin/lessc"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Less": "lib/"
+                },
+                "classmap": [
+                    "lessc.inc.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Agar",
+                    "homepage": "https://github.com/agar"
+                },
+                {
+                    "name": "Martin Jantošovič",
+                    "homepage": "https://github.com/Mordred"
+                },
+                {
+                    "name": "Josh Schmidt",
+                    "homepage": "https://github.com/oyejorge"
+                }
+            ],
+            "description": "PHP port of the Javascript version of LESS http://lesscss.org (Originally maintained by Josh Schmidt)",
+            "keywords": [
+                "css",
+                "less",
+                "less.js",
+                "lesscss",
+                "php",
+                "stylesheet"
+            ],
+            "time": "2018-10-16T05:21:24+00:00"
         },
         {
             "name": "zendframework/zend-cache",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -42,7 +42,7 @@
     "illuminate/container": "5.2.*",
     "illuminate/config": "5.2.*",
     "patchwork/utf8": "~1.2.3|~1.3",
-    "concrete5/less.php": "2.0.0",
+    "wikimedia/less.php": "^1.8.0",
     "imagine/imagine": "1.*",
     "natxet/cssmin": "3.*",
     "tedivm/jshrink": "1.*",


### PR DESCRIPTION
It seems that Wikimedia is going to take care of less.php: https://github.com/oyejorge/less.php/issues/329#issuecomment-430122809