### PR TITLE
Show the actual DB error message in StartingPointPackage

### DIFF
--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -463,7 +463,7 @@ class StartingPointPackage extends BasePackage
             $version->markMigrated();
             $configuration->registerPreviousMigratedVersions();
         } catch (\Exception $e) {
-            throw new \Exception(t('Unable to install database: %s', $db->ErrorMsg() ? $db->ErrorMsg() : $e->getMessage()));
+            throw new \Exception(t('Unable to install database: %s', $e->getMessage()));
         }
     }
 


### PR DESCRIPTION
When a database error occurs, we currently show only its numeric code (that's what returned by the deprecated `$db->ErrorMsg() `).

Let's display the actual error message instead.