### PR TITLE
Avoid infinite loop is the configured charset is the same as the preferred one

### DIFF
--- a/concrete/src/Install/Installer.php
+++ b/concrete/src/Install/Installer.php
@@ -227,6 +227,10 @@ class Installer
             // Unsupported character set and/or collation
             return $connection;
         }
+        if ($connectionCharset === $characterSet && $connectionCollation === $collation) {
+            // No changes required
+            return $connection;
+        }
 
         return $this->reconfigureCharacterSetCollation($connection, $characterSet, $collation);
     }


### PR DESCRIPTION
If someone configures the preferred DB charset to be the same as the fallback one, we have an infinite loop in the install procedure.

Let's avoid that.