### PR TITLE
Don't use utf8mb4 for varchar(>191) indexed fields

### DIFF
--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -126,7 +126,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="ptPublishTargetTypeHandle" type="string" size="255"/>
+    <field name="ptPublishTargetTypeHandle" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="ptPublishTargetTypeName" type="string" size="255"/>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -147,7 +149,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="ptComposerControlTypeHandle" type="string" size="255"/>
+    <field name="ptComposerControlTypeHandle" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="ptComposerControlTypeName" type="string" size="255"/>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -323,6 +327,7 @@
     </field>
     <field name="feHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="feScore" type="integer" size="10">
       <default value="1"/>
@@ -353,6 +358,7 @@
     </field>
     <field name="fcHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -475,6 +481,7 @@
     </field>
     <field name="gaiKey" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="gaiBatchDisplayOrder" type="integer" size="10">
       <unsigned/>
@@ -580,6 +587,7 @@
     </field>
     <field name="gatHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="gatName" type="text" size="65535"/>
     <field name="gatHasCustomClass" type="boolean">
@@ -648,6 +656,7 @@
     <field name="gasName" type="string" size="255"/>
     <field name="gasHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -964,7 +973,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="cnvRatingTypeHandle" type="string" size="255"/>
+    <field name="cnvRatingTypeHandle" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="cnvRatingTypeName" type="string" size="10"/>
     <field name="cnvRatingTypeCommunityPoints" type="integer" size="10"/>
     <field name="pkgID" type="integer" size="10">
@@ -1147,6 +1158,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkID" type="integer" size="10">
       <unsigned/>
@@ -1216,6 +1228,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="arOverrideCollectionPermissions" type="boolean">
       <default value="0"/>
@@ -1290,7 +1303,7 @@
       <notnull/>
     </field>
     <references table="AreaLayouts" ondelete="cascade" onupdate="cascade">
-    	<column local="arLayoutID" foreign="arLayoutID"/>
+      <column local="arLayoutID" foreign="arLayoutID"/>
     </references>
   </table>
 
@@ -1305,7 +1318,9 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="arLayoutPresetName" type="string" size="255"/>
+    <field name="arLayoutPresetName" type="string" size="255">
+        <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <index name="arLayoutID">
       <col>arLayoutID</col>
     </index>
@@ -1385,6 +1400,7 @@
     </field>
     <field name="authTypeHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="authTypeName" type="string" size="255">
       <notnull/>
@@ -1438,6 +1454,7 @@
     <field name="btsName" type="string" size="255"/>
     <field name="btsHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -1516,6 +1533,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="btCachedBlockOutput" type="text"/>
     <field name="btCachedBlockOutputExpires" type="integer" size="10">
@@ -1549,6 +1567,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="btCacheBlockOutput" type="boolean">
       <default value="0"/>
@@ -1704,6 +1723,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="cbRelationID" type="integer" size="10">
       <unsigned/>
@@ -1765,6 +1785,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="issID" type="integer" size="10">
       <unsigned/>
@@ -1793,6 +1814,7 @@
     </field>
     <field name="arHandle" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="issID" type="integer" size="10">
       <unsigned/>
@@ -1901,12 +1923,15 @@
       <key/>
       <default value=""/>
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="configGroup" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="configItem" type="string" size="255">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="configValue" type="text"/>
     <index name="configGroup">
@@ -2066,6 +2091,7 @@
     </field>
     <field name="pkHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkName" type="string" size="255">
       <notnull/>
@@ -2105,6 +2131,7 @@
     </field>
     <field name="pkCategoryHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -2126,6 +2153,7 @@
     </field>
     <field name="petHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="petName" type="string" size="255">
       <notnull/>
@@ -2364,6 +2392,7 @@
     </field>
     <field name="nSubscriptionIdentifier" type="string">
       <key/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <index name="peID">
       <col>peID</col>
@@ -2726,7 +2755,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="gsName" type="string" size="255"/>
+    <field name="gsName" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
       <default value="0"/>
@@ -2795,7 +2826,9 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="gPath" type="text" size="65535"/>
+    <field name="gPath" type="text" size="65535">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
       <default value="0"/>
@@ -2842,6 +2875,7 @@
     </field>
     <field name="jHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="jNotUninstallable" type="smallint" size="4">
       <default value="0"/>
@@ -2992,7 +3026,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="upaHandle" type="string" size="255"/>
+    <field name="upaHandle" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="upaName" type="string" size="255"/>
     <field name="upaDefaultPoints" type="integer" size="11">
       <default value="0"/>
@@ -3400,7 +3436,9 @@
       <deftimestamp/>
       <notnull/>
     </field>
-    <field name="name" type="string" size="255"/>
+    <field name="name" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="state" type="string" size="64">
       <notnull/>
     </field>
@@ -3580,7 +3618,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="channel" type="string" size="255"/>
+    <field name="channel" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="time" type="integer" size="10">
       <unsigned/>
       <notnull/>
@@ -3794,6 +3834,7 @@
     </field>
     <field name="stName" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="stType" type="integer" size="10">
       <unsigned/>
@@ -3829,6 +3870,7 @@
     </field>
     <field name="wpCategoryHandle" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="10">
       <unsigned/>
@@ -3941,7 +3983,9 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="wfName" type="string" size="255"/>
+    <field name="wfName" type="string" size="255">
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
     <field name="wftID" type="integer" size="10">
       <unsigned/>
       <default value="0"/>
@@ -4127,6 +4171,7 @@
   <table name="QueuePageDuplicationRelations">
     <field name="queue_name" type="string" size="255">
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="cID" type="integer" size="10">
       <unsigned/>
@@ -4173,6 +4218,7 @@
     </field>
     <field name="treeTypeHandle" type="string" size="255">
       <default value=""/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="11">
       <unsigned/>
@@ -4195,6 +4241,7 @@
     </field>
     <field name="treeNodeTypeHandle" type="string" size="255">
       <default value=""/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="pkgID" type="integer" size="11">
       <unsigned/>
@@ -4321,6 +4368,7 @@
       <key/>
     </field>
     <field name="savedSearchID" type="string">
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <index name="savedSearchID">
       <col>savedSearchID</col>
@@ -4342,6 +4390,7 @@
     <field name="sessionID" type="string" size="255">
       <key/>
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="sessionValue" type="text">
     </field>
@@ -4369,6 +4418,7 @@
     <field name="thumbnailTypeHandle" type="string" size="255">
       <key/>
       <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
     </field>
     <field name="storageLocationID" type="integer">
       <unsigned/>
@@ -4387,6 +4437,14 @@
     </field>
     <field name="lockID" type="string" size="255"/>
     <field name="lockExpires" type="datetime"/>
+  </table>
+
+  <table name="SystemDatabaseMigrations">
+    <field name="version" type="string" size="255">
+      <key/>
+      <notnull/>
+      <opt for="mysql" collation="utf8_general_ci" />
+    </field>
   </table>
 
 </schema>

--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -52,8 +52,8 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
             $schema = new \Doctrine\DBAL\Schema\Schema();
             $table = $schema->createTable('OauthUserMap');
             $table->addColumn('user_id', 'integer', ['unsigned' => true]);
-            $table->addColumn('binding', 'string', ['length' => 255]);
-            $table->addColumn('namespace', 'string', ['length' => 255]);
+            $table->addColumn('binding', 'string', ['length' => 255])->setPlatformOption('collation', 'utf8_general_ci');
+            $table->addColumn('namespace', 'string', ['length' => 255])->setPlatformOption('collation', 'utf8_general_ci');
 
             $table->setPrimaryKey(['user_id', 'namespace']);
             $table->addUniqueIndex(['binding', 'namespace'], 'oauth_binding');

--- a/concrete/src/Entity/Attribute/Category.php
+++ b/concrete/src/Entity/Attribute/Category.php
@@ -29,7 +29,7 @@ class Category implements CategoryObjectInterface
     protected $akCategoryID;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $akCategoryHandle;
 

--- a/concrete/src/Entity/Attribute/Set.php
+++ b/concrete/src/Entity/Attribute/Set.php
@@ -46,7 +46,7 @@ class Set implements ExportableInterface
     protected $asID;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", options={"collation": "utf8_general_ci"})
      */
     protected $asHandle;
 

--- a/concrete/src/Entity/Attribute/Type.php
+++ b/concrete/src/Entity/Attribute/Type.php
@@ -30,7 +30,7 @@ class Type implements ExportableInterface
     protected $atID;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $atHandle;
 

--- a/concrete/src/Entity/Express/Entity.php
+++ b/concrete/src/Entity/Express/Entity.php
@@ -36,7 +36,7 @@ class Entity implements CategoryObjectInterface, ObjectInterface, ExportableInte
     protected $name;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $handle;
 

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -137,7 +137,7 @@ class Version implements ObjectInterface
     /**
      * The name of the file.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", options={"collation": "utf8_general_ci"})
      *
      * @var string
      */
@@ -227,7 +227,7 @@ class Version implements ObjectInterface
     /**
      * The extension of the file version.
      *
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="string", nullable=true, options={"collation": "utf8_general_ci"})
      *
      * @var string|null
      */

--- a/concrete/src/Entity/Geolocator.php
+++ b/concrete/src/Entity/Geolocator.php
@@ -65,7 +65,7 @@ class Geolocator
     /**
      * The Geolocator handle.
      *
-     * @ORM\Column(type="string", length=255, nullable=false, unique=true, options={"comment": "Geolocator handle"})
+     * @ORM\Column(type="string", length=255, nullable=false, unique=true, options={"collation": "utf8_general_ci", "comment": "Geolocator handle"})
      *
      * @var string
      */

--- a/concrete/src/Entity/OAuth/Client.php
+++ b/concrete/src/Entity/OAuth/Client.php
@@ -34,13 +34,13 @@ class Client implements ClientEntityInterface
 
     /**
      * @var string
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", options={"collation": "utf8_general_ci"})
      */
     protected $clientKey;
 
     /**
      * @var string
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", options={"collation": "utf8_general_ci"})
      */
     protected $clientSecret;
 

--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -15,7 +15,7 @@ class Scope implements ScopeEntityInterface
 {
     /**
      * @var string
-     * @ORM\Id @ORM\Column(type="string")
+     * @ORM\Id @ORM\Column(type="string", options={"collation": "utf8_general_ci"})
      */
     protected $identifier;
 

--- a/concrete/src/Entity/Package.php
+++ b/concrete/src/Entity/Package.php
@@ -21,7 +21,7 @@ class Package implements LocalizablePackageInterface
     protected $pkgID;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $pkgHandle;
 

--- a/concrete/src/Entity/Page/PagePath.php
+++ b/concrete/src/Entity/Page/PagePath.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 class PagePath
 {
     /**
-     * @ORM\Column(type="text")
+     * @ORM\Column(type="text", options={"collation": "utf8_general_ci"})
      */
     protected $cPath;
 

--- a/concrete/src/Entity/Site/Site.php
+++ b/concrete/src/Entity/Site/Site.php
@@ -61,7 +61,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface
     /**
      * The site handle.
      *
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      *
      * @var string
      */

--- a/concrete/src/Entity/Site/Type.php
+++ b/concrete/src/Entity/Site/Type.php
@@ -23,12 +23,12 @@ class Type
     protected $siteTypeID;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $siteTypeHandle;
 
     /**
-     * @ORM\Column(type="string", unique=true)
+     * @ORM\Column(type="string", unique=true, options={"collation": "utf8_general_ci"})
      */
     protected $siteTypeName;
 

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -44,7 +44,7 @@ class User implements UserEntityInterface
     protected $uName;
 
     /**
-     * @ORM\Column(type="string", length=254)
+     * @ORM\Column(type="string", length=254, options={"collation": "utf8_general_ci"})
      */
     protected $uEmail;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20181006212400.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20181006212400.php
@@ -3,14 +3,22 @@
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Database\CharacterSetCollation\Resolver;
-use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\TextType;
 use Exception;
 
 class Version20181006212400 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
 {
+    protected $schemaManager;
+
     /**
      * {@inheritdoc}
      *
@@ -27,16 +35,12 @@ class Version20181006212400 extends AbstractMigration implements RepeatableMigra
             list($charset, $collation) = $resolver->resolveCharacterSetAndCollation($this->connection);
             $this->output(t('Migrating database character set from "%1$s" to "%2$s" with collation "%3$s"...', $params['charset'], $charset, $collation));
             $this->connection->executeQuery('SET foreign_key_checks = 0');
-            $sm = $this->connection->getSchemaManager();
-            foreach ($sm->listTableNames() as $tableName) {
+            try {
+                $this->convertDatabase($charset, $collation);
+            } finally {
                 try {
-                    if ($this->updateTable($this->connection, $tableName, $charset, $collation)) {
-                        $this->output(t('- converting table "%1$s": %2$s', $tableName, tc('table', 'updated.')));
-                    } else {
-                        $this->output(t('- converting table "%1$s": %2$s', $tableName, tc('table', 'already up-to-date.')));
-                    }
-                } catch (Exception $x) {
-                    $this->output(t('- converting table "%1$s": %2$s', $tableName, $x->getMessage()));
+                    $this->connection->executeQuery('SET foreign_key_checks = 1');
+                } catch (Exception $foo) {
                 }
             }
             $config = $this->app->make('config');
@@ -50,7 +54,7 @@ class Version20181006212400 extends AbstractMigration implements RepeatableMigra
             $config->set("database.connections.{$connectionName}.collation", $collation);
             $config->save("database.connections.{$connectionName}.collation", $collation);
         } catch (Exception $x) {
-            $this->output(t('Failed to set character sets: %s', $x->getMessage()));
+            $this->output(t('- failed to set character sets: %s', $x->getMessage()));
         } finally {
             try {
                 $this->connection->executeQuery('SET foreign_key_checks = 1');
@@ -60,26 +64,282 @@ class Version20181006212400 extends AbstractMigration implements RepeatableMigra
     }
 
     /**
-     * @param \Concrete\Core\Database\Connection\Connection $connection
-     * @param string $tableName
+     * Convert the whole database to the specified charset/collation.
+     *
+     * @param string $charset
+     * @param string $collation
+     */
+    protected function convertDatabase($charset, $collation)
+    {
+        $sm = $this->connection->getSchemaManager();
+        $this->output(t('- analyzing database...'));
+        $tables = [];
+        foreach ($sm->listTables() as $table) {
+            $tables[strtolower($table->getName())] = $table;
+        }
+        $allFieldsToSkip = [];
+        foreach ($tables as $table) {
+            $allFieldsToSkip = array_merge_recursive(
+                $allFieldsToSkip,
+                $this->getTableLongIndexes($table, $sm, $tables),
+                $this->getTableLongForeignKeys($table, $sm, $tables)
+            );
+        }
+        $allFieldsToSkip = array_merge_recursive(
+            $allFieldsToSkip,
+            $this->getManualLongIndexes($sm, $tables)
+        );
+        foreach ($tables as $lowerCaseTableName => $table) {
+            $fieldsToSkip = isset($allFieldsToSkip[$lowerCaseTableName]) ? array_keys($allFieldsToSkip[$lowerCaseTableName]) : [];
+            try {
+                if ($this->updateTable($table, $fieldsToSkip, $charset, $collation)) {
+                    $this->output(t('- converting table "%1$s": %2$s', $table->getName(), tc('table', 'updated.')));
+                } else {
+                    $this->output(t('- converting table "%1$s": %2$s', $table->getName(), tc('table', 'already up-to-date.')));
+                }
+            } catch (Exception $x) {
+                $this->output(t('- converting table "%1$s": %2$s', $table->getName(), $x->getMessage()));
+            }
+        }
+    }
+
+    /**
+     * Check if a column is a long text field that may not support utf8mb4.
+     *
+     * @param \Doctrine\DBAL\Schema\Column $column
+     * @param int|null $length
+     *
+     * @return bool
+     */
+    private function isLongTextColumn(Column $column, $length = null)
+    {
+        if ($length === null) {
+            $length = (int) $column->getLength();
+        }
+        $type = $column->getType();
+        if ($type instanceof StringType || $type instanceof TextType) {
+            if ($length > 191) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Add a field not to be convert to the list of fields not to be converted.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param \Doctrine\DBAL\Schema\Column $column
+     * @param array $result
+     */
+    private function addFieldToSkipFieldsResult(Table $table, Column $column, array &$result)
+    {
+        $lowerCaseTableName = strtolower($table->getName());
+        if (!isset($result[$lowerCaseTableName])) {
+            $result[$lowerCaseTableName] = [];
+        }
+        $result[$lowerCaseTableName][strtolower($column->getName())] = true;
+    }
+
+    /**
+     * Collect the fields not to be converted from the table indexes.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param \Doctrine\DBAL\Schema\AbstractSchemaManager $sm
+     * @param \Doctrine\DBAL\Schema\Table[] $tables
+     *
+     * @return array[]
+     */
+    private function getTableLongIndexes(Table $table, AbstractSchemaManager $sm, array $tables)
+    {
+        $result = [];
+        foreach ($table->getIndexes() as $index) {
+            if (!$index->hasFlag('fulltext') && !$index->hasFlag('spatial')) {
+                foreach ($index->getColumns() as $columnName) {
+                    $column = $table->getColumn($columnName);
+                    if ($this->isLongTextColumn($column)) {
+                        $this->addFieldToSkipFieldsResult($table, $column, $result);
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Collect the fields not to be converted from the foreign keys.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param \Doctrine\DBAL\Schema\AbstractSchemaManager $sm
+     * @param \Doctrine\DBAL\Schema\Table[] $tables
+     *
+     * @return array[]
+     */
+    private function getTableLongForeignKeys(Table $table, AbstractSchemaManager $sm, array $tables)
+    {
+        $result = [];
+        foreach ($table->getForeignKeys() as $foreignKey) {
+            $foreignColumnNames = $foreignKey->getForeignColumns();
+            $foreignTable = null;
+            foreach ($foreignKey->getColumns() as $columnIndex => $columnName) {
+                $column = $table->getColumn($columnName);
+                if ($this->isLongTextColumn($column)) {
+                    if ($foreignTable == null) {
+                        $foreignTable = $tables[strtolower($foreignKey->getForeignTableName())];
+                    }
+                    $foreignColumn = $foreignTable->getColumn($foreignColumnNames[$columnIndex]);
+                    $this->addFieldToSkipFieldsResult($table, $column, $result);
+                    $this->addFieldToSkipFieldsResult($foreignTable, $foreignColumn, $result);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Collect the fields not to be converted from the manual index definitions.
+     *
+     * @param \Doctrine\DBAL\Schema\AbstractSchemaManager $sm
+     * @param \Doctrine\DBAL\Schema\Table[] $tables
+     *
+     * @return array[]
+     */
+    private function getManualLongIndexes(AbstractSchemaManager $sm, array $tables)
+    {
+        $result = [];
+        $config = $this->app->make('config');
+        $textIndexes = $config->get('database.text_indexes');
+        if (is_array($textIndexes)) {
+            foreach ($textIndexes as $tableName => $indexes) {
+                $lowerCaseTableName = strtolower($tableName);
+                if (isset($tables[$lowerCaseTableName])) {
+                    $table = $tables[$lowerCaseTableName];
+                    foreach ($indexes as $columnDefinitions) {
+                        foreach ((array) $columnDefinitions as $columnDefinition) {
+                            $columnDefinition = (array) $columnDefinition;
+                            $columnName = array_shift($columnDefinition);
+                            $indexLength = array_pop($columnDefinition);
+                            if ($table->hasColumn($columnName)) {
+                                $column = $table->getColumn($columnName);
+                                if ($this->isLongTextColumn($column, $indexLength)) {
+                                    $this->addFieldToSkipFieldsResult($table, $column, $result);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Update charset/collation of a table.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param string[] $fieldsToSkip
      * @param string $charset
      * @param string $collation
      *
      * @throws \Exception
      *
-     * @return bool true: table updated, false: table already up-to-date
+     * @return bool true: table updated; false: table already up-to-date
      */
-    protected function updateTable(Connection $connection, $tableName, $charset, $collation)
+    private function updateTable(Table $table, array $fieldsToSkip, $charset, $collation)
     {
-        $row = $connection->fetchAssoc('SHOW TABLE STATUS WHERE name like ?', [$tableName]);
+        if ($this->isTableAlreadyConverted($table, $charset, $collation)) {
+            return false;
+        }
+        if (count($fieldsToSkip) === 0) {
+            $this->setTableCharset($table, $charset, $collation, true);
+        } else {
+            foreach ($table->getColumns() as $column) {
+                if (!in_array(strtolower($column->getName()), $fieldsToSkip)) {
+                    if ($this->isStringColumn($column)) {
+                        $this->convertColumn($table, $column, $charset, $collation);
+                    }
+                }
+            }
+            $this->setTableCharset($table, $charset, $collation, false);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a table already has the specified charset/collation as the default ones.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param string $charset
+     * @param string $collation
+     *
+     * @throws \Exception
+     *
+     * @return bool true
+     */
+    private function isTableAlreadyConverted(Table $table, $charset, $collation)
+    {
+        $row = $this->connection->fetchAssoc('SHOW TABLE STATUS WHERE name like ?', [$table->getName()]);
         if ($row === false || !isset($row['Collation'])) {
             throw new Exception(t('failed to retrieve the table collation.'));
         }
-        if (strcasecmp($collation, $row['Collation']) === 0) {
-            return false;
-        }
-        $connection->executeQuery('ALTER TABLE ' . $connection->quoteIdentifier($tableName) . ' CONVERT TO CHARACTER SET ' . $charset . ' COLLATE ' . $collation);
 
-        return true;
+        return strcasecmp($collation, $row['Collation']) === 0;
+    }
+
+    /**
+     * Set charset/collation for a table.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param string $charset
+     * @param string $collation
+     * param bool $convertColumns
+     * @param mixed $convertColumns
+     */
+    private function setTableCharset(Table $table, $charset, $collation, $convertColumns)
+    {
+        if ($convertColumns) {
+            $this->connection->executeQuery('ALTER TABLE ' . $this->connection->quoteIdentifier($table->getName()) . ' CONVERT TO CHARACTER SET ' . $charset . ' COLLATE ' . $collation);
+        } else {
+            $this->connection->executeQuery('ALTER TABLE ' . $this->connection->quoteIdentifier($table->getName()) . ' DEFAULT CHARACTER SET ' . $charset . ' COLLATE ' . $collation);
+        }
+    }
+
+    /**
+     * Is a column a TEXT/STRING column?
+     *
+     * @param \Doctrine\DBAL\Schema\Column $column
+     *
+     * @return bool
+     */
+    private function isStringColumn(Column $column)
+    {
+        $type = $column->getType();
+        if ($type instanceof StringType || $type instanceof TextType) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Convert a specific table column to the specified charset/collation.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param \Doctrine\DBAL\Schema\Column $column
+     * @param string $charset
+     * @param string $collation
+     */
+    private function convertColumn(Table $table, Column $column, $charset, $collation)
+    {
+        $tableDiff = new TableDiff($table->getName());
+        $newColumn = clone $column;
+        $newColumn->setPlatformOption('collation', $collation);
+        $tableDiff->changedColumns[] = new ColumnDiff($column->getName(), $newColumn);
+        $this->connection->getSchemaManager()->alterTable($tableDiff);
     }
 }


### PR DESCRIPTION
As described in #7216, indexed text fields with a length of more that 191 characters may not support `utf8mb4` (full unicode).
This is the case of old MySQL versions, or recent MySQL versions configured with `innodb_large_prefix` set to `OFF`.

The solution of this PR is to use `utf8mb4` except for selected fields that may not support it (that is, the indexed ones).

Fix #7216.