### PR TITLE
Improve SiteLocaleSelector

### DIFF
--- a/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
+++ b/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
@@ -19,6 +19,7 @@ class SiteLocaleSelector
      * @param array $options Supported options are:
      *     bool $allowNull Set to a non falsy value to allow users to choose "no" locale [default: false]
      *     string $noLocaleText The string to represent "no locale" [default: t('No Locale')]
+     *     bool $displayLocaleCode Set to a non falsy value to display the locale ID [default: false]
      *
      * @return string
      */
@@ -29,6 +30,7 @@ class SiteLocaleSelector
 
         $allowNull = !empty($options['allowNull']);
         $nullText = isset($options['noLocaleText']) ? $options['noLocaleText'] : t('No Locale');
+        $displayLocaleCode = !empty($options['displayLocaleCode']);
 
         if ($selectedLocale === null && !$allowNull) {
             $selectedLocale = $site->getDefaultLocale();
@@ -40,7 +42,14 @@ class SiteLocaleSelector
 
         $flag = $selectedLocale ? Flag::getLocaleFlagIcon($selectedLocale) : '';
 
-        $label = $selectedLocale ? $selectedLocale->getLanguageText() : $nullText;
+        if ($selectedLocale) {
+            $label = h($selectedLocale->getLanguageText());
+            if ($displayLocaleCode) {
+                $label .= ' <span class="text-muted small">' . h($selectedLocale->getLocale()) . '</span>';
+            }
+        } else {
+            $label = $nullText;
+        }
 
         $localeHTML = '';
         if ($allowNull) {
@@ -52,7 +61,11 @@ class SiteLocaleSelector
                 $localeHTML .= 'data-locale="default"';
             }
             $localeHTML .= 'data-select-locale="' . $locale->getLocaleID() . '">';
-            $localeHTML .= Flag::getLocaleFlagIcon($locale) . ' ' . $locale->getLanguageText() . '</a></li>';
+            $localeHTML .= Flag::getLocaleFlagIcon($locale) . ' ' . $locale->getLanguageText();
+            if ($displayLocaleCode) {
+                $localeHTML .= ' <span class="text-muted small">' . h($locale->getLocale()) . '</span>';
+            }
+            $localeHTML .= '</a></li>';
         }
 
         $html = <<<EOL

--- a/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
+++ b/concrete/src/Form/Service/Widget/SiteLocaleSelector.php
@@ -155,8 +155,8 @@ EOL;
         }
 
         $fieldNameHtml = h($fieldName . (substr($fieldName, -2) === '[]' ? '' : '[]'));
-        $placeholderHtml = h(isset($options['noLocaleText']) ? $options['noLocaleText'] : t('No Locale'));
-        $jsDisplayLocaleCode = json_encode($displayLocaleCode);
+        $placeholderJS = json_encode(isset($options['noLocaleText']) ? (string) $options['noLocaleText'] : t('No Locale'));
+        $displayLocaleCodeJS = json_encode($displayLocaleCode);
 
         $identifier = 'ccm-sitelocaleselector-' . trim(preg_replace('/\W+/', '_', $fieldName), '_') . '-' . (new Identifier())->getString(32);
         $identifierHtml = h($identifier);
@@ -164,12 +164,12 @@ EOL;
 
         return <<<EOL
 
-<select id="{$identifierHtml}" name="{$fieldNameHtml}" placeholder="{$placeholderHtml}" multiple="multiple" class="ccm-sitelocaleselector">
+<select id="{$identifierHtml}" name="{$fieldNameHtml}" multiple="multiple" class="ccm-sitelocaleselector">
     $htmlOptions
 </select>
 <script type="text/javascript">
 $(document).ready(function() {
-    var displayLocaleCode = {$jsDisplayLocaleCode};
+    var displayLocaleCode = {$displayLocaleCodeJS};
     function render(data, escape) {
         var html = '<div>' + data.localeIcon + ' ' + escape(data.localeName);
         if (displayLocaleCode) {
@@ -179,6 +179,7 @@ $(document).ready(function() {
         return html;
     }
     $('#' + {$identifierJS}).selectize({
+        placeholder: {$placeholderJS},
         plugins: ['remove_button'],
         valueField: 'localeID',
         searchField: displayLocaleCode ? ['localeName', 'localeCode'] : ['localeName'],


### PR DESCRIPTION
This PR improves `SiteLocaleSelector::selectLocale()`: it can now optionally display the locale ID.
This is useful when working with locales with the same language name but different country.
For example, if we have two languages `zh_CN` and `zh_TW`, the language text for both is 'Chinese'.
`selectLocale` is now able to detect if there are two or more locales with the same name: if so, we'll display the language code too (so, `Chinese zh_CN` and `Chinese zh_TW`).
This behavior can be controlled by the new `displayLocaleCode` option.

This PR implements also a new `SiteLocaleSelector::selectLocaleMultiple()`, to let users specify multiple locales.