### PR TITLE
Don't specify travis distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ notifications:
 
 after_script:
 - |
-  if [[ "$TRAVIS_PHP_VERSION" != 'nightly' ]]; then
+  if [ "$TRAVIS_PHP_VERSION" != 'nightly' ] && [ "$DO_PHPUNIT" -ne 0 ]; then
     wget https://scrutinizer-ci.com/ocular.phar
     php ocular.phar code-coverage:upload --format=php-clover coverage.clover
   fi

--- a/.travis/composer-deps.sh
+++ b/.travis/composer-deps.sh
@@ -6,10 +6,9 @@ source "$( dirname "${BASH_SOURCE[0]}" )/travis_retry.sh"
 
 echo 'Configuring PHP'
 phpenv config-add "$( dirname "${BASH_SOURCE[0]}" )/php.ini"
-phpenv config-rm xdebug.ini || true
 
 echo 'Installing Composer packages - Magento''s composer merger'
-travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST 
+travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST
 
 echo 'Installing Composer packages - Merged dependencies'
-travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST 
+travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST


### PR DESCRIPTION
For some reason travis is complaining that xdebug isn't enabled. Let's try using the default dist rather than being explicit 