### PR TITLE
Adding alpha sort to file set list

### DIFF
--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -102,7 +102,7 @@ class Set
                     $queryBuilder->expr()->in('fsType',[self::TYPE_PRIVATE, self::TYPE_STARRED, self::TYPE_PUBLIC]),
                     $queryBuilder->expr()->eq('uID', $user->getUserID())
                 )
-            )->execute();
+            )->orderBy('fsName', 'ASC')->execute();
 
 
         while ($row = $results->fetch()) {


### PR DESCRIPTION
Restoring the sorted file set name that was lost in this commit: https://github.com/concrete5/concrete5/commit/ea0092092d57ad38a739977f35e0b520cc582824