### PR TITLE
Turn off autocomplete for schedule datepicker input

### DIFF
--- a/concrete/elements/pages/schedule.php
+++ b/concrete/elements/pages/schedule.php
@@ -42,3 +42,7 @@ $timezone = $dateService->getTimezoneDisplayName($timezone);
         float: right;
     }
 </style>
+
+<script>
+    $('#cvPublishDate_dt_pub, #cvPublishEndDate_dt_pub').attr('autocomplete', 'nope');
+</script>

--- a/concrete/elements/pages/schedule.php
+++ b/concrete/elements/pages/schedule.php
@@ -42,7 +42,3 @@ $timezone = $dateService->getTimezoneDisplayName($timezone);
         float: right;
     }
 </style>
-
-<script>
-    $('#cvPublishDate_dt_pub, #cvPublishEndDate_dt_pub').attr('autocomplete', 'nope');
-</script>

--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -309,8 +309,8 @@ $(function() {
         $(inst.settings.altField).val('');
       }
     }
-  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs);
-})
+  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'nope');
+});
 </script>
 EOT;
         }
@@ -409,7 +409,7 @@ $(function() {
         $(inst.settings.altField).val('');
       }
     }
-  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs);
+  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'nope');
 });
 </script>
 EOT;


### PR DESCRIPTION
This PR fixes the following issue-

![pasted-2018 10 20-20 17 36](https://user-images.githubusercontent.com/2462951/47352228-73ebd600-d6f4-11e8-9c32-28e16f5b4f67.png)

Reason for using `autocomplete="nope"`
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion


