### PR TITLE
Yoda Style, Disable We Must!

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -32,6 +32,9 @@ return PhpCsFixer\Config::create()
 
         // Allow double-quoted strings, don't force single-quoted strings
         'single_quote' => false,
+
+        // Disable Yoda Style from Symfony configuration
+        'yoda_style' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()


### PR DESCRIPTION
Symfony ruleset includes yoda style in later versions of PHP Cs fixer. 
This PR disables yoda style if you run php-cs-fixer
@mlocati can you test with older version of php-cs-fixer

For those wondering what Yoda style is like this

`if (1 === $variable) {` compared to Normal Style `if ($variable === 1) {`
