### PR TITLE
[IDE Classes] Add return types for entity repositories

### DIFF
--- a/concrete/src/Support/Symbol/MetadataGenerator.php
+++ b/concrete/src/Support/Symbol/MetadataGenerator.php
@@ -112,6 +112,13 @@ class MetadataGenerator
                 $getRepositoryMethod[$entityClass] = "\\{$repositoryClass}::class";
             }
             $output = array_merge($output, $this->getOverride('\Doctrine\ORM\EntityManagerInterface::getRepository(0)', $getRepositoryMethod, '$em->getRepository(EntityClass::class)'));
+            foreach ($customEntityRepositories as $entityClass => $repositoryClass) {
+                $output = array_merge($output, $this->getOverride("\\{$repositoryClass}::find(0)", ['' => "'{$entityClass}|null'"], '$em->getRepository(EntityClass::class)->find()'));
+                $output = array_merge($output, $this->getOverride("\\{$repositoryClass}::findOneBy(0)", ['' => "'{$entityClass}|null'"], '$em->getRepository(EntityClass::class)->findOneBy()'));
+                $output = array_merge($output, $this->getOverride("\\{$repositoryClass}::findAll(0)", ['' => "'{$entityClass}[]'"], '$em->getRepository(EntityClass::class)->find()'));
+                $output = array_merge($output, $this->getOverride("\\{$repositoryClass}::findBy(0)", ['' => "'{$entityClass}[]'"], '$em->getRepository(EntityClass::class)->find()'));
+                $output = array_merge($output, $this->getOverride("\\{$repositoryClass}::matching(0)", ['' => "'Doctrine\Common\Collections\Collection|{$entityClass}[]'"], '$em->getRepository(EntityClass::class)->find()'));
+            }
         }
         $output = array_merge($output, $this->getOverride('\Doctrine\ORM\EntityManagerInterface::find(0)', ['' => "'@'"], '$em->find(EntityClass::class, $id)'));
 


### PR DESCRIPTION
What about telling the IDE the return types of the `find()`/`findOneBy()`/`findAll()`/`findBy()`/`matching()` of custom entity repositories?

I don't know if phpstorms support a syntax like the one provided by the following code- if not, phpstorm users should give a thumb up at https://youtrack.jetbrains.com/issue/WI-27832.

```php
override(\Concrete\Core\Entity\Express\EntityRepository::find(0), map([
  '' => 'Concrete\Core\Entity\Express\Entity|null',
]));
```

BTW I just updated my Eclipse+PDT plugin to support it.

Sample application:

![immagine](https://user-images.githubusercontent.com/928116/47566542-615be180-d92c-11e8-988f-0cad4125ea6e.png)
