### PR TITLE
Use (only) utf8mb4 only if supported for keys

### DIFF
--- a/concrete/src/Database/CharacterSetCollation/Exeption/LongKeysUnsupportedByCollation.php
+++ b/concrete/src/Database/CharacterSetCollation/Exeption/LongKeysUnsupportedByCollation.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Concrete\Core\Database\CharacterSetCollation\Exception;
+
+use Concrete\Core\Database\CharacterSetCollation\Exception;
+
+class LongKeysUnsupportedByCollation extends Exception
+{
+    /**
+     * @var string
+     */
+    protected $collation;
+
+    /**
+     * @var int
+     */
+    protected $wantedKeyLength;
+
+    /**
+     * @param string $collation
+     * @param int $wantedKeyLength
+     */
+    public function __construct($collation, $wantedKeyLength)
+    {
+        $this->collation = $collation;
+        $this->wantedKeyLength = $wantedKeyLength;
+        parent::__construct(t(
+            'The database does not support index fields with a length up to %1$s characters when using the collation "%2$s".',
+            $this->getWantedKeyLength(),
+            $this->getCollation()
+        ));
+    }
+
+    /**
+     * @return string
+     */
+    public function getCollation()
+    {
+        return $this->collation;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWantedKeyLength()
+    {
+        return $this->wantedKeyLength;
+    }
+}

--- a/concrete/src/Database/CharacterSetCollation/Resolver.php
+++ b/concrete/src/Database/CharacterSetCollation/Resolver.php
@@ -27,6 +27,13 @@ class Resolver
     protected $collation;
 
     /**
+     * The maximum length of string fields that should be supported using the specified collation.
+     *
+     * @var int
+     */
+    protected $maximumStringKeyLength = 255;
+
+    /**
      * @param \Concrete\Core\Config\Repository\Repository $config
      */
     public function __construct(Repository $config)
@@ -115,6 +122,30 @@ class Resolver
     }
 
     /**
+     * Get the maximum length of string fields that should be supported using the specified collation.
+     *
+     * @return int
+     */
+    public function getMaximumStringKeyLength()
+    {
+        return $this->maximumStringKeyLength;
+    }
+
+    /**
+     * Set the maximum length of string fields that should be supported using the specified collation.
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function setMaximumStringKeyLength($value)
+    {
+        $this->maximumStringKeyLength = (int) $value;
+
+        return $this;
+    }
+
+    /**
      * Resolve the character set and collation.
      *
      * @param \Concrete\Core\Database\Connection\Connection $connection
@@ -123,6 +154,7 @@ class Resolver
      * @throws \Concrete\Core\Database\CharacterSetCollation\Exception\UnsupportedCharacterSetException
      * @throws \Concrete\Core\Database\CharacterSetCollation\Exception\UnsupportedCollationException
      * @throws \Concrete\Core\Database\CharacterSetCollation\Exception\InvalidCharacterSetCollationCombination
+     * @throws \Concrete\Core\Database\CharacterSetCollation\Exception\LongKeysUnsupportedByCollation
      *
      * return string[] first value is the character set; the second value is the collation
      */
@@ -148,6 +180,9 @@ class Resolver
             $collation = $characterSets[$characterSet];
         } else {
             throw new Exception\NoCharacterSetCollationDefinedException();
+        }
+        if (!$connection->isCollationSupportedForKeys($collation, $this->getMaximumStringKeyLength())) {
+            throw new Exception\LongKeysUnsupportedByCollation($collation, $this->getMaximumStringKeyLength());
         }
 
         return [$characterSet, $collation];


### PR DESCRIPTION
In order to fix #7216, I previously suggested #7221. BTW that PR would have required that every concrete5 developer should use (and know) that they'd have to force `utf8`instead of `utf8mb4` for string keys wider than 191 chars.

Another fix for #7216 is this PR: we always use the same charset: `utf8mb4` if available *and* usable in string keys with up to 255 chars, otherwise we use `utf8`.

PROs: concrete5 developers don't have to deal with charsets

CONs. users with old MySql versions (or with recent MySql versions with `innodb_large_prefix` turned off) won't have a full-unicode support

Here's a sample installation session when MySQL doesn't support utf8mb4 for 255-long key columns:
![immagine](https://user-images.githubusercontent.com/928116/47604153-cdeee300-d9f5-11e8-8b6b-3aa417d85782.png)
