### PR TITLE
Use the ID of the custom collection in the autonav block

### DIFF
--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -164,7 +164,7 @@ class Controller extends BlockController
             $c = $this->collection;
 
             // let's use the ID of the collection passed in $this->collection
-            if ($this->collection instanceof Page) {
+            if ($this->collection instanceof \Concrete\Core\Page\Page) {
                 $this->cID = $this->collection->getCollectionID();
             }
         }

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -162,6 +162,11 @@ class Controller extends BlockController
             }
         } else {
             $c = $this->collection;
+
+            // let's use the ID of the collection passed in $this->collection
+            if ($this->collection instanceof Page) {
+                $this->cID = $this->collection->getCollectionID();
+            }
         }
         //Create an array of parent cIDs so we can determine the "nav path" of the current page
         $inspectC = $c;


### PR DESCRIPTION
We can pass a custom collection to the autonav block by using the `$collection` property.
But the `$cID` property is always retrieved from the current page, this PR allows to use the collection ID of the `$collection` property.