### PR TITLE
Run code coverage just once

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,5 +3,5 @@ filter:
 
 tools:
   external_code_coverage:
-    timeout: 600
+    timeout: 1200
     runs: 1

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,4 +4,4 @@ filter:
 tools:
   external_code_coverage:
     timeout: 600
-    runs: 5
+    runs: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 - 5.5
 - 5.6
 - 7.0
-- 7.1
 - 7.2
 - nightly
 
@@ -22,6 +21,9 @@ env:
 matrix:
   fast_finish: true
   include:
+  - php: 7.1
+    env:
+    - DO_PHPUNIT=2
   - php: 7.1
     env:
     - DO_CS_PHP=1
@@ -46,7 +48,8 @@ before_script:
 script:
 - if test $DO_CS_PHP -ne 0; then echo 'Testing PHP coding style'; composer phpcs; fi
 - if test $DO_CS_JS -ne 0; then echo 'Testing JS coding style'; pushd build && grunt js:check && popd; fi
-- if test $DO_PHPUNIT -ne 0; then echo 'Running tests'; composer test-coverage; fi
+- if test $DO_PHPUNIT -eq 1; then echo 'Running tests'; composer test; fi
+- if test $DO_PHPUNIT -gt 1; then echo 'Running tests (with coverage)'; composer test-coverage; fi
 - if test $DO_BUILDASSETS -ne 0; then ./.travis/rebuild-assets.sh; fi
 
 cache:
@@ -60,7 +63,7 @@ notifications:
 
 after_script:
 - |
-  if [ "$TRAVIS_PHP_VERSION" != 'nightly' ] && [ "$DO_PHPUNIT" -ne 0 ]; then
+  if test $DO_PHPUNIT -gt 1; then
     wget https://scrutinizer-ci.com/ocular.phar
     php ocular.phar code-coverage:upload --format=php-clover coverage.clover
   fi

--- a/.travis/composer-deps.sh
+++ b/.travis/composer-deps.sh
@@ -6,6 +6,9 @@ source "$( dirname "${BASH_SOURCE[0]}" )/travis_retry.sh"
 
 echo 'Configuring PHP'
 phpenv config-add "$( dirname "${BASH_SOURCE[0]}" )/php.ini"
+if test $DO_PHPUNIT -lt 2; then
+    phpenv config-rm xdebug.ini || true
+fi
 
 echo 'Installing Composer packages - Magento''s composer merger'
 travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST


### PR DESCRIPTION
What about enabling xdebug and collecting code coverage in just one of the TravisCI jobs? Otherwise tests take really a lot of time...