### PR TITLE
Translation - Make detach message consistent with other auth types

### DIFF
--- a/concrete/authentication/facebook/controller.php
+++ b/concrete/authentication/facebook/controller.php
@@ -83,7 +83,7 @@ class Controller extends GenericOauth2TypeController
                         \Log::Error(t('Error detaching account : %s', $e->getMessage()));
                             $this->showError(t('Error detaching account'));
                     }
-                    $this->showSuccess(t('Successfully detached'));
+                    $this->showSuccess(t('Successfully detached.'));
                     exit();
                 } else {
                     $this->showError(t('No user id found'));


### PR DESCRIPTION
This prevents a duplication translation message.

![afbeelding](https://user-images.githubusercontent.com/1431100/47839669-ce9bc680-ddb3-11e8-9bf6-6ab185f05f68.png)

'Successfully detached.' is used [elsewhere](https://github.com/concrete5/concrete5/search?q=%22Successfully+detached%22&unscoped_q=%22Successfully+detached%22).