### PR TITLE
Translation - Make it easier to search for a text string

### DIFF
--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -29,7 +29,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <div class="checkbox">
                 <label>
                     <?= $form->checkbox('invalidateOnUserAgentMismatch', '1', $invalidateOnUserAgentMismatch) ?>
-                    <?= t('Log users out if their browser\'s user agent changes') ?>
+                    <?= t("Log users out if their browser's user agent changes") ?>
                 </label>
             </div>
 


### PR DESCRIPTION
My proposal is **to prevent espace characters in t-strings**, because these text strings are often used to search in the code base. If a user would search for "Log users out if their browser\'s user agent changes", he wouldn't find any matches. If we were to use double quotes instead, the string would be found. 

Of course this is a minor change. But if the core team agrees that we should try to avoid escape characters in t-strings, we'd enforce that for future commits, which I think would be useful.

https://github.com/concrete5/concrete5/pull/7227#discussion_r229774805