### PR TITLE
Trigger event when the display order of a page changes

### DIFF
--- a/concrete/src/Page/DisplayOrderUpdateEvent.php
+++ b/concrete/src/Page/DisplayOrderUpdateEvent.php
@@ -2,6 +2,9 @@
 
 namespace Concrete\Core\Page;
 
+/**
+ * @since 8.5.0
+ */
 class DisplayOrderUpdateEvent extends Event
 {
     /**

--- a/concrete/src/Page/DisplayOrderUpdateEvent.php
+++ b/concrete/src/Page/DisplayOrderUpdateEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Concrete\Core\Page;
+
+class DisplayOrderUpdateEvent extends Event
+{
+    /**
+     * Get the old display order
+     *
+     * This is the order *before* the page was moved.
+     *
+     * @return int
+     */
+    public function getOldDisplayOrder()
+    {
+        return (int) $this->getArgument('oldDisplayOrder');
+    }
+
+    /**
+     * Get the new display order
+     *
+     * This is the order *after* the page was moved.
+     *
+     * @return int
+     */
+    public function getNewDisplayOrder()
+    {
+        return (int) $this->getArgument('newDisplayOrder');
+    }
+
+    /**
+     * @param int $displayOrder
+     */
+    public function setOldDisplayOrder($displayOrder)
+    {
+        $this->setArgument('oldDisplayOrder', (int) $displayOrder);
+    }
+
+    /**
+     * @param int $displayOrder
+     */
+    public function setNewDisplayOrder($displayOrder)
+    {
+        $this->setArgument('newDisplayOrder', (int) $displayOrder);
+    }
+}

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3333,6 +3333,20 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
         $db = Database::connection();
         $db->executeQuery('update Pages set cDisplayOrder = ? where cID = ?', [$do, $cID]);
+
+        // Because the display order of another page can be changed,
+        // the page object is retrieved first in order to pass it to the event.
+        $page = $this;
+        if ($cID !== $this->getCollectionID()) {
+            $page = static::getByID($cID);
+        }
+
+        if (!$page->isError()) {
+            $event = new DisplayOrderUpdateEvent($page);
+            $event->setOldDisplayOrder($page->getCollectionDisplayOrder());
+            $event->setNewDisplayOrder($do);
+            Events::dispatch('on_page_display_order_update', $event);
+        }
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3325,12 +3325,27 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      * @param int $displayOrder
      * @param int|null $cID The page ID to set the display order for (if empty, we'll use this page)
      */
-    public function updateDisplayOrder($do, $cID = 0)
+    public function updateDisplayOrder($displayOrder, $cID = 0)
     {
+        $displayOrder = (int) $displayOrder;
+
         //this line was added to allow changing the display order of aliases
         if (!intval($cID)) {
             $cID = ($this->getCollectionPointerOriginalID() > 0) ? $this->getCollectionPointerOriginalID() : $this->cID;
         }
+
+        $app = Application::getFacadeApplication();
+        $db = $app->make(Connection::class);
+
+        $oldDisplayOrder = $db->fetchColumn('SELECT cDisplayOrder FROM Pages WHERE cID = ?', [$cID]);
+
+        // Exit out if the display order for this page doesn't change.
+        if ($oldDisplayOrder === null || $displayOrder === (int) $oldDisplayOrder) {
+            return;
+        }
+
+        // Store the new display order.
+        $db->executeQuery('update Pages set cDisplayOrder = ? where cID = ?', [$displayOrder, $cID]);
 
         // Because the display order of another page can be changed,
         // the page object is retrieved first in order to pass it to the event.
@@ -3343,17 +3358,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             return;
         }
 
-        // Exit out if the display order for this page doesn't change.
-        if ($do === $page->getCollectionDisplayOrder()) {
-            return;
-        }
-
-        $db = Database::connection();
-        $db->executeQuery('update Pages set cDisplayOrder = ? where cID = ?', [$do, $cID]);
-
+        // Fire an event that the page display order has changed.
         $event = new DisplayOrderUpdateEvent($page);
-        $event->setOldDisplayOrder($page->getCollectionDisplayOrder());
-        $event->setNewDisplayOrder($do);
+        $event->setOldDisplayOrder($oldDisplayOrder);
+        $event->setNewDisplayOrder($displayOrder);
         Events::dispatch('on_page_display_order_update', $event);
     }
 

--- a/tests/helpers/Page/PageTestCase.php
+++ b/tests/helpers/Page/PageTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\TestHelpers\Page;
 
+use Concrete\Core\Support\Facade\Application;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use Core;
 use Page;
@@ -10,6 +11,9 @@ use PageType;
 
 abstract class PageTestCase extends ConcreteDatabaseTestCase
 {
+    /** @var \Concrete\Core\Application\Application */
+    protected $app;
+
     protected $fixtures = [];
     protected $tables = [
         'Pages',
@@ -81,6 +85,8 @@ abstract class PageTestCase extends ConcreteDatabaseTestCase
     public function setUp()
     {
         parent::setUp();
+
+        $this->app = Application::getFacadeApplication();
     }
 
     protected static function createPage($name, $parent = false, $type = false, $template = false)

--- a/tests/tests/Page/PageTest.php
+++ b/tests/tests/Page/PageTest.php
@@ -500,26 +500,25 @@ class PageTest extends PageTestCase
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $director */
         $director = $this->app->make('director');
 
-        $listener = function ($event) {
-            $page = $event->getPageObject();
-
-            if ($page->getCollectionName() === 'Display1') {
-                $this->assertEquals(0, $event->getOldDisplayOrder(), 'First page should always be index 0.');
-                $this->assertEquals(10, $event->getNewDisplayOrder());
-            } elseif ($page->getCollectionName() === 'Display2') {
-                $this->assertEquals(1, $event->getOldDisplayOrder(), 'Second page should always be index 1.');
-                $this->assertEquals(5, $event->getNewDisplayOrder());
-            } elseif ($page->getCollectionName() === 'Display3') {
-                $this->assertEquals(2, $event->getOldDisplayOrder(), 'Third page should always be index 2.');
-                $this->assertEquals(99, $event->getNewDisplayOrder());
-            }
+        $map = [];
+        $listener = function ($event) use (&$map) {
+            $map[$event->getPageObject()->getCollectionName()]['old'] = $event->getOldDisplayOrder();
+            $map[$event->getPageObject()->getCollectionName()]['new'] = $event->getNewDisplayOrder();
         };
 
         $director->addListener('on_page_display_order_update', $listener);
 
         $page1->updateDisplayOrder(10);
+        $this->assertEquals(0, $map['Display1']['old'], 'First page should always be index 0.');
+        $this->assertEquals(10, $map['Display1']['new']);
+
         $page2->updateDisplayOrder(5);
+        $this->assertEquals(1, $map['Display2']['old'], 'Second page should always be index 1.');
+        $this->assertEquals(5, $map['Display2']['new']);
+
         $page1->updateDisplayOrder(99, $page3->getCollectionID());
+        $this->assertEquals(2, $map['Display3']['old'], 'Third page should always be index 2.');
+        $this->assertEquals(99, $map['Display3']['new']);
 
         $director->removeListener('on_page_display_order_update', $listener);
     }

--- a/tests/tests/Page/PageTest.php
+++ b/tests/tests/Page/PageTest.php
@@ -492,10 +492,10 @@ class PageTest extends PageTestCase
      */
     public function testPageDisplayOrderUpdateFiresEvent()
     {
-        $parent = self::createPage('DisplayParent');
-        $page1 = self::createPage('Display1', $parent);
-        $page2 = self::createPage('Display2', $parent);
-        $page3 = self::createPage('Display3', $parent);
+        $parent = self::createPage('Parent page to test display order of sub pages');
+        $page1 = self::createPage('Page1', $parent);
+        $page2 = self::createPage('Page2', $parent);
+        $page3 = self::createPage('Page3', $parent);
 
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $director */
         $director = $this->app->make('director');
@@ -509,16 +509,16 @@ class PageTest extends PageTestCase
         $director->addListener('on_page_display_order_update', $listener);
 
         $page1->updateDisplayOrder(10);
-        $this->assertEquals(0, $map['Display1']['old'], 'First page should always be index 0.');
-        $this->assertEquals(10, $map['Display1']['new']);
+        $this->assertEquals(0, $map[$page1->getCollectionName()]['old'], 'First page should always be index 0.');
+        $this->assertEquals(10, $map[$page1->getCollectionName()]['new']);
 
         $page2->updateDisplayOrder(5);
-        $this->assertEquals(1, $map['Display2']['old'], 'Second page should always be index 1.');
-        $this->assertEquals(5, $map['Display2']['new']);
+        $this->assertEquals(1, $map[$page2->getCollectionName()]['old'], 'Second page should always be index 1.');
+        $this->assertEquals(5, $map[$page2->getCollectionName()]['new']);
 
         $page1->updateDisplayOrder(99, $page3->getCollectionID());
-        $this->assertEquals(2, $map['Display3']['old'], 'Third page should always be index 2.');
-        $this->assertEquals(99, $map['Display3']['new']);
+        $this->assertEquals(2, $map[$page3->getCollectionName()]['old'], 'Third page should always be index 2.');
+        $this->assertEquals(99, $map[$page3->getCollectionName()]['new']);
 
         $director->removeListener('on_page_display_order_update', $listener);
     }


### PR DESCRIPTION
I hooked into the event in the bootstrap.php to verify if this event works as expected.

```php
Events::addListener('on_page_display_order_update', function($event) {
    \Log::addInfo(
        $event->getPageObject()->getCollectionName()
        . '. Old order: ' . $event->getOldDisplayOrder()
        . '. New order: ' . $event->getNewDisplayOrder()
    );
});
```

![afbeelding](https://user-images.githubusercontent.com/1431100/47842125-1888aa80-ddbc-11e8-888c-c3120d59e640.png)

https://github.com/concrete5/concrete5/issues/7254#issuecomment-434759474