### PR TITLE
Make sure getCollectionID always returns int or null

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -276,7 +276,7 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function getCollectionID()
     {
-        return $this->cID;
+        return $this->cID ? (int) $this->cID : null;
     }
 
     /**


### PR DESCRIPTION
The `cID` class property in the Page/Collection class sometimes contains a string. Let's make sure it always returns an integer or null, when we call `getCollectionID`.