### PR TITLE
Make sure getCollectionParentID always returns int or null

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1811,9 +1811,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function getCollectionParentID()
     {
-        if (isset($this->cParentID)) {
-            return $this->cParentID;
-        }
+        return isset($this->cParentID) ? (int) $this->cParentID : null;
     }
 
     /**


### PR DESCRIPTION
Because #7266 got merged, I had to add ab277ee3c988be8815cd49222922616025027a4a to #7207

Instead of reverting #7266 (I love it), what about doing the same for `Page::getCollectionParentID`?