### PR TITLE
Refresh thumbnails when adding/removing files to sets only when needed

### DIFF
--- a/tests/tests/File/FileListTest.php
+++ b/tests/tests/File/FileListTest.php
@@ -42,6 +42,7 @@ class FileListTest extends FileStorageTestCase
             'Concrete\Core\Entity\Attribute\Value\Value\Value',
             'Concrete\Core\Entity\Attribute\Type',
             'Concrete\Core\Entity\Attribute\Category',
+            'Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet',
         ]);
     }
 


### PR DESCRIPTION
Follow up of https://github.com/concrete5/concrete5/pull/7249#issuecomment-435215164