### PR TITLE
Add docblocks to verb-route methods in Router

### DIFF
--- a/concrete/src/Routing/Router.php
+++ b/concrete/src/Routing/Router.php
@@ -36,41 +36,105 @@ class Router implements RouterInterface
         return new RouteGroupBuilder($this);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function get($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['GET']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function head($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['HEAD']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function post($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['POST']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function put($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['PUT']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function patch($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['PATCH']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function delete($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['DELETE']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function options($path, $action)
     {
         return $this->createRouteBuilder($path, $action, ['OPTIONS']);
     }
 
+    /**
+     * @param string $path
+     * @param string $action
+     *
+     * @since 8.5.0a2
+     *
+     * @return \Concrete\Core\Routing\RouteBuilder
+     */
     public function all($path, $action)
     {
         return $this->createRouteBuilder($path, $action, [


### PR DESCRIPTION
For package developers it's extremely useful to have `since` tags. For example, `register` is deprecated since [8.5.0.a2](https://github.com/concrete5/concrete5/commit/742d6f936cdf4fa090cfd954759301a94286ca91#diff-14d1f498101c71b53b4fb69738a82c08), but the alternatives (the verb-like methods) are not available in earlier versions.

This PR adds a few docblocks, nothing fancy, but it saves us a lot of BC problems.

PS. @aembler the verb methods are not part of the RouterInterface, is this on purpose? I'm not sure I get the idea of a router interface, if the recommended way of adding new routes is via verb-methods. E.g. `$router->post('url', 'action');`.