### PR TITLE
[FIX] #7280 Save the Default User Attribute Settings

### DIFF
--- a/concrete/src/Attribute/Category/UserCategory.php
+++ b/concrete/src/Attribute/Category/UserCategory.php
@@ -180,6 +180,8 @@ class UserCategory extends AbstractStandardCategory
         $key->setAttributeKeyEditableOnRegister((string) $element['register-editable'] == 1);
         $key->setAttributeKeyRequiredOnRegister((string) $element['register-required'] == 1);
         $key->setAttributeKeyDisplayedOnMemberList((string) $element['member-list-displayed'] == 1);
+        // Save these settings to the database
+        $this->entityManager->flush();
 
         return $key;
     }
@@ -240,7 +242,8 @@ class UserCategory extends AbstractStandardCategory
         $key->setAttributeKeyEditableOnRegister((string) $request->request->get('uakRegisterEdit') == 1);
         $key->setAttributeKeyRequiredOnRegister((string) $request->request->get('uakRegisterEditRequired') == 1);
         $key->setAttributeKeyDisplayedOnMemberList((string) $request->request->get('uakMemberListDisplay') == 1);
-
+        // Actually save the changes to the database
+        $this->entityManager->flush();
         return $key;
     }
 }


### PR DESCRIPTION
Currently if you add a User Attribute to a set you cant save any of the default settings
"Editable in profile" , etc

This is because we normally save to the database in the assignToSetFromRequest function 
https://github.com/concrete5/concrete5/blob/4ccf81248f2b7925e25568eb779acb2bed592d7f/concrete/src/Page/Controller/DashboardAttributesPageController.php#L138

We should save in the saveFromRequest() on the UserCategory (like the parent does)
I also noticed we weren't saving in import either, this could mean in attributes not having the correct settings if previously imported.
