### PR TITLE
Show different text for aliases and external links in removal confirmation

### DIFF
--- a/concrete/views/dialogs/page/delete_alias.php
+++ b/concrete/views/dialogs/page/delete_alias.php
@@ -1,9 +1,14 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+/* @var Concrete\Controller\Dialog\Page\DeleteAlias $controller */
+/* @var Concrete\Core\View\DialogView $view */
+/* @var Concrete\Core\Page\Page $c */
+?>
 <div class="ccm-ui">
 
     <form class="form-stacked" data-dialog-form="delete-alias" method="post" action="<?=$controller->action('submit')?>">
 
-        <p><?=t('Remove this alias or external link?')?></p>
+        <p><?= $c->isExternalLink() ? t('Remove this external link?') : t('Remove this alias?') ?></p>
 
         <div class="dialog-buttons">
             <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>


### PR DESCRIPTION
When deleting an alias or an external link, we ask this confirmation:

![immagine](https://user-images.githubusercontent.com/928116/48251952-a0e1fd80-e403-11e8-8735-95aad7c2e332.png)

What about showing a different message for the two cases?

| ![immagine](https://user-images.githubusercontent.com/928116/48251913-827c0200-e403-11e8-861d-fbf90755d386.png) | ![immagine](https://user-images.githubusercontent.com/928116/48251920-8576f280-e403-11e8-9d8f-a1dd4d65fdd6.png) |
|:-:|:-:|