### PR TITLE
View SVG images like we already do with other image types

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -307,7 +307,7 @@ return [
         'HTML' => ['htm,html', FileType::T_IMAGE],
         'Flash' => ['swf', FileType::T_IMAGE, 'image'],
         'Icon' => ['ico', FileType::T_IMAGE],
-        'SVG' => ['svg', FileType::T_IMAGE],
+        'SVG' => ['svg', FileType::T_IMAGE, false, 'image'],
         'Windows Video' => ['asf,wmv', FileType::T_VIDEO, false, 'video'],
         'Quicktime' => ['mov,qt', FileType::T_VIDEO, false, 'video'],
         'AVI' => ['avi', FileType::T_VIDEO, false, 'video'],

--- a/concrete/elements/files/view/image.php
+++ b/concrete/elements/files/view/image.php
@@ -1,4 +1,15 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?> 
 <?php
-$path = $fv->getURL();
-echo '<img src="' . $path . '" />';
+use HtmlObject\Image;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/* @var Concrete\Core\Entity\File\Version $fv */
+
+$tag = new Image();
+$tag->src($fv->getURL());
+$tag->alt = h($fv->getTitle());
+if ($fv->getTypeObject()->isSVG()) {
+    $tag->addClass('ccm-svg');
+    $tag->style('max-width: 100%');
+}
+echo (string) $tag;

--- a/concrete/elements/files/view/image.php
+++ b/concrete/elements/files/view/image.php
@@ -6,10 +6,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Entity\File\Version $fv */
 
 $tag = new Image();
-$tag->src($fv->getURL());
+$tag->src = $fv->getURL();
 $tag->alt = h($fv->getTitle());
 if ($fv->getTypeObject()->isSVG()) {
     $tag->addClass('ccm-svg');
-    $tag->style('max-width: 100%');
+    $tag->style = 'max-width: 100%';
 }
 echo (string) $tag;


### PR DESCRIPTION
What about considering the SVG images exactly like the other images?

| Before this PR | With this PR |
|:---:|:---:|
| ![immagine](https://user-images.githubusercontent.com/928116/48271814-7d3ba900-e43d-11e8-9182-817c26e9def2.png) | ![immagine](https://user-images.githubusercontent.com/928116/48271848-90e70f80-e43d-11e8-9060-4603b8936178.png) |