### PR TITLE
Limit the maximum width/height of previews of SVG images

### DIFF
--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -379,11 +379,21 @@
 
     ConcreteFileManager.prototype.setupImageThumbnails = function() {
         $('.ccm-file-manager-list-thumbnail[data-hover-image]').each(function( e ){
-            var my = $(this);
+            var my = $(this),
+            	style = [],
+            	maxWidth = my.data('hover-maxwidth'),
+            	maxHeight = my.data('hover-maxheight');
+            if (maxWidth) {
+            	style.push('max-width: ' + maxWidth);
+            }
+            if (maxHeight) {
+            	style.push('max-height: ' + maxHeight);
+            }
+            style = style.length === 0 ? '' : (' style="' + style.join('; ') + '"');
             my.popover({
                 animation: true,
                 html: true,
-                content: '<img class="img-responsive" src="'+my.data('hover-image')+'" alt="Thumbnail"/>',
+                content: '<img class="img-responsive" src="'+my.data('hover-image')+'" alt="Thumbnail"' + style + '/>',
                 container: 'body',
                 placement: 'auto',
                 trigger: 'manual'

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1679,6 +1679,16 @@ class Version implements ObjectInterface
             if($config->get('concrete.file_manager.images.preview_image_popover')){
                 $result .= ' data-hover-image="'.$this->getThumbnailURL($detailType->getBaseVersion()).'"';
             }
+            if ($this->getTypeObject()->isSVG()) {
+                $maxWidth = $detailType->getWidth();
+                if ($maxWidth) {
+                    $result .= ' data-hover-maxwidth="'.$maxWidth.'px"';
+                }
+                $maxHeight = $detailType->getHeight();
+                if ($maxHeight) {
+                    $result .= ' data-hover-maxheight="'.$maxHeight.'px"';
+                }
+            }
             $result .= ' />';
         } else {
             return $this->getTypeObject()->getThumbnail();


### PR DESCRIPTION
SVG images can be very big.

So, we may have very big previews:

![immagine](https://user-images.githubusercontent.com/928116/48274258-3d77c000-e443-11e8-9cfd-b7e89df8da2d.png)

With this change, the previews of SVG images have a size comparable to the one of the other images:

![immagine](https://user-images.githubusercontent.com/928116/48274297-4ff1f980-e443-11e8-8510-1fc05a615e2f.png)
