### PR TITLE
Add a tracker for password usage and a password usage validator

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -265,7 +265,7 @@ class Controller extends AuthenticationTypeController
             $vh = new ValidationHash();
             if ($vh->isValid($uHash)) {
                 if (isset($_POST['uPassword']) && strlen($_POST['uPassword'])) {
-                    Core::make('validator/password')->isValid($_POST['uPassword'], $e);
+                    Core::make('validator/password')->isValidFor($_POST['uPassword'], $ui, $e);
 
                     if (strlen($_POST['uPassword']) && $_POST['uPasswordConfirm'] != $_POST['uPassword']) {
                         $e->add(t('The two passwords provided do not match.'));

--- a/concrete/controllers/single_page/account/edit_profile.php
+++ b/concrete/controllers/single_page/account/edit_profile.php
@@ -98,7 +98,7 @@ class EditProfile extends AccountPageController
             $passwordNew = $data['uPasswordNew'];
             $passwordNewConfirm = $data['uPasswordNewConfirm'];
 
-            $app->make('validator/password')->isValid($passwordNew, $this->error);
+            $app->make('validator/password')->isValidFor($passwordNew, $ui, $this->error);
 
             if ($passwordNew) {
                 if ($passwordNew != $passwordNewConfirm) {

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -281,7 +281,7 @@ class Search extends DashboardPageController
             $password = $this->post('uPassword');
             $passwordConfirm = $this->post('uPasswordConfirm');
 
-            $this->app->make('validator/password')->isValid($password, $this->error);
+            $this->app->make('validator/password')->isValidFor($password, $this->user, $this->error);
 
             if (!$this->app->make('helper/validation/token')->validate('change_password')) {
                 $this->error->add($this->app->make('helper/validation/token')->getErrorMessage());

--- a/concrete/src/Console/ServiceProvider.php
+++ b/concrete/src/Console/ServiceProvider.php
@@ -65,7 +65,7 @@ class ServiceProvider extends Provider
     protected $migrationCommands = [
         \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
-        \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand::class,
+        Command\Orm\GenerateMigrationCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand::class,

--- a/concrete/src/Console/ServiceProvider.php
+++ b/concrete/src/Console/ServiceProvider.php
@@ -65,7 +65,7 @@ class ServiceProvider extends Provider
     protected $migrationCommands = [
         \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
-        Command\Orm\GenerateMigrationCommand::class,
+        \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand::class,
         \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand::class,

--- a/concrete/src/Entity/Validator/UsedString.php
+++ b/concrete/src/Entity/Validator/UsedString.php
@@ -2,6 +2,8 @@
 
 namespace Concrete\Core\Entity\Validator;
 
+use Doctrine\ORM\Mapping as ORM;
+
 /**
  * @ORM\Entity
  * @ORM\Table(

--- a/concrete/src/Entity/Validator/UsedString.php
+++ b/concrete/src/Entity/Validator/UsedString.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Concrete\Core\Entity\Validator;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(
+ *     name="UsedStringLog"
+ * )
+ */
+class UsedString
+{
+
+    /**
+     * The subject this string was used for
+     *
+     * @var int
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * The used string
+     *
+     * @var string The hashed string that was used
+     * @ORM\Column(type="string", length=255, unique=true)
+     */
+    protected $usedString;
+
+    /**
+     * The subject this string was used for
+     *
+     * @var int
+     * @ORM\Column(type="integer")
+     */
+    protected $subject;
+
+    /**
+     * The DateTime the string was used
+     *
+     * @var \DateTime
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    protected $date;
+
+    /**
+     * Get the used string
+     *
+     * @return string
+     */
+    public function getUsedString()
+    {
+        return $this->usedString;
+    }
+
+    /**
+     * Set the used string
+     *
+     * @param string $usedString
+     *
+     * @return \Concrete\Core\Entity\Validator\UsedString
+     */
+    public function setUsedString($usedString)
+    {
+        $this->usedString = $usedString;
+        return $this;
+    }
+
+    /**
+     * Get the subject the string was used with
+     *
+     * @return int
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * Set the subject the string was used with
+     *
+     * @param int $subject
+     *
+     * @return \Concrete\Core\Entity\Validator\UsedString
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        return $this;
+    }
+
+    /**
+     * Get the date this string was used
+     *
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * Set the date this string was used
+     *
+     * @param \DateTime $date
+     *
+     * @return \Concrete\Core\Entity\Validator\UsedString
+     */
+    public function setDate(\DateTime $date)
+    {
+        $this->date = $date;
+        return $this;
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20181109153550.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20181109153550.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\Validator\UsedString;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20181109153550 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * Handle upgrading the database
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            UsedString::class
+        ]);
+    }
+
+    /**
+     * Handle downgrading the database
+     */
+    public function downgradeDatabase()
+    {
+        $this->refreshEntities();
+    }
+}

--- a/concrete/src/User/Password/PasswordChangeEventHandler.php
+++ b/concrete/src/User/Password/PasswordChangeEventHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Concrete\Core\User\Password;
+
+use Concrete\Core\User\Event\UserInfoWithPassword;
+use InvalidArgumentException;
+use Symfony\Component\EventDispatcher\Event;
+
+class PasswordChangeEventHandler
+{
+
+    /**
+     * The usage tracker we're using to track passwords
+     *
+     * @var \Concrete\Core\User\Password\PasswordUsageTracker
+     */
+    protected $tracker;
+
+    public function __construct(PasswordUsageTracker $tracker)
+    {
+        $this->tracker = $tracker;
+    }
+
+    /**
+     * Event handler for `on_user_change_password` events
+     *
+     * @param \Symfony\Component\EventDispatcher\Event $event
+     *
+     * @throws \InvalidArgumentException If the given event is not the proper subclass type. Must be `UserInfoWithPassword`
+     */
+    public function handleEvent(Event $event)
+    {
+        if (!$event instanceof UserInfoWithPassword) {
+            throw new InvalidArgumentException(t('Invalid event type provided. Event type must be "UserInfoWithPassword".'));
+        }
+
+        // Track the password use
+        $this->tracker->trackUse($event->getUserPassword(), $event->getUserInfoObject());
+    }
+}

--- a/concrete/src/User/Password/PasswordUsageTracker.php
+++ b/concrete/src/User/Password/PasswordUsageTracker.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Concrete\Core\User\Password;
+
+use Carbon\Carbon;
+use Concrete\Core\Entity\User\User as EntityUser;
+use Concrete\Core\Entity\Validator\UsedString;
+use Concrete\Core\User\User;
+use Concrete\Core\User\UserInfo;
+use Doctrine\ORM\EntityManagerInterface;
+
+class PasswordUsageTracker
+{
+
+    /**
+     * The entity manager we're saving usages against
+     *
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * The number of used strings we will track per subject
+     *
+     * @var int
+     */
+    protected $maxReuse;
+
+    public function __construct(EntityManagerInterface $entityManager, $maxReuse)
+    {
+        $this->entityManager = $entityManager;
+        $this->maxReuse = $maxReuse;
+    }
+
+    /**
+     * Track a string being used
+     *
+     * @param string $string The password that was used
+     * @param int|\Concrete\Core\User\User|\Concrete\Core\User\UserInfo|\Concrete\Core\Entity\User\User $subject The subject that used the password
+     *
+     * @return bool
+     */
+    public function trackUse($string, $subject)
+    {
+        $id = $this->resolveUserID($subject);
+
+        // If the subject is invalid return false
+        if (!$id) {
+            return false;
+        }
+
+        if (!is_string($string)) {
+            throw new \InvalidArgumentException(t('Invalid mixed value provided. Must be a string.'));
+        }
+
+        if ($this->maxReuse) {
+            // Store the use in the database
+            $this->entityManager->transactional(function (EntityManagerInterface $em) use ($id, $string) {
+                $reuse = new UsedString();
+                $reuse->setDate(Carbon::now());
+                $reuse->setSubject($id);
+                $reuse->setUsedString(password_hash($string, PASSWORD_DEFAULT));
+
+                $em->persist($reuse);
+            });
+        }
+
+        // Prune extra tracked uses
+        $this->pruneUses($id);
+
+        return true;
+    }
+
+    /**
+     * Prune uses for a specific subject
+     *
+     * @param int $subject
+     */
+    private function pruneUses($subject)
+    {
+        $repository = $this->entityManager->getRepository(UsedString::class);
+        $usedStrings = $repository->findBy(['subject' => $subject], ['id' => 'desc']);
+
+        // IF there are extra used strings, prune the extras
+        if (count($usedStrings) > $this->maxReuse) {
+            array_map([$this->entityManager, 'remove'], array_slice($usedStrings, $this->maxReuse));
+            $this->entityManager->flush();
+        }
+    }
+
+    /**
+     * @param $subject
+     *
+     * @return int
+     * @throws \InvalidArgumentException
+     */
+    private function resolveUserID($subject)
+    {
+        // Handle `null`, `0`, and any other falsy subject
+        if (!$subject) {
+            return 0;
+        }
+
+        // If an integer is just passed in
+        if (is_numeric($subject)) {
+            return (int)$subject;
+        }
+
+        // If we get an actual user instance
+        if ($subject instanceof User || $subject instanceof UserInfo || $subject instanceof EntityUser) {
+            return $subject->getUserID();
+        }
+
+        // Non-falsy subject that is unsupported
+        throw new \InvalidArgumentException(t('Unsupported subject provided. Subject must be a User, UserInfo, or User Entity object.'));
+    }
+
+}

--- a/concrete/src/User/UserServiceProvider.php
+++ b/concrete/src/User/UserServiceProvider.php
@@ -1,9 +1,13 @@
 <?php
+
 namespace Concrete\Core\User;
 
+use Concrete\Core\Application\Application;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 use Concrete\Core\User\Event\DeactivateUser;
 use Concrete\Core\User\Notification\UserNotificationEventHandler;
+use Concrete\Core\User\Password\PasswordChangeEventHandler;
+use Concrete\Core\User\Password\PasswordUsageTracker;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -12,23 +16,46 @@ class UserServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $app = $this->app;
-        $this->app->bindShared('user/registration', function() use ($app) {
+        $this->bindContainer($this->app);
+
+        // Handle binding events
+        if ($this->app->resolved(EventDispatcher::class)) {
+            $this->bindEvents($this->app->make(EventDispatcher::class));
+        } else {
+            $this->app->extend(EventDispatcher::class, function (EventDispatcher $director) {
+                $this->bindEvents($director);
+                return $director;
+            });
+        }
+    }
+
+    /**
+     * Bind things to the container
+     *
+     * @param \Concrete\Core\Application\Application $app
+     */
+    protected function bindContainer(Application $app)
+    {
+        $this->app->when(PasswordUsageTracker::class)->needs('$maxReuse')->give(function() {
+            return $this->app['config']->get('concrete.user.password.reuse.track', 5);
+        });
+
+        $this->app->bindShared('user/registration', function () use ($app) {
             return $app->make('Concrete\Core\User\RegistrationService');
         });
-        $this->app->bindShared('user/avatar', function() use ($app) {
+        $this->app->bindShared('user/avatar', function () use ($app) {
             return $app->make('Concrete\Core\User\Avatar\AvatarService');
         });
-        $this->app->bindShared('user/status', function() use ($app) {
+        $this->app->bindShared('user/status', function () use ($app) {
             return $app->make('Concrete\Core\User\StatusService');
         });
-        $this->app->bind('Concrete\Core\User\RegistrationServiceInterface', function() use ($app) {
+        $this->app->bind('Concrete\Core\User\RegistrationServiceInterface', function () use ($app) {
             return $app->make('user/registration');
         });
-        $this->app->bind('Concrete\Core\User\StatusServiceInterface', function() use ($app) {
+        $this->app->bind('Concrete\Core\User\StatusServiceInterface', function () use ($app) {
             return $app->make('user/status');
         });
-        $this->app->bind('Concrete\Core\User\Avatar\AvatarServiceInterface', function() use ($app) {
+        $this->app->bind('Concrete\Core\User\Avatar\AvatarServiceInterface', function () use ($app) {
             return $app->make('user/avatar');
         });
 
@@ -36,7 +63,7 @@ class UserServiceProvider extends ServiceProvider
         if ($this->app->resolved(EventDispatcher::class)) {
             $this->bindEvents($this->app->make(EventDispatcher::class));
         } else {
-            $this->app->extend(EventDispatcher::class, function(EventDispatcher $director) {
+            $this->app->extend(EventDispatcher::class, function (EventDispatcher $director) {
                 $this->bindEvents($director);
                 return $director;
             });
@@ -45,8 +72,12 @@ class UserServiceProvider extends ServiceProvider
 
     protected function bindEvents(EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addListener('on_after_user_deactivate', function($e) {
+        $dispatcher->addListener('on_after_user_deactivate', function ($e) {
             $this->app->call([$this, 'handleEvent'], ['event' => $e]);
+        });
+
+        $dispatcher->addListener('on_user_change_password', function ($event) {
+            $this->app->make(PasswordChangeEventHandler::class)->handleEvent($event);
         });
     }
 
@@ -55,6 +86,8 @@ class UserServiceProvider extends ServiceProvider
      *
      * @param \Symfony\Component\EventDispatcher\Event $event
      * @param \Concrete\Core\User\Notification\UserNotificationEventHandler $service
+     *
+     * @internal
      */
     public function handleEvent(Event $event, UserNotificationEventHandler $service)
     {

--- a/concrete/src/Validator/String/ReuseValidator.php
+++ b/concrete/src/Validator/String/ReuseValidator.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Concrete\Core\Validator\String;
+
+use ArrayAccess;
+use Concrete\Core\Entity\User\User as EntityUser;
+use Concrete\Core\Entity\Validator\UsedString;
+use Concrete\Core\User\User;
+use Concrete\Core\User\UserInfo;
+use Concrete\Core\Validator\AbstractTranslatableValidator;
+use Concrete\Core\Validator\ValidatorForSubjectInterface;
+use Concrete\Core\Validator\ValidatorForSubjectTrait;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ReuseValidator extends AbstractTranslatableValidator implements ValidatorForSubjectInterface
+{
+
+    use ValidatorForSubjectTrait;
+
+    const E_PASSWORD_RECENTLY_USED = 1;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var int
+     */
+    private $maxReuse;
+
+    public function __construct(EntityManagerInterface $entityManager, $maxReuse = 5)
+    {
+        $this->entityManager = $entityManager;
+        $this->maxReuse = $maxReuse;
+
+        $this->setErrorString(self::E_PASSWORD_RECENTLY_USED, t("You've recently used this password, please try a unique password"));
+    }
+
+    /**
+     * Is this mixed value valid for the specified (optional) subject?
+     *
+     * @param mixed $mixed Can be any value, should be a string to be valid
+     * @param mixed|int $subject The user ID the mixed value needs to be valid for
+     * @param \ArrayAccess|null $error
+     *
+     * @throws \InvalidArgumentException throws a InvalidArgumentException when $mixed or $subject are not valid
+     *
+     * @return bool
+     */
+    public function isValidFor($mixed, $subject = null, ArrayAccess $error = null)
+    {
+        $id = $this->resolveUserID($subject);
+
+        // If no subject is provided then we have no data to check against
+        if (!$id) {
+            return true;
+        }
+
+        // Validate the provided mixed type
+        if (!is_string($mixed)) {
+            throw new \InvalidArgumentException(t('Invalid mixed value provided. Must be a string.'));
+        }
+
+        // If the password hasn't been used it's valid
+        if (!$this->hasBeenUsed($mixed, $id)) {
+            return true;
+        }
+
+        // If the password has recently been used, it's invalid
+        if ($error) {
+            $error->add($this->getErrorString(self::E_PASSWORD_RECENTLY_USED, $mixed));
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether a string has been used against an id
+     *
+     * @param string $string
+     * @param int$id
+     *
+     * @return bool
+     */
+    private function hasBeenUsed($string, $id)
+    {
+        $repository = $this->entityManager->getRepository(UsedString::class);
+        $allUses = $repository->findBy(['subject' => $id], ['id' => 'desc'], $this->maxReuse);
+
+        foreach ($allUses as $use) {
+            if ($this->matches($string, $use)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify whether an obfuscated password matches a tracked used password
+     *
+     * @param string $string
+     * @param UsedString $usedString
+     *
+     * @return bool
+     */
+    private function matches($string, UsedString $usedString)
+    {
+        return password_verify($string, $usedString->getUsedString());
+    }
+
+    /**
+     * Protected accessor method for subclasses
+     *
+     * @return \Doctrine\ORM\EntityManagerInterface
+     */
+    protected function getEntityManager()
+    {
+        return $this->entityManager;
+    }
+
+    /**
+     * Protected accessor method for subclasses
+     *
+     * @return int
+     */
+    protected function getMaxReuseCount()
+    {
+        return $this->maxReuse;
+    }
+
+    /**
+     * @param $subject
+     *
+     * @return int
+     * @throws \InvalidArgumentException
+     */
+    private function resolveUserID($subject)
+    {
+        // Handle `null`, `0`, and any other falsy subject
+        if (!$subject) {
+            return 0;
+        }
+
+        // If an integer is just passed in
+        if (is_numeric($subject)) {
+            return (int) $subject;
+        }
+
+        // If we get an actual user instance
+        if ($subject instanceof User || $subject instanceof UserInfo || $subject instanceof EntityUser) {
+            return $subject->getUserID();
+        }
+
+        // Non-falsy subject that is unsupported
+        throw new \InvalidArgumentException(t('Unsupported subject provided. Subject must be a User, UserInfo, or User Entity object.'));
+    }
+}

--- a/concrete/src/Validator/ValidatorForSubjectTrait.php
+++ b/concrete/src/Validator/ValidatorForSubjectTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Validator;
+
+use ArrayAccess;
+
+/**
+ * A trait that provides an implementation of ValidatorInterface::isValid
+ */
+trait ValidatorForSubjectTrait
+{
+
+    /**
+     * @see \Concrete\Core\Validator\ValidatorInterface::isValid()
+     */
+    public function isValid($mixed, ArrayAccess $error = null)
+    {
+        return $this->isValidFor($mixed, null, $error);
+    }
+}

--- a/tests/tests/User/Password/PasswordChangeEventHandlerTest.php
+++ b/tests/tests/User/Password/PasswordChangeEventHandlerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Concrete\Tests\User\Password;
+
+use Concrete\Core\User\Event\UserInfoWithPassword;
+use Concrete\Core\User\Password\PasswordChangeEventHandler;
+use Concrete\Core\User\Password\PasswordUsageTracker;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Symfony\Component\EventDispatcher\Event;
+use PHPUnit_Framework_TestCase;
+use Mockery as M;
+
+class PasswordChangeEventHandlerTest extends PHPUnit_Framework_TestCase
+{
+
+    use MockeryPHPUnitIntegration;
+
+    public function testHandlingSimpleEvent()
+    {
+        $password = 'blah';
+        $userinfo = 'someuserinfoobjectbutnotreally';
+
+        $tracker = M::mock(PasswordUsageTracker::class);
+        $tracker->shouldReceive('trackUse')->once()->with($password, $userinfo);
+
+        $event = M::mock(UserInfoWithPassword::class);
+        $event->shouldReceive([
+            'getUserPassword' => $password,
+            'getUserInfoObject' => $userinfo
+        ]);
+
+        $handler = new PasswordChangeEventHandler($tracker);
+        $handler->handleEvent($event);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid event type provided. Event type must be "UserInfoWithPassword".
+     */
+    public function testInvalidEventType()
+    {
+        $tracker = M::mock(PasswordUsageTracker::class);
+        $event = M::mock(Event::class);
+
+        $handler = new PasswordChangeEventHandler($tracker);
+        $handler->handleEvent($event);
+    }
+
+}

--- a/tests/tests/User/Password/PasswordUsageTrackerTest.php
+++ b/tests/tests/User/Password/PasswordUsageTrackerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Tests\User\Password;
+
+use Concrete\Core\Entity\User\User as EntityUser;
+use Concrete\Core\Entity\Validator\UsedString;
+use Concrete\Core\User\Password\PasswordUsageTracker;
+use Concrete\Core\User\User;
+use Concrete\Core\User\UserInfo;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit_Framework_TestCase;
+use Mockery as M;
+use ReflectionMethod;
+
+class PasswordUsageTrackerTest extends PHPUnit_Framework_TestCase
+{
+
+    use MockeryPHPUnitIntegration;
+
+    public function testTrackUse()
+    {
+        $repository = M::mock(ObjectRepository::class);
+        $repository->shouldReceive('findBy')->with(['subject' => 1337], ['id' => 'desc'])->andReturn([]);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $entityManager->shouldReceive('transactional')->with(\Closure::class)->once()
+            ->andReturnUsing(function($closure) use ($entityManager) {
+                $closure($entityManager);
+            });
+
+        $entityManager->shouldReceive('getRepository')->with(UsedString::class)->once()->andReturn($repository);
+        $entityManager->shouldReceive('persist')->with(UsedString::class)->once()->andReturnUsing(function(UsedString $string) {
+            $this->assertTrue(password_verify('foo', $string->getUsedString()));
+            $this->assertEquals(1337, $string->getSubject());
+        });
+
+        $tracker = new PasswordUsageTracker($entityManager, 1);
+        $this->assertTrue($tracker->trackUse('foo', 1337));
+    }
+
+    public function testDoesNothingWithInvalidSubject()
+    {
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $tracker = new PasswordUsageTracker($entityManager, 1);
+
+        $this->assertFalse($tracker->trackUse('foo', 0));
+    }
+
+    public function testUserNegotiation()
+    {
+        $method = new ReflectionMethod(PasswordUsageTracker::class, 'resolveUserID');
+        $method->setAccessible(true);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $tracker = new PasswordUsageTracker($entityManager, 1);
+
+        $id = 1337;
+        $user = M::mock(User::class)->shouldReceive(['getUserID' => $id])->getMock();
+        $userInfo = M::mock(UserInfo::class)->shouldReceive(['getUserID' => $id])->getMock();
+        $userEntity = M::mock(EntityUser::class)->shouldReceive(['getUserID' => $id])->getMock();
+
+        $this->assertEquals($id, $method->invoke($tracker, 1337));
+        $this->assertEquals($id, $method->invoke($tracker, $user));
+        $this->assertEquals($id, $method->invoke($tracker, $userInfo));
+        $this->assertEquals($id, $method->invoke($tracker, $userEntity));
+    }
+
+    public function testPruning()
+    {
+        $repository = M::mock(ObjectRepository::class);
+        $repository->shouldReceive('findBy')->with(['subject' => 1337], ['id' => 'desc'])->andReturn([5, 4, 3, 2, 1]);
+
+        $method = new ReflectionMethod(PasswordUsageTracker::class, 'pruneUses');
+        $method->setAccessible(true);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $entityManager->shouldReceive('getRepository')->with(UsedString::class)->once()->andReturn($repository);
+        $entityManager->shouldReceive('remove')->with(2)->once();
+        $entityManager->shouldReceive('remove')->with(1)->once();
+        $entityManager->shouldReceive('flush')->once();
+
+        $tracker = new PasswordUsageTracker($entityManager, 3);
+        $method->invoke($tracker, 1337);
+    }
+
+}

--- a/tests/tests/Validator/String/ReuseValidator.php
+++ b/tests/tests/Validator/String/ReuseValidator.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Concrete\Tests\Validator\String;
+
+use Concrete\Core\Entity\Validator\UsedString;
+use Concrete\Core\Validator\String\ReuseValidator;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit_Framework_TestCase;
+use Mockery as M;
+
+class ReuseValidatorTest extends PHPUnit_Framework_TestCase
+{
+
+    use MockeryPHPUnitIntegration;
+
+    public function testValidating()
+    {
+        $repository = M::mock(ObjectRepository::class);
+        $repository->shouldReceive('findBy')->with(['subject' => 1337], ['id' => 'desc'], 4)->twice()->andReturn([
+            $this->mockUsedString('foobar'),
+            $this->mockUsedString('trustno1'),
+            $this->mockUsedString('foo'),
+            $this->mockUsedString('batteriesaredangerous'),
+        ]);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $entityManager->shouldReceive('getRepository')->with(UsedString::class)->andReturn($repository);
+
+        $validator = new ReuseValidator($entityManager, 4);
+
+        $this->assertTrue($validator->isValidFor('bar', 1337));
+        $this->assertFalse($validator->isValidFor('foo', 1337));
+    }
+
+    private function mockUsedString($string, $subject = 1337)
+    {
+        return M::mock(UsedString::class)->shouldReceive([
+            'getUsedString' => password_hash($string, PASSWORD_DEFAULT),
+            'getSubject' => $subject
+        ])->getMock();
+    }
+
+    public function testUserNegotiation()
+    {
+        $method = new ReflectionMethod(ReuseValidator::class, 'resolveUserID');
+        $method->setAccessible(true);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $tracker = new ReuseValidator($entityManager, 1);
+
+        $id = 1337;
+        $user = M::mock(User::class)->shouldReceive(['getUserID' => $id])->getMock();
+        $userInfo = M::mock(UserInfo::class)->shouldReceive(['getUserID' => $id])->getMock();
+        $userEntity = M::mock(EntityUser::class)->shouldReceive(['getUserID' => $id])->getMock();
+
+        $this->assertEquals($id, $method->invoke($tracker, 1337));
+        $this->assertEquals($id, $method->invoke($tracker, $user));
+        $this->assertEquals($id, $method->invoke($tracker, $userInfo));
+        $this->assertEquals($id, $method->invoke($tracker, $userEntity));
+    }
+
+}


### PR DESCRIPTION
This tracker now tracks a fixed amount of used passwords depending on configuration. It hashes these passswords separately from the user table and gives them all unique salts.

closes: #7213