### PR TITLE
Check if we can set session values in Detector class

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -126,7 +126,7 @@ class Detector
                     if ($ms) {
                         $locale = $ms->getLocale();
 
-                        if (self::canSetSessionValue()) {
+                        if ($this->canSetSessionValue()) {
                             $app->make('session')->set('multilingual_default_locale', $locale);
                         }
                     }

--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -27,12 +27,13 @@ class Detector
         $site = $app->make('site')->getSite();
         $siteConfig = $site->getConfigRepository();
         $session = $app->make('session');
+        $detector = $app->make(Detector::class);
 
         $result = null;
         if ($result === null) {
             $locale = false;
             // Detect locale by value stored in session or cookie
-            if (self::canSetSessionValue() && $session->has('multilingual_default_locale')) {
+            if ($detector->canSetSessionValue() && $session->has('multilingual_default_locale')) {
                 $locale = $session->get('multilingual_default_locale');
             } else {
                 $cookie = $app->make('cookie');
@@ -86,7 +87,7 @@ class Detector
             }
         }
 
-        if ($result !== null && self::canSetSessionValue()) {
+        if ($result !== null && $detector->canSetSessionValue()) {
             $session->set('multilingual_default_locale', $result[0]);
         }
 


### PR DESCRIPTION
The issue in #6908 appears to be caused by `$session->has('multilingual_default_locale')`.
I used @mlocati's method to check if we can set session values before using `$session->has()` and to replace the duplicate code. 

Co-Authored-By: mlocati <michele@locati.it>

Fix #6908 