### PR TITLE
Fix dragging aliases in sitemap

### DIFF
--- a/concrete/controllers/dialog/page/drag_request.php
+++ b/concrete/controllers/dialog/page/drag_request.php
@@ -45,7 +45,7 @@ class DragRequest extends UserInterfaceController
         $dragRequestData = $this->app->make(DragRequestData::class);
         $originalPageIDs = [];
         foreach ($dragRequestData->getOriginalPages() as $originalPage) {
-            $originalPageIDs[] = $originalPage->getCollectionID();
+            $originalPageIDs[] = $originalPage->isAliasPage() ? $originalPage->getCollectionPointerOriginalID() : $originalPage->getCollectionID();
         }
         $this->set('validationToken', $this->app->make('token')->generate($this->validationToken));
         $this->set('dragRequestData', $dragRequestData);

--- a/concrete/src/Page/Sitemap/DragRequestData.php
+++ b/concrete/src/Page/Sitemap/DragRequestData.php
@@ -466,6 +466,7 @@ class DragRequestData
             return t('Only the administrator can copy aliased pages.');
         }
         $destinationPageID = $this->getDestinationPage()->getCollectionID();
+        $somePageWithChildren = false;
         foreach ($this->getOriginalPages() as $originalPage) {
             if ($originalPage->getCollectionID() == $destinationPageID) {
                 return t('It\'s not possible to copy the page "%s" and its child pages under the page itself.', $originalPage->getCollectionName());
@@ -473,6 +474,12 @@ class DragRequestData
             if (in_array($destinationPageID, $originalPage->getCollectionChildrenArray())) {
                 return t('It\'s not possible to copy the page "%s" and its child pages under one of its child pages.', $originalPage->getCollectionName());
             }
+            if ($somePageWithChildren === false && !$originalPage->isAliasPageOrExternalLink() && $originalPage->getNumChildrenDirect() > 0) {
+                $somePageWithChildren = true;
+            }
+        }
+        if ($somePageWithChildren === false) {
+            return count($this->getOriginalPages()) === 1 ? t("The page doesn't have any child pages.") : t("The pages don't have any child pages.");
         }
 
         return '';


### PR DESCRIPTION
It turned out that the cause of #7287 was that in #6951 I passed the ID of the pages, not the ID of the aliases.

Fix #7287