### PR TITLE
Initialize the request just once

### DIFF
--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -112,8 +112,7 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
             $this->initializeSystemTimezone();
         }
 
-        // Create the request to use
-        $request = $this->createRequest();
+        $request = Request::getInstance();
 
         if (!$response) {
             $response = $this->server->handleRequest($request);
@@ -229,14 +228,13 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
     }
 
     /**
-     * Create the request object to use.
+     * @deprecated since concrete5 8.5.0a3: the request is initialized in previous steps.
+     *
+     * @return \Concrete\Core\Http\Request
      */
     protected function createRequest()
     {
-        $request = Request::createFromGlobals();
-        $request::setInstance($request);
-
-        return $request;
+        return Request::getInstance();
     }
 
     /**


### PR DESCRIPTION
We currently initialize the Request singleton twice: the first time it's initialized [here](https://github.com/concrete5/concrete5/blob/82df6bb7589d064173f2cc3718ae12298b67640c/concrete/src/Application/Application.php#L400), and after we re-initialize it [here](https://github.com/concrete5/concrete5/blob/82df6bb7589d064173f2cc3718ae12298b67640c/concrete/src/Foundation/Runtime/Run/DefaultRunner.php#L236-L237).

What about removing this second initialization?