### PR TITLE
Avoid accessing undefined var in desktop_waiting_for_me block

### DIFF
--- a/concrete/blocks/desktop_waiting_for_me/controller.php
+++ b/concrete/blocks/desktop_waiting_for_me/controller.php
@@ -39,18 +39,15 @@ class Controller extends BlockController
             $filterValues[$filter->getKey()] = $filter->getName();
         }
 
-        $filter = null;
-        if ($this->request->query->has('filter')) {
-            $filter = $this->request->query->get('filter');
-            $this->set('activeFilter', h($filter));
-        }
-
         $u = new \User();
         $list = $this->app->make(AlertList::class, ['user' => $u]);
-        if ($filter) {
-            $activeFilter = $filterList->getFilterByKey($filter);
-            if ($activeFilter) {
-                $activeFilter->filterAlertList($list);
+        $filter = (string) $this->request->query->get('filter');
+        if ($filter !== '') {
+            $filterObject = $filterList->getFilterByKey($filter);
+            if ($filterObject) {
+                $filterObject->filterAlertList($list);
+            } else {
+                $filter = '';
             }
         }
         $pagination = $list->getPagination();
@@ -63,6 +60,7 @@ class Controller extends BlockController
         $this->set('filterValues', $filterValues);
         $this->set('token', $this->app->make('token'));
         $this->set('pagination', $pagination);
+        $this->set('filter', $filter);
     }
 
     public function action_reload_results()

--- a/concrete/blocks/desktop_waiting_for_me/view.php
+++ b/concrete/blocks/desktop_waiting_for_me/view.php
@@ -1,4 +1,14 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+/* @var Concrete\Core\Block\View\BlockView $view */
+/* @var Concrete\Core\Form\Service\Form $form */
+
+/* @var Concrete\Core\Entity\Notification\NotificationAlert[] $items */
+/* @var array $filterValues */
+/* @var string $filter */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Search\Pagination\Pagination $pagination */
+?>
 <div class="ccm-block-desktop-waiting-for-me" data-wrapper="desktop-waiting-for-me">
 
 
@@ -12,7 +22,7 @@
         <div data-form="notification">
             <form method="get" action="<?=$view->action('reload_results')?>">
             <div class="form-group" style="font-size: 12px">
-                <?=$form->select('filter', $filterValues, $filter)?>
+                <?=$form->select('filter', $filterValues, h($filter))?>
             </div>
             </form>
         </div>
@@ -62,7 +72,7 @@
         <p <?php if (count($items)) { ?> style="display: none"<?php }  ?> data-notification-description="empty"><?=t('There are no items that currently need your attention.')?></p>
 
         <?php if ($pagination && $pagination->haveToPaginate()) {
-            $pagination->setBaseURL($view->action('reload_results') . '?filter=' . $activeFilter);
+            $pagination->setBaseURL($view->action('reload_results') . '?filter=' . rawurlencode($filter));
             ?>
 
             <?=$pagination->renderDefaultView(); ?>


### PR DESCRIPTION
We (sometimes) set the `$activeFilter` variable in the controller, and we use `$activeFilter` and `$filter` in the view.
Let's always use `$filter`.

Ref. #4723