### PR TITLE
Send a JSON error response only if the client is requesting a JSON response

### DIFF
--- a/concrete/src/Error/Handler/JsonErrorHandler.php
+++ b/concrete/src/Error/Handler/JsonErrorHandler.php
@@ -1,8 +1,13 @@
 <?php
+
 namespace Concrete\Core\Error\Handler;
 
 use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Http\RequestMediaTypeParser;
+use Concrete\Core\Support\Facade\Application;
 use Config;
+use Exception;
+use Throwable;
 use Whoops\Exception\Formatter;
 use Whoops\Handler\Handler;
 use Whoops\Util\Misc;
@@ -64,7 +69,7 @@ class JsonErrorHandler extends Handler
         ];
 
         if (Misc::canSendHeaders()) {
-            if (isset($_SERVER['HTTP_ACCEPT']) && preg_match('%^(application|\*)/(json|\*)$%', $_SERVER['HTTP_ACCEPT'])) {
+            if ($this->clientSupportsJson() === true) {
                 header('Content-Type: application/json; charset=' . APP_CHARSET, true);
             } else {
                 header('Content-Type: text/plain; charset=' . APP_CHARSET, true);
@@ -86,5 +91,26 @@ class JsonErrorHandler extends Handler
         return
             !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
             && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest';
+    }
+
+    /**
+     * Check if the client supports JSON.
+     *
+     * @param float $minWeight
+     *
+     * @return bool|null true: yes; false: no; NULL: we weren't able to detect it
+     */
+    private function clientSupportsJson($minWeight = null)
+    {
+        try {
+            $app = Application::getFacadeApplication();
+            $rmrp = $app->make(RequestMediaTypeParser::class);
+
+            return $rmrp->isMediaTypeSupported('application/json', $minWeight);
+        } catch (Exception $x) {
+            return null;
+        } catch (Throwable $x) {
+            return null;
+        }
     }
 }

--- a/concrete/src/Http/RequestMediaTypeParser.php
+++ b/concrete/src/Http/RequestMediaTypeParser.php
@@ -287,7 +287,7 @@ class RequestMediaTypeParser
      * @param string $type
      * @param string $subType
      *
-     * @return string[];
+     * @return string[]
      */
     protected function getMediaTypeAlternatives($type, $subType)
     {

--- a/concrete/src/Http/RequestMediaTypeParser.php
+++ b/concrete/src/Http/RequestMediaTypeParser.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Concrete\Core\Http;
+
+class RequestMediaTypeParser
+{
+    /**
+     * Optional white space characters.
+     *
+     * @see https://tools.ietf.org/html/rfc7230#section-3.2.3
+     *
+     * @var string
+     */
+    const OWS_CHARS = " \t";
+
+    /**
+     * Parameter-separator character.
+     *
+     * @see https://tools.ietf.org/html/rfc7231#section-5.3.2
+     *
+     * @var string
+     */
+    const PARAMETER_SEPARATOR_CHAR = ';';
+
+    /**
+     * List-separator character.
+     *
+     * @see https://tools.ietf.org/html/rfc7230#section-1.2
+     *
+     * @var string
+     */
+    const LIST_SEPARATOR_CHAR = ',';
+
+    /**
+     * Regular expression chunk: token.
+     *
+     * @see https://tools.ietf.org/html/rfc7230#section-3.2.6
+     *
+     * @var string
+     */
+    const RX_TOKEN = '[\w\-\'!#$%&*+.^`|~]+';
+
+    /**
+     * Regular expression chunk: quoted string.
+     *
+     * @see https://tools.ietf.org/html/rfc7230#section-3.2.6
+     *
+     * @var string
+     */
+    const RX_QUOTED_STRING = '"[^"]*"';
+
+    /**
+     * Regular expression chunk: type.
+     *
+     * @see https://tools.ietf.org/html/rfc7231#appendix-D
+     *
+     * @var string
+     */
+    const RX_TYPE = self::RX_TOKEN;
+
+    /**
+     * Regular expression chunk: sub-type.
+     *
+     * @see https://tools.ietf.org/html/rfc7231#appendix-D
+     *
+     * @var string
+     */
+    const RX_SUBTYPE = self::RX_TOKEN;
+
+    /**
+     * @var \Concrete\Core\Http\Request
+     */
+    protected $request;
+
+    /**
+     * @var array|null
+     */
+    private $requestAcceptMap;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Http\Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Check if the client signaled that it supports a media type.
+     *
+     * @param string|string[] $mediaType the media type to be checked (a string like 'text/html', or an array like ['text','html'])
+     * @param float|null $minWeight the minimum weight of the found media type (from 0 to 1); if NULL we won't check it
+     *
+     * @return bool
+     */
+    public function isMediaTypeSupported($mediaType, $minWeight = null)
+    {
+        $data = $this->getMediaTypeData($mediaType);
+        if ($minWeight === null) {
+            return $data !== [];
+        }
+        $minWeight = (float) $minWeight;
+        foreach ($data as $item) {
+            if ($item['q'] >= $minWeight) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the data associated to a media type.
+     *
+     * @param string|string[] $mediaType the media type to be checked (a string like 'text/html', or an array like ['text','html'])
+     *
+     * @return array keys are the media type; values are the associated data, sorted by the preferred type (the 'q' parameter)
+     */
+    public function getMediaTypeData($mediaType)
+    {
+        $map = $this->getRequestAcceptMap();
+        list($type, $subType) = $this->normalizeMediaType($mediaType);
+        $result = [];
+        foreach ($this->getMediaTypeAlternatives($type, $subType) as $alternative) {
+            if (isset($map[$alternative])) {
+                $result[$alternative] = $map[$alternative];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the data extracted from the 'Accept' header.
+     *
+     * @return array keys are the media type; values are the associated data, sorted by the preferred type (the 'q' parameter)
+     *
+     * @example <code>['image/png' => ['q' => 1.0], 'image/*' => ['q' => 0.8]]
+     */
+    public function getRequestAcceptMap()
+    {
+        if ($this->requestAcceptMap === null) {
+            $requestAccept = $this->getRequestAccept();
+            $requestAcceptMap = $this->parseRequestAccept($requestAccept);
+            $requestAcceptMap = $this->sortRequestAcceptMap($requestAcceptMap);
+            $this->requestAcceptMap = $requestAcceptMap;
+        }
+
+        return $this->requestAcceptMap;
+    }
+
+    /**
+     * Get the 'Accept' header of the request.
+     *
+     * @var string empty if not available
+     */
+    protected function getRequestAccept()
+    {
+        $accept = $this->request->headers->get('accept');
+        if (!is_string($accept)) {
+            return '';
+        }
+
+        return trim($accept);
+    }
+
+    /**
+     * @param string $accept
+     *
+     * @return array
+     */
+    protected function parseRequestAccept($accept)
+    {
+        $result = [];
+        $rxMediaType = $this->getTypeSubtypeRegularExpression();
+        $rxParameterAndValue = $this->getParameterAndValueRegularExpression();
+        $matches = null;
+        for (; ;) {
+            if ($accept === '') {
+                break;
+            }
+            // Read type/subtype
+            if (!preg_match("/^({$rxMediaType})/", $accept, $matches)) {
+                // Malformed: return what we read so far
+                return $result;
+            }
+            $foundMediaType = strtolower($matches[1]);
+            $result[$foundMediaType] = ['q' => 1.0];
+            $accept = ltrim(substr($accept, strlen($foundMediaType)), static::OWS_CHARS);
+            // Read parameters (eg "; q=1")
+            while ($accept !== '' && $accept[0] === static::PARAMETER_SEPARATOR_CHAR) {
+                $accept = ltrim(substr($accept, 1), static::OWS_CHARS);
+                if (!preg_match("/^{$rxParameterAndValue}/", $accept, $matches)) {
+                    // Malformed: return what we read so far
+                    return $result;
+                }
+                $accept = ltrim(substr($accept, strlen($matches[0])), static::OWS_CHARS);
+                switch (strtolower($matches[1])) {
+                    case 'q':
+                        if (is_numeric($matches[2])) {
+                            $result[$foundMediaType]['q'] = min(max((float) $matches[2], 0), 1);
+                        }
+                        break;
+                    default:
+                        $result[$foundMediaType][$matches[1]] = $matches[2];
+                        break;
+                }
+            }
+            if ($accept === '') {
+                break;
+            }
+            // Goto next type/subtype
+            if ($accept[0] !== static::LIST_SEPARATOR_CHAR) {
+                // Malformed: return what we read so far
+                return $result;
+            }
+            $accept = ltrim(substr($accept, 1), static::OWS_CHARS);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $requestAcceptMap
+     *
+     * @return array
+     */
+    protected function sortRequestAcceptMap(array $requestAcceptMap)
+    {
+        uasort($requestAcceptMap, function ($a, $b) {
+            if ($a['q'] > $b['q']) {
+                return -1;
+            }
+            if ($a['q'] < $b['q']) {
+                return 1;
+            }
+
+            return 0;
+        });
+
+        return $requestAcceptMap;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTypeSubtypeRegularExpression()
+    {
+        $rxType = static::RX_TYPE;
+        $rxSubType = static::RX_SUBTYPE;
+
+        return "(?:{$rxType}|\*)\/(?:{$rxSubType}|\*)";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getParameterAndValueRegularExpression()
+    {
+        $rxToken = static::RX_TOKEN;
+        $rxQuotedString = static::RX_QUOTED_STRING;
+
+        return "({$rxToken})=({$rxToken}|{$rxQuotedString})";
+    }
+
+    /**
+     * @param string|string[] $mediaType
+     *
+     * @return string[]
+     */
+    protected function normalizeMediaType($mediaType)
+    {
+        if (!is_array($mediaType)) {
+            $mediaType = explode('/', (string) $mediaType, 2);
+        }
+        $type = (string) array_shift($mediaType);
+        $type = $type === '' ? '*' : strtolower($type);
+        $subType = (string) array_shift($mediaType);
+        $subType = $subType === '' ? '*' : strtolower($subType);
+
+        return [$type, $subType];
+    }
+
+    /**
+     * @param string $type
+     * @param string $subType
+     *
+     * @return string[];
+     */
+    protected function getMediaTypeAlternatives($type, $subType)
+    {
+        $result = ['*/*'];
+        if ($type !== '*') {
+            $result[] = "{$type}/*";
+            if ($subType !== '*') {
+                $result[] = "{$type}/{$subType}";
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/tests/Http/RequestMediaTypeParserTest.php
+++ b/tests/tests/Http/RequestMediaTypeParserTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Concrete\Tests\Http;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\RequestMediaTypeParser;
+use Mockery;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+class RequestMediaTypeParserTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @return array
+     */
+    public function provideMediaTypeMap()
+    {
+        return [
+            [
+                null,
+                [],
+            ],
+            [
+                '',
+                [],
+            ],
+            [
+                'invalid',
+                [],
+            ],
+            [
+                'image/png',
+                [
+                    'image/png' => ['q' => 1.0],
+                ],
+            ],
+            [
+                'image/*; q=0.1, image/png;q=1',
+                [
+                    'image/png' => ['q' => 1.0],
+                    'image/*' => ['q' => 0.1],
+                ],
+            ],
+            [
+                'image/*; q=0.1, image/png;q=1;this-is=a-test;really="test it", application/*;   q=0.3; wrong, wont/parse',
+                [
+                    'image/png' => ['q' => 1.0, 'this-is' => 'a-test', 'really' => '"test it"'],
+                    'application/*' => ['q' => 0.3],
+                    'image/*' => ['q' => 0.1],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMediaTypeMap
+     *
+     * @param string|mixed $acceptValue
+     * @param array $expectedMap
+     */
+    public function testMediaTypeMap($acceptValue, array $expectedMap)
+    {
+        $mediaTypeParser = $this->getMediaTypeParser($acceptValue);
+        $actualMap = $mediaTypeParser->getRequestAcceptMap();
+
+        $this->assertSame($expectedMap, $actualMap);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideAcceptMediaType()
+    {
+        return [
+            [null, 'text/html', null, false],
+            [['invalid', 'request', 'value'], 'text/html', null, false],
+            ['text/html', 'text/html', null, true],
+            ['text/*', 'text/html', null, true],
+            ['*/*', 'text/html', null, true],
+            ['text/html', 'text/html', 0, true],
+            ['text/*', 'text/html', 0, true],
+            ['*/*', 'text/html', 0, true],
+            ['text/html', 'text/html', 0.1, true],
+            ['text/*', 'text/html', 0.1, true],
+            ['*/*', 'text/html', 0.1, true],
+            ['text/html', 'text/html', 0.9, true],
+            ['text/*', 'text/html', 0.9, true],
+            ['*/*', 'text/html', 0.9, true],
+            ['text/html', 'text/html', 1, true],
+            ['text/plain,text/html', 'text/html', 1, true],
+            ['text/*', 'text/html', 1, true],
+            ['*/*', 'text/html', 1, true],
+            ['something/else', 'text/html', null, false],
+            ['audio/*; q=0.2; v="test"; v2=value1, audio/basic', 'audio/other', null, true],
+            ['audio/*; q=0.2; v="test"; v2=value1, audio/basic', 'audio/other', 0.1, true],
+            ['audio/*; q=0.2; v="test"; v2=value1, audio/basic', 'audio/other', 0.2, true],
+            ['audio/*; q=0.2; v="test"; v2=value1, audio/basic', 'audio/other', 0.3, false],
+            ['audio/*; q=0.2; some other malformed value', 'image/*', null, false],
+            ['audio/*; q=0.2; some other malformed value', 'audio/mp3', null, true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideAcceptMediaType
+     *
+     * @param string|mixed $acceptValue
+     * @param string|string[] $mediaType
+     * @param float|null $minWeight
+     * @param bool $expectedResult
+     */
+    public function testAcceptMediaType($acceptValue, $mediaType, $minWeight, $expectedResult)
+    {
+        $mediaTypeParser = $this->getMediaTypeParser($acceptValue);
+        $actualResult = $mediaTypeParser->isMediaTypeSupported($mediaType, $minWeight);
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @param string|mixed $acceptValue
+     *
+     * @return \Concrete\Core\Http\RequestMediaTypeParser
+     */
+    protected function getMediaTypeParser($acceptValue)
+    {
+        $headers = Mockery::mock(HeaderBag::class);
+        $headers->shouldReceive('get')->withArgs(['accept'])->andReturn($acceptValue);
+        $request = Mockery::mock(Request::class);
+        $request->headers = $headers;
+
+        return new RequestMediaTypeParser($request);
+    }
+}


### PR DESCRIPTION
Our `JsonErrorHandler` class is sending JSON responses for ajax requests that contain errors.

BTW, if the client is requesting HTML (for example), the `Accept` header (`$_SERVER['HTTP_ACCEPT']`) for PHP will be something like this (just tested with Chrome, Firefox, Edge, Internet Explorer):

```
Accept: text/html, */*; q=0.01
```
(which means: the browser would really like a `text/html` document, but it may also accept anything else - see the `*/*; q=0.01` chunk).

In the above case, we currently answer to ajax calls with the error in JSON format, but with a `text/plain` media type (so, the client won't interpret is as JSON).

The simple regex we [currently have](https://github.com/concrete5/concrete5/blob/230d6f72ec5ea77f8d4385f6b7741b6e59fe2e74/concrete/src/Error/Handler/JsonErrorHandler.php#L67) in the `JsonErrorHandler` class is not enough: we need a more sophisticated way to detect the supported media types (formerly called mime types).

What about using this `RequestMediaTypeParser` class I developed a while ago?