### PR TITLE
Skip display of coverage reports in stdout of TravisCI jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test-coverage": "phpunit --coverage-text --coverage-clover=coverage.clover",
+    "test-coverage": "phpunit --coverage-clover=coverage.clover",
     "phpcs": [
       "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.WhiteSpace.DisallowTabIndent,Generic.PHP.DisallowShortOpenTag concrete/src concrete/controllers",
       "phpcs -p -s --report=full --standard=psr2 --sniffs=Generic.PHP.DisallowShortOpenTag --ignore=\"*.js,*.css,*.less,concrete/vendor/*,concrete/src/*,concrete/controllers/*\" concrete"


### PR DESCRIPTION
We currently have a TravisCI job that collects coverage data.

This job creates an XML file that's sent to Scrutinizer, and display the coverage report on stdout too ([example](https://travis-ci.org/concrete5/concrete5/jobs/456846955#L784-L2131)).

I don't think anyone reads the stdout coverage in TravisCI jobs (Scrutinizer does a much better job in displaying that data). So what about skipping its generation? This may save some time (the travis job is already taking sooooo long...)