### PR TITLE
Use var_dump_safe instead of var_dump in Whoops PlainTextHandler

### DIFF
--- a/concrete/src/Error/Provider/WhoopsServiceProvider.php
+++ b/concrete/src/Error/Provider/WhoopsServiceProvider.php
@@ -26,6 +26,12 @@ class WhoopsServiceProvider extends Provider
 
         if (Misc::isCommandLine()) {
             $cli_handler = new PlainTextHandler();
+            if (method_exists($cli_handler, 'setDumper')) {
+                // Available since Whoops 2.1.10
+                $cli_handler->setDumper(function ($var) {
+                    var_dump_safe($var, true, 2);
+                });
+            }
             $cli_handler->addTraceFunctionArgsToOutput(true);
             $cli_handler->addTraceToOutput(true);
             $run->pushHandler($cli_handler);


### PR DESCRIPTION
The reason why in #7326 we run out of memory is that `var_dump` runs out of memory because of nested loops of self-referencing instances.

What about using `var_dump_safe` instead of `var_dump`?