### PR TITLE
Delete file when processors fail

### DIFF
--- a/concrete/src/File/Image/Svg/Sanitizer.php
+++ b/concrete/src/File/Image/Svg/Sanitizer.php
@@ -83,7 +83,7 @@ class Sanitizer
      */
     protected function getLoadFlags()
     {
-        $flags = LIBXML_NONET | LIBXML_NOWARNING | LIBXML_PARSEHUGE | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD;
+        $flags = LIBXML_NOWARNING | LIBXML_PARSEHUGE | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD;
         if (defined('LIBXML_BIGLINES')) {
             $flags |= LIBXML_BIGLINES;
         }

--- a/concrete/src/File/ImportProcessor/MantatoryProcessorInterface.php
+++ b/concrete/src/File/ImportProcessor/MantatoryProcessorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\File\ImportProcessor;
+
+/**
+ * The interface that file processors should implement when the exceptions thrown by their process() method means that the file shouldn't be imported.
+ */
+interface MantatoryProcessorInterface extends ProcessorInterface
+{
+}

--- a/concrete/src/File/ImportProcessor/SvgSanitizerProcessor.php
+++ b/concrete/src/File/ImportProcessor/SvgSanitizerProcessor.php
@@ -7,7 +7,7 @@ use Concrete\Core\File\Image\Svg\Sanitizer;
 use Concrete\Core\File\Image\Svg\SanitizerOptions;
 use Concrete\Core\File\Type\Type;
 
-class SvgSanitizerProcessor implements ProcessorInterface
+class SvgSanitizerProcessor implements MantatoryProcessorInterface
 {
     /**
      * SVG sanitizer.


### PR DESCRIPTION
In #7291 we added an import processor that sanitizes SVG files.

BTW, if a user tries to import a malformed SVG file (on purpose?), the SVG sanitizer isn't able to parse the file and throws an exception.
In this case, we should remove the imported file from the concrete5 file system.

So, what about adding a `MantatoryProcessorInterface` interface that import processors can implement to say "if the process fails, delete the imported file"?