### PR TITLE
Fix ParentPageField search field when page is no (more) available

### DIFF
--- a/concrete/src/Page/Search/Field/Field/ParentPageField.php
+++ b/concrete/src/Page/Search/Field/Field/ParentPageField.php
@@ -34,16 +34,18 @@ class ParentPageField extends AbstractField
     {
         if ($this->data['cParentIDSearchField'] > 0) {
             $pc = \Page::getByID($this->data['cParentIDSearchField']);
-            if ($pc->isSystemPage()) {
-                $list->includeSystemPages();
-                $list->includeInactivePages();
-            }
-            $list->setSiteTreeObject($pc->getSiteTreeObject());
-            if ($this->data['cParentAll'] == 1) {
-                $cPath = $pc->getCollectionPath();
-                $list->filterByPath($cPath);
-            } else {
-                $list->filterByParentID($this->data['cParentIDSearchField']);
+            if ($pc && !$pc->isError()) {
+                if ($pc->isSystemPage()) {
+                    $list->includeSystemPages();
+                    $list->includeInactivePages();
+                }
+                $list->setSiteTreeObject($pc->getSiteTreeObject());
+                if ($this->data['cParentAll'] == 1) {
+                    $cPath = $pc->getCollectionPath();
+                    $list->filterByPath($cPath);
+                } else {
+                    $list->filterByParentID($this->data['cParentIDSearchField']);
+                }
             }
         }
     }


### PR DESCRIPTION
This should fix the following issue:
```
Argument 1 passed to Concrete\Core\Page\PageList::setSiteTreeObject()
must implement interface Concrete\Core\Site\Tree\TreeInterface, null given,
called in concrete/src/Page/Search/Field/Field/ParentPageField.php on line 41
```