### PR TITLE
Remove 'Version' prefix from migration identifiers

### DIFF
--- a/concrete/src/Updater/Migrations/Configuration.php
+++ b/concrete/src/Updater/Migrations/Configuration.php
@@ -82,6 +82,11 @@ class Configuration extends DoctrineMigrationConfiguration
         if (!in_array($criteria, [static::FORCEDMIGRATION_INCLUSIVE, static::FORCEDMIGRATION_EXCLUSIVE], true)) {
             throw new Exception(t('Invalid initial migration criteria.'));
         }
+
+        // Remove possible 'Version' prefix from the migration identifier.
+        // This allows a user to also use VersionXXXXXXXXXXXX, which corresponds with the class name.
+        $reference = str_replace('Version', '', $reference);
+
         $migration = $this->findInitialMigration($reference, $criteria);
         if ($migration === null) {
             throw new Exception(t('Unable to find a migration with identifier %s', $reference));


### PR DESCRIPTION
This PR makes sure the 'Version' prefix is removed from migration identifiers. Now you can just copy/paste a migration's class name in the CLI.

![afbeelding](https://user-images.githubusercontent.com/1431100/48965816-aecb7d00-efc4-11e8-91e6-1047a59bb319.png)

'Fixes' https://github.com/concrete5/concrete5/issues/7332