### PR TITLE
Fix checking the global single page is already exists

### DIFF
--- a/concrete/src/Page/Single.php
+++ b/concrete/src/Page/Single.php
@@ -135,7 +135,7 @@ class Single
     {
         $pathToFile = static::getPathToNode($cPath, $pkg);
         $txt = Loader::helper('text');
-        $c = CorePage::getByPath("/" . $cPath);
+        $c = CorePage::getByPath($cPath);
         if ($c->isError() && $c->getError() == COLLECTION_NOT_FOUND) {
             // create the page at that point in the tree
 


### PR DESCRIPTION
`Single::addGlobal` can create the same single page repeatedly.