### PR TITLE
Fix user attributes order on Edit Profile and Register pages

### DIFF
--- a/concrete/controllers/single_page/account/edit_profile.php
+++ b/concrete/controllers/single_page/account/edit_profile.php
@@ -1,18 +1,19 @@
 <?php
-
 namespace Concrete\Controller\SinglePage\Account;
 
+use Concrete\Core\Attribute\Category\CategoryService;
+use Concrete\Core\Attribute\Key\UserKey as UserAttributeKey;
 use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Authentication\AuthenticationTypeFailureException;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Controller\AccountPageController;
-use Config;
 use Exception;
-use UserAttributeKey;
 
 class EditProfile extends AccountPageController
 {
+    public $helpers = ['form', 'date'];
+
     public function view()
     {
         $profile = $this->get('profile');
@@ -33,6 +34,27 @@ class EditProfile extends AccountPageController
             $locales = array_merge(['' => tc('Default locale', '** Default')], $locales);
         }
         $this->set('locales', $locales);
+
+        $service = $this->app->make(CategoryService::class);
+        $categoryEntity = $service->getByHandle('user');
+        $category = $categoryEntity->getController();
+        $setManager = $category->getSetManager();
+        $attributeSets = [];
+        foreach ($setManager->getAttributeSets() as $set) {
+            foreach ($set->getAttributeKeys() as $ak) {
+                if ($ak->isAttributeKeyEditableOnProfile()) {
+                    $attributeSets[$set->getAttributeSetDisplayName()][] = $ak;
+                }
+            }
+        }
+        $this->set('attributeSets', $attributeSets);
+        $unassignedAttributes = [];
+        foreach ($setManager->getUnassignedAttributeKeys() as $ak) {
+            if ($ak->isAttributeKeyEditableOnProfile()) {
+                $unassignedAttributes[] = $ak;
+            }
+        }
+        $this->set('unassignedAttributes', $unassignedAttributes);
     }
 
     public function save_complete()
@@ -123,7 +145,8 @@ class EditProfile extends AccountPageController
 
         if (!$this->error->has()) {
             $data['uEmail'] = $email;
-            if (Config::get('concrete.misc.user_timezones')) {
+            $config = $this->app->make('config');
+            if ($config->get('concrete.misc.user_timezones')) {
                 $data['uTimezone'] = $this->post('uTimezone');
             }
 

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -1,16 +1,14 @@
 <?php
-
 namespace Concrete\Controller\SinglePage;
 
+use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Attribute\Context\FrontendFormContext;
 use Concrete\Core\Attribute\Form\Renderer;
+use Concrete\Core\Attribute\Key\UserKey as UserAttributeKey;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Page\Controller\PageController;
-use Config;
-use Loader;
-use User;
-use UserAttributeKey;
-use UserInfo;
+use Concrete\Core\Support\Facade\UserInfo;
+use Concrete\Core\User\User;
 
 class Register extends PageController
 {
@@ -21,6 +19,8 @@ class Register extends PageController
     public function on_start()
     {
         $allowedTypes = ['validate_email', 'enabled'];
+        $token = $this->app->make('token');
+        $this->set('token', $token);
         $config = $this->app->make(Repository::class);
         $currentType = $config->get('concrete.user.registration.type');
 
@@ -40,11 +40,32 @@ class Register extends PageController
         $this->set('displayUserName', $displayUserName);
         $this->requireAsset('css', 'core/frontend/captcha');
         $this->set('renderer', new Renderer(new FrontendFormContext()));
+
+        $service = $this->app->make(CategoryService::class);
+        $categoryEntity = $service->getByHandle('user');
+        $category = $categoryEntity->getController();
+        $setManager = $category->getSetManager();
+        $attributeSets = [];
+        foreach ($setManager->getAttributeSets() as $set) {
+            foreach ($set->getAttributeKeys() as $ak) {
+                if ($ak->isAttributeKeyEditableOnRegister()) {
+                    $attributeSets[$set->getAttributeSetDisplayName()][] = $ak;
+                }
+            }
+        }
+        $this->set('attributeSets', $attributeSets);
+        $unassignedAttributes = [];
+        foreach ($setManager->getUnassignedAttributeKeys() as $ak) {
+            if ($ak->isAttributeKeyEditableOnRegister()) {
+                $unassignedAttributes[] = $ak;
+            }
+        }
+        $this->set('unassignedAttributes', $unassignedAttributes);
     }
 
     public function forward($cID = 0)
     {
-        $this->set('rcID', Loader::helper('security')->sanitizeInt($cID));
+        $this->set('rcID', $this->app->make('helper/security')->sanitizeInt($cID));
     }
 
     public function do_register()
@@ -79,7 +100,7 @@ class Register extends PageController
             if ($this->displayUserName) {
                 $this->app->make('validator/user/name')->isValid($username, $e);
             }
-            
+
             $this->app->make('validator/user/email')->isValid($_POST['uEmail'], $e);
 
             $this->app->make('validator/password')->isValid($password, $e);
@@ -151,7 +172,7 @@ class Register extends PageController
                     $mh->addParameter('siteName', tc('SiteName', \Core::make('site')->getSite()->getSiteName()));
 
                     if ($config->get('concrete.email.register_notification.address')) {
-                        $mh->from(Config::get('concrete.email.register_notification.address'), t('Website Registration Notification'));
+                        $mh->from($config->get('concrete.email.register_notification.address'), t('Website Registration Notification'));
                     } else {
                         $adminUser = UserInfo::getByID(USER_SUPER_ID);
                         if (is_object($adminUser)) {
@@ -173,7 +194,7 @@ class Register extends PageController
                 // if this is successful, uID is loaded into session for this user
 
                 $rcID = $this->post('rcID');
-                $nh = Loader::helper('validation/numbers');
+                $nh = $this->app->make('helper/validation/numbers');
                 if (!$nh->integer($rcID)) {
                     $rcID = 0;
                 }

--- a/concrete/single_pages/account/edit_profile.php
+++ b/concrete/single_pages/account/edit_profile.php
@@ -1,48 +1,53 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
-<h2><?=t($c->getCollectionName())?></h2>
+<h2><?= t($c->getCollectionName()); ?></h2>
 
-<form method="post" action="<?php echo $view->action('save')?>" enctype="multipart/form-data">
-	<?php  $attribs = UserAttributeKey::getEditableInProfileList();
-    $valt->output('profile_edit');
-    ?>
+<form method="post" action="<?= $view->action('save'); ?>" enctype="multipart/form-data">
+	<?php $valt->output('profile_edit'); ?>
 	<fieldset>
-	<legend><?=t('Basic Information')?></legend>
-	<div class="form-group">
-		<?php echo $form->label('uEmail', t('Email'))?>
-		<?php echo $form->text('uEmail', $profile->getUserEmail())?>
-	</div>
-	<?php  if (Config::get('concrete.misc.user_timezones')) {
-     ?>
-		<div class="form-group">
-			<?php echo  $form->label('uTimezone', t('Time Zone'))?>
-			<?php echo  $form->select('uTimezone',
-                Core::make('helper/date')->getTimezones(),
-                ($profile->getUserTimezone() ? $profile->getUserTimezone() : date_default_timezone_get())
-        );
-     ?>
-		</div>
-	<?php
- } ?>
-	<?php  if (is_array($locales) && count($locales)) {
-     ?>
-		<div class="form-group">
-			<?php echo $form->label('uDefaultLanguage', t('Language'))?>
-			<?php echo $form->select('uDefaultLanguage', $locales, Localization::activeLocale())?>
-		</div>
-	<?php
- } ?>
-	<?php
-    if (is_array($attribs) && count($attribs)) {
-        foreach ($attribs as $ak) {
-            echo $profileFormRenderer
-                ->buildView($ak)
-                ->setIsRequired($ak->isAttributeKeyRequiredOnProfile())
-                ->render();
-        }
-    }
-    ?>
+        <legend><?= t('Basic Information'); ?></legend>
+        <div class="form-group">
+            <?= $form->label('uEmail', t('Email')); ?>
+            <?= $form->text('uEmail', $profile->getUserEmail()); ?>
+        </div>
+
+        <?php if (Config::get('concrete.misc.user_timezones')) { ?>
+            <div class="form-group">
+                <?= $form->label('uTimezone', t('Time Zone')); ?>
+                <?= $form->select('uTimezone', $helper_date->getTimezones(), ($profile->getUserTimezone() ? $profile->getUserTimezone() : date_default_timezone_get())); ?>
+            </div>
+        <?php } ?>
+
+        <?php  if (is_array($locales) && count($locales)) { ?>
+            <div class="form-group">
+                <?= $form->label('uDefaultLanguage', t('Language')); ?>
+                <?= $form->select('uDefaultLanguage', $locales, Localization::activeLocale()); ?>
+            </div>
+        <?php } ?>
 	</fieldset>
+
+    <?php foreach ($attributeSets as $setName => $attibutes) { ?>
+        <fieldset>
+            <legend><?= $setName; ?></legend>
+            <?php
+                foreach ($attibutes as $ak) {
+                    $profileFormRenderer->buildView($ak)->setIsRequired($ak->isAttributeKeyRequiredOnProfile())->render();
+                }
+            ?>
+        </fieldset>
+    <?php } ?>
+
+    <?php if (!empty($unassignedAttributes)) { ?>
+        <fieldset>
+            <legend><?= t('Other'); ?></legend>
+            <?php
+                foreach ($unassignedAttributes as $ak) {
+                    $profileFormRenderer->buildView($ak)->setIsRequired($ak->isAttributeKeyRequiredOnProfile())->render();
+                }
+            ?>
+        </fieldset>
+    <?php } ?>
+
 	<?php
     $ats = [];
     foreach (AuthenticationType::getList(true, true) as $at) {
@@ -58,41 +63,36 @@
         }
     }
 
-    if (!empty($ats)) {
-        ?>
+    if (!empty($ats)) { ?>
 		<fieldset>
-			<legend><?=t('Authentication Types')?></legend>
-			<?php
-            foreach ($ats as $at) {
-                call_user_func($at);
-            }
-        ?>
+			<legend><?= t('Authentication Types'); ?></legend>
+            <?php
+                foreach ($ats as $at) {
+                    call_user_func($at);
+                }
+            ?>
 		</fieldset>
-		<?php
-
-    }
-    ?>
-        <br/>
+    <?php } ?>
+    <br/>
 	<fieldset>
-    	<legend><?=t('Change Password')?></legend>
+    	<legend><?= t('Change Password'); ?></legend>
         <div class="form-group">
-            <?php echo $form->label('uPasswordNew', t('New Password'))?>
-            <?php echo $form->password('uPasswordNew', array('autocomplete' => 'off'))?>
-            <a href="javascript:void(0)" title="<?=t("Leave blank to keep current password.")?>"><i class="icon-question-sign"></i></a>
+            <?= $form->label('uPasswordNew', t('New Password')); ?>
+            <?= $form->password('uPasswordNew', ['autocomplete' => 'off']); ?>
+            <a href="javascript:void(0)" title="<?= t('Leave blank to keep current password.'); ?>"><i class="icon-question-sign"></i></a>
 		</div>
 
         <div class="form-group">
-            <?php echo $form->label('uPasswordNewConfirm', t('Confirm New Password'))?>
+            <?= $form->label('uPasswordNewConfirm', t('Confirm New Password')); ?>
             <div class="controls">
-                <?php echo $form->password('uPasswordNewConfirm', array('autocomplete' => 'off'))?>
+                <?= $form->password('uPasswordNewConfirm', ['autocomplete' => 'off']); ?>
             </div>
         </div>
-
 	</fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-    		<input type="submit" name="save" value="<?=t('Save')?>" class="btn btn-primary pull-right" />
+    		<input type="submit" name="save" value="<?= t('Save'); ?>" class="btn btn-primary pull-right" />
         </div>
 	</div>
 

--- a/concrete/single_pages/register.php
+++ b/concrete/single_pages/register.php
@@ -1,139 +1,124 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-
-$token = \Core::make('Concrete\Core\Validation\CSRF\Token');
-?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <div class="row">
     <div class="col-sm-10 col-sm-offset-1">
         <div class="page-header">
-            <h1><?= t('Site Registration') ?></h1>
+            <h1><?= t('Site Registration'); ?></h1>
         </div>
     </div>
 </div>
 
-<?php
-$attribs = UserAttributeKey::getRegistrationList();
-
-if (!empty($registerSuccess)) {
-    ?>
+<?php if (!empty($registerSuccess)) { ?>
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1">
             <?php switch ($registerSuccess) {
-                case "registered":
+                case 'registered':
                     ?>
-                    <p><strong><?= $successMsg ?></strong><br/><br/>
-                        <a href="<?= $view->url('/') ?>"><?= t('Return to Home') ?></a></p>
+                    <p><strong><?= $successMsg; ?></strong><br/><br/>
+                    <a href="<?= $view->url('/'); ?>"><?= t('Return to Home'); ?></a></p>
                     <?php
                     break;
-                case "validate":
+                case 'validate':
                     ?>
-                    <p><?= $successMsg[0] ?></p>
-                    <p><?= $successMsg[1] ?></p>
-                    <p><a href="<?= $view->url('/') ?>"><?= t('Return to Home') ?></a></p>
+                    <p><?= $successMsg[0]; ?></p>
+                    <p><?= $successMsg[1]; ?></p>
+                    <p><a href="<?= $view->url('/'); ?>"><?= t('Return to Home'); ?></a></p>
                     <?php
                     break;
-                case "pending":
+                case 'pending':
                     ?>
-                    <p><?= $successMsg ?></p>
-                    <p><a href="<?= $view->url('/') ?>"><?= t('Return to Home') ?></a></p>
+                    <p><?= $successMsg; ?></p>
+                    <p><a href="<?= $view->url('/'); ?>"><?= t('Return to Home'); ?></a></p>
                     <?php
                     break;
-            }
-            ?>
+            } ?>
         </div>
     </div>
-    <?php
-
-} else {
-    ?>
-    <form method="post" action="<?= $view->url('/register', 'do_register') ?>" class="form-stacked">
-        <?php $token->output('register.do_register') ?>
+<?php } else { ?>
+    <form method="post" action="<?= $view->url('/register', 'do_register'); ?>" class="form-stacked">
+        <?php $token->output('register.do_register'); ?>
         <div class="row">
             <div class="col-sm-10 col-sm-offset-1">
                 <fieldset>
-                    <legend><?= t('Your Details') ?></legend>
-                    <?php
-                    if ($displayUserName) {
-                        ?>
+                    <legend><?= t('Your Details'); ?></legend>
+                    <?php if ($displayUserName) { ?>
                         <div class="form-group">
-                            <?= $form->label('uName', t('Username')) ?>
-                            <?= $form->text('uName') ?>
+                            <?= $form->label('uName', t('Username')); ?>
+                            <?= $form->text('uName'); ?>
                         </div>
-                        <?php
-                    }
-                    ?>
+                    <?php } ?>
                     <div class="form-group">
-                        <?= $form->label('uEmail', t('Email Address')) ?>
-                        <?= $form->text('uEmail') ?>
+                        <?= $form->label('uEmail', t('Email Address')); ?>
+                        <?= $form->text('uEmail'); ?>
                     </div>
                     <div class="form-group">
-                        <?= $form->label('uPassword', t('Password')) ?>
-                        <?= $form->password('uPassword', array('autocomplete' => 'off')) ?>
+                        <?= $form->label('uPassword', t('Password')); ?>
+                        <?= $form->password('uPassword', ['autocomplete' => 'off']); ?>
                     </div>
-                    <?php
-                    if (Config::get('concrete.user.registration.display_confirm_password_field')) {
-                        ?>
+                    <?php if (Config::get('concrete.user.registration.display_confirm_password_field')) { ?>
                         <div class="form-group">
-                            <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
-                            <?= $form->password('uPasswordConfirm', array('autocomplete' => 'off')) ?>
+                            <?= $form->label('uPasswordConfirm', t('Confirm Password')); ?>
+                            <?= $form->password('uPasswordConfirm', ['autocomplete' => 'off']); ?>
                         </div>
-                        <?php
-                    }
-                    ?>
-
+                    <?php } ?>
                 </fieldset>
             </div>
         </div>
-        <?php
-        if (count($attribs) > 0) {
-            ?>
+
+        <?php if (!empty($attributeSets)) { ?>
+            <div class="row">
+                <div class="col-sm-10 col-sm-offset-1">
+                    <?php foreach ($attributeSets as $setName => $attibutes) { ?>
+                        <fieldset>
+                            <legend><?= $setName; ?></legend>
+                            <?php
+                                foreach ($attibutes as $ak) {
+                                    $renderer->buildView($ak)->setIsRequired($ak->isAttributeKeyRequiredOnRegister())->render();
+                                }
+                            ?>
+                        </fieldset>
+                    <?php } ?>
+                </div>
+            </div>
+        <?php } ?>
+
+        <?php if (!empty($unassignedAttributes)) { ?>
             <div class="row">
                 <div class="col-sm-10 col-sm-offset-1">
                     <fieldset>
-                        <legend><?= t('Options') ?></legend>
+                        <legend><?= t('Other'); ?></legend>
                         <?php
-                        foreach ($attribs as $ak) {
-                            $renderer->buildView($ak)->setIsRequired($ak->isAttributeKeyRequiredOnRegister())->render();
-                        }
+                            foreach ($unassignedAttributes as $ak) {
+                                $renderer->buildView($ak)->setIsRequired($ak->isAttributeKeyRequiredOnRegister())->render();
+                            }
                         ?>
                     </fieldset>
                 </div>
             </div>
-            <?php
+        <?php } ?>
 
-        }
-        if (Config::get('concrete.user.registration.captcha')) {
-            ?>
+        <?php if (Config::get('concrete.user.registration.captcha')) { ?>
             <div class="row">
                 <div class="col-sm-10 col-sm-offset-1 ">
 
                     <div class="form-group">
                         <?php
                         $captcha = Loader::helper('validation/captcha');
-                        echo $captcha->label();
-                        ?>
+                        echo $captcha->label(); ?>
                         <?php
                         $captcha->showInput();
-                        $captcha->display();
-                        ?>
+                        $captcha->display(); ?>
                     </div>
                 </div>
             </div>
+        <?php } ?>
 
-            <?php
-        }
-        ?>
         <div class="row">
             <div class="col-sm-10 col-sm-offset-1">
                 <div class="form-actions">
-                    <?= $form->hidden('rcID', isset($rcID) ? $rcID : '');
-                    ?>
-                    <?= $form->submit('register', t('Register') . ' &gt;', array('class' => 'btn-lg btn-primary')) ?>
+                    <?= $form->hidden('rcID', isset($rcID) ? $rcID : ''); ?>
+                    <?= $form->submit('register', t('Register') . ' &gt;', ['class' => 'btn-lg btn-primary']); ?>
                 </div>
             </div>
         </div>
     </form>
-
-    <?php
-
-}
-?>
+<?php } ?>


### PR DESCRIPTION
This PR changes the user attributes display order on the **Edit Profile** and **Register** pages.
Now we use the same order as on the **View/Edit** page of a user and the list of user attributes.

PS : this PR also removes core aliases and facades.

Fixes #7268 and #7269.