### PR TITLE
DatabaseServiceProvider  - Remove incorrect 4th parameter

### DIFF
--- a/concrete/src/Database/DatabaseServiceProvider.php
+++ b/concrete/src/Database/DatabaseServiceProvider.php
@@ -45,8 +45,8 @@ class DatabaseServiceProvider extends ServiceProvider
             function($app) {
             $config = $app->make('Doctrine\ORM\Configuration');
             $configRepository = $app->make('config');
-            $connection = $app->make('Doctrine\DBAL\Connection');
-            return new EntityManagerConfigFactory($app, $config, $configRepository, $connection);
+
+            return new EntityManagerConfigFactory($app, $config, $configRepository);
         });
         $this->app->bind('Concrete\Core\Database\EntityManagerConfigFactoryInterface',
             'Concrete\Core\Database\EntityManagerConfigFactory');


### PR DESCRIPTION
The class doesn't have a `$connection` argument.

https://github.com/concrete5/concrete5/blob/a58b41ded8b74fd81cf371058a4512b565aa4985/concrete/src/Database/EntityManagerConfigFactory.php#L38-L42