### PR TITLE
DatabaseServiceProvider - Fix binding of EntityManagerConfigFactory

### DIFF
--- a/concrete/src/Database/DatabaseServiceProvider.php
+++ b/concrete/src/Database/DatabaseServiceProvider.php
@@ -40,13 +40,14 @@ class DatabaseServiceProvider extends ServiceProvider
             'Concrete\Core\Database\Connection\Connection');
 
 
-        // Bind EntityManager factory
+        // Bind EntityManagerConfigFactory
         $this->app->bind('Concrete\Core\Database\EntityManagerConfigFactory',
             function($app) {
-            $config = $app->make('Doctrine\ORM\Configuration');
-            $configRepository = $app->make('config');
-            return new EntityManagerConfigFactory($app, $config, $configRepository);
-        });
+                $config = $app->make('Doctrine\ORM\Configuration');
+                $configRepository = $app->make('config');
+                return new EntityManagerConfigFactory($app, $config, $configRepository);
+            }
+        );
         $this->app->bind('Concrete\Core\Database\EntityManagerConfigFactoryInterface',
             'Concrete\Core\Database\EntityManagerConfigFactory');
 

--- a/concrete/src/Database/DatabaseServiceProvider.php
+++ b/concrete/src/Database/DatabaseServiceProvider.php
@@ -45,8 +45,7 @@ class DatabaseServiceProvider extends ServiceProvider
             function($app) {
             $config = $app->make('Doctrine\ORM\Configuration');
             $configRepository = $app->make('config');
-            $connection = $app->make('Doctrine\DBAL\Connection');
-            return new EntityManagerConfigFactory($app, $config, $configRepository, $connection);
+            return new EntityManagerConfigFactory($app, $config, $configRepository);
         });
         $this->app->bind('Concrete\Core\Database\EntityManagerConfigFactoryInterface',
             'Concrete\Core\Database\EntityManagerConfigFactory');


### PR DESCRIPTION
There is no 4th argument:
https://github.com/concrete5/concrete5/blob/a58b41ded8b74fd81cf371058a4512b565aa4985/concrete/src/Database/EntityManagerConfigFactory.php#L38-L42