### PR TITLE
Add ability to export a CSV with page versions that changed

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0a3',
     'version_installed' => '8.5.0a3',
-    'version_db' => '20181112211702', // the key of the latest database migration
+    'version_db' => '20181204000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -214,6 +214,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Page Changes" path="/dashboard/reports/page_changes" filename="/dashboard/reports/page_changes.php" pagetype=""
+              description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>changes, csv, report</value>
+                </attributekey>
+            </attributes>
+        </page>
 
         <page name="Pages &amp; Themes" path="/dashboard/pages" filename="/dashboard/pages/view.php" pagetype="" description="Reskin your site." package="" />
         <page name="Themes" path="/dashboard/pages/themes" filename="/dashboard/pages/themes/view.php" pagetype=""

--- a/concrete/controllers/single_page/dashboard/reports/page_changes.php
+++ b/concrete/controllers/single_page/dashboard/reports/page_changes.php
@@ -2,12 +2,82 @@
 
 namespace Concrete\Controller\SinglePage\Dashboard\Reports;
 
+use Concrete\Core\Csv\Export\PageActivityExporter;
+use Concrete\Core\Csv\WriterFactory;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Page\Collection\Version\GlobalVersionList;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PageChanges extends DashboardPageController
 {
     public function view()
     {
+        $this->set('dt', $this->app->make('helper/form/date_time'));
+    }
 
+    public function csv_export()
+    {
+        if (!$this->token->validate('export_page_changes')) {
+            $this->error->add($this->token->getErrorMessage());
+        }
+
+        if ($this->error->has()) {
+            return $this->view();
+        }
+
+        return StreamedResponse::create(function () {
+                $writer = $this->getWriter();
+                $writer->setUnloadDoctrineEveryTick(50);
+                $writer->insertHeaders();
+                $writer->insertList($this->getVersionList());
+            },
+            200,
+            [
+                'Content-Type' => 'text/csv',
+                'Content-Disposition' => 'attachment; filename=page_changes.csv',
+            ]
+        );
+    }
+
+    /**
+     * Get the writer that will create the CSV.
+     *
+     * @return \Concrete\Core\Csv\Export\PageActivityExporter
+     */
+    private function getWriter()
+    {
+        return $this->app->make(
+            PageActivityExporter::class, [
+                'writer' => $this->app->make(WriterFactory::class)
+                    ->createFromPath('php://output', 'w'),
+            ]
+        );
+    }
+
+    /**
+     * Get the item list object.
+     *
+     * @return \Concrete\Core\Page\Collection\Version\GlobalVersionList
+     */
+    private function getVersionList()
+    {
+        /* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
+        $dt = $this->app->make('helper/form/date_time');
+
+        $startDate = $dt->translate('startDate', null, true);
+        $endDate = $dt->translate('endDate', null, true);
+
+        $versionList = new GlobalVersionList();
+        $versionList->sortByDateApprovedDesc();
+
+        if ($startDate !== null) {
+            $versionList->filterByApprovedAfter($startDate);
+        }
+
+        if ($endDate !== null) {
+            $versionList->filterByApprovedBefore($endDate);
+        }
+
+        return $versionList;
     }
 }

--- a/concrete/controllers/single_page/dashboard/reports/page_changes.php
+++ b/concrete/controllers/single_page/dashboard/reports/page_changes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Concrete\Controller\SinglePage\Dashboard\Reports;
+
+use Concrete\Core\Page\Controller\DashboardPageController;
+
+class PageChanges extends DashboardPageController
+{
+    public function view()
+    {
+
+    }
+}

--- a/concrete/controllers/single_page/dashboard/reports/page_changes.php
+++ b/concrete/controllers/single_page/dashboard/reports/page_changes.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Controller\SinglePage\Dashboard\Reports;
 
 use Concrete\Core\Csv\Export\PageActivityExporter;
@@ -25,7 +24,8 @@ class PageChanges extends DashboardPageController
             return $this->view();
         }
 
-        return StreamedResponse::create(function () {
+        return StreamedResponse::create(
+            function () {
                 $writer = $this->getWriter();
                 $writer->setUnloadDoctrineEveryTick(50);
                 $writer->insertHeaders();

--- a/concrete/single_pages/dashboard/reports/page_changes.php
+++ b/concrete/single_pages/dashboard/reports/page_changes.php
@@ -1,0 +1,8 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+
+<form role="form" action="<?=$controller->action('view')?>" class="ccm-search-fields">
+
+    <div class="ccm-search-fields-submit">
+        <button type="submit" class="btn btn-primary pull-right"><?=t('Search')?></button>
+    </div>
+</form>

--- a/concrete/single_pages/dashboard/reports/page_changes.php
+++ b/concrete/single_pages/dashboard/reports/page_changes.php
@@ -1,8 +1,45 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 
-<form role="form" action="<?=$controller->action('view')?>" class="ccm-search-fields">
+/* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
+/* @var \Concrete\Core\Validation\CSRF\Token $token */
+?>
+
+<form role="form" method="post" action="<?php echo $controller->action('csv_export')?>">
+    <?php
+    $token->output('export_page_changes');
+    ?>
+
+    <div class="row">
+        <div class="col-sm-12 col-md-6">
+            <div class="form-group">
+                <label for="startDate" class="control-label">
+                    <?php echo tc('Start date', 'From') ?>
+                </label>
+                <div>
+                    <?php
+                    echo $dt->datetime('startDate', null, true);
+                    ?>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-12 col-md-6">
+            <div class="form-group">
+                <label for="endDate" class="control-label">
+                    <?php echo tc('End date', 'To') ?>
+                </label>
+                <div>
+                    <?php
+                    echo $dt->datetime('endDate', null, true);
+                    ?>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="ccm-search-fields-submit">
-        <button type="submit" class="btn btn-primary pull-right"><?=t('Search')?></button>
+        <button type="submit" class="btn btn-primary pull-right">
+            <?php echo t('Export to CSV')?>
+        </button>
     </div>
 </form>

--- a/concrete/single_pages/dashboard/reports/page_changes.php
+++ b/concrete/single_pages/dashboard/reports/page_changes.php
@@ -5,7 +5,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var \Concrete\Core\Validation\CSRF\Token $token */
 ?>
 
-<form role="form" method="post" action="<?php echo $controller->action('csv_export')?>">
+<form role="form" method="post" action="<?php echo $controller->action('csv_export'); ?>">
     <?php
     $token->output('export_page_changes');
     ?>
@@ -14,7 +14,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="col-sm-12 col-md-6">
             <div class="form-group">
                 <label for="startDate" class="control-label">
-                    <?php echo tc('Start date', 'From') ?>
+                    <?php echo tc('Start date', 'From'); ?>
                 </label>
                 <div>
                     <?php
@@ -26,7 +26,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="col-sm-12 col-md-6">
             <div class="form-group">
                 <label for="endDate" class="control-label">
-                    <?php echo tc('End date', 'To') ?>
+                    <?php echo tc('End date', 'To'); ?>
                 </label>
                 <div>
                     <?php
@@ -39,7 +39,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <div class="ccm-search-fields-submit">
         <button type="submit" class="btn btn-primary pull-right">
-            <?php echo t('Export to CSV')?>
+            <?php echo t('Export to CSV'); ?>
         </button>
     </div>
 </form>

--- a/concrete/src/Csv/Export/AbstractExporter.php
+++ b/concrete/src/Csv/Export/AbstractExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Csv\Export;
 
 use Concrete\Core\Attribute\Category\CategoryInterface;
@@ -18,14 +19,14 @@ abstract class AbstractExporter
     /**
      * The CSV Writer instance.
      *
-     * @var Writer
+     * @var \League\Csv\Writer
      */
     private $writer;
 
     /**
      * The attribute category.
      *
-     * @var CategoryInterface
+     * @var \Concrete\Core\Attribute\Category\CategoryInterface|null
      */
     private $category;
 
@@ -53,13 +54,15 @@ abstract class AbstractExporter
     /**
      * Initialize the instance.
      *
-     * @param CategoryInterface $category the attribute category
-     * @param Writer $writer the CSV Writer instance
+     * @param \League\Csv\Writer $writer the CSV Writer instance
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface|null $category the attribute category
      */
-    protected function __construct(Writer $writer, CategoryInterface $category)
+    protected function __construct(Writer $writer, CategoryInterface $category = null)
     {
         $this->setWriter($writer);
-        $this->setCategory($category);
+        if ($category !== null) {
+            $this->setCategory($category);
+        }
     }
 
     /**
@@ -177,7 +180,7 @@ abstract class AbstractExporter
     /**
      * Set the CSV Writer instance.
      *
-     * @param Writer $writer
+     * @param \League\Csv\Writer $writer
      *
      * @return $this
      */
@@ -191,7 +194,7 @@ abstract class AbstractExporter
     /**
      * Get the CSV Writer instance.
      *
-     * @return Writer
+     * @return \League\Csv\Writer
      */
     protected function getWriter()
     {
@@ -201,7 +204,7 @@ abstract class AbstractExporter
     /**
      * Set the attribute category to be used to export the data.
      *
-     * @param CategoryInterface $category
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
      *
      * @return $this
      */
@@ -216,7 +219,7 @@ abstract class AbstractExporter
     /**
      * Get the attribute category to be used to export the data.
      *
-     * @return CategoryInterface
+     * @return \Concrete\Core\Attribute\Category\CategoryInterface|null
      */
     protected function getCategory()
     {
@@ -304,8 +307,11 @@ abstract class AbstractExporter
     {
         if ($this->attributeKeysAndControllers === null) {
             $list = [];
-            foreach ($this->category->getList() as $attributeKey) {
-                $list[] = [$attributeKey, $attributeKey->getController()];
+            $category = $this->getCategory();
+            if ($category !== null) {
+                foreach ($category->getList() as $attributeKey) {
+                    $list[] = [$attributeKey, $attributeKey->getController()];
+                }
             }
             $this->attributeKeysAndControllers = $list;
         }
@@ -322,9 +328,12 @@ abstract class AbstractExporter
         $app = Application::getFacadeApplication();
         $entityManager = $app->make(EntityManagerInterface::class);
         $entityManager->clear();
-        $categoryClass = ClassUtils::getClass($this->category);
-        if (!$entityManager->getMetadataFactory()->isTransient($categoryClass)) {
-            $entityManager->merge($this->category);
+        $category = $this->getCategory();
+        if ($category !== null) {
+            $categoryClass = ClassUtils::getClass($category);
+            if (!$entityManager->getMetadataFactory()->isTransient($categoryClass)) {
+                $entityManager->merge($category);
+            }
         }
     }
 }

--- a/concrete/src/Csv/Export/PageActivityExporter.php
+++ b/concrete/src/Csv/Export/PageActivityExporter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Csv\Export;
 
 use Concrete\Core\Page\Page;

--- a/concrete/src/Csv/Export/PageActivityExporter.php
+++ b/concrete/src/Csv/Export/PageActivityExporter.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Concrete\Core\Csv\Export;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Attribute\ObjectInterface;
+use Concrete\Core\Localization\Service\Date;
+use League\Csv\Writer;
+
+class PageActivityExporter extends AbstractExporter
+{
+    /**
+     * @var \Concrete\Core\Localization\Service\Date
+     */
+    protected $dateService;
+
+    /**
+     * Initialize the instance.
+     *
+     * A dummy category is used to prevent that all kind of page
+     * attributes values are added to the CSV as well.
+     *
+     * @param \League\Csv\Writer $writer
+     * @param \Concrete\Core\Localization\Service\Date $dateService
+     */
+    public function __construct(Writer $writer, Date $dateService)
+    {
+        parent::__construct($writer);
+
+        $this->dateService = $dateService;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Csv\Export\AbstractExporter::getStaticHeaders()
+     */
+    protected function getStaticHeaders()
+    {
+        yield 'pageId';
+        yield 'pagePath';
+        yield 'pageName';
+        yield 'versionId';
+        yield 'versionDate';
+        yield 'versionComments';
+        yield 'versionAuthorUsername';
+        yield 'versionApproverUsername';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Csv\Export\AbstractExporter::getStaticFieldValues()
+     */
+    protected function getStaticFieldValues(ObjectInterface $version)
+    {
+        /** @var \Concrete\Core\Page\Collection\Version\Version $version */
+
+        /** @var \Concrete\Core\Page\Page $page */
+        $page = Page::getByID($version->getCollectionID());
+
+        yield (int) $page->getCollectionID();
+        yield (string) $page->getCollectionPath();
+        yield (string) $page->getCollectionName();
+        yield (int) $version->getVersionID();
+        yield (string) $this->getLocalizedDate($version->getVersionDateApproved());
+        yield (string) $version->getVersionComments();
+        yield (string) $version->getVersionAuthorUserName();
+        yield (string) $version->getVersionApproverUserName();
+    }
+
+    /**
+     * Converts a system string date to a (localized) app string date.
+     *
+     * @param string|null $value E.g. '2018-21-31 23:59:59'
+     *
+     * @return string|null
+     */
+    private function getLocalizedDate($value = null)
+    {
+        if ($value) {
+            $value = $this->dateService
+                ->toDateTime($value, 'app')
+                ->format(Date::DB_FORMAT);
+        }
+
+        return $value;
+    }
+}

--- a/concrete/src/Page/Collection/Version/GlobalVersionList.php
+++ b/concrete/src/Page/Collection/Version/GlobalVersionList.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Concrete\Core\Page\Collection\Version;
+
+use Concrete\Core\Search\ItemList\Database\ItemList as DatabaseItemList;
+use Concrete\Core\Search\StickyRequest;
+
+/**
+ * An object that holds a list of collection versions.
+ *
+ * If you need a list of versions of multiple collections / pages,
+ * use this class. Otherwise use the VersionList class.
+ */
+class GlobalVersionList extends DatabaseItemList
+{
+    /**
+     * @param \Concrete\Core\Search\StickyRequest|null $req
+     */
+    public function __construct(StickyRequest $req = null)
+    {
+        parent::__construct($req);
+    }
+
+    /**
+     * @param array $queryRow
+     *
+     * @return \Concrete\Core\Page\Collection\Version\Version
+     */
+    public function getResult($queryRow)
+    {
+        $version = new Version();
+        $version->setPropertiesFromArray($queryRow);
+
+        return $version;
+    }
+
+    public function createQuery()
+    {
+        $this->query->select('cv.*')
+            ->from('CollectionVersions', 'cv');
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalResults()
+    {
+        return (int) $this->query
+            ->resetQueryParts(['groupBy', 'orderBy'])
+            ->select('count(1)')
+            ->setMaxResults(1)
+            ->execute()
+            ->fetchColumn();
+    }
+
+    /**
+     * Filter versions that are approved after a certain date.
+     *
+     * @param \DateTime $date
+     */
+    public function filterByApprovedAfter(\DateTime $date)
+    {
+        $this->query->andWhere('cv.cvDateApproved >= :cvDateApprovedAfter');
+        $this->query->setParameter('cvDateApprovedAfter', $date->format('Y-m-d H:i-s'));
+    }
+
+    /**
+     * Filter versions that are approved before a certain date.
+     *
+     * @param \DateTime $date
+     */
+    public function filterByApprovedBefore(\DateTime $date)
+    {
+        $this->query->andWhere('cv.cvDateApproved <= :cvDateApprovedBefore');
+        $this->query->setParameter('cvDateApprovedBefore', $date->format('Y-m-d H:i-s'));
+    }
+
+    /**
+     * Sort by approval date in descending order.
+     */
+    public function sortByDateApprovedDesc()
+    {
+        $this->sortBy('cv.cvDateApproved', 'desc');
+    }
+}

--- a/concrete/src/Page/Collection/Version/GlobalVersionList.php
+++ b/concrete/src/Page/Collection/Version/GlobalVersionList.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Page\Collection\Version;
 
 use Concrete\Core\Search\ItemList\Database\ItemList as DatabaseItemList;

--- a/concrete/src/Page/Collection/Version/GlobalVersionList.php
+++ b/concrete/src/Page/Collection/Version/GlobalVersionList.php
@@ -45,7 +45,9 @@ class GlobalVersionList extends DatabaseItemList
      */
     public function getTotalResults()
     {
-        return (int) $this->query
+        $query = $this->deliverQueryObject();
+
+        return (int) $query
             ->resetQueryParts(['groupBy', 'orderBy'])
             ->select('count(1)')
             ->setMaxResults(1)

--- a/concrete/src/Page/Collection/Version/GlobalVersionList.php
+++ b/concrete/src/Page/Collection/Version/GlobalVersionList.php
@@ -62,8 +62,9 @@ class GlobalVersionList extends DatabaseItemList
      */
     public function filterByApprovedAfter(\DateTime $date)
     {
-        $this->query->andWhere('cv.cvDateApproved >= :cvDateApprovedAfter');
-        $this->query->setParameter('cvDateApprovedAfter', $date->format('Y-m-d H:i-s'));
+        $this->query->andWhere(
+             'cv.cvDateApproved >= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
+        );
     }
 
     /**
@@ -73,8 +74,9 @@ class GlobalVersionList extends DatabaseItemList
      */
     public function filterByApprovedBefore(\DateTime $date)
     {
-        $this->query->andWhere('cv.cvDateApproved <= :cvDateApprovedBefore');
-        $this->query->setParameter('cvDateApprovedBefore', $date->format('Y-m-d H:i-s'));
+        $this->query->andWhere(
+             'cv.cvDateApproved <= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
+        );
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20181204000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20181204000000.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20181204000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        // Create the 'Page Changes' single page
+        $this->createSinglePage('/dashboard/reports/page_changes', 'Page Changes', [
+            'meta_keywords' => 'changes, csv, report'
+        ]);
+    }
+}


### PR DESCRIPTION
This PR:

- Adds a dashboard page under Dashboard > Reports > Page Changes.
- Allows a user to export a list of collection versions that changed with a certain date range to a .csv file.

## Notes
- I couldn't use the VersionList class, because it's bound to a 1 page, whereas we want versions across pages. (therefore ec536fd273841acf63e2d3dac16d33b87c099379)
- A migration for existing installations is added in 727c394d7ce311f7a24d1c9cf4d9914209ed9f64.

## Screenshots
![page-changes-overview](https://user-images.githubusercontent.com/1431100/49453630-cfc17880-f7e3-11e8-9d2a-f13f1f5a2b1c.png)

![page-changes-csv](https://user-images.githubusercontent.com/1431100/49453639-d5b75980-f7e3-11e8-9bf4-746d8b0b29e0.png)

