### PR TITLE
HTML-escape error messages

### DIFF
--- a/concrete/src/Error/ErrorList/Error/AbstractError.php
+++ b/concrete/src/Error/ErrorList/Error/AbstractError.php
@@ -9,7 +9,7 @@ abstract class AbstractError implements HtmlAwareErrorInterface
     /**
      * The field associated to the error.
      *
-     * @var \Concrete\Core\Error\ErrorList\Field\FieldInterface
+     * @var \Concrete\Core\Error\ErrorList\Field\FieldInterface|null
      */
     protected $field;
 
@@ -20,7 +20,7 @@ abstract class AbstractError implements HtmlAwareErrorInterface
      *
      * @var bool
      */
-    private $messageContainsHTML = false;
+    private $messageContainsHtml = false;
 
     /**
      * Get the error message.
@@ -57,11 +57,11 @@ abstract class AbstractError implements HtmlAwareErrorInterface
      *
      * @since concrete5 8.5.0a3
      *
-     * @see \Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface::messageContainsHTML()
+     * @see \Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface::messageContainsHtml()
      */
-    public function messageContainsHTML()
+    public function messageContainsHtml()
     {
-        return $this->messageContainsHTML;
+        return $this->messageContainsHtml;
     }
 
     /**
@@ -73,9 +73,9 @@ abstract class AbstractError implements HtmlAwareErrorInterface
      *
      * @return $this
      */
-    public function setMessageContainsHTML($value)
+    public function setMessageContainsHtml($value)
     {
-        $this->messageContainsHTML = (bool) $value;
+        $this->messageContainsHtml = (bool) $value;
 
         return $this;
     }
@@ -89,7 +89,7 @@ abstract class AbstractError implements HtmlAwareErrorInterface
     {
         $r = [
             'message' => $this->getMessage(),
-            'messageContainsHTML' => $this->messageContainsHTML(),
+            'messageContainsHtml' => $this->messageContainsHtml(),
         ];
         if ($this->field) {
             $r['field'] = $this->field;

--- a/concrete/src/Error/ErrorList/Error/AbstractError.php
+++ b/concrete/src/Error/ErrorList/Error/AbstractError.php
@@ -1,18 +1,32 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Error;
 
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
 
 abstract class AbstractError implements ErrorInterface
 {
-
     /**
-     * @var FieldInterface
+     * The field associated to the error.
+     *
+     * @var \Concrete\Core\Error\ErrorList\Field\FieldInterface
      */
     protected $field;
 
     /**
-     * @return mixed
+     * Get the error message.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getMessage();
+    }
+
+    /**
+     * Get the field associated to the error.
+     *
+     * @return \Concrete\Core\Error\ErrorList\Field\FieldInterface|null
      */
     public function getField()
     {
@@ -20,26 +34,29 @@ abstract class AbstractError implements ErrorInterface
     }
 
     /**
-     * @param mixed $field
+     * Set the field associated to the error.
+     *
+     * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface $field
      */
     public function setField(FieldInterface $field)
     {
         $this->field = $field;
     }
 
-    public function __toString()
-    {
-        return $this->getMessage();
-    }
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
     public function jsonSerialize()
     {
-        $r = ['message' => $this->getMessage()];
+        $r = [
+            'message' => $this->getMessage(),
+        ];
         if ($this->field) {
             $r['field'] = $this->field;
         }
+
         return $r;
     }
-
-
 }

--- a/concrete/src/Error/ErrorList/Error/AbstractError.php
+++ b/concrete/src/Error/ErrorList/Error/AbstractError.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Error\ErrorList\Error;
 
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
 
-abstract class AbstractError implements ErrorInterface
+abstract class AbstractError implements HtmlAwareErrorInterface
 {
     /**
      * The field associated to the error.
@@ -12,6 +12,15 @@ abstract class AbstractError implements ErrorInterface
      * @var \Concrete\Core\Error\ErrorList\Field\FieldInterface
      */
     protected $field;
+
+    /**
+     * Does the message contain an HTML-formatted string?
+     *
+     * @since concrete5 8.5.0a3
+     *
+     * @var bool
+     */
+    private $messageContainsHTML = false;
 
     /**
      * Get the error message.
@@ -46,12 +55,41 @@ abstract class AbstractError implements ErrorInterface
     /**
      * {@inheritdoc}
      *
+     * @since concrete5 8.5.0a3
+     *
+     * @see \Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface::messageContainsHTML()
+     */
+    public function messageContainsHTML()
+    {
+        return $this->messageContainsHTML;
+    }
+
+    /**
+     * Does the message contain an HTML-formatted string?
+     *
+     * @param bool $value
+     *
+     * @since concrete5 8.5.0a3
+     *
+     * @return $this
+     */
+    public function setMessageContainsHTML($value)
+    {
+        $this->messageContainsHTML = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see \JsonSerializable::jsonSerialize()
      */
     public function jsonSerialize()
     {
         $r = [
             'message' => $this->getMessage(),
+            'messageContainsHTML' => $this->messageContainsHTML(),
         ];
         if ($this->field) {
             $r['field'] = $this->field;

--- a/concrete/src/Error/ErrorList/Error/Error.php
+++ b/concrete/src/Error/ErrorList/Error/Error.php
@@ -1,16 +1,23 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Error;
 
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
 
 class Error extends AbstractError
 {
-
+    /**
+     * The error message.
+     *
+     * @var string
+     */
     protected $message;
 
     /**
-     * Error constructor.
-     * @param $message
+     * Class constructor.
+     *
+     * @param string $message
+     * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface|null $field
      */
     public function __construct($message, FieldInterface $field = null)
     {
@@ -21,7 +28,9 @@ class Error extends AbstractError
     }
 
     /**
-     * @return mixed
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Error\ErrorInterface::getMessage()
      */
     public function getMessage()
     {
@@ -29,12 +38,12 @@ class Error extends AbstractError
     }
 
     /**
-     * @param mixed $message
+     * Set the error message.
+     *
+     * @param string $message
      */
     public function setMessage($message)
     {
         $this->message = $message;
     }
-
-
 }

--- a/concrete/src/Error/ErrorList/Error/Error.php
+++ b/concrete/src/Error/ErrorList/Error/Error.php
@@ -16,12 +16,12 @@ class Error extends AbstractError
     /**
      * Class constructor.
      *
-     * @param string $message
+     * @param string|mixed $message a string, a scalar, or an object that implements the __toString() method
      * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface|null $field
      */
     public function __construct($message, FieldInterface $field = null)
     {
-        $this->message = $message;
+        $this->setMessage($message);
         if ($field) {
             $this->setField($field);
         }
@@ -40,10 +40,10 @@ class Error extends AbstractError
     /**
      * Set the error message.
      *
-     * @param string $message
+     * @param string|mixed $message a string, a scalar, or an object that implements the __toString() method
      */
     public function setMessage($message)
     {
-        $this->message = $message;
+        $this->message = (string) $message;
     }
 }

--- a/concrete/src/Error/ErrorList/Error/ErrorInterface.php
+++ b/concrete/src/Error/ErrorList/Error/ErrorInterface.php
@@ -1,9 +1,15 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Error;
 
-interface ErrorInterface extends \JsonSerializable
+use JsonSerializable;
+
+interface ErrorInterface extends JsonSerializable
 {
-
-    function getMessage();
-
+    /**
+     * Get the error message.
+     *
+     * @return string
+     */
+    public function getMessage();
 }

--- a/concrete/src/Error/ErrorList/Error/ExceptionError.php
+++ b/concrete/src/Error/ErrorList/Error/ExceptionError.php
@@ -1,21 +1,26 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Error;
 
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
+use Exception;
 
 class ExceptionError extends AbstractError
 {
-
     /**
+     * The associated Exception.
+     *
      * @var \Exception
      */
     protected $exception;
 
     /**
-     * ExceptionError constructor.
-     * @param $exception
+     * Class constructor.
+     *
+     * @param \Exception $exception
+     * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface|null $field
      */
-    public function __construct(\Exception $exception, FieldInterface $field = null)
+    public function __construct(Exception $exception, FieldInterface $field = null)
     {
         $this->exception = $exception;
         if ($field) {
@@ -24,16 +29,22 @@ class ExceptionError extends AbstractError
     }
 
     /**
-     * @return mixed
+     * Get the associated Exception.
+     *
+     * @return \Exception
      */
     public function getException()
     {
         return $this->exception;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Error\ErrorInterface::getMessage()
+     */
     public function getMessage()
     {
         return $this->exception->getMessage();
     }
-
 }

--- a/concrete/src/Error/ErrorList/Error/FieldNotPresentError.php
+++ b/concrete/src/Error/ErrorList/Error/FieldNotPresentError.php
@@ -1,24 +1,28 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Error;
 
 use Concrete\Core\Error\ErrorList\Field\FieldInterface;
 
 class FieldNotPresentError extends AbstractError
 {
-
     /**
-     * Error constructor.
-     * @param $message
+     * Class constructor.
+     *
+     * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface $field
      */
     public function __construct(FieldInterface $field)
     {
         $this->setField($field);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Error\ErrorInterface::getMessage()
+     */
     public function getMessage()
     {
-        return t('The field %s is required.', $this->field->getDisplayName());
+        return t('The field %s is required.', $this->getField()->getDisplayName());
     }
-
-
 }

--- a/concrete/src/Error/ErrorList/Error/HtmlAwareErrorInterface.php
+++ b/concrete/src/Error/ErrorList/Error/HtmlAwareErrorInterface.php
@@ -12,5 +12,5 @@ interface HtmlAwareErrorInterface extends ErrorInterface
      *
      * @return bool
      */
-    public function messageContainsHTML();
+    public function messageContainsHtml();
 }

--- a/concrete/src/Error/ErrorList/Error/HtmlAwareErrorInterface.php
+++ b/concrete/src/Error/ErrorList/Error/HtmlAwareErrorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Concrete\Core\Error\ErrorList\Error;
+
+/**
+ * @since concrete5 8.5.0a3
+ */
+interface HtmlAwareErrorInterface extends ErrorInterface
+{
+    /**
+     * Does the message contain an HTML-formatted string?
+     *
+     * @return bool
+     */
+    public function messageContainsHTML();
+}

--- a/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
@@ -1,29 +1,41 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Formatter;
 
-use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 
 class StandardFormatter extends AbstractFormatter
 {
-
+    /**
+     * @return string
+     */
     public function getString()
     {
         $html = '';
         if ($this->error->has()) {
             $html .= '<ul class="ccm-error">';
             foreach ($this->error->getList() as $error) {
-                $html .= '<li>' . $error . '</li>';
+                $html .= '<li>';
+                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHTML()) {
+                    $html .= (string) $error;
+                } else {
+                    $html .= h((string) $error);
+                }
+                $html .= '</li>';
             }
             $html .= '</ul>';
         }
+
         return $html;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Formatter\FormatterInterface::render()
+     */
     public function render()
     {
         return $this->getString();
     }
-
-
-
 }

--- a/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
@@ -16,7 +16,7 @@ class StandardFormatter extends AbstractFormatter
             $html .= '<ul class="ccm-error">';
             foreach ($this->error->getList() as $error) {
                 $html .= '<li>';
-                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHTML()) {
+                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
                     $html .= (string) $error;
                 } else {
                     $html .= h((string) $error);

--- a/concrete/src/Package/Dependency/DependencyException.php
+++ b/concrete/src/Package/Dependency/DependencyException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Package\Dependency;
 
 use Concrete\Core\Error\ErrorList\Error\ErrorInterface;
@@ -11,6 +12,8 @@ abstract class DependencyException extends LogicException implements ErrorInterf
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \LogicException::__toString()
      */
     public function __toString()
     {
@@ -19,6 +22,8 @@ abstract class DependencyException extends LogicException implements ErrorInterf
 
     /**
      * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
      */
     public function jsonSerialize()
     {

--- a/concrete/src/Package/Dependency/DependencyException.php
+++ b/concrete/src/Package/Dependency/DependencyException.php
@@ -27,6 +27,8 @@ abstract class DependencyException extends LogicException implements ErrorInterf
      */
     public function jsonSerialize()
     {
-        return ['message' => $this->getMessage()];
+        return [
+            'message' => $this->getMessage(),
+        ];
     }
 }

--- a/concrete/src/Package/Dependency/IncompatiblePackagesException.php
+++ b/concrete/src/Package/Dependency/IncompatiblePackagesException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Package\Dependency;
 
 use Concrete\Core\Package\Package;
@@ -11,22 +12,22 @@ class IncompatiblePackagesException extends DependencyException
     /**
      * The package that doesn't want the other package.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $blockingPackage;
 
     /**
      * The incompatible package.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $incompatiblePackage;
 
     /**
      * Initialize the instance.
      *
-     * @param Package $blockingPackage the package that doesn't want the other package
-     * @param Package $incompatiblePackage the incompatible package
+     * @param \Concrete\Core\Package\Package $blockingPackage the package that doesn't want the other package
+     * @param \Concrete\Core\Package\Package $incompatiblePackage the incompatible package
      */
     public function __construct(Package $blockingPackage, Package $incompatiblePackage)
     {
@@ -42,7 +43,7 @@ class IncompatiblePackagesException extends DependencyException
     /**
      * Get the package that can't be uninstalled.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getBlockingPackage()
     {
@@ -52,7 +53,7 @@ class IncompatiblePackagesException extends DependencyException
     /**
      * Get the incompatible package.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getIncompatiblePackage()
     {

--- a/concrete/src/Package/Dependency/MissingRequiredPackageException.php
+++ b/concrete/src/Package/Dependency/MissingRequiredPackageException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Package\Dependency;
 
 use Concrete\Core\Package\Package;
@@ -11,14 +12,14 @@ class MissingRequiredPackageException extends DependencyException
     /**
      * The package that can't be installed.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $notInstallablePackage;
 
     /**
      * The handle of the package that's not installed.
      *
-     * @var Package
+     * @var string
      */
     protected $missingPackageHandle;
 
@@ -32,7 +33,7 @@ class MissingRequiredPackageException extends DependencyException
     /**
      * Initialize the instance.
      *
-     * @param Package $notInstallablePackage the package that can't be installed
+     * @param \Concrete\Core\Package\Package $notInstallablePackage the package that can't be installed
      * @param string $missingPackageHandle the handle of the package that's not installed
      * @param string|string[]|bool $requirements the version requirements of the package
      */
@@ -69,7 +70,7 @@ class MissingRequiredPackageException extends DependencyException
     /**
      * Get the package that can't be installed.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getNotInstallablePackage()
     {
@@ -79,7 +80,7 @@ class MissingRequiredPackageException extends DependencyException
     /**
      * Get the handle of the package that's not installed.
      *
-     * @return Package
+     * @return string
      */
     public function getMissingPackageHandle()
     {

--- a/concrete/src/Package/Dependency/RequiredPackageException.php
+++ b/concrete/src/Package/Dependency/RequiredPackageException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Package\Dependency;
 
 use Concrete\Core\Package\Package;
@@ -11,22 +12,22 @@ class RequiredPackageException extends DependencyException
     /**
      * The package that can't be uninstalled.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $uninstallablePackage;
 
     /**
      * The package that requires the package that can't be uninstalled.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $blockingPackage;
 
     /**
      * Initialize the instance.
      *
-     * @param Package $uninstallablePackage the package that can't be uninstalled
-     * @param Package $blockingPackage the package that requires the package that can't be uninstalled
+     * @param \Concrete\Core\Package\Package $uninstallablePackage the package that can't be uninstalled
+     * @param \Concrete\Core\Package\Package $blockingPackage the package that requires the package that can't be uninstalled
      */
     public function __construct(Package $uninstallablePackage, Package $blockingPackage)
     {
@@ -42,7 +43,7 @@ class RequiredPackageException extends DependencyException
     /**
      * Get the package that can't be uninstalled.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getUninstallablePackage()
     {
@@ -52,7 +53,7 @@ class RequiredPackageException extends DependencyException
     /**
      * Get the package that requires the package that can't be uninstalled.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getBlockingPackage()
     {

--- a/concrete/src/Package/Dependency/VersionMismatchException.php
+++ b/concrete/src/Package/Dependency/VersionMismatchException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Package\Dependency;
 
 use Concrete\Core\Package\Package;
@@ -11,14 +12,14 @@ class VersionMismatchException extends DependencyException
     /**
      * The package that causes the dependency problem.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $blockingPackage;
 
     /**
      * The package that fails the requirement.
      *
-     * @var Package
+     * @var \Concrete\Core\Package\Package
      */
     protected $package;
 
@@ -32,8 +33,8 @@ class VersionMismatchException extends DependencyException
     /**
      * Initialize the instance.
      *
-     * @param Package $blockingPackage the package that causes the dependency problem
-     * @param Package $package the package that fails the requirement
+     * @param \Concrete\Core\Package\Package $blockingPackage the package that causes the dependency problem
+     * @param \Concrete\Core\Package\Package $package the package that fails the requirement
      * @param string|string[] $requiredVersion the required package version
      */
     public function __construct(Package $blockingPackage, Package $package, $requiredVersion)
@@ -63,7 +64,7 @@ class VersionMismatchException extends DependencyException
     /**
      * Get the package that causes the dependency problem.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getBlockingPackage()
     {
@@ -73,7 +74,7 @@ class VersionMismatchException extends DependencyException
     /**
      * Get the package that fails the requirement.
      *
-     * @return Package
+     * @return \Concrete\Core\Package\Package
      */
     public function getPackage()
     {


### PR DESCRIPTION
When we render an error list as HTML, we may need to escape it (that is, 99% of times).

Fix H1 455699.