### PR TITLE
AppVeyor: Use local machine trusted CA certs instead of using the cURL ones

### DIFF
--- a/.appveyor/configure.ps1
+++ b/.appveyor/configure.ps1
@@ -64,7 +64,7 @@ if (Test-Path -PathType Leaf -Path "$phpInstallPath\php-installed.txt") {
     New-Item -ItemType File -Path "$phpInstallPath\php-installed.txt" | Out-Null
 }
 Write-Host 'Refreshing CA Certificates for PHP'
-Update-PhpCAInfo -Path $phpInstallPath -Verbose
+Update-PhpCAInfo -Path $phpInstallPath -Source LocalMachine -Verbose
 
 # Setup composer
 $Env:Path = 'C:\tools\bin;' + $Env:Path


### PR DESCRIPTION
When running PHP on Windows, we need to manually configure the list of trusted Certification Authorities (CA) for HTTPS/SSL/TLS communications (php isn't able to retrieve them from the system on Windows).

Our AppVeyor job uses [PhpManager](https://github.com/mlocati/powershell-phpmanager) to do it.
At the moment, PhpManager is configured to use the CA certificates provided by https://curl.haxx.se/docs/caextract.html, but it's not the first time that they are misconfigured (when they update the CA certs, the certificates and their hash are not synchronized for some time because of the caching infrastructure they are using).
This leads to errors like this: https://ci.appveyor.com/project/concrete5/concrete5/builds/20781564/job/ojgppvtxrnjjpq9l

So, what about using the CA certificates provided by the system?