### PR TITLE
Make sure View::getInstance always returns a View

### DIFF
--- a/concrete/src/View/AbstractView.php
+++ b/concrete/src/View/AbstractView.php
@@ -58,6 +58,12 @@ abstract class AbstractView
     {
         array_pop(View::$requestInstances);
         self::$requestInstance = last(View::$requestInstances);
+
+        if (self::$requestInstance === false) {
+            // 'last' can return false if there are no request instances.
+            // In that case a fresh instance should be retrieved.
+            self::$requestInstance = View::getInstance();
+        }
     }
 
     abstract public function start($state);

--- a/concrete/src/View/AbstractView.php
+++ b/concrete/src/View/AbstractView.php
@@ -231,6 +231,12 @@ abstract class AbstractView
     }
 
     /**
+     * Get an instance of the View.
+     *
+     * Note: In versions before 8.5.0a3, this method may
+     * return 'false' if it's called after the page
+     * is rendered (for example in middleware).
+     *
      * @return View
      */
     public static function getInstance()

--- a/concrete/src/View/AbstractView.php
+++ b/concrete/src/View/AbstractView.php
@@ -32,7 +32,7 @@ abstract class AbstractView
 
     public static function getRequestInstance()
     {
-        if (null === self::$requestInstance) {
+        if (!self::$requestInstance instanceof View) {
             View::setRequestInstance(new View());
         }
 


### PR DESCRIPTION
If `View::getInstance()` is called in Middleware, it currently returns `false`. This is a bug, and the why is explained in issue #7377. 

Three changes in this PR:
1. Instantiate a new instance in case the property is not a View instance. E.g. if it's `null` (initial value) or `false` (see issue #7377), see 815555c
2. Say the user already has a View instance and the property is set to `false` via `revertRequestInstance`, this might give problems. Therefore a fresh instance is retrieved in that method as well. See ebb8b98.
3. Add comments for (pkg) developers that may rely on this method and support older versions, see 63dcb49

## Screenshot before PR:
![before](https://user-images.githubusercontent.com/1431100/49535317-2b633300-f8c4-11e8-8ced-2ec7f778fbfd.png)

## Screenshot after PR:
![after](https://user-images.githubusercontent.com/1431100/49535318-2dc58d00-f8c4-11e8-8a95-63b5378c81a9.png)