### PR TITLE
 Always use an ErrorList instance when validating a block on edit

### DIFF
--- a/concrete/controllers/backend/user_interface/block.php
+++ b/concrete/controllers/backend/user_interface/block.php
@@ -18,7 +18,7 @@ abstract class Block extends Page
         $pr->setAdditionalDataAttribute('aID', intval($this->area->getAreaID()));
         $pr->setAdditionalDataAttribute('arHandle', $this->area->getAreaHandle());
         $pr->setAdditionalDataAttribute('bID', intval($b->getBlockID()));
-        if ($e) {
+        if (is_object($e)) {
             $pr->setError($e);
         }
         return $pr;

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -6,7 +6,6 @@ use Concrete\Core\Block\Block;
 use Concrete\Core\Block\Events\BlockEdit;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Support\Facade\Events;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Error\ErrorList\Formatter\JsonFormatter;
 use Concrete\Core\Http\ResponseFactoryInterface;
@@ -24,7 +23,7 @@ class Edit extends BackendInterfaceBlockController
         if (isset($_REQUEST['arEnableGridContainer']) && $_REQUEST['arEnableGridContainer'] == 1) {
             $this->area->enableGridContainer();
         }
-        $bv->addScopeItems(array('c' => $this->page, 'a' => $this->area, 'dialogController' => $this));
+        $bv->addScopeItems(['c' => $this->page, 'a' => $this->area, 'dialogController' => $this]);
         $this->set('bv', $bv);
     }
 
@@ -46,7 +45,6 @@ class Edit extends BackendInterfaceBlockController
         return $e;
     }
 
-
     public function submit()
     {
         if ($this->validateAction() && $this->canAccess()) {
@@ -66,8 +64,8 @@ class Edit extends BackendInterfaceBlockController
                 $formatter = new JsonFormatter($e);
                 $response = $formatter->asArray();
                 $response['newbID'] = intval($b->getBlockID());
-                $app = Application::getFacadeApplication();
-                return $app->make(ResponseFactoryInterface::class)->create(json_encode($response));
+
+                return $this->app->make(ResponseFactoryInterface::class)->create(json_encode($response));
             }
 
             $pr->outputJSON();

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -63,7 +63,7 @@ class Edit extends BackendInterfaceBlockController
                 return $this->app->make(ResponseFactoryInterface::class)->create(json_encode($response));
             }
 
-            $pr->outputJSON();
+            return $this->app->make(ResponseFactoryInterface::class)->create($pr->getJSON());
         }
     }
 

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -38,7 +38,7 @@ class Edit extends BackendInterfaceBlockController
         $e = $bi->validate($_POST);
 
         // We need an ErrorList instance even if the block validation returns true
-        if (!$e instanceof ErrorList) {
+        if (!$e instanceof \Concrete\Core\Error\ErrorList\ErrorList) {
             $e = $this->app->make(ErrorList::class);
         }
 
@@ -52,7 +52,7 @@ class Edit extends BackendInterfaceBlockController
             $e = $this->validateBlock($b);
             $pr = $this->getEditResponse($b, $e);
 
-            if (!is_object($e) || ($e instanceof ErrorList && !$e->has())) {
+            if (!is_object($e) || ($e instanceof \Concrete\Core\Error\ErrorList\ErrorList && !$e->has())) {
                 // we can update the block that we're submitting
                 $b->update($_POST);
                 $event = new BlockEdit($b, $this->page);
@@ -60,7 +60,7 @@ class Edit extends BackendInterfaceBlockController
             }
 
             // the block has a new id at this point, we have to pass it to the view
-            if ($e instanceof ErrorList && $e->has()) {
+            if ($e instanceof \Concrete\Core\Error\ErrorList\ErrorList && $e->has()) {
                 $formatter = new JsonFormatter($e);
                 $response = $formatter->asArray();
                 $response['newbID'] = intval($b->getBlockID());

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -37,6 +37,12 @@ class Edit extends BackendInterfaceBlockController
         }
 
         $e = $bi->validate($_POST);
+
+        // We need an ErrorList instance even if the block validation returns true
+        if (!$e instanceof ErrorList) {
+            $e = $this->app->make(ErrorList::class);
+        }
+
         return $e;
     }
 

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -37,11 +37,6 @@ class Edit extends BackendInterfaceBlockController
 
         $e = $bi->validate($_POST);
 
-        // We need an ErrorList instance even if the block validation returns true
-        if (!$e instanceof \Concrete\Core\Error\ErrorList\ErrorList) {
-            $e = $this->app->make(ErrorList::class);
-        }
-
         return $e;
     }
 


### PR DESCRIPTION
Fixes #7379 

An other fix for this issue would have been to return an ErrorList instance in the `validate()` method in concrete/src/Block/BlockController.php but if other functions use it and expect true they might break too.

@aembler What do you think ?