### PR TITLE
Delete thumbnails only for images

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -19,6 +19,7 @@ use Concrete\Core\File\Image\Thumbnail\Type\Type;
 use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailTypeVersion;
 use Concrete\Core\File\Importer;
 use Concrete\Core\File\Menu;
+use Concrete\Core\File\Type\Type as FileType;
 use Concrete\Core\File\Type\TypeList as FileTypeList;
 use Concrete\Core\Http\FlysystemFileResponse;
 use Concrete\Core\Http\Request;
@@ -1107,9 +1108,11 @@ class Version implements ObjectInterface
         $db->executeQuery('DELETE FROM FileVersionLog WHERE fID = ? AND fvID = ?', [$this->getFileID(), $this->fvID]);
 
         if ($deleteFilesAndThumbnails) {
-            $types = Type::getVersionList();
-            foreach ($types as $type) {
-                $this->deleteThumbnail($type);
+            if ($this->getTypeObject()->getGenericType() === FileType::T_IMAGE) {
+                $types = Type::getVersionList();
+                foreach ($types as $type) {
+                    $this->deleteThumbnail($type);
+                }
             }
             try {
                 $fsl = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
@@ -1389,7 +1392,7 @@ class Version implements ObjectInterface
     public function refreshThumbnails($deleteExistingThumbnails)
     {
         $result = false;
-        if ($this->fvType == \Concrete\Core\File\Type\Type::T_IMAGE) {
+        if ($this->fvType == FileType::T_IMAGE) {
             try {
                 $image = $this->getImagineImage();
                 if ($image) {

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -15,7 +15,7 @@ use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\File\Image\Thumbnail\Path\Resolver;
 use Concrete\Core\File\Image\Thumbnail\Thumbnail;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
-use Concrete\Core\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
 use Concrete\Core\File\Image\Thumbnail\Type\Version as ThumbnailTypeVersion;
 use Concrete\Core\File\Importer;
 use Concrete\Core\File\Menu;
@@ -1109,7 +1109,7 @@ class Version implements ObjectInterface
 
         if ($deleteFilesAndThumbnails) {
             if ($this->getTypeObject()->getGenericType() === FileType::T_IMAGE) {
-                $types = Type::getVersionList();
+                $types = ThumbnailType::getVersionList();
                 foreach ($types as $type) {
                     $this->deleteThumbnail($type);
                 }
@@ -1398,7 +1398,7 @@ class Version implements ObjectInterface
                 if ($image) {
                     $imageSize = $image->getSize();
                     unset($image);
-                    $types = Type::getVersionList();
+                    $types = ThumbnailType::getVersionList();
                     $file = $this->getFile();
                     $fsl = null;
                     foreach ($types as $type) {
@@ -1476,10 +1476,10 @@ class Version implements ObjectInterface
             $thumbnailMode = ImageInterface::THUMBNAIL_OUTBOUND;
         } else {
             switch ($type->getSizingMode()) {
-                case Type::RESIZE_EXACT:
+                case ThumbnailType::RESIZE_EXACT:
                     $thumbnailMode = ImageInterface::THUMBNAIL_OUTBOUND;
                     break;
-                case Type::RESIZE_PROPORTIONAL:
+                case ThumbnailType::RESIZE_PROPORTIONAL:
                 default:
                     $thumbnailMode = ImageInterface::THUMBNAIL_INSET;
                     break;
@@ -1628,7 +1628,7 @@ class Version implements ObjectInterface
         if ($imageWidth < 1 || $imageHeight < 1) {
             throw new InvalidDimensionException($this->getFile(), $this, t('Invalid dimensions.'));
         }
-        $types = Type::getVersionList();
+        $types = ThumbnailType::getVersionList();
         $file = $this->getFile();
         foreach ($types as $type) {
             if ($type->shouldExistFor($imageWidth, $imageHeight, $file)) {
@@ -1656,7 +1656,7 @@ class Version implements ObjectInterface
         if ($this->fvHasDetailThumbnail) {
             $app = Application::getFacadeApplication();
             $config = $app->make('config');
-            $type = Type::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
+            $type = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
             $result = '<img src="' . $this->getThumbnailURL($type->getBaseVersion()) . '"';
             if ($config->get('concrete.file_manager.images.create_high_dpi_thumbnails')) {
                 $result .= ' data-at2x="' . $this->getThumbnailURL($type->getDoubledVersion()) . '"';
@@ -1679,8 +1679,8 @@ class Version implements ObjectInterface
         if ($this->fvHasListingThumbnail) {
             $app = Application::getFacadeApplication();
             $config = $app->make('config');
-            $listingType = Type::getByHandle($config->get('concrete.icons.file_manager_listing.handle'));
-            $detailType = Type::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
+            $listingType = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_listing.handle'));
+            $detailType = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
             $result = '<img class="ccm-file-manager-list-thumbnail ccm-thumbnail-'.$config->get('concrete.file_manager.images.preview_image_size').'" src="' . $this->getThumbnailURL($listingType->getBaseVersion()) . '"';
             if ($config->get('concrete.file_manager.images.create_high_dpi_thumbnails')) {
                 $result .= ' data-at2x="' . $this->getThumbnailURL($listingType->getDoubledVersion()) . '"';

--- a/concrete/src/File/Image/Thumbnail/Type/Version.php
+++ b/concrete/src/File/Image/Thumbnail/Type/Version.php
@@ -8,6 +8,7 @@ use Concrete\Core\File\Image\BitmapFormat;
 use Concrete\Core\File\Image\Thumbnail\ThumbnailFormatService;
 use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
 use Concrete\Core\Support\Facade\Application;
+use Exception;
 
 /**
  * Handles regular and retina thumbnails. e.g. Each thumbnail type has two versions of itself
@@ -415,9 +416,16 @@ class Version
         $prefix = $fv->getPrefix();
         $filename = $fv->getFileName();
         $hadImagineImage = $fv->hasImagineImage();
-        if ($this->isKeepAnimations() && $fv->getImagineImage()->layers()->count() > 1) {
-            $thumbnailFormat = BitmapFormat::FORMAT_GIF;
-        } else {
+        $thumbnailFormat = null;
+        if ($this->isKeepAnimations()) {
+            try {
+                if ($fv->getImagineImage()->layers()->count() > 1) {
+                    $thumbnailFormat = BitmapFormat::FORMAT_GIF;
+                }
+            } catch (Exception $x) {
+            }
+        }
+        if ($thumbnailFormat === null) {
             $thumbnailFormat = $app->make(ThumbnailFormatService::class)->getFormatForFile($filename);
         }
         if (!$hadImagineImage) {


### PR DESCRIPTION
When deleting a file version, we currently (try to) delete its associated thumbnails, even if the file is not an image.
This may lead to an uncaught exception if a thumnbail type is set to generate animated gifs.

Let's fix this by:
1. deleting thumbnails only for image files
2. don't break the execution when determining the thumabail extension accordingly to its content.