### PR TITLE
API Integrations: make redirect field an URL input, mark name and redirect as required

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/api/integrations.php
+++ b/concrete/controllers/single_page/dashboard/system/api/integrations.php
@@ -35,19 +35,17 @@ class Integrations extends DashboardPageController
         }
 
         $redirect = $this->request->request->get('redirect');
-        if (!$validator->notempty($redirect)) {
-            $this->error->add(t('You must specify a redirect url for this integration'));
-        }
-
-        try {
-            $uri = Url::createFromUrl($redirect);
-
-            // Do some simple validation
-            if (!$uri->getHost() || !$uri->getScheme()) {
-                throw new \RuntimeException('Invalid URI');
+        if ($validator->notempty($redirect)) {
+            try {
+                $uri = Url::createFromUrl($redirect);
+    
+                // Do some simple validation
+                if (!$uri->getHost() || !$uri->getScheme()) {
+                    throw new \RuntimeException('Invalid URI');
+                }
+            } catch (\Exception $e) {
+                $this->error->add(t('That doesn\'t look like a valid URL.'));
             }
-        } catch (\Exception $e) {
-            $this->error->add(t('That doesn\'t look like a valid URL.'));
         }
     }
 
@@ -82,7 +80,7 @@ class Integrations extends DashboardPageController
             /** @var Client $client */
             $client = $this->get('client');
             $client->setName($this->request->request->get('name'));
-            $client->setRedirectUri($this->request->request->get('redirect'));
+            $client->setRedirectUri((string) $this->request->request->get('redirect'));
 
             $this->entityManager->persist($client);
             $this->entityManager->flush();

--- a/concrete/single_pages/dashboard/system/api/integrations/add.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/add.php
@@ -20,7 +20,7 @@
         <div class="form-group">
             <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
             <div class="input-group">
-                <?php echo $form->url('redirect', array('autocomplete' => 'off', 'required' => 'required')); ?>
+                <?php echo $form->url('redirect', array('autocomplete' => 'off')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/api/integrations/add.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/add.php
@@ -12,7 +12,7 @@
         <div class="form-group">
             <label for="name" class="control-label"><?php echo t('Name'); ?></label>
             <div class="input-group">
-                <?php echo $form->text('name', array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <?php echo $form->text('name', array('autofocus' => 'autofocus', 'autocomplete' => 'off', 'required' => 'required')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>
@@ -20,7 +20,7 @@
         <div class="form-group">
             <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
             <div class="input-group">
-                <?php echo $form->text('redirect', array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <?php echo $form->url('redirect', array('autocomplete' => 'off', 'required' => 'required')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/api/integrations/edit.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/edit.php
@@ -12,7 +12,7 @@
         <div class="form-group">
             <label for="name" class="control-label"><?php echo t('Name'); ?></label>
             <div class="input-group">
-                <?php echo $form->text('name', $client->getName(), array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <?php echo $form->text('name', $client->getName(), array('autofocus' => 'autofocus', 'autocomplete' => 'off', 'required' => 'required')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>
@@ -20,7 +20,7 @@
         <div class="form-group">
             <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
             <div class="input-group">
-                <?php echo $form->text('redirect', $client->getRedirectUri(), array('autofocus' => 'autofocus', 'autocomplete' => 'off')); ?>
+                <?php echo $form->url('redirect', $client->getRedirectUri(), array('autocomplete' => 'off', 'required' => 'required')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>

--- a/concrete/single_pages/dashboard/system/api/integrations/edit.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/edit.php
@@ -20,7 +20,7 @@
         <div class="form-group">
             <label for="redirect" class="control-label"><?php echo t('Redirect'); ?></label>
             <div class="input-group">
-                <?php echo $form->url('redirect', $client->getRedirectUri(), array('autocomplete' => 'off', 'required' => 'required')); ?>
+                <?php echo $form->url('redirect', $client->getRedirectUri(), array('autocomplete' => 'off')); ?>
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>


### PR DESCRIPTION
When creating/editing an API integration, let's add client-side validation of the integration name (it's required), and the integration redirect (it's a required URL).