### PR TITLE
Swap calls to initializeServiceProviders() and initializeLegacyDefinitions()

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -91,17 +91,17 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
 
         /*
          * ----------------------------------------------------------------------------
-         * Setup the core service groups.
-         * ----------------------------------------------------------------------------
-         */
-        $this->initializeServiceProviders($app, $config);
-
-        /*
-         * ----------------------------------------------------------------------------
          * Simple legacy constants like APP_CHARSET
          * ----------------------------------------------------------------------------
          */
         $this->initializeLegacyDefinitions($config, $app);
+
+        /*
+         * ----------------------------------------------------------------------------
+         * Setup the core service groups.
+         * ----------------------------------------------------------------------------
+         */
+        $this->initializeServiceProviders($app, $config);
 
         /*
          * ----------------------------------------------------------------------------


### PR DESCRIPTION
Since `APP_CHARSET` is defined later than the registration of error handlers (see [here](https://github.com/concrete5/concrete5/blob/24c24624f05d04865b1f7e5b75373cd1df620b59/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php#L97-L104) the calls to `initializeServiceProviders()` and `initializeLegacyDefinitions()`), if something wrong happens in `initializeServiceProviders()` we may be referencing an undefined `APP_CHARSET` constant in error handlers.

So, what about swapping the two calls?