### PR TITLE
Fix the check token logic in add_block controller

### DIFF
--- a/concrete/controllers/dialog/page/add_block.php
+++ b/concrete/controllers/dialog/page/add_block.php
@@ -79,10 +79,15 @@ class AddBlock extends BackendInterfacePageController
     {
         $pc = new PageEditResponse($this->error);
         $pc->setPage($this->page);
-        if ($this->validateAction() || is_object($this->blockType)
-            && !$this->blockType->hasAddTemplate()
-            && Loader::helper('validation/token')->validate()
-        ) {
+        if (is_object($this->blockType) && !$this->blockType->hasAddTemplate()) {
+            $token = $this->app->make('token');
+            if (!$token->validate()) {
+                $this->error->add($token->getErrorMessage());
+            }
+        } else {
+            $this->validateAction();
+        }
+        if (!$this->error->has()) {
             $data = $_POST;
             $bt = $this->blockType;
             $u = new User();


### PR DESCRIPTION
The cause of #7384 is #7308 and the way `EditResponse` is initialized when its constructor receives an `ErrorList` instance.

Indeed:
1. before #7308, the error object of `EditResponse` was set to the received instance if it's not empty
  (see [here](https://github.com/concrete5/concrete5/blob/8.4.3/concrete/src/Application/EditResponse.php#L28))
1. after #7308, the error object of `EditResponse` is always set to that instance
  (see [here](https://github.com/concrete5/concrete5/blob/24c24624f05d04865b1f7e5b75373cd1df620b59/concrete/src/Application/EditResponse.php#L75))

(And I do think it's a better approach since it's more predictable and consistent).

When adding a new block type, we [have this code](https://github.com/concrete5/concrete5/blob/24c24624f05d04865b1f7e5b75373cd1df620b59/concrete/controllers/dialog/page/add_block.php#L80-L85) (I rewrite the indentation to better understand it):
```php
$pc = new PageEditResponse($this->error);
if (
    $this->validateAction()
    ||
    is_object($this->blockType) && !$this->blockType->hasAddTemplate() && Loader::helper('validation/token')->validate()
) {
```

`$this->validateAction()` fails because it's checking with a different token (the received one has been generated with `$token->generate('')`, but `validateAction()` assumes that it was generated with `$token->generate('Concrete\Controller\Dialog\Page\AddBlock')`.

This is expected, indeed we have the `|| s_object($this->blockType) etc.` part, so the whole `if` condition passes.

Nevertheless, the `validateAction()` adds the error to the error object of the controller. And, after #7308, it's also added to the error object of the EditResponse.

I'd fix this issue by simply swapping the two conditions of the above `if` (well, actually rewriting it a bit so that it's more clear).

[EDIT]
- fix #7384
- supersedes #7385