### PR TITLE
Bug fixes for external concrete5 authentication

### DIFF
--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -130,7 +130,7 @@ class Controller extends GenericOauth2TypeController
     {
         $config = $this->app->make(Repository::class);
         $this->set('form', $this->app->make('helper/form'));
-        $this->set('data', $config->get('auth.external_concrete5', ''));
+        $this->set('data', $config->get('auth.external_concrete5', []));
         $this->set('redirectUri', $this->urlResolver->resolve(['/ccm/system/authentication/oauth2/external_concrete5/callback']));
 
         $list = $this->app->make(GroupList::class);

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0a3',
     'version_installed' => '8.5.0a3',
-    'version_db' => '20181212000000', // the key of the latest database migration
+    'version_db' => '20181212221911', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -483,11 +483,13 @@ class StartingPointPackage extends BasePackage
         $fba = AuthenticationType::add('facebook', 'Facebook');
         $twa = AuthenticationType::add('twitter', 'Twitter');
         $gat = AuthenticationType::add('google', 'Google');
+        $ext = AuthenticationType::add('external_concrete5', 'External concrete5');
 
         $fba->disable();
         $twa->disable();
         $coa->disable();
         $gat->disable();
+        $ext->disable();
 
         \Concrete\Core\Tree\TreeType::add('group');
         \Concrete\Core\Tree\Node\NodeType::add('group');

--- a/concrete/src/Updater/Migrations/Migrations/Version20181212221911.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20181212221911.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\DBAL\Schema\Schema;
+use Concrete\Core\Authentication\AuthenticationType;
+use Exception;
+
+class Version20181212221911 extends AbstractMigration implements RepeatableMigrationInterface
+{
+
+    public function upgradeDatabase()
+    {
+        /* Add auth types ("handle|name") "twitter|Twitter" and "community|concrete5.org" */
+        try {
+            $external = AuthenticationType::getByHandle('external_concrete5');
+        } catch (Exception $e) {
+            // AuthenticationType::getByHandle throws an exception if the call fails, which is stupid, but here
+            // we are.
+            $external = AuthenticationType::add('external_concrete5', 'External concrete5');
+            if (is_object($external)) {
+                $external->disable();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Install the authentication type properly.

Install it in a migration.

Fix bug when editing it for the first time. 