### PR TITLE
Fix an error when selecting trash or system pages as the parent page on page search

### DIFF
--- a/concrete/src/Page/Search/Field/Field/ParentPageField.php
+++ b/concrete/src/Page/Search/Field/Field/ParentPageField.php
@@ -39,7 +39,10 @@ class ParentPageField extends AbstractField
                     $list->includeSystemPages();
                     $list->includeInactivePages();
                 }
-                $list->setSiteTreeObject($pc->getSiteTreeObject());
+                $siteObject = $pc->getSiteTreeObject();
+                if (is_object($siteObject)) {
+                    $list->setSiteTreeObject($siteObject);
+                }
                 if ($this->data['cParentAll'] == 1) {
                     $cPath = $pc->getCollectionPath();
                     $list->filterByPath($cPath);


### PR DESCRIPTION
This fixes the following error when you do an advanced page search and select the trash page or a system page as a parent page.
```
Argument 1 passed to Concrete\Core\Page\PageList::setSiteTreeObject() must implement interface Concrete\Core\Site\Tree\TreeInterface, null given,
```