### PR TITLE
Make it enable to adding page type composer control block

### DIFF
--- a/concrete/src/Permission/Response/AreaResponse.php
+++ b/concrete/src/Permission/Response/AreaResponse.php
@@ -39,6 +39,9 @@ class AreaResponse extends Response
         if ($bt->getBlockTypeHandle() == BLOCK_HANDLE_LAYOUT_PROXY) {
             return $this->canAddLayout();
         }
+        if ($bt->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
+            return $this->canAddBlocks();
+        }
         $pk = $this->category->getPermissionKeyByHandle('add_block_to_area');
         $pk->setPermissionObject($this->object);
 


### PR DESCRIPTION
Issue: can't add page type composer control output block on page type default, if you're signed in as a non-admin user, even if you have a right permission to edit page type defaults.

My fix works and fixes the issue, but I'm worrying this is the right way to fix this issue.