### PR TITLE
Fix too many results in PagerAdapter::getSlice()

### DIFF
--- a/concrete/src/Search/Pagination/Adapter/PagerAdapter.php
+++ b/concrete/src/Search/Pagination/Adapter/PagerAdapter.php
@@ -46,12 +46,12 @@ class PagerAdapter implements AdapterInterface
             ->setMaxResults($length);
 
         $currentResults = array();
-        $results = $this->itemList->getResults();
-
-        while (count($results) != 0 && count($currentResults) < $length) {
-
+        while (count($currentResults) < $length) {
+            $results = $this->itemList->getResults();
+            if (count($results) === 0) {
+                break;
+            }
             foreach($results as $result) {
-
                 if ($this->checkPermissions($checker, $result)) {
 
                     if (!isset($this->firstResult)) {
@@ -59,13 +59,13 @@ class PagerAdapter implements AdapterInterface
                     }
 
                     $currentResults[] = $result;
+                    if (count($currentResults) >= $length) {
+                        break;
+                    }
                 }
-
             }
-
             $manager->displaySegmentAtCursor($result, $this->itemList);
             $this->itemList->ignorePermissions();
-            $results = $this->itemList->getResults();
         }
 
         $this->itemList->setPermissionsChecker($checker);

--- a/tests/tests/File/FileListTest.php
+++ b/tests/tests/File/FileListTest.php
@@ -238,7 +238,7 @@ class FileListTest extends FileStorageTestCase
             'another.txt' => $sample,
             'funtime.txt' => $sample,
             'funtime2.txt' => $sample,
-            'awesome-o' => $sample,
+            'awesome-o.txt' => $sample,
             'image.png' => $image,
         ];
 
@@ -313,7 +313,7 @@ class FileListTest extends FileStorageTestCase
             'another.txt' => $sample,
             'funtime.txt' => $sample,
             'funtime2.txt' => $sample,
-            'awesome-o' => $sample,
+            'awesome-o.txt' => $sample,
             'image.png' => $image,
         ];
 


### PR DESCRIPTION
PagerAdapter::getSlice() may return more results than expected.

Tests should have revealed this issue, but because a test file is not imported (it doesn't have an allowed file extension), the tests state is not the expected one.

First, let's fix the file import: I'll add the fix when TravisCI tests finish (they should fail).