### PR TITLE
Fixing SQL errors with next_previous block and getFirstChild

### DIFF
--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -224,7 +224,7 @@ from
     inner join CollectionVersions cv
         on Pages.cID = cv.cID
 where
-    and Pages.cID <> ?
+    Pages.cID <> ?
     and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?)
     and cDisplayOrder < ?
     and cParentID = ?
@@ -245,7 +245,7 @@ from
     inner join CollectionVersions cv
         on Pages.cID = cv.cID
 where
-    and Pages.cID <> ?
+    Pages.cID <> ?
     and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?)
     and cDisplayOrder > ?
     and cParentID = ?

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2072,7 +2072,6 @@ from
 where
     cParentID = ?
     and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?)
-    and 
 order by
     {$sortColumn}
 EOT


### PR DESCRIPTION
Fixes some errors with MySQL queries being incorrect (extra and statements) on Page and prev_next block.

@mlocati 