### PR TITLE
Fix editing blocks that refer to deleted pages for non-admins

### DIFF
--- a/concrete/src/Form/Service/Widget/PageSelector.php
+++ b/concrete/src/Form/Service/Widget/PageSelector.php
@@ -34,7 +34,7 @@ class PageSelector
             }
         }
 
-        if ($selectedCID) {
+        if ($selectedCID && \Concrete\Core\Page\Page::getByID($selectedCID)->getError() !== COLLECTION_NOT_FOUND) {
             $args = "{'inputName': '{$fieldName}', 'cID': {$selectedCID}}";
         } else {
             $args = "{'inputName': '{$fieldName}'}";


### PR DESCRIPTION
When a page is permanently deleted there may be (custom) blocks that still refer to the page. The page selector widget, in edit mode, blocks editing of that field for anyone without superadmin priviledges. By checking if the page actually exists permissions are not checked and the widget becomes editable.