### PR TITLE
Set the image format so that it's not inferred from the file extension when saving

### DIFF
--- a/concrete/src/File/Image/BitmapFormat.php
+++ b/concrete/src/File/Image/BitmapFormat.php
@@ -192,8 +192,10 @@ class BitmapFormat
      */
     public function getFormatImagineSaveOptions($format)
     {
-        $result = [];
         $format = $this->normalizeFormat($format);
+        $result = [
+            'format' => $format,
+        ];
         switch ($format) {
             case static::FORMAT_PNG:
                 $result['png_compression_level'] = $this->getDefaultPngCompressionLevel();


### PR DESCRIPTION
When we save an Imagine image, we call `getFormatImagineSaveOptions` to get the save options for a specific format.
BTW, we don't store in the built options the format of the image. In this case Imagine infers it from the file extension, but we may be working without files (for instance sending the image directly to the client) or with files with weird file extensions.

So, what about explicitly set the wanted image format?