### PR TITLE
Always use forward slashes for paths in log stuff

### DIFF
--- a/concrete/src/Logging/Configuration/SimpleFileConfiguration.php
+++ b/concrete/src/Logging/Configuration/SimpleFileConfiguration.php
@@ -21,7 +21,7 @@ class SimpleFileConfiguration extends SimpleConfiguration
     public function __construct(Site $site, $directory, $coreLevel = Logger::DEBUG)
     {
         $this->site = $site;
-        $this->directory = rtrim($directory, DIRECTORY_SEPARATOR);
+        $this->directory = rtrim($directory, '/' . DIRECTORY_SEPARATOR);
         parent::__construct($coreLevel);
     }
 
@@ -41,7 +41,7 @@ class SimpleFileConfiguration extends SimpleConfiguration
 
     public function createHandler($level)
     {
-        $path = $this->getDirectory() . DIRECTORY_SEPARATOR . $this->getFileName();
+        $path = $this->getDirectory() . '/' . $this->getFileName();
         $handler = new StreamHandler($path, $this->coreLevel);
         return $handler;
     }

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -138,7 +138,7 @@ class LogTest extends ConcreteDatabaseTestCase
     public function testFileLogging()
     {
 
-        $directory = __DIR__ . DIRECTORY_SEPARATOR; // let's test with a trailing slash just to be a pain.
+        $directory = str_replace(DIRECTORY_SEPARATOR, '/', __DIR__) . '/'; // let's test with a trailing slash just to be a pain.
 
         $site = $this->getMockBuilder(Site::class)
             ->disableOriginalConstructor()
@@ -149,7 +149,7 @@ class LogTest extends ConcreteDatabaseTestCase
 
         $configuration = new SimpleFileConfiguration($site, $directory, Logger::INFO);
 
-        $this->assertEquals($directory, $configuration->getDirectory() . DIRECTORY_SEPARATOR);
+        $this->assertEquals($directory, $configuration->getDirectory() . '/');
         $this->assertEquals('my-default-site.log', $configuration->getFileName());
 
 


### PR DESCRIPTION
As we already did in #5769, it's much easier to have only the forward slash (`/`) as a directory separator (PHP will handle it transparently).

The only thing we have to take care of is to replace `DIRECTORY_SEPARATOR` with `/` in the results of `__FILE__` / `__DIR__` / `realpath()` (eg `str_replace(DIRECTORY_SEPARATOR, '/', __DIR__)`).

Stop.