### PR TITLE
Fix installation with new log stuff

### DIFF
--- a/concrete/src/Logging/LoggerFactory.php
+++ b/concrete/src/Logging/LoggerFactory.php
@@ -1,8 +1,10 @@
 <?php
 namespace Concrete\Core\Logging;
 
+use Concrete\Core\Application\Application;
 use Concrete\Core\Logging\Configuration\ConfigurationFactory;
 use Concrete\Core\Logging\Configuration\ConfigurationInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class LoggerFactory
@@ -23,15 +25,24 @@ class LoggerFactory
      */
     protected $config;
 
-    public function __construct(ConfigurationFactory $configurationFactory, EventDispatcher $dispatcher)
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    protected $app;
+
+    public function __construct(ConfigurationFactory $configurationFactory, EventDispatcher $dispatcher, Application $app)
     {
         $this->configurationFactory = $configurationFactory;
         $this->dispatcher = $dispatcher;
         $this->config = $this->configurationFactory->createConfiguration();
+        $this->app = $app;
     }
 
     public function createLogger($channel)
     {
+        if (!$this->app->isInstalled()) {
+            return new NullLogger();
+        }
         $logger = $this->config->createLogger($channel);
         $event = new Event($logger);
         $this->dispatcher->dispatch('on_logger_create', $event);

--- a/concrete/src/Logging/LoggingServiceProvider.php
+++ b/concrete/src/Logging/LoggingServiceProvider.php
@@ -2,26 +2,15 @@
 namespace Concrete\Core\Logging;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
-use Concrete\Core\Logging\Configuration\ConfigurationFactory;
 use Psr\Log\NullLogger;
 
 class LoggingServiceProvider extends ServiceProvider
 {
     public function register()
     {
+        $this->app->singleton(LoggerFactory::class);
 
-        $this->app->singleton(LoggerFactory::class, function ($app) {
-            if ($app->isInstalled()) {
-                $logger = new LoggerFactory($app->make(ConfigurationFactory::class), $app->make('director'));
-            } else {
-                $logger = new NullLogger();
-            }
-            return $logger;
-        });
-
-        $this->app->singleton('log/factory', function($app) {
-            return $app->make(LoggerFactory::class);
-        });
+        $this->app->alias(LoggerFactory::class, 'log/factory');
 
         $this->app->singleton('log/application', function($app) {
             if ($app->isInstalled()) {
@@ -38,7 +27,6 @@ class LoggingServiceProvider extends ServiceProvider
         $this->app->singleton('log/exceptions', function($app) {
             $factory = $app->make(LoggerFactory::class);
             return $factory->createLogger(Channels::CHANNEL_EXCEPTIONS);
-            return $logger;
         });
 
     }

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -122,7 +122,7 @@ class LogTest extends ConcreteDatabaseTestCase
             ->method('createConfiguration')
             ->willReturn($configuration);
 
-        $factory = new LoggerFactory($factory, $this->app->make('director'));
+        $factory = $this->app->build(LoggerFactory::class, ['configurationFactory' => $factory]);
         $logger = $factory->createLogger(Channels::CHANNEL_SECURITY);
 
         $logger->debug('This is a debug line.');
@@ -160,7 +160,7 @@ class LogTest extends ConcreteDatabaseTestCase
             ->method('createConfiguration')
             ->willReturn($configuration);
 
-        $factory = new LoggerFactory($factory, $this->app->make('director'));
+        $factory = $this->app->build(LoggerFactory::class, ['configurationFactory' => $factory]);
         $logger = $factory->createLogger(Channels::CHANNEL_SECURITY);
 
         $logger->debug('This is a debug line.');
@@ -294,7 +294,7 @@ class LogTest extends ConcreteDatabaseTestCase
             ->method('createConfiguration')
             ->willReturn($configuration);
 
-        $factory = new LoggerFactory($factory, $this->app->make('director'));
+        $factory = $this->app->build(LoggerFactory::class, ['configurationFactory' => $factory]);
         $logger = $factory->createLogger(Channels::CHANNEL_SECURITY);
         $this->assertInstanceOf(Logger::class, $logger);
         $this->assertCount(0, $logger->getHandlers());


### PR DESCRIPTION
When installing concrete5, we have this error:
```
Call to undefined method
Psr\Log\NullLogger::createLogger()
in file
concrete/src/Application/Application.php on line 414
```

That's because `$app->make('log/factory')` should return a logger factory, not a logger.

