### PR TITLE
Trusted Proxies - Fix saving the list of ip addresses/ranges

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -29,7 +29,7 @@ class TrustedProxies extends DashboardPageController
             }
             if (!$this->error->has()) {
                 $config = $this->app->make('config');
-                $config->save('concrete.security.trusted_proxies.ips', $trustedIPs);
+                $config->save('concrete.security.trusted_proxies.ips', $validIPs);
                 $this->flash('success', t('The trusted proxies configuration has been updated.'));
                 $this->redirect($this->action(''));
             }


### PR DESCRIPTION
Before, the ip addresses weren't saved. ('why do we need code reviews again?')

After PR:
![afbeelding](https://user-images.githubusercontent.com/1431100/50162708-44fe7480-02df-11e9-82f6-74224702c2de.png)
