### PR TITLE
Fix handling of html/text in error messages

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/mail/method/test.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method/test.php
@@ -73,7 +73,7 @@ class Test extends DashboardPageController
                         );
                         $this->redirect($this->action(''));
                     } catch (Exception $x) {
-                        $this->error->add(t('The following error was found while trying to send the test email:') . '<br />' . nl2br(h($x->getMessage())));
+                        $this->error->add(t('The following error was found while trying to send the test email:') . "\n" . $x->getMessage());
                     }
                 }
             }

--- a/concrete/elements/system_errors.php
+++ b/concrete/elements/system_errors.php
@@ -1,8 +1,23 @@
 <?php
 
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 use Concrete\Core\Error\ErrorList\ErrorList;
 
 defined('C5_EXECUTE') or die('Access Denied.');
+
+// Arguments:
+
+/* @var Exception|Concrete\Core\Error\ErrorList\ErrorList|string|string[]|mixed|null $error */
+// the error(s) to display
+
+/* @var string $format */
+// - how to display the errors: 'block' to display them as in a DIV element (fallback: list items)
+
+/* @var string|null $message */
+// - an "info" message in HTML format
+
+/* @var string|null $success */
+// - a "success" message in HTML format
 
 if (isset($error) && $error) {
     $_error = [];
@@ -16,12 +31,16 @@ if (isset($error) && $error) {
         $_error[] = $error;
     }
     if (count($_error) > 0) {
+        $_htmlErrors = [];
+        foreach ($_error as $e) {
+            $_htmlErrors[] = $e instanceof HtmlAwareErrorInterface && $e->messageContainsHtml() ? (string) $e : nl2br(h($e));
+        }
         if (isset($format) && $format == 'block') {
             ?>
             <div class="ccm-system-errors alert alert-danger alert-dismissable"><button type="button" class="close" data-dismiss="alert">×</button>
                 <?php
-                foreach ($_error as $e) {
-                    ?><div><?= nl2br(h($e)) ?></div><?php
+                foreach ($_htmlErrors as $e) {
+                    ?><div><?= $e ?></div><?php
                 }
                 ?>
         	</div>
@@ -30,8 +49,8 @@ if (isset($error) && $error) {
             ?>
             <ul class="ccm-system-errors ccm-error">
                 <?php
-                foreach ($_error as $e) {
-                    ?><li><?php echo nl2br(h($e)) ?></li><?php
+                foreach ($_htmlErrors as $e) {
+                    ?><li><?php echo $e ?></li><?php
                 }
                 ?>
             </ul>

--- a/concrete/js/build/core/app/ajax-request/base.js
+++ b/concrete/js/build/core/app/ajax-request/base.js
@@ -45,47 +45,24 @@
 		},
 
 		errorResponseToString: function(r) {
-			var result = r.responseText;
-			if (r.responseJSON) {
-				var json = r.responseJSON;
-
-				// first, lets check to see if json.error is an object. Because if it is we've enabled
-				// debug error handling and we have a bunch of interesting information about the error to report.
-				if (typeof json.error === 'object' && $.isArray(json.error.trace)) {
-					result = '<p class="text-danger" style="word-break: break-all"><strong>' + json.error.message + '</strong></p>';
-					result += '<p class="text-muted">' + ccmi18n.errorDetails + '</p>';
-					result += '<table class="table"><tbody>';
-					for (var i = 0; i < json.error.trace.length; i++) {
-						var trace = json.error.trace[i];
-						result += '<tr><td style="word-break: break-all">' + trace.file + '(' + trace.line + '): ' + trace.class + '->' + trace.function + '<td></tr>';
-					}
-					result += '</tbody></table>';
-				} else if ($.isArray(json.errors) && json.errors.length > 0 && typeof json.errors[0] === 'string') {
-					result = '<p class="text-danger" style="word-break: break-all"><strong>' + json.errors.join('\n') + '</strong></p>';
-				} else if (typeof json.error === 'string' && json.error !== '') {
-					result = '<p class="text-danger" style="word-break: break-all"><strong>' + json.error + '</strong></p>';
-				}
-			}
-
-			return result;
+			return ConcreteAjaxRequest.renderErrorResponse(r, true);
 		},
 
 		error: function(r, my) {
 			ConcreteEvent.fire('AjaxRequestError', {
-				'response': r
+				response: r
 			});
-
-			ConcreteAlert.dialog(ccmi18n.error, my.errorResponseToString(r));
+			ConcreteAlert.dialog(ccmi18n.error, ConcreteAjaxRequest.renderErrorResponse(r, true));
 		},
 
 		validateResponse: function(r, callback) {
 			if (r.error) {
 				ConcreteEvent.fire('AjaxRequestError', {
-					'response': r
+					response: r
 				});
 				ConcreteAlert.dialog(
 					ccmi18n.error,
-					'<p class="text-danger">' + r.errors.join("<br/>") + '</p>',
+					ConcreteAjaxRequest.renderJsonError(r),
 					function() {
 						if (callback) {
 							callback(false, r);
@@ -114,7 +91,39 @@
 		}
 	};
 
-	// static method
+	// static methods
+	ConcreteAjaxRequest.renderJsonError = function (json, asHtml) {
+		if (!json) {
+			return '';
+		}
+		var toHtml = function(text, index) {
+			if (typeof index === 'number' && $.isArray(json.htmlErrorIndexes) && $.inArray(index, json.htmlErrorIndexes) >= 0) {
+				return text;
+			}
+			return $('<div />').text(text).html().replace(/\n/g, '<br />');
+		};
+		var result = '';
+		if (typeof json.error === 'object' && $.isArray(json.error.trace)) {
+			result = '<p class="text-danger"><strong>' + toHtml(json.error.message) + '</strong></p>';
+			result += '<p class="text-muted">' + ccmi18n.errorDetails + '</p>';
+			result += '<table class="table"><tbody>';
+			for (var i = 0, trace; i < json.error.trace.length; i++) {
+				trace = json.error.trace[i];
+				result += '<tr><td>' + trace.file + '(' + trace.line + '): ' + trace['class'] + '->' + trace['function'] + '<td></tr>';
+			}
+			result += '</tbody></table>';
+		} else if ($.isArray(json.errors) && json.errors.length > 0 && typeof json.errors[0] === 'string') {
+			$.each(json.errors, function (index, text) {
+				result += '<p class="text-danger"><strong>' + toHtml(text, index) + '</strong></p>';
+			});
+		} else if (typeof json.error === 'string' && json.error !== '') {
+			result = '<p class="text-danger" style="word-break: break-all"><strong>' + toHtml(json.error) + '</strong></p>';
+		}
+		return result;
+	};
+	ConcreteAjaxRequest.renderErrorResponse = function (xhr, asHtml) {
+		return ConcreteAjaxRequest.renderJsonError(xhr.responseJSON, asHtml) || xhr.responseText;
+	};
 	ConcreteAjaxRequest.validateResponse = ConcreteAjaxRequest.prototype.validateResponse;
 	ConcreteAjaxRequest.errorResponseToString = ConcreteAjaxRequest.prototype.errorResponseToString;
 

--- a/concrete/js/build/core/app/dialog.js
+++ b/concrete/js/build/core/app/dialog.js
@@ -1,5 +1,5 @@
 /* jshint unused:vars, undef:true, browser:true, jquery:true */
-/* global NProgress, ccmi18n, ConcreteMenuManager */
+/* global NProgress, ccmi18n, ConcreteMenuManager, ConcreteAjaxRequest, ConcreteAlert */
 
 ;(function(global, $) {
     'use strict';
@@ -239,11 +239,8 @@
                     $('<div />').jqdialog(finalSettings).html(r).jqdialog('open');
                 },
                 error: function(xhr, status, error) {
-                    var msg = error, json = xhr ? xhr.responseJSON : null;
-                    if (json && json.error) {
-                        msg = json.errors instanceof Array ? json.errors.join('\n') : json.error;
-                    }
-                    window.alert(msg);
+                	$.fn.dialog.hideLoader();
+                	ConcreteAlert.dialog(ccmi18n.error, ConcreteAjaxRequest.renderErrorResponse(xhr, true));
                 }
             });
         }

--- a/concrete/src/Error/Error.php
+++ b/concrete/src/Error/Error.php
@@ -1,13 +1,13 @@
 <?php
+
 namespace Concrete\Core\Error;
 
 use Concrete\Core\Error\ErrorList\ErrorList;
 
 /**
- * @deprecated
+ * @deprecated Use the ErrorList class
+ * @see \Concrete\Core\Error\ErrorList\ErrorList
  */
 class Error extends ErrorList
 {
-
-
 }

--- a/concrete/src/Error/ErrorList/Error/AbstractError.php
+++ b/concrete/src/Error/ErrorList/Error/AbstractError.php
@@ -55,9 +55,8 @@ abstract class AbstractError implements HtmlAwareErrorInterface
     /**
      * {@inheritdoc}
      *
-     * @since concrete5 8.5.0a3
-     *
      * @see \Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface::messageContainsHtml()
+     * @since concrete5 8.5.0a3
      */
     public function messageContainsHtml()
     {
@@ -69,9 +68,9 @@ abstract class AbstractError implements HtmlAwareErrorInterface
      *
      * @param bool $value
      *
-     * @since concrete5 8.5.0a3
-     *
      * @return $this
+     *
+     * @since concrete5 8.5.0a3
      */
     public function setMessageContainsHtml($value)
     {

--- a/concrete/src/Error/ErrorList/Error/ExceptionError.php
+++ b/concrete/src/Error/ErrorList/Error/ExceptionError.php
@@ -45,6 +45,6 @@ class ExceptionError extends AbstractError
      */
     public function getMessage()
     {
-        return $this->exception->getMessage();
+        return $this->getException()->getMessage();
     }
 }

--- a/concrete/src/Error/ErrorList/Error/ThrowableError.php
+++ b/concrete/src/Error/ErrorList/Error/ThrowableError.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Concrete\Core\Error\ErrorList\Error;
+
+use Concrete\Core\Error\ErrorList\Field\FieldInterface;
+use Throwable;
+
+class ThrowableError extends AbstractError
+{
+    /**
+     * The associated Throwable.
+     *
+     * @var \Throwable
+     */
+    protected $throwable;
+
+    /**
+     * Class constructor.
+     *
+     * @param \Throwable $throwable
+     * @param \Concrete\Core\Error\ErrorList\Field\FieldInterface|null $field
+     */
+    public function __construct(Throwable $throwable, FieldInterface $field = null)
+    {
+        $this->throwable = $throwable;
+        if ($field) {
+            $this->setField($field);
+        }
+    }
+
+    /**
+     * Get the associated Throwable.
+     *
+     * @return \Throwable
+     */
+    public function getThrowable()
+    {
+        return $this->throwable;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Error\ErrorInterface::getMessage()
+     */
+    public function getMessage()
+    {
+        return $this->getThrowable()->getMessage();
+    }
+}

--- a/concrete/src/Error/ErrorList/Formatter/AbstractFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/AbstractFormatter.php
@@ -1,16 +1,25 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Formatter;
 
 use Concrete\Core\Error\ErrorList\ErrorList;
 
 abstract class AbstractFormatter implements FormatterInterface
 {
-
+    /**
+     * The error list to be formatted.
+     *
+     * @var \Concrete\Core\Error\ErrorList\ErrorList
+     */
     protected $error;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Error\ErrorList\ErrorList $error the error list to be formatted
+     */
     public function __construct(ErrorList $error)
     {
         $this->error = $error;
     }
-
 }

--- a/concrete/src/Error/ErrorList/Formatter/FormatterInterface.php
+++ b/concrete/src/Error/ErrorList/Formatter/FormatterInterface.php
@@ -1,12 +1,22 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Formatter;
 
 use Concrete\Core\Error\ErrorList\ErrorList;
 
 interface FormatterInterface
 {
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Error\ErrorList\ErrorList $error the error list to be formatted
+     */
+    public function __construct(ErrorList $error);
 
-    function __construct(ErrorList $error);
-    function render();
-
+    /**
+     * Render the error list.
+     *
+     * @return string
+     */
+    public function render();
 }

--- a/concrete/src/Error/ErrorList/Formatter/JsonFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/JsonFormatter.php
@@ -1,29 +1,48 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Formatter;
 
-use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 
 class JsonFormatter extends AbstractFormatter
 {
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Formatter\FormatterInterface::render()
+     */
     public function render()
     {
-       return json_encode($this->asArray());
+        return json_encode($this->asArray());
     }
 
+    /**
+     * Build an array describing the errors.
+     *
+     * @return array|null return NULL if the error list is empty, an array otherwise
+     */
     public function asArray()
     {
         $error = $this->error;
         if ($error->has()) {
-            $o = array();
-            $o['error'] = true;
-            $o['errors'] = array();
+            $o = [
+                'error' => true,
+                'errors' => [],
+                'htmlErrorIndexes' => [],
+            ];
+            $index = 0;
             foreach ($error->getList() as $error) {
                 $o['errors'][] = (string) $error;
+                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
+                    $o['htmlErrorIndexes'][] = $index;
+                }
+                ++$index;
             }
+            if (empty($o['htmlErrorIndexes'])) {
+                unset($o['htmlErrorIndexes']);
+            }
+
             return $o;
         }
     }
-
-
 }

--- a/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
@@ -7,6 +7,18 @@ use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 class StandardFormatter extends AbstractFormatter
 {
     /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Error\ErrorList\Formatter\FormatterInterface::render()
+     */
+    public function render()
+    {
+        return $this->getString();
+    }
+
+    /**
+     * Build an HTML-formatted string describing the errors.
+     *
      * @return string
      */
     public function getString()
@@ -19,7 +31,7 @@ class StandardFormatter extends AbstractFormatter
                 if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
                     $html .= (string) $error;
                 } else {
-                    $html .= h((string) $error);
+                    $html .= nl2br(h((string) $error));
                 }
                 $html .= '</li>';
             }
@@ -27,15 +39,5 @@ class StandardFormatter extends AbstractFormatter
         }
 
         return $html;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @see \Concrete\Core\Error\ErrorList\Formatter\FormatterInterface::render()
-     */
-    public function render()
-    {
-        return $this->getString();
     }
 }

--- a/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
@@ -1,23 +1,11 @@
 <?php
+
 namespace Concrete\Core\Error\ErrorList\Formatter;
+
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 
 class TextFormatter extends AbstractFormatter
 {
-    /**
-     * @return string
-     */
-    public function getText()
-    {
-        $lines = [];
-        if ($this->error->has()) {
-            foreach ($this->error->getList() as $error) {
-                $lines[] = (string) $error;
-            }
-        }
-
-        return implode("\n", $lines);
-    }
-
     /**
      * {@inheritdoc}
      *
@@ -26,5 +14,26 @@ class TextFormatter extends AbstractFormatter
     public function render()
     {
         return $this->getText();
+    }
+
+    /**
+     * Build an plain text string describing the errors.
+     *
+     * @return string
+     */
+    public function getText()
+    {
+        $lines = [];
+        if ($this->error->has()) {
+            foreach ($this->error->getList() as $error) {
+                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
+                    $lines[] = strip_tags((string) $error);
+                } else {
+                    $lines[] = (string) $error;
+                }
+            }
+        }
+
+        return implode("\n", $lines);
     }
 }

--- a/concrete/src/Error/UserMessageException.php
+++ b/concrete/src/Error/UserMessageException.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace Concrete\Core\Error;
 
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
 use Exception;
 use JsonSerializable;
 
 /**
  * Represents an error that can be safely shown to users.
  */
-class UserMessageException extends Exception implements JsonSerializable
+class UserMessageException extends Exception implements JsonSerializable, HtmlAwareErrorInterface
 {
     /**
      * Can this exception be added to the log?
@@ -15,6 +17,15 @@ class UserMessageException extends Exception implements JsonSerializable
      * @var bool
      */
     protected $canBeLogged = false;
+
+    /**
+     * Does the message contain an HTML-formatted string?
+     *
+     * @since concrete5 8.5.0a3
+     *
+     * @var bool
+     */
+    private $messageContainsHtml = false;
 
     /**
      * Can this exception be added to the log?
@@ -43,15 +54,47 @@ class UserMessageException extends Exception implements JsonSerializable
     /**
      * {@inheritdoc}
      *
+     * @see \Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface::messageContainsHtml()
+     * @since concrete5 8.5.0a3
+     */
+    public function messageContainsHtml()
+    {
+        return $this->messageContainsHtml;
+    }
+
+    /**
+     * Does the message contain an HTML-formatted string?
+     *
+     * @param bool $value
+     *
+     * @return $this
+     *
+     * @since concrete5 8.5.0a3
+     */
+    public function setMessageContainsHtml($value)
+    {
+        $this->messageContainsHtml = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see JsonSerializable::jsonSerialize()
      */
     public function jsonSerialize()
     {
-        return [
+        $result = [
             'error' => true,
             'errors' => [
                 $this->getMessage(),
             ],
         ];
+        if ($this->messageContainsHtml()) {
+            $result['htmlErrorIndexes'] = [0];
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
In #7395 we introduced a way to tell the system if an error is in HTML or in plain text.

In this new PR I add something that was missing in #7395:

1. the `system_errors` element html-escapes all the errors, regardless if they are already in HTML or not. Let's fix this (see commit 3a12fba87598b46c1a34da81becc9079995afa19)
1. the plain-text error formatter should remove HTML stuff when rendering errors in HTML format (see commit cbf6f8bcb17e94b00ae0665df6caffb79ae2067e)
1. adding a simple error string in HTML format to an ErrorList instance is a bit too comples (we need to create an instance of an Error class, set its `messageContainsHtml` flag and add it to the error list). What about adding a new `addHtml()` method in addition to `add()`? See commit 3e67ca1a087e82b3156c1e27c850cd2e24452194
1. we have an `ExceptionError` error class, but not a `ThrowableError` error class. What about adding it? (when we'll require PHP 7+ we can make `ExceptionError` simply extend `ThrowableError`) (see commit 3e67ca1a087e82b3156c1e27c850cd2e24452194)
1. our javascripts aren't aware of errors in HTML or plain text: we need to tell them that errors are in HTML (see the `htmlErrorIndexes` JSON key in 3e67ca1a087e82b3156c1e27c850cd2e24452194 and the new error handling functions of 8ea7815350c3be6e8b1a2a2d356aacc5d167e63d)