### PR TITLE
Fixing PAGE_VERSION_RECENT_UNAPPROVED

### DIFF
--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -261,6 +261,9 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             case 'RECENT':
                 $q .= ' order by cvID desc limit 1';
                 break;
+            case 'RECENT_UNAPPROVED':
+                $q .= 'and (cvIsApproved = 0 or cvIsApproved IS NULL) order by cvID desc limit 1';
+                break;
             default:
                 $v[] = $cvID;
                 $q .= ' and cvID = ?';

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -208,22 +208,9 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 $query->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID)');
                 break;
             case self::PAGE_VERSION_RECENT_UNAPPROVED:
-                $app = Application::getFacadeApplication();
-                $nowParameter = $query->createNamedParameter($app->make('date')->getOverridableNow());
                 $query
                     ->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID)')
-                    ->andWhere($expr->orX(
-                        $expr->eq('cvIsApproved', 0),
-                        $expr->andX(
-                            $expr->isNotNull('cvPublishDate'),
-                            $expr->gt('cvPublishDate', $nowParameter)
-                        ),
-                        $expr->andX(
-                            $expr->isNotNull('cvPublishEndDate'),
-                            $expr->lt('cvPublishEndDate', $nowParameter)
-                        )
-                    ))
-                ;
+                    ->andWhere($expr->eq('cvIsApproved', 0));
                 break;
             case self::PAGE_VERSION_SCHEDULED:
                 $now = new \DateTime();
@@ -360,6 +347,11 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 $cp = new \Permissions($c);
                 if ($cp->canViewPageVersions() || $this->permissionsChecker === -1) {
                     $c->loadVersionObject('SCHEDULED');
+                }
+            } elseif ($this->pageVersionToRetrieve == self::PAGE_VERSION_RECENT_UNAPPROVED) {
+                $cp = new \Permissions($c);
+                if ($cp->canViewPageVersions() || $this->permissionsChecker === -1) {
+                    $c->loadVersionObject('RECENT_UNAPPROVED');
                 }
             }
             if (isset($queryRow['cIndexScore'])) {


### PR DESCRIPTION
Currently in version 8.5.0a3 and below the current PAGE_VERSION_RECENT_UNAPPROVED will return the Active version object rather than the most recent unapproved CollectionVersion

In CollectionVersion we dont have a way to load recent_unapproved versions and on the page list we just get the active version if you select PAGE_VERSION_RECENT_UNAPPROVED as the page version to retrieve.

This PR adds the ability for the CollectionVersion to load RECENT_UNAPPROVED versions and the page list will load them.

I have also removed Future Scheduled pages from the Recent_unapproved page list as it makes no sense to have it. ( We have the ability to filter by scheduled) These pages have been approved for publishing on a set date and as such they are not unapproved version ( this bug was introduced recently )