### PR TITLE
Fix layout cache issue

### DIFF
--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -5,6 +5,7 @@ use Concrete\Core\Area\Layout\CustomLayout;
 use Concrete\Core\Area\Layout\PresetLayout;
 use Concrete\Core\Area\Layout\ThemeGridLayout;
 use Concrete\Core\Area\SubArea;
+use Concrete\Core\Permission\Checker;
 use Core;
 use Database;
 use Concrete\Core\Block\BlockController;
@@ -75,8 +76,18 @@ class Controller extends BlockController
         }
 
         $arrAssetBlocks = [];
-        
+
         foreach ($blocks as $b) {
+            if ($b->overrideAreaPermissions()) {
+                $checker = new Checker($b);
+                if (!$checker->canViewBlock()) {
+                    $btCacheBlockOutput = false;
+                    $btCacheBlockOutputOnPost = false;
+                    $btCacheBlockOutputLifetime = 0;
+                    break;
+                }
+            }
+
             $btCacheBlockOutput = $btCacheBlockOutput && $b->cacheBlockOutput();
             $btCacheBlockOutputOnPost = $btCacheBlockOutputOnPost && $b->cacheBlockOutputOnPost();
 

--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -5,7 +5,6 @@ use Concrete\Core\Area\Layout\CustomLayout;
 use Concrete\Core\Area\Layout\PresetLayout;
 use Concrete\Core\Area\Layout\ThemeGridLayout;
 use Concrete\Core\Area\SubArea;
-use Concrete\Core\Permission\Checker;
 use Core;
 use Database;
 use Concrete\Core\Block\BlockController;
@@ -79,13 +78,10 @@ class Controller extends BlockController
 
         foreach ($blocks as $b) {
             if ($b->overrideAreaPermissions()) {
-                $checker = new Checker($b);
-                if (!$checker->canViewBlock()) {
-                    $btCacheBlockOutput = false;
-                    $btCacheBlockOutputOnPost = false;
-                    $btCacheBlockOutputLifetime = 0;
-                    break;
-                }
+                $btCacheBlockOutput = false;
+                $btCacheBlockOutputOnPost = false;
+                $btCacheBlockOutputLifetime = 0;
+                break;
             }
 
             $btCacheBlockOutput = $btCacheBlockOutput && $b->cacheBlockOutput();

--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -217,6 +217,13 @@ class Controller extends BlockController implements TrackableInterface
         if ($p->canViewPage()) {
             $blocks = $stack->getBlocks();
             foreach ($blocks as $b) {
+                if ($b->overrideAreaPermissions()) {
+                    $btCacheBlockOutput = false;
+                    $btCacheBlockOutputOnPost = false;
+                    $btCacheBlockOutputLifetime = 0;
+                    break;
+                }
+
                 $btCacheBlockOutput = $btCacheBlockOutput && $b->cacheBlockOutput();
                 $btCacheBlockOutputOnPost = $btCacheBlockOutputOnPost && $b->cacheBlockOutputOnPost();
 


### PR DESCRIPTION
If some block in the layout overrides their parent area's permission, and the block cannot be viewable, we shouldn't create a whole area cache.

Steps to reproduce the issue:

1. Create a layout on a page.
2. Add a block in the layout (Content block type is the best).
3. Set Schedule Guest Access for the block.
4. Open the "View as User" panel (c5 will create a layout cache even if the block is not viewable).
5. Change "Date / Time" to future. The scheduled block is still not viewable.