### PR TITLE
Avoid error on getting users of group permission access entity

### DIFF
--- a/concrete/src/Permission/Access/Entity/GroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupEntity.php
@@ -18,7 +18,11 @@ class GroupEntity extends Entity
 
     public function getAccessEntityUsers(PermissionAccess $pa)
     {
-        return $this->group->getGroupMembers();
+        if (is_object($this->group)) {
+            return $this->group->getGroupMembers();
+        }
+
+        return [];
     }
 
     public function getAccessEntityTypeLinkHTML()


### PR DESCRIPTION
If the group already deleted, an exception occurred when using a group entity of the deleted group.

```
Exception Occurred: /Users/hissy/Repositories/concrete5/concrete/src/Permission/Access/Entity/GroupEntity.php:21 Call to a member function getGroupMembers() on boolean (0)
```

Steps to reproduce:

1. Create a group
2. Create a Workflow then set a notification to the group
3. Apply the workflow from full sitemap page
4. Delete the group
5. Create a workflow request with approving a page