### PR TITLE
Fix arCustomTemplates in editmode.js

### DIFF
--- a/concrete/js/build/core/app/edit-mode/editmode.js
+++ b/concrete/js/build/core/app/edit-mode/editmode.js
@@ -186,7 +186,7 @@
                 if (templates) {
                     for (var k in templates) {
                         postData[postData.length] = {
-                            name: 'arCustomTemplate[' + k + ']',
+                            name: 'arCustomTemplates[' + k + ']',
                             value: templates[k]
                         };
                     }


### PR DESCRIPTION
The issue of custom block templates set on the area not working for the Content block has been reported in #6069.

The location of the problem has been correctly identified in 
https://github.com/concrete5/concrete5/issues/6069#issuecomment-340458978 - there is a typo (I assume) in editmode.js - I could find any reference to `arCustomTemplate` anywhere, `arCustomTemplates` seems to be correct.

I confirmed the fix locally by editing app.js as well, but it needs to be compiled again after the merge. I left if away to avoid merge conflicts.