### PR TITLE
Adds New Feature - Logout Inactive users 

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -966,6 +966,13 @@ return [
             'invalidate_on_user_agent_mismatch' => true,
 
             'invalidate_on_ip_mismatch' => true,
+
+            'invalidate_inactive_users' => [
+                // Is the automatically logout inactive users setting enabled?
+                'enabled' => false,
+                // Time window (in seconds) for inactive users to be automatically logout
+                'time' => 300,
+            ]
         ],
         'ban' => [
             'ip' => [

--- a/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
@@ -15,6 +15,8 @@ class AutomatedLogout extends DashboardPageController
     const ITEM_IP = 'concrete.security.session.invalidate_on_ip_mismatch';
     const ITEM_USER_AGENT = 'concrete.security.session.invalidate_on_user_agent_mismatch';
     const ITEM_SESSION_INVALIDATE = 'concrete.session.valid_since';
+    const ITEM_INVALIDATE_INACTIVE_USERS = 'concrete.security.session.invalidate_inactive_users.enabled';
+    const ITEM_INVALIDATE_INACTIVE_USERS_TIME = 'concrete.security.session.invalidate_inactive_users.time';
 
     /**
      * The response factory we use to generate responses
@@ -24,7 +26,7 @@ class AutomatedLogout extends DashboardPageController
     protected $factory;
 
     /**
-     * The config repsository we save to
+     * The config repository we save to
      *
      * @var \Concrete\Core\Config\Repository\Repository
      */
@@ -53,9 +55,12 @@ class AutomatedLogout extends DashboardPageController
      */
     public function view()
     {
+
         $this->set('trustedProxyUrl', $this->urls->resolve(['/dashboard/system/permissions/trusted_proxies']));
         $this->set('invalidateOnIPMismatch', $this->config->get(self::ITEM_IP));
         $this->set('invalidateOnUserAgentMismatch', $this->config->get(self::ITEM_USER_AGENT));
+        $this->set('invalidateInactiveUsers', $this->config->get(self::ITEM_INVALIDATE_INACTIVE_USERS));
+        $this->set('inactiveTime', $this->config->get(self::ITEM_INVALIDATE_INACTIVE_USERS_TIME));
 
         $this->set('saveAction', $this->action('save'));
         $this->set('invalidateAction', $this->action('invalidate_sessions', $this->token->generate('invalidate_sessions')));
@@ -80,10 +85,11 @@ class AutomatedLogout extends DashboardPageController
         }
 
         $post = $this->request->request;
-
         // Save the posted settings
         $this->config->save(self::ITEM_IP, filter_var($post->get('invalidateOnIPMismatch'), FILTER_VALIDATE_BOOLEAN));
         $this->config->save(self::ITEM_USER_AGENT, filter_var($post->get('invalidateOnUserAgentMismatch'), FILTER_VALIDATE_BOOLEAN));
+        $this->config->save(self::ITEM_INVALIDATE_INACTIVE_USERS, filter_var($post->get('invalidateInactiveUsers'), FILTER_VALIDATE_BOOLEAN));
+        $this->config->save(self::ITEM_INVALIDATE_INACTIVE_USERS_TIME, filter_var($post->get('inactiveTime'), FILTER_VALIDATE_INT));
 
         $this->flash('message', t('Successfully saved Session Security settings'));
 

--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -7,6 +7,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var bool $invalidateOnIPMismatch */
 /* @var bool $invalidateOnUserAgentMismatch */
+/* @var bool $invalidateInactiveUsers */
+/* @var number $inactiveTime */
 /* @var string $trustedProxyUrl */
 /* @var string $invalidateAction */
 /* @var string $saveAction */
@@ -17,23 +19,33 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <fieldset>
         <legend><?= t('Session Security') ?></legend>
+        <div class="help-block">
+            <?= t('These settings help prevent a user from stealing other logged in user sessions. You may want to configure %s"Trusted Proxies"%s instead', '<a href="' . $trustedProxyUrl . '">', '</a>') ?>
+        </div>
         <div class="form-group">
-
-            <div class="help-block">
-                <?= t('These settings help prevent a user from stealing other logged in user sessions. You may want to configure %s"Trusted Proxies"%s instead', '<a href="' . $trustedProxyUrl . '">', '</a>') ?>
-            </div>
             <div class="checkbox">
                 <label>
                     <?= $form->checkbox('invalidateOnIPMismatch', '1', $invalidateOnIPMismatch) ?>
                     <?= t('Log users out if their IP changes') ?>
             </div>
+        </div>
+        <div class="form-group">
             <div class="checkbox">
                 <label>
                     <?= $form->checkbox('invalidateOnUserAgentMismatch', '1', $invalidateOnUserAgentMismatch) ?>
                     <?= t("Log users out if their browser's user agent changes") ?>
                 </label>
             </div>
-
+        </div>
+        <div class="form-group">
+            <div class="form-inline">
+                <div class="checkbox">
+                    <label>
+                        <?= $form->checkbox('invalidateInactiveUsers','1', $invalidateInactiveUsers) ?>
+                        <?= t("Automatically log out users who are inactive for %s seconds or more.", $form->number('inactiveTime', $inactiveTime, ["style"=>"width:100px; display:inline-block;"])) ?>
+                    </label>
+                </div>
+            </div>
         </div>
     </fieldset>
 


### PR DESCRIPTION
First step for automatically logout inactive users (issue #7260). This PR only saves the values to the configuration file. The actual logout functionality is still pending per @aembler request. 