### PR TITLE
Add support for custom container settings in import/export

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1827,6 +1827,9 @@ EOT
             if ($this->getBlockFilename() != '') {
                 $blockNode->addAttribute('custom-template', $this->getBlockFilename());
             }
+            if ($this->overrideBlockTypeContainerSettings()) {
+                $blockNode->addAttribute('custom-container-settings', $this->enableBlockContainer() ? 1 : 0);
+            }
             if (($this->c instanceof Page) && $this->c->isMasterCollection()) {
                 $mcBlockID = Loader::helper('validation/identifier')->getString(8);
                 ContentExporter::addMasterCollectionBlockID($this, $mcBlockID);

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -426,6 +426,12 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         // we have to do this this way because we need a bID
         $this->importAdditionalData($b, $blockNode);
 
+        // now we handle container settings
+        $bCustomContainerSettings = (string) $blockNode['custom-container-settings'];
+        if ($bCustomContainerSettings === '0' || $bCustomContainerSettings === '1') {
+            $b->setCustomContainerSettings($bCustomContainerSettings);
+        }
+
         // now we handle the styles
         if (isset($blockNode->style)) {
             $set = StyleSet::import($blockNode->style);


### PR DESCRIPTION
This allows the block setting "Block Container Class" with the values "Disable Grid Container" or "Enable Grid Container" to be exported. It also adds support to use it in the `concrete5-cif` format for packages or starting points.