### PR TITLE
Remove explicit webpack version requirements

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -22,8 +22,6 @@
     "shelljs": "0.2.6",
     "temp": "~0.8.1",
     "uglifyjs-webpack-plugin": "^1.2.7",
-    "vue": "^2.5.7",
-    "webpack": "^3.12.0 <4.0.0",
-    "webpack-dev-server": "^2.11.1 <3.0.0"
+    "vue": "^2.5.7"
   }
 }


### PR DESCRIPTION
laravel-mix is managing these dependencies for us now. I believe I added these explicit version requirements because there was trouble with grunt integration, but I didn't have any trouble this time.