### PR TITLE
Codify the current symfony/http-foundation version

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -31,7 +31,7 @@
     "php": ">=5.5.9",
     "doctrine/dbal": "~2.5",
     "symfony/class-loader": "3.*",
-    "symfony/http-foundation": "3.*",
+    "symfony/http-foundation": "^3.4.17",
     "symfony/routing": "3.*",
     "symfony/http-kernel": "3.4.*",
     "doctrine/orm": "~2.5",


### PR DESCRIPTION
Older versions of this dependency can have issues with trusting IIS headers. We're already set to use `3.4.17` in composer.lock, let's just set composer.json to match