### PR TITLE
What about making an Alias for Database Connection

### DIFF
--- a/concrete/src/Database/DatabaseServiceProvider.php
+++ b/concrete/src/Database/DatabaseServiceProvider.php
@@ -39,6 +39,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->bind('Doctrine\DBAL\Connection',
             'Concrete\Core\Database\Connection\Connection');
 
+        $this->app->alias('Concrete\Core\Database\Connection\Connection', 'database/connection');
 
         // Bind EntityManager factory
         $this->app->bind('Concrete\Core\Database\EntityManagerConfigFactory',


### PR DESCRIPTION
A shortcut for calling database connection
`
$db = $app->make('database/connection');
`