### PR TITLE
Fix failing test when added --prefer-lowest option

### DIFF
--- a/concrete/src/Localization/Service/Date.php
+++ b/concrete/src/Localization/Service/Date.php
@@ -391,7 +391,7 @@ class Date
             $chunks[] = t2('%d second', '%d seconds', $seconds, $seconds);
         }
 
-        return Misc::joinAnd($chunks);
+        return Misc::join($chunks);
     }
 
     /**


### PR DESCRIPTION
`Misc::join` is deprecated in recent Punic library, but we have to keep using this method for old environment.