### PR TITLE
Allow custom class loading from the package for a custom permission key

### DIFF
--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -240,7 +240,7 @@ abstract class Key extends ConcreteObject
         $permissionkeys = [];
         $txt = $app->make('helper/text');
         $e = $db->executeQuery(<<<'EOT'
-select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeyCategories.pkgID
+select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeys.pkgID
 from PermissionKeys
 inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID
 EOT


### PR DESCRIPTION
Now, we can't create a [custom task permission](https://documentation.concrete5.org/developers/permissions-access-security/creating-custom-permissions) with custom class without creating a new category.

This PR allows to create custom task permissions to existing category with custom class from a package.