### PR TITLE
fix: charsets are values in $collations array, not keys

### DIFF
--- a/concrete/src/Database/CharacterSetCollation/Resolver.php
+++ b/concrete/src/Database/CharacterSetCollation/Resolver.php
@@ -168,8 +168,8 @@ class Resolver
                 throw new Exception\UnsupportedCollationException($collation);
             }
             if ($characterSet === '') {
-                $characterSet = $collations[$characterSet];
-            } elseif ($characterSet !== $collations[$characterSet]) {
+                $characterSet = $collations[$collation];
+            } elseif ($characterSet !== $collations[$collation]) {
                 throw new Exception\InvalidCharacterSetCollationCombination($characterSet, $collation, $collations[$characterSet]);
             }
         } elseif ($characterSet !== '') {


### PR DESCRIPTION
`getSupportedCollations()` returns: [array keys: collation (always lower case); array values: associated character set (always lower case)](https://github.com/concrete5/concrete5/blob/738690996281c45d1d193c120a27c047dc013850/concrete/src/Database/Connection/Connection.php#L457), so `$characterSet !== $collations[$characterSet]` will never evaluate correctly.