### PR TITLE
Add logging to the login / logout flow and to sessions

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -345,6 +345,8 @@ class Controller extends AuthenticationTypeController
             $user->setAuthTypeCookie('concrete');
         }
 
+        $loginService->logLoginAttempt($uName);
+
         return $user;
     }
 
@@ -355,9 +357,13 @@ class Controller extends AuthenticationTypeController
             try {
                 $loginService->failLogin($uName, $uPassword);
             } catch (FailedLoginThresholdExceededException $e) {
+                $loginService->logLoginAttempt($uName, ['Failed Login Threshold Exceeded', $e->getMessage()]);
+
                 // Rethrow the failed threshold error
                 throw $e;
             } catch (UserDeactivatedException $e) {
+                $loginService->logLoginAttempt($uName, ['User Deactivated', $e->getMessage()]);
+
                 // Rethrow the user deactivated exception
                 throw $e;
             }
@@ -368,6 +374,8 @@ class Controller extends AuthenticationTypeController
                 $this->redirect('/login/', $this->getAuthenticationType()->getAuthenticationTypeHandle(), 'required_password_upgrade');
             }
         }
+
+        $loginService->logLoginAttempt($uName, ['Invalid Credentials', $e->getMessage()]);
 
         // Rethrow the exception
         throw $e;

--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -14,6 +14,7 @@ use Concrete\Core\Foundation\Runtime\RuntimeInterface;
 use Concrete\Core\Http\DispatcherInterface;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\Query\Logger;
 use Concrete\Core\Package\PackageService;
@@ -32,6 +33,7 @@ use Job;
 use JobSet;
 use Log;
 use Page;
+use Psr\Log\LoggerAwareInterface as PsrLoggerAwareInterface;
 use Redirect;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -410,8 +412,12 @@ class Application extends Container
             if ($object instanceof ApplicationAwareInterface) {
                 $object->setApplication($this);
             }
+
             if ($object instanceof LoggerAwareInterface) {
                 $logger = $this->make('log/factory')->createLogger($object->getLoggerChannel());
+                $object->setLogger($logger);
+            } elseif ($object instanceof PsrLoggerAwareInterface) {
+                $logger = $this->make('log/factory')->createLogger(Channels::CHANNEL_APPLICATION);
                 $object->setLogger($logger);
             }
         }

--- a/concrete/src/Logging/Entry/EntryInterface.php
+++ b/concrete/src/Logging/Entry/EntryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Concrete\Core\Logging\Entry;
+
+/**
+ * An interface for making complex log entries
+ */
+interface EntryInterface
+{
+
+    /**
+     * Convert this entry into a string that can be inserted into the log
+     *
+     * Ex: "Created a new user"
+     *
+     * @return string
+     */
+    public function getMessage();
+
+    /**
+     * Get the added context for the log entry
+     *
+     * Ex: ["username": "...", "email": "...", "id": "...", "created_by": "..."]
+     *
+     * @return array
+     */
+    public function getContext();
+
+}

--- a/concrete/src/Logging/Entry/User/LoginAttempt.php
+++ b/concrete/src/Logging/Entry/User/LoginAttempt.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Concrete\Core\Logging\Entry\User;
+
+use Concrete\Core\Logging\Entry\EntryInterface;
+
+/**
+ * Log entry for user login attempts
+ */
+class LoginAttempt implements EntryInterface
+{
+
+    /**
+     * The attempted login username
+     *
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * The path that the login was submitted to
+     *
+     * @var string
+     */
+    protected $requestPath;
+
+    /**
+     * The group names that this user would have access to
+     *
+     * @var string[]
+     */
+    protected $groups;
+
+    /**
+     * The errors encountered when attempting login
+     *
+     * @var string[]
+     */
+    protected $errors;
+
+    /**
+     * LoginAttempt constructor.
+     *
+     * @param string $username The username used when attempting to log in
+     * @param string $requestPath The path that is being requested
+     * @param string[] $groups The groups the user would have access to
+     * @param string[] $errors
+     */
+    public function __construct($username, $requestPath, $groups = [], $errors = [])
+    {
+        $this->username = $username;
+        $this->requestPath = $requestPath;
+        $this->groups = $groups;
+        $this->errors = $errors;
+    }
+
+    /**
+     * Convert this entry into something that can be inserted into the log
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        $successString = $this->errors ? 'Failed' : 'Successful';
+        return "{$successString} login attempt for \"{$this->username}\"";
+    }
+
+    /**
+     * Get the added context for the log entry
+     *
+     * Ex: ["username": "...", "email": "...", "id": "...", "created_by": "..."]
+     *
+     * @return array
+     */
+    public function getContext()
+    {
+        return [
+            'username' => $this->username,
+            'requestPath' => $this->requestPath,
+            'errors' => $this->errors,
+            'groups' => $this->groups,
+            'successful' => !$this->errors
+        ];
+    }
+}

--- a/concrete/src/Logging/LoggerAwareTrait.php
+++ b/concrete/src/Logging/LoggerAwareTrait.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Logging;
 
 use Psr\Log\LoggerAwareTrait as PsrLoggerAwareTrait;
+
 /**
  * Trait LoggerAwareTrait
  * A trait used with LoggerAwareInterface
@@ -12,6 +13,12 @@ trait LoggerAwareTrait
 
     use PsrLoggerAwareTrait;
 
+    /**
+     * Get the logger channel expected by this LoggerAwareTrait implementation
+     * The user is expected to declare this method and return a valid channel name.
+     *
+     * @return string One of \Concrete\Core\Logging\Channels::CHANNEL_*
+     */
     abstract public function getLoggerChannel();
 
 }

--- a/concrete/src/Logging/Processor/ServerInfoProcessor.php
+++ b/concrete/src/Logging/Processor/ServerInfoProcessor.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Concrete\Core\Logging\Processor;
+
+/**
+ * A processor for packing $_SERVER info into the extra log info
+ */
+class ServerInfoProcessor
+{
+
+    /**
+     * The $_SERVER[...] keys to include in the extra data
+     *
+     * @var string[]
+     */
+    protected $includeKeys = [];
+
+    /**
+     * ServerInfoProcessor constructor.
+     *
+     * @param string[] $includeKeys The keys to pull from `$_SERVER`
+     */
+    public function __construct(array $includeKeys)
+    {
+        $this->includeKeys = $includeKeys;
+    }
+
+    /**
+     * Invoke this processor
+     *
+     * @param array $record The given monolog record
+     *
+     * @return array The modified record
+     */
+    public function __invoke(array $record)
+    {
+        if (!isset($record['extra']['_SERVER'])) {
+            $record['extra']['_SERVER'] = [];
+        }
+
+        foreach ($this->includeKeys as $includeKey) {
+            if (isset($_SERVER[$includeKey])) {
+                $record['extra']['_SERVER'][$includeKey] = $_SERVER[$includeKey];
+            }
+        }
+
+        return $record;
+    }
+
+}
+
+

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -187,7 +187,7 @@ class SessionFactory implements SessionFactoryInterface
 
         $storage->setOptions($options);
 
-        return $storage;
+        return $app->make(Storage\LoggedStorage::class, [$storage]);
     }
 
     /**

--- a/concrete/src/Session/Storage/LoggedStorage.php
+++ b/concrete/src/Session/Storage/LoggedStorage.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Concrete\Core\Session\Storage;
+
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerAwareInterface;
+use Concrete\Core\Logging\LoggerAwareTrait;
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionBagProxy;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+
+class LoggedStorage implements SessionStorageInterface, LoggerAwareInterface
+{
+
+    use LoggerAwareTrait;
+
+    /**
+     * The storage instance we're wrapping / adding logging to
+     *
+     * @var \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface
+     */
+    protected $wrappedStorage;
+
+    public function __construct(SessionStorageInterface $wrappedStorage)
+    {
+        $this->wrappedStorage = $wrappedStorage;
+    }
+
+    /**
+     * Declare our logging channel as "Security"
+     *
+     * @return string
+     */
+    public function getLoggerChannel()
+    {
+        return Channels::CHANNEL_SECURITY;
+    }
+
+    /**
+     * Log details if possible
+     *
+     * @param $message
+     * @param array $context
+     */
+    protected function log($level, $message, array $context = [])
+    {
+        if ($this->logger) {
+            $metadata = $this->getMetadataBag();
+
+            $context['metadata'] = [
+                'created' => $metadata->getCreated(),
+                'lifetime' => $metadata->getLifetime(),
+                'lastused' => $metadata->getLastUsed(),
+                'name' => $metadata->getName(),
+            ];
+
+            if ($this->isStarted()) {
+                $attributes = $this->getBag('attributes');
+
+                if ($attributes instanceof SessionBagProxy) {
+                    $attributes = $attributes->getBag();
+                }
+
+                if ($attributes instanceof AttributeBagInterface) {
+                    $context['metadata']['uID'] = $attributes->get('uID', null);
+                    $context['metadata']['uGroups'] = array_values($attributes->get('uGroups', []));
+                }
+            }
+
+            $this->logger->log($level, $message, $context);
+        }
+    }
+
+    /**
+     * Add info level logs
+     *
+     * @param $message
+     * @param array $context
+     */
+    protected function logInfo($message, array $context = [])
+    {
+        return $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * Add debug level logs
+     *
+     * @param $message
+     * @param array $context
+     */
+    protected function logDebug($message, array $context = [])
+    {
+        return $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * Starts the session.
+     *
+     * @return bool True if started
+     *
+     * @throws \RuntimeException if something goes wrong starting the session
+     */
+    public function start()
+    {
+        $this->logDebug('Session starting.');
+
+        return $this->wrappedStorage->start();
+    }
+
+    /**
+     * Checks if the session is started.
+     *
+     * @return bool True if started, false otherwise
+     */
+    public function isStarted()
+    {
+        return $this->wrappedStorage->isStarted();
+    }
+
+    /**
+     * Returns the session ID.
+     *
+     * @return string The session ID or empty
+     */
+    public function getId()
+    {
+        return $this->wrappedStorage->getId();
+    }
+
+    /**
+     * Sets the session ID.
+     *
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->logDebug('Modifying session ID');
+
+        return $this->wrappedStorage->setId($id);
+    }
+
+    /**
+     * Returns the session name.
+     *
+     * @return mixed The session name
+     */
+    public function getName()
+    {
+        return $this->wrappedStorage->getName();
+    }
+
+    /**
+     * Sets the session name.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        return $this->wrappedStorage->setName($name);
+    }
+
+    /**
+     * Regenerates id that represents this storage.
+     *
+     * This method must invoke session_regenerate_id($destroy) unless
+     * this interface is used for a storage object designed for unit
+     * or functional testing where a real PHP session would interfere
+     * with testing.
+     *
+     * Note regenerate+destroy should not clear the session data in memory
+     * only delete the session data from persistent storage.
+     *
+     * Care: When regenerating the session ID no locking is involved in PHP's
+     * session design. See https://bugs.php.net/bug.php?id=61470 for a discussion.
+     * So you must make sure the regenerated session is saved BEFORE sending the
+     * headers with the new ID. Symfony's HttpKernel offers a listener for this.
+     * See Symfony\Component\HttpKernel\EventListener\SaveSessionListener.
+     * Otherwise session data could get lost again for concurrent requests with the
+     * new ID. One result could be that you get logged out after just logging in.
+     *
+     * @param bool $destroy Destroy session when regenerating?
+     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                       will leave the system settings unchanged, 0 sets the cookie
+     *                       to expire with browser session. Time is in seconds, and is
+     *                       not a Unix timestamp.
+     *
+     * @return bool True if session regenerated, false if error
+     *
+     * @throws \RuntimeException If an error occurs while regenerating this storage
+     */
+    public function regenerate($destroy = false, $lifetime = null)
+    {
+        $this->logDebug('Regenerating session', ['destroy' => $destroy, 'lifetime' => $lifetime]);
+
+        return $this->wrappedStorage->start();
+    }
+
+    /**
+     * Force the session to be saved and closed.
+     *
+     * This method must invoke session_write_close() unless this interface is
+     * used for a storage object design for unit or functional testing where
+     * a real PHP session would interfere with testing, in which case
+     * it should actually persist the session data if required.
+     *
+     * @throws \RuntimeException if the session is saved without being started, or if the session
+     *                           is already closed
+     */
+    public function save()
+    {
+        $this->logDebug('Session saving');
+        return $this->wrappedStorage->save();
+    }
+
+    /**
+     * Clear all session data in memory.
+     */
+    public function clear()
+    {
+        $this->logDebug('Clearing Session.');
+
+        $metadata = $this->getMetadataBag();
+        $lifetime = $metadata->getLifetime();
+        $lastUsed = $metadata->getLastUsed();
+
+        // If the existing session has expired on its own
+        if ($lifetime && time() > $lastUsed + $lifetime) {
+            $this->logInfo('Session expired.');
+        }
+
+        return $this->wrappedStorage->clear();
+    }
+
+    /**
+     * Gets a SessionBagInterface by name.
+     *
+     * @param string $name
+     *
+     * @return SessionBagInterface
+     *
+     * @throws \InvalidArgumentException If the bag does not exist
+     */
+    public function getBag($name)
+    {
+        return $this->wrappedStorage->getBag($name);
+    }
+
+    /**
+     * Registers a SessionBagInterface for use.
+     */
+    public function registerBag(SessionBagInterface $bag)
+    {
+        return $this->wrappedStorage->registerBag($bag);
+    }
+
+    /**
+     * @return MetadataBag
+     */
+    public function getMetadataBag()
+    {
+        return $this->wrappedStorage->getMetadataBag();
+    }
+}

--- a/tests/tests/Logging/Entry/User/LoginAttemptTest.php
+++ b/tests/tests/Logging/Entry/User/LoginAttemptTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Concrete\Tests\Logging\Entry\User;
+
+use Concrete\Core\Logging\Entry\User\LoginAttempt;
+use PHPUnit\Framework\TestCase;
+
+class LoginAttemptTest extends TestCase
+{
+
+    public function testExpectedOutput()
+    {
+        $attempt = new LoginAttempt('foo', '/foobar', ['admin', 'bar'], []);
+
+        $this->assertRegExp('/successful login attempt for .foo./i', (string) $attempt);
+        $this->assertEquals([
+            'groups' => ['admin', 'bar'],
+            'errors' => [],
+            'username' => 'foo',
+            'requestPath' => '/foobar',
+            'successful' => true
+        ], $attempt->getContext());
+    }
+
+    public function testExpectedFailureOutput()
+    {
+        $attempt = new LoginAttempt('foo', '/derp', ['registered', 'baz'], ['Something wasn\'t quite right...']);
+
+        $this->assertRegExp('/failed login attempt for .foo./i', (string) $attempt);
+        $this->assertEquals([
+            'groups' => ['registered', 'baz'],
+            'requestPath' => '/derp',
+            'errors' => ['Something wasn\'t quite right...'],
+            'username' => 'foo',
+            'successful' => false
+        ], $attempt->getContext());
+    }
+
+    public function testSuccessIsBasedOnErrorList()
+    {
+        $attempt = new LoginAttempt('', [], []);
+        $this->assertEquals(true, $attempt->getContext()['successful']);
+
+        $attempt = new LoginAttempt('', '', [], ['']);
+        $this->assertEquals(false, $attempt->getContext()['successful']);
+
+        $attempt = new LoginAttempt('', '', [], ['', '', '']);
+        $this->assertEquals(false, $attempt->getContext()['successful']);
+    }
+
+}

--- a/tests/tests/Logging/Entry/User/LoginAttemptTest.php
+++ b/tests/tests/Logging/Entry/User/LoginAttemptTest.php
@@ -3,9 +3,9 @@
 namespace Concrete\Tests\Logging\Entry\User;
 
 use Concrete\Core\Logging\Entry\User\LoginAttempt;
-use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_TestCase;
 
-class LoginAttemptTest extends TestCase
+class LoginAttemptTest extends PHPUnit_Framework_TestCase
 {
 
     public function testExpectedOutput()

--- a/tests/tests/Logging/Entry/User/LoginAttemptTest.php
+++ b/tests/tests/Logging/Entry/User/LoginAttemptTest.php
@@ -12,7 +12,7 @@ class LoginAttemptTest extends TestCase
     {
         $attempt = new LoginAttempt('foo', '/foobar', ['admin', 'bar'], []);
 
-        $this->assertRegExp('/successful login attempt for .foo./i', (string) $attempt);
+        $this->assertRegExp('/successful login attempt for .foo./i', $attempt->getMessage());
         $this->assertEquals([
             'groups' => ['admin', 'bar'],
             'errors' => [],
@@ -26,7 +26,7 @@ class LoginAttemptTest extends TestCase
     {
         $attempt = new LoginAttempt('foo', '/derp', ['registered', 'baz'], ['Something wasn\'t quite right...']);
 
-        $this->assertRegExp('/failed login attempt for .foo./i', (string) $attempt);
+        $this->assertRegExp('/failed login attempt for .foo./i', $attempt->getMessage());
         $this->assertEquals([
             'groups' => ['registered', 'baz'],
             'requestPath' => '/derp',


### PR DESCRIPTION
This PR:
- Adds a monolog processor that gives the ability to attach `$_SERVER` information to all log entry contexts
- Adds login logging on the authentication channel, both successes and failures
- Wraps the session storage object to log relevant session modifications

I've also added an interface that defines how to delegate the responsibility of building the log message and context to another class. The [LoginAttempt](https://github.com/concrete5/concrete5/compare/develop...KorvinSzanto:feature/comprehensive-logging?expand=1#diff-f0e64195698bbdd3afb0a80bdc22e0d7) class is a good example of this.


--- 

Here's my testing configuration:

```
    'log' => [
        'configuration' => [
            'advanced' => [
                'configuration' => [
                    'handlers' => [
                        'syslog' => [
                            'class' => SyslogHandler::class,
                            'ident' => 'FOO',
                            'level' => LOG_DEBUG,
                        ]
                    ],
                    'processors' => [
                        'serverInfo' => [
                            'class' => ServerInfoProcessor::class,
                            'includeKeys' => ['FCGI_ROLE', 'REMOTE_ADDR']
                    ]
                    ],
                    'loggers' => [
                        Channels::CHANNEL_AUTHENTICATION => [
                            'handlers' => ['syslog'],
                            'processors' => ['serverInfo'],
                            'level' => 'INFO',
                        ],
                        Channels::CHANNEL_SECURITY => [
                            'handlers' => ['syslog'],
                            'processors' => ['serverInfo'],
                            'level' => 'INFO',
                        ]
                    ]
                ],
            ],
        ],
    ],
```