### PR TITLE
Add OIDC id tokens and add consent levels to integrations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5103,37 +5103,37 @@
         },
         {
             "name": "theorchard/monolog-cascade",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theorchard/monolog-cascade.git",
-                "reference": "c40260db7e219dbf5c86dcda24bf245b2666da27"
+                "reference": "5353e00824da0b6073668523b5cdc8e84629f108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theorchard/monolog-cascade/zipball/c40260db7e219dbf5c86dcda24bf245b2666da27",
-                "reference": "c40260db7e219dbf5c86dcda24bf245b2666da27",
+                "url": "https://api.github.com/repos/theorchard/monolog-cascade/zipball/5353e00824da0b6073668523b5cdc8e84629f108",
+                "reference": "5353e00824da0b6073668523b5cdc8e84629f108",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "~1.13",
-                "php": ">=5.3.9",
-                "symfony/config": "~2.7|~3.0",
-                "symfony/options-resolver": "~2.7|~3.0",
-                "symfony/serializer": "~2.7|~3.0",
-                "symfony/yaml": "~2.7|~3.0"
+                "monolog/monolog": "^1.13",
+                "php": "^5.3.9 || ^7.0",
+                "symfony/config": "^2.7 || ^3.0 || ^4.0",
+                "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
+                "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
+                "symfony/yaml": "^2.7 || ^3.0 || ^4.0"
             },
             "require-dev": {
-                "mikey179/vfsstream": "~1.6",
-                "phpunit/phpcov": "~2.0",
-                "phpunit/phpunit": "~4.8",
-                "satooshi/php-coveralls": "~1.0",
-                "squizlabs/php_codesniffer": "~2.5"
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpcov": "^2.0",
+                "phpunit/phpunit": "^4.8",
+                "satooshi/php-coveralls": "^1.0",
+                "squizlabs/php_codesniffer": "^2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.4.x-dev"
+                    "dev-master": "0.5.x-dev"
                 }
             },
             "autoload": {
@@ -5163,7 +5163,7 @@
                 "monolog plugin",
                 "monolog utils"
             ],
-            "time": "2017-08-18T13:37:57+00:00"
+            "time": "2019-01-10T20:41:57+00:00"
         },
         {
             "name": "true/punycode",
@@ -6683,6 +6683,7 @@
                 "testing",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-02T14:39:14+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -991,12 +991,12 @@
             "version": "v2.5.14",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/doctrine2.git",
+                "url": "https://github.com/doctrine/orm.git",
                 "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
                 "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754",
                 "shasum": ""
             },
@@ -1126,16 +1126,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.2.1",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "e79cd403fb77fc8963a99ecc30e80ddd885b3311"
+                "reference": "bc0fd11bc455cc20ee4b5edabc63ebbf859324c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/e79cd403fb77fc8963a99ecc30e80ddd885b3311",
-                "reference": "e79cd403fb77fc8963a99ecc30e80ddd885b3311",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/bc0fd11bc455cc20ee4b5edabc63ebbf859324c7",
+                "reference": "bc0fd11bc455cc20ee4b5edabc63ebbf859324c7",
                 "shasum": ""
             },
             "require": {
@@ -1183,7 +1183,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2018-06-30T13:14:06+00:00"
+            "time": "2018-10-23T09:00:00+00:00"
         },
         {
             "name": "frankkessler/guzzle-oauth2-middleware",
@@ -1282,16 +1282,16 @@
         },
         {
             "name": "gettext/languages",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/cldr-to-gettext-plural-rules.git",
-                "reference": "1b74377bd0c4cd87e8d72b948f5d8867e23505a5"
+                "reference": "78db2d17933f0765a102f368a6663f057162ddbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/cldr-to-gettext-plural-rules/zipball/1b74377bd0c4cd87e8d72b948f5d8867e23505a5",
-                "reference": "1b74377bd0c4cd87e8d72b948f5d8867e23505a5",
+                "url": "https://api.github.com/repos/mlocati/cldr-to-gettext-plural-rules/zipball/78db2d17933f0765a102f368a6663f057162ddbd",
+                "reference": "78db2d17933f0765a102f368a6663f057162ddbd",
                 "shasum": ""
             },
             "require": {
@@ -1339,7 +1339,7 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2018-06-21T15:58:36+00:00"
+            "time": "2018-11-13T22:06:07+00:00"
         },
         {
             "name": "guzzlehttp/command",
@@ -1572,32 +1572,33 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1627,13 +1628,14 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "hautelook/phpass",
@@ -1963,16 +1965,16 @@
         },
         {
             "name": "imagine/imagine",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "05c37ac994e620646b376633c14e6377c35e3399"
+                "reference": "6a84addad63baeda0a25079580a2e369a36ceb29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/05c37ac994e620646b376633c14e6377c35e3399",
-                "reference": "05c37ac994e620646b376633c14e6377c35e3399",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/6a84addad63baeda0a25079580a2e369a36ceb29",
+                "reference": "6a84addad63baeda0a25079580a2e369a36ceb29",
                 "shasum": ""
             },
             "require": {
@@ -1980,7 +1982,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "2.2.*",
-                "symfony/phpunit-bridge": "^3.2 || ^4.0"
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.4"
             },
             "suggest": {
                 "ext-gd": "to use the GD implementation",
@@ -2017,7 +2019,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2018-10-25T06:45:38+00:00"
+            "time": "2018-12-07T16:51:20+00:00"
         },
         {
             "name": "indigophp/hash-compat",
@@ -2072,16 +2074,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.2.4",
+            "version": "3.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "c9704b751315d21735dc98d78d4f37bd73596da7"
+                "reference": "82be04b4753f8b7693b62852b7eab30f97524f9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/c9704b751315d21735dc98d78d4f37bd73596da7",
-                "reference": "c9704b751315d21735dc98d78d4f37bd73596da7",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/82be04b4753f8b7693b62852b7eab30f97524f9b",
+                "reference": "82be04b4753f8b7693b62852b7eab30f97524f9b",
                 "shasum": ""
             },
             "require": {
@@ -2118,7 +2120,7 @@
                 {
                     "name": "Luís Otávio Cobucci Oblonczyk",
                     "email": "lcobucci@gmail.com",
-                    "role": "Developer"
+                    "role": "developer"
                 }
             ],
             "description": "A simple library to work with JSON Web Token and JSON Web Signature",
@@ -2126,7 +2128,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2018-08-03T11:23:50+00:00"
+            "time": "2018-11-11T12:22:26+00:00"
         },
         {
             "name": "league/csv",
@@ -2187,16 +2189,16 @@
         },
         {
             "name": "league/event",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/event.git",
-                "reference": "e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd"
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/event/zipball/e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd",
-                "reference": "e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
                 "shasum": ""
             },
             "require": {
@@ -2204,7 +2206,7 @@
             },
             "require-dev": {
                 "henrikbjorn/phpspec-code-coverage": "~1.0.1",
-                "phpspec/phpspec": "~2.0.0"
+                "phpspec/phpspec": "^2.2"
             },
             "type": "library",
             "extra": {
@@ -2233,20 +2235,20 @@
                 "event",
                 "listener"
             ],
-            "time": "2015-05-21T12:24:47+00:00"
+            "time": "2018-11-26T11:52:41+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.48",
+            "version": "1.0.49",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa"
+                "reference": "a63cc83d8a931b271be45148fa39ba7156782ffd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
-                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a63cc83d8a931b271be45148fa39ba7156782ffd",
+                "reference": "a63cc83d8a931b271be45148fa39ba7156782ffd",
                 "shasum": ""
             },
             "require": {
@@ -2317,7 +2319,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-10-15T13:53:10+00:00"
+            "time": "2018-11-23T23:41:29+00:00"
         },
         {
             "name": "league/flysystem-cached-adapter",
@@ -2506,6 +2508,51 @@
                 "server"
             ],
             "time": "2017-11-29T21:47:00+00:00"
+        },
+        {
+            "name": "league/openid-connect-claims",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/openid-connect-claims.git",
+                "reference": "94c25fafdb36d1ee462dc1e74f95709943c1d363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/openid-connect-claims/zipball/94c25fafdb36d1ee462dc1e74f95709943c1d363",
+                "reference": "94c25fafdb36d1ee462dc1e74f95709943c1d363",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OpenIdConnectClaims\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com"
+                }
+            ],
+            "description": "An OpenID Connect ID claims set implementation",
+            "homepage": "https://github.com/thephpleague/openid-connect-claims",
+            "keywords": [
+                "OpenID Connect",
+                "OpenId",
+                "auth",
+                "claim",
+                "jwt",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2"
+            ],
+            "time": "2016-05-26T14:29:18+00:00"
         },
         {
             "name": "league/url",
@@ -2888,16 +2935,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.23.0",
+            "version": "1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
-                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +3009,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19T01:22:40+00:00"
+            "time": "2018-11-05T09:00:11+00:00"
         },
         {
             "name": "natxet/CssMin",
@@ -3013,16 +3060,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.34.0",
+            "version": "1.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33"
+                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33",
-                "reference": "1dbd3cb01c5645f3e7deda7aa46ef780d95fcc33",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
+                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
                 "shasum": ""
             },
             "require": {
@@ -3030,8 +3077,11 @@
                 "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7"
+            },
+            "suggest": {
+                "friendsofphp/php-cs-fixer": "Needed for the `composer phpcs` command. Allow to automatically fix code style.",
+                "phpstan/phpstan": "Needed for the `composer phpstan` command. Allow to detect potential errors."
             },
             "type": "library",
             "extra": {
@@ -3064,7 +3114,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-09-20T19:36:25+00:00"
+            "time": "2018-12-28T10:07:33+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -3200,16 +3250,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.17",
+            "version": "v2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
                 "shasum": ""
             },
             "require": {
@@ -3245,7 +3295,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-04T16:31:37+00:00"
+            "time": "2019-01-03T20:59:08+00:00"
         },
         {
             "name": "patchwork/utf8",
@@ -3308,16 +3358,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.11",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "7053f06f91b3de78e143d430e55a8f7889efc08b"
+                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7053f06f91b3de78e143d430e55a8f7889efc08b",
-                "reference": "7053f06f91b3de78e143d430e55a8f7889efc08b",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/42603ce3f42a27f7e14e54feab95db7b680ad473",
+                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473",
                 "shasum": ""
             },
             "require": {
@@ -3396,7 +3446,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2018-04-15T16:55:05+00:00"
+            "time": "2018-12-16T17:45:25+00:00"
         },
         {
             "name": "primal/color",
@@ -3594,16 +3644,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -3637,20 +3687,20 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "punic/punic",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/punic/punic.git",
-                "reference": "d31ec0bec7bad65105876812cc5b0106ae095e34"
+                "reference": "db3b99397e7ede380eb8b27b08d7f7a95d85d7db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/punic/punic/zipball/d31ec0bec7bad65105876812cc5b0106ae095e34",
-                "reference": "d31ec0bec7bad65105876812cc5b0106ae095e34",
+                "url": "https://api.github.com/repos/punic/punic/zipball/db3b99397e7ede380eb8b27b08d7f7a95d85d7db",
+                "reference": "db3b99397e7ede380eb8b27b08d7f7a95d85d7db",
                 "shasum": ""
             },
             "require": {
@@ -3711,7 +3761,47 @@
                 "translations",
                 "unicode"
             ],
-            "time": "2018-11-23T10:02:50+00:00"
+            "time": "2018-12-07T16:55:52+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "sunra/php-simple-html-dom-parser",
@@ -3775,16 +3865,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "f31333bdff54c7595f834d510a6d2325573ddb36"
+                "reference": "4513348012c25148f8cbc3a7761a1d1e60ca3e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/f31333bdff54c7595f834d510a6d2325573ddb36",
-                "reference": "f31333bdff54c7595f834d510a6d2325573ddb36",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/4513348012c25148f8cbc3a7761a1d1e60ca3e87",
+                "reference": "4513348012c25148f8cbc3a7761a1d1e60ca3e87",
                 "shasum": ""
             },
             "require": {
@@ -3827,7 +3917,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/config",
@@ -3891,16 +3981,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
-                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a700b874d3692bc8342199adfb6d3b99f62cc61a",
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a",
                 "shasum": ""
             },
             "require": {
@@ -3956,20 +4046,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-01-04T04:42:43+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6"
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
-                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
                 "shasum": ""
             },
             "require": {
@@ -4012,20 +4102,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b2e1f19280c09a42dc64c0b72b80fe44dd6e88fb"
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b2e1f19280c09a42dc64c0b72b80fe44dd6e88fb",
-                "reference": "b2e1f19280c09a42dc64c0b72b80fe44dd6e88fb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
+                "reference": "d1cdd46c53c264a2bd42505bd0e8ce21423bd0e2",
                 "shasum": ""
             },
             "require": {
@@ -4075,20 +4165,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:06:28+00:00"
+            "time": "2019-01-01T18:08:36+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d69930fc337d767607267d57c20a7403d0a822a4"
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d69930fc337d767607267d57c20a7403d0a822a4",
-                "reference": "d69930fc337d767607267d57c20a7403d0a822a4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
                 "shasum": ""
             },
             "require": {
@@ -4125,7 +4215,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4178,16 +4268,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "3a4498236ade473c52b92d509303e5fd1b211ab1"
+                "reference": "2b97319e68816d2120eee7f13f4b76da12e04d03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3a4498236ade473c52b92d509303e5fd1b211ab1",
-                "reference": "3a4498236ade473c52b92d509303e5fd1b211ab1",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/2b97319e68816d2120eee7f13f4b76da12e04d03",
+                "reference": "2b97319e68816d2120eee7f13f4b76da12e04d03",
                 "shasum": ""
             },
             "require": {
@@ -4228,20 +4318,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T08:48:18+00:00"
+            "time": "2019-01-05T08:05:37+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "a0944a9a1d8845da724236cde9a310964acadb1c"
+                "reference": "60bd9d7444ca436e131c347d78ec039dd99a34b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a0944a9a1d8845da724236cde9a310964acadb1c",
-                "reference": "a0944a9a1d8845da724236cde9a310964acadb1c",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/60bd9d7444ca436e131c347d78ec039dd99a34b4",
+                "reference": "60bd9d7444ca436e131c347d78ec039dd99a34b4",
                 "shasum": ""
             },
             "require": {
@@ -4317,20 +4407,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T12:03:34+00:00"
+            "time": "2019-01-06T15:53:59+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "1cf7d8e704a9cc4164c92e430f2dfa3e6983661d"
+                "reference": "8a10e36ffd04c0c551051594952304d34ecece71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/1cf7d8e704a9cc4164c92e430f2dfa3e6983661d",
-                "reference": "1cf7d8e704a9cc4164c92e430f2dfa3e6983661d",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/8a10e36ffd04c0c551051594952304d34ecece71",
+                "reference": "8a10e36ffd04c0c551051594952304d34ecece71",
                 "shasum": ""
             },
             "require": {
@@ -4371,11 +4461,11 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-09-17T17:29:18+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4433,16 +4523,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -4488,20 +4578,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934"
+                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
                 "shasum": ""
             },
             "require": {
@@ -4547,7 +4637,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T06:26:08+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -4612,16 +4702,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "585f6e2d740393d546978769dd56e496a6233e0b"
+                "reference": "445d3629a26930158347a50d1a5f2456c49e0ae6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/585f6e2d740393d546978769dd56e496a6233e0b",
-                "reference": "585f6e2d740393d546978769dd56e496a6233e0b",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/445d3629a26930158347a50d1a5f2456c49e0ae6",
+                "reference": "445d3629a26930158347a50d1a5f2456c49e0ae6",
                 "shasum": ""
             },
             "require": {
@@ -4685,20 +4775,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "8bc00ef47a428bfebc4641f29d158e7c56137fcb"
+                "reference": "3bb84f8a785bf30be3d4aef6f3c80f103acc54df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/8bc00ef47a428bfebc4641f29d158e7c56137fcb",
-                "reference": "8bc00ef47a428bfebc4641f29d158e7c56137fcb",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/3bb84f8a785bf30be3d4aef6f3c80f103acc54df",
+                "reference": "3bb84f8a785bf30be3d4aef6f3c80f103acc54df",
                 "shasum": ""
             },
             "require": {
@@ -4764,20 +4854,20 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:28:39+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "94bc3a79008e6640defedf5e14eb3b4f20048352"
+                "reference": "5f357063f4907cef47e5cf82fa3187fbfb700456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/94bc3a79008e6640defedf5e14eb3b4f20048352",
-                "reference": "94bc3a79008e6640defedf5e14eb3b4f20048352",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/5f357063f4907cef47e5cf82fa3187fbfb700456",
+                "reference": "5f357063f4907cef47e5cf82fa3187fbfb700456",
                 "shasum": ""
             },
             "require": {
@@ -4832,20 +4922,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.17",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f"
+                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/640b6c27fed4066d64b64d5903a86043f4a4de7f",
-                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
+                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
                 "shasum": ""
             },
             "require": {
@@ -4891,7 +4981,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:33:53+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -6268,16 +6358,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.9",
+            "version": "0.9.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
+                "reference": "4876fc0c7d9e5da49712554a35c94d84ed1e9ee5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/4876fc0c7d9e5da49712554a35c94d84ed1e9ee5",
+                "reference": "4876fc0c7d9e5da49712554a35c94d84ed1e9ee5",
                 "shasum": ""
             },
             "require": {
@@ -6329,7 +6419,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-28T12:52:32+00:00"
+            "time": "2018-11-13T20:50:16+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7355,16 +7445,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -7429,24 +7519,25 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -7479,7 +7570,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/concrete/authentication/external_concrete5/controller.php
+++ b/concrete/authentication/external_concrete5/controller.php
@@ -8,6 +8,7 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\User\Group\GroupList;
 use Concrete\Core\User\User;
+use InvalidArgumentException;
 use League\Url\Url;
 
 class Controller extends GenericOauth2TypeController
@@ -106,13 +107,19 @@ class Controller extends GenericOauth2TypeController
                 $url = Url::createFromUrl($passedUrl);
 
                 if (!(string)$url->getScheme() || !(string)$url->getHost()) {
-                    throw new \InvalidArgumentException('No scheme or host provided.');
+                    throw new InvalidArgumentException('No scheme or host provided.');
                 }
 
             } catch (\Exception $e) {
-                throw new \InvalidArgumentException('Invalid URL.');
+                throw new InvalidArgumentException('Invalid URL.');
             }
         }
+
+        $passedName = trim($args['displayName']);
+        if (!$passedName) {
+            throw new InvalidArgumentException('Invalid display name');
+        }
+        $this->authenticationType->setAuthenticationTypeName($passedName);
 
         $config = $this->app->make(Repository::class);
         $config->save('auth.external_concrete5.url', $args['url']);

--- a/concrete/authentication/external_concrete5/type_form.php
+++ b/concrete/authentication/external_concrete5/type_form.php
@@ -4,6 +4,10 @@
 </div>
 
 <div class='form-group'>
+    <?=$form->label('displayName', t('Authentication Type Display Name'))?>
+    <?=$form->text('displayName', $this->getAuthenticationTypeDisplayName())?>
+</div>
+<div class='form-group'>
     <?=$form->label('url', t('External concrete5 URL'))?>
     <?=$form->text('url', $data['url'])?>
 </div>
@@ -23,7 +27,7 @@
 <div class='form-group'>
     <div class="input-group">
         <label type="checkbox">
-            <input type="checkbox" name="registration_enabled" value="1" <?= $data['enabled'] ? 'checked' : '' ?>>
+            <input type="checkbox" name="registration_enabled" value="1" <?= array_get($data, 'registration.enabled', false) ? 'checked' : '' ?>>
             <span style="font-weight:normal"><?= t('Allow automatic registration') ?></span>
         </label>
       </span>
@@ -38,7 +42,7 @@
         foreach ($groups as $group) {
             ?>
             <option value="<?= $group->getGroupID() ?>" <?= intval($group->getGroupID(), 10) === intval(
-                $data['group'],
+                array_get($data, 'registration.group'),
                 10) ? 'selected' : '' ?>>
                 <?= $group->getGroupDisplayName(false) ?>
             </option>

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -81,6 +81,7 @@
     "league/csv": "~8.2",
     "symfony/console": "^3.2",
     "league/oauth2-server": "^5.1.4",
+    "steverhoades/oauth2-openid-connect-server":  "^1.1",
     "indigophp/hash-compat": "^1.1",
     "phpseclib/phpseclib": "^2.0",
     "symfony/psr-http-message-bridge": "^1.0",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -81,6 +81,7 @@
     "league/csv": "~8.2",
     "symfony/console": "^3.2",
     "league/oauth2-server": "^5.1.4",
+    "league/openid-connect-claims": "^1.1.0",
     "indigophp/hash-compat": "^1.1",
     "phpseclib/phpseclib": "^2.0",
     "symfony/psr-http-message-bridge": "^1.0",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -81,7 +81,6 @@
     "league/csv": "~8.2",
     "symfony/console": "^3.2",
     "league/oauth2-server": "^5.1.4",
-    "steverhoades/oauth2-openid-connect-server":  "^1.1",
     "indigophp/hash-compat": "^1.1",
     "phpseclib/phpseclib": "^2.0",
     "symfony/psr-http-message-bridge": "^1.0",

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1179,6 +1179,9 @@ return [
             'system',
             'site',
             'account',
+
+            // For OIDC authentication
+            'openid',
         ],
     ],
 

--- a/concrete/single_pages/dashboard/system/api/integrations/edit.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/edit.php
@@ -1,8 +1,12 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-<?php
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Entity\OAuth\Client;
 /**
  * @var \Concrete\Core\Entity\OAuth\Client $client
  */
+
+// Get the consent type from the client
+$consentType = $client->getConsentType();
 ?>
 
 <form method="post" class="ccm-dashboard-content-form" action="<?=$view->action('update', $client->getIdentifier())?>">
@@ -24,6 +28,28 @@
                 <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
             </div>
         </div>
+
+        <div class="form-group">
+            <label class="control-label"><?=t('User Consent Level')?></label>
+            <div class="checkbox">
+                <div class="form-check">
+                    <label class="radio">
+                        <input type="radio" name="consentType" value="<?= Client::CONSENT_SIMPLE ?>" <?= $consentType === Client::CONSENT_SIMPLE ? 'checked' : '' ?> />
+                        <?= t('Standard') ?>
+                    </label>
+                </div>
+                <div class="form-check">
+                    <label class="radio">
+                        <input type="radio" name="consentType" value="<?= Client::CONSENT_NONE ?>" <?= $consentType === Client::CONSENT_NONE ? 'checked' : '' ?> />
+                        <?= t('None') ?>
+                    </label>
+                </div>
+            </div>
+
+            <div class="consent-warning alert alert-danger <?= $consentType !== Client::CONSENT_NONE ? 'hidden' : '' ?>" >
+                <?= t("Only disable user consent if you trust this integration fully. By disabling user consent, you remove the user's ability to deny access.") ?>
+            </div>
+        </div>
     </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
@@ -34,3 +60,17 @@
     </div>
 
 </form>
+
+<script>
+    (function() {
+        var consentWarning = $('.consent-warning').removeClass('hidden').hide()
+
+        $('[name="consentType"]').change(function() {
+            if ($(this).val() === "<?= Client::CONSENT_NONE ?>") {
+                consentWarning.fadeIn()
+            } else {
+                consentWarning.fadeOut()
+            }
+        })
+    }())
+</script>

--- a/concrete/single_pages/dashboard/system/api/integrations/view_client.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/view_client.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Entity\OAuth\Client; ?>
 <?php
 /**
  * @var \Concrete\Core\Entity\OAuth\Client $client
@@ -9,6 +11,9 @@ $clientSecret = isset($clientSecret) ? $clientSecret : null;
 if ($clientSecret && !password_verify($clientSecret, $client->getClientSecret())) {
     $clientSecret = null;
 }
+
+// Get the consent type from the cclient
+$consentType = $client->getConsentType();
 ?>
 
 <div class="ccm-dashboard-header-buttons">
@@ -51,6 +56,28 @@ if ($clientSecret && !password_verify($clientSecret, $client->getClientSecret())
         </div>
     </div>
 
+    <div class="form-group">
+        <label class="control-label"><?=t('User Consent Level')?></label>
+        <div class="checkbox">
+            <div class="form-check">
+                <label class="radio">
+                    <input disabled type="radio" name="consentLevel" value="<?= Client::CONSENT_SIMPLE ?>" <?= $consentType === Client::CONSENT_SIMPLE ? 'checked' : '' ?> />
+                    <?= t('Standard') ?>
+                </label>
+            </div>
+            <div class="form-check">
+                <label class="radio">
+                    <input disabled type="radio" name="consentLevel" value="<?= Client::CONSENT_NONE ?>" <?= $consentType === Client::CONSENT_NONE ? 'checked' : '' ?> />
+                    <?= t('None') ?>
+                </label>
+            </div>
+        </div>
+
+        <div class="consent-warning alert alert-danger <?= $consentType !== Client::CONSENT_NONE ? 'hidden' : '' ?>" >
+            <?= t("Only disable user consent if you trust this integration fully. By disabling user consent, you remove the user's ability to deny access.") ?>
+        </div>
+    </div>
+
 </fieldset>
 
 <div style="display: none">
@@ -66,4 +93,3 @@ if ($clientSecret && !password_verify($clientSecret, $client->getClientSecret())
         </form>
     </div>
 </div>
-

--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Api;
 
+use Concrete\Core\Api\OAuth\Server\IdTokenResponse;
 use Concrete\Core\Api\OAuth\Validator\DefaultValidator;
 use Concrete\Core\Entity\OAuth\AccessToken;
 use Concrete\Core\Entity\OAuth\AuthCode;
@@ -22,8 +23,10 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use phpseclib\Crypt\RSA;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
+use Zend\Http\Header\Authorization;
 
 class ApiServiceProvider extends ServiceProvider
 {
@@ -130,6 +133,10 @@ class ApiServiceProvider extends ServiceProvider
         // AuthorizationServer on the other hand deals with authorizing a session with a username and password and key and secret
         $this->app->when(AuthorizationServer::class)->needs('$privateKey')->give($this->getKey(self::KEY_PRIVATE));
         $this->app->when(AuthorizationServer::class)->needs('$publicKey')->give($this->getKey(self::KEY_PUBLIC));
+        $this->app->when(AuthorizationServer::class)->needs(ResponseTypeInterface::class)->give(function() {
+            return $this->app->make(IdTokenResponse::class);
+        });
+
         $this->app->extend(AuthorizationServer::class, function (AuthorizationServer $server) {
             $server->setEncryptionKey($this->app->make('config/database')->get('concrete.security.token.encryption'));
 

--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -250,7 +250,7 @@ final class Controller
     /**
      * Prune old authentication tokens
      */
-    public function pruneTokens()
+    private function pruneTokens()
     {
         $now = new \DateTime('now');
         // Delete access tokens that have no refresh token associated

--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -10,6 +10,7 @@ use Concrete\Core\Entity\OAuth\RefreshToken;
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Entity\User\User;
 use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\User\User as UserObject;
 use Concrete\Core\Validation\CSRF\Token;
 use Concrete\Core\View\View;
 use Doctrine\ORM\EntityManagerInterface;
@@ -45,13 +46,17 @@ final class Controller
     /** @var \Concrete\Core\Config\Repository\Repository */
     private $config;
 
+    /** @var \Concrete\Core\User\User The logged in user */
+    private $user;
+
     public function __construct(
         AuthorizationServer $oauthServer,
         EntityManagerInterface $entityManager,
         ServerRequestInterface $request,
         Session $session,
         Token $token,
-        Repository $config
+        Repository $config,
+        UserObject $user = null
     ) {
         $this->oauthServer = $oauthServer;
         $this->entityManager = $entityManager;
@@ -59,6 +64,10 @@ final class Controller
         $this->session = $session;
         $this->token = $token;
         $this->config = $config;
+
+        if ($user && $user->checkLogin()) {
+            $this->user = $user;
+        }
     }
 
     /**
@@ -97,12 +106,31 @@ final class Controller
 
             // Handle login step
             if ($step === self::STEP_LOGIN) {
-                return $this->handleLogin($request);
+                if (!$this->user) {
+                    return $this->handleLogin($request);
+                }
+
+                // We have a fully logged in user, let's just use that
+                $userEntity = $this->entityManager->find(User::class, $this->user->getUserID());
+                $request->setUser($userEntity);
+                $this->storeRequest($request);
+
+                // Update the step
+                $step = $this->determineStep($request);
             }
 
             // Handle authorize step
             if ($step === self::STEP_AUTHORIZE_CLIENT) {
-                return $this->handleAuthorizeClient($request);
+                if ($this->getConsentType($request) !== Client::CONSENT_NONE) {
+                    return $this->handleAuthorizeClient($request);
+                }
+
+                // Otherwise if consent is disabled just mark this request as approved.
+                $request->setAuthorizationApproved(true);
+                $this->storeRequest($request);
+
+                // Update the step
+                $step = $this->determineStep($request);
             }
 
             // We've fallen through all the other steps...
@@ -177,24 +205,28 @@ final class Controller
      * client the access that is being requested.
      *
      * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     *
      * @return \Concrete\Core\Http\Response|\RedirectResponse
+     * @throws \League\OAuth2\Server\Exception\OAuthServerException
      */
     public function handleAuthorizeClient(AuthorizationRequest $request)
     {
         $error = new ErrorList();
+        $client = $request->getClient();
 
         while ($this->request->getMethod() === 'POST') {
 
-            if (!$this->token->validate('oauth_authorize_' . $request->getClient()->getClientKey())) {
+            if (!$this->token->validate('oauth_authorize_' . $client->getClientKey())) {
                 $error->add($this->token->getErrorMessage());
                 break;
             }
 
             $query = $this->request->getParsedBody();
             $authorized = array_get($query, 'authorize_client');
+            $consentType = $this->getConsentType($request);
 
             // User authorized the request
-            if ($authorized) {
+            if ($consentType === Client::CONSENT_NONE || $authorized) {
                 $request->setAuthorizationApproved(true);
                 $this->storeRequest($request);
 
@@ -218,25 +250,85 @@ final class Controller
     /**
      * Prune old authentication tokens
      */
-    private function pruneTokens()
+    public function pruneTokens()
     {
         $now = new \DateTime('now');
+        // Delete access tokens that have no refresh token associated
         $qb = $this->entityManager->createQueryBuilder();
-
-        // Delete all expired refresh tokens
-        $qb->delete(RefreshToken::class, 'token')
+        $items = $qb->select('token')
+            ->from(AccessToken::class, 'token')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
+            ->andWhere($qb->expr()->isNull('token.refreshToken'))
             ->getQuery()->execute([':now' => $now]);
 
-        // Delete all expired access tokens
-        $qb->delete(AccessToken::class, 'token')
+        $this->pruneResults($items);
+
+        // Delete all expired access tokens that have expired refresh tokens
+        $qb = $this->entityManager->createQueryBuilder();
+        $items = $qb->select('token')
+            ->from(AccessToken::class, 'token')
+            ->leftJoin('token.refreshToken', 'refresh')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
+            ->andWhere($qb->expr()->lt('refresh.expiryDateTime', ':now'))
             ->getQuery()->execute([':now' => $now]);
+
+        $this->pruneResults($items);
 
         // Delete all expired auth codes
+        $qb = $this->entityManager->createQueryBuilder();
         $qb->delete(AuthCode::class, 'token')
             ->where($qb->expr()->lt('token.expiryDateTime', ':now'))
             ->getQuery()->execute([':now' => $now]);
+    }
+
+    /**
+     * Loop over a list of results and prune them
+     *
+     * @param $results
+     */
+    private function pruneResults(/*iterable*/ $results)
+    {
+        $buffer = [];
+        foreach ($results as $item) {
+            $buffer[] = $item;
+
+            if (count($buffer) > 50) {
+                $this->clearTokenBuffer($buffer);
+                $buffer = [];
+            }
+        }
+
+        $this->clearTokenBuffer($buffer);
+    }
+
+    /**
+     * Remove items in a buffer from the entity manager
+     *
+     * @param array $buffer
+     */
+    private function clearTokenBuffer(array $buffer)
+    {
+        foreach ($buffer as $bufferItem) {
+            // Clear out associated access token
+            if ($bufferItem instanceof AccessToken) {
+                $refreshToken = $bufferItem->getRefreshToken();
+                if ($refreshToken) {
+                    $this->entityManager->remove($refreshToken);
+                }
+            }
+
+            // Clear out associated refresh token
+            if ($bufferItem instanceof RefreshToken) {
+                $accessToken = $bufferItem->getAccessToken();
+                if ($accessToken) {
+                    $this->entityManager->remove($accessToken);
+                }
+            }
+
+            $this->entityManager->remove($bufferItem);
+        }
+
+        $this->entityManager->flush();
     }
 
     /**
@@ -256,6 +348,19 @@ final class Controller
         $this->storeRequest($request);
 
         return $request;
+    }
+
+    /**
+     * Get the consent type associated with the current request
+     *
+     * @param \League\OAuth2\Server\RequestTypes\AuthorizationRequest $request
+     *
+     * @return int
+     */
+    private function getConsentType(AuthorizationRequest $request)
+    {
+        $client = $request->getClient();
+        return $client instanceof Client ? $client->getConsentType() : Client::CONSENT_SIMPLE;
     }
 
     /**
@@ -376,10 +481,28 @@ final class Controller
      * Create a new authorize login view with the given data in scope
      *
      * @param array $data
+     *
      * @return \Concrete\Core\View\View
+     *
+     * @throws \League\OAuth2\Server\Exception\OAuthServerException
      */
     private function createLoginView(array $data)
     {
+        // Get the client that we're rendering login for
+        $consentType = $this->getConsentType($this->getAuthorizationRequest());
+
+        switch ($consentType) {
+            case Client::CONSENT_NONE:
+                // Don't set anything if the consent type is "none"
+                break;
+
+            case Client::CONSENT_SIMPLE:
+            default:
+                $data['consentView'] = new View('/oauth/consent/simple');
+                break;
+        }
+
+        // Start building a view:
         $contents = new View('/oauth/authorize');
         $contents->setViewTheme('concrete');
         $contents->setViewTemplate('background_image.php');

--- a/concrete/src/Api/OAuth/Server/ClaimsSetFactory.php
+++ b/concrete/src/Api/OAuth/Server/ClaimsSetFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Concrete\Core\Api\OAuth\Server;
+
+use Concrete\Core\User\UserInfo;
+use League\OpenIdConnectClaims\ClaimsSet;
+
+class ClaimsSetFactory
+{
+
+    public function createFromUserInfo(UserInfo $user)
+    {
+        $set = new ClaimsSet();
+        $set->setIdentifier($user->getUserID());
+        $set->setEmail($user->getUserEmail());
+        $set->setEmailVerified($user->isValidated());
+        $set->setUsername($user->getUserName());
+        $set->setProfileUrl($user->getUserPublicProfileUrl());
+
+        $map = [
+            'setFirstName' => 'first_name',
+            'setLastName' => 'last_name',
+        ];
+
+        // Apply arbitrary attributes
+        foreach ($map as $method => $attribute) {
+            $value =  $user->getAttribute($attribute);
+
+            if ($value) {
+                $set->{$method} = $value;
+            }
+        }
+
+        return $set;
+    }
+
+}

--- a/concrete/src/Api/OAuth/Server/IdTokenResponse.php
+++ b/concrete/src/Api/OAuth/Server/IdTokenResponse.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Concrete\Core\Api\OAuth\Server;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Site\Service;
+use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\UserInfoRepository;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use League\OpenIdConnectClaims\ClaimsSet;
+
+class IdTokenResponse extends BearerTokenResponse
+{
+
+    /**
+     * The site service we use to determine the issuer
+     *
+     * @var \Concrete\Core\Site\Service
+     */
+    protected $site;
+
+    /**
+     * A factory for building claim sets
+     *
+     * @var \Concrete\Core\Api\OAuth\Server\ClaimsSetFactory
+     */
+    protected $claimFactory;
+
+    /**
+     * A repository that we can get the active user from
+     *
+     * @var \Concrete\Core\User\UserInfoRepository
+     */
+    protected $userInfoRepository;
+
+    public function __construct(Service $site, ClaimsSetFactory $claimFactory, UserInfoRepository $userInfoRepository)
+    {
+        $this->site = $site;
+        $this->claimFactory = $claimFactory;
+        $this->userInfoRepository = $userInfoRepository;
+    }
+
+    /**
+     * Get the extra params to include
+     * If this is an OIDC request we include the ID token
+     *
+     * @param \League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken
+     *
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        $params = parent::getExtraParams($accessToken);
+
+        // If this is an OIDC request, pack a new id token into it
+        if ($this->isOidcRequest($accessToken->getScopes())) {
+            $user = $this->userInfoRepository->getByID($accessToken->getUserIdentifier());
+
+            if ($user) {
+                $params['id_token'] = (string) $this->createIdToken($accessToken, $this->claimFactory->createFromUserInfo($user));
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * Create an ID token to include with our response
+     *
+     * @param \League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken
+     * @param \League\OpenIdConnectClaims\ClaimsSet $claims
+     *
+     * @return \Lcobucci\JWT\Token
+     */
+    protected function createIdToken(AccessTokenEntityInterface $accessToken, ClaimsSet $claims)
+    {
+        $issuer = $this->site->getSite();
+
+        // Initialize the builder
+        $builder = (new Builder())
+            ->setAudience($accessToken->getClient()->getIdentifier())
+            ->setIssuer($issuer->getSiteCanonicalURL())
+            ->setIssuedAt(time())
+            ->setNotBefore(time())
+            ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
+            ->setSubject($accessToken->getUserIdentifier());
+
+        // Apply claims
+        foreach ($claims->jsonSerialize() as $key => $claim) {
+            $builder->set($key, $claim);
+        }
+
+        // Return the newly signed token
+        return $builder
+            ->sign(new Sha256(), new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()))
+            ->getToken();
+    }
+
+    /**
+     * Determine if this request is an OIDC requadmin   past. We do this by checking if the "openid" scope is included
+     *
+     * @param \League\OAuth2\Server\Entities\ScopeEntityInterface[] $scopes
+     *
+     * @return bool
+     */
+    protected function isOidcRequest(array $scopes)
+    {
+        foreach ($scopes as $scope) {
+            if ($scope->getIdentifier() === 'openid') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Set the application object.
+     *
+     * @param \Concrete\Core\Application\Application $application
+     */
+    public function setApplication(Application $application)
+    {
+        // TODO: Implement setApplication() method.
+    }
+}

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ExternalConcrete5Service.php
@@ -2,8 +2,6 @@
 
 namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
 
-use Concrete\Core\Entity\OAuth\AccessToken;
-use League\OAuth2\Server\Exception\OAuthServerException;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\OAuth2\Service\AbstractService;
@@ -12,6 +10,9 @@ use OAuth\OAuth2\Token\TokenInterface;
 
 class ExternalConcrete5Service extends AbstractService
 {
+
+    /** @var string Scope for forcing OIDC */
+    const SCOPE_OPENID= 'openid';
 
     /** @var string Scope for system info */
     const SCOPE_SYSTEM = 'system';
@@ -48,6 +49,9 @@ class ExternalConcrete5Service extends AbstractService
         $token->setAccessToken($body['access_token']);
         $token->setRefreshToken($body['refresh_token']);
         $token->setLifetime($body['expires_in']);
+
+        // Store the id_token as an "extra param"
+        $token->setExtraParams(['id_token' => $body['id_token']]);
 
         return $token;
     }

--- a/concrete/src/Authentication/Type/ExternalConcrete5/Extractor.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/Extractor.php
@@ -1,12 +1,19 @@
 <?php
 namespace Concrete\Core\Authentication\Type\ExternalConcrete5;
 
+use Lcobucci\JWT\Claim;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Parsing\Decoder;
 use OAuth\Common\Http\Uri\Uri;
+use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\UserData\Extractor\LazyExtractor;
 
 class Extractor extends LazyExtractor
 {
     const USER_PATH = '/ccm/api/v1/account/info';
+
+    /** @var \Concrete\Core\Authentication\Type\ExternalConcrete5\ExternalConcrete5Service */
+    protected $service;
 
     public function __construct()
     {
@@ -24,6 +31,7 @@ class Extractor extends LazyExtractor
             self::FIELD_USERNAME,
         ];
     }
+
     protected function getNormalizersMap()
     {
         return [
@@ -37,31 +45,92 @@ class Extractor extends LazyExtractor
 
     public function idNormalizer($data)
     {
+        if (isset($data['claims'])) {
+            return $this->claim(array_get($data, 'claims.sub'));
+        }
+
         return isset($data['id']) ? (int) $data['id'] : null;
     }
 
     public function emailNormalizer($data)
     {
+        if (isset($data['claims'])) {
+            return $this->claim(array_get($data, 'claims.email'));
+        }
+
         return array_get($data, 'email', null);
     }
 
     public function firstNameNormalizer($data)
     {
+        if (isset($data['claims'])) {
+            return $this->claim(array_get($data, 'claims.given_name'));
+        }
+
         return array_get($data, 'first_name', null);
     }
 
     public function lastNameNormalizer($data)
     {
+        if (isset($data['claims'])) {
+            return $this->claim(array_get($data, 'claims.family_name'));
+        }
+
         return array_get($data, 'last_name', null);
     }
 
     public function usernameNormalizer($data)
     {
+        if (isset($data['claims'])) {
+            return $this->claim(array_get($data, 'claims.preferred_username'));
+        }
+
         return array_get($data, 'username', null);
     }
 
+    /**
+     * Convert a claim into its raw value
+     *
+     * @param \Lcobucci\JWT\Claim $claim
+     *
+     * @return string
+     */
+    protected function claim(Claim $claim = null)
+    {
+        if (!$claim) {
+            return null;
+        }
+
+        return $claim->getValue();
+    }
+
+    /**
+     * Load the external concrete5 profile, either from id_token or through the API
+     *
+     * @return array
+     *
+     * @throws \OAuth\Common\Exception\Exception
+     * @throws \OAuth\Common\Storage\Exception\TokenNotFoundException
+     * @throws \OAuth\Common\Token\Exception\ExpiredTokenException
+     */
     public function profileLoader()
     {
-        return json_decode($this->service->request(self::USER_PATH), true)['data'];
+        $idTokenString = null;
+        $token = $this->service->getStorage()->retrieveAccessToken($this->service->service());
+        if ($token instanceof StdOAuth2Token) {
+            $idTokenString = array_get($token->getExtraParams(), 'id_token');
+        }
+
+        // If we don't have a proper ID token, let's just fetch the data from the API
+        if (!$idTokenString) {
+            return json_decode($this->service->request(self::USER_PATH), true)['data'];
+        }
+
+        $decoder = new Parser();
+        $idToken = $decoder->parse($idTokenString);
+
+        return [
+            'claims' => $idToken->getClaims()
+        ];
     }
 }

--- a/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete5/ServiceFactory.php
@@ -84,9 +84,7 @@ class ServiceFactory
 
         // Create the service using the oauth service factory
         return $factory->createService('external_concrete5', $credentials, $storage, [
-            ExternalConcrete5Service::SCOPE_SYSTEM,
-            ExternalConcrete5Service::SCOPE_SITE,
-            ExternalConcrete5Service::SCOPE_ACCOUNT,
+            ExternalConcrete5Service::SCOPE_OPENID,
         ], $baseApiUrl);
     }
 

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -84,6 +84,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             $this->showError(t('Failed authentication: %s', $e->getMessage()));
             exit;
         }
+
         if ($token) {
             if ($this->bindUser($user, $this->getExtractor(true)->getUniqueId())) {
                 $this->showSuccess(t('Successfully attached.'));

--- a/concrete/src/Entity/OAuth/AccessToken.php
+++ b/concrete/src/Entity/OAuth/AccessToken.php
@@ -25,6 +25,13 @@ class AccessToken implements AccessTokenEntityInterface
     protected $identifier;
 
     /**
+     * @var \League\OAuth2\Server\Entities\RefreshTokenEntityInterface
+     * @ORM\OneToOne(targetEntity="RefreshToken", cascade={"remove"})
+     * @ORM\JoinColumn(name="refreshToken", referencedColumnName="identifier")
+     */
+    protected $refreshToken;
+
+    /**
      * @var \DateTime
      * @ORM\Column(type="datetime")
      */
@@ -145,5 +152,21 @@ class AccessToken implements AccessTokenEntityInterface
     public function setClient(ClientEntityInterface $client)
     {
         $this->client = $client;
+    }
+
+    /**
+     * @return \League\OAuth2\Server\Entities\RefreshTokenEntityInterface
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * @param \Concrete\Core\Entity\OAuth\RefreshToken $refreshToken
+     */
+    public function setRefreshToken(RefreshToken $refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
     }
 }

--- a/concrete/src/Entity/OAuth/Client.php
+++ b/concrete/src/Entity/OAuth/Client.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Entity\OAuth;
 
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 
 /**
@@ -14,6 +15,18 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
  */
 class Client implements ClientEntityInterface
 {
+
+    /**
+     * Disable the users ability to allow / deny consent for this client to access details.
+     * This should only be used if a client is fully trusted and owned by this server
+     */
+    const CONSENT_NONE = 0;
+
+    /**
+     * Give the user the option to allow or deny access without changing scopes
+     */
+    const CONSENT_SIMPLE = 1;
+
     /**
      * @ORM\Id @ORM\Column(type="guid")
      * @ORM\GeneratedValue(strategy="UUID")
@@ -43,6 +56,14 @@ class Client implements ClientEntityInterface
      * @ORM\Column(type="string")
      */
     protected $clientSecret;
+
+    /**
+     * The type of consent this client must get from the user
+     *
+     * @var int
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     */
+    protected $consentType = self::CONSENT_SIMPLE;
 
     /**
      * {@inheritdoc}
@@ -134,5 +155,30 @@ class Client implements ClientEntityInterface
     public function setRedirectUri($redirectUri)
     {
         $this->redirectUri = $redirectUri;
+    }
+
+    /**
+     * Get the consent type required by this client
+     *
+     * @return int Client::CONSENT_SIMPLE | Client::CONSENT_NONE
+     */
+    public function getConsentType()
+    {
+        return $this->consentType;
+    }
+
+    /**
+     * Set the level of consent this client must receive from the authenticating user
+     *
+     * @param int $consentType Client::CONSENT_SIMPLE | Client::CONSENT_NONE
+     */
+    public function setConsentType($consentType)
+    {
+        if ($consentType !== self::CONSENT_SIMPLE &&
+            $consentType !== self::CONSENT_NONE) {
+            throw new InvalidArgumentException('Invalid consent type provided.');
+        }
+
+        $this->consentType = $consentType;
     }
 }

--- a/concrete/src/Entity/OAuth/RefreshToken.php
+++ b/concrete/src/Entity/OAuth/RefreshToken.php
@@ -67,6 +67,7 @@ class RefreshToken implements RefreshTokenEntityInterface
      * {@inheritdoc}
      *
      * @see \League\OAuth2\Server\Entities\RefreshTokenEntityInterface::getAccessToken()
+     * @return \Concrete\Core\Entity\OAuth\AccessToken
      */
     public function getAccessToken()
     {

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\OAuth\Scope;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190110194848 extends AbstractMigration
+{
+
+    public function upgradeDatabase()
+    {
+        $em = $this->connection->getEntityManager();
+        $scope = $em->find(Scope::class, 'openid');
+
+        if ($scope) {
+            // Scope already exists
+            return;
+        }
+
+        $scope = new Scope();
+        $scope->setIdentifier('openid');
+        $scope->setDescription('OpenID Connect authentication flow');
+
+        $em->persist($scope);
+        $em->flush();
+        $em->clear(Scope::class);
+    }
+
+    public function downgradeDatabase()
+    {
+        $em = $this->connection->getEntityManager();
+        $scope = $em->find(Scope::class, 'openid');
+
+        if ($scope) {
+            $em->remove($scope);
+        }
+    }
+
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
-use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
  * Install OIDC scope

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110194848.php
@@ -6,9 +6,9 @@ use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Install OIDC scope
  */
-class Version20190110194848 extends AbstractMigration
+class Version20190110194848 extends AbstractMigration implements RepeatableMigrationInterface
 {
 
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 
 use Concrete\Core\Entity\OAuth\Client;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
  * Update all oauth2 clients to have a consent type of CONSENT_SIMPLE

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
@@ -8,7 +8,7 @@ use Concrete\Core\Updater\Migrations\AbstractMigration;
 /**
  * Update all oauth2 clients to have a consent type of CONSENT_SIMPLE
  */
-class Version20190110231015 extends AbstractMigration
+class Version20190110231015 extends AbstractMigration implements RepeatableMigrationInterface
 {
 
     public function upgradeDatabase()

--- a/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190110231015.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\OAuth\Client;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+
+/**
+ * Update all oauth2 clients to have a consent type of CONSENT_SIMPLE
+ */
+class Version20190110231015 extends AbstractMigration
+{
+
+    public function upgradeDatabase()
+    {
+        // Add the "consentType" field
+        $this->refreshEntities([Client::class]);
+
+        // Update the consent type for all existing clients
+        $entityManager = $this->connection->createEntityManager();
+
+        // Set all clients to use simple consent
+        $qb = $entityManager->createQueryBuilder();
+        $qb->update(Client::class, 'c')
+            ->set('c.consentType', Client::CONSENT_SIMPLE)
+            ->getQuery()->execute();
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\OAuth\Scope;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+
+/**
+ * Update scope descriptions
+ */
+class Version20190111181236 extends AbstractMigration
+{
+
+    private function getScopeDescription($key)
+    {
+        $map = [
+            'account' => t('General user account information'),
+            'openid' => t('User profile information for authentication'),
+            'site' => t('Site configuration'),
+            'system' => t('System configuration'),
+        ];
+
+        return isset($map[$key]) ? $map[$key] : null;
+    }
+
+    public function upgradeDatabase()
+    {
+        // Update the consent type for all existing clients
+        $entityManager = $this->connection->createEntityManager();
+
+        $scopeRepository = $entityManager->getRepository(Scope::class);
+        $scopes = $scopeRepository->findAll();
+
+        /** @var Scope $scope */
+        foreach ($scopes as $scope) {
+            $newDescription = $this->getScopeDescription($scope->getIdentifier());
+            if ($newDescription) {
+                $scope->setDescription($newDescription);
+            }
+        }
+
+        $entityManager->flush();
+
+        // Update all access tokens to be associated with their refresh tokens
+        $tokens = $entityManager->createQueryBuilder()
+            ->select('at,rt')
+            ->from(RefreshToken::class, 'rt')
+            ->join('rt.accessToken', 'at')
+            ->getQuery()->execute();
+
+        $count = 0;
+
+        /** @var RefreshToken $token */
+        foreach ($tokens as $token) {
+            $accessToken = $entityManager->merge($token->getAccessToken());
+
+            if (!$accessToken->getRefreshToken()) {
+                $accessToken->setRefreshToken($token);
+                $count++;
+            }
+
+            if ($count > 50) {
+                $entityManager->flush();
+                $count = 0;
+            }
+        }
+
+        if ($count) {
+            $entityManager->flush();
+        }
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
@@ -8,9 +8,9 @@ use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 
 /**
- * Update scope descriptions
+ * Update scope descriptions and connect access tokens to refresh tokens
  */
-class Version20190111181236 extends AbstractMigration
+class Version20190111181236 extends AbstractMigration implements RepeatableMigrationInterface
 {
 
     private function getScopeDescription($key)

--- a/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
@@ -2,6 +2,8 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
+use Concrete\Core\Entity\OAuth\AccessToken;
+use Concrete\Core\Entity\OAuth\RefreshToken;
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 
@@ -40,6 +42,9 @@ class Version20190111181236 extends AbstractMigration
         }
 
         $entityManager->flush();
+
+        // Refresh the access token entity
+        $this->refreshEntities([AccessToken::class]);
 
         // Update all access tokens to be associated with their refresh tokens
         $tokens = $entityManager->createQueryBuilder()

--- a/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190111181236.php
@@ -6,6 +6,7 @@ use Concrete\Core\Entity\OAuth\AccessToken;
 use Concrete\Core\Entity\OAuth\RefreshToken;
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
 /**
  * Update scope descriptions and connect access tokens to refresh tokens

--- a/concrete/views/oauth/authorize.php
+++ b/concrete/views/oauth/authorize.php
@@ -8,6 +8,7 @@ defined('C5_EXECUTE') or die('Access denied.');
 /* @var \League\OAuth2\Server\RequestTypes\AuthorizationRequest $auth */
 /* @var \Concrete\Core\Http\Request $request */
 /* @var \Concrete\Core\Entity\OAuth\Client $client */
+/* @var \Concrete\Core\View\View $consentView */
 
 $r = ResponseAssetGroup::get();
 $r->requireAsset('javascript', 'underscore');
@@ -41,7 +42,7 @@ $image = (date('Ymd') - 7) . '.jpg';
     </div>
     <div class="col-sm-6 col-sm-offset-3 login-form">
         <div class="row login-row">
-            <div class="controls col-sm-12 col-xs-12">
+            <div class="controls col-sm-12 col-xs-12" style="display:flex; flex-direction: column; overflow: auto">
                 <?php
                 if (!$authorize) {
                     ?>
@@ -50,7 +51,7 @@ $image = (date('Ymd') - 7) . '.jpg';
                 }
                 ?>
 
-                <form method="post" action="<?= $request->getUri() ?>">
+                <form style="display:flex; flex-direction: column; flex: 1" method="post" action="<?= $request->getUri() ?>">
                     <?php
                     if (!$authorize) {
                         ?>
@@ -91,38 +92,9 @@ $image = (date('Ymd') - 7) . '.jpg';
                         } ?>
 
                         <?php
-                    } else {
-                        ?>
-                        <h3 class="scope-title text-center"><strong><?= h($client->getName()) ?></strong></h3>
-                        <h4 class="scope-description text-center">
-                            <?= t('is requesting access to the following scopes') ?>
-                        </h4>
-
-                        <div class="scopes">
-                            <ul>
-                                <?php
-                                foreach ($auth->getScopes() as $scope) {
-                                    ?>
-                                    <li><strong><?= h(ucwords($scope->getIdentifier())) ?></strong>: <?= h($scope->getDescription()) ?></li>
-                                    <?php
-                                }
-                                ?>
-                            </ul>
-                        </div>
-
-                        <?php $token->output('oauth_authorize_' . $client->getClientKey()); ?>
-
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" name="authorize_client" value="1" />
-                                <?= t('Authorize %s', '<strong>' . h($client->getName()) . '</strong>') ?>
-                            </label>
-                        </div>
-
-                        <div class="form-group">
-                            <button class="btn btn-success pull-right"><?= t('Authorize') ?></button>
-                        </div>
-                        <?php
+                    } elseif ($consentView) {
+                        $consentView->addScopeItems($view->getScopeItems());
+                        echo $consentView->render();
                     }
                     ?>
 

--- a/concrete/views/oauth/consent/simple.php
+++ b/concrete/views/oauth/consent/simple.php
@@ -1,0 +1,70 @@
+<?php
+$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+$token = $app->make(\Concrete\Core\Validation\CSRF\Token::class);
+
+$mainScopes = [];
+$additionalScopes = [];
+foreach ($auth->getScopes() as $scope) {
+    if ($scope->getIdentifier() === 'openid') {
+        continue;
+    }
+
+    if (!$scope->getDescription()) {
+        $additionalScopes[] = h($scope->getIdentifier());
+    } else {
+        $mainScopes[] = $scope;
+    }
+}
+?>
+
+<div style="display:flex;flex-direction:column; flex: 1">
+    <div style="flex: 1; flex-shrink: 1; display: flex; flex-direction: column; justify-content: center">
+        <h3 class="scope-title text-center">"<strong><?= h($client->getName()) ?></strong>"</h3>
+        <h4 class="scope-description text-center">
+            <strong><?= t('would like access to your account') ?></strong>
+        </h4>
+
+        <div class="scopes" style="overflow:auto">
+            <?php
+            if ($additionalScopes) {
+                if (count($additionalScopes) > 1) {
+                    $last = array_pop($additionalScopes);
+                    $scopeString = t('%s, and %s', implode(', ', $additionalScopes), $last);
+                } else {
+                    $scopeString = $additionalScopes[0];
+                }
+
+                ?>
+                <p class="text-center"><?= $scopeString ?></p>
+                <?php
+            }
+
+            if ($mainScopes) {
+                ?>
+                <dl class="center" style="border-bottom: solid 1px rgba(255,255,255,0.2)">
+                    <?php
+                    foreach ($mainScopes as $scope) {
+                        ?>
+                        <dd style="border: solid 1px rgba(255,255,255,0.2); border-width: 1px 0 0; padding: 10px">
+                            <i class="fa fa-check-square"></i>
+                            <span style="padding: 0 10px"><?= h($scope->getDescription()) ?></span>
+                        </dd>
+                        <?php
+                    }
+                    ?>
+                </dl>
+                <?php
+            }
+            ?>
+        </div>
+
+        <?php $token->output('oauth_authorize_' . $client->getClientKey()); ?>
+    </div>
+    <div>
+        <div class="form-group">
+            <button class="btn btn-success pull-right" name="authorize_client" value="1" style="margin: 10px 0">
+                <?= t('Authorize') ?>
+            </button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Our oAuth2 server previously only provided authorization for our API server, luckily we had an API endpoint that would give us information about the user's account so we were able to use this for authentication as well. OIDC adds an 'id_token' when the `openid` scope is requested which contains everything we need for authentication so that we don't even need to use the API (other than oauth endpoints) to authenticate anymore.

Also I've put a little more thought into how the scope consent flow should work:
* Instead of showing an arbitrary list of requested scope keywords, let's give all default scopes a description and show that in a list instead (openid is hidden)
* Instead of giving the user a checkbox to allow or deny access, just give them a single button. They can "deny" by not clicking the continue button
* If the integration is 100% trusted (meaning it is not a third party) you can now disable consent entirely and make the oauth flow feel a little more seemless