### PR TITLE
Fix download button in File Manager

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -361,12 +361,7 @@ class File extends Controller
 
     public function download()
     {
-        $fp = FilePermissions::getGlobal();
-        if (!$fp->canSearchFiles()) {
-            throw new UserMessageException(t('Unable to search file sets.'));
-        }
-
-        $files = $this->getRequestFiles('canViewFile');
+        $files = $this->getRequestFiles('canViewFileInFileManager');
         if (count($files) > 1) {
             $fh = $this->app->make('helper/file');
             $vh = $this->app->make('helper/validation/identifier');

--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -1,14 +1,18 @@
 <?php
 namespace Concrete\Core\Http\Client;
 
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerAwareTrait;
 use Zend\Http\Client as ZendClient;
 use Zend\Http\Request as ZendRequest;
 use Zend\Uri\Http as ZendUriHttp;
-use Psr\Log\LoggerAwareInterface;
+use Concrete\Core\Logging\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
 class Client extends ZendClient implements LoggerAwareInterface
 {
+
+    use LoggerAwareTrait;
     /**
      * @var LoggerInterface|null
      */
@@ -22,6 +26,11 @@ class Client extends ZendClient implements LoggerAwareInterface
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    public function getLoggerChannel()
+    {
+        return Channels::CHANNEL_NETWORK;
     }
 
     /**
@@ -56,7 +65,7 @@ class Client extends ZendClient implements LoggerAwareInterface
                 $shortBody = mb_substr($body, 0, 197) . '...';
             }
             $logger->debug(
-                'The response code was {statusCode} and the body was {shortBody}',
+                "The response code was {$statusCode} and the body was {$shortBody}",
                 [
                     'statusCode' => $statusCode,
                     'headers' => $response->getHeaders()->toArray(),
@@ -85,7 +94,7 @@ class Client extends ZendClient implements LoggerAwareInterface
                 $shortBody = mb_substr($body, 0, 197) . '...';
             }
             $logger->debug(
-                'Sending {method} request to {uri} with body {shortBody}',
+                "Sending {$method} request to {$uri} with body {$shortBody}",
                 [
                     'uri' => $uriString,
                     'method' => $method,

--- a/concrete/src/Logging/Channels.php
+++ b/concrete/src/Logging/Channels.php
@@ -79,6 +79,13 @@ class Channels
     const CHANNEL_PERMISSIONS = 'permissions';
 
     /**
+     * Channel identifier: network. Purpose: Log network activity off-site.
+     *
+     * @var string
+     */
+    const CHANNEL_NETWORK = 'network';
+
+    /**
      * Channel identifier: all – Do NOT use this to log to. This is a separate system channel that tells configuration
      * that you want to apply all configuration options to all channels, and listen to all of them.
      *
@@ -102,6 +109,7 @@ class Channels
             self::CHANNEL_PERMISSIONS,
             self::CHANNEL_SPAM,
             self::CHANNEL_SITE_ORGANIZATION,
+            self::CHANNEL_NETWORK,
             self::CHANNEL_USERS,
         ];
     }


### PR DESCRIPTION
Currently the download button when viewing an image in the file manager errors out due to a class that doesn't exist in the controller.

We don't actually need this permissions check – let's just make sure to use the permission check when retrieving the file object. 