### PR TITLE
Fix broken download file button when viewing an image in the file manager

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -361,12 +361,7 @@ class File extends Controller
 
     public function download()
     {
-        $fp = FilePermissions::getGlobal();
-        if (!$fp->canSearchFiles()) {
-            throw new UserMessageException(t('Unable to search file sets.'));
-        }
-
-        $files = $this->getRequestFiles('canViewFile');
+        $files = $this->getRequestFiles('canViewFileInFileManager');
         if (count($files) > 1) {
             $fh = $this->app->make('helper/file');
             $vh = $this->app->make('helper/validation/identifier');


### PR DESCRIPTION
The download button in the View Image dialog in the Dashboard currently throws an error. Let's fix it by removing the deprecated FilePermissions call (which has a missing class) and instead just performing the permissions check in getRequestFiles. 