### PR TITLE
Add missing $btExportPageColumns

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -46,6 +46,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
     protected $btInterfaceHeight = 700;
     protected $btCacheBlockOutput = false;
     protected $btTable = 'btExpressForm';
+    protected $btExportPageColumns = ['redirectCID'];
 
     public $notifyMeOnSubmission;
     public $recipientEmail;

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -17,6 +17,7 @@ class Controller extends BlockController
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 400;
     protected $btTable = 'btTopicList';
+    protected $btExportPageColumns = ['cParentID'];
 
     public function getBlockTypeDescription()
     {


### PR DESCRIPTION
`\Concrete\Core\Multilingual\Page\Section\Processor\ReplaceBlockPageRelationsTask::execute` doesn't affect for topic_list block. I found the reason, `$btExportPageColumns` is missing.

Question: Is it possible to add `internalLinkCID` column in `btImageSliderEntries` table? This value will not replaced too.