### PR TITLE
Set displayCaptcha to true in Express Forms Block

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -117,6 +117,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         $this->set('addFilesToFolder', (new Filesystem())->getRootFolder());
         $this->set('storeFormSubmission', $this->areFormSubmissionsStored());
         $this->set('formSubmissionConfig', $this->getFormSubmissionConfigValue());
+        $this->set('displayCaptcha', 1);
     }
 
     protected function areFormSubmissionsStored()


### PR DESCRIPTION
Manually setting displayCaptcha to true in the controller, so Captcha is sets by default in the Express Forms Block. 