### PR TITLE
Enhancement Autonav block template

### DIFF
--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -48,6 +48,7 @@ class Controller extends BlockController
     protected $btCacheBlockOutputLifetime = 300;
     protected $btWrapperClass = 'ccm-ui';
     protected $btExportPageColumns = array('displayPagesCID');
+    protected $includeParentItem;
 
     public function __construct($obj = null)
     {
@@ -367,7 +368,6 @@ class Controller extends BlockController
                 break;
         }
         $level = 0;
-        $cParentID = 0;
         switch ($this->displayPages) {
             case 'current':
                 $cParentID = $this->cParentID;
@@ -434,8 +434,12 @@ class Controller extends BlockController
 
             $this->getNavigationArray($cParentID, $orderBy, $level);
 
-            // if we're at the top level we add home to the beginning
-            if ($cParentID == Page::getHomePageID($cParentID)) {
+            $shouldIncludeParentItem = $this->shouldIncludeParentItem();
+            if ($shouldIncludeParentItem === null) {
+                // if we're at the top level we add home to the beginning
+                $shouldIncludeParentItem = ($cParentID == Page::getHomePageID($cParentID));
+            }
+            if ($shouldIncludeParentItem) {
                 if ($this->displayUnapproved) {
                     $tc1 = Page::getByID($cParentID, "RECENT");
                 } else {
@@ -802,5 +806,21 @@ class Controller extends BlockController
         ob_end_clean();
 
         return $this->app->make(ResponseFactoryInterface::class)->create($content);
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function shouldIncludeParentItem()
+    {
+        return $this->includeParentItem;
+    }
+
+    /**
+     * @param bool $includeParentItem
+     */
+    public function setIncludeParentItem($includeParentItem)
+    {
+        $this->includeParentItem = $includeParentItem;
     }
 }

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -187,7 +187,7 @@ class Controller extends BlockController
                 if ($cParentID != $this->homePageID) {
                     $selectedPathCIDs[] = $cParentID; //Don't want home page in nav-path-selected
                 }
-                $inspectC = Page::getById($cParentID, 'ACTIVE');
+                $inspectC = Page::getByID($cParentID, 'ACTIVE');
             }
         }
 

--- a/concrete/blocks/autonav/view.php
+++ b/concrete/blocks/autonav/view.php
@@ -117,7 +117,7 @@ if (count($navItems) > 0) {
         if ($ni->hasSubmenu) {
             echo '<ul>'; //opens a dropdown sub-menu
         } else {
-            echo '</li>'; //closes a nav item" onfocus="alert('Stored XSS in SEO Name field')"  autofocus="true"
+            echo '</li>'; //closes a nav item
 
             echo str_repeat('</ul></li>', $ni->subDepth); //closes dropdown sub-menu(s) and their top-level nav item(s)
         }

--- a/concrete/blocks/autonav/view.php
+++ b/concrete/blocks/autonav/view.php
@@ -1,5 +1,23 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
 
+/**
+ * DISPLAY PARENT PAGE OPTION
+ *
+ * If you always want to add a parent page:
+ * $controller->setIncludeParentItem(true);
+ *
+ * If you want never to add a parent page:
+ * $controller->setIncludeParentItem(false);
+ *
+ * By default, the parent page will be added if it is the home page.
+ */
+
+/**
+ * First, let's get navigation items.
+ * If you don't want to exclude any pages, you can ignore "exclude_nav" attribute by passing true.
+ * This option is useful for breadcrumbs navigation.
+ * E.g. $navItems = $controller->getNavItems(true);
+ */
 $navItems = $controller->getNavItems();
 $c = Page::getCurrentPage();
 


### PR DESCRIPTION
By default, Autonav block shows the parent (= home) page if display top-level pages.
Sometimes I did the same thing at 2nd or more level.
Or, sometimes I didn't want to show the home page without set exclude_from_nav attribute.
So I add an option to control whether or not display parent page by this pull request.