### PR TITLE
Revert "Allow custom class loading from the package for a custom perm…

### DIFF
--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -240,7 +240,7 @@ abstract class Key extends ConcreteObject
         $permissionkeys = [];
         $txt = $app->make('helper/text');
         $e = $db->executeQuery(<<<'EOT'
-select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeys.pkgID
+select pkID, pkName, pkDescription, pkHandle, pkCategoryHandle, pkCanTriggerWorkflow, pkHasCustomClass, PermissionKeys.pkCategoryID, PermissionKeyCategories.pkgID
 from PermissionKeys
 inner join PermissionKeyCategories on PermissionKeyCategories.pkCategoryID = PermissionKeys.pkCategoryID
 EOT


### PR DESCRIPTION
…ission key"

This reverts commit 3c08d34c0826a32e300046e68ee30f5e1fe07c87.

This was originally a part of https://github.com/concrete5/concrete5/pull/7472

Unfortunately, this has unintended consequences, and we need a better way of dealing with them. For example, we have custom code that has a custom permission key that's a part of the block permission category. We want this permission key associated with the block category so it shows up at the block level, but we also want it to have its own pkgID so that it can be uninstalled as part of the package. With this pull request applied that permission key breaks. 