### PR TITLE
Make Template::getIcons() static

### DIFF
--- a/concrete/src/Page/Template.php
+++ b/concrete/src/Page/Template.php
@@ -108,7 +108,7 @@ class Template
         return $template;
     }
 
-    public function getIcons()
+    public static function getIcons()
     {
         $f = Core::make('helper/file');
 


### PR DESCRIPTION
It's called statically [here](https://github.com/concrete5/concrete5/blob/0182666c9a818f135d3de006bbaa1f9e3a88458d/concrete/controllers/single_page/dashboard/pages/templates/add.php#L13) and [here](https://github.com/concrete5/concrete5/blob/0182666c9a818f135d3de006bbaa1f9e3a88458d/concrete/controllers/single_page/dashboard/pages/templates.php#L50).