### PR TITLE
Don't define the global JS variable clickedButton when editing blocks

### DIFF
--- a/concrete/elements/block_footer_edit.php
+++ b/concrete/elements/block_footer_edit.php
@@ -30,7 +30,7 @@ else {
         if (!$b->getProxyBlock() && !$supportsInlineEdit) {
             ?>
             <div class="ccm-buttons dialog-buttons">
-                <a href="javascript:clickedButton = true;$('#ccm-form-submit-button').get(0).click()" class="btn pull-right btn-primary"><?= t('Save') ?></a>
+                <a href="javascript:$('#ccm-form-submit-button').get(0).click()" class="btn pull-right btn-primary"><?= t('Save') ?></a>
                 <a style="float:left" href="javascript:void(0)" class="btn btn-default btn-hover-danger" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></a>
             </div>
             <?php


### PR DESCRIPTION
When we click the "Save" button when editing a block, we currently define a global `clickedButton` javascript variable.
But this variable is not used anywhere in the core: what about removing it?

