### PR TITLE
Fix: Express form uploads the same file at twice

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -260,7 +260,11 @@ class Controller extends BlockController implements NotificationProviderInterfac
                     }
                 }
                 if (isset($e) && !$e->has()) {
-                    $submittedAttributeValues = $manager->getEntryAttributeValuesForm($form, $entry);
+                    if ($this->areFormSubmissionsStored() && isset($values)) {
+                        $submittedAttributeValues = $values;
+                    } else {
+                        $submittedAttributeValues = $manager->getEntryAttributeValuesForm($form, $entry);
+                    }
                     $notifier = $controller->getNotifier($this);
                     $notifications = $notifier->getNotificationList();
                     array_walk($notifications->getNotifications(), function ($notification) use ($submittedAttributeValues,$key) {


### PR DESCRIPTION


How to reproduce:

1. Add an express form block(includes a file field with HTML input mode).
2. Select a file from your local then submit the form.
3. Check the file manager. You'll see two files.