### PR TITLE
Fix Urls::getBlockTypeAssetsURL() when the asset is not a JS/CSS asset

### DIFF
--- a/concrete/src/Application/Service/Urls.php
+++ b/concrete/src/Application/Service/Urls.php
@@ -132,8 +132,8 @@ class Urls
                     $repo = $em->getRepository(Package::class);
                     $asset->setPackageObject($repo->findOneBy(['pkgHandle' => $packageHandle]));
                 }
+                $url = $asset->getAssetURL();
             }
-            $url = $asset->getAssetURL();
         }
 
         return $url;


### PR DESCRIPTION
Credits to @hissy 