### PR TITLE
Fix calendar unpublished tooltip

### DIFF
--- a/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
+++ b/concrete/src/Calendar/Event/Formatter/LinkFormatter.php
@@ -62,19 +62,22 @@ class LinkFormatter implements LinkFormatterInterface
         if (!$value) {
             $value = t('(No Title)');
         }
+
+        $value = h($value);
+
         $page = $occurrence->getEvent()->getPageObject();
         $href = 'javascript:void(0)';
         if (!$occurrence->getVersion()->isApproved()) {
             // Output a tooltip with text that makes it clear that there are unpublished changes
             $value .= sprintf(
-                '<i class="fa fa-exclamation-circle z-indexable z-1000" data-toggle="tooltip" data-placement="bottom" title="%s"></i>',
+                '<i class="launch-tooltip fa fa-exclamation-circle z-indexable z-1000" data-toggle="tooltip" data-placement="bottom" title="%s"></i>',
                 t('This event has unpublished versions.')
             );
         }
         $background = $this->getEventOccurrenceBackgroundColor($occurrence);
         $text = $this->getEventOccurrenceTextColor($occurrence);
 
-        $link = new Link($href, h($value));
+        $link = new Link($href, $value);
         $link->setAttribute('style', sprintf('background-color: %s; color: %s', $background, $text));
 
         if ($occurrence->isCancelled()) {


### PR DESCRIPTION
Fix escaped HTML showing in calendar on unpublished versions; make tooltip actually work