### PR TITLE
Fix User Selector when searching/loading new pages

### DIFF
--- a/concrete/views/dialogs/user/search.php
+++ b/concrete/views/dialogs/user/search.php
@@ -16,7 +16,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
     $(function() {
         $('div[data-search=users]').concreteAjaxSearch({
             result: <?=json_encode($result->getJSONObject())?>,
-            onLoad: function (concreteSearch) {
+            onUpdateResults: function (concreteSearch) {
                 concreteSearch.$element.find('select[data-bulk-action=users] option:eq(0)').after('<option value="select_users"><?=t('Choose Users')?></option>');
                 concreteSearch.$element.on('click', 'a[data-user-id]', function () {
                     ConcreteEvent.publish('UserSearchDialogSelectUser', {


### PR DESCRIPTION
Currently when using a userSelector if you search for a user or load a new page and try to use the dropdown to select user(s). The option will disappear.

This PR changes the event from onLoad to onUpdateResults so the choose users option is not lost.

To reproduce on a clean install. 

Go to /dashboard/system/conversations/settings then click on the + icon under ‘Users To Receive Conversation Notifications‘ then search for ‘admin‘ if you click on the checkbox then the drop down. The drop down will be missing the choose users option