### PR TITLE
Make API client have configurable scopes

### DIFF
--- a/concrete/src/API/API.php
+++ b/concrete/src/API/API.php
@@ -78,7 +78,8 @@ class API
             $config = [
                 'client_id' => $this->config['credentials']['client_id'],
                 'client_secret' => $this->config['credentials']['client_secret'],
-                'token_url' => $this->baseUrl . '/oauth/2.0/token'
+                'token_url' => $this->baseUrl . '/oauth/2.0/token',
+                'scope' => $this->config['scope'],
             ];
 
             $token = new ClientCredentials($config);


### PR DESCRIPTION
Now that scopes are requested rather than defined when setting up integrations, let's make it so that the built in API client can have its scopes configured.

In order to configure this one would have to implement `APIProviderInterface`