### PR TITLE
Improve mutex

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -273,11 +273,11 @@ return [
                                 ],
                             ],*/
                             'prefix' => 'c5_overrides',
-                            'database'=>0 // Use different Redis Databases - optional
+                            'database' => 0, // Use different Redis Databases - optional
                         ],
                     ],
                 ],
-                'preferred_driver' => 'core_filesystem'// Use this to specify a preferred driver
+                'preferred_driver' => 'core_filesystem', // Use this to specify a preferred driver
             ],
             'expensive' => [
                 'drivers' => [
@@ -297,11 +297,11 @@ return [
                         'class' => \Concrete\Core\Cache\Driver\RedisStashDriver::class,
                         'options' => [
                             'prefix' => 'c5_expensive',
-                            'database'=>0 // Use different Redis Databases - optional
+                            'database' => 0, // Use different Redis Databases - optional
                         ],
                     ],
                 ],
-                'preferred_driver' => 'core_filesystem'// Use this to specify a preferred driver
+                'preferred_driver' => 'core_filesystem', // Use this to specify a preferred driver
             ],
             'object' => [
                 'drivers' => [
@@ -313,11 +313,11 @@ return [
                         'class' => \Concrete\Core\Cache\Driver\RedisStashDriver::class,
                         'options' => [
                             'prefix' => 'c5_object',
-                            'database'=>0 // Use different Redis Databases - optional
+                            'database' => 0, // Use different Redis Databases - optional
                         ],
                     ],
                 ],
-                'preferred_driver' => 'core_ephemeral'// Use this to specify a preferred driver
+                'preferred_driver' => 'core_ephemeral', // Use this to specify a preferred driver
             ],
         ],
 
@@ -368,13 +368,13 @@ return [
              */
             'mode' => 'simple',
             'simple' => [
-                /**
+                /*
                  * What log level to store core logs in the database
                  * @var string
                  */
                 'core_logging_level' => 'NOTICE',
 
-                /**
+                /*
                  * Which handle to use
                  *
                  * @var string (database|file)
@@ -382,8 +382,7 @@ return [
                 'handler' => 'database',
 
                 'file' => [
-
-                    /**
+                    /*
                      * File path to store logs
                      *
                      * @var string
@@ -393,7 +392,7 @@ return [
             ],
 
             'advanced' => [
-                'configuration' => []
+                'configuration' => [],
             ],
         ],
     ],
@@ -802,7 +801,7 @@ return [
         'name' => 'CONCRETE5',
         'handler' => 'file',
         'redis' => [
-            'database'=>1 // Use different Redis Databases - optional
+            'database' => 1, // Use different Redis Databases - optional
         ],
         'save_path' => null,
         'max_lifetime' => 7200,
@@ -937,7 +936,7 @@ return [
             'authentication_failure' => [
                 'enabled' => false,
                 'amount' => 5, // The number of failures
-                'duration' => 300 // In so many seconds
+                'duration' => 300, // In so many seconds
             ],
             'message' => 'This user is inactive. Please contact us regarding this account.',
         ],
@@ -992,7 +991,7 @@ return [
                 'enabled' => false,
                 // Time window (in seconds) for inactive users to be automatically logout
                 'time' => 300,
-            ]
+            ],
         ],
         'ban' => [
             'ip' => [

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -272,7 +272,7 @@ return [
                                     'ttl' => 10
                                 ],
                             ],*/
-                            'prefix'=>'c5_overrides',
+                            'prefix' => 'c5_overrides',
                             'database'=>0 // Use different Redis Databases - optional
                         ],
                     ],
@@ -296,7 +296,7 @@ return [
                     'redis' => [
                         'class' => \Concrete\Core\Cache\Driver\RedisStashDriver::class,
                         'options' => [
-                            'prefix'=>'c5_expensive',
+                            'prefix' => 'c5_expensive',
                             'database'=>0 // Use different Redis Databases - optional
                         ],
                     ],
@@ -312,7 +312,7 @@ return [
                     'redis' => [
                         'class' => \Concrete\Core\Cache\Driver\RedisStashDriver::class,
                         'options' => [
-                            'prefix'=>'c5_object',
+                            'prefix' => 'c5_object',
                             'database'=>0 // Use different Redis Databases - optional
                         ],
                     ],
@@ -361,7 +361,6 @@ return [
         'enable_dashboard_report' => true,
 
         'configuration' => [
-
             /*
              * Configuration mode
              *
@@ -460,7 +459,6 @@ return [
          * @var string "auto", true or false
          */
         'store_form_submissions' => 'auto',
-
     ],
 
     /*
@@ -1120,5 +1118,16 @@ return [
          * @var bool
          */
         'enabled' => false,
+    ],
+
+    'mutex' => [
+        'semaphore' => [
+            'priority' => 100,
+            'class' => Concrete\Core\System\Mutex\SemaphoreMutex::class,
+        ],
+        'file_lock' => [
+            'priority' => 50,
+            'class' => Concrete\Core\System\Mutex\FileLockMutex::class,
+        ],
     ],
 ];

--- a/concrete/src/System/SystemServiceProvider.php
+++ b/concrete/src/System/SystemServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\System;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\File\Service\File as FileService;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
@@ -11,13 +12,30 @@ class SystemServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(Mutex\MutexInterface::class, function (Application $app) {
-            if (Mutex\SemaphoreMutex::isSupported($app)) {
-                $mutexClass = Mutex\SemaphoreMutex::class;
-            } else {
-                $mutexClass = Mutex\FileLockMutex::class;
+            $config = $app->make('config');
+            $list = $config->get('concrete.mutex') ?: [];
+            $list = array_filter($list, 'is_array');
+            usort($list, function (array $a, array $b) {
+                $priorityA = isset($a['priority']) ? (int) $a['priority'] : 0;
+                $priorityB = isset($b['priority']) ? (int) $b['priority'] : 0;
+                return $priorityB - $priorityA;
+            });
+            foreach ($list as $item) {
+                $class = isset($item['class']) ? (string) $item['class'] : '';
+                if ($class === '') {
+                    continue;
+                }
+                if (!class_exists($class)) {
+                    continue;
+                }
+                if (!$class::isSupported($app)) {
+                    continue;
+                }
+                return $app->make($class);
             }
-
-            return $app->make($mutexClass);
+            $err = new UserMessageException(t("There's no available mutex class."));
+            $err->setCanBeLogged(true);
+            throw $err;
         });
         $this->app
             ->when(Mutex\SemaphoreMutex::class)

--- a/concrete/src/System/SystemServiceProvider.php
+++ b/concrete/src/System/SystemServiceProvider.php
@@ -18,6 +18,7 @@ class SystemServiceProvider extends ServiceProvider
             usort($list, function (array $a, array $b) {
                 $priorityA = isset($a['priority']) ? (int) $a['priority'] : 0;
                 $priorityB = isset($b['priority']) ? (int) $b['priority'] : 0;
+
                 return $priorityB - $priorityA;
             });
             foreach ($list as $item) {
@@ -31,6 +32,7 @@ class SystemServiceProvider extends ServiceProvider
                 if (!$class::isSupported($app)) {
                     continue;
                 }
+
                 return $app->make($class);
             }
             $err = new UserMessageException(t("There's no available mutex class."));

--- a/tests/tests/System/MutexTest.php
+++ b/tests/tests/System/MutexTest.php
@@ -3,11 +3,15 @@
 namespace Concrete\Tests\Update;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Concrete\Core\System\Mutex\FileLockMutex;
 use Concrete\Core\System\Mutex\MutexBusyException;
+use Concrete\Core\System\Mutex\MutexInterface;
 use Concrete\Core\System\Mutex\SemaphoreMutex;
+use Exception;
 use PHPUnit_Framework_TestCase;
+use Throwable;
 
 class MutexTest extends PHPUnit_Framework_TestCase
 {
@@ -89,5 +93,90 @@ class MutexTest extends PHPUnit_Framework_TestCase
             $mutex->release($key2);
             $mutex->release($key1);
         }
+    }
+
+    public function mutexConfigurationProvider()
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+
+        return [
+            [
+                $app,
+                [],
+                UserMessageException::class,
+            ],
+            [
+                $app,
+                [
+                    'semaphore' => [
+                        'priority' => 60,
+                        'class' => SemaphoreMutex::class,
+                    ],
+                ],
+                SemaphoreMutex::isSupported($app) ? SemaphoreMutex::class : UserMessageException::class,
+            ],
+            [
+                $app,
+                [
+                    'file_lock' => [
+                        'priority' => 50,
+                        'class' => FileLockMutex::class,
+                    ],
+                ],
+                FileLockMutex::isSupported($app) ? FileLockMutex::class : UserMessageException::class,
+            ],
+            [
+                $app,
+                [
+                    'semaphore' => [
+                        'priority' => 60,
+                        'class' => SemaphoreMutex::class,
+                    ],
+                    'file_lock' => [
+                        'priority' => 50,
+                        'class' => FileLockMutex::class,
+                    ],
+                ],
+                SemaphoreMutex::isSupported($app) ? SemaphoreMutex::class : (FileLockMutex::isSupported($app) ? FileLockMutex::class : UserMessageException::class),
+            ],
+            [
+                $app,
+                [
+                    'semaphore' => [
+                        'priority' => 50,
+                        'class' => SemaphoreMutex::class,
+                    ],
+                    'file_lock' => [
+                        'priority' => 60,
+                        'class' => FileLockMutex::class,
+                    ],
+                ],
+                FileLockMutex::isSupported($app) ? FileLockMutex::class : (SemaphoreMutex::isSupported($app) ? SemaphoreMutex::class : UserMessageException::class),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mutexConfigurationProvider
+     *
+     * @param \Concrete\Core\Application\Application $app
+     * @param array $mutexConfig
+     * @param string $expectedClassName
+     */
+    public function testMutexConfiguration(Application $app, array $mutexConfig, $expectedClassName)
+    {
+        $config = $app->make('config');
+        $app->forgetInstance(MutexInterface::class);
+        try {
+            $result = null;
+            $config->withKey('concrete.mutex', $mutexConfig, function () use ($app, &$result) {
+                $result = $app->make(MutexInterface::class);
+            });
+        } catch (Exception $x) {
+            $result = $x;
+        } catch (Throwable $x) {
+            $result = $x;
+        }
+        $this->assertInstanceOf($expectedClassName, $result);
     }
 }


### PR DESCRIPTION
We have some reports of users whose installaion/upgrade fails because of this error:

```
 sem_get(): failed for key 0x1234abcd: No space left on device
```

(the `0x1234abcd` part may vary).

This error may occur when PHP is configured to enable semaphores, and concrete5 uses them with the `sem_get()` PHP function.
This `sem_get()` PHP function [calls the `semget()` system function](https://github.com/php/php-src/blob/php-7.3.1/ext/sysvsem/sysvsem.c#L216) which, in case there are no more available semaphores, [returns the `ENOSPC` error identifier](http://man7.org/linux/man-pages/man2/semget.2.html#ERRORS).
The system description of this `ENOSPC` is [`No space left on device`](https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html#index-ENOSPC).
So, a more correct description of this error is *The system ran out of semaphores*.

How concrete5 users can solve this problem?

We have two solutions:

1. they free up some semaphore
    This requires SSH access, some knowledge of the shell commands, or the intervention of a system administrator
2. they configure concrete5 to not use semaphores
    In order to allow this, what about introducing a `concrete.mutex` configuration key?
    That way, users could disable the semaphore-based mutexes simply by creating an `application/config/concrete.php` file with this contents:
    ```php
    <?php
    
    return [
        'mutex' => [
            'semaphore' => false,
        ],
    ];
    ```