### PR TITLE
Use 127.0.0.1 instead of localhost in test DB connection

### DIFF
--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -7,7 +7,7 @@ return [
     'connections' => [
         'travis' => [
             'driver' => 'c5_pdo_mysql',
-            'server' => 'localhost',
+            'server' => '127.0.0.1',
             'database' => 'concrete5_tests',
             'username' => 'travis',
             'password' => '',
@@ -18,7 +18,7 @@ return [
         ],
         'travisWithoutDB' => [
             'driver' => 'c5_pdo_mysql',
-            'server' => 'localhost',
+            'server' => '127.0.0.1',
             'username' => 'travis',
             'password' => '',
             'charset' => 'utf8',


### PR DESCRIPTION
I don't know why, but using `localhost` prevents from running tests in Windows Subsystem for Linux (the `bash` shell that's integrated in recent Windows 10 versions).

Using `127.0.0.1` works fine.