### PR TITLE
Adding migration to install scopes on upgrade

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0a3',
     'version_installed' => '8.5.0a3',
-    'version_db' => '20190112000000', // the key of the latest database migration
+    'version_db' => '20190129000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Updater/Migrations/Migrations/Version20190129000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190129000000.php
@@ -1,0 +1,60 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\OAuth\Scope;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+/**
+ * Update scope descriptions and install missing scopes on upgrades.
+ */
+class Version20190129000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /** @var array Mapping scope identifiers to descriptions */
+    protected $mapping = [];
+
+    private function needsUpdating($key, $value)
+    {
+        if (!isset($this->mapping[$key])) {
+            return false;
+        }
+
+        if ((string) $value == (string) $this->mapping[$key]) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function upgradeDatabase()
+    {
+        // Set the current mapping of api scopes
+        $this->mapping = [
+            'account' => t('General user account information'),
+            'openid' => t('User profile information for authentication'),
+            'site' => t('Site configuration'),
+            'system' => t('System configuration'),
+        ];
+
+        $entityManager = $this->connection->createEntityManager();
+
+        $scopeRepository = $entityManager->getRepository(Scope::class);
+
+        foreach ($this->mapping as $scopeID => $scopeDescription) {
+            // Find existing scope
+            $scope = $scopeRepository->findOneByIdentifier($scopeID);
+            // Create a new scope if it doesnt exist
+            if (!is_object($scope)) {
+                $scope = new Scope();
+                $scope->setIdentifier($scopeID);
+                $scope->setDescription($scopeDescription);
+            } elseif ($this->needsUpdating($scope->getIdentifier(), $scope->getDescription())) {
+                $scope->setDescription($scopeDescription);
+            }
+            // Persist any changes to the entity
+            $entityManager->persist($scope);
+        }
+        $entityManager->flush();
+        $entityManager->clear(Scope::class);
+    }
+}


### PR DESCRIPTION

Previously if you have an older c5 install and then upgrade to the latest develop, you will only have the OpenID scope available to you.

This PR adds a migration to add the scopes to the database when upgrading.