### PR TITLE
Allow newer versions of symfony/console as well

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -79,7 +79,7 @@
     "paragonie/random_compat": "^2.0",
     "league/flysystem-cached-adapter": "~1.0.3",
     "league/csv": "~8.2",
-    "symfony/console": "^3.2",
+    "symfony/console": "^3.2|^4.0",
     "league/oauth2-server": "^5.1.4",
     "league/openid-connect-claims": "^1.1.0",
     "indigophp/hash-compat": "^1.1",


### PR DESCRIPTION
This is similar to #7533 but with the symfony/console dependency. This doesn't change anything for general releases, but allows composer based concrete5 to install newer versions.