### PR TITLE
Fixing issue #7540

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Http;
 
 use Concrete\Controller\Frontend\PageForbidden;
@@ -10,17 +9,14 @@ use Concrete\Core\Controller\Controller;
 use Concrete\Core\Http\Service\Ajax;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Collection\Collection;
-use Concrete\Core\Page\Collection\Version\Version;
 use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Page\Event;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Relation\Menu\Item\RelationListItem;
 use Concrete\Core\Page\Theme\Theme;
-use Concrete\Core\Page\Theme\ThemeRouteCollection;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Routing\RedirectResponse;
-use Concrete\Core\Routing\RouterInterface;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\User\PostLoginLocation;
 use Concrete\Core\User\User;
@@ -97,6 +93,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         if (is_object($c) && !$c->isError()) {
             // Display not found
             $this->request->setCurrentPage($c);
+
             return $this->controller($c->getPageController(), $code, $headers);
         }
 
@@ -259,6 +256,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
                 $v = new View('/frontend/maintenance_mode');
                 $v->addScopeItems(['c' => $collection]);
                 $request->setCurrentPage($collection);
+
                 return $this->view($v, $code, $headers);
             }
         }

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -277,33 +277,10 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             return $this->notFound('', Response::HTTP_NOT_FOUND, $headers);
         }
 
-        $scheduledVersion = Version::get($collection, 'SCHEDULED');
-        $publishDate = $scheduledVersion->getPublishDate();
-        $publishEndDate = $scheduledVersion->getPublishEndDate();
-        //Check if the active has an end date
-        if (empty($publishEndDate)) $publishEndDate = Version::get($collection, 'ACTIVE')->getPublishEndDate();
-        if ($publishEndDate && !$cp->canViewPageVersions()) {
-            $datetime = $this->app->make('helper/date');
-            $now = $datetime->date('Y-m-d G:i:s');
-            if (strtotime($now) >= strtotime($publishEndDate)) {
-                $scheduledVersion->deny();
-
-                return $this->notFound('', Response::HTTP_NOT_FOUND, $headers);
-            }
-        }
-
-        if ($publishDate) {
-            $datetime = $this->app->make('helper/date');
-            $now = $datetime->date('Y-m-d G:i:s');
-
-            if (strtotime($now) >= strtotime($publishDate)) {
-                $scheduledVersion->approve();
-                $collection->loadVersionObject('ACTIVE');
-            }
-        }
-
         if ($cp->canEditPageContents() || $cp->canEditPageProperties() || $cp->canViewPageVersions()) {
             $collection->loadVersionObject('RECENT');
+        } else {
+            $collection->loadVersionObject('ACTIVE');
         }
 
         $vp = new Checker($collection->getVersionObject());

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -250,7 +250,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
 
         switch ($cvID) {
             case 'ACTIVE':
-                $q .= ' and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ? or cvPublishDate is null) order by cvPublishDate desc limit 1';
+                $q .= ' and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?) order by cvPublishDate desc limit 1';
                 $v[] = $now;
                 $v[] = $now;
                 break;


### PR DESCRIPTION
This PR fixes all three issues described in #7540

We now check to see if the active page has an end date and deny.
We now display 404 error with content like other pages do rather than redirect - this also fixes issues with browsers not respecting the header no-cache