### PR TITLE
CLI options: assume empty description instead of NULL

### DIFF
--- a/concrete/src/Console/Parser.php
+++ b/concrete/src/Console/Parser.php
@@ -145,6 +145,6 @@ class Parser
     {
         $parts = preg_split('/\s+:\s+/', trim($token), 2);
 
-        return count($parts) === 2 ? $parts : [$token, null];
+        return count($parts) === 2 ? $parts : [$token, ''];
     }
 }


### PR DESCRIPTION
This fixes the following error:

TypeError: Argument 4 passed to Symfony\Component\Console\Input\InputOption::__construct() must be of the type string, null given, called in concrete/src/Console/Parser.php on line 134 in file vendor/symfony/console/Input/InputOption.php on line 44