### PR TITLE
Invert dependencies for simple logging processors

### DIFF
--- a/concrete/src/Logging/Configuration/ConfigurationFactory.php
+++ b/concrete/src/Logging/Configuration/ConfigurationFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Logging\Configuration;
 
+use Concrete\Core\Application\Application;
 use Concrete\Core\Config\Repository\Repository;
 
 class ConfigurationFactory
@@ -11,9 +12,17 @@ class ConfigurationFactory
      */
     protected $config;
 
-    public function __construct(Repository $config)
+    /**
+     * The IOC container we use to build configurations
+     *
+     * @var Application
+     */
+    protected $app;
+
+    public function __construct(Repository $config, Application $app)
     {
         $this->config = $config;
+        $this->app = $app;
     }
 
     public function createConfiguration()
@@ -23,13 +32,14 @@ class ConfigurationFactory
             return new AdvancedConfiguration($configuration['advanced']['configuration']);
         } else {
             if (isset($configuration['simple']['handler']) && $configuration['simple']['handler'] == 'file') {
-                return new SimpleFileConfiguration(
-                    $configuration['simple']['file']['file'],
-                    $configuration['simple']['core_logging_level']
-                );
+                return $this->app->make(SimpleFileConfiguration::class, [
+                    'filename' => array_get($configuration, 'simple.file.file'),
+                    'coreLevel' => array_get($configuration, 'simple.core_logging_level')
+                ]);
             } else {
-                return new SimpleDatabaseConfiguration($configuration['simple']['core_logging_level']);
-
+                return $this->app->make(SimpleDatabaseConfiguration::class, [
+                    'coreLevel' => array_get($configuration, 'simple.core_logging_level')
+                ]);
             }
         }
 

--- a/tests/tests/Logging/Processor/Concrete5UserProcessorTest.php
+++ b/tests/tests/Logging/Processor/Concrete5UserProcessorTest.php
@@ -61,4 +61,23 @@ class Concrete5UserProcessorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($given, $processor($given));
     }
 
+    public function testProcessorDoesntMakeMoreThanOneUser()
+    {
+        $user = M::mock(User::class);
+        $user->shouldReceive('getUserID')->andReturn(1337);
+        $user->shouldReceive('getUserName')->andReturn('foobaz');
+        $user->shouldReceive('isRegistered')->andReturn(true);
+
+        // Set up the IOC container making sure to flag the ->make() as happening only once
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->once()->withArgs([User::class])->andReturn($user);
+
+        // Set up the processor
+        $processor = new Concrete5UserProcessor($app);
+
+        // Run the processor twice
+        $processor([]);
+        $processor([]);
+    }
+
 }

--- a/tests/tests/Logging/Processor/Concrete5UserProcessorTest.php
+++ b/tests/tests/Logging/Processor/Concrete5UserProcessorTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Concrete\Tests\Logging\Processor;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Logging\Processor\Concrete5UserProcessor;
+use Concrete\Core\User\User;
+use Mockery as M;
+use PHPUnit_Framework_TestCase;
+
+class Concrete5UserProcessorTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testProcessorAddsUserDetails()
+    {
+        $user = M::mock(User::class);
+        $user->shouldReceive('getUserID')->andReturn(1337);
+        $user->shouldReceive('getUserName')->andReturn('foobaz');
+        $user->shouldReceive('isRegistered')->andReturn(true);
+
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->withArgs([User::class])->andReturn($user);
+
+        // Set up the processor
+        $processor = new Concrete5UserProcessor($app);
+
+        // Set up our input
+        $given = [];
+        array_set($given, 'some.other.key.that.should.pass.through', 'foo');
+        array_set($given, 'extra.foo', 'baz');
+
+        // Set up our expected output
+        $expected = $given;
+        array_set($expected, 'extra.user', [
+            1337,
+            'foobaz'
+        ]);
+
+        // Test that the user data gets added to the extra output
+        $this->assertEquals($expected, $processor($given));
+    }
+
+    public function testProcessorIgnoresLoggedOutUsers()
+    {
+        $user = M::mock(User::class);
+        $user->shouldReceive('getUserID')->andReturn(1337);
+        $user->shouldReceive('getUserName')->andReturn('foobaz');
+        $user->shouldReceive('isRegistered')->andReturn(false);
+
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->withArgs([User::class])->andReturn($user);
+
+        // Set up the processor
+        $processor = new Concrete5UserProcessor($app);
+
+        // Set up our input
+        $given = [];
+        array_set($given, 'some.other.key.that.should.pass.through', 'foo');
+        array_set($given, 'extra.foo', 'baz');
+
+        // Test our given input is our output
+        $this->assertEquals($given, $processor($given));
+    }
+
+}


### PR DESCRIPTION
This PR:
* Inverts dependencies for `Concrete5UserProcessor` making it possible to test it without connecting to the database
* Inverts dependencies for the factories in the chain that create the processors so that they can pass in dependencies in an inverted way
* Adds full unit test coverage of the `Concrete5UserProcessor` class without connecting to the database or having any other coupled dependencies tested what-so-ever