### PR TITLE
Improve sanitization in page list controller

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -414,10 +414,14 @@ class Controller extends BlockController
             'cParentID' => null,
         ];
 
+        if (is_numeric($args['cParentID'])) {
+            $args['cParentID'] = intval($args['cParentID']);
+        }
+
         $args['num'] = ($args['num'] > 0) ? $args['num'] : 0;
-        $args['cThis'] = ($args['cParentID'] == $this->cID) ? '1' : '0';
-        $args['cThisParent'] = ($args['cParentID'] == $this->cPID) ? '1' : '0';
-        $args['cParentID'] = ($args['cParentID'] == 'OTHER') ? (empty($args['cParentIDValue']) ? null : $args['cParentIDValue']) : $args['cParentID'];
+        $args['cThis'] = ($args['cParentID'] === $this->cID) ? '1' : '0';
+        $args['cThisParent'] = ($args['cParentID'] === $this->cPID) ? '1' : '0';
+        $args['cParentID'] = ($args['cParentID'] === 'OTHER') ? (empty($args['cParentIDValue']) ? null : $args['cParentIDValue']) : $args['cParentID'];
         if (!$args['cParentID']) {
             $args['cParentID'] = 0;
         }


### PR DESCRIPTION
An unexpected value will be stored when editing page list block on a master collection

```php
$cPID = 0;
$cParentIDs = [
    "0", // Everywhere
    "195", // Beneath this page
    "OTHER", // Beneath another page
];

// Expected:
// bool(true)
// bool(false)
// bool(false)


// Same as current controller
foreach ($cParentIDs as $cParentID) {
    var_dump(($cParentID == $cPID));
}

// bool(true)
// bool(false)
// bool(true)


// How about changing == to === ?
foreach ($cParentIDs as $cParentID) {
    var_dump(($cParentID === $cPID));
}

// bool(false)
// bool(false)
// bool(false)


// How about using intval function if the valud is numeric?
foreach ($cParentIDs as $cParentID) {
    if (is_numeric($cParentID)) {
        $cParentID = intval($cParentID);
    }
    var_dump($cParentID == $cPID);
}

// bool(true)
// bool(false)
// bool(true)


// Correct solution.
foreach ($cParentIDs as $cParentID) {
    if (is_numeric($cParentID)) {
        $cParentID = intval($cParentID);
    }
    var_dump($cParentID === $cPID);
}

// bool(true)
// bool(false)
// bool(false)
```