### PR TITLE
Update AttributeKeyView.php

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -278,7 +278,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $c = Page::getByID($this->redirectCID);
                         if (is_object($c) && !$c->isError()) {
                             $r = Redirect::page($c);
-                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1');
+                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1&entry=' . $entry->getID());
                         }
                     }
 

--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -278,7 +278,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $c = Page::getByID($this->redirectCID);
                         if (is_object($c) && !$c->isError()) {
                             $r = Redirect::page($c);
-                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1&entry=' . $entry->getID());
+                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1');
                         }
                     }
 

--- a/concrete/src/Express/Form/Control/View/AttributeKeyView.php
+++ b/concrete/src/Express/Form/Control/View/AttributeKeyView.php
@@ -18,7 +18,7 @@ class AttributeKeyView extends View
     {
         parent::__construct($context, $control);
         if ($entry = $context->getEntry()) {
-            $this->addScopeItem('value', $entry->getAttributeValueObject($control->getAttributeKey()));
+            $this->addScopeItem('value', $entry->getAttributeValueObject($control->getAttributeKey(), true));
         }
     }
 

--- a/concrete/src/Express/Form/Control/View/AttributeKeyView.php
+++ b/concrete/src/Express/Form/Control/View/AttributeKeyView.php
@@ -18,7 +18,7 @@ class AttributeKeyView extends View
     {
         parent::__construct($context, $control);
         if ($entry = $context->getEntry()) {
-            $this->addScopeItem('value', $entry->getAttributeValueObject($control->getAttributeKey(), true));
+            $this->addScopeItem('value', $entry->getAttributeValueObject($control->getAttributeKey()));
         }
     }
 


### PR DESCRIPTION
If an AttributeValueObject doesn't exist for a given AttributeKey when being loaded into some Context then create a default ExpressValue. This allows the Attribute Controller to handle the empty value. Without the default ExpressValue the 'value' ScopeItem object is of the wrong type and the Attribute Controller is not loaded and can not handle the null case.
