### PR TITLE
TravisCI: sort jobs and give them a name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,100 @@
+# Global/default configuration
 dist: trusty
 language: php
 sudo: false
-
-php:
-- 5.5
-- 5.6
-- 7.0
-- 7.2
-- 7.3
-- nightly
-
-env:
-  global:
-  - COMPOSER_DISABLE_XDEBUG_WARN=1
-  - PREFER_LOWEST=""
-  - DO_PHPUNIT=1
-  - DO_CS_PHP=0
-  - DO_CS_JS=0
-  - DO_BUILDASSETS=0
-
-matrix:
-  fast_finish: true
-  include:
-  - php: 7.1
-    env:
-    - DO_PHPUNIT=2
-  - php: 7.1
-    env:
-    - DO_CS_PHP=1
-    - DO_PHPUNIT=0
-  - php: 7.1
-    env:
-    - PREFER_LOWEST="--prefer-lowest"
-  - language: node_js
-    dist: trusty
-    node_js: lts/*
-    env:
-    - DO_PHPUNIT=0
-    - DO_CS_JS=1
-    - DO_BUILDASSETS=1
-  allow_failures:
-  - php: nightly
-
-before_script:
-- if test $DO_CS_JS -ne 0 || test $DO_BUILDASSETS -ne 0; then ./.travis/setup-build.sh; fi
-- if test $DO_PHPUNIT -ne 0 || test $DO_CS_PHP -ne 0; then ./.travis/composer-deps.sh; fi
-
-script:
-- if test $DO_CS_PHP -ne 0; then echo 'Testing PHP coding style'; composer phpcs; fi
-- if test $DO_CS_JS -ne 0; then echo 'Testing JS coding style'; pushd build && grunt js:check && popd; fi
-- if test $DO_PHPUNIT -eq 1; then echo 'Running tests'; composer test; fi
-- if test $DO_PHPUNIT -gt 1; then echo 'Running tests (with coverage)'; phpdbg -qrr ./concrete/vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.clover; fi
-- if test $DO_BUILDASSETS -ne 0; then ./.travis/rebuild-assets.sh; fi
-
 cache:
   yarn: true
   directories:
-  - "$HOME/.composer/cache"
-  - build/node_modules
-
+    - $HOME/.composer/cache
+    - build/node_modules
 notifications:
   email: false
 
-after_script:
-- |
-  if test $DO_PHPUNIT -gt 1; then
-    wget https://scrutinizer-ci.com/ocular.phar
-    php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-  fi
+# Job list
+matrix:
+  fast_finish: true
+  allow_failures:
+    - name: Test with PHP nightly
+  include:
+
+    - name: Test with PHP 7.1 (with code coverage)
+      php: '7.1'
+      before_script:
+        - wget --tries=5 https://scrutinizer-ci.com/ocular.phar
+        - ./.travis/composer-deps.sh
+      script:
+        - phpdbg -qrr ./concrete/vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.clover
+      after_script:
+        - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+    - name: Check PHP coding style
+      php: '7.1'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer phpcs
+
+    - name: Check JS coding style
+      language: node_js
+      node_js: '10'
+      before_script:
+        - ./.travis/setup-build.sh
+      script:
+        - pushd build && grunt js:check && popd
+
+    - name: Rebuild JS assets
+      language: node_js
+      node_js: '10'
+      before_script:
+        - ./.travis/setup-build.sh
+      script:
+        - ./.travis/rebuild-assets.sh
+
+    - name: Test with PHP 5.5
+      php: '5.5'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP 5.6
+      php: '5.6'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP 7.0
+      php: '7.0'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP 7.1 (lowest composer dependencies)
+      php: '7.1'
+      before_script:
+        - COMPOSER_PREFER_LOWEST=1 ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP 7.2
+      php: '7.2'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP 7.3
+      php: '7.3'
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test
+
+    - name: Test with PHP nightly
+      php: nightly
+      before_script:
+        - ./.travis/composer-deps.sh
+      script:
+        - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
     - name: Test with PHP 7.1 (lowest composer dependencies)
       php: '7.1'
       before_script:
-        - COMPOSER_PREFER_LOWEST=1 ./.travis/composer-deps.sh
+        - COMPOSER_FLAGS='--prefer-lowest' ./.travis/composer-deps.sh
       script:
         - composer test
 

--- a/.travis/composer-deps.sh
+++ b/.travis/composer-deps.sh
@@ -2,14 +2,21 @@
 
 set -o errexit
 
-source "$( dirname "${BASH_SOURCE[0]}" )/travis_retry.sh"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+source "$SCRIPT_DIR/travis_retry.sh"
 
 echo 'Configuring PHP'
-phpenv config-add "$( dirname "${BASH_SOURCE[0]}" )/php.ini"
+phpenv config-add "$SCRIPT_DIR/php.ini"
 phpenv config-rm xdebug.ini || true
 
+FLAGS=''
+if test -n "${COMPOSER_PREFER_LOWEST:-}"; then
+    FLAGS="$FLAGS --prefer-lowest"
+fi
+
 echo 'Installing Composer packages - Magento''s composer merger'
-travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST
+travis_retry composer update --no-suggest --no-interaction $FLAGS
 
 echo 'Installing Composer packages - Merged dependencies'
-travis_retry composer update --no-suggest --no-interaction $PREFER_LOWEST
+travis_retry composer update --no-suggest --no-interaction $FLAGS

--- a/.travis/composer-deps.sh
+++ b/.travis/composer-deps.sh
@@ -10,13 +10,8 @@ echo 'Configuring PHP'
 phpenv config-add "$SCRIPT_DIR/php.ini"
 phpenv config-rm xdebug.ini || true
 
-FLAGS=''
-if test -n "${COMPOSER_PREFER_LOWEST:-}"; then
-    FLAGS="$FLAGS --prefer-lowest"
-fi
-
 echo 'Installing Composer packages - Magento''s composer merger'
-travis_retry composer update --no-suggest --no-interaction $FLAGS
+travis_retry composer update --no-suggest --no-interaction ${COMPOSER_FLAGS:-}
 
 echo 'Installing Composer packages - Merged dependencies'
-travis_retry composer update --no-suggest --no-interaction $FLAGS
+travis_retry composer update --no-suggest --no-interaction ${COMPOSER_FLAGS:-}

--- a/.travis/rebuild-assets.sh
+++ b/.travis/rebuild-assets.sh
@@ -5,7 +5,6 @@ set -o nounset
 
 AUTO_REPOSITORY_OWNER='concrete5'
 AUTO_REPOSITORY_NAME='concrete5'
-AUTO_PROCESS_BRANCH='develop'
 AUTO_COMMIT_NAME_BASE='Automatic assets rebuilding'
 AUTO_COMMIT_AUTHOR_NAME='concrete5 TravisCI Bot'
 AUTO_COMMIT_AUTHOR_EMAIL='concrete5-bot@concrete5.org'
@@ -16,8 +15,13 @@ if test "${TRAVIS_PULL_REQUEST:-}" != 'false'; then
     exit 0
 fi
 
-if test "${TRAVIS_BRANCH:-}" != "${AUTO_PROCESS_BRANCH}"; then
-    printf '%s: skipping because pushing to "%s" instead of "%s".\n' "${AUTO_COMMIT_NAME_BASE}" "${TRAVIS_BRANCH:-}" "${AUTO_PROCESS_BRANCH}"
+if test -n "${TRAVIS_TAG:-}"; then
+    printf '%s: skipping because the the current build is for a git tag.\n' "${AUTO_COMMIT_NAME_BASE}"
+    exit 0
+fi
+
+if test -z "${TRAVIS_BRANCH:-}"; then
+    printf '%s: skipping because the current branch is not available.\n' "${AUTO_COMMIT_NAME_BASE}"
     exit 0
 fi
 
@@ -87,5 +91,5 @@ git config user.name "${AUTO_COMMIT_AUTHOR_NAME}"
 git config user.email "${AUTO_COMMIT_AUTHOR_EMAIL}"
 git commit -m "${AUTO_COMMIT_NAME}"
 git remote add deploy "https://${GITHUB_ACCESS_TOKEN}@github.com/${AUTO_REPOSITORY_OWNER}/${AUTO_REPOSITORY_NAME}.git"
-git push deploy "${AUTO_PROCESS_BRANCH}" -vvv
+git push deploy "${TRAVIS_BRANCH}" -vvv
 printf '%s: repository updated.\n' "${AUTO_COMMIT_NAME_BASE}"

--- a/.travis/rebuild-assets.sh
+++ b/.travis/rebuild-assets.sh
@@ -8,30 +8,30 @@ AUTO_REPOSITORY_NAME='concrete5'
 AUTO_COMMIT_NAME_BASE='Automatic assets rebuilding'
 AUTO_COMMIT_AUTHOR_NAME='concrete5 TravisCI Bot'
 AUTO_COMMIT_AUTHOR_EMAIL='concrete5-bot@concrete5.org'
-AUTO_COMMIT_NAME="[skip ci] ${AUTO_COMMIT_NAME_BASE}"
+AUTO_COMMIT_NAME="[skip ci] $AUTO_COMMIT_NAME_BASE"
 
 if test "${TRAVIS_PULL_REQUEST:-}" != 'false'; then
-    printf '%s: skipping because it''s a pull request.\n' "${AUTO_COMMIT_NAME_BASE}"
+    printf '%s: skipping because it''s a pull request.\n' "$AUTO_COMMIT_NAME_BASE"
     exit 0
 fi
 
 if test -n "${TRAVIS_TAG:-}"; then
-    printf '%s: skipping because the the current build is for a git tag.\n' "${AUTO_COMMIT_NAME_BASE}"
+    printf '%s: skipping because the the current build is for a git tag.\n' "$AUTO_COMMIT_NAME_BASE"
     exit 0
 fi
 
 if test -z "${TRAVIS_BRANCH:-}"; then
-    printf '%s: skipping because the current branch is not available.\n' "${AUTO_COMMIT_NAME_BASE}"
+    printf '%s: skipping because the current branch is not available.\n' "$AUTO_COMMIT_NAME_BASE"
     exit 0
 fi
 
-if test "${TRAVIS_REPO_SLUG:-}" != "${AUTO_REPOSITORY_OWNER}/${AUTO_REPOSITORY_NAME}"; then
-    printf '%s: skipping because repository is "%s" instead of "%s/%s".\n' "${AUTO_COMMIT_NAME_BASE}" "${TRAVIS_REPO_SLUG:-}" "${AUTO_REPOSITORY_OWNER}" "${AUTO_REPOSITORY_NAME}"
+if test "${TRAVIS_REPO_SLUG:-}" != "$AUTO_REPOSITORY_OWNER/$AUTO_REPOSITORY_NAME"; then
+    printf '%s: skipping because repository is "%s" instead of "%s/%s".\n' "$AUTO_COMMIT_NAME_BASE" "${TRAVIS_REPO_SLUG:-}" "$AUTO_REPOSITORY_OWNER" "$AUTO_REPOSITORY_NAME"
     exit 0
 fi
 
-if test "${TRAVIS_COMMIT_MESSAGE:-}" = "${AUTO_COMMIT_NAME}"; then
-    printf '%s: skipping because commit is already "%s".\n' "${AUTO_COMMIT_NAME_BASE}" "${AUTO_COMMIT_NAME}"
+if test "${TRAVIS_COMMIT_MESSAGE:-}" = "$AUTO_COMMIT_NAME"; then
+    printf '%s: skipping because commit is already "%s".\n' "$AUTO_COMMIT_NAME_BASE" "$AUTO_COMMIT_NAME"
     exit 0
 fi
 
@@ -46,23 +46,24 @@ To create it:
  - travis encrypt --repo %s/%s GITHUB_ACCESS_TOKEN=<YOUR_ACCESS_TOKEN>
  - Add to the env setting of:
    secure: "encrypted string"
-' "${AUTO_COMMIT_NAME_BASE}" "${AUTO_REPOSITORY_OWNER}" "${AUTO_REPOSITORY_NAME}"
+' "$AUTO_COMMIT_NAME_BASE" "$AUTO_REPOSITORY_OWNER" "$AUTO_REPOSITORY_NAME"
     exit 0
 fi
 
-printf '%s: checking out %s\n' "${AUTO_COMMIT_NAME_BASE}" "${TRAVIS_BRANCH}"
-git checkout -qf "${TRAVIS_BRANCH}"
+printf '%s: checking out %s\n' "$AUTO_COMMIT_NAME_BASE" "$TRAVIS_BRANCH"
+cd "$TRAVIS_BUILD_DIR"
+git checkout -qf "$TRAVIS_BRANCH"
 
-printf '%s: building assets\n' "${AUTO_COMMIT_NAME_BASE}"
-cd "${TRAVIS_BUILD_DIR}/build"
+printf '%s: building assets\n' "$AUTO_COMMIT_NAME_BASE"
+cd "$TRAVIS_BUILD_DIR/build"
 printf -- '- CSS\n'
 grunt css:release
 printf -- '- JS\n'
 grunt js:release
 
-printf '%s: checking changes\n' "${AUTO_COMMIT_NAME_BASE}"
+printf '%s: checking changes\n' "$AUTO_COMMIT_NAME_BASE"
 CHANGES_DETECTED=0
-cd "${TRAVIS_BUILD_DIR}/concrete/css"
+cd "$TRAVIS_BUILD_DIR/concrete/css"
 if test -n "$(git status --porcelain .)"; then
     printf -- '- changes detected in CSS assets\n'
     git add --all .
@@ -70,7 +71,7 @@ if test -n "$(git status --porcelain .)"; then
 else
     printf -- '- no changes in CSS assets\n'
 fi
-cd "${TRAVIS_BUILD_DIR}/concrete/js"
+cd "$TRAVIS_BUILD_DIR/concrete/js"
 if test -n "$(git status --porcelain .)"; then
     printf -- '- changes detected in JS assets\n'
     git add --all .
@@ -79,17 +80,17 @@ else
     printf -- '- no changes in JS assets\n'
 fi
 
-if test ${CHANGES_DETECTED} -eq 0; then
-    printf '%s: skipping because assets are already up-to-date\n' "${AUTO_COMMIT_NAME_BASE}"
+if test $CHANGES_DETECTED -eq 0; then
+    printf '%s: skipping because assets are already up-to-date\n' "$AUTO_COMMIT_NAME_BASE"
     exit 0
 fi
 
-printf '%s: commiting and pushing changes.\n' "${AUTO_COMMIT_NAME_BASE}"
+printf '%s: commiting and pushing changes.\n' "$AUTO_COMMIT_NAME_BASE"
 git status
 git add --all .
-git config user.name "${AUTO_COMMIT_AUTHOR_NAME}"
-git config user.email "${AUTO_COMMIT_AUTHOR_EMAIL}"
-git commit -m "${AUTO_COMMIT_NAME}"
-git remote add deploy "https://${GITHUB_ACCESS_TOKEN}@github.com/${AUTO_REPOSITORY_OWNER}/${AUTO_REPOSITORY_NAME}.git"
-git push deploy "${TRAVIS_BRANCH}" -vvv
-printf '%s: repository updated.\n' "${AUTO_COMMIT_NAME_BASE}"
+git config user.name "$AUTO_COMMIT_AUTHOR_NAME"
+git config user.email "$AUTO_COMMIT_AUTHOR_EMAIL"
+git commit -m "$AUTO_COMMIT_NAME"
+git remote add deploy "https://$GITHUB_ACCESS_TOKEN@github.com/$AUTO_REPOSITORY_OWNER/$AUTO_REPOSITORY_NAME.git"
+git push deploy "$TRAVIS_BRANCH" -vvv
+printf '%s: repository updated.\n' "$AUTO_COMMIT_NAME_BASE"


### PR DESCRIPTION
The current TravisCI configuration report leads to a quite cryptic name/variable list:
https://travis-ci.org/concrete5/concrete5/builds/490430820

What about switching to a wonderful list with beautiful job names?
https://travis-ci.org/mlocati/concrete5/builds/490466416

Furthermore, moving the code-coverage job to the first position may help saving some time.

PS: in order to avoid merge conflicts, I included #7558 in this PR.