### PR TITLE
Use $date instead of $helper_date in edit_profile view

### DIFF
--- a/concrete/single_pages/account/edit_profile.php
+++ b/concrete/single_pages/account/edit_profile.php
@@ -14,7 +14,7 @@
         <?php if (Config::get('concrete.misc.user_timezones')) { ?>
             <div class="form-group">
                 <?= $form->label('uTimezone', t('Time Zone')); ?>
-                <?= $form->select('uTimezone', $helper_date->getTimezones(), ($profile->getUserTimezone() ? $profile->getUserTimezone() : date_default_timezone_get())); ?>
+                <?= $form->select('uTimezone', $date->getTimezones(), ($profile->getUserTimezone() ? $profile->getUserTimezone() : date_default_timezone_get())); ?>
             </div>
         <?php } ?>
 


### PR DESCRIPTION
This fixes the following issue:

`Call to a member function getTimezones() on null`

(that's because we have to use `$date` instead of `$helper_date`)