### PR TITLE
Correctly detect if sendPrivateMessage returned an error

### DIFF
--- a/concrete/controllers/single_page/account/messages.php
+++ b/concrete/controllers/single_page/account/messages.php
@@ -169,7 +169,7 @@ class Messages extends AccountPageController
             $u = new User();
             $sender = UserInfo::getByID($u->getUserID());
             $r = $sender->sendPrivateMessage($this->get('recipient'), $this->post('msgSubject'), $this->post('msgBody'), $this->get('msg'));
-            if ($r instanceof \Concrete\Core\Helper\Validation\Error) {
+            if ($r instanceof \Concrete\Core\Error\ErrorList\ErrorList) {
                 $this->error = $r;
             } else {
                 if ($this->post('msgID') > 0) {


### PR DESCRIPTION
The `Concrete\Core\Helper\Validation\Error` class does not exist: we should use `Concrete\Core\Error\ErrorList\ErrorList`