### PR TITLE
Define PrivateMessage\Limit methods as static

### DIFF
--- a/concrete/src/User/PrivateMessage/Limit.php
+++ b/concrete/src/User/PrivateMessage/Limit.php
@@ -18,7 +18,7 @@ class Limit
      *
      * @return bool
      */
-    public function isOverLimit($uID)
+    public static function isOverLimit($uID)
     {
         if (Config::get('concrete.user.private_messages.throttle_max') == 0) {
             return false;
@@ -42,7 +42,7 @@ class Limit
         }
     }
 
-    public function getErrorObject()
+    public static function getErrorObject()
     {
         $ve = Loader::helper('validation/error');
         $ve->add(t('You may not send more than %s messages in %s minutes', Config::get('concrete.user.private_messages.throttle_max'), Config::get('concrete.user.private_messages.throttle_max_timespan')));


### PR DESCRIPTION
These two methods are [called statically](https://github.com/concrete5/concrete5/blob/6a204e60a10050e5589aebc1ec72f29b997712cd/concrete/src/User/UserInfo.php#L349-L351).

Ref. #4723