### PR TITLE
Http Client: avoid double definition of $logger

### DIFF
--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -13,10 +13,6 @@ class Client extends ZendClient implements LoggerAwareInterface
 {
 
     use LoggerAwareTrait;
-    /**
-     * @var LoggerInterface|null
-     */
-    protected $logger = null;
 
     /**
      * Get the currently configured logger.


### PR DESCRIPTION
This fixes the following `E_STRICT` warning:

```
Concrete\Core\Http\Client\Client
and
Concrete\Core\Logging\LoggerAwareTrait
define the same property ($logger) in the composition of
Concrete\Core\Http\Client\Client
This might be incompatible, to improve maintainability consider using accessor methods
in traits instead.
Class was composed
```

@aembler What about turning on the `Consider warnings as errors` flag in the `dashboard/system/environment/debug` dashboard page? This is very helpful to spot problems while developing :wink: