### PR TITLE
Fix issue #6699, 'Stay signed in for two weeks' not working

### DIFF
--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -64,16 +64,14 @@ class DefaultDispatcher implements DispatcherInterface
     private function getEarlyDispatchResponse()
     {
         $validator = $this->app->make(SessionValidator::class);
-        if ($validator->hasActiveSession()) {
-            $session = $this->app['session'];
-            if (!$session->has('uID')) {
-                User::verifyAuthTypeCookie();
-            }
+        $session = $this->app['session'];
+        if (!$validator->hasActiveSession() || !$session->has('uID')) {
+            User::verifyAuthTypeCookie();
+        }
 
-            // User may have been logged in, so lets check status again.
-            if ($session->has('uID') && $session->get('uID') > 0 && $response = $this->validateUser()) {
-                return $response;
-            }
+        // User may have been logged in, so lets check status again.
+        if ($validator->hasActiveSession() && $session->has('uID') && $session->get('uID') > 0 && $response = $this->validateUser()) {
+            return $response;
         }
     }
 

--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -64,14 +64,16 @@ class DefaultDispatcher implements DispatcherInterface
     private function getEarlyDispatchResponse()
     {
         $validator = $this->app->make(SessionValidator::class);
-        $session = $this->app['session'];
-        if (!$validator->hasActiveSession() || !$session->has('uID')) {
-            User::verifyAuthTypeCookie();
-        }
+        if ($validator->hasActiveSession()) {
+            $session = $this->app['session'];
+            if (!$session->has('uID')) {
+                User::verifyAuthTypeCookie();
+            }
 
-        // User may have been logged in, so lets check status again.
-        if ($validator->hasActiveSession() && $session->has('uID') && $session->get('uID') > 0 && $response = $this->validateUser()) {
-            return $response;
+            // User may have been logged in, so lets check status again.
+            if ($session->has('uID') && $session->get('uID') > 0 && $response = $this->validateUser()) {
+                return $response;
+            }
         }
     }
 

--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -134,8 +134,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     public function hasActiveSession()
     {
         $cookie = $this->app['cookie'];
-        $session = $this->app['session'];
-        return $cookie->has($this->config->get('concrete.session.name')) || $session->isStarted();
+        return $cookie->has($this->config->get('concrete.session.name'));
     }
 
     /**

--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -134,7 +134,8 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     public function hasActiveSession()
     {
         $cookie = $this->app['cookie'];
-        return $cookie->has($this->config->get('concrete.session.name'));
+        $session = $this->app['session'];
+        return $cookie->has($this->config->get('concrete.session.name')) || $session->isStarted();
     }
 
     /**

--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -134,7 +134,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     public function hasActiveSession()
     {
         $cookie = $this->app['cookie'];
-        return $cookie->has($this->config->get('concrete.session.name'));
+        return $cookie->has($this->config->get('concrete.session.name')) || $cookie->has('ccmAuthUserHash');
     }
 
     /**


### PR DESCRIPTION
Fixes issue #6699.

The ccmAuthUserhash cookie was only evaluated when a session existed, which usually does not since the GDPR changes, so now it gets evaluated if there is no session or no uID set in the session.

SessionValidator needed to be changed because with the above changes we have a started session but haven't set the session cookie in $app['cookies'].