### PR TITLE
Add Stack panel: draggable name, toggle expansion

### DIFF
--- a/concrete/css/build/core/app/panels.less
+++ b/concrete/css/build/core/app/panels.less
@@ -406,18 +406,31 @@ div#ccm-panel-add-clipboard-block-list {
       cursor: pointer;
     }
 
-    img.ccm-panel-add-block-stack-item-handle,
+    .ccm-panel-add-block-stack-item-handle,
     div.block-name {
       cursor: -moz-grab;
       cursor: -webkit-grab;
       cursor: grab;
     }
 
-    img.ccm-panel-add-block-stack-item-handle {
+    .ccm-panel-add-block-stack-item-handle {
+      img {
+        position: absolute;
+        top: 15px;
+        left: 12px;
+        width: 20px;
+      }
+    }
+    .ccm-stack-expander {
       position: absolute;
-      top: 15px;
-      left: 12px;
-      width: 20px;
+      top: 1em;
+      right: 1em;
+      > i {
+        transition: all 0.4s ease;
+      }
+    }
+    &.ccm-panel-add-block-stack-item-expanded .ccm-stack-expander > i{
+      transform: rotateZ(-180deg);
     }
 
     div.blocks {

--- a/concrete/js/build/core/app/edit-mode/editmode.js
+++ b/concrete/js/build/core/app/edit-mode/editmode.js
@@ -482,7 +482,7 @@
 
 
             $(element).find('div.ccm-panel-add-block-stack-item').each(function () {
-                var stack, me = $(this), dragger = me.find('img.ccm-panel-add-block-stack-item-handle');
+                var stack, me = $(this), dragger = me.find('.ccm-panel-add-block-stack-item-handle');
                 stack = new Concrete.Stack($(this), my, dragger, next_area);
 
                 stack.setPeper(dragger);

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -47,8 +47,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
                         data-dragging-avatar="<?= h('<p><img src="' . DIR_REL . '/concrete/images/stack.png' . '" /><span>' . t('Stack') . '</span></p>') ?>"
                         data-block-id="<?= (int) $stack->getCollectionID() ?>"                    >
                         <div class="stack-name">
-                            <img class="ccm-panel-add-block-stack-item-handle" src="<?=DIR_REL?>/concrete/images/stack.png" />
-                            <span class="stack-name-inner"><?= h($stack->getStackName()) ?></span>
+                            <div class="ccm-panel-add-block-stack-item-handle"> 
+                                <img src="<?=DIR_REL?>/concrete/images/stack.png" />
+                                <span class="stack-name-inner"><?= h($stack->getStackName()) ?></span>
+                            </div>
+                            <a  class="ccm-stack-expander" href="javascript:void(0);"><i class="fa fa-arrow-down"></i></a>
                         </div>
                     </div>
                     <?php
@@ -58,6 +61,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <script>
             $('div.ccm-panel-add-block-stack-item').on('click', function () {
                 var $stack = $(this);
+                if ($stack.data('ccm-stack-content-loaded')) {
+                	$stack.toggleClass('ccm-panel-add-block-stack-item-expanded');
+                	$stack.data('ccm-stack-content-loaded').toggle($stack.hasClass('ccm-panel-add-block-stack-item-expanded'));
+                    return;
+                }
                 if ($stack.hasClass('ccm-panel-add-block-stack-item-expanded')) {
                     return;
                 }
@@ -67,9 +75,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
                     data: {'cID': $(this).attr('data-cID'), 'stackID': $(this).attr('data-sID'), 'ccm_token': $(this).attr('data-token')},
                     url: '<?=URL::to('/ccm/system/panels/add/get_stack_contents')?>',
                     success: function (r) {
+                        var $content = $(r);
+                        $stack.append($content);
+                        $stack.data('ccm-stack-content-loaded', $content);
                         $stack.addClass('ccm-panel-add-block-stack-item-expanded');
-                        $stack.append(r);
-                        $stack.find('div.block').each(function () {
+                        $content.find('div.block').each(function () {
                             var block, me = $(this), dragger = me.find('div.block-name');
                             var stack = new Concrete.Stack($stack, Concrete.getEditMode(), null);
                             block = new Concrete.StackBlock($(this), stack, stack, dragger);


### PR DESCRIPTION
About the "Add Stack" panel:
1. let user drag the stack name, not just the icon
2. add an arrow to expand the stack content
2. collapse the stack content if the arrow is clicked again.

This should fix everything in #7526 except point 3 (I haven't take a look at that specific issue yet).

![add-stack-expand-collapse-content](https://user-images.githubusercontent.com/928116/52871885-5fbc6080-314b-11e9-850a-0e2dc9949dec.gif)
