### PR TITLE
Translate dashboard page titles

### DIFF
--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -91,7 +91,7 @@ class DashboardPageController extends PageController
     {
         $pageTitle = $this->get('pageTitle');
         if (!$pageTitle) {
-            $this->set('pageTitle', $this->c->getCollectionName());
+            $this->set('pageTitle', t($this->c->getCollectionName()));
         }
         $dbConfig = $this->app->make('config/database');
         $this->set('showPrivacyPolicyNotice', !$dbConfig->get('app.privacy_policy_accepted'));


### PR DESCRIPTION
The names of the dashboard pages are translated everywhere, except in the html `<title>` tag: let's fix this.