### PR TITLE
Add missing h() to option values

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/basics/icons.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/icons.php
@@ -1,45 +1,35 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Basics;
 
-use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
-use Config;
 use View;
 use Core;
 
-class Icons extends DashboardSitePageController
-{
+class Icons extends DashboardSitePageController {
+
     public $helpers = array('form', 'concrete/asset_library', 'json');
 
-    public function on_start()
-    {
+    public function on_start() {
         parent::on_start();
         $view = View::getInstance();
         $view->requireAsset('core/colorpicker');
         $this->set('config', $this->getSite()->getConfigRepository());
     }
 
-    public function icons_saved()
-    {
+    public function icons_saved() {
         $this->set('message', t("Icons updated successfully."));
     }
 
-    public function update_icons()
-    {
+    public function update_icons() {
         $config = $this->getSite()->getConfigRepository();
         if ($this->token->validate("update_icons")) {
 
             $s = Core::make('helper/security');
-            $faviconFID = $s->sanitizeInt($this->post('faviconFID'));
-            $iosHomeFID = $s->sanitizeInt($this->post('iosHomeFID'));
-            $androidHomeFID = $s->sanitizeInt($this->post('androidHomeFID'));
-            $modernThumbFID = $s->sanitizeInt($this->post('modernThumbFID'));
+            $appIconFID = $s->sanitizeInt($this->post('appIconFID'));
             $modernThumbBG = $s->sanitizeString($this->post('modernThumbBG'));
 
-            $config->save('misc.favicon_fid', intval($faviconFID));
-            $config->save('misc.iphone_home_screen_thumbnail_fid', intval($iosHomeFID));
-            $config->save('misc.android_home_screen_thumbnail_fid', intval($androidHomeFID));
-            $config->save('misc.modern_tile_thumbnail_fid', intval($modernThumbFID));
+            $config->save('misc.app_icon_fid', intval($appIconFID));
             $config->save('misc.modern_tile_thumbnail_bgcolor', $modernThumbBG);
 
             $this->redirect('/dashboard/system/basics/icons/', 'icons_saved');

--- a/concrete/controllers/single_page/dashboard/system/basics/icons.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/icons.php
@@ -32,11 +32,13 @@ class Icons extends DashboardSitePageController
             $s = Core::make('helper/security');
             $faviconFID = $s->sanitizeInt($this->post('faviconFID'));
             $iosHomeFID = $s->sanitizeInt($this->post('iosHomeFID'));
+            $androidHomeFID = $s->sanitizeInt($this->post('androidHomeFID'));
             $modernThumbFID = $s->sanitizeInt($this->post('modernThumbFID'));
             $modernThumbBG = $s->sanitizeString($this->post('modernThumbBG'));
 
             $config->save('misc.favicon_fid', intval($faviconFID));
             $config->save('misc.iphone_home_screen_thumbnail_fid', intval($iosHomeFID));
+            $config->save('misc.android_home_screen_thumbnail_fid', intval($androidHomeFID));
             $config->save('misc.modern_tile_thumbnail_fid', intval($modernThumbFID));
             $config->save('misc.modern_tile_thumbnail_bgcolor', $modernThumbBG);
 

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -109,8 +109,27 @@ if (($favIconFID = (int) $config->get('misc.favicon_fid')) && ($favIconFile = Fi
     $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
 }
 if (($appleIconFID = (int) $config->get('misc.iphone_home_screen_thumbnail_fid')) && ($appleIconFile = File::getByID($appleIconFID))) {
-    $linkTags['apple-touch-icon'] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
+    $appleIconHTML = "<link rel=\"apple-touch-icon\" sizes=\"57x57\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 57, 57, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"60x60\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 60, 60, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"72x72\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 72, 72, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"76x76\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 76, 76, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"114x114\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 114, 114, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"120x120\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 120, 120, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"144x144\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 144, 144, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"152x152\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 152, 152, true)->src . "\">\n";
+    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 180, 180, true)->src . "\">";
+    
+    $linkTags['apple-touch-icon'] = $appleIconHTML;
 }
+
+if (($androidIconFID = (int) $config->get('misc.android_home_screen_thumbnail_fid')) && ($androidIconFile = File::getByID($androidIconFID))) {
+    $androidIconHTML = "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"192x192\"  href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 192, 192, true)->src . "\">\n";
+    $androidIconHTML .= "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"32x32\" href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 32, 32, true)->src . "\">\n";
+    $androidIconHTML .= "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"96x96\" href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 96, 96, true)->src . "\">";
+    
+    $linkTags['android icon'] = $androidIconHTML;
+}
+
 $alternateHreflangTags = [];
 if ($c !== null && $config->get('multilingual.set_alternate_hreflang') && !$c->isAdminArea() && $app->make('multilingual/detector')->isEnabled()) {
     $multilingualSection = Section::getBySectionOfSite($c);

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -109,23 +109,52 @@ if (($favIconFID = (int) $config->get('misc.favicon_fid')) && ($favIconFile = Fi
     $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
 }
 if (($appleIconFID = (int) $config->get('misc.iphone_home_screen_thumbnail_fid')) && ($appleIconFile = File::getByID($appleIconFID))) {
-    $appleIconHTML = "<link rel=\"apple-touch-icon\" sizes=\"57x57\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 57, 57, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"60x60\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 60, 60, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"72x72\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 72, 72, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"76x76\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 76, 76, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"114x114\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 114, 114, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"120x120\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 120, 120, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"144x144\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 144, 144, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"152x152\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 152, 152, true)->src . "\">\n";
-    $appleIconHTML .= "<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"" . Core::make('helper/image')->getThumbnail($appleIconFile, 180, 180, true)->src . "\">";
+    $thumbnailer = Core::make('helper/image');
+
+    $appleIconHTML = "";
+    
+    $appleIconSizes = array(57, 60, 72, 76, 114, 120, 144, 152, 180);
+    
+    foreach($appleIconSizes as $size) {
+        $thumbnail = $thumbnailer->getThumbnail($appleIconFile, $size, $size, true);
+        
+        if (is_object($thumbnail)) {
+            $appleIconHTML .= sprintf(
+                "%s<link rel=\"apple-touch-icon\" sizes=\"%sx%s\" href=\"%s\">",
+                    
+                strlen($appleIconHTML) === 0 ? "" : "\n",
+                $size,
+                $size,
+                $thumbnail->src
+            );
+        }
+    }
     
     $linkTags['apple-touch-icon'] = $appleIconHTML;
 }
 
 if (($androidIconFID = (int) $config->get('misc.android_home_screen_thumbnail_fid')) && ($androidIconFile = File::getByID($androidIconFID))) {
-    $androidIconHTML = "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"192x192\"  href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 192, 192, true)->src . "\">\n";
-    $androidIconHTML .= "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"32x32\" href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 32, 32, true)->src . "\">\n";
-    $androidIconHTML .= "<link rel=\"icon\" type=\"image/" . $androidIconFile->getExtension() . "\" sizes=\"96x96\" href=\"" . Core::make('helper/image')->getThumbnail($androidIconFile, 96, 96, true)->src . "\">";
+    $thumbnailer = Core::make('helper/image');
+
+    $androidIconHTML = "";
+    
+    $androidIconSizes = array(32, 96, 192);
+    
+    foreach($androidIconSizes as $size) {
+        $thumbnail = $thumbnailer->getThumbnail($androidIconFile, $size, $size, true);
+        
+        if (is_object($thumbnail)) {
+            $androidIconHTML .= sprintf(
+                "%s<link rel=\"icon\" type=\"image/%s\" sizes=\"%sx%s\"  href=\"%s\">",
+                    
+                strlen($androidIconHTML) === 0 ? "" : "\n",
+                $androidIconFile->getExtension(),
+                $size,
+                $size,
+                $thumbnail->src
+            );
+        }
+    }
     
     $linkTags['android icon'] = $androidIconHTML;
 }

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -95,33 +95,25 @@ if ($c !== null && $c->getAttribute('exclude_search_index')) {
     $metaTags['robots'] = sprintf('<meta name="robots" content="%s"/>', 'noindex');
 }
 $metaTags['generator'] = sprintf('<meta name="generator" content="%s"/>', 'concrete5' . ($appConfig->get('concrete.misc.app_version_display_in_header') ? ' - ' . APP_VERSION : null));
-if (($modernIconFID = (int) $config->get('misc.modern_tile_thumbnail_fid')) && ($modernIconFile = File::getByID($modernIconFID))) {
-    $metaTags['msapplication-TileImage'] = sprintf('<meta name="msapplication-TileImage" content="%s"/>', $modernIconFile->getURL());
-    $modernIconBGColor = (string) $config->get('misc.modern_tile_thumbnail_bgcolor');
-    if ($modernIconBGColor !== '') {
-        $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s"/>', $modernIconBGColor);
-    }
-}
 $linkTags = [];
-if (($favIconFID = (int) $config->get('misc.favicon_fid')) && ($favIconFile = File::getByID($favIconFID))) {
-    $favIconFileURL = $favIconFile->getURL();
-    $linkTags['shortcut icon'] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
-    $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
-}
-if (($appleIconFID = (int) $config->get('misc.iphone_home_screen_thumbnail_fid')) && ($appleIconFile = File::getByID($appleIconFID))) {
-    $thumbnailer = Core::make('helper/image');
-
-    $appleIconHTML = "";
+if (($appIconFID = (int) $config->get('misc.app_icon_fid')) && ($appIconFile = File::getByID($appIconFID))) {
+    // Favicons
+    if (($iconFileURL = Core::make("helper/icon")->getRealIconURL($appIconFile)) !== false) {
+        $linkTags['shortcut icon'] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $iconFileURL);
+        $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $iconFileURL);
+    }
     
+    $thumbnailer = Core::make("helper/image");
+    
+    // iOS icons
     $appleIconSizes = array(57, 60, 72, 76, 114, 120, 144, 152, 180);
     
     foreach($appleIconSizes as $size) {
-        $thumbnail = $thumbnailer->getThumbnail($appleIconFile, $size, $size, true);
+        $thumbnail = $thumbnailer->getThumbnail($appIconFile, $size, $size, true);
         
         if (is_object($thumbnail)) {
             $appleIconHTML .= sprintf(
                 "%s<link rel=\"apple-touch-icon\" sizes=\"%sx%s\" href=\"%s\">",
-                    
                 strlen($appleIconHTML) === 0 ? "" : "\n",
                 $size,
                 $size,
@@ -131,24 +123,20 @@ if (($appleIconFID = (int) $config->get('misc.iphone_home_screen_thumbnail_fid')
     }
     
     $linkTags['apple-touch-icon'] = $appleIconHTML;
-}
-
-if (($androidIconFID = (int) $config->get('misc.android_home_screen_thumbnail_fid')) && ($androidIconFile = File::getByID($androidIconFID))) {
-    $thumbnailer = Core::make('helper/image');
-
+ 
+    // Android icons
     $androidIconHTML = "";
     
-    $androidIconSizes = array(32, 96, 192);
+    $androidIconSizes = array(32, 96, 128, 196);
     
     foreach($androidIconSizes as $size) {
-        $thumbnail = $thumbnailer->getThumbnail($androidIconFile, $size, $size, true);
+        $thumbnail = $thumbnailer->getThumbnail($appIconFile, $size, $size, true);
         
         if (is_object($thumbnail)) {
             $androidIconHTML .= sprintf(
                 "%s<link rel=\"icon\" type=\"image/%s\" sizes=\"%sx%s\"  href=\"%s\">",
-                    
                 strlen($androidIconHTML) === 0 ? "" : "\n",
-                $androidIconFile->getExtension(),
+                $appIconFile->getExtension(),
                 $size,
                 $size,
                 $thumbnail->src
@@ -156,7 +144,36 @@ if (($androidIconFID = (int) $config->get('misc.android_home_screen_thumbnail_fi
         }
     }
     
-    $linkTags['android icon'] = $androidIconHTML;
+    $linkTags['android icon'] = $androidIconHTML;   
+    
+    // Windows icons
+    $windowsIconHTML = "";
+    
+    $windowsIconSizes = array(
+        "msapplication-TileImage" => 144,
+        "msapplication-square70x70logo" => 70,
+        "msapplication-square150x150logo" => 150,
+        "msapplication-square310x310logo" => 310
+    );
+    
+    foreach($windowsIconSizes as $iconName => $size) {
+        $thumbnail = $thumbnailer->getThumbnail($appIconFile, $size, $size, true);
+        
+        if (is_object($thumbnail)) {
+            $windowsIconHTML .= sprintf(
+                "%s<meta name=\"%s\" content=\"%s\" />",
+                strlen($windowsIconHTML) === 0 ? "" : "\n",
+                $iconName,
+                $thumbnail->src
+            );
+        }
+    }
+    
+    $metaTags['msapplication-TileImage'] = $windowsIconHTML;
+    
+    if (($modernIconBGColor = (string) $config->get('misc.modern_tile_thumbnail_bgcolor')) !== '') {
+        $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s"/>', $modernIconBGColor);
+    }
 }
 
 $alternateHreflangTags = [];

--- a/concrete/single_pages/dashboard/system/basics/icons.php
+++ b/concrete/single_pages/dashboard/system/basics/icons.php
@@ -1,62 +1,29 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-<form method="post" class="form-horizontal" id="favicon-form" action="<?=$view->action('update_icons')?>" >
-    <?=$this->controller->token->output('update_icons')?>
+<form method="post" class="form-horizontal" id="favicon-form" action="<?php echo $view->action('update_icons')?>" >
+    <?php echo $this->controller->token->output('update_icons')?>
     <fieldset>
-        <legend><?=t('Favicon')?></legend>
-            <div class="help-block"><?=t('Your image should be 16x16 pixels, and should be a gif or a png with a .ico file extension.')?></div>
-            <?php
-            $faviconFID = intval($config->get('misc.favicon_fid'));
-            $f = File::getByID($faviconFID);
-            ?>
-            <div class="form-group">
-                <?=$concrete_asset_library->file('ccm-favicon-file', 'faviconFID', t('Choose File'), $f);?>
-            </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?=t('iPhone Thumbnail')?></legend>
-        <div class="help-block"><?=t('iPhone home screen icons should be %1$dx%2$d and be in the %3$s format.', 180, 180, '.png')?></div>
+        <legend><?php echo t('Icon')?></legend>
+        <div class="help-block"><?php echo t('The master icon should be %1$dx%2$d and be in the %3$s format.  All icons (Favicon, iOS, Android &amp; Metro) will be automatically generated from the master icon.', 512, 512, '.png')?></div>
         <?php
-        $iosHomeFID = intval($config->get('misc.iphone_home_screen_thumbnail_fid'));
-        $f = File::getByID($iosHomeFID);
+            $appIconFID = intval($config->get('misc.app_icon_fid'));
+            $f = File::getByID($appIconFID);
         ?>
         <div class="form-group">
-            <?=$concrete_asset_library->file('ccm-iphone-file', 'iosHomeFID', t('Choose File'), $f);?>
+            <?php echo $concrete_asset_library->file('ccm-appicon-file', 'appIconFID', t('Choose File'), $f);?>
         </div>
     </fieldset>
-
     <fieldset>
-        <legend><?=t('Android Thumbnail')?></legend>
-        <div class="help-block"><?=t('Android home screen icons should be %1$dx%2$d and be in the %3$s format.', 192, 192, '.png')?></div>
-        <?php
-        $androidHomeFID = intval($config->get('misc.android_home_screen_thumbnail_fid'));
-        $f = File::getByID($androidHomeFID);
-        ?>
+        <legend><?php echo t('Additional Options'); ?></legend>
+        <div class="help-block"><?php echo t('For Windows metro tiles you can define also a background color.'); ?></div>
         <div class="form-group">
-            <?=$concrete_asset_library->file('ccm-android-file', 'androidHomeFID', t('Choose File'), $f);?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Windows 8 Thumbnail'); ?></legend>
-        <div class="help-block"><?=t('Windows 8 start screen tiles should be 144x144 and be in the .png format.'); ?></div>
-        <?php
-        $modernThumbFID = intval($config->get('misc.modern_tile_thumbnail_fid'));
-        $f = File::getByID($modernThumbFID);
-        $modernThumbBG = strval($config->get('misc.modern_tile_thumbnail_bgcolor'));
-        ?>
-        <div class="form-group">
-            <label class="control-label"><?=t('File')?></label>
-            <?=$concrete_asset_library->file('ccm-modern-file', 'modernThumbFID', t('Choose File'), $f);?>
-        </div>
-        <div class="form-group">
-            <label class="control-label"><?=t('Background Color')?></label>
+            <label class="control-label"><?php echo t('Background Color')?></label>
             <div>
-            <?php
-            $widget = Core::make('helper/form/color');
-            echo $widget->output('modernThumbBG', $modernThumbBG);
-            ?>
+                <?php
+                    $widget = Core::make('helper/form/color');
+                    $modernThumbBG = $config->get('misc.modern_tile_thumbnail_bgcolor');
+                    echo $widget->output('modernThumbBG', $modernThumbBG);
+                ?>
             </div>
         </div>
 
@@ -64,7 +31,7 @@
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button class="pull-right btn btn-primary" type="submit" ><?=t('Save')?></button>
+            <button class="pull-right btn btn-primary" type="submit" ><?php echo t('Save')?></button>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/system/basics/icons.php
+++ b/concrete/single_pages/dashboard/system/basics/icons.php
@@ -16,13 +16,25 @@
 
     <fieldset>
         <legend><?=t('iPhone Thumbnail')?></legend>
-        <div class="help-block"><?=t('iPhone home screen icons should be 57x57 and be in the .png format.')?></div>
+        <div class="help-block"><?=t('iPhone home screen icons should be 180x180 and be in the .png format.')?></div>
         <?php
         $iosHomeFID = intval($config->get('misc.iphone_home_screen_thumbnail_fid'));
         $f = File::getByID($iosHomeFID);
         ?>
         <div class="form-group">
             <?=$concrete_asset_library->file('ccm-iphone-file', 'iosHomeFID', t('Choose File'), $f);?>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend><?=t('Android Thumbnail')?></legend>
+        <div class="help-block"><?=t('Android home screen icons should be 192x192 and be in the .png format.')?></div>
+        <?php
+        $androidHomeFID = intval($config->get('misc.android_home_screen_thumbnail_fid'));
+        $f = File::getByID($androidHomeFID);
+        ?>
+        <div class="form-group">
+            <?=$concrete_asset_library->file('ccm-android-file', 'androidHomeFID', t('Choose File'), $f);?>
         </div>
     </fieldset>
 

--- a/concrete/single_pages/dashboard/system/basics/icons.php
+++ b/concrete/single_pages/dashboard/system/basics/icons.php
@@ -16,7 +16,7 @@
 
     <fieldset>
         <legend><?=t('iPhone Thumbnail')?></legend>
-        <div class="help-block"><?=t('iPhone home screen icons should be 180x180 and be in the .png format.')?></div>
+        <div class="help-block"><?=t('iPhone home screen icons should be %1$dx%2$d and be in the %3$s format.', 180, 180, '.png')?></div>
         <?php
         $iosHomeFID = intval($config->get('misc.iphone_home_screen_thumbnail_fid'));
         $f = File::getByID($iosHomeFID);
@@ -28,7 +28,7 @@
 
     <fieldset>
         <legend><?=t('Android Thumbnail')?></legend>
-        <div class="help-block"><?=t('Android home screen icons should be 192x192 and be in the .png format.')?></div>
+        <div class="help-block"><?=t('Android home screen icons should be %1$dx%2$d and be in the %3$s format.', 192, 192, '.png')?></div>
         <?php
         $androidHomeFID = intval($config->get('misc.android_home_screen_thumbnail_fid'));
         $f = File::getByID($androidHomeFID);

--- a/concrete/src/File/FileServiceProvider.php
+++ b/concrete/src/File/FileServiceProvider.php
@@ -13,6 +13,7 @@ class FileServiceProvider extends ServiceProvider
             'helper/file' => '\Concrete\Core\File\Service\File',
             'helper/concrete/file' => '\Concrete\Core\File\Service\Application',
             'helper/image' => '\Concrete\Core\File\Image\BasicThumbnailer',
+            'helper/icon' => '\Concrete\Core\File\Image\IconGenerator',
             'helper/mime' => '\Concrete\Core\File\Service\Mime',
             'helper/zip' => '\Concrete\Core\File\Service\Zip',
         );

--- a/concrete/src/File/Image/IconGenerator.php
+++ b/concrete/src/File/Image/IconGenerator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\Core\File\Image;
+
+use File;
+use Imagine\Gd\Image;
+use Imagine\Gd\Imagine;
+use Imagine\Image\Box;
+use Imagine\Image\Point;
+
+class IconGenerator {
+
+    /**
+     * @param File $fileObject
+     * 
+     * @return mixed
+     */
+    public function getRealIconURL($fileObject) {
+        $retVal = false;
+
+        if ($fileObject instanceof \Concrete\Core\Entity\File\File) {
+            $filesystem = $fileObject->getFileStorageLocationObject()->getFileSystemObject();
+
+            $configuration = $fileObject->getFileStorageLocationObject()->getConfigurationObject();
+
+            $fID = $fileObject->getFileID();
+
+            $timestamp = $fileObject->getFileResource()->getTimestamp();
+
+            $icoFileName = '/cache/thumbnails/' . md5(implode(':', array($fID, $timestamp))) . ".ico";
+
+            if ($filesystem->has($icoFileName) === false) {
+                $fileData = $fileObject->getFileContents();
+
+                $imagine = new Imagine();
+
+                $resizedImage = $imagine->load($fileData)->resize(new Box(16, 16))->crop(new Point(0, 0), new Box(16, 16));
+
+                if ($resizedImage instanceof Image) {
+                    // https://msdn.microsoft.com/de-de/library/windows/desktop/dd183376(v=vs.85).aspx
+                    $bitmapData = pack("VVVvvVVVVVV", 40, 16, 32, 1, 32, 0, 0, 0, 0, 0, 0);
+
+                    for ($y = 15; $y >= 0; $y--) {
+                        for ($x = 0; $x < 16; $x++) {
+                            $bitmapData .= pack('V', imagecolorat($resizedImage->getGdResource(), $x, $y) & 0xFFFFFF);
+                        }
+                    }
+
+                    // https://msdn.microsoft.com/en-us/library/ms997538.aspx
+                    $icoHeader = pack("vvvCCCCvvVV", 0, 1, 1, 16, 16, 0, 0, 1, 32, strlen($bitmapData), 22);
+
+                    // Merge ico header + bitmap data together
+                    $icoFileContent = $icoHeader . $bitmapData;
+
+                    // write to file
+                    $filesystem->write($icoFileName, $icoFileContent);
+                }
+            }
+
+            $retVal = $configuration->getPublicURLToFile($icoFileName);
+        }
+
+        return $retVal;
+    }
+
+}

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -470,7 +470,7 @@ class Form
                 }
                 $str .= '</optgroup>';
             } else {
-                $str .= '<option value="' . $k . '"';
+                $str .= '<option value="' . h($k) . '"';
                 if ((string) $k === (string) $selectedValue) {
                     $str .= ' selected="selected"';
                 }


### PR DESCRIPTION
Hello,

i have added a missing h() into the form service class to escape option values of select boxes.

Info: I'm not very familiar with pull request. I think with this pull request i may also have uploaded my other changes from previous. If yes please ignore! The only file i want to migrate is:
https://github.com/concrete5/concrete5/commit/05b6c2f868f2ae2c3e42695d99308e0a279dd343

