### PR TITLE
Fixing compose btn group

### DIFF
--- a/concrete/views/dialogs/page/add/compose.php
+++ b/concrete/views/dialogs/page/add/compose.php
@@ -10,13 +10,12 @@ $composer = Core::make("helper/concrete/composer");
         <div class="dialog-buttons">
             <button type="button" data-dialog-action="cancel" class="btn btn-default pull-left"><?=t('Cancel')?></button>
             <div class="btn-group pull-right">
-                <button style="margin-right: 0;" type="button" data-composer-dialog-action="publish" value="publish" class="btn btn-primary"><?=t('Publish Page')?>
-                    <button style="padding-right: 5px; padding-left: 5px; width: 35px;" data-page-type-composer-form-btn="schedule" type="button" class="btn btn-primary">
-                        <i class="fa fa-clock-o"></i>
-                    </button>
+                <button type="button" data-dialog-action="submit" value="preview" data-page-type-composer-form-btn="preview" class="btn btn-success"><?=t('Edit Mode')?></button>
+                <button style="margin-right: 0;" type="button" data-composer-dialog-action="publish" value="publish" class="btn btn-primary"><?=t('Publish Page')?></button>
+                <button style="padding-right: 5px; padding-left: 5px; width: 35px;" data-page-type-composer-form-btn="schedule" type="button" class="btn btn-primary">
+                    <i class="fa fa-clock-o"></i>
                 </button>
             </div>
-            <button type="button" data-dialog-action="submit" value="preview" data-page-type-composer-form-btn="preview" class="btn btn-success pull-right"><?=t('Edit Mode')?></button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
This PR fixes a small issue with the **Add Page** dialog `btn-group` :

Before :
<img width="680" alt="capture d ecran 2019-02-21 a 20 23 07" src="https://user-images.githubusercontent.com/29543909/53195994-2d14db00-3617-11e9-85cd-649bde693b28.png">

After :
<img width="682" alt="capture d ecran 2019-02-21 a 20 22 52" src="https://user-images.githubusercontent.com/29543909/53195993-2c7c4480-3617-11e9-8784-d3ff131a31f8.png">

