### PR TITLE
Fix #7572 and Moving sitemap_search_selector from tools to new route

### DIFF
--- a/concrete/controllers/dialog/page/sitemap_selector.php
+++ b/concrete/controllers/dialog/page/sitemap_selector.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Controller\Dialog\Page;
 
 use Concrete\Controller\Backend\UserInterface as UserInterfaceController;
@@ -32,7 +31,6 @@ class SitemapSelector extends UserInterfaceController
 
     public function view()
     {
-
         $this->requireAsset('core/sitemap');
 
         /** @var $sanitizer SanitizeService */
@@ -50,8 +48,6 @@ class SitemapSelector extends UserInterfaceController
         } else {
             $this->set('selectMode', '');
         }
-
-
     }
 
     protected function canAccess()
@@ -59,7 +55,5 @@ class SitemapSelector extends UserInterfaceController
         $siteHelper = $this->app->make('helper/concrete/dashboard/sitemap');
 
         return $siteHelper->canRead();
-
     }
-
 }

--- a/concrete/controllers/dialog/page/sitemap_selector.php
+++ b/concrete/controllers/dialog/page/sitemap_selector.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\Controller\Dialog\Page;
+
+use Concrete\Controller\Backend\UserInterface as UserInterfaceController;
+use Concrete\Core\Validation\SanitizeService;
+
+class SitemapSelector extends UserInterfaceController
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\Controller::$viewPath
+     */
+    protected $viewPath = '/dialogs/page/sitemap_selector';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Controller\Controller::$controllerActionPath
+     */
+    protected $controllerActionPath = '/ccm/system/dialogs/page/sitemap_selector';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Controller\Backend\UserInterface::$validationToken
+     */
+    protected $validationToken = '/dialogs/page/sitemap_selector';
+
+    protected $helpers = ['concrete/ui'];
+
+    public function view()
+    {
+
+        $this->requireAsset('core/sitemap');
+
+        /** @var $sanitizer SanitizeService */
+        $sanitizer = $this->app->make(SanitizeService::class);
+        $cID = $this->request->query->get('cID');
+        $cID = (int) $sanitizer->sanitizeInt($cID);
+
+        if (!empty($cID)) {
+            $this->set('cID', $cID);
+        }
+
+        $selectMode = $sanitizer->sanitizeString($this->request->query->get('sitemap_select_mode'));
+        if (!empty($selectMode)) {
+            $this->set('selectMode', $selectMode);
+        } else {
+            $this->set('selectMode', '');
+        }
+
+
+    }
+
+    protected function canAccess()
+    {
+        $siteHelper = $this->app->make('helper/concrete/dashboard/sitemap');
+
+        return $siteHelper->canRead();
+
+    }
+
+}

--- a/concrete/js/build/core/sitemap/search.js
+++ b/concrete/js/build/core/sitemap/search.js
@@ -1,5 +1,5 @@
 /* jshint unused:vars, undef:true, browser:true, jquery:true */
-/* global _, ccmi18n, ccmi18n_sitemap, CCM_DISPATCHER_FILENAME, CCM_TOOLS_PATH, Concrete, ConcreteAjaxSearch, ConcreteAlert, ConcreteEvent */
+/* global _, ccmi18n, ccmi18n_sitemap, CCM_DISPATCHER_FILENAME, Concrete, ConcreteAjaxSearch, ConcreteAlert, ConcreteEvent */
 
 ;(function(global, $) {
     'use strict';

--- a/concrete/js/build/core/sitemap/search.js
+++ b/concrete/js/build/core/sitemap/search.js
@@ -109,7 +109,7 @@
         $.fn.dialog.open({
             width: w,
             height: '100%',
-            href: CCM_TOOLS_PATH + '/sitemap_search_selector',
+            href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/sitemap_selector',
             modal: true,
             title: ccmi18n_sitemap.pageLocationTitle,
             onClose: function() {
@@ -188,7 +188,7 @@
                                     '<li><a class="dialog-launch" dialog-on-close="ConcreteSitemap.exitEditMode(<%=item.cID%>)" dialog-width="360" dialog-height="250" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.deletePage + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/delete_from_sitemap?cID=<%=item.cID%>">' + ccmi18n_sitemap.deletePage + '</a></li>',
                                 '<% } %>',
                                 '<li class="divider" data-sitemap-mode="explore"></li>',
-                                '<li data-sitemap-mode="explore"><a class="dialog-launch" dialog-width="90%" dialog-height="70%" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.moveCopyPage + '" href="' + CCM_TOOLS_PATH + '/sitemap_search_selector?sitemap_select_mode=move_copy_delete&cID=<%=item.cID%>">' + ccmi18n_sitemap.moveCopyPage + '</a></li>',
+                                '<li data-sitemap-mode="explore"><a class="dialog-launch" dialog-width="90%" dialog-height="70%" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.moveCopyPage + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/sitemap_selector?sitemap_select_mode=move_copy_delete&cID=<%=item.cID%>">' + ccmi18n_sitemap.moveCopyPage + '</a></li>',
                                 '<li data-sitemap-mode="explore"><a href="' + CCM_DISPATCHER_FILENAME + '/dashboard/sitemap/explore?cNodeID=<%=item.cID%>&task=send_to_top">' + ccmi18n_sitemap.sendToTop + '</a></li>',
                                 '<li data-sitemap-mode="explore"><a href="' + CCM_DISPATCHER_FILENAME + '/dashboard/sitemap/explore?cNodeID=<%=item.cID%>&task=send_to_bottom">' + ccmi18n_sitemap.sendToBottom + '</a></li>',
                                 '<% if (item.numSubpages > 0) { %>',

--- a/concrete/js/build/vendor/redactor/redactor.js
+++ b/concrete/js/build/vendor/redactor/redactor.js
@@ -3887,7 +3887,7 @@
 								height: '70%',
 								modal: false,
 								title: ccmi18n_sitemap.choosePage,
-								href: CCM_TOOLS_PATH + '/sitemap_search_selector'
+								href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/sitemap_selector'
 							});
 							ConcreteEvent.unsubscribe('SitemapSelectPage');
 							ConcreteEvent.subscribe('SitemapSelectPage', function(e, data) {
@@ -6221,7 +6221,7 @@
                                 height: '70%',
                                 modal: false,
                                 title: ccmi18n_sitemap.choosePage,
-                                href: CCM_TOOLS_PATH + '/sitemap_search_selector'
+                                href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/sitemap_selector'
                             });
                             ConcreteEvent.unsubscribe('SitemapSelectPage');
                             ConcreteEvent.subscribe('SitemapSelectPage', function(e, data) {

--- a/concrete/js/ckeditor4/core/concrete5link/plugin.js
+++ b/concrete/js/ckeditor4/core/concrete5link/plugin.js
@@ -48,7 +48,7 @@
                                         height: '70%',
                                         modal: false,
                                         title: ccmi18n_sitemap.choosePage,
-                                        href: CCM_TOOLS_PATH + '/sitemap_search_selector'
+                                        href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/sitemap_selector'
                                     });
                                     ConcreteEvent.unsubscribe('SitemapSelectPage');
                                     ConcreteEvent.subscribe('SitemapSelectPage', function(e, data) {

--- a/concrete/routes/dialogs/pages.php
+++ b/concrete/routes/dialogs/pages.php
@@ -33,6 +33,7 @@ $router->all('/edit_external/submit', 'EditExternal::submit');
 $router->all('/location', 'Location::view');
 $router->all('/search', 'Search::view');
 $router->all('/seo', 'Seo::view');
+$router->all('/sitemap_selector', 'SitemapSelector::view');
 $router->all('/drag_request', 'DragRequest::view');
 $router->all('/drag_request/submit', 'DragRequest::submit');
 $router->all('/drag_request/copy_all', 'DragRequest::doCopyAll');

--- a/concrete/views/dialogs/page/drag_request.php
+++ b/concrete/views/dialogs/page/drag_request.php
@@ -36,7 +36,12 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
     if ($singleOriginalPage === null) {
         echo t('What do you wish to do?');
     } else {
-        echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+        if ($dragRequestData->getDragMode() === 'none') {
+            echo t('You selected to move/copy "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+        } else {
+            echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+        }
+
     }
     ?>
 </div>

--- a/concrete/views/dialogs/page/sitemap_selector.php
+++ b/concrete/views/dialogs/page/sitemap_selector.php
@@ -1,0 +1,102 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+
+<div class="ccm-ui" id="ccm-sitemap-search-selector">
+
+    <?php
+        echo $concrete_ui->tabs([
+            ['sitemap', t('Full Sitemap')],
+            ['explore', t('Flat View')],
+            ['search', t('Search')],
+        ]);
+    ?>
+
+    <div id="ccm-tab-content-sitemap" class="ccm-tab-content"></div>
+
+    <div id="ccm-tab-content-explore" class="ccm-tab-content"></div>
+
+    <div id="ccm-tab-content-search" class="ccm-tab-content"></div>
+
+</div>
+
+<script type="text/javascript">
+    ccm_sitemapSearchSelectorHideBottom = function() {
+        $('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').hide();
+    }
+
+    ccm_sitemapSearchSelectorShowBottom = function() {
+        $('#ccm-sitemap-search-selector').parent().parent().find('.ui-dialog-buttonpane').show();
+    }
+
+    loadSitemapOverlay = function(type, url) {
+        jQuery.cookie('ccm-sitemap-selector-tab', type, { path: '<?=DIR_REL; ?>/' });
+
+        switch (type) {
+            case 'search':
+                ccm_sitemapSearchSelectorShowBottom();
+                break;
+            default:
+                ccm_sitemapSearchSelectorHideBottom();
+                break;
+        }
+
+        if ($('#ccm-tab-content-' + type).html() == '') {
+            jQuery.fn.dialog.showLoader();
+            $('#ccm-tab-content-' + type).load(url, function() {
+                jQuery.fn.dialog.hideLoader();
+            });
+        }
+    }
+
+    <?php if ($selectMode == 'move_copy_delete') {
+       ?>
+    ConcreteEvent.unsubscribe('SitemapSelectPage.search');
+
+    var subscription = function (e, data) {
+        Concrete.event.unsubscribe(e);
+        url = CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/drag_request?dragMode=none&origCID=<?=$cID?>&destCID=' + data.cID;
+        $.fn.dialog.open({
+            width: 520,
+            height: 'auto',
+            href: url,
+            title: ccmi18n_sitemap.moveCopyPage,
+            onDirectClose: function() {
+                ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
+            }
+        });
+    };
+    ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
+    <?php
+
+    }?>
+
+
+    $(function() {
+        var cParentID = 0;
+        var sst = jQuery.cookie('ccm-sitemap-selector-tab');
+        if (sst !== 'explore' && sst !== 'search') {
+            sst = 'sitemap';
+        }
+        $('a[data-tab=' + sst + ']').parent().addClass('active');
+        ccm_sitemapSearchSelectorHideBottom();
+        $('a[data-tab=sitemap]').click(function() {
+            loadSitemapOverlay('sitemap', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay');
+        });
+        $('a[data-tab=explore]').click(function() {
+            loadSitemapOverlay('explore', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay?display=flat&cParentID=' + cParentID);
+        });
+        $('a[data-tab=search]').click(function() {
+            loadSitemapOverlay('search', '<?= URL::to('/ccm/system/dialogs/page/search'); ?>');
+        });
+
+        $('#ccm-sitemap-search-selector ul li.active a').click();
+
+        $('#ccm-tab-content-sitemap').on('click', '.ccm-sitemap-open-flat-view', function(event) {
+            var node = $.ui.fancytree.getNode(event);
+            if (node && node.data && node.data.cParentID) {
+                cParentID = node.data.cParentID;
+            }
+            $('#ccm-tab-content-explore').html('');
+            $('a[data-tab=explore]').trigger('click');
+        });
+    });
+</script>


### PR DESCRIPTION
This PR fixes the issue with #7572 and also moves sitemap_search_selector to the CCM route system
I have kept the old sitemap_search_selector in tools incase of any packages using it (unlikely but don't want to BC break)