### PR TITLE
Fix Collection::getAttributeValueObject call

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -513,7 +513,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function getAttributeValueObject($akHandle, $createIfNotExists = false)
     {
         if (is_object($this->vObj)) {
-            return $this->vObj->getAttributeValue($akHandle);
+            return $this->vObj->getAttributeValueObject($akHandle, $createIfNotExists);
         }
     }
 


### PR DESCRIPTION
Calling `Version::getAttributeValue($ak)`  is exactly the same as calling `Version::getAttributeValueObject($ak, false)` (see [here](https://github.com/concrete5/concrete5/blob/b5648881c19529753a5f81e15fece3313374931e/concrete/src/Attribute/ObjectTrait.php#L38)).

In order to correctly forward the value of the `$createIfNotExists` parameter, we should call `Version::getAttributeValueObject($ak, $createIfNotExists)`.