### PR TITLE
Ignore errors when logging HTTP requests

### DIFF
--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -8,6 +8,8 @@ use Zend\Http\Request as ZendRequest;
 use Zend\Uri\Http as ZendUriHttp;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Exception;
+use Throwable;
 
 class Client extends ZendClient implements LoggerAwareInterface
 {
@@ -54,7 +56,13 @@ class Client extends ZendClient implements LoggerAwareInterface
         $logger = $this->getLogger();
         if ($logger !== null) {
             $statusCode = $response->getStatusCode();
-            $body = $response->getBody();
+            try {
+                $body = $response->getBody();
+            } catch (Exception $x) {
+                $body = '';
+            } catch (Throwable $x) {
+                $body = '';
+            }
             if (mb_strlen($body) <= 200) {
                 $shortBody = $body;
             } else {


### PR DESCRIPTION
The `getBody` method of the Response object may throw Exceptions.
This leads to a broken execution.

PS: before the logging stuff was refactored, this wasn't a big problem since the Http Client logger was set only if configured so.