### PR TITLE
Add mission "and" to password restriction error message

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -903,8 +903,8 @@ return [
             'allowed_characters' => [
                 'boundary' => 'A-Za-z0-9',
                 'middle' => 'A-Za-z0-9_\.',
-                'requirement_string' => 'A username may only contain letters, numbers, dots (not at the beginning/end), underscores (not at the beginning/end).',
-                'error_string' => 'A username may only contain letters, numbers, dots (not at the beginning/end), underscores (not at the beginning/end).',
+                'requirement_string' => 'A username may only contain letters, numbers, dots (not at the beginning/end), and underscores (not at the beginning/end).',
+                'error_string' => 'A username may only contain letters, numbers, dots (not at the beginning/end), and underscores (not at the beginning/end).',
             ],
         ],
         'password' => [


### PR DESCRIPTION
Client who is very picky about grammar point out missing `and` in the error message.
So sending a PR for it.