### PR TITLE
Fix broken user attribute editing introduced in #7562

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -533,7 +533,10 @@ class Search extends DashboardPageController
             $this->canSignInAsUser = $this->canEdit && $tp->canSudo() && $me->getUserID() != $ui->getUserID();
             $this->canDeleteUser = $this->canEdit && $tp->canDeleteUser() && $me->getUserID() != $ui->getUserID();
             $this->canAddGroup = $this->canEdit && $tp->canAccessGroupSearch();
-            $this->allowedEditAttributes = $this->canEdit && $this->assignment->getAttributesAllowedArray();
+            $this->allowedEditAttributes = [];
+            if ($this->canEdit) {
+                $this->allowedEditAttributes = $this->assignment->getAttributesAllowedArray();
+            }
             $this->set('user', $ui);
             $this->set('canEditAvatar', $this->canEditAvatar);
             $this->set('canEditUserName', $this->canEditUserName);


### PR DESCRIPTION
We turned an array into a boolean by not properly checking what was going on in a particular block of code, leading to attributes being unable to be edited on a user detail page in the Dashboard. This should fix that. 