### PR TITLE
Don't override CLI commands description if already set

### DIFF
--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -78,7 +78,9 @@ abstract class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        $this->setDescription($this->description);
+        if ((string) $this->description !== '') {
+            $this->setDescription($this->description);
+        }
         $this->setHidden($this->hidden);
         if (! isset($this->signature)) {
             $this->specifyParameters();


### PR DESCRIPTION
| Before | After |
|:---:|:---:|
| ![immagine](https://user-images.githubusercontent.com/928116/53580582-3b657880-3b7c-11e9-8b8b-08574d49b485.png) | ![immagine](https://user-images.githubusercontent.com/928116/53580593-43251d00-3b7c-11e9-9519-263d2aa04e3b.png) |