### PR TITLE
Fix AllDay determination of Event Occurrences

### DIFF
--- a/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
+++ b/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
@@ -120,7 +120,7 @@ class CalendarEventOccurrence
     public function isAllDay()
     {
         $diff = $this->getEnd() - $this->getStart();
-        if ($diff == 0) {
+        if ($diff == 86399) {
             return true;
         }
 

--- a/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
+++ b/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Entity\Calendar;
 
 use Doctrine\ORM\Mapping as ORM;
+use Carbon\Carbon;
 
 /**
  * @ORM\Entity
@@ -119,8 +120,9 @@ class CalendarEventOccurrence
 
     public function isAllDay()
     {
+        $dayDuration = Carbon::create($occurrence->getStart())->startOfDay()->secondsUntilEndOfDay();
         $diff = $this->getEnd() - $this->getStart();
-        if ($diff == 86399) {
+        if ($diff == $dayDuration) {
             return true;
         }
 

--- a/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
+++ b/concrete/src/Entity/Calendar/CalendarEventOccurrence.php
@@ -120,7 +120,7 @@ class CalendarEventOccurrence
 
     public function isAllDay()
     {
-        $dayDuration = Carbon::create($occurrence->getStart())->startOfDay()->secondsUntilEndOfDay();
+        $dayDuration = Carbon::create($this->getStart())->startOfDay()->secondsUntilEndOfDay();
         $diff = $this->getEnd() - $this->getStart();
         if ($diff == $dayDuration) {
             return true;


### PR DESCRIPTION
The assumpition that allDay Events have a diff of 0 is wrong. All Day Events are saved with a Duration from 00:00:00 to 23:59:59 which would be a int value of 86399