### PR TITLE
Fix creation of localized stacks/global areas

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0RC2',
     'version_installed' => '8.5.0RC2',
-    'version_db' => '20190225184524', // the key of the latest database migration
+    'version_db' => '20190301133300', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -160,7 +160,7 @@ class Cloner
                 'stName' => $newPage->getCollectionName(),
                 'cID' => $newPage->getCollectionID(),
                 'stType' => $page->getStackType(),
-                'stMultilingualSection' => $page->getMultilingualSectionID(),
+                'stMultilingualSection' => 0,
             ]);
             $newPage = Stack::getByID($newPage->getCollectionID());
             if ($page->isNeutralStack()) {

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -460,13 +460,13 @@ class Stack extends Page implements ExportableInterface
         Area::getOrCreate($localizedStackPage, STACKS_AREA_NAME);
         $localizedStackCID = $localizedStackPage->getCollectionID();
         $db = Database::connection();
-        $db->executeQuery('
-            insert into Stacks (stName, cID, stType, stMultilingualSection) values (?, ?, ?, ?)',
+        $db->update(
+            'Stacks',
             [
-                $name,
-                $localizedStackCID,
-                $this->getStackType(),
-                $section->getCollectionID()
+                'stMultilingualSection' => $section->getCollectionID(),
+            ],
+            [
+                'cID' => $localizedStackCID,
             ]
         );
         $localizedStack = static::getByID($localizedStackCID);

--- a/concrete/src/Updater/Migrations/Migrations/Version20190301133300.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190301133300.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use PDO;
+
+class Version20190301133300 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->fixDuplicatedStacks();
+    }
+
+    protected function fixDuplicatedStacks()
+    {
+        foreach ($this->getDuplicatedStacks() as $duplicatedStack) {
+            $this->fixDuplicatedStack($duplicatedStack);
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    protected function getDuplicatedStacks()
+    {
+        $rs = $this->connection->executeQuery(<<<'EOT'
+SELECT
+    Stacks.stID, Stacks.cID, SiteTrees.siteTreeID
+FROM
+    Stacks
+    INNER JOIN (
+        SELECT cID
+        FROM Stacks
+        GROUP BY cID
+        HAVING COUNT(stID) > 1
+    ) AS DuplicatedStacks
+    ON Stacks.cID = DuplicatedStacks.CID
+    LEFT JOIN SiteTrees
+    ON Stacks.stMultilingualSection = SiteTrees.siteHomePageID
+EOT
+        );
+        $dataPerCID = [];
+        while (($row = $rs->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $cID = $row['cID'];
+            if (!isset($dataPerCID[$cID])) {
+                $dataPerCID[$cID] = [];
+            }
+            $dataPerCID[$cID][] = $row;
+        }
+
+        return array_values($dataPerCID);
+    }
+
+    /**
+     * @param array[] $stackList
+     */
+    protected function fixDuplicatedStack(array $stackList)
+    {
+        $stacksWithSection = array_filter($stackList, function (array $stack) {
+            return !empty($stack['siteTreeID']);
+        });
+        if (!empty($stacksWithSection)) {
+            foreach ($stackList as $stack) {
+                if (!in_array($stack, $stacksWithSection, true)) {
+                    $this->connection->delete('Stacks', ['stID' => $stack['stID']]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When we create a localized version of a Stack, we (mistakenly) added two rows in the `Stacks` database table ([here](https://github.com/concrete5/concrete5/blob/0dab0af0d9ed1a235357a5201e23a01fa33e1371/concrete/src/Page/Cloner.php#L159-L164) and [here](https://github.com/concrete5/concrete5/blob/0dab0af0d9ed1a235357a5201e23a01fa33e1371/concrete/src/Page/Stack/Stack.php#L463-L471)).

Let's just add one row.

I also included a migration that fixes those duplicated rows.

Fix #7615