### PR TITLE
Add CkeditorEditor::outputEditorWithOptions()

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -229,7 +229,21 @@ EOL;
      */
     public function outputStandardEditor($key, $content = null)
     {
-        $options = [
+        return $this->outputEditorWithOptions($key, [], $content);
+    }
+
+    /**
+     * Generate the HTML to be placed in a page to display the editor.
+     *
+     * @param string $key the name of the field to be used to POST the editor content
+     * @param array $options custom options
+     * @param string|null $content The initial value of the editor content
+     *
+     * @return string
+     */
+    public function outputEditorWithOptions($key, array $options = [], $content = null)
+    {
+        $options += [
             'disableAutoInline' => true,
         ];
 


### PR DESCRIPTION
It'd be very useful to be able to fine tune the Rich Text editor.

Since every editor has its own specific options, we can't add a method to the `EditorInterface` interface (options for `CkeditorEditor` may not be applicable to `RedactorEditor`, and vice versa), so I added here a `outputEditorWithOptions` method only to the `CkeditorEditor` class.