### PR TITLE
Change datepicker autocomplete value from `nope` to `off`

### DIFF
--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -309,7 +309,7 @@ $(function() {
         $(inst.settings.altField).val('');
       }
     }
-  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'nope');
+  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'off');
 });
 </script>
 EOT;
@@ -409,7 +409,7 @@ $(function() {
         $(inst.settings.altField).val('');
       }
     }
-  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'nope');
+  },{$datePickerOptionsAsJSON})).datepicker('setDate', $defaultDateJs).attr('autocomplete', 'off');
 });
 </script>
 EOT;

--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -93,7 +93,7 @@ class DateTime
      *
      * @return string
      */
-    public function datetime($field, $value = null, $includeActivation = false, $calendarAutoStart = true, $classes = null, $timeResolution = 60, array $datePickerOptions = array())
+    public function datetime($field, $value = null, $includeActivation = false, $calendarAutoStart = true, $classes = null, $timeResolution = 60, array $datePickerOptions = [])
     {
         $app = Application::getFacadeApplication();
         $dh = $app->make('helper/date');
@@ -345,7 +345,7 @@ EOT;
      *
      * @return string
      */
-    public function date($field, $value = null, $calendarAutoStart = true, array $datePickerOptions = array())
+    public function date($field, $value = null, $calendarAutoStart = true, array $datePickerOptions = [])
     {
         $app = Application::getFacadeApplication();
         $dh = $app->make('helper/date');


### PR DESCRIPTION
The most recent version of google chrome isn't supporting the value `nope` for autocompletion which was implemented on https://github.com/concrete5/concrete5/pull/7234.
The Mozilla documentation also has removed this from their [documentation](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion). 

[Edit History](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion$history)
