### PR TITLE
Validate given year & month value to avoid error

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -380,6 +380,19 @@ class Controller extends BlockController
             return false;
         }
 
+        if ($method === 'action_filter_by_date') {
+            // Parameter 0 must be set
+            if (!isset($parameters[0]) || $parameters[0] < 0 || $parameters[0] > 9999) {
+                return false;
+            }
+            // Parameter 1 can be null
+            if (isset($parameters[1])) {
+                if ($parameters[1] < 1 || $parameters[1] > 12) {
+                    return false;
+                }
+            }
+        }
+
         return parent::isValidControllerTask($method, $parameters);
     }
 

--- a/concrete/blocks/page_title/controller.php
+++ b/concrete/blocks/page_title/controller.php
@@ -148,4 +148,26 @@ class Controller extends BlockController
 
         return $title;
     }
+
+    public function isValidControllerTask($method, $parameters = [])
+    {
+        if (!$this->useFilterTitle) {
+            return false;
+        }
+
+        if ($method === 'action_date') {
+            // Parameter 0 must be set
+            if (!isset($parameters[0]) || $parameters[0] < 0 || $parameters[0] > 9999) {
+                return false;
+            }
+            // Parameter 1 can be null
+            if (isset($parameters[1])) {
+                if ($parameters[1] < 1 || $parameters[1] > 12) {
+                    return false;
+                }
+            }
+        }
+
+        return parent::isValidControllerTask($method, $parameters);
+    }
 }


### PR DESCRIPTION
How to reproduce

Access to page list with invalid year & month like:
http://concrete5.test/index.php/blog/10000/13

You'll get this error: `Can't convert '10000-13-01 00:00:00' to a \DateTime`