### PR TITLE
Fix calendar block issues with all-day events

### DIFF
--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -39,6 +39,7 @@ if ($c->isEditMode()) {
                 <?php } ?>
 
                 events: '<?=$view->action('get_events')?>',
+                nextDayThreshold: '00:00:00',
 
                 eventRender: function(event, element) {
                     <?php if ($controller->supportsLightbox()) { ?>

--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -40,6 +40,12 @@ if ($c->isEditMode()) {
 
                 events: '<?=$view->action('get_events')?>',
                 nextDayThreshold: '00:00:00',
+                eventDataTransform: function(event) {
+                    if(event.allDay) {
+                        event.end = moment(event.end).add(1, 'days')
+                    }
+                    return event;
+                },
 
                 eventRender: function(event, element) {
                     <?php if ($controller->supportsLightbox()) { ?>


### PR DESCRIPTION
This PR fixes the following two issues of the calendar block related to [fullcalendar](https://fullcalendar.io).

- Doesn't show the last date of the events which end time is before 9 am. Because full calendar has `default: "09:00:00" (9am)` [threshold](https://fullcalendar.io/docs/nextDayThreshold).
- Doesn't show the last date of an all-day event. It's because `The exclusive date/time an event ends`. Check [here](https://fullcalendar.io/docs/event-object)

Noted that, it doesn't reflect on the dashboard page because of PHP validation.

There is a discussion regarding this issue on full calendar git and it's still open!
https://github.com/fullcalendar/fullcalendar/issues/2985


### Screenshots

#### Dashboard
![screen shot 2019-03-07 at 15 56 10](https://user-images.githubusercontent.com/2462951/53938973-32812380-40f5-11e9-8fc9-807dc120f0af.png)

#### Calendar block
![screen shot 2019-03-07 at 15 57 42](https://user-images.githubusercontent.com/2462951/53939077-7116de00-40f5-11e9-9201-24aea66e3832.png)
