### PR TITLE
Fix counting non countable in Survey block view

### DIFF
--- a/concrete/blocks/survey/view.php
+++ b/concrete/blocks/survey/view.php
@@ -33,6 +33,7 @@ $optionResults = array();
 $graphColors = array();
 $i = 1;
 $totalVotes = 0;
+$optionNamesAbbrev = [];
 foreach ($options as $opt) {
     $optionNamesAbbrev[] = $i;
     $optionResults[] = $opt->getResults();


### PR DESCRIPTION
See https://www.concrete5.org/developers/bugs/8-4-3/survey-bug-count-parameter-must-be-an-array-or-an-object-that-im/