### PR TITLE
Hide "Publish Now" button from a user who can’t approve versions

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -499,7 +499,11 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                             $date = $dateHelper->formatDate($publishDate);
                             $time = $dateHelper->formatTime($publishDate);
                             $message = t(/*i18n: %1$s is a date, %2$s is a time */'This version of the page is scheduled to be published on %1$s at %2$s.', $date, $time);
-                            $button = '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $cID . '&ctask=publish-now' . $token . '" class="btn btn-primary btn-xs">' . t('Publish Now') . '</a>';
+                            if ($canApprovePageVersions && !$c->isCheckedOut()) {
+                                $button = '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $cID . '&ctask=publish-now' . $token . '" class="btn btn-primary btn-xs">' . t('Publish Now') . '</a>';
+                            } else {
+                                $button = '';
+                            }
                             echo $cih->notify(array(
                                 'title' => t('Publish Pending.'),
                                 'text' => $message,


### PR DESCRIPTION
How to reproduce:

1. Edit a page and set schedule
2. Add a new user
3. Change the permission of the page. Give "View Versions" permission only to the user
4. Sign in as the user then access to the page
5. You can see the "Publish Now" button but you can't publish because you can't approve versions