### PR TITLE
Fix error on package uninstall while remove the package directory is checked

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -75,7 +75,7 @@ class Install extends DashboardPageController
                 $r = Package::uninstall($p);
                 if ($this->post('pkgMoveToTrash')) {
                     $r = $pkg->backup();
-                    if (is_object($r)) {
+                    if ($r instanceof ErrorList) {
                         $this->error->add($r);
                     }
                 }


### PR DESCRIPTION
On package uninstallation if you select `Yes, remove the package's directory from the installation directory.` It shows the following error. This PR fixes the error.
```
Object of class Concrete\Package\MyPackage\Controller could not be converted to string
```