### PR TITLE
Adding the placeholder orders for the language with a lot of grammar d…

### DIFF
--- a/concrete/src/Logging/Entry/Group/AddGroup.php
+++ b/concrete/src/Logging/Entry/Group/AddGroup.php
@@ -7,7 +7,7 @@ class AddGroup extends Group
 
     public function getEntryMessage()
     {
-        return t('Group %s (ID %s) was created by an automated process.',
+        return t('Group %1$s (ID %2$s) was created by an automated process.',
             $this->group->getGroupName(),
             $this->group->getGroupID()
         );
@@ -15,7 +15,7 @@ class AddGroup extends Group
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) created group %s (ID %s).',
+        return t('User %1$s (ID %2$s) created group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
             $this->group->getGroupName(),

--- a/concrete/src/Logging/Entry/Group/DeleteGroup.php
+++ b/concrete/src/Logging/Entry/Group/DeleteGroup.php
@@ -7,7 +7,7 @@ class DeleteGroup extends Group
 
     public function getEntryMessage()
     {
-        return t('Group %s (ID %s) was deleted by an automated process.',
+        return t('Group %1$s (ID %2$s) was deleted by an automated process.',
             $this->group->getGroupName(),
             $this->group->getGroupID()
         );
@@ -15,7 +15,7 @@ class DeleteGroup extends Group
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) deleted group %s (ID %s).',
+        return t('User %1$s (ID %2$s) deleted group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
             $this->group->getGroupName(),

--- a/concrete/src/Logging/Entry/Group/EnterGroup.php
+++ b/concrete/src/Logging/Entry/Group/EnterGroup.php
@@ -10,7 +10,7 @@ class EnterGroup extends UserGroup
 
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was added to group %s (ID %s) by an automated process.',
+        return t('User %1$s (ID %2$s) was added to group %3$s (ID %4$s) by an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->group->getGroupName(),
@@ -20,7 +20,7 @@ class EnterGroup extends UserGroup
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was added to group %s (ID %s) by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was added to group %3$s (ID %4$s) by %5$s (ID %6$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->group->getGroupName(),

--- a/concrete/src/Logging/Entry/Group/ExitGroup.php
+++ b/concrete/src/Logging/Entry/Group/ExitGroup.php
@@ -10,7 +10,7 @@ class ExitGroup extends UserGroup
 
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was removed from group %s (ID %s) by an automated process.',
+        return t('User %1$s (ID %2$s) was removed from group %3$s (ID %4$s) by an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->group->getGroupName(),
@@ -20,7 +20,7 @@ class ExitGroup extends UserGroup
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was removed from group %s (ID %s) by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was removed from group %3$s (ID %4$s) by %5$s (ID %6$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->group->getGroupName(),

--- a/concrete/src/Logging/Entry/Group/UpdateGroup.php
+++ b/concrete/src/Logging/Entry/Group/UpdateGroup.php
@@ -7,7 +7,7 @@ class UpdateGroup extends Group
 
     public function getEntryMessage()
     {
-        return t('Group %s (ID %s) was updated by an automated process.',
+        return t('Group %1$s (ID %2$s) was updated by an automated process.',
             $this->group->getGroupName(),
             $this->group->getGroupID()
         );
@@ -15,7 +15,7 @@ class UpdateGroup extends Group
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) updated group %s (ID %s).',
+        return t('User %1$s (ID %2$s) updated group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
             $this->group->getGroupName(),

--- a/concrete/src/Logging/Entry/Permission/Assignment/Assignment.php
+++ b/concrete/src/Logging/Entry/Permission/Assignment/Assignment.php
@@ -61,10 +61,10 @@ class Assignment implements EntryInterface
              * @var $object ObjectInterface
              */
             $object = $object->getPermissionObjectIdentifier();
-            return t('Permission assignment applied for permission %s on object %s by user %s',
+            return t('Permission assignment applied for permission %1$s on object %2$s by user %3$s',
                 $permission, $object, $applier);
         } else {
-            return t('Permission assignment applied for permission %s by user %s',
+            return t('Permission assignment applied for permission %1$s by user %2$s',
                 $permission, $applier);
         }
     }

--- a/concrete/src/Logging/Entry/User/ActivateUser.php
+++ b/concrete/src/Logging/Entry/User/ActivateUser.php
@@ -7,7 +7,7 @@ class ActivateUser extends User
 
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was activated by code or an automated process.',
+        return t('User %1$s (ID %2$s) was activated by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -15,7 +15,7 @@ class ActivateUser extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was activated by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was activated by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),

--- a/concrete/src/Logging/Entry/User/ChangeUserPassword.php
+++ b/concrete/src/Logging/Entry/User/ChangeUserPassword.php
@@ -7,7 +7,7 @@ class ChangeUserPassword extends User
 
     public function getEntryMessage()
     {
-        return t('Password for user %s (ID %s) was changed by code or an automated process.',
+        return t('Password for user %1$s (ID %2$s) was changed by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -15,7 +15,7 @@ class ChangeUserPassword extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('Password for user %s (ID %s) was changed by %s (ID %s).',
+        return t('Password for user %1$s (ID %2$s) was changed by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),

--- a/concrete/src/Logging/Entry/User/DeactivateUser.php
+++ b/concrete/src/Logging/Entry/User/DeactivateUser.php
@@ -7,7 +7,7 @@ class DeactivateUser extends User
 
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was deactivated by code or an automated process.',
+        return t('User %1$s (ID %2$s) was deactivated by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -15,7 +15,7 @@ class DeactivateUser extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was deactivated by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was deactivated by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),

--- a/concrete/src/Logging/Entry/User/DeleteUser.php
+++ b/concrete/src/Logging/Entry/User/DeleteUser.php
@@ -7,7 +7,7 @@ class DeleteUser extends User
 
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was deleted by code or an automated process.',
+        return t('User %1$s (ID %2$s) was deleted by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -15,7 +15,7 @@ class DeleteUser extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was deleted by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was deleted by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),

--- a/concrete/src/Logging/Entry/User/ResetUserPassword.php
+++ b/concrete/src/Logging/Entry/User/ResetUserPassword.php
@@ -7,7 +7,7 @@ class ResetUserPassword extends User
 
     public function getEntryMessage()
     {
-        return t('Password for user %s (ID %s) was reset by code or an automated process.',
+        return t('Password for user %1$s (ID %2$s) was reset by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -15,7 +15,7 @@ class ResetUserPassword extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('Password for user %s (ID %s) was reset by %s (ID %s).',
+        return t('Password for user %1$s (ID %2$s) was reset by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),

--- a/concrete/src/Logging/Entry/User/UpdateUser.php
+++ b/concrete/src/Logging/Entry/User/UpdateUser.php
@@ -6,7 +6,7 @@ class UpdateUser extends User
 {
     public function getEntryMessage()
     {
-        return t('User %s (ID %s) was updated by code or an automated process.',
+        return t('User %1$s (ID %2$s) was updated by code or an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID()
         );
@@ -14,7 +14,7 @@ class UpdateUser extends User
 
     public function getEntryMessageWithApplier()
     {
-        return t('User %s (ID %s) was updated by %s (ID %s).',
+        return t('User %1$s (ID %2$s) was updated by %3$s (ID %4$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
             $this->applier->getUserName(),


### PR DESCRIPTION
I was translating the strings of new logging features.

```
User %s (ID %s) was added to group %s (ID %s) by %s (ID %s).
```
to
```
User %1$s (ID %2$s) was added to group %3$s (ID %4$s) by %5$s (ID %6$s).
```

There are 6 placeholders!
I have to change the order to sounds natural for Japanese.