### PR TITLE
Fixes issue on Style-customizer 5.8.0RC2

### DIFF
--- a/concrete/src/Permission/Access/Entity/GroupSetEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupSetEntity.php
@@ -32,7 +32,7 @@ class GroupSetEntity extends Entity
             $ingids[] = $key;
         }
         $instr = implode(',', $ingids);
-        $peIDs = $db->GetCol('select peID from PermissionAccessEntityGroupSets paegs inner join GroupSetGroups gsg on paegs.gsID = gsg.gsID where gsg.gID in (' . $instr . ')');
+        $peIDs = $db->GetCol('select peID from PermissionAccessEntityGroupSets paegs inner join GroupSetGroups gsg on paegs.gsID = gsg.gsID where gsg.gID in (?)',array($instr));
         if (is_array($peIDs)) {
             foreach ($peIDs as $peID) {
                 $entity = Entity::getByID($peID);


### PR DESCRIPTION
An exception occurred while executing 'select peID from PermissionAccessEntityGroupSets paegs inner join GroupSetGroups gsg on paegs.gsID = gsg.gsID where gsg.gID in ()': SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1
