### PR TITLE
Update phpdoc and fix some warnings of Stack class

### DIFF
--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -73,9 +73,10 @@ class Stack extends Page implements ExportableInterface
     /**
      * @param string $stackName
      * @param string $cvID
+     * @param TreeInterface|null $site
      * @param int $multilingualContentSource
-     *
-     * @return Page
+     * 
+     * @return Stack|false|null
      */
     public static function getByName($stackName, $cvID = 'RECENT', TreeInterface $site = null, $multilingualContentSource = self::MULTILINGUAL_CONTENT_SOURCE_CURRENT)
     {

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -2,7 +2,6 @@
 namespace Concrete\Core\Page\Stack;
 
 use Area;
-use Concrete\Core\Entity\Site\Tree;
 use Concrete\Core\Export\ExportableInterface;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Page\Stack\Folder\Folder;
@@ -75,7 +74,7 @@ class Stack extends Page implements ExportableInterface
      * @param string $cvID
      * @param TreeInterface|null $site
      * @param int $multilingualContentSource
-     * 
+     *
      * @return Stack|false|null
      */
     public static function getByName($stackName, $cvID = 'RECENT', TreeInterface $site = null, $multilingualContentSource = self::MULTILINGUAL_CONTENT_SOURCE_CURRENT)
@@ -96,7 +95,7 @@ class Stack extends Page implements ExportableInterface
                     $ms = self::getMultilingualSectionFromType($multilingualContentSource);
                 }
                 $sql = 'select cID from Stacks where stName = ?';
-                $q = array($stackName);
+                $q = [$stackName];
                 if ($ms) {
                     $sql .= ' and (stMultilingualSection = ? or stMultilingualSection = 0)';
                     $q[] = $ms->getCollectionID();
@@ -123,7 +122,7 @@ class Stack extends Page implements ExportableInterface
             $db = Database::connection();
             $cID = $db->fetchColumn(
                 'select cID from Stacks where stName = ? and stMultilingualSection = 0',
-                array($stackName)
+                [$stackName]
             );
         }
 
@@ -159,7 +158,7 @@ class Stack extends Page implements ExportableInterface
 
     private static function addStackToCategory(\Concrete\Core\Page\Page $parent, $name, $type = 0)
     {
-        $data = array();
+        $data = [];
         $data['name'] = $name;
         if (!$name) {
             $data['name'] = t('No Name');
@@ -175,7 +174,7 @@ class Stack extends Page implements ExportableInterface
         $stackCID = $page->getCollectionID();
         //$siteTreeID = $parent->getSiteTreeObject()->getSiteTreeID();
         //$v = array($name, $stackCID, $type, $siteTreeID);
-        $v = array($name, $stackCID, $type);
+        $v = [$name, $stackCID, $type];
         $db->Execute('insert into Stacks (stName, cID, stType) values (?, ?, ?)', $v);
 
         $stack = static::getByID($stackCID);
@@ -202,6 +201,7 @@ class Stack extends Page implements ExportableInterface
     public static function addGlobalArea($area)
     {
         $parent = \Page::getByPath(STACKS_PAGE_PATH);
+
         return self::addStackToCategory($parent, $area, static::ST_TYPE_GLOBAL_AREA);
     }
 
@@ -222,7 +222,7 @@ class Stack extends Page implements ExportableInterface
     {
         $db = Database::connection();
 
-        return $db->GetOne('select stType from Stacks where cID = ?', array($this->getCollectionID()));
+        return $db->GetOne('select stType from Stacks where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -245,7 +245,7 @@ class Stack extends Page implements ExportableInterface
 
             $db = Database::connection();
             $stackName = $data['stackName'];
-            $db->Execute('update Stacks set stName = ? WHERE cID = ?', array($stackName, $this->getCollectionID()));
+            $db->Execute('update Stacks set stName = ? WHERE cID = ?', [$stackName, $this->getCollectionID()]);
         }
 
         return $worked;
@@ -271,7 +271,7 @@ class Stack extends Page implements ExportableInterface
         parent::delete();
         $db = Database::connection();
 
-        return $db->Execute('delete from Stacks where cID = ?', array($this->getCollectionID()));
+        return $db->Execute('delete from Stacks where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -281,7 +281,7 @@ class Stack extends Page implements ExportableInterface
     {
         $db = Database::connection();
 
-        return $db->GetOne('select stName from Stacks where cID = ?', array($this->getCollectionID()));
+        return $db->GetOne('select stName from Stacks where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -300,6 +300,7 @@ class Stack extends Page implements ExportableInterface
     {
         return new \Concrete\Core\Export\Item\Stack();
     }
+
     /**
      * @return bool|string
      */
@@ -326,7 +327,7 @@ class Stack extends Page implements ExportableInterface
     {
         if (!isset($this->multilingualSectionID)) {
             $db = Database::connection();
-            $cID = $db->GetOne('select stMultilingualSection from Stacks where cID = ?', array($this->getCollectionID()));
+            $cID = $db->GetOne('select stMultilingualSection from Stacks where cID = ?', [$this->getCollectionID()]);
             $this->multilingualSectionID = $cID ? (int) $cID : 0;
         }
 
@@ -352,13 +353,13 @@ class Stack extends Page implements ExportableInterface
         return $result;
     }
 
-/*
-    public function updateMultilingualSection(Section $section)
-    {
-        $db = Database::connection();
-        $db->Execute('update Stacks set stMultilingualSection = ? where cID = ?', array($section->getCollectionID(), $this->getCollectionID()));
-    }
-*/
+    /*
+        public function updateMultilingualSection(Section $section)
+        {
+            $db = Database::connection();
+            $db->Execute('update Stacks set stMultilingualSection = ? where cID = ?', array($section->getCollectionID(), $this->getCollectionID()));
+        }
+    */
 
     /**
      * Returns the collection ID of the locale.neutral version of this stack (or null if this instance is already the neutral version).
@@ -426,7 +427,7 @@ class Stack extends Page implements ExportableInterface
     	               Pages.cParentID = ? and Stacks.stMultilingualSection = ?
                     limit 1
                 ',
-                array($neutralID, $section->getCollectionID())
+                [$neutralID, $section->getCollectionID()]
             );
             if ($localizedID) {
                 $localized = static::getByID($localizedID, $cvID);

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -44,6 +44,13 @@ class Stack extends Page implements ExportableInterface
         }
     }
 
+    /**
+     * @param string $path
+     * @param string $version
+     * @param TreeInterface|null $siteTree
+     *
+     * @return bool|Page
+     */
     public static function getByPath($path, $version = 'RECENT', TreeInterface $siteTree = null)
     {
         $c = parent::getByPath(STACKS_PAGE_PATH . '/' . trim($path, '/'), $version, $siteTree);
@@ -156,6 +163,13 @@ class Stack extends Page implements ExportableInterface
         return $stack->getPageTypeHandle() == STACKS_PAGE_TYPE;
     }
 
+    /**
+     * @param Page $parent
+     * @param $name
+     * @param int $type
+     *
+     * @return Stack|false
+     */
     private static function addStackToCategory(\Concrete\Core\Page\Page $parent, $name, $type = 0)
     {
         $data = [];
@@ -182,6 +196,11 @@ class Stack extends Page implements ExportableInterface
         return $stack;
     }
 
+    /**
+     * @param $type
+     *
+     * @return Section|false|null
+     */
     protected static function getMultilingualSectionFromType($type)
     {
         $detector = Core::make('multilingual/detector');
@@ -198,6 +217,11 @@ class Stack extends Page implements ExportableInterface
         return $ms;
     }
 
+    /**
+     * @param $area
+     *
+     * @return Stack|false
+     */
     public static function addGlobalArea($area)
     {
         $parent = \Page::getByPath(STACKS_PAGE_PATH);
@@ -205,6 +229,12 @@ class Stack extends Page implements ExportableInterface
         return self::addStackToCategory($parent, $area, static::ST_TYPE_GLOBAL_AREA);
     }
 
+    /**
+     * @param $stack
+     * @param Folder|null $folder
+     *
+     * @return Stack|false
+     */
     public static function addStack($stack, Folder $folder = null)
     {
         $parent = \Page::getByPath(STACKS_PAGE_PATH);
@@ -296,6 +326,9 @@ class Stack extends Page implements ExportableInterface
         return true;
     }
 
+    /**
+     * @return \Concrete\Core\Export\Item\ItemInterface|\Concrete\Core\Export\Item\Stack|\Concrete\Core\Page\Exporter
+     */
     public function getExporter()
     {
         return new \Concrete\Core\Export\Item\Stack();

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -2,7 +2,6 @@
 namespace Concrete\Core\Page\Stack;
 
 use Area;
-use Concrete\Core\Export\ExportableInterface;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Page\Stack\Folder\Folder;
 use Concrete\Core\Site\Tree\TreeInterface;
@@ -19,7 +18,7 @@ use Concrete\Core\Entity\Site\Site;
  *
  * \@package Concrete\Core\Page\Stack
  */
-class Stack extends Page implements ExportableInterface
+class Stack extends Page
 {
     const ST_TYPE_USER_ADDED = 0;
     const ST_TYPE_GLOBAL_AREA = 20;

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -46,9 +46,9 @@ class Stack extends Page
     /**
      * @param string $path
      * @param string $version
-     * @param TreeInterface|null $siteTree
+     * \Concrete\Core\Site\Tree\TreeInterface|null $siteTree
      *
-     * @return bool|Page
+     * @return bool|\Concrete\Core\Page\Page
      */
     public static function getByPath($path, $version = 'RECENT', TreeInterface $siteTree = null)
     {
@@ -61,9 +61,9 @@ class Stack extends Page
     }
 
     /**
-     * @param $stackName
+     * @param string $stackName
      *
-     * @return Stack
+     * @return self
      */
     public static function getOrCreateGlobalArea($stackName)
     {
@@ -78,10 +78,10 @@ class Stack extends Page
     /**
      * @param string $stackName
      * @param string $cvID
-     * @param TreeInterface|null $site
+     * \Concrete\Core\Site\Tree\TreeInterface|null $site
      * @param int $multilingualContentSource
      *
-     * @return Stack|false|null
+     * @return self|false|null
      */
     public static function getByName($stackName, $cvID = 'RECENT', TreeInterface $site = null, $multilingualContentSource = self::MULTILINGUAL_CONTENT_SOURCE_CURRENT)
     {
@@ -139,7 +139,7 @@ class Stack extends Page
      * @param int    $cID
      * @param string $cvID
      *
-     * @return Stack|false
+     * @return \Concrete\Core\Page\Page|self|false
      */
     public static function getByID($cID, $cvID = 'RECENT')
     {
@@ -153,7 +153,7 @@ class Stack extends Page
     }
 
     /**
-     * @param Stack $stack
+     * @param \Concrete\Core\Page\Stack\Stack $stack
      *
      * @return bool
      */
@@ -163,11 +163,11 @@ class Stack extends Page
     }
 
     /**
-     * @param Page $parent
+     * @param \Concrete\Core\Page\Page $parent
      * @param $name
      * @param int $type
      *
-     * @return Stack|false
+     * @return self|false
      */
     private static function addStackToCategory(\Concrete\Core\Page\Page $parent, $name, $type = 0)
     {
@@ -198,7 +198,7 @@ class Stack extends Page
     /**
      * @param $type
      *
-     * @return Section|false|null
+     * @return \Concrete\Core\Multilingual\Page\Section\Section|false|null
      */
     protected static function getMultilingualSectionFromType($type)
     {
@@ -219,7 +219,7 @@ class Stack extends Page
     /**
      * @param $area
      *
-     * @return Stack|false
+     * @return self|false
      */
     public static function addGlobalArea($area)
     {
@@ -230,9 +230,9 @@ class Stack extends Page
 
     /**
      * @param $stack
-     * @param Folder|null $folder
+     * @param \Concrete\Core\Page\Stack\Folder\Folder|null $folder
      *
-     * @return Stack|false
+     * @return self|false
      */
     public static function addStack($stack, Folder $folder = null)
     {
@@ -369,7 +369,7 @@ class Stack extends Page
     /**
      * Returns the multilingual section associated to this stack (or null if it's the language-neutral version).
      *
-     * @return Section|null
+     * @return \Concrete\Core\Multilingual\Page\Section\Section|null
      */
     public function getMultilingualSection()
     {
@@ -418,7 +418,7 @@ class Stack extends Page
      *
      * @param string|int $cvID
      *
-     * @return Stack|null
+     * @return self|null
      */
     public function getNeutralStack($cvID = 'RECENT')
     {
@@ -434,10 +434,10 @@ class Stack extends Page
     /**
      * Returns the localized version of this stack.
      *
-     * @param Section $section
+     * @param \Concrete\Core\Multilingual\Page\Section\Section $section
      * @param string|int $cvID
      *
-     * @return static|null
+     * @return self|null
      */
     public function getLocalizedStack(Section $section, $cvID = 'RECENT')
     {
@@ -473,7 +473,7 @@ class Stack extends Page
     }
 
     /**
-     * @param Section $section
+     * @param \Concrete\Core\Multilingual\Page\Section\Section $section
      *
      * @return self
      */


### PR DESCRIPTION
https://github.com/concrete5/concrete5/blob/0c349867acc59458f2a6df8a98c485e6720440b2/concrete/src/Page/Stack/Stack.php#L78

This actually returns `Stack|false|null`.
This PR fixes some warnings, adds new phpdoc blocks including the above fix.