### PR TITLE
Remove 'static' keyword from isEnabled() and getPreferredSection()

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -98,6 +98,8 @@ class Detector
      * Set the locale associated to the 'site' localization context.
      *
      * @param Page $c The page to be used to determine the site locale (if null we'll use the current page)
+     *
+     * @throws \Exception
      */
     public function setupSiteInterfaceLocalization(Page $c = null)
     {
@@ -150,6 +152,8 @@ class Detector
      * Check if there's some multilingual section.
      *
      * @return bool
+     *
+     * @throws \Exception
      */
     public function isEnabled()
     {

--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -21,7 +21,7 @@ class Detector
      *
      * @return Section|null
      */
-    public static function getPreferredSection()
+    public function getPreferredSection()
     {
         $app = Facade::getFacadeApplication();
         $site = $app->make('site')->getSite();
@@ -122,7 +122,7 @@ class Detector
                 if ($this->isEnabled()) {
                     $ms = Section::getBySectionOfSite($c);
                     if (!$ms) {
-                        $ms = static::getPreferredSection();
+                        $ms = $this->getPreferredSection();
                     }
                     if ($ms) {
                         $locale = $ms->getLocale();
@@ -151,7 +151,7 @@ class Detector
      *
      * @return bool
      */
-    public static function isEnabled()
+    public function isEnabled()
     {
         $app = Facade::getFacadeApplication();
         $cache = $app->make('cache/request');


### PR DESCRIPTION
`isEnabled()` & `getPreferredSection()` has been called dynamically in everywhere.
Should we remove the `static` keyword then?

https://github.com/concrete5/concrete5/blob/0c349867acc59458f2a6df8a98c485e6720440b2/concrete/src/Multilingual/Service/Detector.php#L24
https://github.com/concrete5/concrete5/blob/0c349867acc59458f2a6df8a98c485e6720440b2/concrete/src/Multilingual/Service/Detector.php#L154