### PR TITLE
Implement generic IP Control Access

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -197,6 +197,7 @@ return [
         'geolocator_library',
         'group',
         'group_set',
+        'ip_access_control_category',
         'job',
         'mail_importer',
         'permission_access_entity_type',
@@ -268,6 +269,7 @@ return [
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSystemCaptchaLibrariesRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportSystemContentEditorSnippetsRoutine',
         'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportGeolocatorsRoutine',
+        'Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportIpAccessControlCategoriesRoutine',
     ],
 
     /*

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.0',
     'version_installed' => '8.5.0',
-    'version_db' => '20190301133300', // the key of the latest database migration
+    'version_db' => '20190317123600', // the key of the latest database migration
 
     /*
      * Installation status
@@ -991,18 +991,6 @@ return [
                 'enabled' => false,
                 // Time window (in seconds) for inactive users to be automatically logout
                 'time' => 300,
-            ],
-        ],
-        'ban' => [
-            'ip' => [
-                // Is the automatic ban system enabled?
-                'enabled' => true,
-                // Maximum number of login attempts before banning the IP address
-                'attempts' => 5,
-                // Time window (in seconds) for past failed login attempts
-                'time' => 300,
-                // Ban duration (in minutes) when <attempts> failed logins occurred in the past <time> seconds
-                'length' => 10,
             ],
         ],
         'misc' => [

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -3485,31 +3485,6 @@
     </index>
   </table>
 
-  <table name="LoginControlIpRanges" comment="IP ranges used to control login attempts">
-    <field name="lcirID" type="integer" comment="Record identifier">
-      <unsigned/>
-      <autoincrement/>
-      <key/>
-    </field>
-    <field name="lcirIpFrom" type="string" size="40" comment="Start of the range">
-      <notnull/>
-    </field>
-    <field name="lcirIpTo" type="string" size="40" comment="End of the range">
-      <notnull/>
-    </field>
-    <field name="lcirType" type="smallint" comment="Type of the record">
-      <unsigned/>
-      <notnull/>
-    </field>
-    <field name="lcirExpires" type="datetime" comment="Record end-of-life timestamp">
-    </field>
-    <index name="IX_LoginControlIpRanges_Search">
-      <col>lcirIpFrom</col>
-      <col>lcirIpTo</col>
-      <col>lcirExpires</col>
-    </index>
-  </table>
-
   <table name="UserGroups">
     <field name="uID" type="integer" size="10">
       <unsigned/>
@@ -3674,21 +3649,6 @@
       <unique/>
       <col>mHash</col>
     </index>
-  </table>
-
-  <table name="FailedLoginAttempts" comment="Records failed login attempts">
-    <field name="lcirID" type="integer" comment="Record identifier">
-      <unsigned/>
-      <autoincrement/>
-      <key/>
-    </field>
-    <field name="flaIp" type="string" size="40" comment="IP address of the failed login attempt">
-      <notnull/>
-    </field>
-    <field name="flaTimestamp" type="timestamp" comment="Timestamp of the failed login attempt">
-      <deftimestamp/>
-      <notnull/>
-    </field>
   </table>
 
   <table name="FilePermissionAssignments">

--- a/concrete/config/install/base/config.xml
+++ b/concrete/config/install/base/config.xml
@@ -21,4 +21,19 @@
 		</geolocator>
 	</geolocators>
 
+    <!-- IP Access Control Categories -->
+    <ipaccesscontrolcategories>
+        <ipaccesscontrolcategory
+            handle="failed_login"
+            enabled="1"
+            name="Failed Login Attempts"
+            max-events="5"
+            time-window="300"
+            ban-duration="600"
+            site-specific="0"
+            log-channel-handle=""
+            package=""
+        />
+    </ipaccesscontrolcategories>
+
 </concrete5-cif>

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -850,11 +850,19 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Configure IP Blocking" path="/dashboard/system/permissions/blacklist/configure"
+              filename="/dashboard/system/permissions/blacklist/configure.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="exclude_nav">
+                    <value>1</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="IP Range" path="/dashboard/system/permissions/blacklist/range"
               filename="/dashboard/system/permissions/blacklist/range.php" pagetype="" description="" package="">
             <attributes>
 				<attributekey handle="exclude_nav">
-                    <value>0</value>
+                    <value>1</value>
                 </attributekey>
             </attributes>
         </page>

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
@@ -133,11 +133,10 @@ class Configure extends Blacklist
 
     /**
      * @param string $name
-     * @param mixed $dbg
      *
      * @return int|null
      */
-    protected function getPostedSeconds($name, $dbg = false)
+    protected function getPostedSeconds($name)
     {
         $post = $this->request->request;
         $unit = $post->get("{$name}Unit");

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
@@ -71,7 +71,7 @@ class Configure extends Blacklist
             if ($post->get('banDurationUnlimited')) {
                 $category->setBanDuration(null);
             } else {
-                $banDuration = $this->getPostedSeconds('banDuration', true);
+                $banDuration = $this->getPostedSeconds('banDuration');
                 if ($banDuration !== null && $banDuration > 0) {
                     $category->setBanDuration($banDuration);
                 } else {

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/configure.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist;
+
+use Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist;
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Punic\Unit;
+
+class Configure extends Blacklist
+{
+    const UNIT_SECONDS = 's';
+    const UNIT_MINUTES = 'm';
+    const UNIT_HOURS = 'h';
+    const UNIT_DAYS = 'd';
+
+    public function view($id = '')
+    {
+        $category = $this->getCategory($id);
+        if ($category === null) {
+            return $this->app->make(ResponseFactoryInterface::class)->redirect(
+                $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/system/permissions/blacklist']),
+                302
+            );
+        }
+        $this->set('pageTitle', t('%s: Configure IP blocking', $category->getDisplayName()));
+        $this->set('category', $category);
+        $this->set('units', [
+            self::UNIT_SECONDS => Unit::getName('duration/second', 'long'),
+            self::UNIT_MINUTES => Unit::getName('duration/minute', 'long'),
+            self::UNIT_HOURS => Unit::getName('duration/hour', 'long'),
+            self::UNIT_DAYS => Unit::getName('duration/day', 'long'),
+        ]);
+    }
+
+    public function update_ipblacklist($id = '')
+    {
+        $category = $this->getCategory($id);
+        if ($category === null) {
+            $this->flash('error', t('Unable to find the requested category'));
+
+            return $this->app->make(ResponseFactoryInterface::class)->redirect(
+                $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/system/permissions/blacklist']),
+                302
+            );
+        }
+        try {
+            if (!$this->token->validate('update_ipblacklist-' . $category->getIpAccessControlCategoryID())) {
+                throw new UserMessageException($this->token->getErrorMessage());
+            }
+            $post = $this->request->request;
+            $valn = $this->app->make('helper/validation/numbers');
+            $category->setEnabled($post->get('banEnabled'));
+            /* @var \Concrete\Core\Utility\Service\Validation\Numbers $valn */
+
+            $maxEvents = $post->get('maxEvents');
+            if ($valn->integer($maxEvents, 1)) {
+                $category->setMaxEvents($maxEvents);
+            } else {
+                $this->error->add(t('Please specify a number greater than zero for the maximum number of events'), 'maxEvents');
+            }
+
+            $timeWindow = $this->getPostedSeconds('timeWindow');
+            if ($timeWindow === null || $timeWindow > 0) {
+                $category->setTimeWindow($timeWindow);
+            } else {
+                $this->error->add(t('Please specify a number greater than zero for the time window'));
+            }
+
+            if ($post->get('banDurationUnlimited')) {
+                $category->setBanDuration(null);
+            } else {
+                $banDuration = $this->getPostedSeconds('banDuration', true);
+                if ($banDuration !== null && $banDuration > 0) {
+                    $category->setBanDuration($banDuration);
+                } else {
+                    $this->error->add(t('Please specify a number greater than zero for the ban duration'));
+                }
+            }
+
+            if (!$this->error->has()) {
+                $this->entityManager->flush($category);
+                $this->flash('success', t('IP Blacklist settings saved.'));
+
+                return $this->app->make(ResponseFactoryInterface::class)->redirect(
+                    $this->action('view', $category->getIpAccessControlCategoryID()),
+                    302
+                );
+            }
+        } catch (UserMessageException $x) {
+            $this->error->add($x->getMessage());
+        }
+        $this->view($category->getIpAccessControlCategoryID());
+    }
+
+    /**
+     * @param int|null $seconds
+     *
+     * @return array
+     */
+    public function splitSeconds($seconds)
+    {
+        if ((string) $seconds === '') {
+            $selectedUnit = self::UNIT_SECONDS;
+            $unitValue = '';
+        } else {
+            $seconds = (int) $seconds;
+            if ($seconds < 60 || $seconds % 60 !== 0) {
+                $selectedUnit = self::UNIT_SECONDS;
+                $unitValue = (string) $seconds;
+            } else {
+                $minutes = round($seconds / 60);
+                if ($minutes < 60 || $minutes % 60 !== 0) {
+                    $selectedUnit = self::UNIT_MINUTES;
+                    $unitValue = (string) $minutes;
+                } else {
+                    $hours = round($minutes / 60);
+                    if ($hours < 24 || $hours % 24 !== 0) {
+                        $selectedUnit = self::UNIT_HOURS;
+                        $unitValue = (string) $hours;
+                    } else {
+                        $days = round($hours / 24);
+                        $selectedUnit = self::UNIT_DAYS;
+                        $unitValue = (string) $days;
+                    }
+                }
+            }
+        }
+
+        return [$selectedUnit, $unitValue];
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $dbg
+     *
+     * @return int|null
+     */
+    protected function getPostedSeconds($name, $dbg = false)
+    {
+        $post = $this->request->request;
+        $unit = $post->get("{$name}Unit");
+        if ($unit === self::UNIT_SECONDS) {
+            $multiplier = 1;
+        } elseif ($unit === self::UNIT_MINUTES) {
+            $multiplier = 1 * 60;
+        } elseif ($unit === self::UNIT_HOURS) {
+            $multiplier = 1 * 60 * 60;
+        } elseif ($unit === self::UNIT_DAYS) {
+            $multiplier = 1 * 60 * 60 * 24;
+        } else {
+            return null;
+        }
+        $value = $post->get("{$name}Value");
+        $valn = $this->app->make('helper/validation/numbers');
+        if (!$valn->integer($value, 0)) {
+            return null;
+        }
+
+        return $multiplier * (int) $value;
+    }
+}

--- a/concrete/elements/dashboard/system/permissions/blacklist/menu.php
+++ b/concrete/elements/dashboard/system/permissions/blacklist/menu.php
@@ -1,10 +1,14 @@
 <?php
-use Concrete\Core\Permission\IPService;
+
+use Concrete\Core\Permission\IpAccessControlService;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
 // Arguments
+/* @var Concrete\Core\Entity\Permission\IpAccessControlCategory|null $category */
 /* @var int|null $type */
+
+$categoryID = $category->getIpAccessControlCategoryID();
 ?>
 <div class="ccm-dashboard-header-buttons">
     <div class="btn-group">
@@ -13,22 +17,22 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <span class="caret"></span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
-            <li<?= ($type === null) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist')?>"><?= t('Options') ?></a></li>
+            <li<?= $type === null ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/configure', 'view', $categoryID)?>"><?= t('Options') ?></a></li>
             <li class="divider"></li>
-            <li<?= ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) ?>"><?= t('Blacklisted IP addresses (automatic)') ?></a></li>
-            <li<?= ($type === IPService::IPRANGETYPE_BLACKLIST_MANUAL) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_BLACKLIST_MANUAL) ?>"><?= t('Blacklisted IP addresses (manual)') ?></a></li>
-            <li<?= ($type === IPService::IPRANGETYPE_WHITELIST_MANUAL) ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IPService::IPRANGETYPE_WHITELIST_MANUAL) ?>"><?= t('Whitelisted IP addresses') ?></a></li>
+            <li<?= $type === IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC, $categoryID) ?>"><?= t('Blacklisted IP addresses (automatic)') ?></a></li>
+            <li<?= $type === IpAccessControlService::IPRANGETYPE_BLACKLIST_MANUAL ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IpAccessControlService::IPRANGETYPE_BLACKLIST_MANUAL, $categoryID) ?>"><?= t('Blacklisted IP addresses (manual)') ?></a></li>
+            <li<?= $type === IpAccessControlService::IPRANGETYPE_WHITELIST_MANUAL ? ' class="active"' : '' ?>><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'view', IpAccessControlService::IPRANGETYPE_WHITELIST_MANUAL, $categoryID) ?>"><?= t('Whitelisted IP addresses') ?></a></li>
             <?php
             if ($type !== null) {
                 $token = Core::make('token');
                 /* @var Concrete\Core\Validation\CSRF\Token $token */
                 ?>
                 <li class="divider"></li>
-                <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, 0, $token->generate("iprange/export/range/{$type}/0")) ?>"><?= t('Export as CSV') ?></a></li>
+                <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, $categoryID, 0, $token->generate("iprange/export/range/{$type}/{$categoryID}/0")) ?>"><?= t('Export as CSV') ?></a></li>
                 <?php
-                if ($type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+                if ($type === IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
                     ?>
-                    <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, 1, $token->generate("iprange/export/range/{$type}/1")) ?>"><?= t('Export as CSV (including expired)') ?></a></li>
+                    <li><a href="<?= URL::to('/dashboard/system/permissions/blacklist/range', 'export', $type, $categoryID, 1, $token->generate("iprange/export/range/{$type}/{$categoryID}/1")) ?>"><?= t('Export as CSV (including expired)') ?></a></li>
                     <?php
                 }
             }

--- a/concrete/single_pages/dashboard/system/permissions/blacklist.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist.php
@@ -2,49 +2,48 @@
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var Concrete\Core\Page\View\PageView $view */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
-/* @var Concrete\Core\Form\Service\Form $form */
 
-/* @var bool $banEnabled */
-/* @var int $allowedAttempts */
-/* @var int $attemptsTimeWindow */
-/* @var int $banDuration */
+/* @var Concrete\Core\Entity\Permission\IpAccessControlCategory[] $categories */
 
-$view->element('dashboard/system/permissions/blacklist/menu', ['type' => null]);
-?>
-
-<form method="post" id="ipblacklist-form" action="<?= $view->action('update_ipblacklist') ?>">
-    <?php $token->output('update_ipblacklist') ?>
-    <div class="ccm-pane-body">
-        <div class="form-group form-inline">
-            <?= $form->checkbox('banEnabled', 1, $banEnabled) ?>
-            <?= t(
-                'Lock IP after %1$s failed login attempts in %2$s seconds',
-                $form->number('allowedAttempts', $allowedAttempts, ['style' => 'width:70px', 'min' => 1]),
-                $form->number('attemptsTimeWindow', $attemptsTimeWindow, ['style' => 'width:90px', 'min' => 1])
-            ) ?>
-        </div>
-
-        <div class="form-group">
-            <?= $form->label('banDurationUnlimited', t('Ban Duration'))?>
-            <div class="radio">
-                <label>
-                    <?= $form->radio('banDurationUnlimited', 0, $banDuration ? 0 : 1) ?>
-                    <?= t('Ban IP for %s minutes', $form->number('banDuration', $banDuration ?: 300, ['style' => 'width:90px; display: inline-block', 'min' => 1])) ?>
-                </label>
-            </div>
-            <div class="radio">
-                <label>
-                    <?= $form->radio('banDurationUnlimited', 1, $banDuration ? 0 : 1) ?>
-                    <?= t('Ban Forever') ?>
-                </label>
-            </div>
-        </div>
+if (empty($categories)) {
+    ?>
+    <div class="alert alert-warning">
+        <?= t('No IP Access Control Category defined.') ?>
     </div>
-
-    <div class="ccm-dashboard-form-actions-wrapper">
-        <div class="ccm-dashboard-form-actions">
-            <input type="submit" class="btn btn-primary pull-right" value="<?= t('Save') ?>" />
-        </div>
-    </div>
-</form>
+    <?php
+}
+else {
+    ?>
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th><?= t('Handle') ?></th>
+                <th><?= t('Name') ?></th>
+                <th><?= t('Enabled') ?></th>
+                <th><?= t('Package') ?></th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php
+        foreach ($categories as $category) {
+            $href = $view->action('configure', $category->getIpAccessControlCategoryID());
+            ?>
+            <tr class="ccm_ip-access-control-category" onclick="<?= h('window.location.href = ' . json_encode($href) . ';') ?>">
+                <td><a href="<?= h($href) ?>"><code><?= h($category->getHandle()) ?></code></a></td>
+                <td><a href="<?= h($href) ?>"><?= h($category->getDisplayName()) ?></a></td>
+                <td><?= $category->isEnabled() ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-ban text-danger"></i>' ?></td>
+                <td>
+                    <?php
+                    if ($category->getPackage() !== null) {
+                        echo h($category->getPackage()->getPackageName());
+                    }
+                    ?>
+                </td>
+            </tr>
+            <?php
+        }
+        ?>
+        </tbody>
+    </table>
+    <?php
+}

--- a/concrete/single_pages/dashboard/system/permissions/blacklist/configure.php
+++ b/concrete/single_pages/dashboard/system/permissions/blacklist/configure.php
@@ -1,0 +1,64 @@
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/* @var Concrete\Core\Page\View\PageView $view */
+/* @var Concrete\Core\Validation\CSRF\Token $token */
+/* @var Concrete\Core\Form\Service\Form $form */
+/* @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\Blacklist\Configure $controller */
+
+/* @var Concrete\Core\Entity\Permission\IpAccessControlCategory $category */
+/* @var array $units */
+
+$view->element('dashboard/system/permissions/blacklist/menu', ['category' => $category, 'type' => null]);
+?>
+
+<form method="post" id="ipblacklist-form" action="<?= $view->action('update_ipblacklist', $category->getIpAccessControlCategoryID()) ?>">
+    <?php $token->output('update_ipblacklist-' . $category->getIpAccessControlCategoryID()) ?>
+    <div class="ccm-pane-body">
+        <div class="form-group form-inline">
+            <?= $form->checkbox('banEnabled', 1, $category->isEnabled()) ?>
+            <?php
+            list($selectedUnit, $unitValue) = $controller->splitSeconds($category->getTimeWindow());
+            echo t(
+                /* i18n: %1$s is the number of events, %2$s is the number of seconds/minutes/hours/days, %3$s is "seconds", "minutes", "hours" or "days" */
+                'Lock IP after %1$s events in %2$s %3$s',
+                $form->number('maxEvents', $category->getMaxEvents(), ['style' => 'width:90px', 'required' => 'required', 'min' => 1]),
+                $form->number('timeWindowValue', $unitValue, ['style' => 'width:90px', 'min' => 1]),
+                $form->select('timeWindowUnit', $units, $selectedUnit)
+            );
+            ?>
+        </div>
+
+        <div class="form-group form-inline">
+            <?= $form->label('banDurationUnlimited', t('Ban Duration'))?>
+            <br />
+            <div class="radio">
+                <label>
+                    <?= $form->radio('banDurationUnlimited', '0', $category->getBanDuration() === null ? '1' : '0') ?>
+                    <?php
+                    list($selectedUnit, $unitValue) = $controller->splitSeconds($category->getBanDuration() === null ? 300 : $category->getBanDuration());
+                    echo t(
+                        /* i18n: %1$s is the number of seconds/minutes/hours/days, %2$s is "seconds", "minutes", "hours" or "days" */
+                        'Ban IP for %1$s %2$s',
+                        $form->number('banDurationValue', $unitValue, ['style' => 'width:90px', 'min' => 1]),
+                        $form->select('banDurationUnit', $units, $selectedUnit)
+                    );
+                    ?>
+                </label>
+            </div>
+            <br />
+            <div class="radio">
+                <label>
+                    <?= $form->radio('banDurationUnlimited', '1', $category->getBanDuration() === null ? '1' : '0') ?>
+                    <?= t('Ban Forever') ?>
+                </label>
+            </div>
+        </div>
+    </div>
+
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <input type="submit" class="btn btn-primary pull-right" value="<?= t('Save') ?>" />
+        </div>
+    </div>
+</form>

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
+
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
+use SimpleXMLElement;
+
+class ImportIpAccessControlCategoriesRoutine extends AbstractRoutine
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::getHandle()
+     */
+    public function getHandle()
+    {
+        return 'ipaccesscontrolcategories';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::import()
+     */
+    public function import(SimpleXMLElement $sx)
+    {
+        if (isset($sx->ipaccesscontrolcategories) && isset($sx->ipaccesscontrolcategories->ipaccesscontrolcategory)) {
+            $app = Application::getFacadeApplication();
+            $em = $app->make(EntityManagerInterface::class);
+            $repo = $em->getRepository(IpAccessControlCategory::class);
+            $categories = [];
+            foreach ($sx->ipaccesscontrolcategories->ipaccesscontrolcategory as $xIpAccessControlCategory) {
+                $handle = (string) $xIpAccessControlCategory['handle'];
+                if ($handle !== '' && $repo->findOneBy(['handle' => $handle]) === null) {
+                    $enabled = (string) $xIpAccessControlCategory['enabled'];
+                    $category = new IpAccessControlCategory();
+                    $category
+                        ->setHandle($handle)
+                        ->setName($xIpAccessControlCategory['name'])
+                        ->setEnabled($enabled === '' ? true : $enabled)
+                        ->setMaxEvents($xIpAccessControlCategory['max-events'])
+                        ->setTimeWindow($xIpAccessControlCategory['time-window'])
+                        ->setBanDuration($xIpAccessControlCategory['ban-duration'])
+                        ->setSiteSpecific($xIpAccessControlCategory['site-specific'])
+                        ->setPackage(static::getPackageObject($xIpAccessControlCategory['package']))
+                    ;
+                    $logChannelHandle = (string) $xIpAccessControlCategory['logChannelHandle'];
+                    if ($logChannelHandle !== '') {
+                        $category->setLogChannelHandle($logChannelHandle);
+                    }
+                    $em->persist($category);
+                    $categories[] = $category;
+                }
+            }
+            if (!empty($categories)) {
+                $em->flush($categories);
+            }
+        }
+    }
+}

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -126,13 +126,23 @@ EOT
             }
             if ($automaticBans !== null) {
                 if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
-                    if ($onlyExpired) {
-                        $output->write('Deleting the expired automatic bans... ');
-                    } else {
-                        $output->write('Deleting all the automatic bans... ');
+                    switch ($automaticBans) {
+                        case static::DELETE_AUTOMATIC_BANS_ALL:
+                            $output->write('Deleting all the automatic bans... ');
+                            break;
+                        case static::DELETE_AUTOMATIC_BANS_EXPIRED:
+                            $output->write('Deleting the expired automatic bans... ');
+                            break;
                     }
                 }
-                $count = $service->deleteAutomaticBlacklist($onlyExpired);
+                switch ($automaticBans) {
+                    case static::DELETE_AUTOMATIC_BANS_ALL:
+                        $count = $service->deleteAutomaticBlacklist(false);
+                        break;
+                    case static::DELETE_AUTOMATIC_BANS_EXPIRED:
+                        $count = $service->deleteAutomaticBlacklist(true);
+                        break;
+                }
                 if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
                     $output->writeln("{$count} records deleted.");
                 }

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -1,9 +1,16 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
 use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Permission\IpAccessControlService;
 use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
+use Punic\Comparer;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,13 +23,16 @@ class BlacklistClear extends Command
         $this
             ->setName('c5:blacklist:clear')
             ->setDescription('Clear blacklist-related data')
+            ->addArgument('handle', InputArgument::IS_ARRAY, 'List of IP Access Control Category handles', ['failed_login'])
             ->addEnvOption()
-            ->addOption('failed-login-age', 'f', InputOption::VALUE_REQUIRED, 'Clear failed login attempts older that this number of seconds (0 for all)')
+            ->addOption('min-age', 'm', InputOption::VALUE_REQUIRED, 'Clear events older that this number of seconds (0 for all)')
             ->addOption('automatic-bans', 'b', InputOption::VALUE_REQUIRED, 'Clear automatic bans ("expired" to only delete expired bans, "all" to delete the current bans too)')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List the available IP Access Control Category handles')
+            ->addOption('failed-login-age', 'f', InputOption::VALUE_REQUIRED, '*DEPRECATED* use --min-age')
             ->setHelp(<<<EOT
 You can use this command to clear the data related to IP address blacklist.
 
-To clear the failed login attempts data, use the --failed-login-age option.
+To clear the events data, use the --min-age option.
 To clear the automatic bans, use the --automatic-bans option.
 
 Returns codes:
@@ -37,25 +47,22 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('list')) {
+            $this->listCategories($output);
+
+            return 0;
+        }
         $app = Application::getFacadeApplication();
-        $ipService = $app->make('ip');
-        /* @var \Concrete\Core\Permission\IPService $ipService */
-        $someOperation = false;
-        $failedLoginAge = $input->getOption('failed-login-age');
-        if ($failedLoginAge !== null) {
+        $minAge = $input->getOption('min-age');
+        if ($minAge === null) {
+            $minAge = $input->getOption('failed-login-age');
+        }
+        if ($minAge !== null) {
             $valn = $app->make('helper/validation/numbers');
-            /* @var \Concrete\Core\Utility\Service\Validation\Numbers $valn */
-            if (!$valn->integer($failedLoginAge, 0)) {
-                throw new UserMessageException('Invalid value of the --failed-login-age option: please specify a non-negative integer.');
+            if (!$valn->integer($minAge, 0)) {
+                throw new UserMessageException('Invalid value of the --min-age option: please specify a non-negative integer.');
             }
-            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
-                $output->write("Clearing failed login attempts older that $failedLoginAge seconds... ");
-            }
-            $count = $ipService->deleteFailedLoginAttempts((int) $failedLoginAge);
-            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
-                $output->writeln("$count records deleted.");
-            }
-            $someOperation = true;
+            $minAge = (int) $minAge;
         }
         $automaticBans = $input->getOption('automatic-bans');
         if ($automaticBans !== null) {
@@ -69,21 +76,68 @@ EOT
                 default:
                     throw new UserMessageException('Invalid value of the --automatic-bans option: valid values are "expired" and "all".');
             }
-            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
-                if ($onlyExpired) {
-                    $output->write('Deleting the expired automatic bans... ');
-                } else {
-                    $output->write('Deleting all the automatic bans... ');
+        }
+        if ($minAge === null && $automaticBans === null) {
+            throw new UserMessageException('Please specify at least one of the options --min-age option or --automatic-bans');
+        }
+        $repo = $app->make(EntityManagerInterface::class)->getRepository(IpAccessControlCategory::class);
+        $categories = [];
+        foreach ($input->getArgument('handle') as $handle) {
+            $category = $repo->findOneBy(['handle' => $handle]);
+            if ($category === null) {
+                throw new UserMessageException(sprintf('Unknown IP Access Control Category handle: "%s"', $handle));
+            }
+            if (!in_array($category, $categories, true)) {
+                $categories[] = $category;
+            }
+        }
+        if (empty($categories)) {
+            throw new UserMessageException('No IP Access Control Category handle specified');
+        }
+        foreach ($categories as $category) {
+            $output->writeln("# {$category->getName()}");
+            $service = $app->make(IpAccessControlService::class, ['category' => $category]);
+            if ($minAge !== null) {
+                if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                    $output->write("Clearing events older than {$minAge} seconds... ");
+                }
+                $count = $service->deleteEvents($minAge);
+                if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                    $output->writeln("{$count} records deleted.");
                 }
             }
-            $count = $ipService->deleteAutomaticBlacklist((int) $onlyExpired);
-            if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
-                $output->writeln("$count records deleted.");
+            if ($automaticBans !== null) {
+                if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                    if ($onlyExpired) {
+                        $output->write('Deleting the expired automatic bans... ');
+                    } else {
+                        $output->write('Deleting all the automatic bans... ');
+                    }
+                }
+                $count = $service->deleteAutomaticBlacklist($onlyExpired);
+                if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {
+                    $output->writeln("{$count} records deleted.");
+                }
             }
-            $someOperation = true;
         }
-        if ($someOperation === false) {
-            throw new UserMessageException('Please specify at least one of the options --failed-login-age option or --automatic-bans');
+
+        return 0;
+    }
+
+    protected function listCategories(OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+        $repo = $app->make(EntityManagerInterface::class)->getRepository(IpAccessControlCategory::class);
+        $categories = $repo->findAll();
+        $cmp = new Comparer();
+        usort($categories, function (IpAccessControlCategory $a, IpAccessControlCategory $b) use ($cmp) {
+            return $cmp->compare($a->getDisplayName(), $b->getDisplayName());
+        });
+        $table = new Table($output);
+        $table->setHeaders(['Handle', 'Name', 'Enabled']);
+        foreach ($categories as $category) {
+            $table->addRow([$category->getHandle(), $category->getName(), $category->isEnabled() ? 'Yes' : 'No']);
         }
+        $table->render();
     }
 }

--- a/concrete/src/Entity/Permission/IpAccessControlCategory.php
+++ b/concrete/src/Entity/Permission/IpAccessControlCategory.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace Concrete\Core\Entity\Permission;
+
+use Concrete\Core\Entity\Package;
+use Concrete\Core\Logging\Channels;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Represent an IP Access Control Category.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(
+ *     name="IpAccessControlCategories",
+ *     options={
+ *         "comment": "List of IP Access Control Categories"
+ *     }
+ * )
+ */
+class IpAccessControlCategory
+{
+    /**
+     * The IP Access Control Category identifier.
+     *
+     * @ORM\Column(name="iaccID", type="integer", nullable=false, options={"unsigned":true , "comment": "The IP Access Control Category identifier"})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL when the record has not been saved yet
+     */
+    protected $ipAccessControlCategoryID;
+
+    /**
+     * The IP Access Control Category handle.
+     *
+     * @ORM\Column(name="iaccHandle", type="string", length=255, nullable=false, unique=true, options={"comment": "The IP Access Control handle"})
+     *
+     * @var string
+     */
+    protected $handle;
+
+    /**
+     * The IP Access Control Category name.
+     *
+     * @ORM\Column(name="iaccName", type="string", length=255, nullable=false, options={"comment": "The IP Access Control name"})
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The package that defines this IP Access Control Category.
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\Package")
+     * @ORM\JoinColumn(name="iaccPackage", referencedColumnName="pkgID", nullable=true, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Package|null
+     */
+    protected $package;
+
+    /**
+     * Is this IP Access Control Category enabled?
+     *
+     * @ORM\Column(name="iaccEnabled", type="boolean", nullable=false, options={"comment": "Is this IP Access Control enabled?"})
+     *
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
+     * The maximum allowed events in the time window.
+     *
+     * @ORM\Column(name="iaccMaxEvents", type="integer", nullable=false, options={"unsigned": true, "comment": "The maximum allowed events in the time window"})
+     *
+     * @var int
+     */
+    protected $maxEvents;
+
+    /**
+     * The time window (in seconds) where the events should be counted (NULL means no limits).
+     *
+     * @ORM\Column(name="iaccTimeWindow", type="integer", nullable=true, options={"unsigned": true, "comment": "The time window (in seconds) where the events should be counted (NULL means no limits)"})
+     *
+     * @var int|null
+     */
+    protected $timeWindow;
+
+    /**
+     * The duration (in seconds) of the ban when the maximum number of events occur in the time window (NULL means forever).
+     *
+     * @ORM\Column(name="iaccBanDuration", type="integer", nullable=true, options={"unsigned": true, "comment": "The duration (in seconds) of the ban when the maximum number of events occur in the time window (NULL means forever)"})
+     *
+     * @var int|null
+     */
+    protected $banDuration;
+
+    /**
+     * Is this IP Access Control Category site-specific?
+     *
+     * @ORM\Column(name="iaccSiteSpecific", type="boolean", nullable=false, options={"comment": "Is this IP Access Control Category site-specific?"})
+     *
+     * @var bool
+     */
+    protected $siteSpecific;
+
+    /**
+     * The log channel handle.
+     *
+     * @ORM\Column(name="iaccLogChannel", type="string", length=255, nullable=false, options={"comment": "The log channel handle"})
+     *
+     * @var string
+     */
+    protected $logChannelHandle = Channels::CHANNEL_SECURITY;
+
+    /**
+     * The list of recorded events associated to this category.
+     *
+     * @ORM\OneToMany(targetEntity="Concrete\Core\Entity\Permission\IpAccessControlEvent", mappedBy="category")
+     *
+     * @var \Doctrine\Common\Collections\ArrayCollection|\Concrete\Core\Entity\Permission\IpAccessControlEvent[]
+     */
+    protected $events;
+
+    /**
+     * The list of defined ranges associated to this category.
+     *
+     * @ORM\OneToMany(targetEntity="Concrete\Core\Entity\Permission\IpAccessControlRange", mappedBy="category")
+     *
+     * @var \Doctrine\Common\Collections\ArrayCollection|\Concrete\Core\Entity\Permission\IpAccessControlRange[]
+     */
+    protected $ranges;
+
+    /**
+     * Initialize the instance.
+     */
+    public function __construct()
+    {
+        $this->events = new ArrayCollection();
+        $this->ranges = new ArrayCollection();
+    }
+
+    /**
+     * Get the IP Access Control Category identifier.
+     *
+     * @return int|null returns NULL when the record has not been saved yet
+     */
+    public function getIpAccessControlCategoryID()
+    {
+        return $this->ipAccessControlCategoryID;
+    }
+
+    /**
+     * Get the IP Access Control handle.
+     *
+     * @return string
+     */
+    public function getHandle()
+    {
+        return $this->handle;
+    }
+
+    /**
+     * Set the IP Access Control handle.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setHandle($value)
+    {
+        $this->handle = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the IP Access Control name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the IP Access Control display name.
+     *
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return tc('IpAccessControlCategory', $this->name);
+    }
+
+    /**
+     * Set the IP Access Control name.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setName($value)
+    {
+        $this->name = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the package that defines this IP Access Control Category.
+     *
+     * @return \Concrete\Core\Entity\Package|null
+     */
+    public function getPackage()
+    {
+        return $this->package;
+    }
+
+    /**
+     * Set the package that defines this IP Access Control Category.
+     *
+     * @param \Concrete\Core\Entity\Package|null $value
+     *
+     * @return $this
+     */
+    public function setPackage(Package $value = null)
+    {
+        $this->package = $value;
+
+        return $this;
+    }
+
+    /**
+     * Is this IP Access Control Category enabled?
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Is this IP Access Control Category enabled?
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setEnabled($value)
+    {
+        $this->enabled = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the maximum allowed events in the time window.
+     *
+     * @return int
+     */
+    public function getMaxEvents()
+    {
+        return $this->maxEvents;
+    }
+
+    /**
+     * Set the maximum allowed events in the time window.
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function setMaxEvents($value)
+    {
+        $this->maxEvents = (int) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the time window (in seconds) where the events should be counted (NULL means no limits).
+     *
+     * @return int|null
+     */
+    public function getTimeWindow()
+    {
+        return $this->timeWindow;
+    }
+
+    /**
+     * Get the time window (in seconds) where the events should be counted (NULL means no limits).
+     *
+     * @param int|null $value
+     *
+     * @return $this
+     */
+    public function setTimeWindow($value)
+    {
+        $this->timeWindow = ((string) $value === '') ? null : (int) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the duration (in seconds) of the ban when the maximum number of events occur in the time window (NULL means forever).
+     *
+     * @return int|null
+     */
+    public function getBanDuration()
+    {
+        return $this->banDuration;
+    }
+
+    /**
+     * Set the duration (in seconds) of the ban when the maximum number of events occur in the time window (NULL means forever).
+     *
+     * @param int|null $value
+     *
+     * @return $this
+     */
+    public function setBanDuration($value)
+    {
+        $this->banDuration = ((string) $value === '') ? null : (int) $value;
+
+        return $this;
+    }
+
+    /**
+     * Is this IP Access Control Category site-specific?
+     *
+     * @return bool
+     */
+    public function isSiteSpecific()
+    {
+        return $this->siteSpecific;
+    }
+
+    /**
+     * Is this IP Access Control Category site-specific?
+     *
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setSiteSpecific($value)
+    {
+        $this->siteSpecific = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the log channel handle (empty string if log is disabled).
+     *
+     * @return string
+     */
+    public function getLogChannelHandle()
+    {
+        return $this->logChannelHandle;
+    }
+
+    /**
+     * Set the log channel handle (empty string if log is disabled).
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setLogChannelHandle($value)
+    {
+        $this->logChannelHandle = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the list of recorded events associated to this category.
+     *
+     * @return \Doctrine\Common\Collections\ArrayCollection|\Concrete\Core\Entity\Permission\IpAccessControlEvent[]
+     */
+    public function getEvents()
+    {
+        return $this->events;
+    }
+
+    /**
+     * Get the list of defined ranges associated to this category.
+     *
+     * @return \Doctrine\Common\Collections\ArrayCollection|\Concrete\Core\Entity\Permission\IpAccessControlRange[]
+     */
+    public function getRanges()
+    {
+        return $this->ranges;
+    }
+}

--- a/concrete/src/Entity/Permission/IpAccessControlEvent.php
+++ b/concrete/src/Entity/Permission/IpAccessControlEvent.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Concrete\Core\Entity\Permission;
+
+use Concrete\Core\Entity\Site\Site;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use IPLib\Address\AddressInterface;
+use IPLib\Factory;
+
+/**
+ * Represent an IP Access Control Event.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(
+ *     name="IpAccessControlEvents",
+ *     options={
+ *         "comment": "List of IP Access Control Events"
+ *     }
+ * )
+ */
+class IpAccessControlEvent
+{
+    /**
+     * The IP Access Control Event identifier.
+     *
+     * @ORM\Column(name="iaceID", type="integer", nullable=false, options={"unsigned":true , "comment": "The IP Access Control Event identifier"})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL when the record has not been saved yet
+     */
+    protected $ipAccessControlEventID;
+
+    /**
+     * The associated IP Access Control Category.
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\Permission\IpAccessControlCategory", inversedBy="events")
+     * @ORM\JoinColumn(name="iaceCategory", referencedColumnName="iaccID", nullable=false, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    protected $category;
+
+    /**
+     * The Site where this event occurred (if applicable).
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\Site\Site")
+     * @ORM\JoinColumn(name="iaceSite", referencedColumnName="siteID", nullable=true, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Site\Site|null
+     */
+    protected $site;
+
+    /**
+     * The IP address associated to this event.
+     *
+     * @ORM\Column(name="iaceIp", type="string", length=40, nullable=false, options={"comment": "The IP address associated to this event"})
+     *
+     * @var string
+     */
+    protected $ip;
+
+    /**
+     * The date/time when this event occurred.
+     *
+     * @ORM\Column(name="iaceDateTime", type="datetime", nullable=false, options={"comment": "The date/time when this event occurred"})
+     *
+     * @var \DateTime
+     */
+    protected $dateTime;
+
+    /**
+     * the IP address associated to this event.
+     *
+     * @var \IPLib\Address\AddressInterface|null
+     */
+    private $ipAddress;
+
+    /**
+     * Get the IP Access Control Event identifier.
+     *
+     * @return int|null returns NULL when the record has not been saved yet
+     */
+    public function getIpAccessControlEventID()
+    {
+        return $this->ipAccessControlEventID;
+    }
+
+    /**
+     * Get the associated IP Access Control Category.
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    public function getCategory()
+    {
+        return $this->category;
+    }
+
+    /**
+     * Set the associated IP Access Control Category.
+     *
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlCategory $value
+     *
+     * @return $this
+     */
+    public function setCategory(IpAccessControlCategory $value)
+    {
+        $this->category = $value;
+        
+        return $this;
+    }
+
+    /**
+     * Get the Site where this event occurred (if applicable).
+     *
+     * @return \Concrete\Core\Entity\Site\Site|null
+     */
+    public function getSite()
+    {
+        return $this->site;
+    }
+
+    /**
+     * Set the Site where this event occurred (if applicable).
+     *
+     * @param \Concrete\Core\Entity\Site\Site|null $value
+     *
+     * @return $this
+     */
+    public function setSite(Site $value = null)
+    {
+        $this->site = $value;
+        
+        return $this;
+    }
+
+    /**
+     * Get the IP address associated to this event.
+     *
+     * @return \IPLib\Address\AddressInterface
+     */
+    public function getIpAddress()
+    {
+        if ($this->ipAddress === null) {
+            $ip = (string) $this->getIp();
+            if ($ip !== '') {
+                $this->ipAddress = Factory::addressFromString($ip);
+            }
+        }
+
+        return $this->ipAddress;
+    }
+
+    /**
+     * Set the IP address associated to this event.
+     *
+     * @param \IPLib\Address\AddressInterface $value
+     *
+     * @return $this
+     */
+    public function setIpAddress(AddressInterface $value)
+    {
+        $this->setIp($value->getComparableString());
+        $this->ipAddress = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the date/time when this event occurred.
+     *
+     * @return \DateTime
+     */
+    public function getDateTime()
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * Set the date/time when this event occurred.
+     *
+     * @param \DateTime $value
+     *
+     * @return $this
+     */
+    public function setDateTime(DateTime $value)
+    {
+        $this->dateTime = $value;
+        
+        return $this;
+    }
+
+    /**
+     * Get the IP address associated to this event.
+     *
+     * @return string
+     */
+    protected function getIp()
+    {
+        return $this->ip;
+    }
+
+    /**
+     * Set the IP address associated to this event.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    protected function setIp($value)
+    {
+        $this->ip = (string) $value;
+        $this->ipAddress = null;
+        
+        return $this;
+    }
+}

--- a/concrete/src/Entity/Permission/IpAccessControlRange.php
+++ b/concrete/src/Entity/Permission/IpAccessControlRange.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Concrete\Core\Entity\Permission;
+
+use Concrete\Core\Entity\Site\Site;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use IPLib\Factory;
+use IPLib\Range\RangeInterface;
+
+/**
+ * Represent an IP Access Control Range.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(
+ *     name="IpAccessControlRanges",
+ *     indexes={
+ *         @ORM\Index(name="IPIntervalExpiration", columns={"iacrIpFrom", "iacrIpTo", "iacrExpiration"})
+ *     },
+ *     options={
+ *         "comment": "List of IP Access Control Ranges"
+ *     }
+ * )
+ */
+class IpAccessControlRange
+{
+    /**
+     * The IP Access Control Range identifier.
+     *
+     * @ORM\Column(name="iacrID", type="integer", nullable=false, options={"unsigned":true , "comment": "The IP Access Control Range identifier"})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL when the record has not been saved yet
+     */
+    protected $ipAccessControlRangeID;
+
+    /**
+     * The associated IP Access Control Category.
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\Permission\IpAccessControlCategory", inversedBy="ranges")
+     * @ORM\JoinColumn(name="iacrCategory", referencedColumnName="iaccID", nullable=false, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    protected $category;
+
+    /**
+     * The Site where this range is defined occurred (if applicable).
+     *
+     * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\Site\Site")
+     * @ORM\JoinColumn(name="iacrSite", referencedColumnName="siteID", nullable=true, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Site\Site|null
+     */
+    protected $site;
+
+    /**
+     * The initial IP address of the range.
+     *
+     * @ORM\Column(name="iacrIpFrom", type="string", length=40, nullable=false, options={"comment": "The initial IP address of the range"})
+     *
+     * @var string
+     */
+    protected $ipFrom;
+
+    /**
+     * The final IP address of the range.
+     *
+     * @ORM\Column(name="iacrIpTo", type="string", length=40, nullable=false, options={"comment": "The final IP address of the range"})
+     *
+     * @var string
+     */
+    protected $ipTo;
+
+    /**
+     * The type of this range.
+     *
+     * @ORM\Column(name="iacrType", type="integer", nullable=false, options={"unsigned": true, "comment": "The type of this range"})
+     *
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * The date/time when this range expires (NULL means no expiration).
+     *
+     * @ORM\Column(name="iacrExpiration", type="datetime", nullable=true, options={"comment": "The date/time when this range expires (NULL means no expiration)"})
+     *
+     * @var \DateTime|null
+     */
+    protected $expiration;
+
+    /**
+     * The RangeInterface instance associated to this range.
+     *
+     * @var \IPLib\Range\RangeInterface|null
+     */
+    private $ipRange;
+
+    /**
+     * Get the IP Access Control Range identifier.
+     *
+     * @return int|null returns NULL when the record has not been saved yet
+     */
+    public function getIpAccessControlRangeID()
+    {
+        return $this->ipAccessControlRangeID;
+    }
+
+    /**
+     * Get the associated IP Access Control Category.
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    public function getCategory()
+    {
+        return $this->category;
+    }
+
+    /**
+     * Set the associated IP Access Control Category.
+     *
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlCategory $value
+     *
+     * @return $this
+     */
+    public function setCategory(IpAccessControlCategory $value)
+    {
+        $this->category = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the Site where this range is defined occurred (if applicable).
+     *
+     * @return \Concrete\Core\Entity\Site\Site|null
+     */
+    public function getSite()
+    {
+        return $this->site;
+    }
+
+    /**
+     * @param \Concrete\Core\Entity\Site\Site|null $value
+     *
+     * @return $this
+     */
+    public function setSite(Site $value = null)
+    {
+        $this->site = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the RangeInterface instance associated to this range.
+     *
+     * @return \IPLib\Range\RangeInterface
+     */
+    public function getIpRange()
+    {
+        if ($this->ipRange === null) {
+            $ipFrom = (string) $this->getIpFrom();
+            if ($ipFrom !== '') {
+                $ipTo = (string) $this->getIpTo();
+                if ($ipTo !== '') {
+                    $this->ipRange = Factory::rangeFromBoundaries($ipFrom, $ipTo);
+                }
+            }
+        }
+
+        return $this->ipRange;
+    }
+
+    /**
+     * Set the RangeInterface instance associated to this range.
+     *
+     * @param \IPLib\Address\AddressInterface $value
+     *
+     * @return $this
+     */
+    public function setIpRange(RangeInterface $value)
+    {
+        $this->setIpFrom($value->getStartAddress()->getComparableString());
+        $this->setIpTo($value->getEndAddress()->getComparableString());
+        $this->ipRange = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the type of this range.
+     *
+     * @return int
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Set the type of this range.
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function setType($value)
+    {
+        $this->type = (int) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the date/time when this range expires (NULL means no expiration).
+     *
+     * @return \DateTime|null
+     */
+    public function getExpiration()
+    {
+        return $this->expiration;
+    }
+
+    /**
+     * Set the date/time when this range expires (NULL means no expiration).
+     *
+     * @param \DateTime| $value
+     *
+     * @return $this
+     */
+    public function setExpiration(DateTime $value = null)
+    {
+        $this->expiration = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the initial IP address of the range.
+     *
+     * @return string
+     */
+    protected function getIpFrom()
+    {
+        return $this->ipFrom;
+    }
+
+    /**
+     * Set the initial IP address of the range.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    protected function setIpFrom($value)
+    {
+        $this->ipFrom = (string) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the final IP address of the range.
+     *
+     * @return string
+     */
+    protected function getIpTo()
+    {
+        return $this->ipTo;
+    }
+
+    /**
+     * Set the final IP address of the range.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    protected function setIpTo($value)
+    {
+        $this->ipTo = (string) $value;
+
+        return $this;
+    }
+}

--- a/concrete/src/Entity/Permission/IpAccessControlRange.php
+++ b/concrete/src/Entity/Permission/IpAccessControlRange.php
@@ -183,8 +183,8 @@ class IpAccessControlRange
      */
     public function setIpRange(RangeInterface $value)
     {
-        $this->setIpFrom($value->getStartAddress()->getComparableString());
-        $this->setIpTo($value->getEndAddress()->getComparableString());
+        $this->setIpFrom($value->getComparableStartString());
+        $this->setIpTo($value->getComparableEndString());
         $this->ipRange = $value;
 
         return $this;

--- a/concrete/src/Package/ItemCategory/IpAccessControlCategory.php
+++ b/concrete/src/Package/ItemCategory/IpAccessControlCategory.php
@@ -2,8 +2,8 @@
 
 namespace Concrete\Core\Package\ItemCategory;
 
-use Concrete\Core\Entity\Geolocator;
 use Concrete\Core\Entity\Package;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory as Entity;
 use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -56,7 +56,7 @@ class IpAccessControlCategory extends AbstractCategory
      */
     public function removeItem($ipAccessControlCategory)
     {
-        if ($ipAccessControlCategory instanceof Geolocator && $ipAccessControlCategory->getIpAccessControlCategoryID() !== null) {
+        if ($ipAccessControlCategory instanceof Entity && $ipAccessControlCategory->getIpAccessControlCategoryID() !== null) {
             $app = Application::getFacadeApplication();
             $em = $app->make(EntityManagerInterface::class);
             $em->remove($ipAccessControlCategory);

--- a/concrete/src/Package/ItemCategory/IpAccessControlCategory.php
+++ b/concrete/src/Package/ItemCategory/IpAccessControlCategory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\Core\Package\ItemCategory;
+
+use Concrete\Core\Entity\Geolocator;
+use Concrete\Core\Entity\Package;
+use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class IpAccessControlCategory extends AbstractCategory
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\ItemCategory\ItemInterface::getItemCategoryDisplayName()
+     */
+    public function getItemCategoryDisplayName()
+    {
+        return t('IP Access Control Categories');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\ItemCategory\ItemInterface::getItemName()
+     *
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlCategory $ipAccessControlCategory
+     */
+    public function getItemName($ipAccessControlCategory)
+    {
+        return $ipAccessControlCategory->getDisplayName();
+    }
+
+    /**
+     * @param \Concrete\Core\Entity\Package $package
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlCategory[]
+     */
+    public function getPackageItems(Package $package)
+    {
+        $app = Application::getFacadeApplication();
+        $em = $app->make(EntityManagerInterface::class);
+        $repo = $em->getRepository(self::class);
+
+        return $repo->findBy(['package' => $package]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\ItemCategory\AbstractCategory::removeItem()
+     *
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlCategory|mixed $ipAccessControlCategory
+     */
+    public function removeItem($ipAccessControlCategory)
+    {
+        if ($ipAccessControlCategory instanceof Geolocator && $ipAccessControlCategory->getIpAccessControlCategoryID() !== null) {
+            $app = Application::getFacadeApplication();
+            $em = $app->make(EntityManagerInterface::class);
+            $em->remove($ipAccessControlCategory);
+            $em->flush($ipAccessControlCategory);
+        }
+    }
+}

--- a/concrete/src/Package/ItemCategory/Manager.php
+++ b/concrete/src/Package/ItemCategory/Manager.php
@@ -170,6 +170,11 @@ class Manager extends CoreManager
         return $this->app->make(SiteType::class);
     }
 
+    public function createIpAccessControlCategoryDriver()
+    {
+        return $this->app->make(IpAccessControlCategory::class);
+    }
+
     public function getPackageItems(Package $package)
     {
         $items = array();

--- a/concrete/src/Permission/IPRange.php
+++ b/concrete/src/Permission/IPRange.php
@@ -1,10 +1,14 @@
 <?php
 namespace Concrete\Core\Permission;
 
+use Concrete\Core\Entity\Permission\IpAccessControlRange;
 use DateTime;
 use IPLib\Factory as IPFactory;
 use IPLib\Range\RangeInterface;
 
+/**
+ * @deprecated Use the methods of $app->make('failed_login')
+ */
 class IPRange
 {
     /**
@@ -83,6 +87,22 @@ class IPRange
         $result->ipRange = IPFactory::rangeFromBoundaries($row['lcirIpFrom'], $row['lcirIpTo']);
         $result->type = (int) $row['lcirType'];
         $result->expires = empty($row['lcirExpires']) ? null : DateTime::createFromFormat($dateTimeFormat, $row['lcirExpires']);
+
+        return $result;
+    }
+
+    /**
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlRange $range
+     *
+     * @return static
+     */
+    public static function createFromEntity(IpAccessControlRange $range)
+    {
+        $result = new static();
+        $result->id = $range->getIpAccessControlRangeID();
+        $result->ipRange = $range->getIpRange();
+        $result->type = $range->getType();
+        $result->expires = $range->getExpiration();
 
         return $result;
     }

--- a/concrete/src/Permission/IPRangesCsvWriter.php
+++ b/concrete/src/Permission/IPRangesCsvWriter.php
@@ -71,8 +71,7 @@ class IPRangesCsvWriter
     /**
      * A generator that takes a collection of IPRange/IpAccessControlRange ranges and converts it to CSV rows.
      *
-     * @param \Concrete\Core\Permission\IPRange[]|\Concrete\Core\Entity\Permission\IpAccessControlRange[]|\Generator $list
-     * @param mixed $ranges
+     * @param \Concrete\Core\Permission\IPRange[]|\Concrete\Core\Entity\Permission\IpAccessControlRange[]|\Generator $ranges
      *
      * @return array[]|\Generator
      */

--- a/concrete/src/Permission/IPRangesCsvWriter.php
+++ b/concrete/src/Permission/IPRangesCsvWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Permission;
 
 use Concrete\Core\Localization\Service\Date;
@@ -14,7 +15,7 @@ class IPRangesCsvWriter
     protected $writer;
 
     /**
-     * One of the IPService::IPRANGETYPE_... constants.
+     * One of the IpAccessControlService::IPRANGETYPE_... constants.
      *
      * @var int
      */
@@ -29,7 +30,7 @@ class IPRangesCsvWriter
 
     /**
      * @param Writer $writer the writer we use to output
-     * @param int $type One of the IPService::IPRANGETYPE_... constants
+     * @param int $type One of the IpAccessControlService::IPRANGETYPE_... constants
      * @param Date $dateHelper the Date localization service
      */
     public function __construct(Writer $writer, $type, Date $dateHelper)
@@ -48,9 +49,9 @@ class IPRangesCsvWriter
     }
 
     /**
-     * Insert a list of IPRange instances.
+     * Insert a list of IPRange/IpAccessControlRange instances.
      *
-     * @param IPRange[]|Generator $ranges
+     * @param \Concrete\Core\Permission\IPRange[]|\Concrete\Core\Entity\Permission\IpAccessControlRange[]|\Generator $ranges
      */
     public function insertRanges($ranges)
     {
@@ -58,21 +59,22 @@ class IPRangesCsvWriter
     }
 
     /**
-     * Insert an IPRange instance.
+     * Insert an IPRange/IpAccessControlRange instance.
      *
-     * @param IPRange $range
+     * @param \Concrete\Core\Permission\IPRange|\Concrete\Core\Entity\Permission\IpAccessControlRange $range
      */
-    public function insertRange(IPRange $range)
+    public function insertRange($range)
     {
         $this->writer->insertOne($this->projectRange($range));
     }
 
     /**
-     * A generator that takes a collection of IPRange ranges and converts it to CSV rows.
+     * A generator that takes a collection of IPRange/IpAccessControlRange ranges and converts it to CSV rows.
      *
-     * @param IPRange[]|Generator $list
+     * @param \Concrete\Core\Permission\IPRange[]|\Concrete\Core\Entity\Permission\IpAccessControlRange[]|\Generator $list
+     * @param mixed $ranges
      *
-     * @return array[]|Generator
+     * @return array[]|\Generator
      */
     private function projectRanges($ranges)
     {
@@ -82,21 +84,22 @@ class IPRangesCsvWriter
     }
 
     /**
-     * Turn an IPRange instance into an array.
+     * Turn an IPRange/IpAccessControlRange instance into an array.
      *
-     * @param IPRange $range
+     * @param \Concrete\Core\Permission\IPRange|\Concrete\Core\Entity\Permission\IpAccessControlRange $range
      *
      * @return string[]
      */
-    private function projectRange(IPRange $range)
+    private function projectRange($range)
     {
+        $ipRange = $range->getIpRange();
         $result = [
-            $range->getIpRange()->toString(),
-            $range->getIpRange()->getComparableStartString(),
-            $range->getIpRange()->getComparableEndString(),
+            $ipRange->toString(),
+            $ipRange->getComparableStartString(),
+            $ipRange->getComparableEndString(),
         ];
-        if ($this->type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
-            $dt = $range->getExpires();
+        if ($this->type === IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+            $dt = $range instanceof IPRange ? $range->getExpires() : $range->getExpiration();
             if ($dt === null) {
                 $result[] = '';
             } else {
@@ -115,7 +118,7 @@ class IPRangesCsvWriter
     private function getHeaders()
     {
         $headers = [t('IP Range'), t('Start address'), t('End address')];
-        if ($this->type === IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
+        if ($this->type === IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC) {
             $headers[] = t('Expiration');
         }
 

--- a/concrete/src/Permission/IPService.php
+++ b/concrete/src/Permission/IPService.php
@@ -7,90 +7,88 @@ use Concrete\Core\Http\Request;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Utility\IPAddress;
 use DateTime;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory as IPFactory;
 use IPLib\Range\RangeInterface;
 
+/**
+ * @deprecated check single methods to see the non-deprecated alternatives
+ */
 class IPService implements LoggerAwareInterface
 {
-
     use LoggerAwareTrait;
 
-    public function getLoggerChannel()
-    {
-        return Channels::CHANNEL_SECURITY;
-    }
-
     /**
-     * Bit mask for blacklist ranges.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGEFLAG_BLACKLIST
      *
      * @var int
      */
-    const IPRANGEFLAG_BLACKLIST = 0x0001;
+    const IPRANGEFLAG_BLACKLIST = IpAccessControlService::IPRANGEFLAG_BLACKLIST;
 
     /**
-     * Bit mask for whitelist ranges.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGEFLAG_WHITELIST
      *
      * @var int
      */
-    const IPRANGEFLAG_WHITELIST = 0x0002;
+    const IPRANGEFLAG_WHITELIST = IpAccessControlService::IPRANGEFLAG_WHITELIST;
 
     /**
-     * Bit mask for manually generated ranges.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGEFLAG_MANUAL
      *
      * @var int
      */
-    const IPRANGEFLAG_MANUAL = 0x0010;
+    const IPRANGEFLAG_MANUAL = IpAccessControlService::IPRANGEFLAG_MANUAL;
 
     /**
-     * Bit mask for automatically generated ranges.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGEFLAG_AUTOMATIC
      *
      * @var int
      */
-    const IPRANGEFLAG_AUTOMATIC = 0x0020;
+    const IPRANGEFLAG_AUTOMATIC = IpAccessControlService::IPRANGEFLAG_AUTOMATIC;
 
     /**
-     * IP range type: manually added to the blacklist.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGETYPE_BLACKLIST_MANUAL
      *
      * @var int
      */
-    const IPRANGETYPE_BLACKLIST_MANUAL = 0x0011; // IPRANGEFLAG_BLACKLIST | IPRANGEFLAG_MANUAL
+    const IPRANGETYPE_BLACKLIST_MANUAL = IpAccessControlService::IPRANGETYPE_BLACKLIST_MANUAL;
 
     /**
-     * IP range type: automatically added to the blacklist.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC
      *
      * @var int
      */
-    const IPRANGETYPE_BLACKLIST_AUTOMATIC = 0x0021; // IPRANGEFLAG_BLACKLIST | IPRANGEFLAG_AUTOMATIC
+    const IPRANGETYPE_BLACKLIST_AUTOMATIC = IpAccessControlService::IPRANGETYPE_BLACKLIST_AUTOMATIC;
 
     /**
-     * IP range type: manually added to the whitelist.
+     * @deprecated Use \Concrete\Core\Permission\IpAccessControlService::IPRANGETYPE_WHITELIST_MANUAL
      *
      * @var int
      */
-    const IPRANGETYPE_WHITELIST_MANUAL = 0x0012; // IPRANGEFLAG_WHITELIST | IPRANGEFLAG_MANUAL
+    const IPRANGETYPE_WHITELIST_MANUAL = IpAccessControlService::IPRANGETYPE_WHITELIST_MANUAL;
 
     /**
-     * @var Repository
+     * @var \Concrete\Core\Config\Repository\Repository
      */
     protected $config;
 
     /**
-     * @var Connection
+     * @var \Concrete\Core\Database\Connection\Connection
      */
     protected $connection;
 
     /**
-     * @var Request
+     * @var \Concrete\Core\Http\Request
      */
     protected $request;
 
     /**
-     * @param Repository $config
-     * @param Connection $connection
-     * @param Request $request
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     * @param \Concrete\Core\Http\Request $request
      */
     public function __construct(Repository $config, Connection $connection, Request $request)
     {
@@ -100,7 +98,17 @@ class IPService implements LoggerAwareInterface
     }
 
     /**
-     * Get the IP address of the current request.
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Logging\LoggerAwareInterface::getLoggerChannel()
+     */
+    public function getLoggerChannel()
+    {
+        return Channels::CHANNEL_SECURITY;
+    }
+
+    /**
+     * @deprecated Use $app->make(\IPLib\Address\AddressInterface::class)
      *
      * @return \IPLib\Address\AddressInterface
      */
@@ -110,315 +118,175 @@ class IPService implements LoggerAwareInterface
     }
 
     /**
-     * Check if an IP adress is blacklisted.
+     * @deprecated use $app->make('failed_login')->isBlacklisted()
+     *
+     * @param \IPLib\Address\AddressInterface|null $ip
      *
      * @return bool
      */
     public function isBlacklisted(AddressInterface $ip = null)
     {
-        if ($ip === null) {
-            $ip = $this->getRequestIPAddress();
-        }
-        $rangeType = $this->getRangeType($ip);
-
-        return $rangeType !== null && ($rangeType & static::IPRANGEFLAG_BLACKLIST) === static::IPRANGEFLAG_BLACKLIST;
+        return $this->getFailedLoginService()->isBlacklisted($ip);
     }
 
     /**
-     * Check if an IP adress is blacklisted.
+     * @deprecated use $app->make('failed_login')->isWhitelisted()
+     *
+     * @param \IPLib\Address\AddressInterface|null $ip
      *
      * @return bool
      */
     public function isWhitelisted(AddressInterface $ip = null)
     {
-        if ($ip === null) {
-            $ip = $this->getRequestIPAddress();
-        }
-        $rangeType = $this->getRangeType($ip);
-
-        return $rangeType !== null && ($rangeType & static::IPRANGEFLAG_WHITELIST) === static::IPRANGEFLAG_WHITELIST;
+        return $this->getFailedLoginService()->isWhitelisted($ip);
     }
 
     /**
-     * Get the (localized) message telling the users that their IP address has been banned.
+     * @deprecated use $app->make('failed_login')->getErrorMessage()
      *
      * @return string
      */
     public function getErrorMessage()
     {
-        return t('Unable to complete action: your IP address has been banned. Please contact the administrator of this site for more information.');
+        return $this->getFailedLoginService()->getErrorMessage();
     }
 
     /**
-     * Add the current IP address to the list of IPs with failed login attempts.
+     * @deprecated use $app->make('failed_login')->registerEvent()
      *
-     * @param AddressInterface $ip the IP address to log (if null, we'll use the current IP address)
-     * @param bool $ignoreConfig if set to true, we'll add the record even if the IP ban system is disabled in the configuration
+     * @param \IPLib\Address\AddressInterface|null $ip
+     * @param bool $ignoreConfig
      */
     public function logFailedLogin(AddressInterface $ip = null, $ignoreConfig = false)
     {
-        if ($ignoreConfig || $this->config->get('concrete.security.ban.ip.enabled')) {
-            if ($ip === null) {
-                $ip = $this->getRequestIPAddress();
-            }
-            $comparableIP = $ip->getComparableString();
-            $this->connection->executeQuery(
-                '
-                    INSERT INTO FailedLoginAttempts
-                        (flaIp, flaTimestamp)
-                    VALUES
-                        (?, ' . $this->connection->getDatabasePlatform()->getNowExpression() . ')
-                ',
-                [$ip->getComparableString()]
-            );
-            $this->logger->notice(t('Failed login attempt recorded from IP address %s', $ip->toString(), ['ip_address' => $ip->toString()]));
-        }
+        return $this->getFailedLoginService()->registerEvent($ip, $ignoreConfig);
     }
 
     /**
-     * Check if the current IP address has reached the failed login attempts threshold.
+     * @deprecated use $app->make('failed_login')->isThresholdReached()
      *
-     * @param AddressInterface $ip the IP address to log (if null, we'll use the current IP address)
-     * @param bool $ignoreConfig if set to true, we'll check the IP even if the IP ban system is disabled in the configuration
+     * @param \IPLib\Address\AddressInterface|null $ip
+     * @param bool $ignoreConfig
      *
      * @return bool
      */
     public function failedLoginsThresholdReached(AddressInterface $ip = null, $ignoreConfig = false)
     {
-        $result = false;
-        if ($ignoreConfig || $this->config->get('concrete.security.ban.ip.enabled')) {
-            if ($ip === null) {
-                $ip = $this->getRequestIPAddress();
-            }
-            if (!$this->isWhitelisted($ip)) {
-                $thresholdSeconds = (int) $this->config->get('concrete.security.ban.ip.time');
-                $thresholdTimestamp = new DateTime("-{$thresholdSeconds} seconds");
-                $rs = $this->connection->executeQuery(
-                    '
-                        SELECT
-                            ' . $this->connection->getDatabasePlatform()->getCountExpression('lcirID') . ' AS n
-                        FROM
-                            FailedLoginAttempts
-                        WHERE
-                            flaIp = ?
-                            AND flaTimestamp > ?
-                    ',
-                    [$ip->getComparableString(), $thresholdTimestamp->format($this->connection->getDatabasePlatform()->getDateTimeFormatString())]
-                );
-                $count = $rs->fetchColumn();
-                $rs->closeCursor();
-                $thresholdAttempts = (int) $this->config->get('concrete.security.ban.ip.attempts');
-                if ($count !== false && (int) $count >= $thresholdAttempts) {
-                    $result = true;
-                }
-            }
-        }
-
-        return $result;
+        return $this->getFailedLoginService()->isThresholdReached($ip, $ignoreConfig);
     }
 
     /**
-     * Add an IP address to the list of IPs banned for too many failed login attempts.
+     * @deprecated use $app->make('failed_login')->addToBlacklistForThresholdReached()
      *
-     * @param AddressInterface $ip the IP to add to the blacklist (if null, we'll use the current IP address)
-     * @param bool $ignoreConfig if set to true, we'll add the IP address even if the IP ban system is disabled in the configuration
+     * @param \IPLib\Address\AddressInterface $ip
+     * @param bool $ignoreConfig
      */
     public function addToBlacklistForThresholdReached(AddressInterface $ip = null, $ignoreConfig = false)
     {
-        if ($ignoreConfig || $this->config->get('concrete.security.ban.ip.enabled')) {
-            if ($ip === null) {
-                $ip = $this->getRequestIPAddress();
-            }
-            $banDurationMinutes = (int) $this->config->get('concrete.security.ban.ip.length');
-            if ($banDurationMinutes > 0) {
-                $expires = new DateTime("+{$banDurationMinutes} minutes");
-            } else {
-                $expires = null;
-            }
-            $this->createRange(IPFactory::rangeFromBoundaries($ip, $ip), static::IPRANGETYPE_BLACKLIST_AUTOMATIC, $expires);
-            $this->logger->warning(t('IP address %s added to blacklist.', $ip->toString(), $expires), [
-                'ip_address' => $ip->toString()
-            ]);
-        }
+        $this->getFailedLoginService()->addToBlacklistForThresholdReached($ip, $ignoreConfig);
     }
 
     /**
-     * Add persist an IP address range type.
+     * @deprecated use $app->make('failed_login')->createRange()
      *
-     * @param RangeInterface $range the IP address range to persist
-     * @param int $type The range type (one of the IPService::IPRANGETYPE_... constants)
-     * @param DateTime $expiration The optional expiration of the range type
+     * @param \IPLib\Range\RangeInterface $range
+     * @param int $type
+     * @param \DateTime|null $expiration
      *
-     * @return IPRange
+     * @return \Concrete\Core\Permission\IPRange
      */
     public function createRange(RangeInterface $range, $type, DateTime $expiration = null)
     {
-        $dateTimeFormat = $this->connection->getDatabasePlatform()->getDateTimeFormatString();
-        $this->connection->executeQuery(
-            '
-                INSERT INTO LoginControlIpRanges
-                    (lcirIpFrom, lcirIpTo, lcirType, lcirExpires)
-                VALUES
-                    (?, ?, ?, ?)
-            ',
-            [
-                $range->getComparableStartString(),
-                $range->getComparableEndString(),
-                $type,
-                ($expiration === null) ? null : $expiration->format($dateTimeFormat),
-            ]
-        );
-        $id = $this->connection->lastInsertId();
-        $rs = $this->connection->executeQuery('SELECT * FROM LoginControlIpRanges WHERE lcirID = ? LIMIT 1', [$id]);
-        $row = $rs->fetch();
-        $rs->closeCursor();
+        $rangeEntity = $this->getFailedLoginService()->createRange($range, $type, $expiration);
 
-        return IPRange::createFromRow($row, $dateTimeFormat);
+        return IPRange::createFromEntity($rangeEntity);
     }
 
     /**
-     * Get the list of currently available ranges.
+     * @deprecated use $app->make('failed_login')->getRanges()
      *
      * @param int $type (one of the IPService::IPRANGETYPE_... constants)
      * @param bool $includeExpired Include expired records?
      *
-     * @return IPRange[]|\Generator
+     * @return \Concrete\Core\Permission\IPRange[]|\Generator
      */
     public function getRanges($type, $includeExpired = false)
     {
-        $sql = 'SELECT * FROM LoginControlIpRanges WHERE lcirType = ?';
-        $params = [(int) $type];
-        if (!$includeExpired) {
-            $sql .= ' AND (lcirExpires IS NULL OR lcirExpires > ' . $this->connection->getDatabasePlatform()->getNowExpression() . ')';
-        }
-        $sql .= ' ORDER BY lcirID';
-        $result = [];
-        $dateTimeFormat = $this->connection->getDatabasePlatform()->getDateTimeFormatString();
-        $rs = $this->connection->executeQuery($sql, $params);
-        while (($row = $rs->fetch()) !== false) {
-            yield IPRange::createFromRow($row, $dateTimeFormat);
+        $rangeEntities = $this->getFailedLoginService()->getRanges($type, $includeExpired);
+        foreach ($rangeEntities as $rangeEntity) {
+            yield IPRange::createFromEntity($rangeEntity);
         }
     }
 
     /**
-     * Find already defined range given its record ID.
+     * @deprecated use $app->make('failed_login')->getRangeByID()
      *
      * @param int $id
      *
-     * @return IPRange|null
+     * @return \Concrete\Core\Permission\IPRange|null
      */
     public function getRangeByID($id)
     {
-        $result = null;
-        if ($id) {
-            $rs = $this->connection->executeQuery(
-                'SELECT * FROM LoginControlIpRanges WHERE lcirID = ? LIMIT 1',
-                [$id]
-            );
-            $row = $rs->fetch();
-            $rs->closeCursor();
-            if ($row !== false) {
-                $result = IPRange::createFromRow($row, $this->connection->getDatabasePlatform()->getDateTimeFormatString());
-            }
-        }
+        $rangeEntity = $this->getFailedLoginService()->getRangeByID($id);
 
-        return $result;
+        return $rangeEntity === null ? null : IPRange::createFromEntity($rangeEntity);
     }
 
     /**
-     * Delete a range record.
+     * @deprecated use $app->make('failed_login')->deleteRange()
      *
-     * @param IPRange|int $range
+     * @param \Concrete\Core\Permission\IPRange|int $range
      */
     public function deleteRange($range)
     {
-        if ($range instanceof IPRange) {
-            $id = $range->getID();
-        } else {
-            $id = (int) $range;
+        if (!$range) {
+            return;
         }
-        if ($id) {
-            $this->connection->executeQuery('DELETE FROM LoginControlIpRanges WHERE lcirID = ? LIMIT 1', [$id]);
-        }
+        $id = $range instanceof IPRange ? $range->getID() : $range;
+        $this->getFailedLoginService()->deleteRange($id);
     }
 
     /**
-     * Get the range type (if defined) of an IP adress.
+     * @deprecated use $app->make('failed_login')->deleteEvents()
      *
-     * @return int|null One of the IPRANGETYPE_... constants (or null if range is not defined).
-     */
-    protected function getRangeType(AddressInterface $ip)
-    {
-        $comparableIP = $ip->getComparableString();
-        $rs = $this->connection->executeQuery(
-            '
-                SELECT
-                    lcirType
-                FROM
-                    LoginControlIpRanges
-                WHERE
-                    lcirIpFrom <= ? AND ? <= lcirIpTo
-                    AND (lcirExpires IS NULL OR lcirExpires > ' . $this->connection->getDatabasePlatform()->getNowExpression() . ')
-            ',
-            [$comparableIP, $comparableIP]
-        );
-        $type = null;
-        while (($col = $rs->fetchColumn()) !== false) {
-            $type = (int) $col;
-            if (($type & static::IPRANGEFLAG_WHITELIST) === static::IPRANGEFLAG_WHITELIST) {
-                break;
-            }
-        }
-        $rs->closeCursor();
-
-        return $type;
-    }
-
-    /**
-     * Delete the failed login attempts.
+     * @param int|null $maxAge
      *
-     * @param int|null $maxAge the maximum age (in seconds) of the records (specify an empty value do delete all records)
-     *
-     * @return int return the number of records deleted
+     * @return int
      */
     public function deleteFailedLoginAttempts($maxAge = null)
     {
-        $sql = 'DELETE FROM FailedLoginAttempts';
-        if ($maxAge) {
-            $platform = $this->connection->getDatabasePlatform();
-            $sql .= ' WHERE flaTimestamp <= ' . $platform->getDateSubSecondsExpression($platform->getNowExpression(), (int) $maxAge);
-        }
-
-        return (int) $this->connection->executeQuery($sql)->rowCount();
+        return $this->getFailedLoginService()->deleteEvents($maxAge);
     }
 
     /**
      * Clear the IP addresses automatically blacklisted.
      *
      * @param bool $onlyExpired Clear only the expired bans?
+     *
+     * @return int
      */
     public function deleteAutomaticBlacklist($onlyExpired = true)
     {
-        $sql = 'DELETE FROM LoginControlIpRanges WHERE lcirType = ' . (int) static::IPRANGETYPE_BLACKLIST_AUTOMATIC;
-        if ($onlyExpired) {
-            $platform = $this->connection->getDatabasePlatform();
-            $sql .= ' AND lcirExpires <= ' . $platform->getNowExpression();
-        }
-
-        return (int) $this->connection->executeQuery($sql)->rowCount();
+        return $this->getFailedLoginService()->deleteAutomaticBlacklist($onlyExpired);
     }
 
     /**
-     * @deprecated Use \Core::make('ip')->getRequestIPAddress()
+     * @deprecated Use $app->make(\IPLib\Address\AddressInterface::class)
+     *
+     * @return \Concrete\Core\Utility\IPAddress
      */
     public function getRequestIP()
     {
-        $ip = $this->getRequestIPAddress();
+        $app = Application::getFacadeApplication();
+        $ip = $app->make(\IPLib\Address\AddressInterface::class);
+
         return new IPAddress($ip === null ? null : (string) $ip);
     }
 
     /**
-     * @deprecated Use \Core::make('ip')->isBlacklisted()
+     * @deprecated use $app->make('failed_login')->isBlacklisted()
+     *
+     * @param mixed $ip
      */
     public function isBanned($ip = false)
     {
@@ -427,11 +295,14 @@ class IPService implements LoggerAwareInterface
             $ipAddress = IPFactory::addressFromString($ip->getIp(IPAddress::FORMAT_IP_STRING));
         }
 
-        return $this->isBlacklisted($ipAddress);
+        return $this->getFailedLoginService()->isBlacklisted($ipAddress);
     }
 
     /**
-     * @deprecated Use \Core::make('ip')->addToBlacklist()
+     * * @deprecated use $app->make('failed_login')->addToBlacklistForThresholdReached()
+     *
+     * @param mixed $ip
+     * @param mixed $ignoreConfig
      */
     public function createIPBan($ip = false, $ignoreConfig = false)
     {
@@ -439,30 +310,60 @@ class IPService implements LoggerAwareInterface
         if ($ip instanceof IPAddress) {
             $ipAddress = IPFactory::addressFromString($ip->getIp(IPAddress::FORMAT_IP_STRING));
         }
-        $this->addToBlacklistForThresholdReached($ipAddress, $ignoreConfig);
+        $this->getFailedLoginService()->addToBlacklistForThresholdReached($ipAddress, $ignoreConfig);
     }
 
     /**
-     * @deprecated Use \Core::make('ip')->logFailedLogin()
+     * @deprecated use $app->make('failed_login')->registerEvent()
+     *
+     * @param bool $ignoreConfig
      */
     public function logSignupRequest($ignoreConfig = false)
     {
-        $this->logFailedLogin(null, $ignoreConfig);
+        return $this->getFailedLoginService()->registerEvent(null, $ignoreConfig);
     }
 
     /**
-     * @deprecated use signupRequestThresholdReached (same syntax, just fixed the typo in the name)
+     * @deprecated use $app->make('failed_login')->isThresholdReached()
+     *
+     * @param bool $ignoreConfig
      */
     public function signupRequestThreshholdReached($ignoreConfig = false)
     {
-        return $this->failedLoginsThresholdReached(null, $ignoreConfig);
+        return $this->getFailedLoginService()->isThresholdReached(null, $ignoreConfig);
     }
 
     /**
-     * @deprecated Use \Core::make('ip')->failedLoginsThresholdReached()
+     * @deprecated use $app->make('failed_login')->isThresholdReached()
+     *
+     * @param bool $ignoreConfig
      */
     public function signupRequestThresholdReached($ignoreConfig = false)
     {
-        return $this->failedLoginsThresholdReached(null, $ignoreConfig);
+        return $this->getFailedLoginService()->isThresholdReached(null, $ignoreConfig);
+    }
+
+    /**
+     * @deprecated use $app->make('failed_login')->getRangeType()
+     *
+     * @param \IPLib\Address\AddressInterface $ip
+     *
+     * @return int|null
+     */
+    protected function getRangeType(AddressInterface $ip)
+    {
+        $range = $this->getFailedLoginService()->getRange($ip);
+
+        return $range === null ? null : $range->getType();
+    }
+
+    /**
+     * @return \Concrete\Core\Permission\IpAccessControlService
+     */
+    private function getFailedLoginService()
+    {
+        $app = Application::getFacadeApplication();
+
+        return $app->make('failed_login');
     }
 }

--- a/concrete/src/Permission/IpAccessControlService.php
+++ b/concrete/src/Permission/IpAccessControlService.php
@@ -355,7 +355,7 @@ class IpAccessControlService implements LoggerAwareInterface
      * Delete the recorded events.
 
      *
-     * @param int|null $maxAge the maximum age (in seconds) of the records (specify an empty value to delete all records)
+     * @param int|null $minAge the minimum age (in seconds) of the records (specify an empty value to delete all records)
      *
      * @return int the number of records deleted
      */

--- a/concrete/src/Permission/IpAccessControlService.php
+++ b/concrete/src/Permission/IpAccessControlService.php
@@ -1,0 +1,480 @@
+<?php
+
+namespace Concrete\Core\Permission;
+
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Entity\Permission\IpAccessControlEvent;
+use Concrete\Core\Entity\Permission\IpAccessControlRange;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\Logging\LoggerAwareInterface;
+use Concrete\Core\Logging\LoggerAwareTrait;
+use DateTime;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManagerInterface;
+use IPLib\Address\AddressInterface;
+use IPLib\Factory as IPFactory;
+use IPLib\Range\RangeInterface;
+
+class IpAccessControlService implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * Bit mask for blacklist ranges.
+     *
+     * @var int
+     */
+    const IPRANGEFLAG_BLACKLIST = 0x0001;
+
+    /**
+     * Bit mask for whitelist ranges.
+     *
+     * @var int
+     */
+    const IPRANGEFLAG_WHITELIST = 0x0002;
+
+    /**
+     * Bit mask for manually generated ranges.
+     *
+     * @var int
+     */
+    const IPRANGEFLAG_MANUAL = 0x0010;
+
+    /**
+     * Bit mask for automatically generated ranges.
+     *
+     * @var int
+     */
+    const IPRANGEFLAG_AUTOMATIC = 0x0020;
+
+    /**
+     * IP range type: manually added to the blacklist.
+     *
+     * @var int
+     */
+    const IPRANGETYPE_BLACKLIST_MANUAL = 0x0011; // IPRANGEFLAG_BLACKLIST | IPRANGEFLAG_MANUAL
+
+    /**
+     * IP range type: automatically added to the blacklist.
+     *
+     * @var int
+     */
+    const IPRANGETYPE_BLACKLIST_AUTOMATIC = 0x0021; // IPRANGEFLAG_BLACKLIST | IPRANGEFLAG_AUTOMATIC
+
+    /**
+     * IP range type: manually added to the whitelist.
+     *
+     * @var int
+     */
+    const IPRANGETYPE_WHITELIST_MANUAL = 0x0012; // IPRANGEFLAG_WHITELIST | IPRANGEFLAG_MANUAL
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @var \Concrete\Core\Entity\Site\Site
+     */
+    protected $site;
+
+    /**
+     * The IP Access Control Category.
+     *
+     * @var \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    protected $category;
+
+    /**
+     * @var \IPLib\Address\AddressInterface
+     */
+    protected $defaultIpAddress;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Concrete\Core\Entity\Site\Site $site
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlCategory $category
+     * @param \IPLib\Address\AddressInterface $defaultIpAddress
+     */
+    public function __construct(EntityManagerInterface $em, Site $site, IpAccessControlCategory $category, AddressInterface $defaultIpAddress)
+    {
+        $this->em = $em;
+        $this->site = $site;
+        $this->category = $category;
+        $this->defaultIpAddress = $defaultIpAddress;
+    }
+
+    /**
+     * Get the IP Access Control Category.
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlCategory
+     */
+    public function getCategory()
+    {
+        return $this->category;
+    }
+
+    /**
+     * Check if an IP address is blacklisted.
+     *
+     * @param \IPLib\Address\AddressInterface|null $ipAddress
+     *
+     * @return bool
+     */
+    public function isBlacklisted(AddressInterface $ipAddress = null)
+    {
+        $range = $this->getRange($ipAddress);
+
+        return $range !== null && ($range->getType() & self::IPRANGEFLAG_BLACKLIST);
+    }
+
+    /**
+     * Check if an IP address is whitelisted.
+     *
+     * @param \IPLib\Address\AddressInterface|null $ipAddress
+     *
+     * @return bool
+     */
+    public function isWhitelisted(AddressInterface $ipAddress = null)
+    {
+        $range = $this->getRange($ipAddress);
+
+        return $range !== null && ($range->getType() & self::IPRANGEFLAG_WHITELIST);
+    }
+
+    /**
+     * Create and save an IP Access Control Event.
+     *
+     * @param \IPLib\Address\AddressInterface|null $ipAddress
+     * @param bool $evenIfDisabled
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlEvent|null
+     */
+    public function registerEvent(AddressInterface $ipAddress = null, $evenIfDisabled = false)
+    {
+        if (!$evenIfDisabled && !$this->getCategory()->isEnabled()) {
+            return null;
+        }
+        $event = new IpAccessControlEvent();
+        $event
+            ->setCategory($this->getCategory())
+            ->setSite($this->site)
+            ->setIpAddress($ipAddress ?: $this->defaultIpAddress)
+            ->setDateTime(new DateTime('now'))
+        ;
+        $this->em->persist($event);
+        $this->em->flush($event);
+
+        return $event;
+    }
+
+    /**
+     * Check if the IP address has reached the threshold.
+     *
+     * @param \IPLib\Address\AddressInterface $ipAddress
+     * @param bool $evenIfDisabled
+     *
+     * @return bool
+     */
+    public function isThresholdReached(AddressInterface $ipAddress = null, $evenIfDisabled = false)
+    {
+        if (!$evenIfDisabled && !$this->getCategory()->isEnabled()) {
+            return false;
+        }
+        if ($this->isWhitelisted($ipAddress)) {
+            return false;
+        }
+        if ($ipAddress === null) {
+            $ipAddress = $this->defaultIpAddress;
+        }
+        $qb = $this->em->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->from(IpAccessControlEvent::class, 'e')
+            ->select($x->count('e.ipAccessControlEventID'))
+            ->where($x->eq('e.ip', ':ip'))
+            ->andWhere($x->eq('e.category', ':category'))
+            ->setParameter('ip', $ipAddress->getComparableString())
+            ->setParameter('category', $this->getCategory()->getIpAccessControlCategoryID())
+        ;
+        if ($this->getCategory()->getTimeWindow() !== null) {
+            $dateTimeLimit = new DateTime('-' . $this->getCategory()->getTimeWindow() . ' seconds');
+            $qb
+                ->andWhere($x->gt('e.dateTime', ':dateTimeLimit'))
+                ->setParameter('dateTimeLimit', $dateTimeLimit)
+            ;
+        }
+        if ($this->getCategory()->isSiteSpecific()) {
+            $qb
+                ->andWhere(
+                    $x->orX(
+                        $x->isNull('e.site'),
+                        $x->eq('e.site', ':site')
+                    )
+                )
+                ->setParameter('site', $this->site->getSiteID())
+            ;
+        }
+        $numEvents = (int) $qb->getQuery()->getSingleScalarResult();
+
+        return $numEvents >= $this->getCategory()->getMaxEvents();
+    }
+
+    /**
+     * Add an IP address to the list of blacklisted IP address when too many events occur.
+     *
+     * @param \IPLib\Address\AddressInterface $ipAddress the IP to add to the blacklist (if null, we'll use the current IP address)
+     * @param bool $evenIfDisabled if set to true, we'll add the IP address even if the IP ban system is disabled in the configuration
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlRange|null
+     */
+    public function addToBlacklistForThresholdReached(AddressInterface $ipAddress = null, $evenIfDisabled = false)
+    {
+        if (!$evenIfDisabled && !$this->getCategory()->isEnabled()) {
+            return null;
+        }
+        if ($ipAddress === null) {
+            $ipAddress = $this->defaultIpAddress;
+        }
+        if ($this->getCategory()->getBanDuration() === null) {
+            $banExpiration = null;
+        } else {
+            $banExpiration = new DateTime('+' . $this->getCategory()->getBanDuration() . ' minutes');
+        }
+
+        $range = $this->createRange(
+            IPFactory::rangeFromBoundaries($ipAddress, $ipAddress),
+            static::IPRANGETYPE_BLACKLIST_AUTOMATIC,
+            $banExpiration
+        );
+
+        if ($this->getCategory()->getLogChannelHandle() !== '') {
+            $this->logger->warning(
+                t('IP address %1$s added to blacklist for the category %2$s.', $ipAddress->toString(), $this->getCategory()->getDisplayName()),
+                [
+                    'ip_address' => $ipAddress->toString(),
+                    'category' => $this->getCategory()->getHandle(),
+                ]
+            );
+        }
+
+        return $range;
+    }
+
+    /**
+     * Add persist an IP address range type.
+     *
+     * @param \IPLib\Range\RangeInterface $range the IP address range to persist
+     * @param int $type The range type (one of the IpAccessControlService::IPRANGETYPE_... constants)
+     * @param \DateTime $expiration The optional expiration of the range type
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlRange
+     */
+    public function createRange(RangeInterface $range, $type, DateTime $expiration = null)
+    {
+        $result = new IpAccessControlRange();
+        $result
+            ->setCategory($this->getCategory())
+            ->setIpRange($range)
+            ->setType($type)
+            ->setExpiration($expiration)
+            ->setSite($this->site)
+        ;
+        $this->em->persist($result);
+        $this->em->flush($result);
+
+        return $result;
+    }
+
+    /**
+     * Get the list of currently available ranges.
+     *
+     * @param int $type (one of the IPService::IPRANGETYPE_... constants)
+     * @param bool $includeExpired Include expired records?
+     *
+     * @return \Doctrine\Common\Collections\Collection|\Concrete\Core\Entity\Permission\IpAccessControlRange[]
+     */
+    public function getRanges($type, $includeExpired = false)
+    {
+        $criteria = new Criteria();
+        $x = $criteria->expr();
+        $criteria->andWhere($x->eq('type', (int) $type));
+        if (!$includeExpired) {
+            $criteria->andWhere(
+                $x->orX(
+                    $x->isNull('expiration'),
+                    $x->gt('expiration', new DateTime('now'))
+                )
+            );
+        }
+
+        return $this->getCategory()->getRanges()->matching($criteria);
+    }
+
+    /**
+     * Get a saved range for this category given its ID.
+     *
+     * @param int $id
+     *
+     * \Concrete\Core\Entity\Permission\IpAccessControlRange|null
+     */
+    public function getRangeByID($id)
+    {
+        if (!$id) {
+            return null;
+        }
+        $entity = $this->em->find(IpAccessControlRange::class, ['ipAccessControlRangeID' => (int) $id]);
+        if ($entity === null) {
+            return null;
+        }
+        if ($entity->getCategory() !== $this->getCategory()) {
+            return null;
+        }
+
+        return $entity;
+    }
+
+    /**
+     * Delete a saved range given its instance or its ID.
+     *
+     * @param \Concrete\Core\Entity\Permission\IpAccessControlRange|int $range
+     */
+    public function deleteRange($range)
+    {
+        $entity = is_numeric($range) ? $this->getRangeByID($range) : $range;
+        if (!($entity instanceof IpAccessControlRange) || $entity->getCategory() !== $this->getCategory()) {
+            return;
+        }
+        $this->em->remove($entity);
+        $this->em->flush($entity);
+    }
+
+    /**
+     * Delete the recorded events.
+
+     *
+     * @param int|null $maxAge the maximum age (in seconds) of the records (specify an empty value to delete all records)
+     *
+     * @return int the number of records deleted
+     */
+    public function deleteEvents($minAge = null)
+    {
+        $qb = $this->em->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->delete(IpAccessControlEvent::class, 'e')
+            ->where($x->eq('e.category', ':category'))
+            ->setParameter('category', $this->getCategory()->getIpAccessControlCategoryID())
+        ;
+        if ($minAge) {
+            $dateTimeLimit = new DateTime('-' . ((int) $minAge) . ' seconds');
+            $qb
+                ->andWhere($x->lte('e.dateTime', ':dateTimeLimit'))
+                ->setParameter('dateTimeLimit', $dateTimeLimit)
+            ;
+        }
+
+        return (int) $qb->getQuery()->execute();
+    }
+
+    /**
+     * Clear the IP addresses automatically blacklisted.
+     *
+     * @param bool $onlyExpired
+     *
+     * @return int the number of records deleted
+     */
+    public function deleteAutomaticBlacklist($onlyExpired = true)
+    {
+        $qb = $this->em->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->delete(IpAccessControlRange::class, 'r')
+            ->where($x->eq('r.category', ':category'))
+            ->andWhere($x->eq('r.type', ':type'))
+            ->setParameter('category', $this->getCategory()->getIpAccessControlCategoryID())
+            ->setParameter('type', self::IPRANGETYPE_BLACKLIST_AUTOMATIC)
+        ;
+        if ($onlyExpired) {
+            $dateTimeLimit = new DateTime('now');
+            $qb
+                ->andWhere($x->lte('r.expiration', ':dateTimeLimit'))
+                ->setParameter('dateTimeLimit', $dateTimeLimit)
+            ;
+        }
+
+        return (int) $qb->getQuery()->execute();
+    }
+
+    /**
+     * Get the (localized) message telling the users that their IP address has been banned.
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return t('Unable to complete action: your IP address has been banned. Please contact the administrator of this site for more information.');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Logging\LoggerAwareInterface::getLoggerChannel()
+     */
+    public function getLoggerChannel()
+    {
+        return $this->getCategory()->getLogChannelHandle();
+    }
+
+    /**
+     * @param \IPLib\Address\AddressInterface $ipAddress
+     *
+     * @return \Concrete\Core\Entity\Permission\IpAccessControlRange|null
+     */
+    public function getRange(AddressInterface $ipAddress = null)
+    {
+        if ($ipAddress === null) {
+            $ipAddress = $this->defaultIpAddress;
+        }
+        $qb = $this->em->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->from(IpAccessControlRange::class, 'r')
+            ->select('r')
+            ->where($x->lte('r.ipFrom', ':ip'))
+            ->andWhere($x->gte('r.ipTo', ':ip'))
+            ->andWhere(
+                $x->orX(
+                    $x->isNull('r.expiration'),
+                    $x->gt('r.expiration', ':now')
+                )
+            )
+            ->setParameter('ip', $ipAddress->getComparableString())
+            ->setParameter('now', new DateTime('now'))
+        ;
+        if ($this->getCategory()->isSiteSpecific()) {
+            $qb
+                ->andWhere(
+                    $x->orX(
+                        $x->isNull('r.site'),
+                        $x->eq('r.site', ':site')
+                    )
+                )
+                ->setParameter('site', $this->site->getSiteID())
+            ;
+        }
+        $query = $qb->getQuery();
+        $result = null;
+        foreach ($query->getResult() as $range)
+        {
+            $result = $range;
+            if ($range->getType() & self::IPRANGEFLAG_WHITELIST) {
+                break;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/concrete/src/Permission/PermissionServiceProvider.php
+++ b/concrete/src/Permission/PermissionServiceProvider.php
@@ -1,14 +1,46 @@
 <?php
 namespace Concrete\Core\Permission;
 
+use Concrete\Core\Application\Application;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
-use Concrete\Core\Page\Type\Validator\Manager as ValidatorManager;
-use Concrete\Core\Page\Type\Saver\Manager as SaverManager;
+use Concrete\Core\Http\Request;
+use Doctrine\ORM\EntityManagerInterface;
+use IPLib\Address\AddressInterface;
+use IPLib\Factory as IPFactory;
 
 class PermissionServiceProvider extends ServiceProvider
 {
     public function register()
     {
         $this->app->singleton('Concrete\Core\Permission\Inheritance\Registry\BlockRegistry');
+
+        $this->app
+            ->when(IpAccessControlService::class)
+            ->needs(Site::class)
+            ->give(function (Application $app) {
+                return $app->make('site')->getSite();
+            }
+        );
+
+        $this->app->bind(AddressInterface::class, function (Application $app) {
+            if ($app->isRunThroughCommandLineInterface()) {
+                $ip = '127.0.0.1';
+            } else {
+                $request = $this->app->make(Request::class);
+                $ip = $request->getClientIp();
+            }
+
+            return IPFactory::addressFromString($ip);
+        });
+
+        $this->app->bind('failed_login', function (Application $app) {
+            $em = $app->make(EntityManagerInterface::class);
+            $repo = $em->getRepository(IpAccessControlCategory::class);
+            $category = $repo->findOneBy(['handle' => 'failed_login']);
+
+            return $app->make(IpAccessControlService::class, ['category' => $category]);
+        });
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20190317123600.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190317123600.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Attribute\Category\PageCategory;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Entity\Permission\IpAccessControlEvent;
+use Concrete\Core\Entity\Permission\IpAccessControlRange;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+class Version20190317123600 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            IpAccessControlCategory::class,
+            IpAccessControlRange::class,
+            IpAccessControlEvent::class,
+        ]);
+        $this->createFailedLoginCategory();
+        $this->createSinglePage(
+            '/dashboard/system/permissions/blacklist/configure',
+            'Configure IP Blocking',
+            ['exclude_nav' => true]
+        );
+        $rangePage = Page::getByPath('/dashboard/system/permissions/blacklist/range');
+        if ($rangePage && !$rangePage->isError()) {
+            if ($this->isAttributeHandleValid(PageCategory::class, 'exclude_nav')) {
+                $rangePage->setAttribute('exclude_nav', true);
+            }
+        }
+    }
+
+    protected function createFailedLoginCategory()
+    {
+        $em = $this->app->make(EntityManagerInterface::class);
+        $repo = $em->getRepository(IpAccessControlCategory::class);
+        if ($repo->findOneBy(['handle' => 'failed_login']) !== null) {
+            return;
+        }
+        $config = $this->app->make('config');
+        $category = new IpAccessControlCategory();
+        $category
+            ->setHandle('failed_login')
+            ->setName('Failed Login Attempts')
+            ->setEnabled($config->get('concrete.security.ban.ip.enabled', true))
+            ->setMaxEvents($config->get('concrete.security.ban.ip.attempts', 5))
+            ->setTimeWindow($config->get('concrete.security.ban.ip.time', 300))
+            ->setBanDuration(60 * $config->get('concrete.security.ban.ip.length', 10) ?: null)
+            ->setSiteSpecific(false)
+        ;
+        $em->persist($category);
+        $em->flush($category);
+        $this->copyLoginControlIpRanges($category);
+        $this->copyFailedLoginAttempts($category);
+    }
+
+    protected function copyLoginControlIpRanges(IpAccessControlCategory $category)
+    {
+        $site = $this->app->make('site')->getSite();
+        $this->connection->executeQuery(
+            '
+INSERT INTO IpAccessControlRanges
+    (
+        iacrCategory,
+        iacrSite,
+        iacrIpFrom,
+        iacrIpTo,
+        iacrType,
+        iacrExpiration
+    )
+    SELECT
+        ?,
+        ?,
+        lcirIpFrom,
+        lcirIpTo,
+        lcirType,
+        lcirExpires
+    FROM
+        LoginControlIpRanges
+            ',
+            [
+                $category->getIpAccessControlCategoryID(),
+                $site ? $site->getSiteID() : null,
+            ]
+        );
+    }
+
+    protected function copyFailedLoginAttempts(IpAccessControlCategory $category)
+    {
+        $site = $this->app->make('site')->getSite();
+        $this->connection->executeQuery(
+            '
+INSERT INTO IpAccessControlEvents
+    (
+        iaceCategory,
+        iaceSite,
+        iaceIp,
+        iaceDateTime
+    )
+    SELECT
+        ?,
+        ?,
+        flaIp,
+        flaTimestamp
+    FROM
+        FailedLoginAttempts
+            ',
+            [
+                $category->getIpAccessControlCategoryID(),
+                $site ? $site->getSiteID() : null,
+            ]
+        );
+    }
+}

--- a/tests/tests/Permission/IPServiceTest.php
+++ b/tests/tests/Permission/IPServiceTest.php
@@ -7,51 +7,62 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use DateTime;
 use IPLib\Factory as IPFactory;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Entity\Permission\IpAccessControlEvent;
+use Concrete\Core\Entity\Permission\IpAccessControlRange;
+use Doctrine\ORM\EntityManagerInterface;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\Site\Factory as SiteFactory;
 
 class IPServiceTest extends ConcreteDatabaseTestCase
 {
     protected $tables = [
-        'FailedLoginAttempts',
-        'LoginControlIpRanges',
         'Logs',
     ];
 
+    protected $metadatas = [
+        Site::class,
+        IpAccessControlCategory::class,
+        IpAccessControlEvent::class,
+        IpAccessControlRange::class,
+    ];
+    
     /**
-     * @var \Concrete\Core\Config\Repository\Repository
+     * @var \Concrete\Core\Entity\Permission\IpAccessControlCategory
      */
-    private $config;
+    private $category;
 
     /**
-     * @var array
-     */
-    private $originalConfig;
-
-    /**
-     * @var IPService
+     * @var \Concrete\Core\Permission\IPService
      */
     private $ipService;
 
     protected function setUp()
     {
         parent::setUp();
-        $this->connection()->executeQuery('DELETE FROM FailedLoginAttempts');
-        $this->connection()->executeQuery('DELETE FROM LoginControlIpRanges');
         $app = Application::getFacadeApplication();
-        $this->config = $app->make('config');
-        $this->originalConfig = $this->config->get('concrete.security.ban.ip');
-        $this->ipService = $app->build(
-            IPService::class,
-            [
-                'config' => $this->config,
-                'connection' => $this->connection(),
-            ]
-        );
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->config->set('concrete.security.ban.ip', $this->originalConfig);
+        $app->make('cache/request')->flush();
+        $em = $app->make(EntityManagerInterface::class);
+        $em->createQueryBuilder()->delete(Site::class)->getQuery()->execute();
+        $em->createQueryBuilder()->delete(IpAccessControlEvent::class)->getQuery()->execute();
+        $em->createQueryBuilder()->delete(IpAccessControlRange::class)->getQuery()->execute();
+        $em->createQueryBuilder()->delete(IpAccessControlCategory::class)->getQuery()->execute();
+        $site = $app->make(SiteFactory::class)->createDefaultEntity();
+        $em->persist($site);
+        $em->flush($site);
+        $this->category = new IpAccessControlCategory();
+        $this->category
+            ->setHandle('failed_login')
+            ->setName('Failed Login Attempts')
+            ->setEnabled(true)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+            ->setSiteSpecific(false)
+        ;
+        $em->persist($this->category);
+        $em->flush($this->category);
+        $this->ipService = $app->make(IPService::class);
     }
 
     public function automaticBanEnabledProvider()
@@ -70,10 +81,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
      */
     public function testAutomaticBanEnabled($allowedAttempts)
     {
-        $this->config->set('concrete.security.ban.ip.enabled', true);
-        $this->config->set('concrete.security.ban.ip.attempts', $allowedAttempts);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(true)
+            ->setMaxEvents($allowedAttempts)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         for ($attempt = 1; $attempt <= $allowedAttempts; ++$attempt) {
             $this->assertFalse($this->ipService->isWhitelisted($ip));
@@ -98,10 +111,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
 
     public function testAutomaticBanDisabled()
     {
-        $this->config->set('concrete.security.ban.ip.enabled', false);
-        $this->config->set('concrete.security.ban.ip.attempts', 3);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(false)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         for ($attempt = 1; $attempt <= 10; ++$attempt) {
             $this->ipService->logFailedLogin($ip);
@@ -112,10 +127,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
 
     public function testWhitelisted()
     {
-        $this->config->set('concrete.security.ban.ip.enabled', true);
-        $this->config->set('concrete.security.ban.ip.attempts', 3);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(true)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
@@ -132,10 +149,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
 
     public function testBlacklistedPermament()
     {
-        $this->config->set('concrete.security.ban.ip.enabled', true);
-        $this->config->set('concrete.security.ban.ip.attempts', 3);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(true)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
@@ -146,10 +165,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
 
     public function testBlacklistedExpiration()
     {
-        $this->config->set('concrete.security.ban.ip.enabled', true);
-        $this->config->set('concrete.security.ban.ip.attempts', 3);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(true)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
@@ -163,10 +184,12 @@ class IPServiceTest extends ConcreteDatabaseTestCase
 
     public function testBlacklistedVsWhitelisted()
     {
-        $this->config->set('concrete.security.ban.ip.enabled', true);
-        $this->config->set('concrete.security.ban.ip.attempts', 3);
-        $this->config->set('concrete.security.ban.ip.time', 300);
-        $this->config->set('concrete.security.ban.ip.length', 10);
+        $this->category
+            ->setEnabled(true)
+            ->setMaxEvents(3)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+        ;
         $ip = IPFactory::addressFromString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));


### PR DESCRIPTION
Let's generalize the Failed Login Attempts approach, introducing an extensible way to check/limit generic actions performed from visitors.

This PR does not break BC, except for:
- the `concrete.security.ban.ip.*` configuration keys has been removed (these settings are now handled in the new `IpAccessControlCategory` entity)
- the dashboard pages to manage IP Blocking have been rewritten (so that users can manage any IP Access Control Category, not only the "Failed Login Attempts")
- the `projectRange` method of the `IPRangesCsvWriter` class changed its signature (if PL wants to keep BC compatibility for this, it's very easy to make the `IPRangesCsvWriter` fully BC)

Closes #7621