### PR TITLE
Avoid infinite recursion in Page::rescanCollectionPath()

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3223,8 +3223,12 @@ EOT
 
             $children = $this->getCollectionChildren();
             if (count($children) > 0) {
+                $myCollectionID = $this->getCollectionID();
                 foreach ($children as $child) {
-                    $child->rescanCollectionPath();
+                    // Let's avoid recursion caused by potentially malformed data
+                    if ($child->getCollectionID() !== $myCollectionID) {
+                        $child->rescanCollectionPath();
+                    }
                 }
             }
         //}


### PR DESCRIPTION
In case we have malformed data in the Pages table (that is, cID === cParentID), the rescanCollectionPath method runs forever.
Let's avoid that.