### PR TITLE
Add SessionValidator::getActiveSession()

### DIFF
--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Session;
 
 use Carbon\Carbon;
@@ -7,10 +8,9 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
 use Concrete\Core\Permission\IPService;
-use Concrete\Core\Utility\IPAddress;
-use Concrete\Core\Logging\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
 
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
  */
 class SessionValidator implements SessionValidatorInterface, LoggerAwareInterface
 {
-
     use LoggerAwareTrait;
 
     /** @var \Concrete\Core\Application\Application */
@@ -46,6 +45,11 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
         $this->logger = $logger;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Logging\LoggerAwareInterface::getLoggerChannel()
+     */
     public function getLoggerChannel()
     {
         return Channels::CHANNEL_AUTHENTICATION;
@@ -53,7 +57,8 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
 
     /**
      * @param \Symfony\Component\HttpFoundation\Session\Session $session
-     * @return bool True if the session invalidated, false otherwise.
+     *
+     * @return bool true if the session invalidated, false otherwise
      */
     public function handleSessionValidation(SymfonySession $session)
     {
@@ -90,10 +95,13 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
         // Validate the request IP
         if ($this->shouldCompareIP() && $ip && $ip != $request_ip) {
             if ($this->logger) {
-                $this->logger->notice('Session Invalidated. Session IP "{session}" did not match provided IP "{client}".',
-                    array(
+                $this->logger->notice(
+                    'Session Invalidated. Session IP "{session}" did not match provided IP "{client}".',
+                    [
                         'session' => $ip,
-                        'client' => $request_ip, ));
+                        'client' => $request_ip,
+                    ]
+                );
             }
 
             $invalidate = true;
@@ -102,10 +110,13 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
         // Validate the request user agent
         if ($this->shouldCompareAgent() && $agent && $agent != $request_agent) {
             if ($this->logger) {
-                $this->logger->notice('Session Invalidated. Session user agent "{session}" did not match provided agent "{client}"',
-                    array(
+                $this->logger->notice(
+                    'Session Invalidated. Session user agent "{session}" did not match provided agent "{client}"',
+                    [
                         'session' => $agent,
-                        'client' => $request_agent, ));
+                        'client' => $request_agent,
+                    ]
+                );
             }
 
             $invalidate = true;
@@ -126,6 +137,11 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
         return $invalidate;
     }
 
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     *
+     * @return bool
+     */
     public function shouldValidateUserActivity(SymfonySession $session)
     {
         return $this->config->get('concrete.security.session.invalidate_inactive_users.enabled') &&
@@ -133,14 +149,23 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
             $session->get('uOnlineCheck') > 0;
     }
 
+    /**
+     * @return int
+     */
     public function getUserActivityThreshold()
     {
         return $this->config->get('concrete.security.session.invalidate_inactive_users.time');
     }
 
+    /**
+     * Check if there is an active session.
+     *
+     * @return bool
+     */
     public function hasActiveSession()
     {
         $cookie = $this->app['cookie'];
+
         return $cookie->has($this->config->get('concrete.session.name')) || $cookie->has('ccmAuthUserHash');
     }
 
@@ -154,6 +179,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
         if ($this->hasActiveSession()) {
             return $this->app->make('session');
         }
+
         return null;
     }
 
@@ -176,7 +202,7 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     /**
      * Sets a logger instance on the object.
      *
-     * @param LoggerInterface $logger
+     * @param \Psr\Log\LoggerInterface $logger
      */
     public function setLogger(LoggerInterface $logger)
     {

--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -145,6 +145,19 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     }
 
     /**
+     * Get the current session (if it exists).
+     *
+     * @return \Symfony\Component\HttpFoundation\Session\Session|null
+     */
+    public function getActiveSession()
+    {
+        if ($this->hasActiveSession()) {
+            return $this->app->make('session');
+        }
+        return null;
+    }
+
+    /**
      * @return bool
      */
     private function shouldCompareIP()


### PR DESCRIPTION
When getting a value from the Session, we have to:
1. get the `SessionValidator` instance
2. check if `SessionValidator::hasActiveSession()`
3. get the session instance if it returns `true`

What about simplifying it a bit, by adding `SessionValidator::getActiveSession()`?