### PR TITLE
Simplify DefaultDispatcher::handleDispatch()

### DIFF
--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -104,7 +104,6 @@ class DefaultDispatcher implements DispatcherInterface
 
     private function handleDispatch($request)
     {
-        $callDispatcher = false;
         try {
             $route = $this->router->matchRoute($request)->getRoute();
             $dispatcher = new RouteDispatcher($this->router, $route, []);
@@ -125,14 +124,10 @@ class DefaultDispatcher implements DispatcherInterface
             }
             return $stack->process($request);
         } catch (ResourceNotFoundException $e) {
-            $callDispatcher = true;
         } catch (MethodNotAllowedException $e) {
-            $callDispatcher = true;
         }
-        if ($callDispatcher) {
-            $c = \Page::getFromRequest($request);
-            $response = $this->app->make(ResponseFactoryInterface::class)->collection($c);
-        }
+        $c = \Page::getFromRequest($request);
+        $response = $this->app->make(ResponseFactoryInterface::class)->collection($c);
 
         return $response;
     }


### PR DESCRIPTION
The use of the `$callDispatcher` variable is useless: let's remove it.