### PR TITLE
Make sure custom thumbnails have upscaling enabled

### DIFF
--- a/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
+++ b/concrete/src/File/Image/Thumbnail/Type/CustomThumbnail.php
@@ -11,7 +11,7 @@ class CustomThumbnail extends ThumbnailVersion
 
     protected $path;
     protected $cropped;
-  
+
     /**
      * CustomThumbnail constructor.
      * @param int $width
@@ -27,7 +27,7 @@ class CustomThumbnail extends ThumbnailVersion
         $cropped = (int) $cropped;
         $this->path = $path;
         $this->cropped = (bool) $cropped;
-        parent::__construct(REL_DIR_FILES_CACHE, "ccm_{$width}x{$height}_{$cropped}", 'Custom', $width, $height, false, $sizingMode);
+        parent::__construct(REL_DIR_FILES_CACHE, "ccm_{$width}x{$height}_{$cropped}", 'Custom', $width, $height, false, $sizingMode, false, [], true);
     }
 
     public function getFilePath(FileVersion $fv)


### PR DESCRIPTION
When [we added upscaling as a configurable part of thumbnail types](https://github.com/concrete5/concrete5/commit/fb5176710cad83d679480d7935c92b928bc2f176), we inadvertently changed `CustomThumbnail` instances to fail to generate thumbnails larger than their source image. That's not necessarily a bad thing but it's a break in backwards compatibility that's better suited for 9.0 and some documentation.