### PR TITLE
Password Requirements dashboard page was not installed via 8.5.0 & 8.5.1 fresh install

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.1',
     'version_installed' => '8.5.1',
-    'version_db' => '20190301133300', // the key of the latest database migration
+    'version_db' => '20190405171430', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -948,6 +948,13 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Password Requirements" path="/dashboard/system/registration/password_requirements" filename="/dashboard/system/registration/password_requirements.php" pagetype="" description="Set password rule and regulations." package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>password, rules</value>
+                </attributekey>
+            </attributes>
+        </page>
 
         <page name="Email" path="/dashboard/system/mail" filename="/dashboard/system/mail/view.php" pagetype=""
               description="Control how your site send and processes mail." package="">

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -951,7 +951,7 @@
         <page name="Password Requirements" path="/dashboard/system/registration/password_requirements" filename="/dashboard/system/registration/password_requirements.php" pagetype="" description="Set password rule and regulations." package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>password, rules</value>
+                    <value>password, requirements, code, key, login, registration, security, nist</value>
                 </attributekey>
             </attributes>
         </page>

--- a/concrete/src/Updater/Migrations/Migrations/Version20190405171430.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190405171430.php
@@ -13,21 +13,18 @@ class Version20190405171430 extends AbstractMigration implements RepeatableMigra
 
     public function upgradeDatabase()
     {
-        $sp = Page::getByPath('/dashboard/system/registration/password_requirements');
-        if (is_object($sp) && !$sp->isError()) {
-            $this->createSinglePage('/dashboard/system/registration/password_requirements', 'Password Requirements', [
-                'meta_keywords' => implode(', ', [
-                    'password',
-                    'requirements',
-                    'code',
-                    'key',
-                    'login',
-                    'registration',
-                    'security',
-                    'nist',
-                ])
-            ]);
-        }
+        $this->createSinglePage('/dashboard/system/registration/password_requirements', 'Password Requirements', [
+            'meta_keywords' => implode(', ', [
+                'password',
+                'requirements',
+                'code',
+                'key',
+                'login',
+                'registration',
+                'security',
+                'nist',
+            ])
+        ]);
 
         $this->refreshEntities();
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20190405171430.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190405171430.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\DBAL\Schema\Schema;
+
+
+class Version20190405171430 extends AbstractMigration implements RepeatableMigrationInterface
+{
+
+    public function upgradeDatabase()
+    {
+        $sp = Page::getByPath('/dashboard/system/registration/password_requirements');
+        if (is_object($sp) && !$sp->isError()) {
+            $this->createSinglePage('/dashboard/system/registration/password_requirements', 'Password Requirements', [
+                'meta_keywords' => implode(', ', [
+                    'password',
+                    'requirements',
+                    'code',
+                    'key',
+                    'login',
+                    'registration',
+                    'security',
+                    'nist',
+                ])
+            ]);
+        }
+
+        $this->refreshEntities();
+    }
+
+}


### PR DESCRIPTION
When you tried clean install concrete5 8.5.0 & 8.5.1, Password Requirement page doesn't get installed.

You forgot to add installation xml page.

Adding additional migration script for 8.5.0 & 8.5.1 fresh-installed site.
I didn't bother to add downgradeSchema(). Which is also set in `Version20181222183445.php`.