### PR TITLE
import Config class for usage

### DIFF
--- a/concrete/src/Localization/Service/Date.php
+++ b/concrete/src/Localization/Service/Date.php
@@ -10,6 +10,7 @@ use Concrete\Core\User\User;
 use Punic\Calendar;
 use Punic\Comparer;
 use Punic\Misc;
+use Config;
 
 class Date
 {


### PR DESCRIPTION
the Config class is called in various places within the Concrete\Core\Localization\Service\Date Class but it wasn't imported yet which leads to Class not found exceptions when certain methods are used.