### PR TITLE
Site services: let the classes be singletons

### DIFF
--- a/concrete/src/Site/ServiceProvider.php
+++ b/concrete/src/Site/ServiceProvider.php
@@ -2,20 +2,25 @@
 
 namespace Concrete\Core\Site;
 
-use Concrete\Core\Foundation\Service\Provider;
+use Concrete\Core\Application\Application;
+use Concrete\Core\Foundation\Service\Provider as BaseServiceProvider;
+use Concrete\Core\Site\Resolver\DriverInterface;
+use Concrete\Core\Site\Resolver\StandardDriver;
+use Concrete\Core\Site\Service as SiteService;
+use Concrete\Core\Site\Type\Service as SiteTypeService;
 
-class ServiceProvider extends Provider
+class ServiceProvider extends BaseServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('Concrete\Core\Site\Service');
-        $this->app->alias('Concrete\Core\Site\Service', 'site');
+        $this->app->singleton(SiteService::class);
+        $this->app->alias(SiteService::class, 'site');
 
-        $this->app->singleton('Concrete\Core\Site\Type\Service');
-        $this->app->alias('Concrete\Core\Site\Type\Service', 'site/type');
+        $this->app->singleton(SiteTypeService::class);
+        $this->app->alias(SiteTypeService::class, 'site/type');
 
-        $this->app->singleton('Concrete\Core\Site\Resolver\DriverInterface', function ($app) {
-            return $app->make('Concrete\Core\Site\Resolver\StandardDriver');
+        $this->app->singleton(DriverInterface::class, function (Application $app) {
+            return $this->app->make(StandardDriver::class);
         });
     }
 }

--- a/concrete/src/Site/ServiceProvider.php
+++ b/concrete/src/Site/ServiceProvider.php
@@ -1,25 +1,21 @@
 <?php
+
 namespace Concrete\Core\Site;
 
-use Concrete\Core\Foundation\Service\Provider as BaseServiceProvider;
-use Concrete\Core\Site\Resolver\Resolver;
-use Concrete\Core\Site\Resolver\StandardDriver;
+use Concrete\Core\Foundation\Service\Provider;
 
-class ServiceProvider extends BaseServiceProvider
+class ServiceProvider extends Provider
 {
     public function register()
     {
-        $app = $this->app;
-        $this->app->singleton('site', function() use ($app) {
-            return $app->make('Concrete\Core\Site\Service');
-        });
-        $this->app->singleton('site/type', function() use ($app) {
-            return $app->make('Concrete\Core\Site\Type\Service');
-        });
+        $this->app->singleton('Concrete\Core\Site\Service');
+        $this->app->alias('Concrete\Core\Site\Service', 'site');
 
-        $this->app->singleton('Concrete\Core\Site\Resolver\DriverInterface', function() use ($app) {
-            $resolver = $this->app->make('Concrete\Core\Site\Resolver\StandardDriver');
-            return $resolver;
+        $this->app->singleton('Concrete\Core\Site\Type\Service');
+        $this->app->alias('Concrete\Core\Site\Type\Service', 'site/type');
+
+        $this->app->singleton('Concrete\Core\Site\Resolver\DriverInterface', function ($app) {
+            return $app->make('Concrete\Core\Site\Resolver\StandardDriver');
         });
     }
 }

--- a/tests/tests/Site/SiteTest.php
+++ b/tests/tests/Site/SiteTest.php
@@ -20,8 +20,16 @@ class SiteTest extends PHPUnit_Framework_TestCase
 {
     public function testService()
     {
-        $service = \Core::make('site');
-        $this->assertInstanceOf('Concrete\Core\Site\Service', $service);
+        $singletons = [
+            'site' => \Concrete\Core\Site\Service::class,
+            'site/type' => \Concrete\Core\Site\Type\Service::class,
+        ];
+        foreach ($singletons as $alias => $implementation) {
+            $this->assertInstanceOf($implementation, \Core::make($alias));
+            $this->assertSame(\Core::make($alias), \Core::make($alias), 'Making the alias should always return the same instance');
+            $this->assertSame(\Core::make($implementation), \Core::make($implementation), 'Making the implementation should always return the same instance');
+            $this->assertSame(\Core::make($alias), \Core::make($implementation), 'Making the alias and the implementation should return the same instance');
+        }
     }
 
     public function testGetDefault()


### PR DESCRIPTION
The site service provider defines `'site'` and `'site/type'` as singletons.
BTW, the `Concrete\Core\Site\Service` and `Concrete\Core\Site\Type\Service` mapped classes are not singletons (which is bad when we use dependency injection).

So, what about making the classes as singletons, and `'site'`/`'site/type'` as aliases to them? That way, everything will be a singleton.