### PR TITLE
Add 'noCountryText' option to Form::selectCountry()

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -475,6 +475,7 @@ class Form
      * @param string $key The name of the element. If $key denotes an array, the ID will start with $key but will have a progressive unique number added; if $key does not denotes an array, the ID attribute will be $key.
      * @param string $selectedCountryCode the code of the Country to be initially selected
      * @param array $configuration Configuration options. Supported keys are:
+     * - 'noCountryText': the text to be displayed when no country is selected
      * - 'required': do users must choose a Country?
      * - 'allowedCountries': an array containing a list of acceptable Country codes. If not set, all the countries will be selectable.
      * - 'linkStateProvinceField': set to true to look for text fields that have a "data-countryfield" attribute with the same value as this Country field name (updating the Country select will automatically update the State/Province list).
@@ -483,6 +484,7 @@ class Form
     public function selectCountry($key, $selectedCountryCode = '', array $configuration = [], array $miscFields = [])
     {
         $configuration += [
+            'noCountryText' => '',
             'required' => false,
             'allowedCountries' => null,
             'linkStateProvinceField' => false,
@@ -523,7 +525,7 @@ class Form
             $id = $key;
         }
         if ($selectedCountryCode === '' || !$configuration['required']) {
-            $optionValues = ['' => ''];
+            $optionValues = ['' => (string) $configuration['noCountryText']];
         } else {
             $optionValues = [];
         }


### PR DESCRIPTION
When there's no currently selected country, we display a blank option.
What about allowing developers to display a custom text for this case?