### PR TITLE
Add Search All Sites functionality to the Search Block

### DIFF
--- a/concrete/blocks/search/controller.php
+++ b/concrete/blocks/search/controller.php
@@ -118,6 +118,13 @@ class Controller extends BlockController
     protected $hColor = '#EFE795';
 
     /**
+     * Whether or not to search all sites
+     *
+     * @var bool
+     */
+    protected $search_all;
+
+    /**
      * {@inheritdoc}
      */
     public function getBlockTypeName()
@@ -300,6 +307,7 @@ class Controller extends BlockController
     public function edit()
     {
         $this->set('pageSelector', $this->app->make('helper/form/page_selector'));
+        $this->set('searchAll', $this->search_all);
     }
 
     /**
@@ -323,6 +331,7 @@ class Controller extends BlockController
             'baseSearchPath' => '',
             'postTo_cID' => null,
             'resultsURL' => '',
+            'search_all' => 0,
         ];
         switch ($data['baseSearchPath']) {
             case 'THIS':
@@ -340,11 +349,14 @@ class Controller extends BlockController
                     }
                 }
                 break;
+            case 'ALL':
+                $args['search_all'] = true;
+                break;
         }
         if ($args['baseSearchPath'] === '/') {
             $args['baseSearchPath'] = '';
         }
-        
+
         switch ($data['resultsPageKind']) {
             case 'CID':
                 if ($data['postTo_cID']) {
@@ -372,6 +384,12 @@ class Controller extends BlockController
         $query = (string) $this->request->request('query');
 
         $ipl = new PageList();
+
+        //If Search All is enabled set search site tree to all.
+        if ((int) $this->search_all === 1) {
+            $ipl->setSiteTreeToAll();
+        }
+
         $aksearch = false;
         $akIDs = $this->request->request('akID');
         if (is_array($akIDs)) {

--- a/concrete/blocks/search/db.xml
+++ b/concrete/blocks/search/db.xml
@@ -11,6 +11,7 @@
     <field name="title" type="string" size="255"/>
     <field name="buttonText" type="string" size="128"/>
     <field name="baseSearchPath" type="string" size="255"/>
+    <field name="search_all" type="boolean"/>
     <field name="postTo_cID" type="integer">
       <unsigned/>
     </field>

--- a/concrete/blocks/search/form_setup_html.php
+++ b/concrete/blocks/search/form_setup_html.php
@@ -11,6 +11,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var Concrete\Core\Block\View\BlockView $view */
 /* @var Concrete\Core\Form\Service\Widget\PageSelector $pageSelector */
 
+$sites = Site::getList();
+
 if (!$controller->indexExists()) {
     ?>
     <div class="ccm-error"><?= t('The search index does not appear to exist. This block will not function until the reindex job has been run at least once in the dashboard.') ?></div>
@@ -48,9 +50,17 @@ if (!$controller->indexExists()) {
         <div class="radio">
             <label>
                 <?= $form->radio('baseSearchPath', 'EVERYWHERE', $baseSearchPath === 'EVERYWHERE') ?>
-                <?= t('Everywhere') ?>
+                <?= t('In the Current Site') ?>
             </label>
         </div>
+        <?php if (count($sites) > 1) : ?>
+            <div class="radio">
+                <label>
+                    <?= $form->radio('baseSearchPath', 'ALL', (int) $searchAll === 1) ?>
+                    <?= t('In all Sites') ?>
+                </label>
+            </div>
+        <?php endif; ?>
         <div class="radio">
             <label>
                 <?= $form->radio('baseSearchPath', 'THIS', $baseSearchPath === 'THIS') ?>

--- a/concrete/src/Updater/Migrations/Migrations/Version20190416224702.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190416224702.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20190416224702 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * @param Schema $schema
+     */
+    public function upgradeSchema(Schema $schema)
+    {
+        $this->refreshBlockType('search');
+    }
+}


### PR DESCRIPTION
The Everywhere option in the Search block is limited only to the current site and not to across all sites. 

This update adds a new Search All option that be available if the project has more than one site.