### PR TITLE
Format install errors

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -359,14 +359,14 @@ class Install extends Controller
                         case PreconditionResult::STATE_PASSED:
                             break;
                         case PreconditionResult::STATE_WARNING:
-                            $warnings->add($precondition->getName() . ': ' . $check->getMessage());
+                            $warnings->addHtml('<span class="label label-warning">' . h($precondition->getName()) . '</span><br />' . nl2br(h($check->getMessage())));
                             break;
                         case PreconditionResult::STATE_FAILED:
                         default:
                             if ($precondition->isOptional()) {
-                                $warnings->add($precondition->getName() . ': ' . $check->getMessage());
+                                $warnings->addHtml('<span class="label label-warning">' . h($precondition->getName()) . '</span><br />' . nl2br(h($check->getMessage())));
                             } else {
-                                $error->add($precondition->getName() . ': ' . $check->getMessage());
+                                $error->addHtml('<span class="label label-danger">' . h($precondition->getName()) . '</span><br />' . nl2br(h($check->getMessage())));
                             }
                             break;
                     }
@@ -490,7 +490,7 @@ class Install extends Controller
                         break;
                     case PreconditionResult::STATE_FAILED:
                     default:
-                        $e->add($precondition->getName() . ': ' . $check->getMessage());
+                        $e->addHtml('<span class="label label-danger">' . h($precondition->getName()) . '</span><br />' . nl2br(h($check->getMessage())));
                         break;
                 }
             }

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -1,4 +1,6 @@
 <?php
+
+use Concrete\Core\Error\ErrorList\Error\AbstractError;
 use Concrete\Core\Install\PreconditionResult;
 use Concrete\Core\Install\WebPreconditionInterface;
 use Concrete\Core\Localization\Localization;
@@ -361,7 +363,16 @@ switch ($installStep) {
                             <?php
                             foreach ($warnings->getList() as $warning) {
                                 ?>
-                                <div><?= nl2br(h($warning)) ?></div><?php
+                                <div>
+                                    <?php
+                                    if ($warning instanceof AbstractError && $warning->messageContainsHtml()) {
+                                        echo $warning->getMessage();
+                                    } else {
+                                        echo nl2br(h($warning));
+                                    }
+                                    ?>
+                                </div>
+                                <?php
                             }
                             ?>
                             <div class="checkbox">


### PR DESCRIPTION
Install errors/warnings contains a title and an error message.

We currently display them on the same line, which may result in a bit odd sentences:

![immagine](https://user-images.githubusercontent.com/928116/56341471-7e73bd80-61b5-11e9-9823-e2291c3274cf.png)

What about separating titles and messages?

![immagine](https://user-images.githubusercontent.com/928116/56341489-87fd2580-61b5-11e9-8455-28aad5a0d84e.png)
