### PR TITLE
Disable the autosaver completely when publishing through composer

### DIFF
--- a/concrete/views/panels/details/page/composer.php
+++ b/concrete/views/panels/details/page/composer.php
@@ -80,7 +80,7 @@ var ConcretePageComposerDetail = {
             newElements.bind('change', function() {
                 my.saver.requestSave();
             });
-    
+
             newElements.bind('keyup', function() {
                 my.saver.requestSave(true);
             });
@@ -167,8 +167,11 @@ var ConcretePageComposerDetail = {
         });
 
         ConcreteEvent.subscribe('PanelComposerPublish',function(e, data) {
-
-            my.disableAutosave();
+            // Disable the autosaver completely so that it is not posting a
+            // request after the publish event has been called. This could
+            // otherwise lead to an extra version being created for the page
+            // after the publish action has been already called.
+            my.saver.disable();
             var submitSuccess = false;
             $.concreteAjax({
                 data: data.data,

--- a/concrete/views/panels/details/page/composer.php
+++ b/concrete/views/panels/details/page/composer.php
@@ -18,9 +18,9 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 
 <section class="ccm-ui">
-    <header><?= t('Composer - %s', $pagetype->getPageTypeDisplayName()) ?></header>
+    <header><?= t('Composer - %s', $pagetype->getPageTypeDisplayName()); ?></header>
     <form method="post" data-panel-detail-form="compose">
-        <?= $ui->display('panel', '/page/composer') ?>
+        <?= $ui->display('panel', '/page/composer'); ?>
 
         <?php $composer->display($pagetype, $c); ?>
     </form>
@@ -43,7 +43,7 @@ var ConcretePageComposerDetail = {
             beforeSubmit: function() {
                 my.saving = true;
             },
-            url: <?= json_encode($controller->action('autosave')) ?>,
+            url: <?= json_encode($controller->action('autosave')); ?>,
             success: function(r) {
                 my.saving = false;
                 $('#ccm-page-type-composer-form-save-status').html(r.message).show();
@@ -104,7 +104,7 @@ var ConcretePageComposerDetail = {
                         });
                     },
                     {
-                        idleTimeout: <?= $idleTimeout ?>
+                        idleTimeout: <?= $idleTimeout; ?>
                     }
                 )
                 .data('SaveCoordinator');
@@ -113,11 +113,11 @@ var ConcretePageComposerDetail = {
         ?>
 
         $('button[data-page-type-composer-form-btn=discard]').on('click', function() {
-            if (confirm(<?= json_encode(t('This will remove this draft and it cannot be undone. Are you sure?')) ?>)) {
+            if (confirm(<?= json_encode(t('This will remove this draft and it cannot be undone. Are you sure?')); ?>)) {
                 my.disableAutosave();
                 $.concreteAjax({
-                    url: <?= json_encode($controller->action('discard')) ?>,
-                    data: {cID: <?= $cID ?>},
+                    url: <?= json_encode($controller->action('discard')); ?>,
+                    data: {cID: <?= $cID; ?>},
                     success: function(r) {
                         window.location.href = r.redirectURL;
                     }
@@ -128,7 +128,7 @@ var ConcretePageComposerDetail = {
         $('button[data-page-type-composer-form-btn=preview]').on('click', function() {
             my.disableAutosave();
             function redirect() {
-                window.location.href = CCM_DISPATCHER_FILENAME + <?= json_encode('?cID=' . $cID . '&ctask=check-out&' . $token->getParameter()) ?>;
+                window.location.href = CCM_DISPATCHER_FILENAME + <?= json_encode('?cID=' . $cID . '&ctask=check-out&' . $token->getParameter()); ?>;
             }
             if (!my.saving) {
                 my.saveDraft(redirect);
@@ -141,7 +141,7 @@ var ConcretePageComposerDetail = {
             my.disableAutosave();
             var submitSuccess = false;
             my.$form.concreteAjaxForm({
-                url: <?= json_encode($controller->action('save_and_exit')) ?>,
+                url: <?= json_encode($controller->action('save_and_exit')); ?>,
                 success: function(r) {
                     submitSuccess = true;
                     window.location.href = r.redirectURL;
@@ -175,7 +175,7 @@ var ConcretePageComposerDetail = {
             var submitSuccess = false;
             $.concreteAjax({
                 data: data.data,
-                url: <?= json_encode($controller->action('publish')) ?>,
+                url: <?= json_encode($controller->action('publish')); ?>,
                 success: function(r) {
                     submitSuccess = true;
                     window.location.href = r.redirectURL;


### PR DESCRIPTION
Previously the autosave could still launch once after the "publish" button has been clicked from the composer view.

This prevents that from happening.

This caused occasionally an extra page version to be created which is visible to the user because the "page is pending for approval" popup appears straight after the page has been published.