### PR TITLE
Check that LIBXML constants are defined

### DIFF
--- a/concrete/src/File/Image/Svg/Sanitizer.php
+++ b/concrete/src/File/Image/Svg/Sanitizer.php
@@ -4,10 +4,9 @@ namespace Concrete\Core\File\Image\Svg;
 
 use DOMDocument;
 use DOMElement;
-use Illuminate\Filesystem\Filesystem;
 use Exception;
+use Illuminate\Filesystem\Filesystem;
 use Throwable;
-
 
 class Sanitizer
 {
@@ -83,9 +82,17 @@ class Sanitizer
      */
     protected function getLoadFlags()
     {
-        $flags = LIBXML_NONET | LIBXML_NOWARNING | LIBXML_PARSEHUGE | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD;
-        if (defined('LIBXML_BIGLINES')) {
-            $flags |= LIBXML_BIGLINES;
+        $flags = LIBXML_NONET | LIBXML_NOWARNING;
+
+        foreach ([
+            'LIBXML_PARSEHUGE', //  libxml >= 2.7.0
+            'LIBXML_HTML_NOIMPLIED', // libxml >= 2.7.7
+            'LIBXML_HTML_NODEFDTD', // libxml >= 2.7.8
+            'LIBXML_BIGLINES', // libxml >= 2.9.0
+        ] as $flagName) {
+            if (defined($flagName)) {
+                $flags |= constant($flagName);
+            }
         }
 
         return $flags;


### PR DESCRIPTION
There are some LIBXML constants that may not be defined.
Accordingly to the [PHP docs](https://www.php.net/manual/en/libxml.constants.php), those constants should be defined for PHP 5.5+, but a concrete5 user reported that they are not defined (his PHP version is compiled with libxml 2.7.6 even if PHP is 7.1.28).

So, we have to check if these variables are defined.