### PR TITLE
output_vars: change "/* @var" to "/** @var"

### DIFF
--- a/concrete/src/Support/Symbol/PhpDocGenerator.php
+++ b/concrete/src/Support/Symbol/PhpDocGenerator.php
@@ -80,7 +80,7 @@ class PhpDocGenerator
      */
     public function describeVar($name, $value)
     {
-        return $this->indentation . '/* @var ' . $this->getVarType($value) . ' ' . ($name[0] === '$' ? '' : '$') . $name . " */\n";
+        return $this->indentation . '/** @var ' . $this->getVarType($value) . ' ' . ($name[0] === '$' ? '' : '$') . $name . " */\n";
     }
 
     /**


### PR DESCRIPTION
The `output_vars` function generates PHPDoc describing the defined variables.

This PR changes its output, so that it generates phpdoc comments instead of normal comments.