### PR TITLE
[WIP] Fix Sitemap compose permission not to publish the page when the user doesn't have proper permission

### DIFF
--- a/concrete/controllers/dialog/page/add/compose.php
+++ b/concrete/controllers/dialog/page/add/compose.php
@@ -33,17 +33,20 @@ class Compose extends Controller
         }
 
         $canApprove = false;
-        if ($parent->overrideTemplatePermissions()){
-            $parentPermission= new Permissions($parent);
-            if ($parentPermission->canApprovePageVersions()) {
-                $canApprove = true;
+        if (!$e->has()) {
+            if ($parent->overrideTemplatePermissions()) {
+                $parent = Page::getByID($cParentID);
+                $parentPermission = new Permissions($parent);
+                if ($parentPermission->canApprovePageVersions()) {
+                    $canApprove = true;
+                }
+            } else {
+                if ($ptp->canApprovePageVersions()) {
+                    $canApprove = true;
+                }
             }
-        } else {
-            if ($ptp->canApprovePageVersions()) {
-                $canApprove = true;
-            }
+            $this->set('canApprove', $canApprove);
         }
-        $this->set('canApprove', $canApprove);
 
         if (!$e->has()) {
             $this->view = new DialogView('/dialogs/page/add/compose');

--- a/concrete/controllers/dialog/page/add/compose.php
+++ b/concrete/controllers/dialog/page/add/compose.php
@@ -32,6 +32,19 @@ class Compose extends Controller
             $e->add(t('Invalid parent page.'));
         }
 
+        $canApprove = false;
+        if ($parent->overrideTemplatePermissions()){
+            $parentPermission= new Permissions($parent);
+            if ($parentPermission->canApprovePageVersions()) {
+                $canApprove = true;
+            }
+        } else {
+            if ($ptp->canApprovePageVersions()) {
+                $canApprove = true;
+            }
+        }
+        $this->set('canApprove', $canApprove);
+
         if (!$e->has()) {
             $this->view = new DialogView('/dialogs/page/add/compose');
             $this->set('parent', $parent);

--- a/concrete/views/dialogs/page/add/compose.php
+++ b/concrete/views/dialogs/page/add/compose.php
@@ -10,11 +10,13 @@ $composer = Core::make("helper/concrete/composer");
         <div class="dialog-buttons">
             <button type="button" data-dialog-action="cancel" class="btn btn-default pull-left"><?=t('Cancel')?></button>
             <div class="btn-group pull-right">
-                <button type="button" data-dialog-action="submit" value="preview" data-page-type-composer-form-btn="preview" class="btn btn-success"><?=t('Edit Mode')?></button>
-                <button style="margin-right: 0;" type="button" data-composer-dialog-action="publish" value="publish" class="btn btn-primary"><?=t('Publish Page')?></button>
-                <button style="padding-right: 5px; padding-left: 5px; width: 35px;" data-page-type-composer-form-btn="schedule" type="button" class="btn btn-primary">
-                    <i class="fa fa-clock-o"></i>
-                </button>
+                <button type="button" style="margin-right: 5px;" data-dialog-action="submit" value="preview" data-page-type-composer-form-btn="preview" class="btn btn-success"><?=t('Edit Mode')?></button>
+                <?php if ($canApprove) {?>
+                    <button style="margin-right: 0;" type="button" data-composer-dialog-action="publish" value="publish" class="btn btn-primary"><?=t('Publish Page')?></button>
+                    <button style="padding-right: 5px; padding-left: 5px; width: 35px;" data-page-type-composer-form-btn="schedule" type="button" class="btn btn-primary">
+                        <i class="fa fa-clock-o"></i>
+                    </button>
+                <?php } ?>
             </div>
         </div>
     </form>


### PR DESCRIPTION
This is work-in-progress PR.
(I want to check-in if I'm on the right direction.)

# Main Problem

The user, who don't have `Approve Changes` permission, can actually publish the page from sitemap if the user has `Add Sub-Page`. The user without `Approve Changes` permission should not be able to publish the page at all.

## Direct Problem

When rendering a pop-up composer window, it only checks `Add Sub-Page` permission to display "Publish" button

![Composer_From_Sitemap](https://user-images.githubusercontent.com/485751/56489683-78ffd580-651d-11e9-832d-a915df9aac09.png)

## How to reproduce steps

- Install a fresh copy of concrete5 (8.5.1)
- Log-in as super admin.
- Create an additional group (e.g., `editors`)
- Create an additional user, which belongs to `editors` group
- Enable advanced permission
- Give `editors` group all permissions as "Administrators" permission EXCEPT "Approve Changes" but they can `Add Sub-Page`.
- Log-in as editor user.
- Try to add a page from Full Site Map.
- Select any page type that editor has a permission
- The pop up window DOES have publish button, even if we don't want to.

## What is debating

My code is WIP.
I'm posting here to get more opinion & finishing up the PR.

Thanks