### PR TITLE
Add native lazy loading and JavaScript lazy loading support to the "html/image" service

### DIFF
--- a/concrete/src/Html/Object/ImageNoScriptFallback.php
+++ b/concrete/src/Html/Object/ImageNoScriptFallback.php
@@ -1,0 +1,140 @@
+<?php
+namespace Concrete\Core\Html\Object;
+
+use HtmlObject\Element;
+use HtmlObject\Image;
+
+class ImageNoScriptFallback extends Element
+{
+    /**
+     * Whether the element is self closing.
+     *
+     * @var bool
+     */
+    protected $isSelfClosing = false;
+
+    ////////////////////////////////////////////////////////////////////
+    //////////////////////////// CORE METHODS //////////////////////////
+    ////////////////////////////////////////////////////////////////////
+
+    public function __construct($src, $attributes = array(), $lazyLoadNative)
+    {
+        $this->noScriptImageFallback($src, $lazyLoadNative);
+        $this->img($src, $lazyLoadNative);
+    }
+
+    /**
+     * Static alias for constructor.
+     *
+     * @param string|null $src
+     * @param array $attributes
+     * @param bool|null $lazyLoadNative
+     *
+     * @return \Concrete\Core\Html\Object\ImageNoScriptFallback
+     */
+    public static function create($src = false, $attributes = array(), $lazyLoadNative = false)
+    {
+        return new static($src, $attributes, $lazyLoadNative);
+    }
+
+    /**
+     * Create an img element wrapped in "<noscript></noscript>". The image will be displayed if JavaScript is disabled.
+     *
+     * Example output:
+     * <noscript>
+     *     <img src="...">
+     * </noscript>
+     * or
+     * <noscript>
+     *     <img src="..." loading="lazy">
+     * </noscript>
+     *
+     * @param string $src The file path of an image.
+     * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
+     *
+     * @return \Concrete\Core\Html\Object\ImageNoScriptFallback
+     */
+    public function noScriptImageFallback($src, $lazyLoadNative)
+    {
+        $this->nest('<noscript>');
+
+        $img = Image::create();
+        $img->src($src);
+
+        if ($lazyLoadNative) {
+            $img->loading('lazy');
+        }
+
+        $this->setChild($img);
+
+        $this->nest('</noscript>');
+
+        return $this;
+    }
+
+    /**
+     * Create an image element with the image path set to a "data-src" attribute.
+     *
+     * Example output:
+     * <img data-src="...">
+     * or
+     * <img data-src="..." loading="lazy">
+     *
+     * @param string $src The file path of an image.
+     * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
+     */
+    public function img($src, $lazyLoadNative)
+    {
+        $img = Image::create();
+        $img->src(false);
+        $img->dataSrc($src);
+
+        if ($lazyLoadNative) {
+            $img->loading('lazy');
+        }
+
+        $this->setChild($img);
+    }
+
+    /**
+     * Set the image and noscript image fallback "alt" attribute value.
+     *
+     * @param string $alt
+     */
+    public function alt($alt)
+    {
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
+                $child->alt($alt);
+            }
+        }
+    }
+
+    /**
+     * Set the image and noscript image fallback "title" attribute value.
+     *
+     * @param string $title
+     */
+    public function title($title)
+    {
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
+                $child->title($title);
+            }
+        }
+    }
+
+    /**
+     * Add one or more CSS classes to the image and noscript image fallback.
+     *
+     * @param string $classes A string of space separated CSS classes.
+     */
+    public function addClass($classes)
+    {
+        foreach ($this->getChildren() as $child) {
+            if ($child instanceof Image) {
+                $child->addClass($classes);
+            }
+        }
+    }
+}

--- a/concrete/src/Html/Object/JavaScriptLazyImage.php
+++ b/concrete/src/Html/Object/JavaScriptLazyImage.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Html\Object;
 use HtmlObject\Element;
 use HtmlObject\Image;
 
-class ImageNoScriptFallback extends Element
+class JavaScriptLazyImage extends Element
 {
     /**
      * Whether the element is self closing.
@@ -19,7 +19,7 @@ class ImageNoScriptFallback extends Element
 
     public function __construct($src, $attributes = array(), $lazyLoadNative)
     {
-        $this->noScriptImageFallback($src, $lazyLoadNative);
+        $this->noscriptFallback($src, $lazyLoadNative);
         $this->img($src, $lazyLoadNative);
     }
 
@@ -30,7 +30,7 @@ class ImageNoScriptFallback extends Element
      * @param array $attributes
      * @param bool|null $lazyLoadNative
      *
-     * @return \Concrete\Core\Html\Object\ImageNoScriptFallback
+     * @return \Concrete\Core\Html\Object\JavaScriptLazyImage
      */
     public static function create($src = false, $attributes = array(), $lazyLoadNative = false)
     {
@@ -52,9 +52,9 @@ class ImageNoScriptFallback extends Element
      * @param string $src The file path of an image.
      * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
      *
-     * @return \Concrete\Core\Html\Object\ImageNoScriptFallback
+     * @return \Concrete\Core\Html\Object\JavaScriptLazyImage
      */
-    public function noScriptImageFallback($src, $lazyLoadNative)
+    public function noscriptFallback($src, $lazyLoadNative = false)
     {
         $this->nest('<noscript>');
 
@@ -83,7 +83,7 @@ class ImageNoScriptFallback extends Element
      * @param string $src The file path of an image.
      * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
      */
-    public function img($src, $lazyLoadNative)
+    public function img($src, $lazyLoadNative = false)
     {
         $img = Image::create();
         $img->src(false);

--- a/concrete/src/Html/Object/JavaScriptLazyImage.php
+++ b/concrete/src/Html/Object/JavaScriptLazyImage.php
@@ -17,7 +17,7 @@ class JavaScriptLazyImage extends Element
     //////////////////////////// CORE METHODS //////////////////////////
     ////////////////////////////////////////////////////////////////////
 
-    public function __construct($src, $attributes = array(), $lazyLoadNative)
+    public function __construct($src, $attributes = array(), $lazyLoadNative = false)
     {
         $this->noscriptFallback($src, $lazyLoadNative);
         $this->img($src, $lazyLoadNative);

--- a/concrete/src/Html/Object/Picture.php
+++ b/concrete/src/Html/Object/Picture.php
@@ -31,7 +31,7 @@ class Picture extends Element
     //////////////////////////// CORE METHODS //////////////////////////
     ////////////////////////////////////////////////////////////////////
 
-    public function __construct(array $sources = array(), $fallbackSrc, $attributes = array(), $lazyLoadNative, $lazyLoadJavaScript)
+    public function __construct(array $sources = array(), $fallbackSrc, $attributes = array(), $lazyLoadNative = false, $lazyLoadJavaScript = false)
     {
         $this->sources($sources, $lazyLoadJavaScript);
 

--- a/concrete/src/Html/Object/Picture.php
+++ b/concrete/src/Html/Object/Picture.php
@@ -31,31 +31,59 @@ class Picture extends Element
     //////////////////////////// CORE METHODS //////////////////////////
     ////////////////////////////////////////////////////////////////////
 
-    public function __construct(array $sources = array(), $fallbackSrc, $attributes = array())
+    public function __construct(array $sources = array(), $fallbackSrc, $attributes = array(), $lazyLoadNative, $lazyLoadJavaScript)
     {
-        $this->sources($sources);
-        $this->fallback($fallbackSrc);
+        $this->sources($sources, $lazyLoadJavaScript);
+
+        if ($lazyLoadJavaScript) {
+            $this->noScriptFallback($fallbackSrc, $lazyLoadNative);
+        }
+
+        $this->fallback($fallbackSrc, $lazyLoadNative, $lazyLoadJavaScript);
     }
 
     /**
      * Static alias for constructor.
      *
-     * @param string $element
-     * @param string|null|Tag $value
+     * @param array $sources
+     * @param string|null $fallbackSrc
      * @param array $attributes
+     * @param bool|null $lazyLoadNative
+     * @param bool|null $lazyLoadJavaScript
      *
-     * @return                Table
+     * @return \Concrete\Core\Html\Object\Picture
      */
-    public static function create($sources = array(), $fallbackSrc = false, $attributes = array())
+    public static function create($sources = array(), $fallbackSrc = false, $attributes = array(), $lazyLoadNative = false, $lazyLoadJavaScript = false)
     {
-        return new static($sources, $fallbackSrc, $attributes);
+        return new static($sources, $fallbackSrc, $attributes, $lazyLoadNative, $lazyLoadJavaScript);
     }
 
     ////////////////////////////////////////////////////////////////////
     /////////////////////////////// CHILDREN ///////////////////////////
     ////////////////////////////////////////////////////////////////////
 
-    public function sources($sources)
+    /**
+     * Create the source elements for the picture element.
+     *
+     * Example output:
+     * <!--[if IE 9]><video style='display: none;'><![endif]-->
+     * <source srcset="..." media="(min-width: ...)">
+     * <source srcset="..." media="(min-width: ...)">
+     * <source srcset="...">
+     * <!--[if IE 9]></video><![endif]-->
+     * or
+     * <!--[if IE 9]><video style='display: none;'><![endif]-->
+     * <source data-srcset="..." media="(min-width: ...)">
+     * <source data-srcset="..." media="(min-width: ...)">
+     * <source data-srcset="...">
+     * <!--[if IE 9]></video><![endif]-->
+     *
+     * @param array $sources An array of image thumbnail file paths.
+     * @param bool $lazyLoadJavaScript If true, the source image thumbnail file path is set to a "data-srcset" attribute instead of "srcset".
+     *
+     * @return \Concrete\Core\Html\Object\Picture
+     */
+    public function sources($sources, $lazyLoadJavaScript)
     {
         $this->nest("<!--[if IE 9]><video style='display: none;'><![endif]-->");
 
@@ -63,7 +91,13 @@ class Picture extends Element
             $path = $source['src'];
             $width = $source['width'];
             $source = Source::create();
-            $source->srcset($path);
+
+            if ($lazyLoadJavaScript) {
+                $source->dataSrcset($path);
+            } else {
+                $source->srcset($path);
+            }
+
             if ($width != 0) {
                 $source->media("(min-width: $width)");
             }
@@ -75,13 +109,79 @@ class Picture extends Element
         return $this;
     }
 
-    public function fallback($src)
+    /**
+     * Create an img element wrapped in "<noscript></noscript>". The image will be displayed if JavaScript is disabled.
+     *
+     * Example output:
+     * <noscript>
+     *     <img src="...">
+     * </noscript>
+     * or
+     * <noscript>
+     *     <img src="..." loading="lazy">
+     * </noscript>
+     *
+     * @param string $src The file path of an image.
+     * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
+     *
+     * @return \Concrete\Core\Html\Object\Picture
+     */
+    public function noScriptFallback($src, $lazyLoadNative)
+    {
+        $this->nest('<noscript>');
+
+        $img = Image::create();
+        $img->src($src);
+
+        if ($lazyLoadNative) {
+            $img->loading('lazy');
+        }
+
+        $this->setChild($img);
+
+        $this->nest('</noscript>');
+
+        return $this;
+    }
+
+    /**
+     * Create the img element fallback for the picture element.
+     *
+     * Example output:
+     * <img src="...">
+     * or
+     * <img src="..." loading="lazy">
+     * or
+     * <img data-src="..." loading="lazy">
+     * or
+     * <img data-src="...">
+     *
+     * @param string $src The file path of an image.
+     * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
+     * @param bool $lazyLoadJavaScript If true, the image path is set to a "data-src" attribute.
+     */
+    public function fallback($src, $lazyLoadNative, $lazyLoadJavaScript)
     {
         $img = Image::create();
         $img->src($src);
+
+        if ($lazyLoadNative) {
+            $img->loading('lazy');
+        }
+
+        if ($lazyLoadJavaScript) {
+            $img->src(false);
+            $img->dataSrc($src);
+        }
+
         $this->setChild($img);
     }
 
+    /**
+     * Set the image fallback and noscript image fallback "alt" attribute value.
+     *
+     * @param string $alt
+     */
     public function alt($alt)
     {
         foreach ($this->getChildren() as $child) {
@@ -91,6 +191,11 @@ class Picture extends Element
         }
     }
 
+    /**
+     * Set the image fallback and noscript image fallback "title" attribute value.
+     *
+     * @param string $title
+     */
     public function title($title)
     {
         foreach ($this->getChildren() as $child) {
@@ -100,6 +205,11 @@ class Picture extends Element
         }
     }
 
+    /**
+     * Add one or more CSS classes to the image and noscript image fallback.
+     *
+     * @param string $classes A string of space separated CSS classes.
+     */
     public function addClass($classes)
     {
         foreach ($this->getChildren() as $child) {

--- a/concrete/src/Html/Object/Picture.php
+++ b/concrete/src/Html/Object/Picture.php
@@ -36,7 +36,7 @@ class Picture extends Element
         $this->sources($sources, $lazyLoadJavaScript);
 
         if ($lazyLoadJavaScript) {
-            $this->noScriptFallback($fallbackSrc, $lazyLoadNative);
+            $this->noscriptFallback($fallbackSrc, $lazyLoadNative);
         }
 
         $this->fallback($fallbackSrc, $lazyLoadNative, $lazyLoadJavaScript);
@@ -83,7 +83,7 @@ class Picture extends Element
      *
      * @return \Concrete\Core\Html\Object\Picture
      */
-    public function sources($sources, $lazyLoadJavaScript)
+    public function sources($sources, $lazyLoadJavaScript = false)
     {
         $this->nest("<!--[if IE 9]><video style='display: none;'><![endif]-->");
 
@@ -126,7 +126,7 @@ class Picture extends Element
      *
      * @return \Concrete\Core\Html\Object\Picture
      */
-    public function noScriptFallback($src, $lazyLoadNative)
+    public function noscriptFallback($src, $lazyLoadNative = false)
     {
         $this->nest('<noscript>');
 
@@ -160,7 +160,7 @@ class Picture extends Element
      * @param bool $lazyLoadNative If true, the image "loading" attribute is set to "lazy".
      * @param bool $lazyLoadJavaScript If true, the image path is set to a "data-src" attribute.
      */
-    public function fallback($src, $lazyLoadNative, $lazyLoadJavaScript)
+    public function fallback($src, $lazyLoadNative = false, $lazyLoadJavaScript = false)
     {
         $img = Image::create();
         $img->src($src);


### PR DESCRIPTION
Native image lazy loading is due to be available in Chrome 75 (around the first week of June 2019 for Chrome and in the near future for other Chromium based browsers). This draft pull request updates the "html/image" service to add native lazy loading and JavaScript lazy loading support. This is a draft pull request because native lazy loading is only available in Chrome stable behind flags and lazy loading feature detection does not work. I tested this pull request using the latest Chrome stable and Chrome Canary with flags enabled and disabled.

**For more information on native lazy loading and lazy loading:**
https://addyosmani.com/blog/lazy-loading
https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video
https://css-tricks.com/a-deep-dive-into-native-lazy-loading-for-images-and-frames/
https://web.dev/native-lazy-loading

Some users may prefer native lazy loading, JavaScript lazy loading, or the option to use one or the other based on browser support. Native lazy loading requires that an `img` element has a `loading` attribute set to `lazy` and a height and width set (either using CSS, height and width attributes, or an inline style) to prevent page reflow. The most common JavaScript lazy loading pattern requires custom CSS and HTML markup (`src` and `srcset` attribute image path values saved in the data attributes `data-src` and `data-srcset`).

Currently native lazy loading does not expose any controls or options for how images are lazy loaded, with loading decided purely by the browser (and is expected to remain that way in Chrome). In contrast, JavaScript lazy loading generally offers various controls and options such as defining viewport offsets for when to load, callbacks, and loading state classes.

**Popular JavaScript lazy loading libraries using the `data-src`/`data-srcset` pattern:**
https://github.com/aFarkas/lazysizes
https://github.com/verlok/lazyload

## Using Native Lazy Loading with JavaScript Fallback
To use native lazy loading with a JavaScript fallback, you feature detect for native lazy loading in the page head - checking for the existence of `loading` in the `HTMLImageElement.prototype`. If native lazy loading is supported, the `data-src` and/or `data-srcset` values of images and picture elements are set to `src` and/or `srcset`. For browsers that don't support native lazy loading, a JavaScript lazy loading library is loaded at the end of the head. The goal of adding the script to the end of the head is that it doesn't block page rendering while it downloads and executes.

**Example: native lazy loading feature detection with JavaScript fallback**
```
<script>
    document.addEventListener('DOMContentLoaded', function () {
        if ('loading' in HTMLImageElement.prototype) {
            var containers = document.querySelectorAll('.lazy-image-container');
            containers.forEach(function (container) {
                container.classList.add('native-lazy-load');
            });
            var images = document.querySelectorAll('img.lazyload');
            images.forEach(function (img) {
                img.src = img.getAttribute('data-src');
                var parent = img.parentElement;
                var sources = parent.querySelectorAll('source');
                sources.forEach(function (source) {
                    source.srcset = source.getAttribute('data-srcset');
                });
            });
        } else {
            var head = document.getElementsByTagName('head')[0];
            var script = document.createElement('script');
            script.src = "<?php echo $view->getThemePath(); ?>/js/lazysizes.min.js";
            head.appendChild(script);
        }
    });
</script>
```

## JavaScript Lazy Loading Only
If you want to use JavaScript lazy loading only, just add the lazy loading library file before the closing body element.

**Example:**
```
<script src="<?php echo $view->getThemePath()?>/js/lazysizes.min.js"></script>
```

## JavaScript Lazy Loading with JavaScript Disabled (noscript fallback)
When JavaScript is disabled JavaScript lazy loaded images will not load. To ensure images are available even if JavaScript is disabled, the HTML created for each image includes a "noscript fallback". The "noscript fallback" is an `img` wrapped in a `<noscript></noscript>` element that will only download and display when JavaScript is disabled. The blogging site [medium.com](https://medium.com) offers a good example of using JavaScript image lazy loading with noscript fallbacks.

## JavaScript Lazy Loading CSS
JavaScript lazy load images have no height or width until they are loaded. As the page is scrolled and the lazy load images are loaded, the page will reflow and jump. To prevent this you need to set an explicit image height and width (not responsive) or use a responsive aspect ratio box placeholder. When using a responsive aspect ratio box, the image will fill its containing parent.

**For more information on responsive aspect ratio boxes:**
https://css-tricks.com/aspect-ratio-boxes/

**Placeholder**
Until an image lazy loads (or if it fails to load) a background placeholder can be displayed. The background placeholder could be a solid color, radial gradient, loading GIF, PNG8 image, low quality image placeholder (LQIP), etc.

**Loading Transition**
To make the image loading appear smoother, an opacity transition can be used between the unloaded and loaded states. JavaScript lazy loading libraries will often apply a class to an image once it has been loaded - e.g. "loaded" or "lazyloaded". That class can be used to transition the image opacity between 0 and 1.

**noscript CSS**
When JavaScript is disabled the image is made visible. This CSS would be added to the page in a `noscript` element. The CSS could be added inline or using a `link` element.

## Example CSS and HTML for JavaScript Lazy Loading Using the lazysizes Library

This example includes a loading transition, placeholder, and styles to cancel out if native lazy loading is supported (using the `native-lazy-load` class applied in the feature detection script). The placeholder is the background set in the `lazy-image-container` class. The lazysizes library applies a `lazyloaded` class to images that have been loaded and is used for the loading transition.   

### CSS

```
.lazy-image-container.native-lazy-load img {
    opacity: 1;
    transition: none;
}

.lazy-image-container {
    background: #eee; /* background placeholder */
    display: block;
    height: 0;
    overflow: hidden;
    position: relative;
    width: 100%;
}

.lazy-image-container img {
    display: block;
    height: 100%;
    left: 0;
    opacity: 0;
    position: absolute;
    top: 0;
    transition: opacity 200ms ease;
    width: 100%;
}

img.lazyload:not([src]) {
    visibility: hidden;
}

.lazy-image-container img.lazyloaded {
    opacity: 1;
}
```

**noscript inline style CSS**
```
<noscript>
    <style>
        .lazy-image-container img {
            opacity: 1;
        }
    </style>
</noscript>
```

**noscript external file CSS**
```
<noscript>
    <link rel="stylesheet" href="<?php echo $view->getThemePath()?>/css/noscript.css">
</noscript>
```

### HTML

**Responsive Aspect Ratio Box**
To create the aspect ratio box, the image height is divided by the image width and then multiplied by 100. This creates an aspect ratio box that matches the height and width ratio of the original image. Calculating the aspect ratio is done using PHP and the height and width file object attributes, then applied to the containing element as an inline style.

**Example PHP**
```
$app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
$picture = $app->make('html/image', [$f, ['lazyLoadJavaScript' => true]]);
$tag = $picture->getTag();
$tag->addClass('lazyload');

echo sprintf('<div class="lazy-image-container" style="padding-bottom: %d%%;">', $f->getAttribute('height') / $f->getAttribute('width') * 100);
echo $tag;
echo '</div>'
```

**Example HTML Output**
```
<div class="lazy-image-container" style="padding-bottom: 66%;">
    <picture>
        <!--[if IE 9]><video style='display: none;'><![endif]-->
        <source data-srcset="/application/files/thumbnails/large/1234/1234/5678/plants.jpg" media="(min-width: 900px)">
        <source data-srcset="/application/files/thumbnails/medium/1234/1234/5678/plants.jpg" media="(min-width: 768px)">
        <source data-srcset="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
        <!--[if IE 9]></video><![endif]-->
        <noscript>
            <img src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" alt="#" class="lazyload">
        </noscript>
        <img alt="#" data-src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" class="lazyload">
    </picture>
</div>
```

## Example "html/image" Service Output

### picture

**PHP**
```
$picture = $app->make('html/image', [$f]);
echo $picture->getTag();
```

**HTML Output**
```
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="/application/files/thumbnails/large/1234/1234/5678/plants.jpg" media="(min-width: 900px)">
    <source srcset="/application/files/thumbnails/medium/1234/1234/5678/plants.jpg" media="(min-width: 768px)">
    <source srcset="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
    <!--[if IE 9]></video><![endif]-->
    <img src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" alt="#">
</picture>
```

### img

**PHP**
```
$image = $app->make('html/image', [$f, false]); // deprecated
$image = $app->make('html/image', [$f, ['usePictureTag' => false]]);
echo $image->getTag();
```

**HTML Output**
```
<img src="/application/files/1234/1234/5678/plants.jpg" alt="plants.jpg" width="1600" height="1066">
```

### img + native lazy loading (loading="lazy")

**PHP**
```
$image = $app->make('html/image', [$f, ['usePictureTag' => false, 'lazyLoadNative' => true]]);
echo $image->getTag();
```

**HTML Output**
```
<img src="/application/files/1234/1234/5678/plants.jpg" alt="plants.jpg" width="1600" height="1066" loading="lazy">
```

### img + noscript img fallback + JavaScript lazy loading (data-src="...")

**PHP**
```
$image = $app->make('html/image', [$f, ['usePictureTag' => false, 'lazyLoadJavaScript' => true]]);
echo $image->getTag();
```

**HTML Output**
```
<noscript>
    <img src="/application/files/1234/1234/5678/plants.jpg" alt="#">
</noscript>
<img alt="#" data-src="/application/files/1234/1234/5678/plants.jpg">
```

### img + native lazy loading (loading="lazy") + noscript img fallback (loading="lazy") + JavaScript lazy loading (data-src="...")

**PHP**
```
$image = $app->make('html/image', [$f, ['usePictureTag' => false, 'lazyLoadNative' => true, 'lazyLoadJavaScript' => true]]);
echo $image->getTag();
```

**HTML Output**
```
<noscript>
    <img src="/application/files/1234/1234/5678/plants.jpg" alt="#" loading="lazy">
</noscript>
<img alt="#" data-src="/application/files/1234/1234/5678/plants.jpg" loading="lazy">
```

### picture + native lazy loading (loading="lazy")

**PHP**
```
$picture = $app->make('html/image', [$f, ['lazyLoadNative' => true]]);
echo $picture->getTag();
```

**HTML Output**
```
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source srcset="/application/files/thumbnails/large/1234/1234/5678/plants.jpg" media="(min-width: 900px)">
    <source srcset="/application/files/thumbnails/medium/1234/1234/5678/plants.jpg" media="(min-width: 768px)">
    <source srcset="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
    <!--[if IE 9]></video><![endif]-->
    <img src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" alt="#" loading="lazy">
</picture>
```

### picture + native lazy loading (loading="lazy") + noscript img fallback (loading="lazy") + JavaScript lazy loading (data-src="..." and data-srcset="...")

**PHP**
```
$picture = $app->make('html/image', [$f, ['lazyLoadNative' => true, 'lazyLoadJavaScript' => true]]);
echo $picture->getTag();
```

**HTML Output**
```
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source data-srcset="/application/files/thumbnails/large/1234/1234/5678/plants.jpg" media="(min-width: 900px)">
    <source data-srcset="/application/files/thumbnails/medium/1234/1234/5678/plants.jpg" media="(min-width: 768px)">
    <source data-srcset="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
    <!--[if IE 9]></video><![endif]-->
    <noscript>
        <img src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" alt="#" loading="lazy">
    </noscript>
    <img alt="#" loading="lazy" data-src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
</picture>
```

### picture + noscript img fallback + JavaScript lazy loading (data-src="..." and data-srcset="...")

**PHP**
```
$picture = $app->make('html/image', [$f, ['lazyLoadJavaScript' => true]]);
echo $picture->getTag();
```

**HTML Output**
```
<picture>
    <!--[if IE 9]><video style='display: none;'><![endif]-->
    <source data-srcset="/application/files/thumbnails/large/1234/1234/5678/plants.jpg" media="(min-width: 900px)">
    <source data-srcset="/application/files/thumbnails/medium/1234/1234/5678/plants.jpg" media="(min-width: 768px)">
    <source data-srcset="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
    <!--[if IE 9]></video><![endif]-->
    <noscript>
        <img src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg" alt="#">
    </noscript>
    <img alt="#" data-src="/application/files/thumbnails/small/1234/1234/5678/plants.jpg">
</picture>
```