### PR TITLE
Add rel="noopener noreferrer" to external link in image block

### DIFF
--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -36,7 +36,7 @@ if (is_object($f) && $f->getFileID()) {
     }
 
     if ($linkURL) {
-        echo '<a href="' . $linkURL . '" '. ($openLinkInNewWindow ? 'target="_blank"' : '') .'>';
+        echo '<a href="' . $linkURL . '" '. ($openLinkInNewWindow ? 'target="_blank" rel="noopener noreferrer"' : '') .'>';
     }
 
     // add data attributes for hover effect


### PR DESCRIPTION
- rel="noopener" prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.

- rel="noreferrer" attribute has the same effect, but also prevents the Referer header from being sent to the new page.

As the following link describes 
https://developers.google.com/web/tools/lighthouse/audits/noopener