### PR TITLE
Add rel="noopener noreferrer" to external link in social_links block

### DIFF
--- a/concrete/blocks/social_links/view.php
+++ b/concrete/blocks/social_links/view.php
@@ -7,7 +7,7 @@
     if ($service) {
         ?>
             <li>
-                <a target="_blank" href="<?php echo h($link->getURL()); ?>"
+                <a target="_blank" rel="noopener noreferrer" href="<?php echo h($link->getURL()); ?>"
                     aria-label="<?php echo $service->getDisplayName(); ?>"><?php echo $service->getServiceIconHTML(); ?></a>
             </li>
         <?php


### PR DESCRIPTION
- rel="noopener" prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.

- rel="noreferrer" attribute has the same effect, but also prevents the Referer header from being sent to the new page.

As the following link describes
https://developers.google.com/web/tools/lighthouse/audits/noopener