### PR TITLE
Add rel="noopener noreferrer" to external link in share_this_page block

### DIFF
--- a/concrete/blocks/share_this_page/view.php
+++ b/concrete/blocks/share_this_page/view.php
@@ -4,7 +4,7 @@
     <ul class="list-inline">
     <?php foreach ($selected as $service) { ?>
         <li>
-            <a href="<?php echo h($service->getServiceLink()) ?>" target="_blank" aria-label="<?php echo h($service->getDisplayName()) ?>"><?php echo $service->getServiceIconHTML()?></a>
+            <a href="<?php echo h($service->getServiceLink()) ?>" target="_blank" rel="noopener noreferrer" aria-label="<?php echo h($service->getDisplayName()) ?>"><?php echo $service->getServiceIconHTML()?></a>
         </li>
     <?php } ?>
     </ul>


### PR DESCRIPTION
- rel="noopener" prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.

- rel="noreferrer" attribute has the same effect, but also prevents the Referer header from being sent to the new page.

As the following link describes
https://developers.google.com/web/tools/lighthouse/audits/noopener