### PR TITLE
Let SessionValidator::getActiveSession() start the session

### DIFF
--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -172,11 +172,13 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
     /**
      * Get the current session (if it exists).
      *
-     * @return \Symfony\Component\HttpFoundation\Session\Session|null
+     * @param bool $start set to true to initialize the current session if it's not already started
+     *
+     * @return \Symfony\Component\HttpFoundation\Session\Session|null Returns NULL if $start is falsy and the session is not already started
      */
-    public function getActiveSession()
+    public function getActiveSession($start = false)
     {
-        if ($this->hasActiveSession()) {
+        if ($start || $this->hasActiveSession()) {
             return $this->app->make('session');
         }
 


### PR DESCRIPTION
Since #7679, we can use the `getActiveSession` method of `SessionValidator` to get the session if it's already started.

This is very handy when we have to read a value from the session, without starting the session if it's not already started. Here's a sample code:

```php
function getValueFromSession()
{
    $session = $this->sessionValidator->getActiveSession();
    return $session === null ? null : $session->get('key');
}
```

When writing the session, we always need the session instance, and start it. This implies that service classes currently need the `Application` dependency, because we have to write some code like this:

```php
function getValueFromSession()
{
    $session = $this->sessionValidator->getActiveSession();
    return $session === null ? null : $session->get('key');
}
function setValueToSession()
{
    $session = $this->app->make('session');
    $session->set('key', 'value');
}
```

With the change in this pull request, we can write the second method like this:

```php
function setValueToSession()
{
    $session = $this->sessionValidator->getActiveSession(true);
    $session->set('key', 'value');
}
```

So we can avoid having the `Application` dependency.