### PR TITLE
Bugfix: Null pointer exception calendar dashboard

### DIFF
--- a/concrete/src/Page/Controller/DashboardCalendarPageController.php
+++ b/concrete/src/Page/Controller/DashboardCalendarPageController.php
@@ -19,7 +19,7 @@ class DashboardCalendarPageController extends DashboardSitePageController
         if (count($calendars) == 0) {
             $this->redirect('/dashboard/calendar/add');
         }
-        $defaultCalendar = $calendars[0];
+        $defaultCalendar = reset($calendars);
         if ($caID) {
             $calendar = Calendar::getByID(intval($caID));
             $cp = new \Permissions($calendar);


### PR DESCRIPTION
array_filter doesn't change keys so $calendars[0] can be null.
For example if a user doesn't have permissions on the first calendar, $calendar[0] is null and a null pointer exception is thrown.