### PR TITLE
Replace deprecated function action() with getActionURL() in Document Library Block

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -868,8 +868,8 @@ class Controller extends BlockController
                 );
             case 'title':
                 $view = new BlockView($this->getBlockObject());
-                /** @var UrlImmutable $action */
-                $action = $view->action('navigate');
+                /** @var UrlImmutable $action */ 
+                $action = $this->getActionURL('navigate');
                 $actionPath = $action->getPath();
                 $actionPath->append($folder->getTreeNodeID());
                 $action = $action->setPath($actionPath);
@@ -901,7 +901,7 @@ class Controller extends BlockController
             if ($crumb->getTreeNodeID() == $this->getRootFolder()->getTreeNodeID()) {
                 $action = $this->getBlockObject()->getBlockCollectionObject()->getCollectionLink();
             } else {
-                $action = $view->action('navigate');
+                $action = $this->getActionURL('navigate');
                 $actionPath = $action->getPath();
                 $actionPath->append($crumb->getTreeNodeID());
                 $action = $action->setPath($actionPath);


### PR DESCRIPTION
This commit fixes also the false navigate URL that comes when you click on a folder
(e.g /ccm/system/block/action/edit/1846/Main/490/navigate/1401)
