### PR TITLE
Add MySQL version and SQL_MODE to environment information

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/info.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/info.php
@@ -12,6 +12,10 @@ class Info extends DashboardPageController
 
         echo "# concrete5 Version\n".$info->getCoreVersions()."\n\n";
 
+        if ($info->isInstalled()) {
+            echo "# Database Information\nVersion: {$info->getDBMSVersion()}\nSQL Mode: {$info->getDBMSSqlMode()}\n\n";
+        }
+
         echo "# concrete5 Packages\n".($info->getPackages() ?: 'None')."\n\n";
 
         echo "# concrete5 Overrides\n".($info->getOverrides() ?: 'None')."\n\n";

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -36,6 +36,13 @@ EOT
         $output->writeln('Installed - ' . ($info->isInstalled() ? 'Yes' : 'No'));
         $output->writeln($info->getCoreVersions());
 
+        if ($info->isInstalled()) {
+            $output->writeln('');
+            $output->writeln('<info># Database Information</info>');
+            $output->writeln('Version - ' . $info->getDBMSVersion());
+            $output->writeln('SQL Mode - ' . $info->getDBMSSqlMode());
+        }
+
         $output->writeln('');
         $output->writeln('<info># Paths</info>');
         $output->writeln('Web root - ' . $info->getWebRootDirectory());

--- a/concrete/src/System/Info.php
+++ b/concrete/src/System/Info.php
@@ -3,11 +3,17 @@ namespace Concrete\Core\System;
 
 use Localization;
 use Concrete\Core\Support\Facade\Facade;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Foundation\Environment;
 use Concrete\Core\Package\PackageList;
 
 class Info
 {
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private $app;
+
     /**
      * @var bool
      */
@@ -73,18 +79,27 @@ class Info
      */
     protected $dbVersion;
 
+    /**
+     * @var string|null
+     */
+    private $dbmsVersion;
+
+    /**
+     * @var string|null
+     */
+    private $dbmsSqlMode;
 
     public function __construct()
     {
         $loc = Localization::getInstance();
         $loc->pushActiveContext(Localization::CONTEXT_SYSTEM);
         try {
-            $app = Facade::getFacadeApplication();
-            $config = $app->make('config');
+            $this->app = Facade::getFacadeApplication();
+            $config = $this->app->make('config');
             $maxExecutionTime = ini_get('max_execution_time');
             @set_time_limit(5);
 
-            $this->installed = (bool) $app->isInstalled();
+            $this->installed = (bool) $this->app->isInstalled();
 
             $this->webRootDirectory = DIR_BASE;
 
@@ -138,7 +153,7 @@ class Info
             if ($config->get('concrete.cache.full_page_lifetime')) {
                 $cache[] = sprintf("Full Page Cache Lifetime - %s",
                     $config->get('concrete.cache.full_page_lifetime') == 'default' ?
-                        sprintf('Every %s (default setting).', $app->make('helper/date')->describeInterval($config->get('concrete.cache.lifetime')))
+                        sprintf('Every %s (default setting).', $this->app->make('helper/date')->describeInterval($config->get('concrete.cache.lifetime')))
                         :
                         (
                         $config->get('concrete.cache.full_page_lifetime') == 'forever' ?
@@ -172,7 +187,7 @@ class Info
             phpinfo();
             $buffer = ob_get_clean();
             $phpinfo = [];
-            if ($app->isRunThroughCommandLineInterface()) {
+            if ($this->app->isRunThroughCommandLineInterface()) {
                 $section = null;
                 foreach (preg_split('/[\r\n]+/', $buffer) as $line) {
                     $chunks = array_map('trim', explode('=>', $line));
@@ -421,5 +436,41 @@ class Info
         return $this->dbVersion;
     }
 
+    /**
+     * @return string
+     */
+    public function getDBMSVersion()
+    {
+        if ($this->dbmsVersion === null) {
+            $this->dbmsVersion = '';
+            if ($this->installed) {
+                try {
+                    $cn = $this->app->make(Connection::class);
+                    $this->dbmsVersion = (string) $cn->fetchColumn('select @@version');
+                } catch (\Exception $x) {
+                }
+            }
+        }
 
+        return $this->dbmsVersion;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDBMSSqlMode()
+    {
+        if ($this->dbmsSqlMode === null) {
+            $this->dbmsSqlMode = '';
+            if ($this->installed) {
+                try {
+                    $cn = $this->app->make(Connection::class);
+                    $this->dbmsSqlMode = (string) $cn->fetchColumn('select @@sql_mode');
+                } catch (\Exception $x) {
+                }
+            }
+        }
+
+        return $this->dbmsSqlMode;
+    }
 }


### PR DESCRIPTION
What about adding this information to the `/dashboard/system/environment/info` dashboard page and to the `c5:info` CLI command?

Sample output of the `c5:info` CLI command (notice the new `# Database Information` section):

```
# concrete5 Version
Installed - Yes
Core Version - 8.5.2a1
Version Installed - 8.5.1
Database Version - 20190301133300

# Database Information
Version - 5.7.24
SQL Mode - NO_ENGINE_SUBSTITUTION

# Paths
Web root - /path/to/concrete5
[...]
```