### PR TITLE
Changed group name to the correct qualified label

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/groups/message.php
+++ b/concrete/controllers/single_page/dashboard/users/groups/message.php
@@ -16,7 +16,7 @@ class Message extends DashboardPageController
         $groupList = new GroupList();
         foreach ($groupList->getResults() as $group) {
             /** @var \Concrete\Core\User\Group\Group $group */
-            $groups[$group->getGroupID()] = $group->getGroupName();
+            $groups[$group->getGroupID()] = $group->getGroupDisplayName();
         }
 
         $this->set('groups', $groups);


### PR DESCRIPTION
The send message to group page was not displaying the correct qualified label. 