### PR TITLE
Inhibit dashboard updates

### DIFF
--- a/concrete/blocks/desktop_app_status/controller.php
+++ b/concrete/blocks/desktop_app_status/controller.php
@@ -26,6 +26,8 @@ class Controller extends BlockController
 
     public function view()
     {
+        $config = $this->app->make('config');
+        $this->set('current_version', $config->get('concrete.version'));
         $this->set('latest_version', Update::getLatestAvailableVersionNumber());
         $local = [];
         $remote = [];

--- a/concrete/blocks/desktop_app_status/controller.php
+++ b/concrete/blocks/desktop_app_status/controller.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Concrete\Block\DesktopAppStatus;
 
-use Concrete\Core\Updater\Update;
-use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\Block\BlockController;
-use Concrete\Core\Permission\Checker as Permissions;
+use Concrete\Core\Package\PackageService;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Updater\Update;
 
 class Controller extends BlockController
 {
@@ -29,24 +30,19 @@ class Controller extends BlockController
         $config = $this->app->make('config');
         $this->set('current_version', $config->get('concrete.version'));
         $this->set('latest_version', Update::getLatestAvailableVersionNumber());
-        $local = [];
-        $remote = [];
-        $p = new Permissions();
-        if ($p->canInstallPackages()) {
-            $local = Package::getLocalUpgradeablePackages();
-            $remote = Package::getRemotelyUpgradeablePackages();
-        }
-
-        // now we strip out any dupes for the total
         $updates = 0;
-        $localHandles = [];
-        foreach ($local as $_pkg) {
-            ++$updates;
-            $localHandles[] = $_pkg->getPackageHandle();
-        }
-        foreach ($remote as $_pkg) {
-            if (!in_array($_pkg->getPackageHandle(), $localHandles)) {
+        $p = new Checker();
+        if ($p->canInstallPackages()) {
+            $packageService = $this->app->make(PackageService::class);
+            $localHandles = [];
+            foreach ($packageService->getLocalUpgradeablePackages() as $pkg) {
                 ++$updates;
+                $localHandles[] = $pkg->getPackageHandle();
+            }
+            foreach ($packageService->getRemotelyUpgradeablePackages() as $pkg) {
+                if (!in_array($pkg->getPackageHandle(), $localHandles)) {
+                    ++$updates;
+                }
             }
         }
         $this->set('updates', $updates);

--- a/concrete/blocks/desktop_app_status/view.php
+++ b/concrete/blocks/desktop_app_status/view.php
@@ -1,10 +1,15 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-
 <?php
-if (version_compare($latest_version, APP_VERSION, '>')) {
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/** @var Concrete\Core\Block\View\BlockView $view */
+/** @var string $current_version the currently installed concrete5 version */
+/** @var string $latest_version the last available concrete5 version */
+/** @var int $updates number of packages with new versions available */
+
+if (version_compare($latest_version, $current_version, '>')) {
     ?>
     <div class="alert alert-info">
-        <?php echo t('The latest version of concrete5 is <strong>%s</strong>. You are currently running concrete5 version <strong>%s</strong>.', $latest_version, APP_VERSION) ?>
+        <?php echo t('The latest version of concrete5 is <strong>%s</strong>. You are currently running concrete5 version <strong>%s</strong>.', $latest_version, $current_version) ?>
         <a class="pull-right btn btn-info btn-xs" href="<?php echo $view->url('/dashboard/system/update/update')?>"><?php echo t('Update')?></a>
     </div>
     <?php

--- a/concrete/blocks/desktop_app_status/view.php
+++ b/concrete/blocks/desktop_app_status/view.php
@@ -8,12 +8,6 @@ if (version_compare($latest_version, APP_VERSION, '>')) {
         <a class="pull-right btn btn-info btn-xs" href="<?php echo $view->url('/dashboard/system/update/update')?>"><?php echo t('Update')?></a>
     </div>
     <?php
-} elseif (version_compare(APP_VERSION, Config::get('concrete.version'), '>')) {
-    ?>
-    <div class="alert alert-warning">
-        <?php echo t('You have downloaded a new version of concrete5 but have not upgraded to it yet.'); ?>
-        <a href="<?php echo REL_DIR_FILES_TOOLS_REQUIRED ?>/upgrade" class="pull-right btn btn-warning btn-xs"><?php echo t('Update')?></a></div>
-    <?php
 }
 
 if ($updates > 0) {

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -603,6 +603,11 @@ return [
             'get_available_updates' => 'http://www.concrete5.org/tools/update_core',
             'inspect_update' => 'http://www.concrete5.org/tools/inspect_update',
         ],
+        // Set to true to skip checking if there's a newer core version available (useful for example if the core is upgraded via composer) 
+        'skip_core' => false,
+        // Space-separated list of package handles that shouldn't be checked for new versions in marketplace (useful for example if the core is upgraded via composer)
+        // Set to true to skip all the packages
+        'skip_packages' => '',
     ],
     'paths' => [
         'trash' => '/!trash',

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -605,9 +605,9 @@ return [
         ],
         // Set to true to skip checking if there's a newer core version available (useful for example if the core is upgraded via composer) 
         'skip_core' => false,
-        // Space-separated list of package handles that shouldn't be checked for new versions in marketplace (useful for example if the core is upgraded via composer)
+        // List of package handles that shouldn't be checked for new versions in marketplace (useful for example if the core is upgraded via composer)
         // Set to true to skip all the packages
-        'skip_packages' => '',
+        'skip_packages' => [],
     ],
     'paths' => [
         'trash' => '/!trash',

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -186,9 +186,18 @@ class Marketplace implements ApplicationAwareInterface
      */
     public static function checkPackageUpdates()
     {
+        $marketplace = static::getInstance();
+        $skipPackages = $marketplace->config->get('concrete.updates.skip_packages');
+        if ($skipPackages === true) {
+            return;
+        }
+        $skipPackages = preg_split('/\s+/', (string) $skipPackages, -1, PREG_SPLIT_NO_EMPTY);
         $em = \ORM::entityManager();
         $items = self::getAvailableMarketplaceItems(false);
         foreach ($items as $i) {
+            if (in_array($i->getHandle(), $skipPackages)) {
+                continue;
+            }
             $p = Package::getByHandle($i->getHandle());
             if (is_object($p)) {
                 /**

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -233,7 +233,7 @@ class Marketplace implements ApplicationAwareInterface
             } catch (Exception $e) {
             }
 
-            if ($filterInstalled && is_array($addons)) {
+            if ($filterInstalled) {
                 $handles = Package::getInstalledHandles();
                 if (is_array($handles)) {
                     $adlist = array();

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -191,11 +191,17 @@ class Marketplace implements ApplicationAwareInterface
         if ($skipPackages === true) {
             return;
         }
-        $skipPackages = preg_split('/\s+/', (string) $skipPackages, -1, PREG_SPLIT_NO_EMPTY);
+        if (!$skipPackages) {
+            // In case someone uses false or NULL or an empty string
+            $skipPackages = [];
+        } else {
+            // In case someone uses a single package handle
+            $skipPackages = (array) $skipPackages;
+        }
         $em = \ORM::entityManager();
         $items = self::getAvailableMarketplaceItems(false);
         foreach ($items as $i) {
-            if (in_array($i->getHandle(), $skipPackages)) {
+            if (in_array($i->getHandle(), $skipPackages, true)) {
                 continue;
             }
             $p = Package::getByHandle($i->getHandle());

--- a/concrete/src/Updater/Update.php
+++ b/concrete/src/Updater/Update.php
@@ -256,6 +256,9 @@ class Update
     {
         $app = Application::getFacadeApplication();
         $config = $app->make('config');
+        if ($config->get('concrete.updates.skip_core')) {
+            return null;
+        }
         $client = $app->make('http/client')->setUri($config->get('concrete.updates.services.get_available_updates'));
         $client->getRequest()
             ->setMethod('POST')


### PR DESCRIPTION
There are cases when we'd like to disable upgrading the core and/or packages from within the dashboard (for example, as discussed in [C5 Dev Round Up #1](http://www.youtube.com/watch?v=GLH0RFCAIc0&t=30m37s), upgrading via the dashboard should be avoided when using composer).