### PR TITLE
Fix warnings in process.php

### DIFF
--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -100,7 +100,6 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
         case 'check-out-first':
             if ($cp->canEditPageContents() || $cp->canEditPageProperties() || $cp->canApprovePageVersions()) {
                 // checking out the collection for editing
-                $u = new User();
                 $u->loadCollectionEdit($c);
 
                 if ($_REQUEST['ctask'] == 'check-out-add-block') {
@@ -115,7 +114,6 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
 
         case 'approve-recent':
             if ($cp->canApprovePageVersions()) {
-                $u = new User();
                 $pkr = new \Concrete\Core\Workflow\Request\ApprovePageRequest();
                 $pkr->setRequestedPage($c);
                 $v = CollectionVersion::get($c, "RECENT");

--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -3,6 +3,8 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 use Concrete\Core\Page\Stack\Pile\PileContent;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Http\Request;
 
 # Filename: _process.php
 # Author: Andrew Embler (andrew@concrete5.org)
@@ -20,8 +22,18 @@ use Concrete\Core\Page\Stack\Pile\PileContent;
 /** @var Concrete\Core\Http\Request $request */
 /** @var Concrete\Core\Page\Collection\Collection $c */
 /** @var Concrete\Core\Permission\Checker $cp */
+/** @var Concrete\Core\Application\Application $app */
 
-$valt = Loader::helper('validation/token');
+if (!isset($app)) {
+    // Just in case this file is currently included in a custom place (that is, not in ResponseFactory::collection());
+    $app = Application::getFacadeApplication();
+}
+if (!isset($request)) {
+    // Just in case this file is currently included in a custom place (that is, not in ResponseFactory::collection());
+    $request = $app->make(Request::class);
+}
+
+$valt = $app->make('helper/validation/token');
 
 // If the user has checked out something for editing, we'll increment the lastedit variable within the database
 $u = new User();
@@ -67,7 +79,7 @@ if ($request->query->get('atask') && $valt->validate()) {
                     $obj->error = false;
 
                     $db = null;
-                    if (Core::make('helper/validation/numbers')->integer($getRequest('dragAreaBlockID'), 1)) {
+                    if ($app->make('helper/validation/numbers')->integer($getRequest('dragAreaBlockID'), 1)) {
                         $db = Block::getByID(
                             $getRequest('dragAreaBlockID'),
                             isset($this->pageToModify) ? $this->pageToModify : null,
@@ -89,7 +101,7 @@ if ($request->query->get('atask') && $valt->validate()) {
                 $obj->response = array(t('Invalid stack.'));
             }
 
-            echo Loader::helper('json')->encode($obj);
+            echo $app->make('helper/json')->encode($obj);
             exit;
 
             break;
@@ -109,7 +121,7 @@ if ($getRequest('ctask') && $valt->validate()) {
                 if ($getRequest('ctask') == 'check-out-add-block') {
                     setcookie("ccmLoadAddBlockWindow", "1", -1, DIR_REL . '/');
                     header(
-                        'Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
+                        'Location: ' . Application::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
                     exit;
                     break;
                 }
@@ -126,7 +138,7 @@ if ($getRequest('ctask') && $valt->validate()) {
                 $u->unloadCollectionEdit($c);
                 $pkr->trigger();
                 header(
-                    'Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
+                    'Location: ' . Application::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
                 exit;
             }
             break;
@@ -136,7 +148,7 @@ if ($getRequest('ctask') && $valt->validate()) {
                 $v = CollectionVersion::get($c, "SCHEDULED");
                 $v->approve(false);
 
-                header('Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME .
+                header('Location: ' . Application::getApplicationURL() . '/' . DISPATCHER_FILENAME .
                     '?cID=' . $c->getCollectionID());
 
                 exit;
@@ -160,7 +172,7 @@ if ($getRequest('ptask') && $valt->validate()) {
                 //global scrapbooks
             } elseif ($getRequest('bID') > 0 && $getRequest('arHandle')) {
                 $bID = (int) $getRequest('bID');
-                $scrapbookHelper = Loader::helper('concrete/scrapbook');
+                $scrapbookHelper = $app->make('helper/concrete/scrapbook');
                 $globalScrapbookC = $scrapbookHelper->getGlobalScrapbookPage();
                 $globalScrapbookA = Area::get($globalScrapbookC, $getRequest('arHandle'));
                 $block = Block::getById($bID, $globalScrapbookC, $globalScrapbookA);
@@ -259,7 +271,7 @@ if ($getRequest('processBlock') && $valt->validate()) {
 
                 $obj = new stdClass();
                 if (is_object($nb)) {
-                    if (Loader::helper('validation/numbers')->integer($getRequest('dragAreaBlockID'), 1)) {
+                    if ($app->make('helper/validation/numbers')->integer($getRequest('dragAreaBlockID'), 1)) {
                         $db = Block::getByID(
                             $getRequest('dragAreaBlockID'),
                             $this->pageToModify,
@@ -279,12 +291,12 @@ if ($getRequest('processBlock') && $valt->validate()) {
                     $obj->bID = $nb->getBlockID();
                     $obj->error = false;
                 } else {
-                    $e = Loader::helper('validation/error');
+                    $e = $app->make('helper/validation/error');
                     $e->add(t('Invalid block.'));
                     $obj->error = true;
                     $obj->response = $e->getList();
                 }
-                echo Loader::helper('json')->encode($obj);
+                echo $app->make('helper/json')->encode($obj);
                 exit;
             }
         }

--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -101,7 +101,7 @@ if ($request->query->get('atask') && $valt->validate()) {
                 $obj->response = array(t('Invalid stack.'));
             }
 
-            echo $app->make('helper/json')->encode($obj);
+            echo json_encode($obj);
             exit;
 
             break;
@@ -296,7 +296,7 @@ if ($getRequest('processBlock') && $valt->validate()) {
                     $obj->error = true;
                     $obj->response = $e->getList();
                 }
-                echo $app->make('helper/json')->encode($obj);
+                echo json_encode($obj);
                 exit;
             }
         }

--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -1,7 +1,7 @@
 <?php
 
 defined('C5_EXECUTE') or die("Access Denied.");
-use Concrete\Core\Block\Events\BlockDelete;
+
 use Concrete\Core\Page\Stack\Pile\PileContent;
 
 # Filename: _process.php
@@ -15,16 +15,19 @@ use Concrete\Core\Page\Stack\Pile\PileContent;
 
 // ATTENTION! This file is legacy and needs to die. We are moving it's various pieces into
 // controllers.
+
+/** @var Concrete\Core\Http\ResponseFactory $this */
+/** @var Concrete\Core\Http\Request $request */
+/** @var Concrete\Core\Page\Collection\Collection $c */
+/** @var Concrete\Core\Permission\Checker $cp */
+
 $valt = Loader::helper('validation/token');
-$token = '&' . $valt->getParameter();
 
 // If the user has checked out something for editing, we'll increment the lastedit variable within the database
 $u = new User();
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $u->refreshCollectionEdit($c);
 }
-
-$securityHelper = Loader::helper('security');
 
 if (isset($_GET['atask']) && $_GET['atask'] && $valt->validate()) {
     switch ($_GET['atask']) {
@@ -119,7 +122,7 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
                 $pkr->setRequestedVersionID($v->getVersionID());
                 $pkr->setRequesterUserID($u->getUserID());
                 $u->unloadCollectionEdit($c);
-                $response = $pkr->trigger();
+                $pkr->trigger();
                 header(
                     'Location: ' . \Core::getApplicationURL() . '/' . DISPATCHER_FILENAME . '?cID=' . $c->getCollectionID());
                 exit;

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -339,7 +339,9 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $dl->setupSiteInterfaceLocalization($collection);
 
         $request->setCurrentPage($collection);
-        $c = $collection; // process.php needs this
+        // process.php needs these
+        $c = $collection; 
+        $app = $this->app;
         require DIR_BASE_CORE . '/bootstrap/process.php';
         $u = $this->app->make(User::class);
 


### PR DESCRIPTION
The option introduced in #6835 is a real life saver while developing, but it requires that the core doesn't raise any warning.

In `process.php` we have still some `Undefined offset` warnings. Instead of adding other `isset()` checks, what about switching from superglobals to the `Request` instance?

I know that this `process.php` file is going to die in the future, but I'm developing today, not tomorrow :wink:

PS: ref. #4723