### PR TITLE
Avoid accessing undefined array index in CountryList::getCountryName()

### DIFF
--- a/concrete/src/Localization/Service/CountryList.php
+++ b/concrete/src/Localization/Service/CountryList.php
@@ -42,16 +42,18 @@ class CountryList
         return $this->countries[Localization::activeLocale()];
     }
 
-    /** Gets a country full name given its code
+    /**
+     * Gets a country name given its code.
+     *
      * @param string $code The country code
      *
-     * @return string
+     * @return string|null returns NULL if $code is not valid
      */
     public function getCountryName($code)
     {
         $countries = $this->getCountries(true);
 
-        return $countries[$code];
+        return isset($countries[$code]) ? $countries[$code] : null;
     }
 
     /**


### PR DESCRIPTION
This is not a BC break. the result is the same. The only difference is that PHP won't raise a warning in case a country code is not valid.

Ref. #4723