### PR TITLE
Entry ID to thanks page

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -278,7 +278,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $c = Page::getByID($this->redirectCID);
                         if (is_object($c) && !$c->isError()) {
                             $r = Redirect::page($c);
-                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1');
+                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1&entry=' . $entry->getID());
                         }
                     }
 


### PR DESCRIPTION
If the form redirects to a thank you page, pass the entry id so that the page can interact with the entry if desired.