### PR TITLE
Fix #7778

### DIFF
--- a/concrete/src/Express/Association/Formatter/AbstractFormatter.php
+++ b/concrete/src/Express/Association/Formatter/AbstractFormatter.php
@@ -33,7 +33,9 @@ abstract class AbstractFormatter implements FormatterInterface
             $name = $formatter->format($mask, $entry);
         }
 
-        $name = $entry->getLabel();
+        if (!$name) {
+            $name = $entry->getLabel();
+        }
 
         if ($name = trim($name)) {
             return $name;


### PR DESCRIPTION
We had already had the ability to have custom association display name masks using attributes – but we had a bug in the code that wasn't using it.

If you have an association you're displaying in a form, it will show the association entry numerical ID by default. But in the form configuration itself, you can specify a custom association entity display format; just list out some attributes with % signs around them, and that will control how the items look. e.g. if you're listing students in a list and your student's have a first_name and a last_name attribute, you'd specify

    %first_name% %last_name%

as the format. See this screenshot: 
![Screen Shot 2019-05-09 at 12 15 04 PM](https://user-images.githubusercontent.com/527809/57480370-5d523a00-7254-11e9-82e0-668081db85f5.png)
