### PR TITLE
set 303 as standard redirect status code for download_file url

### DIFF
--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -126,7 +126,7 @@ class DownloadFile extends PageController
         $configuration = $fsl->getConfigurationObject();
         $fv = $file->getVersion();
         if ($configuration->hasPublicURL()) {
-            return \Redirect::url($fv->getURL())->send();
+            return \Redirect::url($fv->getURL(),'303')->send();
         } else {
             return $fv->forceDownload();
         }


### PR DESCRIPTION
Hi guys,

After many evaluations that we made  for our websites with some SEO Tools i saw that they complain about those 302 file redirects. As i researched this thema i am convinced that in this case of redirect we should use 303 instead of 302. 

Any input is welcome here.