### PR TITLE
allow page attribute block to use template for attribute

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -3,6 +3,7 @@ namespace Concrete\Block\PageAttributeDisplay;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Attribute\Key\CollectionKey as CollectionAttributeKey;
+use Concrete\Core\Block\View\BlockViewTemplate;
 use Concrete\Core\Entity\Attribute\Value\Value\SelectValue;
 use Database;
 use Core;
@@ -253,6 +254,15 @@ class Controller extends BlockController
         $templateHandle = $this->getTemplateHandle();
         if (in_array($templateHandle, ['date_time', 'boolean'])) {
             $this->render('templates/' . $templateHandle);
+        } else {
+            // check if there is a template that matches the selected attribute
+            $template = \Core::make(BlockViewTemplate::class, [$this->getBlockObject()]);
+            $template->setBlockCustomTemplate("templates/" . $this->attributeHandle . '.php');
+            $info = pathinfo($template->getTemplate());
+
+            if ($info['basename'] != 'view.php') {
+                $this->render('templates/' . $info['filename'] );
+            }
         }
       }
     }


### PR DESCRIPTION
this change has the page attribute block search the templates directory to see if there is a template that matches the selected attribute's handle. If so, this template will be used automatically.

Note: this currently does not work with template in a folder.

Example:
selected attribute handle: `my_attribute`

works:
`/application/blocks/page_attribute_display/templates/my_attribute.php`

does not work:
`/application/blocks/page_attribute_display/templates/my_attribute/view.php`

There have been quite a few times where I have had to create a template for a specific attribute and then select it each time an instance of the block is needed. In my opinion, it would be handy (and reasonably logical) to have a template that matches the selected attribute handle automatically applied if no custom attribute was selected.

I'm not convinced this was the most elegant way to add this functionality (there is likely a way to check for the existence of a block template, but I did not happen across it)

There is the potential that this could be considered a non-backwards compatible change in the case a site has a template which has the same name as the selected attribute handle and it was not intended for them to be used all of the time.