### PR TITLE
Fixing issues when deleting Workflow Types

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -211,9 +211,9 @@ return [
         'storage_location_type',
         'theme',
         'user_point_action',
+        'workflow',
         'workflow_progress_category',
         'workflow_type',
-        'workflow',
     ],
 
     'importer_routines' => [

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2a1',
     'version_installed' => '8.5.2a1',
-    'version_db' => '20190301133300', // the key of the latest database migration
+    'version_db' => '20190507177700', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Updater/Migrations/Migrations/Version20190507177700.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190507177700.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20190507177700 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->fixWorkflowsPackage();
+    }
+
+    private function fixWorkflowsPackage() {
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('pkgID, wftID')->from('WorkflowTypes')->where($qb->expr()->gt('pkgID',0));
+        $results = $qb->execute()->fetchAll();
+        foreach ($results as $result) {
+            $this->connection->update('Workflows', ['pkgID'=>$result['pkgID']], ['pkgID'=>0, 'wftID'=>$result['wftID']]);
+        }
+
+
+    }
+
+
+}

--- a/concrete/src/Workflow/Type.php
+++ b/concrete/src/Workflow/Type.php
@@ -233,7 +233,7 @@ class Type extends ConcreteObject
         $db = $app->make('database')->connection();
         $db->insert('WorkflowTypes',
             ['wftHandle'=>$wftHandle, 'wftName'=>$wftName, 'pkgID', $pkgID],
-            [\PDO::STR, \PDO::STR, \PDO::INT]);
+            [\PDO::PARAM_STR, \PDO::PARAM_STR, \PDO::PARAM_INT]);
         $id = $db->lastInsertId();
         $est = static::getByID($id);
 

--- a/concrete/src/Workflow/Type.php
+++ b/concrete/src/Workflow/Type.php
@@ -2,56 +2,98 @@
 namespace Concrete\Core\Workflow;
 
 use Concrete\Core\Foundation\ConcreteObject;
-use Loader;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Package\PackageList;
 
 class Type extends ConcreteObject
 {
+    /**
+     * Returns this Workflow Type's ID
+     *
+     * @return int
+     */
     public function getWorkflowTypeID()
     {
         return $this->wftID;
     }
+
+    /**
+     * Returns this Workflow Type's Handle
+     *
+     * @return string
+     */
     public function getWorkflowTypeHandle()
     {
         return $this->wftHandle;
     }
+    /**
+     * Returns this Workflow Type's Name
+     *
+     * @return string
+     */
     public function getWorkflowTypeName()
     {
         return $this->wftName;
     }
 
+    /**
+     * Gets a WorkflowType By ID
+     *
+     * @param $wftID int
+     * @return Type | null
+     */
     public static function getByID($wftID)
     {
-        $db = Loader::db();
-        $row = $db->GetRow('select wftID, pkgID, wftHandle, wftName from WorkflowTypes where wftID = ?', array($wftID));
+        $app = Application::getFacadeApplication();
+        /** @var $db \Concrete\Core\Database\Connection\Connection */
+        $db = $app->make('database')->connection();
+        $qb = $db->createQueryBuilder();
+        $qb->select('wftID, pkgID, wftHandle, wftName')
+            ->from('WorkflowTypes')
+            ->where($qb->expr()->eq('wftID', $wftID))->setMaxResults(1);
+
+        $row = $qb->execute()->fetch();
         if ($row['wftHandle']) {
             $wt = new static();
             $wt->setPropertiesFromArray($row);
 
             return $wt;
         }
+
+        return null;
     }
 
+    /**
+     * Returns a list of WorkflowTypes currently installed
+     *
+     * @return Type[]
+     */
     public static function getList()
     {
-        $db = Loader::db();
-        $list = array();
-        $r = $db->Execute('select wftID from WorkflowTypes order by wftID asc');
+        $app = Application::getFacadeApplication();
+        /** @var $db \Concrete\Core\Database\Connection\Connection */
+        $db = $app->make('database')->connection();
+        $list = [];
+        $qb = $db->createQueryBuilder();
+        $qb->select('wftID')->from('WorkflowTypes')->orderBy('wftID', 'asc');
+        $result = $qb->execute()->fetchColumn();
 
-        while ($row = $r->FetchRow()) {
-            $list[] = static::getByID($row['wftID']);
+        foreach ($result as $id) {
+            $list[] = static::getByID($id);
         }
 
-        $r->Close();
 
         return $list;
     }
 
+    /**
+     * This function is used to add the workflow type list to an existing XML export file.
+     *
+     * @param \SimpleXMLElement $xml
+     */
     public static function exportList($xml)
     {
         $wtypes = static::getList();
-        $db = Loader::db();
         $axml = $xml->addChild('workflowtypes');
         foreach ($wtypes as $wt) {
             $wtype = $axml->addChild('workflowtype');
@@ -72,7 +114,8 @@ class Type extends ConcreteObject
         /** @var $db \Concrete\Core\Database\Connection\Connection */
         $db = $app->make('database')->connection();
         $qb = $db->createQueryBuilder();
-        $qb->select('wfID')->from('Workflows')->where($qb->expr()->eq('wftID',$this->getWorkflowTypeID()));
+        $qb->select('wfID')->from('Workflows')
+            ->where($qb->expr()->eq('wftID',$this->getWorkflowTypeID()));
         $results = $qb->execute()->fetchColumn();
         foreach ($results as $result) {
             $workflow = Workflow::getByID($result);
@@ -102,46 +145,96 @@ class Type extends ConcreteObject
         $db->delete('WorkflowTypes',['wftID', $this->getWorkflowTypeID()]);
     }
 
+    /**
+     * @param $pkg \Concrete\Core\Package\Package | \Concrete\Core\Entity\Package
+     * @return Type[]
+     */
     public static function getListByPackage($pkg)
     {
-        $db = Loader::db();
-        $list = array();
-        $r = $db->Execute('select wftID from WorkflowTypes where pkgID = ? order by wftID asc', array($pkg->getPackageID()));
-        while ($row = $r->FetchRow()) {
-            $list[] = static::getByID($row['wftID']);
+        $list = [];
+        $app = Application::getFacadeApplication();
+        /** @var $db \Concrete\Core\Database\Connection\Connection */
+        $db = $app->make('database')->connection();
+        $qb = $db->createQueryBuilder();
+        $qb->select('wfID')->from('WorkflowTypes')
+            ->where($qb->expr('pkgID'), $pkg->getPackageID());
+        $result = $qb->execute()->fetchColumn();
+
+        foreach ($result as $id) {
+            $list[] = static::getByID($id);
         }
-        $r->Close();
+
 
         return $list;
     }
 
+    /**
+     * Returns this Workflow Type's Package ID.
+     *
+     * @return int
+     */
     public function getPackageID()
     {
-        return $this->pkgID;
+        return (int) $this->pkgID;
     }
+
+    /**
+     * Returns this Workflow Type's Package handle
+     *
+     * Will return false, if no package.
+     *
+     * @return string|bool
+     */
     public function getPackageHandle()
     {
         return PackageList::getHandle($this->pkgID);
     }
 
+    /**
+     * Gets a Workflow Type by handle
+     *
+     * @param $wftHandle
+     * @return Type|null
+     */
     public static function getByHandle($wftHandle)
     {
-        $db = Loader::db();
-        $wftID = $db->GetOne('select wftID from WorkflowTypes where wftHandle = ?', array($wftHandle));
+        $app = Application::getFacadeApplication();
+        /** @var $db \Concrete\Core\Database\Connection\Connection */
+        $db = $app->make('database')->connection();
+        $qb = $db->createQueryBuilder();
+        $qb->select('wfID')->from('WorkflowTypes')
+            ->where($qb->expr('wftHandle'), $wftHandle)->setMaxResults(1);
+        $wftID = $qb->execute()->fetchColumn();
         if ($wftID > 0) {
             return self::getByID($wftID);
         }
     }
 
+    /**
+     * Add a new Workflow Type.
+     *
+     * e.g Type::add('wft_handle','Type Name') - for no package
+     * e.g Type::add('wft_handle','Type Name', $pkg) - with package
+     * where $pkg is a Package Object/Entity
+     *
+     * @param $wftHandle string
+     * @param $wftName string
+     * @param \Concrete\Core\Package\Package | \Concrete\Core\Entity\Package | bool $pkg
+     * @return Type|null
+     */
     public static function add($wftHandle, $wftName, $pkg = false)
     {
         $pkgID = 0;
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
-        $db = Loader::db();
-        $db->Execute('insert into WorkflowTypes (wftHandle, wftName, pkgID) values (?, ?, ?)', array($wftHandle, $wftName, $pkgID));
-        $id = $db->Insert_ID();
+        $app = Application::getFacadeApplication();
+        /** @var $db \Concrete\Core\Database\Connection\Connection */
+        $db = $app->make('database')->connection();
+        $db->insert('WorkflowTypes',
+            ['wftHandle'=>$wftHandle, 'wftName'=>$wftName, 'pkgID', $pkgID],
+            [\PDO::STR, \PDO::STR, \PDO::INT]);
+        $id = $db->lastInsertId();
         $est = static::getByID($id);
 
         return $est;

--- a/concrete/src/Workflow/Type.php
+++ b/concrete/src/Workflow/Type.php
@@ -232,7 +232,7 @@ class Type extends ConcreteObject
         /** @var $db \Concrete\Core\Database\Connection\Connection */
         $db = $app->make('database')->connection();
         $db->insert('WorkflowTypes',
-            ['wftHandle'=>$wftHandle, 'wftName'=>$wftName, 'pkgID', $pkgID],
+            ['wftHandle'=>$wftHandle, 'wftName'=>$wftName, 'pkgID'=>$pkgID],
             [\PDO::PARAM_STR, \PDO::PARAM_STR, \PDO::PARAM_INT]);
         $id = $db->lastInsertId();
         $est = static::getByID($id);

--- a/concrete/src/Workflow/Workflow.php
+++ b/concrete/src/Workflow/Workflow.php
@@ -152,7 +152,11 @@ abstract class Workflow extends ConcreteObject implements \Concrete\Core\Permiss
         $db = Loader::db();
         $wfID = $db->getOne('SELECT wfID FROM Workflows WHERE wfName=?', array($name));
         if (!$wfID) {
-            $pkgID = 0;
+            $pkgID = $wt->getPackageID();
+            if (empty($pkgID)) {
+                $pkgID = 0;
+            }
+
             if (is_object($pkg)) {
                 $pkgID = $pkg->getPackageID();
             }


### PR DESCRIPTION
This PR fixes the following issues with Workflow Types

Workflow's belong to a type that Belongs to a package, are not correctly added to that package. It means
When deleting Workflow Types it will not remove existing workflows, it instead just hides them. This means if you have any existing workflow progresses submitted. It will break the site. The order of the package get items was wrong for workflows (removed workflow types before workflows, would cause errors).

I've also removed legacy code from workflow/type.php


Change-log Text:
Fixed Issues when removing Custom Workflow Types
Fixed Issues when adding Workflows that have custom workflow types.
Refactored Workflow Types Class to use newer code.