### PR TITLE
Check that the File author was not removed

### DIFF
--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -14,6 +14,7 @@ use Concrete\Core\Tree\Node\NodeType;
 use Concrete\Core\Tree\Node\Type\FileFolder;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityNotFoundException;
 use FileSet;
 use League\Flysystem\AdapterInterface;
 use Loader;
@@ -307,13 +308,36 @@ class File implements \Concrete\Core\Permission\ObjectInterface
     }
 
     /**
-     * Returns the user ID of the author of the file (if available).
+     * Get the user ID of the author of the file (if available).
      *
      * @return int|null
      */
     public function getUserID()
     {
-        return $this->author ? $this->author->getUserID() : null;
+        $user = $this->getUser();
+
+        return $user ? $user->getUserID() : null;
+    }
+
+    /**
+     * Get the author of the file (if available).
+     *
+     * @return \Concrete\Core\Entity\User\User|null
+     *
+     * @since concrete5 8.5.2
+     */
+    public function getUser()
+    {
+        if ($this->author) {
+            // Check that the user was not deleted
+            try {
+                $this->author->getUserID();
+            } catch (EntityNotFoundException $x) {
+                $this->author = null;
+            }
+        }
+
+        return $this->author;
     }
 
     /**


### PR DESCRIPTION
In case the `uID` field of the `Files` table points to a deleted user, we have an uncaught `EntityNotFoundException` exception: let's intercept this issue.

PS: Let's also add the `getUser()` method (the author is already an instance of the User entity)

