### PR TITLE
Add dashboard page to change database character set / collation

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2a1',
     'version_installed' => '8.5.2a1',
-    'version_db' => '20190301133300', // the key of the latest database migration
+    'version_db' => '20190520070000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -1128,6 +1128,13 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Database Character Set" path="/dashboard/system/environment/database_charset" filename="/dashboard/system/environment/database_charset.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>database, character set, charset, collation, utf8</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="Geolocation" path="/dashboard/system/environment/geolocation" filename="/dashboard/system/environment/geolocation.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">

--- a/concrete/controllers/single_page/dashboard/system/environment/database_charset.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/database_charset.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Concrete\Controller\SinglePage\Dashboard\System\Environment;
+
+use Concrete\Core\Database\CharacterSetCollation\Exception;
+use Concrete\Core\Database\CharacterSetCollation\Manager;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+
+class DatabaseCharset extends DashboardPageController
+{
+    public function view()
+    {
+        $this->requireAsset('selectize');
+        $connection = $this->app->make(Connection::class);
+        $this->set('charsetsAndCollations', $this->listCharsetsAndCollations($connection));
+        $this->set('collation', $this->getConfiguredCollation($connection));
+    }
+
+    public function set_connection_collation()
+    {
+        if (!$this->token->validate(__FUNCTION__)) {
+            $this->error->add($this->token->getErrorMessage());
+        } else {
+            $collation = $this->request->request->get('collation');
+            $manager = $this->app->make(Manager::class);
+            $warnings = $this->app->make('error');
+            try {
+                $manager->apply('', $collation, '', '', null, $warnings);
+            } catch (Exception $x) {
+                $this->errors->add($x);
+            }
+        }
+        if ($this->error->has()) {
+            $this->view();
+        } else {
+            if ($warnings->has()) {
+                $this->flash('set_connection_collation_warnings', $warnings);
+            } else {
+                $this->flash('success', t('The character set and the collation of the connection and all the tables have been updated.'));
+            }
+
+            return $this->app->make(ResponseFactoryInterface::class)->redirect(
+                $this->app->make(ResolverManagerInterface::class)->resolve([$this->request->getCurrentPage()]),
+                302
+            );
+        }
+    }
+
+    /**
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     *
+     * @return array
+     */
+    protected function listCharsetsAndCollations(Connection $connection)
+    {
+        $charsetsAndDefaultCollation = $connection->getSupportedCharsets();
+        ksort($charsetsAndDefaultCollation, SORT_NATURAL);
+        $collationsForCharsets = $connection->getSupportedCollations();
+        ksort($collationsForCharsets, SORT_NATURAL);
+        $result = [];
+        foreach ($charsetsAndDefaultCollation as $charset => $defaultCollation) {
+            $collations = [
+                $defaultCollation => $defaultCollation,
+            ];
+            foreach ($collationsForCharsets as $collation => $forCharset) {
+                if ($forCharset === $charset && $collation !== $defaultCollation) {
+                    $collations[$collation] = $collation;
+                }
+            }
+            $result[t('Character set: %s', $charset)] = $collations;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     *
+     * @return string
+     */
+    protected function getConfiguredCollation(Connection $connection)
+    {
+        $params = $connection->getParams();
+        if (!empty($params['collation'])) {
+            return $params['collation'];
+        }
+        // legacy support
+        if (!empty($params['charset'])) {
+            $charsetsAndDefaultCollation = $connection->getSupportedCharsets();
+            if (isset($charsetsAndDefaultCollation[$params['charset']])) {
+                return $charsetsAndDefaultCollation[$params['charset']];
+            }
+        }
+
+        return '';
+    }
+}

--- a/concrete/single_pages/dashboard/system/environment/database_charset.php
+++ b/concrete/single_pages/dashboard/system/environment/database_charset.php
@@ -1,0 +1,101 @@
+<?php
+
+use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Core\Form\Service\Form
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var array $charsetsAndCollations
+ * @var string $collation
+ * @var Concrete\Core\Error\ErrorList\ErrorList|null $set_connection_collation_warnings
+ */
+if (isset($set_connection_collation_warnings)) {
+    ?>
+    <div class="alert alert-warning alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <?= t('The character set and the collation of the connection and have been updated, but the following warnings occurred while updating the database tables') ?>
+        <ul>
+        <?php
+        foreach ($set_connection_collation_warnings->getList() as $warning) {
+            ?>
+            <li>
+                <?php
+                if ($warning instanceof HtmlAwareErrorInterface && $warning->messageContainsHtml()) {
+                    echo $warning->getMessage();
+                } else {
+                    echo nl2br(h((string) $warning));
+                }
+                ?>
+            </li>
+            <?php
+        }
+        ?>
+        </ul>
+    </div>
+    <?php
+}
+?>
+
+<form method="POST" action="<?= $view->action('set_connection_collation') ?>">
+
+    <?= $token->output('set_connection_collation') ?>
+
+        <div class="form-group">
+            <?= $form->label('collation', t('Collation')) ?>
+            <div class="ccm-search-field-content">
+                <?= $form->select('collation', $charsetsAndCollations, $collation, ['required' => 'required']) ?>
+            </div>
+        </div>
+    
+    <div class="alert alert-danger">
+        <?= t('Warning: changing the character set may result in data loss!') ?>
+    </div>
+
+    <div class="alert alert-info">
+        <?= t('Changing the character set may require a lot of time. If the operation times out, you can re-apply the setting more times.') ?>
+    </div>
+
+    
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <button class="pull-right btn btn-primary" type="submit" ><?= t('Save') ?></button>
+        </div>
+    </div>
+
+</form>
+
+<script>
+$(document).ready(function() {
+    var submitted = false;
+    $('#collation')
+        .selectize({
+    	   allowEmptyOption: false
+        })
+        .closest('form')
+            .on('submit', function(e) {
+                if (submitted) {
+                    e.preventDefault();
+                    return;
+                }
+                if ($('#collation').val() !== <?= json_encode($collation) ?>) {
+                    if (!window.confirm(<?= json_encode(t('Warning: changing the character set may result in data loss!') . "\n\n" . t('Are you sure you want to proceed?')) ?>)) {
+                        e.preventDefault();
+                        return;
+                    }
+                }
+                submitted = true;
+                setTimeout(
+                    function() {
+                        $(window).on('beforeunload', function() {
+                            return true;
+                        });
+                    },
+                    0
+                );
+            })
+    ;
+});
+</script>

--- a/concrete/src/Updater/Migrations/Migrations/Version20190520070000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190520070000.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20190520070000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->createSinglePage(
+            '/dashboard/system/environment/database_charset',
+            'Database Character Set',
+            [
+                'meta_keywords' => 'database, character set, charset, collation, utf8',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
At install time, concrete5 detects if we can use the `utf8mb4` character set (if not, we fall back to `utf8`).

This works great, but there are a couple of issues:
1. if at install time `utf8mb4` is not supported, but after MySQL is updated, `utf8mb4` may become usable
1. an SQL dump exported from a server that supports `utf8mb4` can be imported to a server that doesn't support it

In these cases, users may want/need to change the character set.
We already have the `c5:database:charset:set` CLI command, but not everybody can (or knows how to) use SSH.

So, what about adding a dashboard page to change the character set / collation?