### PR TITLE
Set quoted-printable encoding for outgoing emails

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -741,6 +741,7 @@ class Service
             $result = new MimePart($this->body);
             $result->setType(Mime::TYPE_TEXT);
             $result->setCharset(APP_CHARSET);
+            $result->setEncoding(Mime::ENCODING_QUOTEDPRINTABLE);
         }
 
         return $result;
@@ -774,6 +775,7 @@ class Service
             $html = new MimePart($this->bodyHTML);
             $html->setType(Mime::TYPE_HTML);
             $html->setCharset(APP_CHARSET);
+            $html->setEncoding(Mime::ENCODING_QUOTEDPRINTABLE);
             $inlineAttachments = [];
             foreach ($this->attachments as $attachment) {
                 if ($this->isInlineAttachment($attachment)) {


### PR DESCRIPTION
When sending text/html emails, we currently use the "8-bit" transfer encoding.

This works 99% of times, but sometimes (when there are long lines), a new line is automatically inserted in a quite random place. And that may break HTML code (for example, a newline may occur in the middle of an `href` attribute).

So, what about using the quoted-printable transfer encoding?