### PR TITLE
Account menu fixes

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -1108,6 +1108,7 @@ return [
         ],
         'core/account' => [
             [
+                ['javascript', 'jquery'],
                 ['javascript', 'core/account'],
                 ['javascript', 'bootstrap/dropdown'],
                 ['css', 'bootstrap/dropdown'],

--- a/concrete/elements/footer_required.php
+++ b/concrete/elements/footer_required.php
@@ -6,9 +6,12 @@ use Concrete\Core\View\View;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-// Arguments
-/* @var bool $disableTrackingCode: set to true to avoid including the footer tracking code. */
-/* @var bool $display_account_menu: set to true to display the user menu, false to avoid it, null (or not set) to use the default confguration option. */
+/**
+ * Arguments:
+ *
+ * @var bool|null $disableTrackingCode
+ * @var bool|null $display_account_menu
+ */
 
 $app = Application::getFacadeApplication();
 $c = Page::getCurrentPage();

--- a/concrete/elements/footer_required.php
+++ b/concrete/elements/footer_required.php
@@ -18,9 +18,8 @@ $c = Page::getCurrentPage();
 $site = $app->make('site')->getSite();
 $config = $site->getConfigRepository();
 $localization = Localization::getInstance();
-
-if (is_object($c)) {
-    $cp = new Permissions($c);
+$cp = is_object($c) ? new Permissions($c) : null;
+if ($cp !== null) {
     $localization->pushActiveContext(Localization::CONTEXT_UI);
     try {
         View::element('page_controls_footer', ['cp' => $cp, 'c' => $c]);
@@ -39,18 +38,20 @@ if (!isset($display_account_menu)) {
     $display_account_menu = $config->get('user.display_account_menu');
 }
 if ($display_account_menu) {
-    $u = $app->make(User::class);
-    if ($u->isRegistered()) {
-        $dh = $app->make('helper/concrete/dashboard');
-        if (!$dh->inDashboard($c)) {
-            $v = View::getRequestInstance();
-            $v->requireAsset('core/account');
-            $v->addFooterItem('<script>$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
-            $localization->pushActiveContext(Localization::CONTEXT_UI);
-            try {
-                View::element('account/menu');
-            } finally {
-                $localization->popActiveContext();
+    if ($cp === null || !$cp->canViewToolbar()) {
+        $u = $app->make(User::class);
+        if ($u->isRegistered()) {
+            $dh = $app->make('helper/concrete/dashboard');
+            if (!$dh->inDashboard($c)) {
+                $v = View::getRequestInstance();
+                $v->requireAsset('core/account');
+                $v->addFooterItem('<script>$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
+                $localization->pushActiveContext(Localization::CONTEXT_UI);
+                try {
+                    View::element('account/menu');
+                } finally {
+                    $localization->popActiveContext();
+                }
             }
         }
     }

--- a/concrete/elements/footer_required.php
+++ b/concrete/elements/footer_required.php
@@ -1,6 +1,8 @@
 <?php
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
+use Concrete\Core\View\View;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
@@ -34,13 +36,19 @@ if (!isset($display_account_menu)) {
     $display_account_menu = $config->get('user.display_account_menu');
 }
 if ($display_account_menu) {
-    $dh = $app->make('helper/concrete/dashboard');
-    if (!$dh->inDashboard($c)) {
-        $localization->pushActiveContext(Localization::CONTEXT_UI);
-        try {
-            View::element('account/menu');
-        } finally {
-            $localization->popActiveContext();
+    $u = $app->make(User::class);
+    if ($u->isRegistered()) {
+        $dh = $app->make('helper/concrete/dashboard');
+        if (!$dh->inDashboard($c)) {
+            $v = View::getRequestInstance();
+            $v->requireAsset('core/account');
+            $v->addFooterItem('<script>$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
+            $localization->pushActiveContext(Localization::CONTEXT_UI);
+            try {
+                View::element('account/menu');
+            } finally {
+                $localization->popActiveContext();
+            }
         }
     }
 }

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -181,11 +181,6 @@ if (!empty($alternateHreflangTags)) {
 
 <?php
 $v = View::getRequestInstance();
-$u = new User();
-if ($u->isRegistered()) {
-    $v->requireAsset('core/account');
-    $v->addFooterItem('<script type="text/javascript">$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
-}
 if ($cp) {
     View::element('page_controls_header', ['cp' => $cp, 'c' => $c]);
     if ($isEditMode) {

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -7,6 +7,15 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
+/**
+ * Arguments:
+ *
+ * @var string|null $pageTitle
+ * @var string|null $pageDescription
+ * @var string|null $pageMetaKeywords
+ * @var bool|null $disableTrackingCode
+ */
+
 $c = Page::getCurrentPage();
 $cp = false;
 $isEditMode = false;


### PR DESCRIPTION
A couple of fixes here:

- the account menu requires jQuery: let's add it to the `core/account` asset group
- we include the `core/account` asset group if (1) the user is registered  
  but
  we enable when (1) the user is registered, (2) the theme or the configuration doesn't disable it, and (3) we are not in the dashboard
  We should include the `core/account` asset group only if use it.

EDIT: fix #4588