### PR TITLE
Fix migrations 20150515000000 and 20170118000000

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20150515000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150515000000.php
@@ -24,21 +24,21 @@ class Version20150515000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema([
+        $this->refreshDatabaseTables([
             'PageFeeds',
+            'PageTypeComposerOutputBlocks',
         ]);
 
         // I can't seem to get the doctrine cache to clear any other way.
-        $cms = \Core::make('app');
-        $cms->clearCaches();
+        $this->app->clearCaches();
 
         $this->purgeOrphanedScrapbooksBlocks();
     }
 
     protected function purgeOrphanedScrapbooksBlocks()
     {
-        $db = \Database::connection();
-        $orphanedCollectionVersionBlocks = $db->fetchAll(
+        $this->refreshDatabaseTables(['PageTypeComposerOutputBlocks']);
+        $orphanedCollectionVersionBlocks = $this->connection->fetchAll(
             '
             select cID, cvID, cvb.bID, arHandle
             from CollectionVersionBlocks cvb


### PR DESCRIPTION
- Migration 20150515000000 may call `deleteBlock`, which may require an updated `PageTypeComposerOutputBlocks` table structure (otherwise we may have an `Unknown column 'cvID' in 'where clause'` when running the `delete from PageTypeComposerOutputBlocks where cID = ? and cvID = ?` query)
- Migration 20170118000000 should update the `PageTypeComposerOutputBlocks..cvID` field only once (since that migration is marked as repeatable, users may run it more than once
