### PR TITLE
Keep existing file attribute value when using HTML file input

### DIFF
--- a/concrete/attributes/image_file/controller.php
+++ b/concrete/attributes/image_file/controller.php
@@ -17,6 +17,7 @@ use Concrete\Core\Error\ErrorList\Field\AttributeField;
 use Concrete\Core\File\Importer;
 use Core;
 use File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Controller extends AttributeTypeController implements SimpleTextExportableAttributeInterface
 {
@@ -122,7 +123,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
             $bf = $this->getAttributeValue()->getValue();
         }
         $this->set('mode', $this->getAttributeKeySettings()->getMode());
-        $this->set('file', $bf);
+        $this->set('file', $bf ?: null);
     }
 
     public function importKey(\SimpleXMLElement $akey)
@@ -200,46 +201,51 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
             }
         }
         if ($this->getAttributeKeySettings()->isModeHtmlInput()) {
-            $tmp_name = $_FILES['akID']['tmp_name'][$this->attributeKey->getAttributeKeyID()]['value'];
-            $name = $_FILES['akID']['name'][$this->attributeKey->getAttributeKeyID()]['value'];
-            if (!empty($tmp_name) && is_uploaded_file($tmp_name)) {
-                $fh = \Core::make('helper/validation/file');
-                if (!$fh->file($tmp_name)) {
-                    return new Error(t('You have not uploaded a valid file.'),
-                        new AttributeField($this->getAttributeKey())
-                    );
+            $previousFileID = empty($data['previousFile']) ? 0 : (int) $data['previousFile'];
+            if ($previousFileID !== 0) {
+                $operation = empty($data['operation']) ? 'replace' : $data['operation'];
+                if (in_array($operation, ['keep', 'remove'], true)) {
+                    return true;
                 }
-
-                if (!$fh->extension($name)) {
-                    return new Error(t('Invalid file extension.'),
-                        new AttributeField($this->getAttributeKey())
-                    );
-                }
-
-                return true;
-            } else {
+            }
+            $uploadedFile = array_get($this->request->files->all(), "akID.{$this->attributeKey->getAttributeKeyID()}.value");
+            if (!$uploadedFile instanceof UploadedFile || !$uploadedFile->isValid()) {
                 return new FieldNotPresentError(new AttributeField($this->getAttributeKey()));
             }
+            $name = $uploadedFile->getClientOriginalName();
+            $fh = $this->app->make('helper/validation/file');
+            if (!$fh->extension($name)) {
+                return new Error(t('Invalid file extension.'),
+                    new AttributeField($this->getAttributeKey())
+                );
+            }
+            return true;
         }
     }
 
     public function createAttributeValueFromRequest()
     {
-        $data = $this->post();
         if ($this->getAttributeKeySettings()->isModeFileManager()) {
-            if ($data['value'] > 0) {
-                $f = File::getByID($data['value']);
-
-                return $this->createAttributeValue($f);
+            $fID = (int) $this->post('value');
+            if ($fID !== 0) {
+                return $this->createAttributeValue(File::getByID($fID));
             }
         }
         if ($this->getAttributeKeySettings()->isModeHtmlInput()) {
-            // import the file.
-            $tmp_name = $_FILES['akID']['tmp_name'][$this->attributeKey->getAttributeKeyID()]['value'];
-            $name = $_FILES['akID']['name'][$this->attributeKey->getAttributeKeyID()]['value'];
-            if (!empty($tmp_name) && is_uploaded_file($tmp_name)) {
+            $previousFileID = (int) $this->post('previousFile');
+            if ($previousFileID !== 0) {
+                $operation = $this->post('operation') ?: 'replace';
+                if ($operation === 'remove') {
+                    return $this->createAttributeValue(null);
+                }
+                if ($operation === 'keep') {
+                    return $this->createAttributeValue(File::getByID($previousFileID));
+                }
+            }
+            $uploadedFile = array_get($this->request->files->all(), "akID.{$this->attributeKey->getAttributeKeyID()}.value");
+            if ($uploadedFile instanceof UploadedFile && $uploadedFile->isValid()) {
                 $importer = new Importer();
-                $f = $importer->import($tmp_name, $name);
+                $f = $importer->import($uploadedFile->getPathname(), $uploadedFile->getClientOriginalName());
                 if (is_object($f)) {
                     return $this->createAttributeValue($f->getFile());
                 }

--- a/concrete/attributes/image_file/form.php
+++ b/concrete/attributes/image_file/form.php
@@ -1,12 +1,90 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php
 
-if ($mode == \Concrete\Core\Entity\Attribute\Key\Settings\ImageFileSettings::TYPE_FILE_MANAGER) {
+use Concrete\Core\Entity\Attribute\Key\Settings\ImageFileSettings;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var int $akID
+ * @var Concrete\Attribute\ImageFile\Controller $controller
+ * @var Concrete\Core\Entity\File\File|null $file
+ * @var int $mode
+ * @var array $scopeItems
+ * @var Concrete\Core\Attribute\View $this
+ * @var Concrete\Core\Attribute\View $view
+ */
+
+if ($mode == ImageFileSettings::TYPE_FILE_MANAGER) {
 
     $al = Core::make('helper/concrete/asset_library');
-    print $al->file('ccm-file-akID-' . $controller->getAttributeKey()->getAttributeKeyID(), $this->field('value'), t('Choose File'), $file);
+    echo $al->file('ccm-file-akID-' . $controller->getAttributeKey()->getAttributeKeyID(), $this->field('value'), t('Choose File'), $file);
 
-} else { ?>
+} else {
+    $htmlFileID = trim(preg_replace('/\W+/', '-', $view->field('value')), '-');
+    if ($file === null) {
+        ?>
+        <input type="file" name="<?= h($view->field('value')) ?>" id="<?= $htmlFileID ?>" />
+        <?php
+    } else {
+        $form = Core::make('helper/form');
+        $htmlRadioIDPrefix = trim(preg_replace('/\W+/', '-', $view->field('operation')), '-') . '-';
+        ?>
+        <input type="hidden" name="<?= $view->field('previousFile') ?>" value="<?= $file->getFileID() ?>" />
+        <div class="radio">
+            <label>
+                <?= $form->radio($view->field('operation'), 'keep', true, ['id' => "{$htmlRadioIDPrefix}keep"]) ?>
+                <?= t('Keep existing file (%s)', h($file->getFileName())) ?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?= $form->radio($view->field('operation'), 'remove', false, ['id' => "{$htmlRadioIDPrefix}remove"]) ?>
+                <?= t('Remove current file') ?>
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?= $form->radio($view->field('operation'), 'replace', false, ['id' => "{$htmlRadioIDPrefix}replace"]) ?>
+                <?= t('Replace with') ?>
+                <input type="file" name="<?= h($view->field('value')) ?>" id="<?= $htmlFileID ?>" disabled="disabled" />
+            </label>
+        </div>
+        <?php
+    }
+    ?>
+    <script>
+    (function() {
+        var hook = window.addEventListener ?
+            function (node, eventName, callback) { node.addEventListener(eventName, callback, false); } :
+            function (node, eventName, callback) { node.attachEvent('on' + eventName, callback); }
+        ;
 
-    <input type="file" name="<?=$view->field('value')?>" id="<?=$view->field('value')?>">
+        hook(window, 'load', function () {
+            var fileElement = document.getElementById(<?= json_encode($htmlFileID) ?>);
+            for (var element = fileElement; element && element != document.body; element = element.parentNode || element.parentElement) {
+                if (typeof element.nodeName === 'string' && element.nodeName.toLowerCase() === 'form') {
+                    if (typeof element.enctype !== 'string' || element.enctype === '' || element.enctype.toLowerCase() === 'application/x-www-form-urlencoded') {
+                        element.enctype = 'multipart/form-data';
+                    }
+                    break;
+                }
+            }
+            <?php
+            if ($file !== null) {
+                ?>
+                var options = {},
+                    updateDisabled = function () {
+                        fileElement.disabled = !options.replace.checked;
+                    };
+                for (var optionValues = ['keep', 'remove', 'replace'], i = 0; i < optionValues.length; i++) {
+                    options[optionValues[i]] = document.getElementById(<?= json_encode($htmlRadioIDPrefix) ?> + optionValues[i]);
+                    hook(options[optionValues[i]], 'change', updateDisabled);
+                }
+                <?php
+            }
+            ?>
+        });
+    })();
+    </script>
 
 <?php } ?>


### PR DESCRIPTION
When using a File/Image attribute configured to use an HTML file input, we have the issue described in #4678 and #5599: when we edit an existing entity, we don't have a way to keep the previously selected file.

What about asking users what they want to do in this case?

Fix #4678
Fix #5599