### PR TITLE
Handling of NULL values for Number attributes

### DIFF
--- a/concrete/attributes/number/controller.php
+++ b/concrete/attributes/number/controller.php
@@ -20,9 +20,16 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
         return new FontAwesomeIconFormatter('hashtag');
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see \Concrete\Core\Attribute\AttributeInterface::getDisplayValue()
+     */
     public function getDisplayValue()
     {
-        return (float) ($this->attributeValue->getValue());
+        $value = $this->attributeValue->getValue();
+
+        return $value === null ? '' : (float) $value;
     }
 
     public function getAttributeValueClass()

--- a/concrete/attributes/number/controller.php
+++ b/concrete/attributes/number/controller.php
@@ -80,7 +80,6 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     public function createAttributeValue($value)
     {
         $av = new NumberValue();
-        $value = ($value == false || $value == '0') ? 0 : $value;
         $av->setValue($value);
 
         return $av;

--- a/concrete/src/Entity/Attribute/Value/Value/NumberValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/NumberValue.php
@@ -32,11 +32,8 @@ class NumberValue extends AbstractValue
      */
     public function setValue($value)
     {
-        if ($value === null || $value === '') {
-            $this->value = null;
-        } else {
-            $this->value = (string) $value;
-        }
+        $value = (string) $value;
+        $this->value = $value === '' ? null : $value;
     }
 
     public function __toString()


### PR DESCRIPTION
Number attributes may contain `NULL` values, which is very different from `0`.
So:
1. we should let the system create `NULL` values (see 4345d33dc3f8942ff80bec0ecb65caa5e154f938)
1. we should display an empty value instead of `0` when the value is `NULL` (see 2728459aab9a00e4029d933eda79da448e518724)
