### PR TITLE
Migrate Symfony 3.2- trusted header configuration to Symfony 3.3+

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2a1',
     'version_installed' => '8.5.2a1',
-    'version_db' => '20190301133300', // the key of the latest database migration
+    'version_db' => '20190530123000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -15,7 +15,6 @@ use Concrete\Core\Routing\SystemRouteList;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Support\Facade\Route;
 use Illuminate\Config\Repository;
-use Symfony\Component\HttpFoundation\Request as SymphonyRequest;
 use Symfony\Component\HttpFoundation\Response;
 
 class DefaultBooter implements BootInterface, ApplicationAwareInterface
@@ -398,39 +397,7 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
          */
         $trustedProxiesIps = $config->get('concrete.security.trusted_proxies.ips');
         if ($trustedProxiesIps) {
-            $proxyHeaders = $config->get('concrete.security.trusted_proxies.headers');
-            if (defined(SymphonyRequest::class . '::HEADER_X_FORWARDED_ALL')) {
-                // Symphony 3.3+
-                if (is_array($proxyHeaders)) {
-                    $proxyHeadersBitfield = 0;
-                    $legacyValues = [
-                        'forwarded' => Request::HEADER_FORWARDED,
-                        'client_ip' => Request::HEADER_X_FORWARDED_FOR,
-                        'client_host' => Request::HEADER_X_FORWARDED_HOST,
-                        'client_proto' => Request::HEADER_X_FORWARDED_PROTO,
-                        'client_port' => Request::HEADER_X_FORWARDED_PORT,
-                    ];
-                    foreach ($proxyHeaders as $proxyHeader) {
-                        if (isset($legacyValues[$proxyHeader])) {
-                            $proxyHeadersBitfield |= $legacyValues[$proxyHeader];
-                        }
-                    }
-                } else {
-                    $proxyHeadersBitfield = (int) $proxyHeaders;
-                }
-                if ($proxyHeadersBitfield === 0) {
-                    $proxyHeadersBitfield = -1;
-                }
-                Request::setTrustedProxies($trustedProxiesIps, $proxyHeadersBitfield);
-            } else {
-                // Symphony 3.2-
-                if (is_array($proxyHeaders)) {
-                    foreach ($proxyHeaders as $key => $value) {
-                        Request::setTrustedHeaderName($key, $value);
-                    }
-                }
-                Request::setTrustedProxies($trustedProxiesIps);
-            }
+            Request::setTrustedProxies($trustedProxiesIps, (int) $config->get('concrete.security.trusted_proxies.headers'));
         }
 
         /*

--- a/concrete/src/Updater/Migrations/Migrations/Version20190530123000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190530123000.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class Version20190530123000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        // Convert trusted headers from Symfony 3.2- to Symfony 3.3+
+        $config = $this->app->make('config');
+        $configKey = 'concrete.security.trusted_proxies.headers';
+        $headers = $config->get($configKey);
+        if (is_array($headers)) {
+            $flags = $this->convertNamesToFlags($headers);
+        } else {
+            $flags = (int) $headers;
+        }
+        $config->set($configKey, $flags);
+        $config->save($configKey, $flags);
+    }
+
+    /**
+     * Get the mapping from the Symfony 3.2- header names and the Symfony 3.3+ bit flags.
+     *
+     * @return array
+     */
+    protected function getNameToFlagMap()
+    {
+        return [
+            'forwarded' => Request::HEADER_FORWARDED,
+            'client_ip' => Request::HEADER_X_FORWARDED_FOR,
+            'client_host' => Request::HEADER_X_FORWARDED_HOST,
+            'client_proto' => Request::HEADER_X_FORWARDED_PROTO,
+            'client_port' => Request::HEADER_X_FORWARDED_PORT,
+        ];
+    }
+
+    /**
+     * Convert a list of Symfony 3.2- header names to an integer using the Symfony 3.3+ bit flags.
+     *
+     * @param string[] $names
+     *
+     * @return int
+     */
+    protected function convertNamesToFlags(array $names)
+    {
+        $result = 0;
+        $map = $this->getNameToFlagMap();
+        foreach ($names as $name) {
+            if (isset($map[$name])) {
+                $result |= $map[$name];
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Since #7466 got merged, concrete5 requires at least `symfony/http-foundation` version 3.4.17.

Before that PR got merged, we could use an older version of that library (for example, in concrete5 8.0.3 we were using version 3.1.4).

Since version 3.2, the definition of the trusted headers changed from a list of header names (eg `'forwarded'`, `'client_ip'`, ...) to an integer (whose bits represents the trusted headers).

This PR converts the former configuration to the new configuration.