### PR TITLE
Add GUI to configure trusted headers received by a proxy

### DIFF
--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -886,7 +886,7 @@
               filename="/dashboard/system/permissions/trusted_proxies.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>trusted, proxy, proxies, ip, cloudflare</value>
+                    <value>trusted, proxy, proxies, ip, header, cloudflare</value>
                 </attributekey>
             </attributes>
         </page>

--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -47,6 +47,15 @@ class TrustedProxies extends DashboardPageController
         $this->set('trustedHeaders', $this->getTrustedHeaderNames());
         $this->set('requestForwardedHeaders', $this->getRequestForwardedHeaders());
         $this->set('request', $this->request);
+        $currentProxyIP = null;
+        if ($this->request->isFromTrustedProxy()) {
+            $clientIP = Factory::addressFromString($this->request->getClientIp());
+            $rawClientIP  = Factory::addressFromString($this->request->server->get('REMOTE_ADDR'));
+            if ((string) $clientIP !== (string) $rawClientIP) {
+                $currentProxyIP = $rawClientIP;
+            }
+        }
+        $this->set('currentProxyIP', $currentProxyIP); 
     }
 
     public function save()

--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -2,12 +2,39 @@
 
 namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions;
 
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use IPLib\Factory;
 use IPLib\Range\Pattern;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TrustedProxies extends DashboardPageController
 {
+    /**
+     * @var string
+     */
+    const HEADERNAME_FORWARDED = 'FORWARDED';
+
+    /**
+     * @var string
+     */
+    const HEADERNAME_X_FORWARDED_FOR = 'X_FORWARDED_FOR';
+
+    /**
+     * @var string
+     */
+    const HEADERNAME_X_FORWARDED_HOST = 'X_FORWARDED_HOST';
+
+    /**
+     * @var string
+     */
+    const HEADERNAME_X_FORWARDED_PROTO = 'X_FORWARDED_PROTO';
+
+    /**
+     * @var string
+     */
+    const HEADERNAME_X_FORWARDED_PORT = 'X_FORWARDED_PORT';
+
     public function view()
     {
         $config = $this->app->make('config');
@@ -16,54 +43,145 @@ class TrustedProxies extends DashboardPageController
             $trustedIPs = [];
         }
         $this->set('trustedIPs', $trustedIPs);
+        $this->set('trustableHeaders', $this->getTrustableHeaderNames());
+        $this->set('trustedHeaders', $this->getTrustedHeaderNames());
+        $this->set('requestForwardedHeaders', $this->getRequestForwardedHeaders());
+        $this->set('request', $this->request);
     }
 
     public function save()
     {
-        if ($this->token->validate('ccm_trusted_proxies_save')) {
-            $post = $this->request->request;
-            $this->parseIPList($post->get('trustedIPs'), $validIPs, $invalidIPs);
-            $numInvalid = count($invalidIPs);
-            if ($numInvalid > 0) {
-                $this->error->add(t2('This IP address is not valid: %2$s', 'These IP addresses are not valid: %2$s', $numInvalid, "\n- " . implode("\n- ", $invalidIPs)));
-            }
-            if (!$this->error->has()) {
-                $config = $this->app->make('config');
-                $config->save('concrete.security.trusted_proxies.ips', $validIPs);
-                $this->flash('success', t('The trusted proxies configuration has been updated.'));
-                $this->redirect($this->action(''));
-            }
-        } else {
+        if (!$this->token->validate('ccm_trusted_proxies_save')) {
             $this->error->add($this->token->getErrorMessage());
         }
-        $this->view();
+        $post = $this->request->request;
+        list($validIPs, $invalidIPs) = $this->parseIPList($post->get('trustedIPs'));
+        $numInvalid = count($invalidIPs);
+        if ($numInvalid > 0) {
+            $this->error->add(t2('This IP address is not valid: %2$s', 'These IP addresses are not valid: %2$s', $numInvalid, "\n- " . implode("\n- ", $invalidIPs)));
+        }
+        $trustedHeaderFlags = 0;
+        $trustedHeaderNames = $post->get('trustedHeaders');
+        if (is_array($trustedHeaderNames)) {
+            $map = $this->getSymfonyHeadersMap();
+            foreach ($trustedHeaderNames as $trustedHeaderName) {
+                $flag = array_search($trustedHeaderName, $map, true);
+                if ($flag !== false) {
+                    $trustedHeaderFlags |= (int) $flag;
+                }
+            }
+        }
+
+        if ($this->error->has()) {
+            $this->view();
+
+            return;
+        }
+        $config = $this->app->make('config');
+        $config->save('concrete.security.trusted_proxies.ips', $validIPs);
+        $config->save('concrete.security.trusted_proxies.headers', $trustedHeaderFlags);
+        $this->flash('success', t('The configuration has been updated.'));
+
+        return $this->app->make(ResponseFactoryInterface::class)->redirect(
+            $this->action(''),
+            302
+        );
     }
 
     /**
-     * @param string $input
-     * @param string[] $validIPs
-     * @param string[] $invalidIPs
+     * @param string|mixed $input
+     *
+     * @return string[][]
      */
-    private function parseIPList($input, &$validIPs, &$invalidIPs)
+    protected function parseIPList($input)
     {
         $validIPs = [];
         $invalidIPs = [];
         if (is_string($input)) {
-            if (preg_match_all('/\S+/', $input, $matches)) {
-                foreach ($matches[0] as $rawRange) {
-                    if (!in_array($rawRange, $invalidIPs, true)) {
-                        $range = Factory::rangeFromString($rawRange);
-                        if ($range === null || $range instanceof Pattern) {
-                            $invalidIPs[] = $rawRange;
-                        } else {
-                            $range = (string) $range;
-                            if (!in_array($range, $validIPs, true)) {
-                                $validIPs[] = $range;
-                            }
+            foreach (preg_split('/\s+/', $input, -1, PREG_SPLIT_NO_EMPTY) as $rawRange) {
+                if (!in_array($rawRange, $invalidIPs, true)) {
+                    $range = Factory::rangeFromString($rawRange);
+                    if ($range === null || $range instanceof Pattern) {
+                        $invalidIPs[] = $rawRange;
+                    } else {
+                        $range = (string) $range;
+                        if (!in_array($range, $validIPs, true)) {
+                            $validIPs[] = $range;
                         }
                     }
                 }
             }
         }
+
+        return [$validIPs, $invalidIPs];
+    }
+
+    /**
+     * Get the list of headers that can be marked as trusted.
+     *
+     * @return string[]
+     */
+    protected function getTrustableHeaderNames()
+    {
+        return [
+            static::HEADERNAME_FORWARDED,
+            static::HEADERNAME_X_FORWARDED_FOR,
+            static::HEADERNAME_X_FORWARDED_HOST,
+            static::HEADERNAME_X_FORWARDED_PROTO,
+            static::HEADERNAME_X_FORWARDED_PORT,
+        ];
+    }
+
+    /**
+     * Get the map from the Symfony header bits to the header names.
+     *
+     * @return array
+     */
+    protected function getSymfonyHeadersMap()
+    {
+        return [
+            SymfonyRequest::HEADER_FORWARDED => static::HEADERNAME_FORWARDED,
+            SymfonyRequest::HEADER_X_FORWARDED_FOR => static::HEADERNAME_X_FORWARDED_FOR,
+            SymfonyRequest::HEADER_X_FORWARDED_HOST => static::HEADERNAME_X_FORWARDED_HOST,
+            SymfonyRequest::HEADER_X_FORWARDED_PROTO => static::HEADERNAME_X_FORWARDED_PROTO,
+            SymfonyRequest::HEADER_X_FORWARDED_PORT => static::HEADERNAME_X_FORWARDED_PORT,
+        ];
+    }
+
+    /**
+     * Get the currently configured trusted header names.
+     *
+     * @return string[]
+     */
+    protected function getTrustedHeaderNames()
+    {
+        $result = [];
+        $flags = (int) $this->app->make('config')->get('concrete.security.trusted_proxies.headers');
+        $map = $this->getSymfonyHeadersMap();
+        foreach ($map as $headerFlag => $headerName) {
+            if ((int) $headerFlag & $flags) {
+                $result[] = $headerName;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract the prospective forwarded header names and their values.
+     *
+     * @return array
+     */
+    protected function getRequestForwardedHeaders()
+    {
+        $result = [];
+        $server = $this->request->server;
+        foreach ($this->getTrustableHeaderNames() as $name) {
+            if ($server->has("HTTP_{$name}")) {
+                $result[$name] = $server->get("HTTP_{$name}");
+            }
+        }
+
+        return $result;
     }
 }

--- a/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
@@ -1,18 +1,35 @@
 <?php
+use Punic\Misc;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var Concrete\Core\Form\Service\Form $form */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
-/* @var Concrete\Core\Page\View\PageView $view */
-
-/* @var array $trustedIPs */
-
+/**
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\TrustedProxies $controller
+ * @var string[] $trustedIPs
+ * @var string[] $trustableHeaders
+ * @var string[] $trustedHeaders
+ * @var array[] $requestForwardedHeaders
+ * @var Concrete\Core\Http\Request $request
+ */
 ?>
 <form method="post" action="<?= $view->action('save') ?>">
     <?php $token->output('ccm_trusted_proxies_save') ?>
 
+    <?php
+    if (count($requestForwardedHeaders) === 0) {
+        ?>
+        <div class="alert alert-warning">
+            <p><?= t('No forwarded header has been detected. This may mean that you are not using a proxy and that all the following options should be empty.') ?></p>
+        </div>
+        <?php
+    }
+    ?>
+
     <div class="form-group">
-        <?= $form->label('trustedIPs', t('List of IP address/ranges of our proxy')) ?>
+        <?= $form->label('trustedIPs', t('List of IP address/ranges of your proxy')) ?>
         <?= $form->textarea('trustedIPs', implode("\n", $trustedIPs), ['style' => 'resize:vertical', 'rows' => '10']) ?>
         <div class="text-muted">
             <?= t('Separate IP addresses with spaces or new lines.') ?><br />
@@ -24,6 +41,71 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 '<code>::1/8</code>'
             ) ?><br />
         </div>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('trustedHeaders', t('List of headers that should be trusted')) ?>
+        <?php
+        foreach ($trustableHeaders as $trustableHeader) {
+            ?>
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('trustedHeaders[]', $trustableHeader, in_array($trustableHeader, $trustedHeaders, true)) ?>
+                    <code><?= h($trustableHeader) ?></code>
+                </label>
+            </div>
+            <?php
+        }
+        ?>
+        <div class="alert alert-info">
+            <p><?= t('Notes: ')?></p>
+            <ul>
+                <li><?= t('The checked headers above will be trusted only when PHP detects that the connection is made via a trusted proxy') ?></li>
+                <li><?= t(/*%s is the name of an HTTP header*/'The %s header should be selected when using RFC 7239', '<code>' . $controller::HEADERNAME_FORWARDED . '</code>') ?>
+                <li><?= t('The other headers starting with %1$s are not standard but are widely used by popular reverse proxies (like %2$s).', '<code>X_...</code>', Misc::join(['Apache mod_proxy', 'Amazon EC2']))?> 
+            </ul>
+            <?php
+            if (count($requestForwardedHeaders) > 0) {
+                ?>
+                <br />
+                <p><?= t('In the current request, the following headers are present (you may want to select them - and only them):')?></p>
+                <ul>
+                    <?php
+                    foreach ($requestForwardedHeaders as $requestForwardedHeaderName => $requestForwardedHeaderValue) {
+                        ?>
+                        <li>
+                            <?php
+                            if (is_string($requestForwardedHeaderValue)) {
+                                echo t('%s (value: %s)', '<code>' . h($requestForwardedHeaderName) . '</code>', '<code>' . h($requestForwardedHeaderValue) . '</code>');
+                            } else {
+                                echo '<code>' . h($requestForwardedHeaderName) . '</code>';
+                            }
+                            ?>
+                        </li>
+                        <?php
+                    }
+                    ?>
+                </ul>
+                <?php
+            }
+            ?>
+        </div>
+    </div>
+
+    <div class="alert alert-info">
+        <p><?= t('With the currently configured IPs and headers, PHP detected these values:') ?></p>
+        <dl class="dl-horizontal">
+            <dt><?= t('Protocol') ?></dt>
+            <dd><?= h($request->getScheme()) ?></dd>
+            <dt><?= t('Protocol version') ?></dt>
+            <dd><?= h($request->getProtocolVersion()) ?></dd>
+            <dt><?= t('Host') ?></dt>
+            <dd><?= h($request->getHost()) ?></dd>
+            <dt><?= t('Port') ?></dt>
+            <dd><?= h($request->getPort()) ?></dd>
+            <dt><?= t('Client IP') ?></dt>
+            <dd><?= h($request->getClientIp()) ?></dd>
+        </dl>
     </div>
 
     <div class="ccm-dashboard-form-actions-wrapper">

--- a/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
@@ -58,42 +58,34 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <?php
         }
         ?>
-        <div class="alert alert-info">
-            <p><?= t('Notes: ')?></p>
-            <ul>
-                <li><?= t('The checked headers above will be trusted only when PHP detects that the connection is made via a trusted proxy') ?></li>
-                <li><?= t(/*%s is the name of an HTTP header*/'The %s header should be selected when using RFC 7239', '<code>' . $controller::HEADERNAME_FORWARDED . '</code>') ?>
-                <li><?= t('The other headers starting with %1$s are not standard but are widely used by popular reverse proxies (like %2$s).', '<code>X_...</code>', Misc::join(['Apache mod_proxy', 'Amazon EC2']))?> 
-            </ul>
-            <?php
-            if (count($requestForwardedHeaders) > 0) {
-                ?>
-                <br />
-                <p><?= t('In the current request, the following headers are present (you may want to select them - and only them):')?></p>
-                <ul>
-                    <?php
-                    foreach ($requestForwardedHeaders as $requestForwardedHeaderName => $requestForwardedHeaderValue) {
-                        ?>
-                        <li>
-                            <?php
-                            if (is_string($requestForwardedHeaderValue)) {
-                                echo t('%s (value: %s)', '<code>' . h($requestForwardedHeaderName) . '</code>', '<code>' . h($requestForwardedHeaderValue) . '</code>');
-                            } else {
-                                echo '<code>' . h($requestForwardedHeaderName) . '</code>';
-                            }
-                            ?>
-                        </li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-                <?php
-            }
-            ?>
-        </div>
     </div>
 
     <div class="alert alert-info">
+        <?php
+        if (count($requestForwardedHeaders) > 0) {
+            ?>
+            <p><?= t('In the current request, the following headers are present (you may want to select them - and only them):')?></p>
+            <ul>
+                <?php
+                foreach ($requestForwardedHeaders as $requestForwardedHeaderName => $requestForwardedHeaderValue) {
+                    ?>
+                    <li>
+                        <?php
+                        if (is_string($requestForwardedHeaderValue)) {
+                            echo t('%s (value: %s)', '<code>' . h($requestForwardedHeaderName) . '</code>', '<code>' . h($requestForwardedHeaderValue) . '</code>');
+                        } else {
+                            echo '<code>' . h($requestForwardedHeaderName) . '</code>';
+                        }
+                        ?>
+                    </li>
+                    <?php
+                }
+                ?>
+            </ul>
+            <br />
+            <?php
+        }
+        ?>
         <p><?= t('With the currently configured IPs and headers, PHP detected these values:') ?></p>
         <dl class="dl-horizontal">
             <dt><?= t('Protocol') ?></dt>

--- a/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
@@ -13,6 +13,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var string[] $trustedHeaders
  * @var array[] $requestForwardedHeaders
  * @var Concrete\Core\Http\Request $request
+ * @var IPLib\Address\AddressInterface|null $currentProxyIP
  */
 ?>
 <form method="post" action="<?= $view->action('save') ?>">
@@ -105,6 +106,16 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <dd><?= h($request->getPort()) ?></dd>
             <dt><?= t('Client IP') ?></dt>
             <dd><?= h($request->getClientIp()) ?></dd>
+            <dt><?= t('Using Proxy') ?></dt>
+            <dd><?= $currentProxyIP === null ? t('No') : t('Yes') ?></dd>
+            <?php
+            if ($currentProxyIP !== null) {
+                ?>
+                <dt><?= t('Proxy IP') ?></dt>
+                <dd><?= h((string) $currentProxyIP) ?></dd>
+                <?php
+            }
+            ?>
         </dl>
     </div>
 

--- a/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/single_pages/dashboard/system/permissions/trusted_proxies.php
@@ -1,5 +1,4 @@
 <?php
-use Punic\Misc;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 

--- a/concrete/src/Application/Service/UserInterface/Help/DashboardManager.php
+++ b/concrete/src/Application/Service/UserInterface/Help/DashboardManager.php
@@ -37,7 +37,12 @@ class DashboardManager extends AbstractManager
             '/dashboard/system/permissions/tasks' => t("Control users' ability to do perform specific tasks, such as install packages, alter permissions, etc."),
             '/dashboard/system/permissions/file_types' => t('View and change which file types you permit users to upload to your File Manager.'),
             '/dashboard/system/permissions/files' => t("Control how users interact with your site's File Manager, allowing or disallowing actions like search, upload, replace and more."),
-            '/dashboard/system/permissions/trusted_proxies' => t('If your website uses a reverse proxy (like <a href="%s" target="_blank">Cloudflare</a>), you have to specify here the list of the IP addresses of the proxy, so that concrete5 can detect the actual IP address of the visitors.', 'https://www.cloudflare.com/ips/'),
+            '/dashboard/system/permissions/trusted_proxies' => implode('<br /><br />', [
+                t('If your website uses a reverse proxy (like <a href="%s" target="_blank">Cloudflare</a>), you have to specify here the list of the IP addresses of the proxy, so that concrete5 can detect the actual IP address of the visitors.', 'https://www.cloudflare.com/ips/'),
+                t('The checked headers will be trusted only when PHP detects that the connection is made via a trusted proxy.'),
+                t(/*%s is the name of an HTTP header*/'The %s header should be selected when using RFC 7239.', '<code>FORWARDED</code>'),
+                t('The other headers starting with %1$s are not standard but are widely used by popular reverse proxies (like %2$s).', '<code>X_...</code>', 'Apache mod_proxy/Amazon EC2'),
+            ]),
             '/dashboard/system/basics/editor' => t("Control which set of tools the content-editor toolbar includes (e.g., Simple, Advanced, Office), and the toolbar's spatial dimensions."),
             '/dashboard/system/basics/multilingual' => t('View available language packs installed for the concrete5 Dashboard and editing interface.'),
             '/dashboard/system/basics/multilingual/update' => t('Install new language files and update the outdated ones.<br />You can contribute to translations on %s', '<a href="https://translate.concrete5.org" target="_blank">translate.concrete5.org</a>.'),

--- a/concrete/src/Updater/Migrations/Migrations/Version20180920000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180920000000.php
@@ -9,6 +9,6 @@ class Version20180920000000 extends AbstractMigration implements RepeatableMigra
 {
     public function upgradeDatabase()
     {
-        $this->createSinglePage('/dashboard/system/permissions/trusted_proxies', 'Trusted Proxies', ['meta_keywords' => 'trusted, proxy, proxies, ip, cloudflare']);
+        $this->createSinglePage('/dashboard/system/permissions/trusted_proxies', 'Trusted Proxies', ['meta_keywords' => 'trusted, proxy, proxies, ip, header, cloudflare']);
     }
 }


### PR DESCRIPTION
We have a nice page to configure the trusted proxies, but we lacks a GUI to configure which headers should be trusted (so, that page is actually useless: you still have to manually set the `'concrete.security.trusted_proxies.headers` configuration key).

The result  of this PR will be:

- when using a proxy:  
![proxy](https://user-images.githubusercontent.com/928116/58640723-faefd500-82f9-11e9-8ef5-56324a12585f.png)
- when NOT using a proxy:  
![no-proxy](https://user-images.githubusercontent.com/928116/58640892-53bf6d80-82fa-11e9-9a99-00155a4df2ee.png)
