### PR TITLE
Add the author column on express entries CSV export.

### DIFF
--- a/concrete/src/Entity/Express/Entry.php
+++ b/concrete/src/Entity/Express/Entry.php
@@ -442,7 +442,7 @@ class Entry implements \JsonSerializable, PermissionObjectInterface, AttributeOb
     }
 
     /**
-     * @return mixed
+     * @return \Concrete\Core\Entity\User\User
      */
     public function getAuthor()
     {

--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -92,6 +92,13 @@ class CsvWriter
             yield 'ccm_date_created' => null;
         }
 
+        $author = $entry->getAuthor();
+        if ($author) {
+            yield 'author_name' => $author->getUserInfoObject()->getUserDisplayName();
+        } else {
+            yield 'author_name' => null;
+        }
+
         $attributes = $entry->getAttributes();
         foreach ($attributes as $attribute) {
             yield $attribute->getAttributeKey()->getAttributeKeyHandle() => $attribute->getPlainTextValue();
@@ -106,6 +113,7 @@ class CsvWriter
     private function getHeaders(Entity $entity)
     {
         yield 'ccm_date_created' => 'dateCreated';
+        yield 'author_name' => 'authorName';
 
         $attributes = $entity->getAttributes();
         foreach ($attributes as $attribute) {

--- a/tests/tests/Express/Export/EntryList/CsvWriterTest.php
+++ b/tests/tests/Express/Export/EntryList/CsvWriterTest.php
@@ -7,9 +7,11 @@ use Concrete\Core\Entity\Attribute\Key\ExpressKey;
 use Concrete\Core\Entity\Attribute\Value\ExpressValue;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Entity\Express\Entry;
+use Concrete\Core\Entity\User\User;
 use Concrete\Core\Express\EntryList;
 use Concrete\Core\Express\Export\EntryList\CsvWriter;
 use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\User\UserInfo;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use League\Csv\Writer;
@@ -38,7 +40,12 @@ class CsvWriterTest extends \PHPUnit_Framework_TestCase
         $entry = M::mock(Entry::class);
 
         $created = Carbon::now()->subDays(mt_rand(1, 10000));
+        $userInfo = M::mock(UserInfo::class);
+        $userInfo->shouldReceive('getUserDisplayName')->andReturn('author name');
+        $author = M::mock(User::class);
+        $author->shouldReceive('getUserInfoObject')->andReturn($userInfo);
         $entry->shouldReceive('getDateCreated')->andReturn($created);
+        $entry->shouldReceive('getAuthor')->andReturn($author);
         $entry->shouldReceive('getAttributes')->andReturn($entryKeys);
 
         $list = M::mock(TestEntryList::class);
@@ -62,6 +69,7 @@ class CsvWriterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame([
             'ccm_date_created' => 'dateCreated',
+            'author_name' => 'authorName',
             'foo' => 'Foo',
             'bar' => 'Bar',
             'baz' => 'Baz',
@@ -70,6 +78,7 @@ class CsvWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame([
             [
                 'ccm_date_created' => 'not now',
+                'author_name' => 'author name',
                 'foo' => 'Foo value',
                 'bar' => 'BAR value',
                 'baz' => 'Baz value',


### PR DESCRIPTION
We can add an author to the Express entries since 8.5.0, but it is not included in the exported CSV file.

https://github.com/concrete5/concrete5/pull/7023

Let's add the author column on CSV export.