### PR TITLE
Fix editor plugins when using multisite

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -304,7 +304,7 @@ EOL;
         $this->config->save('editor.concrete.enable_filemanager', (bool) $request->request->get('enable_filemanager'));
         $this->config->save('editor.concrete.enable_sitemap', (bool) $request->request->get('enable_sitemap'));
 
-        $selected = $this->config->get('editor.ckeditor4.plugins.selected_hidden');
+        $selected = (array) $this->config->get('editor.ckeditor4.plugins.selected_hidden', []);
         $post = $request->request->get('plugin');
         if (is_array($post)) {
             $selected = array_merge($selected, $post);

--- a/concrete/src/Editor/EditorServiceProvider.php
+++ b/concrete/src/Editor/EditorServiceProvider.php
@@ -4,11 +4,13 @@ namespace Concrete\Core\Editor;
 
 use AssetList;
 use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Liaison;
+use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 use Concrete\Core\Legacy\FilePermissions;
 use Concrete\Core\Legacy\TaskPermission;
 use Concrete\Core\Localization\Localization;
-use Concrete\Core\Site\Config\Liaison;
+use Concrete\Core\Site\Service;
 
 class EditorServiceProvider extends ServiceProvider
 {
@@ -17,25 +19,20 @@ class EditorServiceProvider extends ServiceProvider
         $this->app->singleton(
             CkeditorEditor::class,
             function (Application $app) {
-                $config = $app->make('site')->getSite()->getConfigRepository();
+                $siteService = $app->make('site');
+                $activeSite = $siteService->getActiveSiteForEditing();
+                $config = $activeSite->getConfigRepository();
+
                 $styles = $config->get('editor.ckeditor4.styles', []);
+
+                // Load plugins and select the site specific ones
                 $pluginManager = new PluginManager();
-                $selectedPlugins = $config->get('editor.ckeditor4.plugins.selected');
-                if (!is_array($selectedPlugins)) {
-                    $defaultPlugins = [];
-                    $selectedHiddenPlugins = [];
-                    if (is_array($config->get('editor.ckeditor4.plugins.selected_default'))) {
-                        $defaultPlugins = $config->get('editor.ckeditor4.plugins.selected_default');
-                    }
-                    if (is_array($config->get('editor.ckeditor4.plugins.selected_hidden'))) {
-                        $selectedHiddenPlugins = $config->get('editor.ckeditor4.plugins.selected_hidden');
-                    }
-                    $selectedPlugins = array_merge($defaultPlugins, $selectedHiddenPlugins);
-                }
-                $pluginManager->select($selectedPlugins);
                 $this->registerCkeditorPlugins($pluginManager);
                 $this->registerCorePlugins($pluginManager);
-                $editor = $app->build(CkeditorEditor::class, ['config' => $config, 'pluginManager' => $pluginManager, 'styles' => $styles]);
+                $pluginManager->select($this->resolveSelectedPlugins($activeSite, $config, $siteService));
+
+                $editor = $app->build(CkeditorEditor::class,
+                    ['config' => $config, 'pluginManager' => $pluginManager, 'styles' => $styles]);
                 $editor->setToken($app->make('token')->generate('editor'));
 
                 $filePermission = FilePermissions::getGlobal();
@@ -356,5 +353,40 @@ class EditorServiceProvider extends ServiceProvider
         $plugin->setName(t('concrete5 Styles'));
         $plugin->requireAsset('editor/ckeditor4/concrete5styles');
         $pluginManager->register($plugin);
+    }
+
+    /**
+     * Find the selected ckeditor plugins
+     *
+     * @param \Concrete\Core\Entity\Site\Site $activeSite
+     * @param \Concrete\Core\Config\Repository\Liaison $config
+     * @param \Concrete\Core\Site\Service $siteService
+     *
+     * @return array
+     */
+    protected function resolveSelectedPlugins(Site $activeSite, Liaison $config, Service $siteService)
+    {
+        // Load the selected plugins from the current site
+        $selectedPlugins = $config->get('editor.ckeditor4.plugins.selected');
+
+        if (!is_array($selectedPlugins)) {
+            // Resolve the default config to use
+            if ($activeSite->getSiteHandle() === 'default') {
+                $defaultConfig = $config;
+            } else {
+                $defaultConfig = $siteService->getDefault()->getConfigRepository();
+            }
+
+            // Load in default selected plugins and hidden plugins
+            $selectedPlugins = (array) $defaultConfig->get('editor.ckeditor4.plugins.selected_default', []);
+        }
+
+        // Load in local site selected hidden
+        if ($activeSite->getSiteHandle() !== 'default') {
+            $selectedHidden = (array) $config->get('editor.ckeditor4.plugins.selected_hidden', []);
+            $selectedPlugins = array_merge($selectedPlugins, $selectedHidden);
+        }
+
+        return $selectedPlugins;
     }
 }


### PR DESCRIPTION
The current version of the `EditorServiceProvider` has two issues that are resolved by this pr:
1. When using multisite the dashboard page to edit plugins doesn't actually save for the site you're editing
2. When no custom plugins have been selected for a site other than default, no default plugins are selected.