### PR TITLE
Set Name as URL-Slug for External Link

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -982,7 +982,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
         // make the handle out of the title
         $cLink = $ds->sanitizeURL($cLink);
-        $handle = $dt->urlify($cLink);
+        $handle = $dt->urlify($cName);
         $data = [
             'handle' => $handle,
             'name' => $cName,


### PR DESCRIPTION
I think it makes more sense than setting the linkname as url slug.