### PR TITLE
Fix arranging stacks in pages

### DIFF
--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -97,9 +97,8 @@ class ArrangeBlocks extends Page
 
                     return;
                 }
-                $bt = $block->getBlockTypeObject();
-                if (!$destAP->canAddBlock($bt)) {
-                    $e->add(t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destinationAreaHandle));
+                if (!$destAP->canAddBlock($block)) {
+                    $e->add(t('You may not add %s to area %s.', t($block->getBlockTypeObject()->getBlockTypeName()), $destinationAreaHandle));
 
                     return;
                 }

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -33,10 +33,11 @@ class ArrangeBlocks extends Page
     protected function performArrangement(PageEditResponse $pc)
     {
         $e = $pc->getError();
+        $post = $this->request->request;
 
         $nvc = $this->page->getVersionToModify();
-        $sourceAreaID = intval($_POST['sourceArea']);
-        $destinationAreaID = intval($_POST['area']);
+        $sourceAreaID = (int) $post->get('sourceArea');
+        $destinationAreaID = (int) $post->get('area');
 
         if (Config::get('concrete.permissions.model') == 'advanced') {
             // first, we check to see if we have permissions to edit the area contents for the source area.
@@ -63,9 +64,9 @@ class ArrangeBlocks extends Page
                 // a block of this type to the destination area.
                 if ($ar->isGlobalArea()) {
                     $stack = Stack::getByName($arHandle);
-                    $b = Block::getByID($_REQUEST['block'], $stack, STACKS_AREA_NAME);
+                    $b = Block::getByID((int) $post->get('block'), $stack, STACKS_AREA_NAME);
                 } else {
-                    $b = Block::getByID($_REQUEST['block'], $nvc, $arHandle);
+                    $b = Block::getByID((int) $post->get('block'), $nvc, $arHandle);
                 }
                 $bt = $b->getBlockTypeObject();
                 if (!$destAP->canAddBlock($bt)) {
@@ -90,7 +91,7 @@ class ArrangeBlocks extends Page
                 $stack = Stack::getByName($source_area->getAreaHandle());
                 $stackToModify = $stack->getVersionToModify();
                 $nvc->relateVersionEdits($stackToModify);
-                $block = Block::getByID($_POST['block'], $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
+                $block = Block::getByID((int) $post->get('block'), $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
                 $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
 
@@ -102,9 +103,9 @@ class ArrangeBlocks extends Page
                 if ($source_area->isGlobalArea()) {
                     $sourceStackToModify = Stack::getByName($source_area->getAreaHandle())->getVersionToModify();
                     $nvc->relateVersionEdits($sourceStackToModify);
-                    $block = Block::getByID($_POST['block'], $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
+                    $block = Block::getByID((int) $post->get('block'), $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
                 } else {
-                    $block = Block::getByID($_POST['block'], $nvc, $source_area);
+                    $block = Block::getByID((int) $post->get('block'), $nvc, $source_area);
                 }
                 $block->move($stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
             }

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -1,15 +1,13 @@
 <?php
 namespace Concrete\Controller\Backend\Page;
 
-use Area;
-use Block;
 use Concrete\Controller\Backend\UserInterface\Page;
-use Concrete\Core\Page\EditResponse as PageEditResponse;
-use Config;
-use Loader;
-use Permissions;
-use Stack;
+use Concrete\Core\Area\Area;
+use Concrete\Core\Block\Block;
 use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\EditResponse as PageEditResponse;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Permission\Checker;
 
 class ArrangeBlocks extends Page
 {
@@ -68,9 +66,9 @@ class ArrangeBlocks extends Page
 
         $otherBlockIDs = $post->get('blocks', []);
 
-        if (Config::get('concrete.permissions.model') == 'advanced') {
+        if ($this->app->make('config')->get('concrete.permissions.model') == 'advanced') {
             // first, we check to see if we have permissions to edit the area contents for the source area.
-            $ap = new Permissions($sourceArea);
+            $ap = new Checker($sourceArea);
             if (!$ap->canEditAreaContents()) {
                 $e->add(t('You may not arrange the contents of area %s.', $sourceAreaHandle));
 
@@ -79,7 +77,7 @@ class ArrangeBlocks extends Page
             // now we get further in. We check to see if we're dealing with both a source AND a destination area.
             // if so, we check the area permissions for the destination area.
             if ($sourceAreaID !== $destinationAreaID) {
-                $destAP = new Permissions($desinationArea);
+                $destAP = new Checker($desinationArea);
                 if (!$destAP->canEditAreaContents()) {
                     $e->add(t('You may not arrange the contents of area %s.', $destinationAreaHandle));
 

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -105,37 +105,34 @@ class ArrangeBlocks extends Page
         }
 
 
-        if ($sourceAreaID !== $destinationAreaID) {
-            if ($destinationArea->isGlobalArea()) {
-                $destinationStack = Stack::getByName($destinationAreaHandle);
-                $destinationStackToModify = $destinationStack->getVersionToModify();
+        if ($destinationArea->isGlobalArea()) {
+            $destinationStack = Stack::getByName($destinationAreaHandle);
+            $destinationStackToModify = $destinationStack->getVersionToModify();
+            $actualDestinationArea = Area::get($destinationStackToModify, STACKS_AREA_NAME);
+            $actualDestinationAreaID = $actualDestinationArea->getAreaID();
+            if ($sourceAreaID !== $destinationAreaID) {
                 $nvc->relateVersionEdits($destinationStackToModify);
                 // If the source area is global, we need to get the block from there rather than from the view controller
                 if ($sourceArea->isGlobalArea()) {
-                    $sourceStackToModify = Stack::getByName($sourceAreaHandle)->getVersionToModify();
+                    $sourceStack = Stack::getByName($sourceAreaHandle);
+                    $sourceStackToModify = $sourceStack->getVersionToModify();
                     $nvc->relateVersionEdits($sourceStackToModify);
                     $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
                 } else {
                     $block = Block::getByID($movingBlockID, $nvc, $sourceArea);
                 }
-                $block->move($destinationStackToModify, Area::get($destinationStackToModify, STACKS_AREA_NAME));
-            } elseif ($sourceArea->isGlobalArea()) {
+                $block->move($destinationStackToModify, $actualDestinationArea);
+            }
+            $nvc->relateVersionEdits($destinationStackToModify);
+            $destinationStackToModify->processArrangement($actualDestinationAreaID, $movingBlockID, $otherBlockIDs);
+        } else {
+            if ($sourceAreaID !== $destinationAreaID && $sourceArea->isGlobalArea()) {
                 $sourceStack = Stack::getByName($sourceAreaHandle);
                 $sourceStackToModify = $sourceStack->getVersionToModify();
                 $nvc->relateVersionEdits($sourceStackToModify);
                 $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
                 $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
-        }
-
-        if ($destinationArea->isGlobalArea()) {
-            $destinationStack = Stack::getByName($destinationAreaHandle);
-            $destinationStackToModify = $destinationStack->getVersionToModify();
-            $actualDestinationArea = Area::get($destinationStackToModify, STACKS_AREA_NAME);
-            $actualDestinationAreaID = $actualDestinationArea->getAreaID();
-            $nvc->relateVersionEdits($destinationStackToModify);
-            $destinationStackToModify->processArrangement($actualDestinationAreaID, $movingBlockID, $otherBlockIDs);
-        } else {
             $nvc->processArrangement($destinationAreaID, $movingBlockID, $otherBlockIDs);
         }
     }

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -40,8 +40,6 @@ class ArrangeBlocks extends Page
         $sourceArea = (string) $sourceAreaHandle === '' ? null : Area::get($nvc, $sourceAreaHandle);
         if ($sourceArea === null) {
             $e->add(t('Unable to find the source area.'));
-
-            return;
         }
 
         $destinationAreaID = (int) $post->get('area');
@@ -53,16 +51,12 @@ class ArrangeBlocks extends Page
             $destinationArea = (string) $destinationAreaHandle === '' ? null : Area::get($nvc, $destinationAreaHandle);
             if ($destinationArea === null) {
                 $e->add(t('Unable to find the destination area.'));
-
-                return;
             }
         }
 
         $movingBlockID = (int) $post->get('block');
         if ($movingBlockID === 0) {
             $e->add(t('Unable to find the block to be moved.'));
-
-            return;
         }
 
         $sortedBlockIDs = $post->get('blocks', []);
@@ -73,7 +67,9 @@ class ArrangeBlocks extends Page
         }
         if (!in_array($movingBlockID, $sortedBlockIDs, true)) {
             $e->add(t('Unable to find the block to be moved.'));
+        }
 
+        if ($e->has()) {
             return;
         }
 
@@ -82,8 +78,6 @@ class ArrangeBlocks extends Page
             $ap = new Checker($sourceArea);
             if (!$ap->canEditAreaContents()) {
                 $e->add(t('You may not arrange the contents of area %s.', $sourceAreaHandle));
-
-                return;
             }
             // now we get further in. We check to see if we're dealing with both a source AND a destination area.
             // if so, we check the area permissions for the destination area.
@@ -91,8 +85,6 @@ class ArrangeBlocks extends Page
                 $destAP = new Checker($destinationArea);
                 if (!$destAP->canEditAreaContents()) {
                     $e->add(t('You may not arrange the contents of area %s.', $destinationAreaHandle));
-
-                    return;
                 }
                 // we're not done yet. Now we have to check to see whether this user has permission to add
                 // a block of this type to the destination area.
@@ -104,14 +96,12 @@ class ArrangeBlocks extends Page
                 }
                 if (!$block) {
                     $e->add(t('Unable to find the block to be moved.'));
-
-                    return;
-                }
-                if (!$destAP->canAddBlock($block)) {
+                } elseif (!$destAP->canAddBlock($block)) {
                     $e->add(t('You may not add %s to area %s.', t($block->getBlockTypeObject()->getBlockTypeName()), $destinationAreaHandle));
-
-                    return;
                 }
+            }
+            if ($e->has()) {
+                return;
             }
             // now, if we get down here we perform the arrangement
             // it will be set to true if we're in simple permissions mode, or if we've passed all the checks

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -87,11 +87,16 @@ class ArrangeBlocks extends Page
                 // a block of this type to the destination area.
                 if ($sourceArea->isGlobalArea()) {
                     $sourceStack = Stack::getByName($sourceAreaHandle);
-                    $b = Block::getByID($movingBlockID, $sourceStack, STACKS_AREA_NAME);
+                    $block = Block::getByID($movingBlockID, $sourceStack, STACKS_AREA_NAME);
                 } else {
-                    $b = Block::getByID($movingBlockID, $nvc, $sourceAreaHandle);
+                    $block = Block::getByID($movingBlockID, $nvc, $sourceAreaHandle);
                 }
-                $bt = $b->getBlockTypeObject();
+                if (!$block) {
+                    $e->add(t('Unable to find the block to be moved.'));
+                    
+                    return;
+                }
+                $bt = $block->getBlockTypeObject();
                 if (!$destAP->canAddBlock($bt)) {
                     $e->add(t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destinationAreaHandle));
 
@@ -119,6 +124,11 @@ class ArrangeBlocks extends Page
                 } else {
                     $block = Block::getByID($movingBlockID, $nvc, $sourceArea);
                 }
+                if (!$block) {
+                    $e->add(t('Unable to find the block to be moved.'));
+                    
+                    return;
+                }
                 $block->move($destinationStackToModify, $actualDestinationArea);
             }
             $nvc->relateVersionEdits($destinationStackToModify);
@@ -127,8 +137,13 @@ class ArrangeBlocks extends Page
             if ($sourceAreaID !== $destinationAreaID && $sourceArea->isGlobalArea()) {
                 $sourceStack = Stack::getByName($sourceAreaHandle);
                 $sourceStackToModify = $sourceStack->getVersionToModify();
-                $nvc->relateVersionEdits($sourceStackToModify);
                 $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
+                if (!$block) {
+                    $e->add(t('Unable to find the block to be moved.'));
+                    
+                    return;
+                }
+                $nvc->relateVersionEdits($sourceStackToModify);
                 $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
             $nvc->processArrangement($destinationAreaID, $movingBlockID, $otherBlockIDs);

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\Backend\Page;
 
 use Concrete\Controller\Backend\UserInterface\Page;
@@ -52,7 +53,7 @@ class ArrangeBlocks extends Page
             $destinationArea = (string) $destinationAreaHandle === '' ? null : Area::get($nvc, $destinationAreaHandle);
             if ($destinationArea === null) {
                 $e->add(t('Unable to find the destination area.'));
-                
+
                 return;
             }
         }
@@ -60,7 +61,7 @@ class ArrangeBlocks extends Page
         $movingBlockID = (int) $post->get('block');
         if ($movingBlockID === 0) {
             $e->add(t('Unable to find the block to be moved.'));
-            
+
             return;
         }
 
@@ -93,7 +94,7 @@ class ArrangeBlocks extends Page
                 }
                 if (!$block) {
                     $e->add(t('Unable to find the block to be moved.'));
-                    
+
                     return;
                 }
                 $bt = $block->getBlockTypeObject();
@@ -106,7 +107,6 @@ class ArrangeBlocks extends Page
             // now, if we get down here we perform the arrangement
             // it will be set to true if we're in simple permissions mode, or if we've passed all the checks
         }
-
 
         if ($destinationArea->isGlobalArea()) {
             $destinationStack = Stack::getByName($destinationAreaHandle);
@@ -126,7 +126,7 @@ class ArrangeBlocks extends Page
                 }
                 if (!$block) {
                     $e->add(t('Unable to find the block to be moved.'));
-                    
+
                     return;
                 }
                 $block->move($destinationStackToModify, $actualDestinationArea);
@@ -140,7 +140,7 @@ class ArrangeBlocks extends Page
                 $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
                 if (!$block) {
                     $e->add(t('Unable to find the block to be moved.'));
-                    
+
                     return;
                 }
                 $nvc->relateVersionEdits($sourceStackToModify);

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -9,6 +9,7 @@ use Config;
 use Loader;
 use Permissions;
 use Stack;
+use Concrete\Core\Http\ResponseFactoryInterface;
 
 class ArrangeBlocks extends Page
 {
@@ -21,7 +22,17 @@ class ArrangeBlocks extends Page
     {
         $pc = new PageEditResponse();
         $pc->setPage($this->page);
-        $e = Loader::helper('validation/error');
+        $this->performArrangement($pc);
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($pc);
+    }
+
+    /**
+     * @param \Concrete\Core\Page\EditResponse $pc
+     */
+    protected function performArrangement(PageEditResponse $pc)
+    {
+        $e = $pc->getError();
 
         $nvc = $this->page->getVersionToModify();
         $sourceAreaID = intval($_POST['sourceArea']);
@@ -39,93 +50,87 @@ class ArrangeBlocks extends Page
             $ap = new Permissions($ar);
             if (!$ap->canEditAreaContents()) {
                 $e->add(t('You may not arrange the contents of area %s.', $arHandle));
-            } else {
-                // now we get further in. We check to see if we're dealing with both a source AND a destination area.
-                // if so, we check the area permissions for the destination area.
-                if ($sourceAreaID != $destinationAreaID) {
-                    $destAreaHandle = Area::getAreaHandleFromID($destinationAreaID);
-                    $destArea = Area::getOrCreate($nvc, $destAreaHandle);
-                    $destAP = new Permissions($destArea);
-                    if (!$destAP->canEditAreaContents()) {
-                        $e->add(t('You may not arrange the contents of area %s.', $destAreaHandle));
-                    } else {
-                        // we're not done yet. Now we have to check to see whether this user has permission to add
-                        // a block of this type to the destination area.
 
-                        if ($ar->isGlobalArea()) {
-                            $stack = Stack::getByName($arHandle);
-                            $b = Block::getByID($_REQUEST['block'], $stack, STACKS_AREA_NAME);
-                        } else {
-                            $b = Block::getByID($_REQUEST['block'], $nvc, $arHandle);
-                        }
-                        $bt = $b->getBlockTypeObject();
-                        if (!$destAP->canAddBlock($bt)) {
-                            $e->add(t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destAreaHandle));
-                        }
-                    }
+                return;
+            }
+            // now we get further in. We check to see if we're dealing with both a source AND a destination area.
+            // if so, we check the area permissions for the destination area.
+            if ($sourceAreaID != $destinationAreaID) {
+                $destAreaHandle = Area::getAreaHandleFromID($destinationAreaID);
+                $destArea = Area::getOrCreate($nvc, $destAreaHandle);
+                $destAP = new Permissions($destArea);
+                if (!$destAP->canEditAreaContents()) {
+                    $e->add(t('You may not arrange the contents of area %s.', $destAreaHandle));
+
+                    return;
+                }
+                // we're not done yet. Now we have to check to see whether this user has permission to add
+                // a block of this type to the destination area.
+                if ($ar->isGlobalArea()) {
+                    $stack = Stack::getByName($arHandle);
+                    $b = Block::getByID($_REQUEST['block'], $stack, STACKS_AREA_NAME);
+                } else {
+                    $b = Block::getByID($_REQUEST['block'], $nvc, $arHandle);
+                }
+                $bt = $b->getBlockTypeObject();
+                if (!$destAP->canAddBlock($bt)) {
+                    $e->add(t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destAreaHandle));
+
+                    return;
                 }
             }
-
             // now, if we get down here we perform the arrangement
             // it will be set to true if we're in simple permissions mode, or if we've passed all the checks
         }
 
-        if (!$e->has()) {
-            $source_area = Area::get($nvc, Area::getAreaHandleFromID($sourceAreaID));
-            $destination_area = Area::get($this->page, Area::getAreaHandleFromID($destinationAreaID));
-    
-            if ($sourceAreaID !== $destinationAreaID &&
-                ($source_area->isGlobalArea() || $destination_area->isGlobalArea())
-            ) {
-    
-                // If the source_area is the only global area
-                if ($source_area->isGlobalArea() && !$destination_area->isGlobalArea()) {
-                    $cp = new Permissions($nvc);
-                    $stack = Stack::getByName($source_area->getAreaHandle());
-                    $stackToModify = $stack->getVersionToModify();
-                    $nvc->relateVersionEdits($stackToModify);
-                    $block = Block::getByID($_POST['block'], $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
-                    $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
-                }
-    
-                if ($destination_area->isGlobalArea()) {
-                    $cp = new Permissions($nvc);
-                    $stack = Stack::getByName($destination_area->getAreaHandle());
-                    $stackToModify = $stack->getVersionToModify();
-                    $nvc->relateVersionEdits($stackToModify);
-                    // If the source area is global, we need to get the block from there rather than from the view controller
-                    if ($source_area->isGlobalArea()) {
-                        $sourceStackToModify = Stack::getByName($source_area->getAreaHandle())->getVersionToModify();
-                        $nvc->relateVersionEdits($sourceStackToModify);
-                        $block = Block::getByID($_POST['block'], $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
-                    } else {
-                        $block = Block::getByID($_POST['block'], $nvc, $source_area);
-                    }
-                    $block->move($stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
-                }
+        $source_area = Area::get($nvc, Area::getAreaHandleFromID($sourceAreaID));
+        $destination_area = Area::get($this->page, Area::getAreaHandleFromID($destinationAreaID));
+
+        if ($sourceAreaID !== $destinationAreaID &&
+            ($source_area->isGlobalArea() || $destination_area->isGlobalArea())
+        ) {
+
+            // If the source_area is the only global area
+            if ($source_area->isGlobalArea() && !$destination_area->isGlobalArea()) {
+                $cp = new Permissions($nvc);
+                $stack = Stack::getByName($source_area->getAreaHandle());
+                $stackToModify = $stack->getVersionToModify();
+                $nvc->relateVersionEdits($stackToModify);
+                $block = Block::getByID($_POST['block'], $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
+                $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
-    
-            if (!$e->has()) {
-                $request = \Request::getInstance();
-                $area_id = $request->post('area', 0);
-                $block_id = $request->post('block', 0);
-                $block_ids = $request->post('blocks', array());
-    
-                if ($destination_area->isGlobalArea()) {
-                    $stack = Stack::getByName($destination_area->getAreaHandle());
-                    $stackToModify = $stack->getVersionToModify();
-                    $area = Area::get($stackToModify, STACKS_AREA_NAME);
-                    $area_id = $area->getAreaID();
-                    $nvc->relateVersionEdits($stackToModify);
-                    $stackToModify->processArrangement($area_id, $block_id, $block_ids);
+
+            if ($destination_area->isGlobalArea()) {
+                $cp = new Permissions($nvc);
+                $stack = Stack::getByName($destination_area->getAreaHandle());
+                $stackToModify = $stack->getVersionToModify();
+                $nvc->relateVersionEdits($stackToModify);
+                // If the source area is global, we need to get the block from there rather than from the view controller
+                if ($source_area->isGlobalArea()) {
+                    $sourceStackToModify = Stack::getByName($source_area->getAreaHandle())->getVersionToModify();
+                    $nvc->relateVersionEdits($sourceStackToModify);
+                    $block = Block::getByID($_POST['block'], $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
                 } else {
-                    $nvc->processArrangement($area_id, $block_id, $block_ids);
+                    $block = Block::getByID($_POST['block'], $nvc, $source_area);
                 }
+                $block->move($stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
             }
         }
 
-        $pc->setError($e);
-        $pc->outputJSON();
-        exit;
+        $request = \Request::getInstance();
+        $area_id = $request->post('area', 0);
+        $block_id = $request->post('block', 0);
+        $block_ids = $request->post('blocks', array());
+
+        if ($destination_area->isGlobalArea()) {
+            $stack = Stack::getByName($destination_area->getAreaHandle());
+            $stackToModify = $stack->getVersionToModify();
+            $area = Area::get($stackToModify, STACKS_AREA_NAME);
+            $area_id = $area->getAreaID();
+            $nvc->relateVersionEdits($stackToModify);
+            $stackToModify->processArrangement($area_id, $block_id, $block_ids);
+        } else {
+            $nvc->processArrangement($area_id, $block_id, $block_ids);
+        }
     }
 }

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -70,55 +70,57 @@ class ArrangeBlocks extends Page
             // it will be set to true if we're in simple permissions mode, or if we've passed all the checks
         }
 
-        $source_area = Area::get($nvc, Area::getAreaHandleFromID($sourceAreaID));
-        $destination_area = Area::get($this->page, Area::getAreaHandleFromID($destinationAreaID));
-
-        if ($sourceAreaID !== $destinationAreaID &&
-            ($source_area->isGlobalArea() || $destination_area->isGlobalArea())
-        ) {
-
-            // If the source_area is the only global area
-            if ($source_area->isGlobalArea() && !$destination_area->isGlobalArea()) {
-                $cp = new Permissions($nvc);
-                $stack = Stack::getByName($source_area->getAreaHandle());
-                $stackToModify = $stack->getVersionToModify();
-                $nvc->relateVersionEdits($stackToModify);
-                $block = Block::getByID($_POST['block'], $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
-                $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
-            }
-
-            if ($destination_area->isGlobalArea()) {
-                $cp = new Permissions($nvc);
-                $stack = Stack::getByName($destination_area->getAreaHandle());
-                $stackToModify = $stack->getVersionToModify();
-                $nvc->relateVersionEdits($stackToModify);
-                // If the source area is global, we need to get the block from there rather than from the view controller
-                if ($source_area->isGlobalArea()) {
-                    $sourceStackToModify = Stack::getByName($source_area->getAreaHandle())->getVersionToModify();
-                    $nvc->relateVersionEdits($sourceStackToModify);
-                    $block = Block::getByID($_POST['block'], $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
-                } else {
-                    $block = Block::getByID($_POST['block'], $nvc, $source_area);
-                }
-                $block->move($stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
-            }
-        }
-
         if (!$e->has()) {
-            $request = \Request::getInstance();
-            $area_id = $request->post('area', 0);
-            $block_id = $request->post('block', 0);
-            $block_ids = $request->post('blocks', array());
-
-            if ($destination_area->isGlobalArea()) {
-                $stack = Stack::getByName($destination_area->getAreaHandle());
-                $stackToModify = $stack->getVersionToModify();
-                $area = Area::get($stackToModify, STACKS_AREA_NAME);
-                $area_id = $area->getAreaID();
-                $nvc->relateVersionEdits($stackToModify);
-                $stackToModify->processArrangement($area_id, $block_id, $block_ids);
-            } else {
-                $nvc->processArrangement($area_id, $block_id, $block_ids);
+            $source_area = Area::get($nvc, Area::getAreaHandleFromID($sourceAreaID));
+            $destination_area = Area::get($this->page, Area::getAreaHandleFromID($destinationAreaID));
+    
+            if ($sourceAreaID !== $destinationAreaID &&
+                ($source_area->isGlobalArea() || $destination_area->isGlobalArea())
+            ) {
+    
+                // If the source_area is the only global area
+                if ($source_area->isGlobalArea() && !$destination_area->isGlobalArea()) {
+                    $cp = new Permissions($nvc);
+                    $stack = Stack::getByName($source_area->getAreaHandle());
+                    $stackToModify = $stack->getVersionToModify();
+                    $nvc->relateVersionEdits($stackToModify);
+                    $block = Block::getByID($_POST['block'], $stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
+                    $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
+                }
+    
+                if ($destination_area->isGlobalArea()) {
+                    $cp = new Permissions($nvc);
+                    $stack = Stack::getByName($destination_area->getAreaHandle());
+                    $stackToModify = $stack->getVersionToModify();
+                    $nvc->relateVersionEdits($stackToModify);
+                    // If the source area is global, we need to get the block from there rather than from the view controller
+                    if ($source_area->isGlobalArea()) {
+                        $sourceStackToModify = Stack::getByName($source_area->getAreaHandle())->getVersionToModify();
+                        $nvc->relateVersionEdits($sourceStackToModify);
+                        $block = Block::getByID($_POST['block'], $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
+                    } else {
+                        $block = Block::getByID($_POST['block'], $nvc, $source_area);
+                    }
+                    $block->move($stackToModify, Area::get($stackToModify, STACKS_AREA_NAME));
+                }
+            }
+    
+            if (!$e->has()) {
+                $request = \Request::getInstance();
+                $area_id = $request->post('area', 0);
+                $block_id = $request->post('block', 0);
+                $block_ids = $request->post('blocks', array());
+    
+                if ($destination_area->isGlobalArea()) {
+                    $stack = Stack::getByName($destination_area->getAreaHandle());
+                    $stackToModify = $stack->getVersionToModify();
+                    $area = Area::get($stackToModify, STACKS_AREA_NAME);
+                    $area_id = $area->getAreaID();
+                    $nvc->relateVersionEdits($stackToModify);
+                    $stackToModify->processArrangement($area_id, $block_id, $block_ids);
+                } else {
+                    $nvc->processArrangement($area_id, $block_id, $block_ids);
+                }
             }
         }
 

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -37,11 +37,6 @@ class ArrangeBlocks extends Page
         $nvc = $this->page->getVersionToModify();
         $sourceAreaID = intval($_POST['sourceArea']);
         $destinationAreaID = intval($_POST['area']);
-        $affectedAreaIDs = array();
-        $affectedAreaIDs[] = $sourceAreaID;
-        if ($sourceAreaID != $destinationAreaID) {
-            $affectedAreaIDs[] = $destinationAreaID;
-        }
 
         if (Config::get('concrete.permissions.model') == 'advanced') {
             // first, we check to see if we have permissions to edit the area contents for the source area.
@@ -92,7 +87,6 @@ class ArrangeBlocks extends Page
 
             // If the source_area is the only global area
             if ($source_area->isGlobalArea() && !$destination_area->isGlobalArea()) {
-                $cp = new Permissions($nvc);
                 $stack = Stack::getByName($source_area->getAreaHandle());
                 $stackToModify = $stack->getVersionToModify();
                 $nvc->relateVersionEdits($stackToModify);
@@ -101,7 +95,6 @@ class ArrangeBlocks extends Page
             }
 
             if ($destination_area->isGlobalArea()) {
-                $cp = new Permissions($nvc);
                 $stack = Stack::getByName($destination_area->getAreaHandle());
                 $stackToModify = $stack->getVersionToModify();
                 $nvc->relateVersionEdits($stackToModify);

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -47,7 +47,7 @@ class ArrangeBlocks extends Page
         $destinationAreaID = (int) $post->get('area');
         if ($destinationAreaID === $sourceAreaID) {
             $destinationAreaHandle = $sourceAreaHandle;
-            $desinationArea = $sourceArea;
+            $destinationArea = $sourceArea;
         } else {
             $destinationAreaHandle = $destinationAreaID === 0 ? null : Area::getAreaHandleFromID($destinationAreaID);
             $destinationArea = (string) $destinationAreaHandle === '' ? null : Area::get($nvc, $destinationAreaHandle);
@@ -78,7 +78,7 @@ class ArrangeBlocks extends Page
             // now we get further in. We check to see if we're dealing with both a source AND a destination area.
             // if so, we check the area permissions for the destination area.
             if ($sourceAreaID !== $destinationAreaID) {
-                $destAP = new Checker($desinationArea);
+                $destAP = new Checker($destinationArea);
                 if (!$destAP->canEditAreaContents()) {
                     $e->add(t('You may not arrange the contents of area %s.', $destinationAreaHandle));
 

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -65,7 +65,17 @@ class ArrangeBlocks extends Page
             return;
         }
 
-        $otherBlockIDs = $post->get('blocks', []);
+        $sortedBlockIDs = $post->get('blocks', []);
+        if (is_array($sortedBlockIDs)) {
+            $sortedBlockIDs = array_values(array_filter(array_map('intval', $sortedBlockIDs)));
+        } else {
+            $sortedBlockIDs = [];
+        }
+        if (!in_array($movingBlockID, $sortedBlockIDs, true)) {
+            $e->add(t('Unable to find the block to be moved.'));
+
+            return;
+        }
 
         if ($this->app->make('config')->get('concrete.permissions.model') == 'advanced') {
             // first, we check to see if we have permissions to edit the area contents for the source area.
@@ -131,7 +141,7 @@ class ArrangeBlocks extends Page
                 $block->move($destinationStackToModify, $actualDestinationArea);
             }
             $nvc->relateVersionEdits($destinationStackToModify);
-            $destinationStackToModify->processArrangement($actualDestinationAreaID, $movingBlockID, $otherBlockIDs);
+            $destinationStackToModify->processArrangement($actualDestinationAreaID, $movingBlockID, $sortedBlockIDs);
         } else {
             if ($sourceAreaID !== $destinationAreaID && $sourceArea->isGlobalArea()) {
                 $sourceStack = Stack::getByName($sourceAreaHandle);
@@ -145,7 +155,7 @@ class ArrangeBlocks extends Page
                 $nvc->relateVersionEdits($sourceStackToModify);
                 $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
-            $nvc->processArrangement($destinationAreaID, $movingBlockID, $otherBlockIDs);
+            $nvc->processArrangement($destinationAreaID, $movingBlockID, $sortedBlockIDs);
         }
     }
 }

--- a/concrete/controllers/backend/page/arrange_blocks.php
+++ b/concrete/controllers/backend/page/arrange_blocks.php
@@ -105,16 +105,7 @@ class ArrangeBlocks extends Page
         }
 
 
-        if ($sourceAreaID !== $destinationAreaID && ($sourceArea->isGlobalArea() || $destinationArea->isGlobalArea())) {
-            // If the source area is the only global area
-            if ($sourceArea->isGlobalArea() && !$destinationArea->isGlobalArea()) {
-                $sourceStack = Stack::getByName($sourceAreaHandle);
-                $sourceStackToModify = $sourceStack->getVersionToModify();
-                $nvc->relateVersionEdits($sourceStackToModify);
-                $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
-                $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
-            }
-
+        if ($sourceAreaID !== $destinationAreaID) {
             if ($destinationArea->isGlobalArea()) {
                 $destinationStack = Stack::getByName($destinationAreaHandle);
                 $destinationStackToModify = $destinationStack->getVersionToModify();
@@ -128,6 +119,12 @@ class ArrangeBlocks extends Page
                     $block = Block::getByID($movingBlockID, $nvc, $sourceArea);
                 }
                 $block->move($destinationStackToModify, Area::get($destinationStackToModify, STACKS_AREA_NAME));
+            } elseif ($sourceArea->isGlobalArea()) {
+                $sourceStack = Stack::getByName($sourceAreaHandle);
+                $sourceStackToModify = $sourceStack->getVersionToModify();
+                $nvc->relateVersionEdits($sourceStackToModify);
+                $block = Block::getByID($movingBlockID, $sourceStackToModify, Area::get($sourceStackToModify, STACKS_AREA_NAME));
+                $block->move($nvc, Area::get($nvc, STACKS_AREA_NAME));
             }
         }
 

--- a/concrete/src/Permission/Response/AreaResponse.php
+++ b/concrete/src/Permission/Response/AreaResponse.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Permission\Response;
 
+use Concrete\Core\Block\Block;
 use User;
 
 class AreaResponse extends Response
@@ -34,18 +35,31 @@ class AreaResponse extends Response
     {
         return $this->validate('add_layout_to_area');
     }
-    public function canAddBlock($bt)
+
+    /**
+     * Check if a new block can be added to the area, or if an existing block can be moved to it.
+     *
+     * @param \Concrete\Core\Entity\Block\BlockType\BlockType|\Concrete\Core\Block\Block $blockTypeOrBlock specify a block type when adding a new block, a block instance when adding an existing block.
+     *
+     * @return bool
+     */
+    public function canAddBlock($blockTypeOrBlock)
     {
-        if ($bt->getBlockTypeHandle() == BLOCK_HANDLE_LAYOUT_PROXY) {
-            return $this->canAddLayout();
+        if ($blockTypeOrBlock instanceof Block) {
+            $blockType = $blockTypeOrBlock->getBlockTypeObject();
+        } else {
+            $blockType = $blockTypeOrBlock;
         }
-        if ($bt->getBlockTypeHandle() == BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY) {
-            return $this->canAddBlocks();
+        switch ($blockType->getBlockTypeHandle()) {
+            case BLOCK_HANDLE_LAYOUT_PROXY:
+                return $this->canAddLayout();
+            case BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY:
+                return $this->canAddBlocks();
         }
         $pk = $this->category->getPermissionKeyByHandle('add_block_to_area');
         $pk->setPermissionObject($this->object);
 
-        return $pk->validate($bt);
+        return $pk->validate($blockTypeOrBlock);
     }
 
     // convenience function


### PR DESCRIPTION
Consider this situation:

- enable advanced permissions
- login as a user that can edit pages and stacks, but not as the super user ID
- create a new stack
- add that stack to an area of the page
- move the stack to another area of the page

You'll see have the error message "You may not add Stack Display to area Main.", but the stack is shown as moved to the new area.

If you move the stack to another area again, you'll see the error message "Call to a member function getBlockTypeObject() on null".

There are three bugs here:
1. the user *is* authorized to move the stack
1. when the code detects an unauthorized access, it still moves the block if the source and/or the destination area is global
1. in the case the arrange operation fails, the UI doesn't reflect the actual arrangement saved in the database

This PR fixes the first two issues (an upcoming PR will fix the third one).

I also "modernized" and simplified the code: see each commit description.