### PR TITLE
Make sure we are resolving the homepage from the active site rather than the active page

### DIFF
--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -424,6 +424,9 @@ class Service
     }
 
     /**
+     * Resolve the active site
+     * This method MUST be treated as `final` by extending drivers, but MAY be replaced by a complete override.
+     *
      * @return Site|null
      */
     public function getSite()
@@ -439,7 +442,11 @@ class Service
         return $site;
     }
 
+
     /**
+     * Resolve the active site for editing
+     * This method MUST be treated as `final` by extending drivers, but MAY be replaced by a complete override.
+     *
      * @return Site|null
      */
     public function getActiveSiteForEditing()

--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -426,7 +426,7 @@ class Service
     /**
      * @return Site|null
      */
-    final public function getSite()
+    public function getSite()
     {
         $item = $this->cache->getItem('site');
         if (!$item->isMiss()) {
@@ -442,7 +442,7 @@ class Service
     /**
      * @return Site|null
      */
-    final public function getActiveSiteForEditing()
+    public function getActiveSiteForEditing()
     {
         return $this->resolverFactory->createResolver($this)->getActiveSiteForEditing();
     }

--- a/concrete/src/User/PostLoginLocation.php
+++ b/concrete/src/User/PostLoginLocation.php
@@ -6,6 +6,9 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Desktop\DesktopList;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Site\Service;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Support\Facade\Site;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\Utility\Service\Validation\Numbers;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,21 +52,34 @@ class PostLoginLocation
     protected $valn;
 
     /**
+     * @var \Concrete\Core\Site\Service
+     */
+    protected $siteService;
+
+    /**
      * Initialize the instance.
      *
      * @param \Concrete\Core\Config\Repository\Repository $config
      * @param \Symfony\Component\HttpFoundation\Session\Session $session
      * @param \Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $resolverManager
-     * @param \Concrete\Core\Utility\Service\Validation\Numbers $valn
      * @param \Concrete\Core\Http\ResponseFactoryInterface $responseFactory
+     * @param \Concrete\Core\Utility\Service\Validation\Numbers $valn
+     * @param \Concrete\Core\Site\Service $siteService
      */
-    public function __construct(Repository $config, Session $session, ResolverManagerInterface $resolverManager, ResponseFactoryInterface $responseFactory, Numbers $valn)
-    {
+    public function __construct(
+        Repository $config,
+        Session $session,
+        ResolverManagerInterface $resolverManager,
+        ResponseFactoryInterface $responseFactory,
+        Numbers $valn,
+        Service $siteService
+    ) {
         $this->config = $config;
         $this->session = $session;
         $this->resolverManager = $resolverManager;
         $this->responseFactory = $responseFactory;
         $this->valn = $valn;
+        $this->siteService = $siteService;
     }
 
     /**
@@ -167,8 +183,10 @@ class PostLoginLocation
      */
     public function getFallbackPostLoginUrl()
     {
-        $homeCid = Page::getHomePageID();
-        $home = $homeCid ? Page::getByID($homeCid) : null;
+        /** @var \Concrete\Core\Entity\Site\Site $site */
+        $site = $this->siteService->getSite();
+        $home = $site->getSiteHomePageObject();
+
         if ($home && !$home->isError()) {
             $result = (string) $this->resolverManager->resolve([$home]);
         } else {

--- a/tests/tests/User/PostLoginLocationTest.php
+++ b/tests/tests/User/PostLoginLocationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Concrete\Tests\User;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Site\Service;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\User\PostLoginLocation;
+use Concrete\Core\Utility\Service\Validation\Numbers;
+use Mockery as M;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class PostLoginLocationTest extends \PHPUnit_Framework_TestCase
+{
+
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    /** @var \Illuminate\Contracts\Config\Repository|\Mockery\MockInterface */
+    protected $config;
+
+    /** @var Session|\Mockery\MockInterface */
+    protected $session;
+
+    /** @var ResolverManagerInterface|\Mockery\MockInterface */
+    protected $resolver;
+
+    /** @var ResponseFactoryInterface|\Mockery\MockInterface */
+    protected $responseFactory;
+
+    /** @var Numbers|\Mockery\MockInterface */
+    protected $numberValidator;
+
+    /** @var \Concrete\Core\Site\Service|\Mockery\MockInterface */
+    protected $siteService;
+
+    /** @var PostLoginLocation|\Mockery\MockInterface */
+    protected $location;
+
+    /**
+     * @before
+     */
+    public function prepare()
+    {
+        $this->config = M::mock(Repository::class);
+        $this->session = M::mock(Session::class);
+        $this->resolver = M::mock(ResolverManagerInterface::class);
+        $this->responseFactory = M::mock(ResponseFactoryInterface::class);
+        $this->numberValidator = M::mock(Numbers::class);
+        $this->siteService = M::mock(Service::class);
+
+        $this->location = new PostLoginLocation(
+            $this->config,
+            $this->session,
+            $this->resolver,
+            $this->responseFactory,
+            $this->numberValidator,
+            $this->siteService);
+    }
+
+    /**
+     * @after
+     */
+    public function destroy()
+    {
+        $this->config =
+        $this->session =
+        $this->resolver =
+        $this->responseFactory =
+        $this->numberValidator =
+        $this->siteService =
+        $this->location = null;
+    }
+
+    public function testGetFallbackPostLoginUrl()
+    {
+        // Set up a fake site to be resolved
+        $fakeSite = M::mock(Site::class);
+        $this->siteService->shouldReceive('getSite')->twice()->andReturn($fakeSite);
+
+        // Set up a fake homepage for our fake site
+        $fakePage = M::mock(Page::class);
+        $fakeSite->shouldReceive('getSiteHomePageObject')->andReturn($fakePage);
+
+        // First test what happens when the page has an error, then test when it doesn't have one.
+        $fakePage->shouldReceive('isError')->andReturnValues([true, false]);
+
+        // Set up the resolver manager to resolve both error and non error
+        $fallbackHomePath = 'Site homepage had an error';
+        $siteHomePath = 'Real site homepath';
+
+        $this->resolver->shouldReceive('resolve')->with(['/'])->andReturn($fallbackHomePath);
+        $this->resolver->shouldReceive('resolve')->with([$fakePage])->andReturn($siteHomePath);
+
+        $this->assertEquals($fallbackHomePath, $this->location->getFallbackPostLoginUrl());
+        $this->assertEquals($siteHomePath, $this->location->getFallbackPostLoginUrl());
+    }
+}


### PR DESCRIPTION
Before this PR logging into a multisite site other than the default site caused you to be redirected to the default site. With this change, the fallback redirect is determined using the active site rather than the active page.