### PR TITLE
Add openID scope to listing of scopes

### DIFF
--- a/concrete/views/oauth/consent/simple.php
+++ b/concrete/views/oauth/consent/simple.php
@@ -5,10 +5,6 @@ $token = $app->make(\Concrete\Core\Validation\CSRF\Token::class);
 $mainScopes = [];
 $additionalScopes = [];
 foreach ($auth->getScopes() as $scope) {
-    if ($scope->getIdentifier() === 'openid') {
-        continue;
-    }
-
     if (!$scope->getDescription()) {
         $additionalScopes[] = h($scope->getIdentifier());
     } else {


### PR DESCRIPTION
Before, when using an external concrete5 auth type and being redirected to the user portal:

![Screen Shot 2019-06-12 at 12 15 14 PM](https://user-images.githubusercontent.com/527809/59391922-b406d400-8d2a-11e9-889b-991aabaea0ec.png)

After:


![Screen Shot 2019-06-12 at 12 14 18 PM](https://user-images.githubusercontent.com/527809/59391933-bb2de200-8d2a-11e9-875d-ad0970f21720.png)
