### PR TITLE
Force attribute keys to be in one set only during import

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportAttributeSetsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportAttributeSetsRoutine.php
@@ -1,37 +1,54 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Block\BlockType\BlockType;
-use Concrete\Core\Permission\Category;
-use Concrete\Core\Validation\BannedWord\BannedWord;
+use Concrete\Core\Attribute\Category\CategoryService;
+use Concrete\Core\Attribute\SetFactory;
+use Concrete\Core\Support\Facade\Application;
+use SimpleXMLElement;
 
 class ImportAttributeSetsRoutine extends AbstractRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'attribute_sets';
     }
 
-    public function import(\SimpleXMLElement $sx)
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::import()
+     */
+    public function import(SimpleXMLElement $sx)
     {
         if (isset($sx->attributesets)) {
+            $app = Application::getFacadeApplication();
+            $setFactory = $app->make(SetFactory::class);
+            $categoryService = $app->make(CategoryService::class);
             foreach ($sx->attributesets->attributeset as $as) {
-                $set = \Concrete\Core\Attribute\Set::getByHandle((string) $as['handle']);
-                $akc = \Concrete\Core\Attribute\Key\Category::getByHandle($as['category']);
+                $set = $setFactory->getByHandle((string) $as['handle']);
+                $akc = $categoryService->getByHandle($as['category']);
                 $controller = $akc->getController();
                 $manager = $controller->getSetManager();
-                if (!is_object($set)) {
+                if ($set === null) {
                     $pkg = static::getPackageObject($as['package']);
                     $set = $manager->addSet((string) $as['handle'], (string) $as['name'], $pkg, $as['locked']);
                 }
                 foreach ($as->children() as $ask) {
                     $ak = $controller->getAttributeKeyByHandle((string) $ask['handle']);
-                    if (is_object($ak)) {
-                        $manager->addKey($set, $ak);
+                    if ($ak) {
+                        $keySets = $setFactory->getByAttributeKey($ak);
+                        if (empty($keySets)) {
+                            $manager->addKey($set, $ak);
+                        }
                     }
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
When we assign the attribute keys to the attribute sets via the dashboard, we are not allowed to add the same key to multiple sets.

What about forcing this in the "import from xml" procedure too?