### PR TITLE
Disable request cache when installing package XML contents

### DIFF
--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -290,7 +290,18 @@ abstract class Package implements LocalizablePackageInterface
     public function installContentFile($file)
     {
         $ci = new ContentImporter();
-        $ci->importContentFile($this->getPackagePath() . '/' . $file);
+        $cache = $this->app->make('cache/request');
+        $cacheEnabled = $cache->isEnabled();
+        if ($cacheEnabled) {
+            $cache->disable();
+        }
+        try {
+            $ci->importContentFile($this->getPackagePath() . '/' . $file);
+        } finally {
+            if ($cacheEnabled) {
+                $cache->enable();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When a package installs attribute keys and attribute key sets, the sets will be empty.

That's because:
1. before the attribute keys, the code calls the "get attribute by handle" method, which stores in the request cache that there's no attribute with this handle
2. the attribute key is created
3. the attribute set is created
4. the code calls the "get attribute by handle" method to see if there's such attribute to be associated to the set. Since at point 1 we stored in the cache that the key doesn't exist, the attribute appears as non existing, so it's not added to the set

So, what about disabling the request cache when importing XML files?