### PR TITLE
Let attribute controllers define the "no value" text

### DIFF
--- a/concrete/elements/attribute/editable_attribute.php
+++ b/concrete/elements/attribute/editable_attribute.php
@@ -1,33 +1,42 @@
 <?php
+
+use Concrete\Core\Attribute\CustomNoValueTextAttributeInterface;
+
 /**
  * @var Concrete\Core\Entity\Attribute\Key\Key $ak
- * @var $objects
- * @var $object
+ * @var Traversable|array|null $objects
+ * @var object|null $object
  * @var callback $permissionsCallback
  * @var array $permissionsArguments
  * @var string $clearAction
  * @var string $saveAction
  * @var string $display
  */
+$display = null;
+$noValueDisplayHtml = '';
 if (isset($objects)) {
+    $previousDisplay = null;
     foreach ($objects as $object) {
         $value = $object->getAttributeValueObject($ak);
-        if (!is_object($value)) {
-            $display = '';
-        } else {
-            $display = $value->getDisplayValue();
+        if (is_object($value)) {
+            $display = (string) $value->getDisplayValue();
         }
-        if (isset($lastDisplay) && $display != $lastDisplay) {
+        if ($previousDisplay !== null && $display !== $previousDisplay) {
             $display = t('Multiple Values');
+            break;
         }
-        $lastDisplay = $display;
+        $previousDisplay = $display;
     }
 } else {
+    if (method_exists($ak, 'getController')) {
+        $attributeController = $ak->getController();
+        if ($attributeController instanceof CustomNoValueTextAttributeInterface) {
+            $noValueDisplayHtml = (string) $attributeController->getNoneTextDisplayValue();
+        }
+    }
     $value = $object->getAttributeValueObject($ak);
     if (is_object($value)) {
-        $display = $value->getDisplayValue();
-    } else {
-        $display = '';
+        $display = (string) $value->getDisplayValue();
     }
 }
 
@@ -50,16 +59,25 @@ $canEdit = $permissionsCallback($ak, isset($permissionsArguments) ? $permissions
                     </ul>
                 <?php } ?>
                 <span
-                    <?php if ($canEdit) { ?>
+                    <?php
+                    if ($canEdit) {
+                        ?>
                         data-title="<?= $ak->getAttributeKeyDisplayName() ?>"
                         data-key-id="<?= $ak->getAttributeKeyID() ?>"
                         data-name="<?= $ak->getAttributeKeyID() ?>"
                         data-editable-field-type="xeditableAttribute"
                         data-url="<?= $saveAction ?>"
                         data-type="concreteattribute"
-                        <?php echo $ak->getAttributeTypeHandle() === 'textarea' ? "data-editableMode='inline'" : ''; ?>
-                    <?php } ?>
-                    ><?= $display ?></span>
+                        <?php
+                        if ($ak->getAttributeTypeHandle() === 'textarea') {
+                            echo ' data-editableMode="inline" ';
+                        }
+                        if ($noValueDisplayHtml !== '') {
+                            echo ' data-no-value-html="' . h($noValueDisplayHtml) . '" ';
+                        }
+                    }
+                    ?>
+                    ><?= $canEdit || $display !== null ? $display : $noValueDisplayHtml ?></span>
             </div>
         </div>
     </div>

--- a/concrete/js/build/core/editable-field/container.js
+++ b/concrete/js/build/core/editable-field/container.js
@@ -39,7 +39,7 @@
 				ajaxOptions: {
 					dataType: 'json'
 				},
-				emptytext: ccmi18n.none,
+				emptytext: $field.data('no-value-html') || ccmi18n.none,
 				showbuttons: true,
 				params: my.options.data,
 				url: my.options.url,
@@ -61,7 +61,7 @@
 					dataType: 'json'
 				},
 				mode: $field.data('editablemode'),
-				emptytext: ccmi18n.none,
+				emptytext: $field.data('no-value-html') || ccmi18n.none,
 				showbuttons: true,
 				savenochange: true,
 				autotext: 'never',

--- a/concrete/src/Attribute/CustomNoValueTextAttributeInterface.php
+++ b/concrete/src/Attribute/CustomNoValueTextAttributeInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Concrete\Core\Attribute;
+
+/**
+ * Attribute controllers should implement this interface to customize the display value when there's no current value.
+ */
+interface CustomNoValueTextAttributeInterface
+{
+    /**
+     * Return the text (in HTML format) to be displayed when there's no current value.
+     *
+     * @return string
+     */
+    public function getNoneTextDisplayValue();
+}


### PR DESCRIPTION
When we render attributes without a value, we always display `None`.

What about letting attribute controllers provide a different text?

Demo:

![custom-attribute-novalue-text](https://user-images.githubusercontent.com/928116/59493139-d879c200-8e8a-11e9-962b-8af1d766b5cf.gif)
