### PR TITLE
Fix search with attributes in sets

### DIFF
--- a/concrete/src/User/Search/Field/Manager.php
+++ b/concrete/src/User/Search/Field/Manager.php
@@ -33,8 +33,8 @@ class Manager extends FieldManager
         $attributeSets = $setManager->getAttributeSets();
         $unassigned = $setManager->getUnassignedAttributeKeys();
 
-        $attributes = [];
         foreach($attributeSets as $set) {
+            $attributes = [];
             foreach($set->getAttributeKeys() as $key) {
                 $field = new AttributeKeyField($key);
                 $attributes[] = $field;


### PR DESCRIPTION
When using attributes grouped in sets, and filtering by one of these attributes, we may result in duplicated fields searched.

The reason of this is that the Search Field Manager adds the same attribute to more than one group, resulting in the same field detected as being filtered twice in the `getFieldsFromRequest` method.

Let's fix this.