### PR TITLE
Fix form context registry override

### DIFF
--- a/concrete/src/Form/Context/Registry/ControlRegistry.php
+++ b/concrete/src/Form/Context/Registry/ControlRegistry.php
@@ -58,7 +58,7 @@ class ControlRegistry
                 }
             }
         }
-        if ($index) {
+        if ($index !== null) {
             $this->entries[$index] = $entry;
         } else {
             $this->entries[] = $entry;

--- a/concrete/src/Form/Context/Registry/ControlRegistry.php
+++ b/concrete/src/Form/Context/Registry/ControlRegistry.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Core\Form\Context\Registry;
 
-use Concrete\Core\Application\Application;
 use Concrete\Core\Express\Form\Context\FormContext;
 use Concrete\Core\Express\Form\Context\ViewContext;
 use Concrete\Core\Express\Form\Control\View\AssociationFormView;
@@ -12,11 +11,10 @@ use Concrete\Core\Express\Form\Control\View\AttributeKeyView;
 
 /**
  * A simple class for registering context to view bindings, in the event that certain contexts ought to
- * deliver different views. (Used by Express Attribute Key View vs Form)
+ * deliver different views. (Used by Express Attribute Key View vs Form).
  */
 class ControlRegistry
 {
-
     public function __construct()
     {
         $this->registerControl('express_control_attribute_key', [
@@ -27,7 +25,6 @@ class ControlRegistry
             [new FormContext(), AssociationFormView::class],
             [new ViewContext(), AssociationView::class],
         ]);
-
     }
 
     /**
@@ -37,7 +34,7 @@ class ControlRegistry
 
     public function registerControl($handle, $entries)
     {
-        foreach($entries as $row) {
+        foreach ($entries as $row) {
             $this->register($row[0], $handle, $row[1]);
         }
     }
@@ -51,7 +48,7 @@ class ControlRegistry
     protected function addOrReplaceEntry(ControlEntry $entry)
     {
         $index = null;
-        foreach($this->entries as $key => $existingEntry) {
+        foreach ($this->entries as $key => $existingEntry) {
             if ($entry->getHandle() == $existingEntry->getHandle()) {
                 if (get_class($existingEntry->getContext()) == get_class($entry->getContext())) {
                     $index = $key;
@@ -67,7 +64,7 @@ class ControlRegistry
 
     protected function getEntryFromContext(ContextInterface $context, $handle)
     {
-        foreach($this->entries as $key => $existingEntry) {
+        foreach ($this->entries as $key => $existingEntry) {
             if ($handle == $existingEntry->getHandle()) {
                 $entryContext = $existingEntry->getContext();
                 if ($context instanceof $entryContext) {
@@ -77,7 +74,7 @@ class ControlRegistry
         }
     }
 
-    public function getControlView(ContextInterface $context, $handle, $arguments = array())
+    public function getControlView(ContextInterface $context, $handle, $arguments = [])
     {
         $entry = $this->getEntryFromContext($context, $handle);
         array_unshift($arguments, $context);
@@ -89,5 +86,4 @@ class ControlRegistry
             );
         }
     }
-
 }

--- a/tests/assets/Express/Form/Control/View/TestView.php
+++ b/tests/assets/Express/Form/Control/View/TestView.php
@@ -1,25 +1,11 @@
 <?php
 namespace Concrete\Tests\Express\Form\Control\View;
 
-use Concrete\Core\Entity\Express\Control\AttributeKeyControl;
-use Concrete\Core\Entity\Express\Control\Control;
 use Concrete\Core\Express\Form\Control\View\View;
-use Concrete\Core\Express\Form\Context\ContextInterface;
 use Concrete\Core\Filesystem\TemplateLocator;
 
 class TestView extends View
 {
-    /**
-     * AttributeKeyView constructor.
-     *
-     * @param ContextInterface $context
-     * @param AttributeKeyControl $control
-     */
-    public function __construct(ContextInterface $context, Control $control)
-    {
-        parent::__construct($context, $control);
-    }
-
     public function getControlID()
     {
         return 'tests';

--- a/tests/assets/Express/Form/Control/View/TestView.php
+++ b/tests/assets/Express/Form/Control/View/TestView.php
@@ -1,0 +1,34 @@
+<?php
+namespace Concrete\Tests\Express\Form\Control\View;
+
+use Concrete\Core\Entity\Express\Control\AttributeKeyControl;
+use Concrete\Core\Entity\Express\Control\Control;
+use Concrete\Core\Express\Form\Control\View\View;
+use Concrete\Core\Express\Form\Context\ContextInterface;
+use Concrete\Core\Filesystem\TemplateLocator;
+
+class TestView extends View
+{
+
+    /**
+     * AttributeKeyView constructor.
+     * @param ContextInterface $context
+     * @param AttributeKeyControl $control
+     */
+    public function __construct(ContextInterface $context, Control $control)
+    {
+        parent::__construct($context, $control);
+    }
+
+    public function getControlID()
+    {
+        return 'tests';
+    }
+
+    public function createTemplateLocator()
+    {
+        $locator = new TemplateLocator('tests');
+
+        return $locator;
+    }
+}

--- a/tests/assets/Express/Form/Control/View/TestView.php
+++ b/tests/assets/Express/Form/Control/View/TestView.php
@@ -9,9 +9,9 @@ use Concrete\Core\Filesystem\TemplateLocator;
 
 class TestView extends View
 {
-
     /**
      * AttributeKeyView constructor.
+     *
      * @param ContextInterface $context
      * @param AttributeKeyControl $control
      */

--- a/tests/tests/Form/Context/Registry/ControlRegistryTest.php
+++ b/tests/tests/Form/Context/Registry/ControlRegistryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Concrete\Tests\Form\Context\Registry;
+
+use Concrete\Core\Entity\Attribute\Type;
+use Concrete\Core\Entity\Attribute\Key\ExpressKey;
+use Concrete\Core\Entity\Express\Control\AssociationControl;
+use Concrete\Core\Entity\Express\Control\AttributeKeyControl;
+use Concrete\Core\Entity\Express\Entity;
+use Concrete\Core\Entity\Express\OneToOneAssociation;
+use Concrete\Core\Express\Form\Context\FormContext;
+use Concrete\Core\Express\Form\Context\ViewContext;
+use Concrete\Core\Express\Form\Control\View\AssociationFormView;
+use Concrete\Core\Express\Form\Control\View\AssociationView;
+use Concrete\Core\Express\Form\Control\View\AttributeKeyFormView;
+use Concrete\Core\Express\Form\Control\View\AttributeKeyView;
+use Concrete\Core\Form\Context\Registry\ControlRegistry;
+use Concrete\Tests\Express\Form\Control\View\TestView;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\ClassLoader\MapClassLoader;
+
+class ContextRegistryTest extends PHPUnit_Framework_TestCase
+{
+    private static $classLoader;
+
+    public static function setUpBeforeClass()
+    {
+        static::$classLoader = new MapClassLoader([
+            TestView::class => DIR_TESTS . '/assets/Express/Form/Control/View/TestView.php',
+        ]);
+        static::$classLoader->register(true);
+    }
+
+    public function testAttributeKeyControls()
+    {
+        $registry = new ControlRegistry();
+
+        $akControl = $this->getAttributeKeyControl();
+
+        $this->assertInstanceOf(
+            AttributeKeyFormView::class,
+            $registry->getControlView(
+                new FormContext(),
+                'express_control_attribute_key',
+                [$akControl]
+            )
+        );
+        $this->assertInstanceOf(
+            AttributeKeyView::class,
+            $registry->getControlView(
+                new ViewContext(),
+                'express_control_attribute_key',
+                [$akControl]
+            )
+        );
+    }
+
+    public function testAssociationControls()
+    {
+        $registry = new ControlRegistry();
+
+        $asControl = $this->getAssociationControl();
+
+        $this->assertInstanceOf(
+            AssociationFormView::class,
+            $registry->getControlView(
+                new FormContext(),
+                'express_control_association',
+                [$asControl]
+            )
+        );
+        $this->assertInstanceOf(
+            AssociationView::class,
+            $registry->getControlView(
+                new ViewContext(),
+                'express_control_association',
+                [$asControl]
+            )
+        );
+    }
+
+    public function testReplaceFirstControl()
+    {
+        $registry = new ControlRegistry();
+        $registry->register(
+            new FormContext(),
+            'express_control_attribute_key',
+            TestView::class
+        );
+
+        $this->assertInstanceOf(
+            TestView::class,
+            $registry->getControlView(
+                new FormContext(),
+                'express_control_attribute_key',
+                [$this->getAttributeKeyControl()]
+            )
+        );
+    }
+
+    public function testReplaceLastControl()
+    {
+        $registry = new ControlRegistry();
+        $registry->register(
+            new ViewContext(),
+            'express_control_association',
+            TestView::class
+        );
+
+        $this->assertInstanceOf(
+            TestView::class,
+            $registry->getControlView(
+                new ViewContext(),
+                'express_control_association',
+                [$this->getAssociationControl()]
+            )
+        );
+    }
+
+    private function getAttributeKeyControl()
+    {
+        $at = new Type();
+        $at->setAttributeTypeHandle('text');
+        $ak = new ExpressKey();
+        $ak->setAttributeType($at);
+
+        $akControl = new AttributeKeyControl();
+        $akControl->setAttributeKey($ak);
+        return $akControl;
+    }
+
+    private function getAssociationControl()
+    {
+        $entity = new Entity();
+        $entity->setName('Test');
+
+        $assoc = new OneToOneAssociation();
+        $assoc->setTargetEntity($entity);
+
+        $asControl = new AssociationControl();
+        $asControl->setAssociation($assoc);
+        // Use a selector mode that will not cause any database interaction
+        $asControl->setEntrySelectorMode(
+            AssociationControl::TYPE_ENTRY_SELECTOR
+        );
+
+        return $asControl;
+    }
+}

--- a/tests/tests/Form/Context/Registry/ControlRegistryTest.php
+++ b/tests/tests/Form/Context/Registry/ControlRegistryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Tests\Form\Context\Registry;
 
 use Concrete\Core\Entity\Attribute\Type;
@@ -126,6 +125,7 @@ class ContextRegistryTest extends PHPUnit_Framework_TestCase
 
         $akControl = new AttributeKeyControl();
         $akControl->setAttributeKey($ak);
+
         return $akControl;
     }
 


### PR DESCRIPTION
When overriding the first form control in the registry, it does not currently work because of the check that does not consider that the index can have a zero value (.

This fixes that issue and adds some tests to ensure this bug does not reappear.

Example code to replicate this bug:

```php
$app = \Concrete\Core\Support\Facade\Facade::getFacadeApplication();
$registry = $app->make(\Concrete\Core\Form\Context\Registry\ControlRegistry::class);
$registry->register(
    new \Concrete\Core\Express\Form\Context\FormContext(),
    'express_control_attribute_key',
    \Application\Express\Form\Control\View\AttributeKeyFormView::class
);
```

In order to get the example code working, you obviously need to define the `AttributeKeyFormView` class. The test included in this PR provides a more concrete example which fails without this fix.