### PR TITLE
Remove unused route in Files API

### DIFF
--- a/concrete/routes/api/file.php
+++ b/concrete/routes/api/file.php
@@ -10,5 +10,3 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $router->get('/file/{fID}', '\Concrete\Core\File\Api\FilesController::read')
     ->setRequirement('fID' ,'[0-9]+')
     ->setScopes('files:read');
-$router->get('/files', '\Concrete\Core\File\Api\FilesController::listFiles')
-    ->setScopes('files:read');


### PR DESCRIPTION
Since @aembler removed this function this route no longer exists. So it should be removed but...

...I'll try to find time to add back List Files in with proper functionality, rather than the half baked list before.
