### PR TITLE
Fix Search Preset Console errors and Fix Reloading

### DIFF
--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -460,6 +460,11 @@
 				cs.ajaxUpdate(data.preset.actionURL);
 			}
 		});
+		ConcreteEvent.unsubscribe('SavedSearchCreated');
+		ConcreteEvent.subscribe('SavedSearchCreated', function(e, data) {
+			cs.updateResults(data);
+
+		});
 		// NEW SEARCH
 		cs.$element.find('div[data-header] form').on('submit', function() {
 			var data = $(this).serializeArray();

--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -447,6 +447,19 @@
 			cs.$headerSearchInput.prop('disabled', true).val('');
 			cs.$headerSearchInput.attr('placeholder', '');
 		});
+		ConcreteEvent.unsubscribe('SavedSearchDeleted');
+		ConcreteEvent.subscribe('SavedSearchDeleted', function() {
+			$.fn.dialog.closeAll();
+			cs.$resetSearchButton.trigger('click');
+		});
+
+		ConcreteEvent.unsubscribe('SavedSearchUpdated');
+		ConcreteEvent.subscribe('SavedSearchUpdated', function(e, data) {
+			$.fn.dialog.closeAll();
+			if (data.preset && data.preset.actionURL) {
+				cs.ajaxUpdate(data.preset.actionURL);
+			}
+		});
 		// NEW SEARCH
 		cs.$element.find('div[data-header] form').on('submit', function() {
 			var data = $(this).serializeArray();

--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -442,6 +442,10 @@
 		ConcreteEvent.unsubscribe('SavedPresetSubmit');
 		ConcreteEvent.subscribe('SavedPresetSubmit', function (e, data) {
 			cs.ajaxUpdate(data);
+			cs.$resetSearchButton.show();
+			cs.$headerSearch.find('div.btn-group').hide();
+			cs.$headerSearchInput.prop('disabled', true).val('');
+			cs.$headerSearchInput.attr('placeholder', '');
 		});
 		// NEW SEARCH
 		cs.$element.find('div[data-header] form').on('submit', function() {

--- a/concrete/js/build/core/app/search/preset-selector.js
+++ b/concrete/js/build/core/app/search/preset-selector.js
@@ -17,10 +17,6 @@
             if (!$(e.target).is('button') && $(this).data('action')) {
                 $.fn.dialog.closeTop();
                 ConcreteEvent.publish('SavedPresetSubmit',$(this).data('action'));
-                my.$resetSearchButton.show();
-                my.$headerSearch.find('div.btn-group').hide();
-                my.$headerSearchInput.prop('disabled', true).val('');
-                my.$headerSearchInput.attr('placeholder', '');
             }
         });
 

--- a/concrete/js/build/core/app/search/preset-selector.js
+++ b/concrete/js/build/core/app/search/preset-selector.js
@@ -51,7 +51,7 @@
                 url: $presetForm.attr('action'),
                 success: function(r) {
                     $.fn.dialog.closeAll();
-                    ConcreteEvent.publish('SavedSearchCreated', {search: r});
+                    ConcreteEvent.publish('SavedSearchCreated', r);
                 }
             });
             return false;

--- a/concrete/js/build/core/app/search/preset-selector.js
+++ b/concrete/js/build/core/app/search/preset-selector.js
@@ -71,19 +71,7 @@
             });
         });
 
-        ConcreteEvent.unsubscribe('SavedSearchDeleted');
-        ConcreteEvent.subscribe('SavedSearchDeleted', function() {
-            $.fn.dialog.closeAll();
-            my.ajaxUpdate(my.$resetSearchButton.data('button-action-url'));
-        });
 
-        ConcreteEvent.unsubscribe('SavedSearchUpdated');
-        ConcreteEvent.subscribe('SavedSearchUpdated', function(e, data) {
-            $.fn.dialog.closeAll();
-            if (data.preset && data.preset.actionURL) {
-                my.ajaxUpdate(data.preset.actionURL);
-            }
-        });
     }
 
 

--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -315,11 +315,6 @@
         ConcreteEvent.subscribe('ConcreteTreeDeleteTreeNode.concreteTree', function(e, r) {
             my.reloadFolder();
         });
-        ConcreteEvent.unsubscribe('SavedSearchCreated');
-        ConcreteEvent.subscribe('SavedSearchCreated', function(e, data) {
-            my.ajaxUpdate(data.search.baseUrl, {});
-
-        });
 
         ConcreteEvent.unsubscribe('FileManagerUpdateFileProperties');
         ConcreteEvent.subscribe('FileManagerUpdateFileProperties', function(e, r) {


### PR DESCRIPTION
This pull request fixes the following issues:

Javascript console errors present when trying to submit, save or delete search presets.
Delete saved preset not actually reseting the search preset.
File search preset results being returned twice when created. (once with the response from created, then the result is submitted again).

It also adds the ability of other search presets (other than the file manager) to actually use the `SearchPresetCreated` event and update the results with the data received from the search preset saved