### PR TITLE
Allow Page::getSiteHomePageID to use default site (fixes upgrade from 5.7)

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3124,6 +3124,11 @@ EOT
             if ($siteTree != null) {
                 return $siteTree->getSiteHomePageID();
             }
+        } else {
+            $siteTree = Application::getFacadeApplication()->make('site')->getDefault();
+            if (is_object($siteTree)) {
+                return $siteTree->getSiteHomePageID();
+            }
         }
 
         return null;

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3124,12 +3124,20 @@ EOT
             if ($siteTree != null) {
                 return $siteTree->getSiteHomePageID();
             }
-        } else {
-            $siteTree = Application::getFacadeApplication()->make('site')->getDefault();
-            if (is_object($siteTree)) {
-                return $siteTree->getSiteHomePageID();
-            }
         }
+
+        $entityManager = Application::getFacadeApplication()->make(EntityManagerInterface::class);
+
+        try {
+            $site = $entityManager->getRepository('Concrete\Core\Entity\Site\Site')
+                ->findOneBy(['siteIsDefault' => true]);
+            if ($site !== null) {
+                return $site->getSiteHomePageID();
+            }
+        } catch (\Exception $e) {
+            return null;
+        }
+
 
         return null;
     }


### PR DESCRIPTION
This PR allows Page::getSiteHomePageID to use the default site and return its home page id.

Currently when upgrading from 5.7 the migrations will fail as it tries to get the locale home page id as they don't exist when trying to install the new version 8 Pages. They are installed after, since getSiteHomePageID should generally return something, its best to return the default site HomePageID rather than HOME_CID/1