### PR TITLE
Fix block templates that edit the scope variables within the block view

### DIFF
--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -12,12 +12,10 @@ use Environment;
 use User;
 use Page;
 use Concrete\Core\Block\Block;
-use BlockType;
-use URL;
 use View;
 
 /**
- * Work with the rendered view of a block
+ * Work with the rendered view of a block.
  *
  * <code>
  * $b = $this->getBlockObject();
@@ -39,11 +37,9 @@ class BlockView extends AbstractView
     protected $didPullFromOutputCache = false;
 
     /**
-     * Construct a block view object
+     * Construct a block view object.
      *
      * @param mixed $mixed block or block type to view
-     *
-     * @return void
      */
     protected function constructView($mixed)
     {
@@ -105,7 +101,7 @@ class BlockView extends AbstractView
     }
 
     /**
-     * @deprecated In views, use $controller->getActionURL() using the same arguments.
+     * @deprecated in views, use $controller->getActionURL() using the same arguments
      *
      * @return \Concrete\Core\Url\UrlImmutable|null
      */
@@ -136,7 +132,7 @@ class BlockView extends AbstractView
             }
         }
         $customFilenameToRender = null;
-        if (!in_array($this->viewToRender, array('view', 'add', 'edit', 'scrapbook'))) {
+        if (!in_array($this->viewToRender, ['view', 'add', 'edit', 'scrapbook'])) {
             // then we're trying to render a custom view file, which we'll pass to the bottom functions as $_filename
             $customFilenameToRender = $view . '.php';
             $view = 'view';
@@ -216,22 +212,20 @@ class BlockView extends AbstractView
 
     protected function onBeforeGetContents()
     {
-        if (in_array($this->viewPerformed, array('scrapbook', 'view'))) {
-            $this->controller->runAction('on_page_view', array($this));
+        if (in_array($this->viewPerformed, ['scrapbook', 'view'])) {
+            $this->controller->runAction('on_page_view', [$this]);
             $this->controller->outputAutoHeaderItems();
         }
     }
 
     /**
-     * Echo block contents
+     * Echo block contents.
      *
      * @param array $scopeItems array of items to render (outputContent, blockViewHeaderFile, blockViewFooterFile)
-     *
-     * @return void
      */
     public function renderViewContents($scopeItems)
     {
-        $shouldRender = function() {
+        $shouldRender = function () {
             $app = Application::getFacadeApplication();
 
             // If you hook into this event and use `preventRendering()`,
@@ -356,7 +350,7 @@ class BlockView extends AbstractView
         return $base;
     }
 
-    public function inc($fileToInclude, $args = array())
+    public function inc($fileToInclude, $args = [])
     {
         extract($args);
         extract($this->getScopeItems());
@@ -428,7 +422,7 @@ class BlockView extends AbstractView
 
         if (!$this->outputContent) {
             $this->didPullFromOutputCache = false;
-            if (in_array($this->viewToRender, array('view', 'add', 'edit', 'composer'))) {
+            if (in_array($this->viewToRender, ['view', 'add', 'edit', 'composer'])) {
                 $method = $this->viewToRender;
             } else {
                 $method = 'view';
@@ -446,7 +440,7 @@ class BlockView extends AbstractView
                 }
             }
 
-            $parameters = array();
+            $parameters = [];
             if (!$passthru) {
                 $this->controller->runAction($method, $parameters);
             }
@@ -465,7 +459,7 @@ class BlockView extends AbstractView
     }
 
     /**
-     * Fire an event just before the block is outputted on the page
+     * Fire an event just before the block is outputted on the page.
      *
      * Custom code can modify the block contents before
      * the block contents are 'echoed' out on the page.

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -250,9 +250,10 @@ class BlockView extends AbstractView
             ob_end_clean();
         }
 
-        // In case the view changes any scope items, the block footer could
-        // otherwise break. This can happen if the block view changes any
-        // local variables such as the `$b` variable.
+        // In case the view changes any scope items, the block header/footer
+        // could break without extracting the scope items again. This can happen
+        // if the block view changes any local variables such as the `$b`
+        // variable which is possible as they can be user defined.
         extract($scopeItems);
 
         // The translatable texts in the block header/footer need to be printed

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -256,6 +256,11 @@ class BlockView extends AbstractView
             ob_end_clean();
         }
 
+        // In case the view changes any scope items, the block footer could
+        // otherwise break. This can happen if the block view changes any
+        // local variables such as the `$b` variable.
+        extract($scopeItems);
+
         // The translatable texts in the block header/footer need to be printed
         // out in the system language.
         $loc = Localization::getInstance();

--- a/tests/assets/Block/weird_template.php
+++ b/tests/assets/Block/weird_template.php
@@ -1,0 +1,7 @@
+<?php
+// This is just a dummy block template to test that changing the scope items
+// inside the block template will not break the block header/footer rendering.
+$b = 'Replaces the $b variable';
+?>
+
+<p><?php echo $b; ?></p>

--- a/tests/tests/Block/BlockRenderTest.php
+++ b/tests/tests/Block/BlockRenderTest.php
@@ -12,7 +12,7 @@ use Concrete\Core\User\UserInfo;
 use Concrete\TestHelpers\Page\PageTestCase;
 use Doctrine\ORM\EntityManagerInterface;
 
-class BlockViewTest extends PageTestCase
+class BlockRenderTest extends PageTestCase
 {
     /** @var \Concrete\Core\Application\Application */
     protected $app;

--- a/tests/tests/Block/BlockRenderTest.php
+++ b/tests/tests/Block/BlockRenderTest.php
@@ -1,0 +1,129 @@
+<?php
+namespace Concrete\Tests\Block;
+
+use Area;
+use Concrete\Core\Block\BlockType\BlockType;
+use Concrete\Core\Block\View\BlockView;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\Support\Facade\Facade;
+use Concrete\Core\User\UserInfo;
+use Concrete\TestHelpers\Page\PageTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+class BlockViewTest extends PageTestCase
+{
+    /** @var \Concrete\Core\Application\Application */
+    protected $app;
+
+    /** @var Page */
+    protected $c;
+
+    /** @var \Concrete\Core\Page\Collection\Version\Version */
+    protected $cv;
+
+    /** @var Area */
+    protected $area;
+
+    /** @var BlockType */
+    protected $bt;
+
+    protected $btHandle = 'content';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->tables[] = 'Blocks';
+        $this->tables[] = 'Config';
+        $this->tables[] = 'UserGroups';
+        $this->tables[] = 'SystemContentEditorSnippets';
+        $this->tables[] = 'btContentLocal';
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Block\BlockType\BlockType';
+        $this->metadatas[] = 'Concrete\Core\Entity\User\User';
+        $this->metadatas[] = 'Concrete\Core\Entity\User\UserSignup';
+        $this->metadatas[] = 'Concrete\Core\Entity\Package';
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        $app = Facade::getFacadeApplication();
+        $em = $app->make(EntityManagerInterface::class);
+
+        // Install the theme and make it the site theme.
+        $theme = Theme::add('elemental');
+        $site = $app->make('site')->getSite();
+        $site->setThemeID($theme->getThemeID());
+        $em->persist($site);
+        $em->flush();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Add the page and the area
+        $this->c = Page::getByID(Page::getHomePageID());
+        $this->cv = $this->c->getVersionToModify();
+        $this->area = Area::getOrCreate($this->c, 'Main');
+        $this->bt = BlockType::installBlockType($this->btHandle);
+    }
+
+    public function testBlockNormalRender()
+    {
+        $blockContent = '<p>Testing content block.</p>';
+        $block = $this->cv->addBlock($this->bt, $this->area, [
+            'content' => $blockContent,
+        ]);
+
+        $bv = new BlockView($block);
+        $bv->setAreaObject($this->area);
+
+        ob_start();
+        $bv->render('view');
+        $contents = ob_get_clean();
+
+        $this->assertEquals($blockContent, trim($contents));
+    }
+
+    public function testBlockViewChangingScopeVariables()
+    {
+        // Add the user
+        $ui = UserInfo::add([
+            'uName' => 'terry',
+            'uEmail' => 'terry@tester.org',
+        ]);
+
+        // Make it the "current" user and load the collection to edit mode with
+        // that user.
+        $req = Request::getInstance();
+        $req->setCustomRequestUser($ui);
+        $ui->getUserObject()->loadCollectionEdit($this->c);
+
+        // Add the block type and the actual block to the page
+        $block = $this->cv->addBlock($this->bt, $this->area, []);
+
+        // Render the block view with the "weird" template which will modify
+        // some of the local variables inside the BlockView class.
+        $template = DIR_TESTS . '/assets/Block/weird_template.php';
+
+        $view = new BlockView($block);
+        $view->start($block);
+        $view->setAreaObject($this->area);
+        $view->setupRender();
+        $view->setViewTemplate($template);
+
+        ob_start();
+        $view->renderViewContents($view->getScopeItems());
+        $contents = ob_get_clean();
+
+        $this->assertContains(
+            'data-block-id="' . $block->getBlockID() . '"',
+            $contents
+        );
+    }
+}


### PR DESCRIPTION
Some custom templates may change the block view's local scope variables as they are unaware what is happening "above" them. Changing the `$b` variable in particular inside the block templates is problematic as it will break the rendering of the block's edit controls (coming from the header/footer templates).

This happened to me personally when working with a custom template for the stacks block in which I was iterating through an array of blocks and storing them one-by-one in the `$b` variable. In this case, it was very hard to track down the bug as the edit view worked properly but just the edit controls pointed to the wrong block ID. Furthermore, this broke the "edit block" link which caused an error stating "Invalid Area" coming from here:
https://github.com/concrete5/concrete5/blob/473a8efe38cc1eb077f7ed4f599e8ba32283da28/concrete/controllers/backend/user_interface/block.php#L41

The fix extracts the scope variables again after rendering the user defined view which ensures they are always properly set, no matter what variable names the developer decided to use.