### PR TITLE
Preload file uploader dialog

### DIFF
--- a/concrete/css/build/core/file-manager.less
+++ b/concrete/css/build/core/file-manager.less
@@ -183,6 +183,10 @@ div.ccm-file-manager-import-files {
     }
   }
 }
+div.ccm-tab-content-incoming {
+    height: 360px;
+    overflow: auto;
+}
 
 /**
  *Thumbnail listing

--- a/concrete/routes/dialogs/files.php
+++ b/concrete/routes/dialogs/files.php
@@ -46,4 +46,5 @@ $router->all('/advanced_search/preset/delete', 'Preset\Delete::view');
 $router->all('/advanced_search/preset/delete/remove_search_preset', 'Preset\Delete::remove_search_preset');
 
 $router->all('/import', 'Import::view');
+$router->all('/import/refresh-incoming', 'Import::refreshIncoming');
 $router->all('/replace', 'Replace::view');

--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -319,6 +319,10 @@ EOT
         ) ?>
 });
 
+$dialog.on('dialogclose', function() {
+	$dropzone[0].dropzone.destroy();
+});
+
 // Setup incoming tab
 <?php
 if ($replacingFile === null) {

--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -25,12 +25,12 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <div class="ccm-ui ccm-file-manager-import-files" id="<?= $formID ?>">
     <?= $ui->tabs([
-        ['local', t('Your Computer'), true],
-        ['incoming', t('Incoming Directory')],
-        ['remote', t('Remote Files')],
+        ["{$formID}-local", t('Your Computer'), true],
+        ["{$formID}-incoming", t('Incoming Directory')],
+        ["{$formID}-remote", t('Remote Files')],
     ]) ?>
 
-    <div class="ccm-tab-content" id="ccm-tab-content-local">
+    <div class="ccm-tab-content ccm-tab-content-local" id="ccm-tab-content-<?= $formID ?>-local">
         <form action="<?= $resolverManager->resolve(['/ccm/system/file/upload']) ?>" class="dropzone">
             <?php $token->output() ?>
             <input type="hidden" name="responseFormat" value="dropzone" />
@@ -48,7 +48,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         </form>
     </div>
 
-    <div class="ccm-tab-content" id="ccm-tab-content-incoming">
+    <div class="ccm-tab-content ccm-tab-content-incoming" id="ccm-tab-content-<?= $formID ?>-incoming">
         <?php
         if ($incomingContentsError !== null) {
             ?>
@@ -64,7 +64,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <?php
         } else {
             ?>
-            <form id="ccm-file-add-incoming-form" method="POST" action="<?= $resolverManager->resolve(['/ccm/system/file/import_incoming']) ?>">
+            <form method="POST" action="<?= $resolverManager->resolve(['/ccm/system/file/import_incoming']) ?>">
                 <?php $token->output('import_incoming') ?>
                 <?php
                 if ($currentFolder !== null) {
@@ -145,8 +145,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
         ?>
     </div>
 
-    <div class="ccm-tab-content" id="ccm-tab-content-remote">
-        <form id="ccm-file-add-remote-form" method="POST" action="<?= $resolverManager->resolve(['/ccm/system/file/import_remote']) ?>">
+    <div class="ccm-tab-content ccm-tab-content-remote" id="ccm-tab-content-<?= $formID ?>-remote">
+        <form method="POST" action="<?= $resolverManager->resolve(['/ccm/system/file/import_remote']) ?>">
             <?php $token->output('import_remote') ?>
             <?php
             if ($currentFolder !== null) {
@@ -170,7 +170,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
 </div>
 
 <script>
-$(document).ready(function() {
+$(document).ready(function() { setTimeout(function() {
+
 var $dialog = $('#' + <?= json_encode($formID) ?>).closest('.ui-dialog-content'),
     $dialogContainer = $dialog.closest('.ui-dialog'),
     uploadedFiles = [];
@@ -248,7 +249,7 @@ function refreshDialogButtons() {
                     .text(<?= json_encode($replacingFile === null ? t('Add Files') : t('Replace File')) ?>)
                     .on('click', function(e) {
                         e.preventDefault();
-                        $dialog.find('#ccm-tab-content-' + tab + ' form').submit();
+                        $dialog.find('.ccm-tab-content-' + tab + ' form').submit();
                     })
                 );
             }
@@ -262,7 +263,7 @@ $dialog.find('ul.nav-tabs a[data-tab]').on('click', function() {
 setTimeout(function() { refreshDialogButtons(); }, 0);
 
 //Setup upload tab
-var $dropzone = $dialog.find('#ccm-tab-content-local form').dropzone({
+var $dropzone = $dialog.find('.ccm-tab-content-local form').dropzone({
     maxFiles: <?= $replacingFile === null ? 'null' : 1 ?>,
     sending: function() {
         $dialogContainer.find('.ui-dialog-buttonpane button').attr('disabled', 'disabled');
@@ -329,7 +330,7 @@ if ($replacingFile === null) {
     <?php
 }
 ?>
-$dialog.find('#ccm-tab-content-incoming form').concreteAjaxForm({
+$dialog.find('.ccm-tab-content-incoming form').concreteAjaxForm({
     skipResponseValidation: true,
     success: function(r) {
         handleImportResponse(r, true);
@@ -338,7 +339,7 @@ $dialog.find('#ccm-tab-content-incoming form').concreteAjaxForm({
 });
 
 // Setup incoming tab
-$dialog.find('#ccm-tab-content-remote form').concreteAjaxForm({
+$dialog.find('.ccm-tab-content-remote form').concreteAjaxForm({
     skipResponseValidation: true,
     success: function(r) {
         handleImportResponse(r, true);
@@ -346,5 +347,5 @@ $dialog.find('#ccm-tab-content-remote form').concreteAjaxForm({
     }
 });
 
-});
+}, 0);});
 </script>


### PR DESCRIPTION
Since #7314 got merged, we have just one tool to upload files to the file manager.

This implies that we have to wait that the dialog is loaded in order to drop files into the browser.

What about preloading the dialog? That way, it will appear almost instantaneously.

Fix #7916

PS: Here's a couple of video recordings using the same (slow) web server:

### Before

![upload-by-drag-and-drop-before](https://user-images.githubusercontent.com/928116/60104062-fc79b500-9760-11e9-87b7-729238eda7a8.gif)

### After

![upload-by-drag-and-drop-after](https://user-images.githubusercontent.com/928116/60104098-11eedf00-9761-11e9-8924-d9951d1cd0d7.gif)
