### PR TITLE
Prevent leading/trailing commas from triggering errors in Legacy Form block 

### DIFF
--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -207,7 +207,7 @@ class Controller extends BlockController
             $data['displayCaptcha'] = 0;
         }
 
-        $v = [$data['qsID'], $data['surveyName'], $data['submitText'], intval($data['notifyMeOnSubmission']), $data['recipientEmail'], $data['thankyouMsg'], intval($data['displayCaptcha']), intval($data['redirectCID']), intval($data['addFilesToSet']), intval($this->bID)];
+        $v = [$data['qsID'], $data['surveyName'], $data['submitText'], intval($data['notifyMeOnSubmission']), trim($data['recipientEmail'], " ..,"), $data['thankyouMsg'], intval($data['displayCaptcha']), intval($data['redirectCID']), intval($data['addFilesToSet']), intval($this->bID)];
 
         //is it new?
         if (intval($total) == 0) {

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -207,7 +207,18 @@ class Controller extends BlockController
             $data['displayCaptcha'] = 0;
         }
 
-        $v = [$data['qsID'], $data['surveyName'], $data['submitText'], intval($data['notifyMeOnSubmission']), trim($data['recipientEmail'], " ..,"), $data['thankyouMsg'], intval($data['displayCaptcha']), intval($data['redirectCID']), intval($data['addFilesToSet']), intval($this->bID)];
+        $v = [
+            $data['qsID'],
+            $data['surveyName'],
+            $data['submitText'],
+            intval($data['notifyMeOnSubmission']),
+            trim($data['recipientEmail'], " ..,"),
+            $data['thankyouMsg'],
+            intval($data['displayCaptcha']),
+            intval($data['redirectCID']),
+            intval($data['addFilesToSet']),
+            intval($this->bID)
+        ];
 
         //is it new?
         if (intval($total) == 0) {


### PR DESCRIPTION
This pull request trims leading and trailing whitespace and commas from the "Send form submissions to email addresses" Legacy Form block form input.

When the "Send form submissions to email addresses" checkbox is checked in the Legacy Form block form, any leading or trailing commas will cause Zend Mail to throw an exception. Trailing commas are particularly hard to debug if you don't know what to look for.

### Examples:

**Email Address Input**

`test@test.com,`

**Error**
```
Zend \ Mail \ Exception \ InvalidArgumentException
Invalid address format
```
Zend\Mail\Exception\InvalidArgumentException 
…\vendor\zendframework\zend-mail\src\AddressList.php:94

**Email Address Input**

`,test@test.com`

**Error**
```
Zend \ Mail \ Exception \ InvalidArgumentException
',test' can not be matched against dot-atom format
```
Zend\Mail\Exception\InvalidArgumentException 
…\vendor\zendframework\zend-mail\src\Address.php:41

**Email Address Input**

`,test@test.com,`

**Error:**
```
Zend \ Mail \ Exception \ InvalidArgumentException
'test.com,' is not a valid hostname for the email address
```
Zend\Mail\Exception\InvalidArgumentException 
…\vendor\zendframework\zend-mail\src\Address.php:41
