### PR TITLE
Fixes issue with broken links to files in textarea(richtext) attribute

### DIFF
--- a/concrete/attributes/textarea/controller.php
+++ b/concrete/attributes/textarea/controller.php
@@ -81,7 +81,7 @@ class Controller extends DefaultController
         $this->load();
         $value = null;
         if (is_object($this->attributeValue)) {
-            $value = $this->getAttributeValue()->getValue();
+            $value = $this->getAttributeValue()->getValueObject();
 
             if ($value) {
                 if ($this->akTextareaDisplayMode == 'rich_text') {


### PR DESCRIPTION
This is a fix for a really interesting issue that causes broken file links in textareas attributes when a page is edited.

**Steps to reproduce:**
1. Add a textarea attribute as richtext.
2. Add a link to file in this attribute
3. Save  page. (At this point you will have in your frontend a link like "{URL}/download_file/3/12")
4. Go again to edit mode and republish the page (no need to change anything).
5. At this point you will have a broken link like "{URL}/download_file/3/12/12"

This is because the LinkAbstractor keeps adding the current page id to the file link.

@aembler i think this is a really important issue that needs more eyes. Maybe it would be also useful a script that detects these broken links and fixes them. (If you think that this is necessary i can build an automated job for this or make a tutorial)