### PR TITLE
Add asset version number to cache bursting query string

### DIFF
--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -256,6 +256,8 @@ abstract class Asset implements AssetInterface
                 $config = $app->make('config');
                 $noCacheValue = $config->get('concrete.version_installed') . '-' . $config->get('concrete.version_db');
             }
+            $assetVersion = $this->getAssetVersion();
+            $noCacheValue = !empty($assetVersion) ? $noCacheValue . '-' . $assetVersion : $noCacheValue;
             $noCacheValue = $this->obfuscateNoCacheValue($noCacheValue);
             $result .= (strpos($result, '?') === false ? '?' : '&') . static::OUTPUT_NOCACHE_PARAM . '=' . rawurlencode($noCacheValue);
         }


### PR DESCRIPTION
Assets are burst out of Concrete5's own cache based on changing the version number.
The same should be true for the browser's cache. Relying solely on the package's version number is not enough. As an example, in my package Buttons Factory, I generate a CSS file and the asset version number is set dynamically.

This adds the version number, if any, to the string before obfuscating it so the asset will burst out of browser's cache if its version number changes.