### PR TITLE
User Selector Attribute: Adding search() & searchForm() methods

### DIFF
--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -91,8 +91,8 @@ class Controller extends AttributeTypeController
     }
 
     public function searchForm($list) {
-        $PagecID = $this->request('value');
-        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $PagecID, '=');
+        $UserID = $this->request('value');
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $UserID, '=');
         return $list;
     }
 

--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -89,4 +89,16 @@ class Controller extends AttributeTypeController
             $avn = $akn->addChild('value', $user->getUserID());
         }
     }
+
+    public function searchForm($list) {
+        $PagecID = $this->request('value');
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $PagecID, '=');
+        return $list;
+    }
+
+    public function search() {
+        $form_selector = $this->app->make('helper/form/user_selector');
+        print $form_selector->selectUser($this->field('value'), $this->request('value'), false);
+    }
+
 }


### PR DESCRIPTION
I've been using my own version of User Selector attribute.

https://github.com/katzueno/concrete5-addon-user_selector_attribute

And I noticed that new core User Selector Attribute is missing search() and searchForm().
I would like to add it to the core.

I think It would be nice add-on anyway.
(I want to avoid override every time).