### PR TITLE
PageList Class: very minor comment fix

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -495,7 +495,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filters by page type ID.
      *
-     * @param array | integer $cParentID
+     * @param array | integer $ptID
      */
     public function filterByPageTypeID($ptID)
     {


### PR DESCRIPTION
filterByPageTypeID() comment had the wrong parameter `$cParentID`.
It was a bit confusing :)