### PR TITLE
 Fix#7948 Can't access to rss feed when Viewing Permissions is not public

### DIFF
--- a/concrete/src/Entity/Page/Feed.php
+++ b/concrete/src/Entity/Page/Feed.php
@@ -10,6 +10,7 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Access\Entity\GroupEntity;
 use Concrete\Core\Site\Resolver\Resolver;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -349,18 +350,16 @@ class Feed
             $pl->ignorePermissions();
         } else {
             $vp = \Concrete\Core\Permission\Key\Key::getByHandle('view_page');
-            $guest = \Group::getByID(GUEST_GROUP_ID);
-            $access = GroupEntity::getOrCreate($guest);
-            // we set page permissions to be Guest group only, because
-            // authentication won't work with RSS feeds
-            $pl->setPermissionsChecker(function ($page) use ($vp, $access) {
+            $user = new User();
+            $accessEntites = $user->getUserAccessEntityObjects();
+            $pl->setPermissionsChecker(function ($page) use ($vp, $accessEntites) {
                 $vp->setPermissionObject($page);
                 $pa = $vp->getPermissionAccessObject($page);
                 if (!is_object($pa)) {
                     return false;
                 }
 
-                return $pa->validateAccessEntities([$access]);
+                return $pa->validateAccessEntities($accessEntites);
             });
         }
         $parent = null;

--- a/concrete/src/Entity/Page/Feed.php
+++ b/concrete/src/Entity/Page/Feed.php
@@ -7,7 +7,6 @@ use Concrete\Core\Http\Request;
 use Concrete\Core\Page\FeedEvent;
 use Concrete\Core\Page\PageList;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Permission\Access\Entity\GroupEntity;
 use Concrete\Core\Site\Resolver\Resolver;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
@@ -159,6 +158,7 @@ class Feed
 
     /**
      * @param string $format
+     *
      * @return string
      */
     public function getFeedDisplayTitle($format = 'html')
@@ -314,6 +314,7 @@ class Feed
     {
         return \URL::to('/rss/' . $this->getHandle());
     }
+
     /**
      * @ORM\Column(type="boolean")
      */


### PR DESCRIPTION
>  we set page permissions to be Guest group only, because
       authentication won't work with RSS feeds

`$user->getUserAccessEntityObjects()` already does the similar thing. It returns the `guest` group access entity if theres is no active session.

Want a review from the community as @hissy think it's not the expected way to fix.