### PR TITLE
Show error message only in Error List or Edit Response

### DIFF
--- a/concrete/src/Application/EditResponse.php
+++ b/concrete/src/Application/EditResponse.php
@@ -263,7 +263,11 @@ class EditResponse implements JsonSerializable
             $o->error = true;
             $o->errors = [];
             foreach ($error->getList() as $e) {
-                $o->errors[] = (string) $e;
+                if ($e instanceof Exception) {
+                    $o->errors[] = $e->getMessage();
+                } else {
+                    $o->errors[] = (string)$e;
+                }
             }
         } else {
             $error = (string) $error;

--- a/concrete/src/Error/ErrorList/Formatter/JsonFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/JsonFormatter.php
@@ -32,7 +32,11 @@ class JsonFormatter extends AbstractFormatter
             ];
             $index = 0;
             foreach ($error->getList() as $error) {
-                $o['errors'][] = (string) $error;
+                if ($error instanceof \Exception) {
+                    $o['errors'][] = $error->getMessage();
+                } else {
+                    $o['errors'][] = (string)$error;
+                }
                 if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
                     $o['htmlErrorIndexes'][] = $index;
                 }

--- a/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/StandardFormatter.php
@@ -29,7 +29,9 @@ class StandardFormatter extends AbstractFormatter
             foreach ($this->error->getList() as $error) {
                 $html .= '<li>';
                 if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
-                    $html .= (string) $error;
+                    $html .= (string)$error;
+                } elseif ($error instanceof \Exception) {
+                    $html .= nl2br(h($error->getMessage()));
                 } else {
                     $html .= nl2br(h((string) $error));
                 }

--- a/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
@@ -27,7 +27,9 @@ class TextFormatter extends AbstractFormatter
         if ($this->error->has()) {
             foreach ($this->error->getList() as $error) {
                 if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
-                    $lines[] = strip_tags((string) $error);
+                    $lines[] = strip_tags((string)$error);
+                } elseif ($error instanceof \Exception) {
+                    $lines[] = $error->getMessage();
                 } else {
                     $lines[] = (string) $error;
                 }


### PR DESCRIPTION
If you add any Exceptions into the ErrorList, you can get full stack trace even if your `concrete.debug.display_errors` setting is 'message' .

For example, you'll get stacktrace when you upload a file with disallowed file extension.

<img width="685" alt="Screen Shot 2019-07-03 at 23 05 56" src="https://user-images.githubusercontent.com/514294/60598839-61c84880-9de8-11e9-9f3d-a1fff5df8848.png">

IMO, we should avoid displaying sensitive system information.