### PR TITLE
correcting ordering of question emailed

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -260,11 +260,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                     }
                 }
                 if (isset($e) && !$e->has()) {
-                    if ($this->areFormSubmissionsStored() && isset($values)) {
-                        $submittedAttributeValues = $values;
-                    } else {
-                        $submittedAttributeValues = $manager->getEntryAttributeValuesForm($form, $entry);
-                    }
+                    $submittedAttributeValues = $manager->getEntryAttributeValuesForm($form, $entry);
                     $notifier = $controller->getNotifier($this);
                     $notifications = $notifier->getNotificationList();
                     array_walk($notifications->getNotifications(), function ($notification) use ($submittedAttributeValues,$key) {


### PR DESCRIPTION
I'd be lieing if I said I fully understood what this was doing but it does seem to fix the issue. There might be a better way to use those values and ordering them ahead of this without having to go back to the manager but I'm not sure.

Fixes #7875 