### PR TITLE
Fix link abstractor export functionality

### DIFF
--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -90,7 +90,7 @@ class LinkAbstractor extends ConcreteObject
         $app = Application::getFacadeApplication();
         $entityManager = $app->make(EntityManagerInterface::class);
         $resolver = $app->make(ResolverManagerInterface::class);
-        
+
         $text = preg_replace(
             [
                 '/{CCM:BASE_URL}/i',
@@ -321,18 +321,18 @@ class LinkAbstractor extends ConcreteObject
             $text,
             '{CCM:CID_([0-9]+)}',
             function ($cID) {
-                return ContentExporter::replacePageWithPlaceHolderInMatch($cID);
+                return ContentExporter::replacePageWithPlaceHolder($cID);
             }
         );
 
         $text = static::replacePlaceholder(
             $text,
             '{CCM:FID_DL_([0-9]+)}',
-            function ($cID) {
-                return ContentExporter::replaceFileWithPlaceHolderInMatch($cID);
+            function ($fID) {
+                return ContentExporter::replaceFileWithPlaceHolder($fID);
             }
         );
-        
+
         $dom = new HtmlDomParser();
         $r = $dom->str_get_html($text, true, true, DEFAULT_TARGET_CHARSET, false);
         if (is_object($r)) {

--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -41,7 +41,7 @@ class LinkAbstractor extends ConcreteObject
         $r = $dom->str_get_html($text, true, true, DEFAULT_TARGET_CHARSET, false);
         if ($r) {
             foreach ($r->find('img') as $img) {
-                $attrString = "";
+                $attrString = '';
                 foreach ($img->attr as $key => $val) {
                     if (!in_array($key, self::$blackListImgAttributes)) {
                         $attrString .= "$key=\"$val\" ";
@@ -125,12 +125,12 @@ class LinkAbstractor extends ConcreteObject
                 if ($fo !== null) {
                     $style = (string) $picture->style;
                     // move width px to width attribute and height px to height attribute
-                    $widthPattern = "/(?:^width|[^-]width):\\s([0-9]+)px;?/i";
+                    $widthPattern = '/(?:^width|[^-]width):\\s([0-9]+)px;?/i';
                     if (preg_match($widthPattern, $style, $matches)) {
                         $style = preg_replace($widthPattern, '', $style);
                         $picture->width = $matches[1];
                     }
-                    $heightPattern = "/(?:^height|[^-]height):\\s([0-9]+)px;?/i";
+                    $heightPattern = '/(?:^height|[^-]height):\\s([0-9]+)px;?/i';
                     if (preg_match($heightPattern, $style, $matches)) {
                         $style = preg_replace($heightPattern, '', $style);
                         $picture->height = $matches[1];
@@ -210,6 +210,7 @@ class LinkAbstractor extends ConcreteObject
                     if ($currentPage !== false) {
                         $args[] = $currentPage->getCollectionID();
                     }
+
                     return $resolver->resolve($args);
                 }
             }
@@ -259,7 +260,7 @@ class LinkAbstractor extends ConcreteObject
             foreach ($r->find('concrete-picture') as $picture) {
                 $fID = $picture->fid;
 
-                $attrString = "";
+                $attrString = '';
                 foreach ($picture->attr as $attr => $val) {
                     if (!in_array($attr, self::$blackListImgAttributes)) {
                         $attrString .= "$attr=\"$val\" ";
@@ -269,7 +270,7 @@ class LinkAbstractor extends ConcreteObject
                 $picture->outertext = '<img src="' . $resolver->resolve([
                         '/download_file',
                         'view_inline',
-                        $fID
+                        $fID,
                     ]) . '" ' . $attrString . '/>';
             }
 

--- a/tests/tests/Editor/LinkAbstractorTest.php
+++ b/tests/tests/Editor/LinkAbstractorTest.php
@@ -1,0 +1,187 @@
+<?php
+namespace Concrete\Tests\Editor;
+
+use Concrete\Core\Cache\CacheLocal;
+use Concrete\Core\Editor\LinkAbstractor;
+use Concrete\Core\Support\Facade\Facade;
+use Core;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit_Framework_TestCase;
+
+class LinkAbstractorTest extends PHPUnit_Framework_TestCase
+{
+    public function testTranslateFromEditMode()
+    {
+        $baseUrl = 'http://www.dummyco.com/path/to/server';
+
+        $input = '<a href="{CCM:BASE_URL}/test">Link</a>';
+        $this->assertEquals(
+            '<a href="' . $baseUrl . '/test">Link</a>',
+            LinkAbstractor::translateFromEditMode($input)
+        );
+
+        $input = '<a href="{CCM:CID_123}">Link</a>';
+        $this->assertEquals(
+            '<a href="' . $baseUrl . '/index.php?cID=123">Link</a>',
+            LinkAbstractor::translateFromEditMode($input)
+        );
+
+        $input = '<concrete-picture fID="123" />';
+        $this->assertEquals(
+            '<img src="' . $baseUrl . '/index.php/download_file/view_inline/123" />',
+            LinkAbstractor::translateFromEditMode($input)
+        );
+
+        $input = '<a href="{CCM:FID_123}">Link</a>';
+        $this->assertEquals(
+            '<a href="' . $baseUrl . '/index.php/download_file/view_inline/123">Link</a>',
+            LinkAbstractor::translateFromEditMode($input)
+        );
+
+        $input = '<a href="{CCM:FID_DL_123}">Link</a>';
+        $this->assertEquals(
+            '<a href="' . $baseUrl . '/index.php/download_file/view/123">Link</a>',
+            LinkAbstractor::translateFromEditMode($input)
+        );
+    }
+
+    public function testTranslateTo()
+    {
+        $baseUrl = 'http://www.dummyco.com/path/to/server';
+
+        $input = '<a href="' . $baseUrl . '/test">Link</a>';
+        $this->assertEquals(
+            '<a href="{CCM:BASE_URL}/test">Link</a>',
+            LinkAbstractor::translateTo($input)
+        );
+
+        $input = '<a href="' . $baseUrl . '/index.php?cID=123">Link</a>';
+        $this->assertEquals(
+            '<a href="{CCM:CID_123}">Link</a>',
+            LinkAbstractor::translateTo($input)
+        );
+
+        $input = '<img src="' . $baseUrl . '/index.php/download_file/view_inline/123" />';
+        $this->assertEquals(
+            '<concrete-picture fID="123" />',
+            LinkAbstractor::translateTo($input)
+        );
+
+        $input = '<a href="' . $baseUrl . '/index.php/download_file/view/123">Link</a>';
+        $this->assertEquals(
+            '<a href="{CCM:FID_DL_123}">Link</a>',
+            LinkAbstractor::translateTo($input)
+        );
+    }
+
+    public function testExport()
+    {
+        $app = Facade::getFacadeApplication();
+
+        // Mock the cache class so that we can return a mocked page object
+        // without initializing the page related database tables.
+        $origCache = Core::make('cache/request');
+        $cache = $this->getMockBuilder('Concrete\Core\Cache\Level\RequestCache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $app->bind('cache/request', function () use ($cache) {
+            return $cache;
+        });
+
+        // Make the local request cache enabled always.
+        $cache->expects($this->any())->method('isEnabled')->willReturn(true);
+
+        // Mock the entity manager so that we can return a mocked file object
+        // without initializing the files related database tables.
+        $origEm = Core::make(EntityManagerInterface::class);
+        $em = $this->getMockBuilder(EntityManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $app->bind(EntityManagerInterface::class, function () use ($em) {
+            return $em;
+        });
+
+        // Create a mock page object and corresponding cache item to return by
+        // the mocked cache class.
+        $mockPage = $this->getMockBuilder('Concrete\Core\Page\Page')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockPage->expects($this->once())
+            ->method('getCollectionPath')
+            ->willReturn('/test/page/path');
+        $pageCacheItem = $this->getMockBuilder('Stash\Item')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pageCacheItem->expects($this->once())
+            ->method('isMiss')
+            ->willReturn(false);
+        $pageCacheItem->expects($this->once())
+            ->method('get')
+            ->willReturn($mockPage);
+
+        // Bind the cache getEntry method to return the corresponding page
+        // cache item.
+        $cache->expects($this->once())
+            ->method('getItem')
+            ->with(
+                CacheLocal::key('page', '123/RECENT/Concrete\Core\Page\Page')
+            )
+            ->willReturn($pageCacheItem);
+
+        // Test that the link abstractor exports the page correctly
+        $input = '<a href="{CCM:CID_123}">Link</a>';
+        $this->assertEquals(
+            '<a href="{ccm:export:page:/test/page/path}">Link</a>',
+            LinkAbstractor::export($input)
+        );
+
+        // Create a mock file object and make the mocked entity manager return
+        // that.
+        $mockFile = $this->getMockBuilder('Concrete\Core\Entity\File\File')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFile->expects($this->any())
+            ->method('__call')
+            ->will($this->returnCallback(function ($method, $args) {
+                if ($method === 'getPrefix') {
+                    return '123456789012';
+                } elseif ($method === 'getFileName' ||
+                    $method === 'getFilename'
+                ) {
+                    return 'test_file.jpg';
+                }
+
+                return null;
+            }));
+
+        $em->expects($this->exactly(2))
+            ->method('find')
+            ->with(
+                $this->equalTo('Concrete\Core\Entity\File\File'),
+                $this->equalTo(123)
+            )
+            ->willReturn($mockFile);
+
+        // Test that the link abstractor exports the file correctly
+        $input = '<a href="{CCM:FID_DL_123}">Link</a>';
+        $this->assertEquals(
+            '<a href="{ccm:export:file:123456789012:test_file.jpg}">Link</a>',
+            LinkAbstractor::export($input)
+        );
+
+        // The that the link abstractor exports the images correctly
+        $input = '<concrete-picture fID="123" />';
+        $this->assertEquals(
+            '<concrete-picture file="123456789012:test_file.jpg" />',
+            LinkAbstractor::export($input)
+        );
+
+        // Revert to the defaults
+        $app->bind('cache/request', function () use ($origCache) {
+            return $origCache;
+        });
+        $app->bind(EntityManagerInterface::class, function () use ($origEm) {
+            return $origEm;
+        });
+    }
+}


### PR DESCRIPTION
The export method of the link abstractor has been broken by 06dcbdece84d087479db6e9730298525cc45164f.

This fixes that and adds some tests to assure this won't happen again.