### PR TITLE
Updates the format of Page List RSS URL to alphanumeric with hyphens

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -338,8 +338,8 @@ class Controller extends BlockController
             $pf = Feed::getByID($this->pfID);
         }
         if ($args['rss'] && !is_object($pf)) {
-            if (!$vs->handle($args['rssHandle'])) {
-                $e->add(t('Your RSS feed must have a valid URL, containing only letters, numbers or underscores'));
+            if (!$vs->alphanum($args['rssHandle'], false, true)) {
+                $e->add(t('Your RSS feed must have a valid URL, containing only letters, numbers or hyphens'));
             }
             if (!$vs->notempty($args['rssTitle'])) {
                 $e->add(t('Your RSS feed must have a valid title.'));

--- a/concrete/src/Routing/SystemRouteList.php
+++ b/concrete/src/Routing/SystemRouteList.php
@@ -65,7 +65,7 @@ class SystemRouteList implements RouteListInterface
             ->setPrefix('/ccm/system/dialogs/block')
             ->routes('dialogs/blocks.php');
 
-        $router->buildGroup()->setRequirements(['identifier' => '[A-Za-z0-9_/.]+'])->routes('rss.php');
+        $router->buildGroup()->setRequirements(['identifier' => '[A-Za-z0-9-/.]+'])->routes('rss.php');
 
         $router->buildGroup()->routes('attributes.php');
 

--- a/concrete/src/Routing/SystemRouteList.php
+++ b/concrete/src/Routing/SystemRouteList.php
@@ -65,7 +65,7 @@ class SystemRouteList implements RouteListInterface
             ->setPrefix('/ccm/system/dialogs/block')
             ->routes('dialogs/blocks.php');
 
-        $router->buildGroup()->setRequirements(['identifier' => '[A-Za-z0-9-/.]+'])->routes('rss.php');
+        $router->buildGroup()->setRequirements(['identifier' => '[A-Za-z0-9-_/.]+'])->routes('rss.php');
 
         $router->buildGroup()->routes('attributes.php');
 


### PR DESCRIPTION
Currently the validation on save of the Page List block forces the slug for an RSS URL to be alphanumeric with underscores, not hyphens. This is at odds with the typical generated URLs used throughout the rest of Concrete5.

There may be a better way of checking the string then `alphanum($string, false, true)` (perhaps by validating the entire URL?) but this was a function from the same helper and seemed appropriate.