### PR TITLE
Update composer.json to add PDO ext

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -28,6 +28,7 @@
   },
   "bin": [ "bin/concrete5" ],
   "require": {
+    "ext-PDO": "*",
     "php": ">=5.5.9",
     "doctrine/dbal": "~2.5",
     "symfony/class-loader": "3.*",


### PR DESCRIPTION
Update composer.json to add PDO ext as dependency for project.

The purpose of this commit is to explicitly inform developers of any php ext dependencies.


