### PR TITLE
fix for #7971

### DIFF
--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -216,8 +216,7 @@ class Controller extends BlockController
             }
 
             if ($this->request->query->get('keywords') && $this->enableSearch) {
-                $keywords = trim($this->request->query->get('keywords'));
-                $keywords = explode(' ', $keywords);
+                $keywords = preg_split('/\s+/', $this->request->query->get('keywords'), -1, PREG_SPLIT_NO_EMPTY);
                 foreach ($keywords  as $keyword) {
                     $list->filterByKeywords($keyword);
                 }

--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -216,7 +216,11 @@ class Controller extends BlockController
             }
 
             if ($this->request->query->get('keywords') && $this->enableSearch) {
-                $list->filterByKeywords($this->request->query->get('keywords'));
+                $keywords = trim($this->request->query->get('keywords'));
+                $keywords = explode(' ', $keywords);
+                foreach ($keywords  as $keyword) {
+                    $list->filterByKeywords($keyword);
+                }
             }
 
             $tableSearchProperties = [];


### PR DESCRIPTION
Default Express Entry List search functionality does not allow for searching for multiple fields simultaneously.  This was occurring even when first_name and last_name attributes were added to the search index.

Example: Searching for 'John Doe' does not return a result, while searching for either 'John' or 'Doe' does return results.

This fix is simply trimming the search parameters, exploding on white space, and using a loop to search for each keyword.
