### PR TITLE
Fix for #7920 (Vol. 2)

### DIFF
--- a/concrete/js/build/core/app/in-context-menu.js
+++ b/concrete/js/build/core/app/in-context-menu.js
@@ -259,7 +259,7 @@
                 my.hide(e);
             });
 
-            $(document).unbind('.concreteMenuDisable').on('click.concreteMenuDisable', function (e) {
+            $(document).unbind('.concreteMenuDisable').on('click.concreteMenuDisable','body', function (e) {
                 my.hide(e);
             });
 


### PR DESCRIPTION
This is a second try to fix the Issue described in #7920 and also the sideeffect described in this [comment](https://github.com/concrete5/concrete5/issues/7920#issuecomment-509990326)

The difference with my previous PL #7960 is that i leave $(document) as selector for the unbind event and i add body selector in the on click event. That seems to fix the filemanager problem and has no side-effect in the Design & Custom Template toolbar.