### PR TITLE
Show only the message when we have in case of UserMessageException

### DIFF
--- a/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
+++ b/concrete/src/Error/ErrorList/Formatter/TextFormatter.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Error\ErrorList\Formatter;
 
 use Concrete\Core\Error\ErrorList\Error\HtmlAwareErrorInterface;
+use Concrete\Core\Error\UserMessageException;
 
 class TextFormatter extends AbstractFormatter
 {
@@ -26,10 +27,15 @@ class TextFormatter extends AbstractFormatter
         $lines = [];
         if ($this->error->has()) {
             foreach ($this->error->getList() as $error) {
-                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
-                    $lines[] = strip_tags((string) $error);
+                if ($error instanceof UserMessageException) {
+                    $errorMessage = $error->getMessage();
                 } else {
-                    $lines[] = (string) $error;
+                    $errorMessage = (string) $error;
+                }
+                if ($error instanceof HtmlAwareErrorInterface && $error->messageContainsHtml()) {
+                    $lines[] = strip_tags($errorMessage);
+                } else {
+                    $lines[] = $errorMessage;
                 }
             }
         }


### PR DESCRIPTION
When serializing errors represented by `UserMessageException` instances, we should keep just the message, not the whole stack trace of the error.