### PR TITLE
Refactoring of the way dropzone works

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -156,6 +156,13 @@ module.exports = function(grunt) {
             ]
         },
 
+        fileuploader: {
+            dest: '<%= DIR_BASE %>/concrete/js/file-uploader.js',
+            src: [
+                '<%= DIR_BASE %>/concrete/js/build/core/app/file-uploader.js',
+            ]
+        },
+
         express: {
             dest: '<%= DIR_BASE %>/concrete/js/express.js',
             src: [

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -619,6 +619,9 @@ return [
             ['javascript', 'js/file-manager.js', ['minify' => false]],
             ['css', 'css/file-manager.css', ['minify' => false]],
         ],
+        'core/file-uploader' => [
+            ['javascript', 'js/file-uploader.js', ['minify' => false]],
+        ],
         'core/express' => [
             ['javascript', 'js/express.js', ['minify' => false]],
         ],
@@ -911,6 +914,7 @@ return [
                 ['css', 'jquery/ui'],
                 ['css', 'core/file-manager'],
                 ['css', 'selectize'],
+                ['javascript', 'dropzone'],
                 ['javascript', 'core/events'],
                 ['javascript', 'core/asset-loader'],
                 ['javascript', 'bootstrap/tooltip'],
@@ -920,10 +924,20 @@ return [
                 ['javascript-localized', 'jquery/ui'],
                 ['javascript', 'selectize'],
                 ['javascript-localized', 'core/localization'],
+                ['javascript-localized', 'dropzone'],
                 ['javascript', 'core/app'],
                 ['javascript', 'jquery/fileupload'],
                 ['javascript', 'core/tree'],
+                ['javascript', 'core/file-uploader'],
                 ['javascript', 'core/file-manager'],
+            ],
+        ],
+        'core/file-uploader' => [
+            [
+                ['css', 'dropzone'],
+                ['javascript', 'dropzone'],
+                ['javascript-localized', 'dropzone'],
+                ['javascript', 'core/file-uploader'],
             ],
         ],
         'core/duration' => [

--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -182,6 +182,7 @@ class File extends Controller
     {
         $errors = $this->app->make('error');
         $importedFileVersions = [];
+        $replacingFile = $this->getFileToBeReplaced();
         try {
             if ($post_max_size = $this->app->make('helper/number')->getBytes(ini_get('post_max_size'))) {
                 if ($post_max_size < $_SERVER['CONTENT_LENGTH']) {
@@ -192,7 +193,6 @@ class File extends Controller
             if (!$token->validate()) {
                 throw new UserMessageException($token->getErrorMessage(), 401);
             }
-            $replacingFile = $this->getFileToBeReplaced();
             if ($this->request->files->has('file')) {
                 $importedFileVersion = $this->handleUpload('file');
                 if ($importedFileVersion !== null) {
@@ -750,7 +750,7 @@ class File extends Controller
         switch ($this->request->request->get('responseFormat')) {
             case 'dropzone':
                 if ($errors->has()) {
-                    return $responseFactory->create($errors->toText(), 422, ['Content-Type' => 'text/plain; charset='.APP_CHARSET]);
+                    return $responseFactory->create(json_encode($errors->toText()), 422, ['Content-Type' => 'application/json; charset='.APP_CHARSET]);
                 }
                 break;
             default:

--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -600,28 +600,38 @@ jQuery.ui.fancytree.prototype.options.strings.loadError = ' . json_encode(t('Loa
      */
     public function getDropzoneJavascript()
     {
-        $content = ';
-Dropzone.prototype.defaultOptions.dictDefaultMessage = ' . json_encode(t('Drop files here or click to upload.')) . ';
-Dropzone.prototype.defaultOptions.dictFallbackMessage = ' . json_encode(t("Your browser does not support drag'n'drop file uploads.")) . ';
-Dropzone.prototype.defaultOptions.dictFallbackText = ' . json_encode(t('Please use the fallback form below to upload your files like in the olden days.')) . ';
-Dropzone.prototype.defaultOptions.dictFallbackText = ' . json_encode(t('Please use the fallback form below to upload your files like in the olden days.')) . ';
-Dropzone.prototype.defaultOptions.dictFileTooBig = ' . json_encode(t('File is too big ({{filesize}}MiB). Max filesize: {{maxFilesize}}MiB.')) . ';
-Dropzone.prototype.defaultOptions.dictInvalidFileType = ' . json_encode(t('You can\'t upload files of this type.')) . ';
-Dropzone.prototype.defaultOptions.dictResponseError = ' . json_encode(t('Server responded with {{statusCode}} code.')) . ';
-Dropzone.prototype.defaultOptions.dictCancelUpload = ' . json_encode(t('Cancel upload')) . ';
-Dropzone.prototype.defaultOptions.dictCancelUploadConfirmation = ' . json_encode(t('Are you sure you want to cancel this upload?')) . ';
-Dropzone.prototype.defaultOptions.dictRemoveFile = ' . json_encode(t('Remove file')) . ';
-Dropzone.prototype.defaultOptions.dictMaxFilesExceeded = ' . json_encode(t('You can not upload any more files.')) . ';
-Dropzone.prototype.defaultOptions.resizeQuality = ' . ($this->app->make(BitmapFormat::class)->getDefaultJpegQuality() / 100) . ';
-';
         $config = $this->app->make('config');
+        $token = $this->app->make('token');
+        $options = [
+            'dictDefaultMessage' => t('Drop files here or click to upload.'),
+            'dictFallbackMessage' => t("Your browser does not support drag'n'drop file uploads."),
+            'dictFallbackText' => t('Please use the fallback form below to upload your files like in the olden days.'),
+            'dictFallbackText' => t('Please use the fallback form below to upload your files like in the olden days.'),
+            'dictFileTooBig' => t('File is too big ({{filesize}}MiB). Max filesize: {{maxFilesize}}MiB.'),
+            'dictInvalidFileType' => t('You can\'t upload files of this type.'),
+            'dictResponseError' => t('Server responded with {{statusCode}} code.'),
+            'dictCancelUpload' => t('Cancel upload'),
+            'dictCancelUploadConfirmation' => t('Are you sure you want to cancel this upload?'),
+            'dictRemoveFile' => t('Remove file'),
+            'dictMaxFilesExceeded' => t('You can not upload any more files.'),
+            'resizeQuality' => $this->app->make(BitmapFormat::class)->getDefaultJpegQuality() / 100,
+            'chunking' => (bool) $config->get('concrete.upload.chunking.enabled'),
+            'chunkSize' => $this->getDropzoneChunkSize(),
+            'params' => [
+                $token::DEFAULT_TOKEN_NAME => $token->generate(),
+            ],
+        ];
         $maxWidth = (int) $config->get('concrete.file_manager.restrict_max_width');
         if ($maxWidth > 0) {
-            $content .= "Dropzone.prototype.defaultOptions.resizeWidth = {$maxWidth};\n";
+            $options['resizeWidth'] = $maxWidth;
         }
         $maxHeight = (int) $config->get('concrete.file_manager.restrict_max_height');
         if ($maxHeight > 0) {
-            $content .= "Dropzone.prototype.defaultOptions.resizeHeight = {$maxHeight};\n";
+            $options['resizeHeight'] = $maxHeight;
+        }
+        $content = '';
+        foreach ($options as $optionKey => $optionValue) {
+            $content .= 'Dropzone.prototype.defaultOptions[' . json_encode($optionKey) . '] = ' . json_encode($optionValue) . ";\n";
         }
         if ($maxWidth > 0 || $maxHeight > 0) {
             $content .= <<<'EOT'
@@ -696,5 +706,39 @@ jQuery.fn.concreteConversationAttachments.localize(' . json_encode([
         }
 
         return $this->createJavascriptResponse($content);
+    }
+
+    /**
+     * @return int
+     */
+    private function getDropzoneChunkSize()
+    {
+        $config = $this->app->make('config');
+        $chunkSize = (int) $config->get('concrete.upload.chunking.chunkSize');
+
+        return $chunkSize > 0 ? $chunkSize : $this->getDropzoneAutomaticChunkSize();
+    }
+
+    /**
+     * @return int
+     */
+    private function getDropzoneAutomaticChunkSize()
+    {
+        $nh = $this->app->make('helper/number');
+        // Maximum size of an uploaded file, minus a small value (just in case)
+        $uploadMaxFilesize = (int) $nh->getBytes(ini_get('upload_max_filesize')) - 100;
+        // Max size of post data allowed, minus enough space to consider other posted fields.
+        $postMaxSize = (int) $nh->getBytes(ini_get('post_max_size')) - 10000;
+        if ($uploadMaxFilesize < 1 && $postMaxSize < 1) {
+            return 2000000;
+        }
+        if ($uploadMaxFilesize < 1) {
+            return $postMaxSize;
+        }
+        if ($postMaxSize < 1) {
+            return $uploadMaxFilesize;
+        }
+        
+        return min($uploadMaxFilesize, $postMaxSize);
     }
 }

--- a/concrete/js/build/core/app/file-uploader.js
+++ b/concrete/js/build/core/app/file-uploader.js
@@ -1,0 +1,260 @@
+/* jshint unused:vars, undef:true, jquery:true, browser:true */
+/* global ConcreteAjaxRequest, ConcreteAlert, ConcreteEvent, NProgress */
+
+/*
+ * Usage:
+ * var options = {
+ *     // Defines where to display the file previews
+ *     previewsContainer: <false|HTMLElement|string>,
+ *     // Defines what can be clicked to open the system file secttor
+ *     clickable: <false|HTMLElement|string>
+ *     // Can be used to limit the maximum number of files that will be handled by this Dropzone
+ *     maxFiles: <Number|null>
+ *     // Called when the upload starts
+ *     uploadStarted: <Function|null>; parameters: file, xhr, formData
+ *     // Called when one or more files have been uploaded
+ *     uploadCompleted: <Function|null>; parameters: files
+ *     // Called when all the queued uploads completed
+ *     uploadQueueCompleted: <Function|null>; parameters: none
+ *     // Called when all the upload completed
+ *     uploadFailed: <Function|null>; parameters: message
+ *     // When replacing a file, its ID
+ *     replacingFileID: <Number|Function|null>
+ *     // The page associated to the files being uploaded
+ *     originalPageID: <Number|Function|null>
+ *     // The ID of the tree node of the folder where the files should be uploaded to
+ *     folderID: <Number|Function|null>
+ * };
+ * window.ccm_fileUploader.start(options);
+ * window.ccm_fileUploader.stop(options);
+ */
+;(function(global, $) {
+'use strict';
+
+if (typeof global.ccm_fileUploader !== 'undefined') {
+    return;
+}
+
+/**
+ * Is the document already loaded?
+ */
+var documentLoaded = false;
+
+/**
+ * The Dropzone instance (NULL if the file uploader is not started).
+ */
+var dropzone = null;
+
+/**
+ * The options stack (empty if the file uploader should be stopped).
+ */
+var optionsStack = [];
+
+/**
+ * Get the default options for dropzone (also defines the only keys of the user-defined options that are applicable to Dropzone)
+ */
+function getDefaultOptions() {
+    return {
+        previewsContainer: false,
+        maxFiles: null,
+        previewTemplate: global.Dropzone.prototype.defaultOptions.previewTemplate,
+        clickable: false,
+    };
+}
+
+/**
+ * Let's start the drop zone when the document is loaded (if asked so).
+ */
+$(document).ready(function() {
+    documentLoaded = true;
+    if (optionsStack.length !== 0) {
+        startDropzone(optionsStack[optionsStack.length - 1]);
+    }
+});
+
+/**
+ * Stop the file uploader.
+ */
+function stopDropzone() {
+    if (dropzone !== null) {
+        dropzone.destroy();
+        dropzone = null;
+    }
+}
+
+/**
+ * (Re) start the file uploader.
+ */
+function startDropzone(customOptions) {
+    stopDropzone();
+    var options = {},
+        defaultOptions = getDefaultOptions();
+    Object.keys(defaultOptions).forEach(function(optionKey) {
+        options[optionKey] = customOptions.hasOwnProperty(optionKey) ? customOptions[optionKey] : defaultOptions[optionKey];
+    });
+    var showProgressbar = options.previewsContainer === false;
+    $.extend(options, {
+        method: 'POST',
+        url: global.CCM_DISPATCHER_FILENAME + '/ccm/system/file/upload',
+        sending: function(file, xhr, formData) {
+            if(showProgressbar) {
+                NProgress.start();
+            }
+            formData.append('responseFormat', 'dropzone');
+            var options = optionsStack[optionsStack.length - 1];
+            if (options.originalPageID) {
+                formData.append('ocID', isFunction(options.originalPageID) ? options.originalPageID() : options.originalPageID);
+            }
+            if (options.replacingFileID) {
+                formData.append('fID', isFunction(options.replacingFileID) ? options.replacingFileID() : options.replacingFileID);
+            }
+            if (options.folderID) {
+                formData.append('currentFolder', isFunction(options.folderID) ? options.folderID() : options.folderID);
+            }
+            if (options.uploadStarted) {
+                options.uploadStarted(file, xhr, formData);
+            }
+        },
+        success: function(data, r) {
+            handleResponse(r);
+        },
+        chunksUploaded: function (file, done) {
+            if (file.xhr.response) {
+                handleResponse(JSON.parse(file.xhr.response));
+            }
+            done();
+        },
+        // We may need to allow people to re-try uploading a file if maxFiles === 1 and the upload of the file filed
+        error: function(files, message, xhr) {
+            this.defaultOptions.error.apply(this, arguments);
+            if (this.options.maxFiles === 1 && files) {
+                if (!(files instanceof Array)) {
+                    files = [files];
+                }
+                files.forEach(function(file) {
+                    if (file && file.accepted) {
+                        file.accepted = false;
+                    }
+                });
+            }
+            if (optionsStack[optionsStack.length - 1].uploadFailed) {
+                optionsStack[optionsStack.length - 1].uploadFailed(message);
+            } else {
+                ConcreteAlert.error({
+                    message: message,
+                    appendTo: document.body
+                });
+            }
+        },
+        queuecomplete: function() {
+            if(showProgressbar) {
+                NProgress.done();
+            }
+            if (optionsStack.length && optionsStack[optionsStack.length - 1].uploadQueueCompleted) {
+                optionsStack[optionsStack.length - 1].uploadQueueCompleted();
+            }
+        }
+    });
+    dropzone = new global.Dropzone(
+        window.document.body,
+        options
+    );
+}
+
+/**
+ * Handles the dropzone succesfull responses.
+ */
+function handleResponse(response) {
+    if (!response) {
+        return;
+    }
+    ConcreteAjaxRequest.validateResponse(
+        response,
+        function(good) {
+            var options = optionsStack[optionsStack.length - 1];
+            if (!good) {
+                if (response.message) {
+                    if (options.uploadFailed) {
+                        options.uploadFailed(response.message);
+                    }
+                    ConcreteAlert.notify({
+                        title: response.title,
+                        message: response.message,
+                        appendTo: document.body
+                    });
+                }
+            } else {
+                if (response.files && response.files.length) {
+                    if (options.uploadCompleted) {
+                        options.uploadCompleted(response.files);
+                    } else {
+                        var replacingFileID = isFunction(options.replacingFileID) ? options.replacingFileID() : options.replacingFileID;
+                        if (replacingFileID) {
+                            ConcreteEvent.publish('FileManagerReplaceFileComplete', {files: response.files});
+                        } else {
+                            ConcreteEvent.publish('FileManagerAddFilesComplete', {files: response.files});
+                        }
+                    }
+                }
+            }
+        }
+    );
+}
+
+/**
+ * Check if an object is a function
+ * @see https://jsperf.com/alternative-isfunction-implementations
+ */
+function isFunction(value) {
+    return !!(value && value.constructor && value.call && value.apply);
+}
+
+var ccm_fileUploader = {};
+Object.defineProperties(ccm_fileUploader, {
+    /**
+     * Start the file uploader, or re-configure it with specific options.
+     * @param Object options
+     */
+    start: {
+        writable: false,
+        value: function(options) {
+            options = options || {};
+            optionsStack.push(options);
+            if (documentLoaded) {
+                startDropzone(options);
+            }
+        }
+    },
+    /**
+     * Stop the file uploader (or reset it to a previous state)
+     * @param Object options the same "options" variable passed to the start method (it must be the same object instance)
+     */
+    stop: {
+        writable: false,
+        value: function(options) {
+            var optionsIndex = optionsStack.indexOf(options);
+            if (optionsIndex < 0) {
+                global.console.error('Invalid options passed to ccm_fileUploader.stop()');
+                return;
+            }
+            var isCurrent = optionsIndex === optionsStack.length - 1;
+            optionsStack.splice(optionsIndex, 1);
+            if (!isCurrent) {
+                return;
+            }
+            stopDropzone();
+            if (documentLoaded && optionsStack.length > 0) {
+                startDropzone(optionsStack[optionsStack.length - 1]);
+            }
+        }
+    }
+});
+
+Object.defineProperties(global, {
+    ccm_fileUploader: {
+        writable: false,
+        value: ccm_fileUploader
+    }
+});
+
+})(this, jQuery);

--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -215,36 +215,28 @@
         }
     };
 
-    ConcreteFileManager.onDragOver = function (e) {
-        if (ConcreteFileManager.openingFileImporter) {
-            return;
-        }
-        var dataTransfer = e.originalEvent && e.originalEvent.dataTransfer;
-        if (dataTransfer && $.inArray('Files', dataTransfer.types) !== -1) {
-            if ($('div.ccm-file-manager-import-files').length === 0) {
-                e.stopPropagation();
-                $('a[data-dialog=add-files]').trigger('click');
-            }
-        }
-    };
     ConcreteFileManager.prototype.setupFileUploads = function() {
         var my = this;
-        $(document)
-            .off('dragover', ConcreteFileManager.onDragOver)
-            .on('dragover', ConcreteFileManager.onDragOver)
-        ;
+        my.fileUploaderOptions = {
+        	folderID: function() {
+        		return my.currentFolder;
+        	}
+        };
+        window.ccm_fileUploader.start(my.fileUploaderOptions);
+        var $dialog = this.$element.closest('.ui-dialog-content');
+        if ($dialog.length !== 0) {
+        	$dialog.on('dialogclose', function() {
+        		window.ccm_fileUploader.stop(my.fileUploaderOptions);
+        	});
+        }
         $('a[data-dialog=add-files]').on('click', function(e) {
-            ConcreteFileManager.openingFileImporter = true;
             e.preventDefault();
             $.fn.dialog.open({
                 width: 620,
                 height: 400,
                 modal: true,
                 title: ccmi18n_filemanager.addFiles,
-                href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/file/import?currentFolder=' + my.currentFolder,
-                onOpen: function() {
-                    ConcreteFileManager.openingFileImporter = false;
-                }
+                href: CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/file/import?currentFolder=' + my.currentFolder
             });
         });
 

--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -15,8 +15,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var string $formID */
 /* @var Concrete\Core\Tree\Node\Type\FileFolder|null $currentFolder */
 /* @var Concrete\Core\Page\Page|null $originalPage */
-/* @var bool $isChunkingEnabled */
-/* @var int $chunkSize */
 /* @var Concrete\Core\Entity\File\StorageLocation\StorageLocation $incomingStorageLocation */
 /* @var string $incomingPath */
 /* @var array $incomingContents */
@@ -31,20 +29,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     ]) ?>
 
     <div class="ccm-tab-content" id="ccm-tab-content-local">
-        <form action="<?= $resolverManager->resolve(['/ccm/system/file/upload']) ?>" class="dropzone">
-            <?php $token->output() ?>
-            <input type="hidden" name="responseFormat" value="dropzone" />
-            <?php
-            if ($currentFolder !== null) {
-                ?><input type="hidden" name="currentFolder" value="<?= $currentFolder->getTreeNodeID() ?> " /><?php
-            }
-            if ($originalPage !== null) {
-                ?><input type="hidden" name="ocID" value="<?= $originalPage->getCollectionID() ?> " /><?php
-            }
-            if ($replacingFile !== null) {
-                ?><input type="hidden" name="fID" value="<?= $replacingFile->getFileID() ?> " /><?php
-            }
-            ?>
+        <form class="dropzone">
         </form>
     </div>
 
@@ -173,26 +158,70 @@ defined('C5_EXECUTE') or die('Access Denied.');
 $(document).ready(function() {
 var $dialog = $('#' + <?= json_encode($formID) ?>).closest('.ui-dialog-content'),
     $dialogContainer = $dialog.closest('.ui-dialog'),
-    uploadedFiles = [];
+    uploadedFiles = [],
+    uploaderOptions = {
+        maxFiles: <?= json_encode($replacingFile === null ? null : 1) ?>,
+        previewsContainer: $('#ccm-tab-content-local form')[0],
+        clickable: $('#ccm-tab-content-local form')[0],
+        replacingFileID: <?= json_encode($replacingFile === null ? null : $replacingFile->getFileID()) ?>,
+        originalPageID: <?= json_encode($originalPage === null ? null : $originalPage->getCollectionID()) ?>,
+        folderID: <?= json_encode($currentFolder === null ? null : $currentFolder->getTreeNodeID()) ?>,
+        uploadStarted: function() {
+            $dialogContainer.find('.ui-dialog-buttonpane button').attr('disabled', 'disabled');
+        },
+        uploadFailed: function() {
+        },
+        uploadCompleted: function(files) {
+            handleImportSuccessfull(files, <?= $replacingFile ? 'true' : 'false' ?>);
+        },
+        uploadQueueCompleted: function() {
+            refreshDialogButtons();
+        },
+        previewTemplate: <?= json_encode(<<<'EOT'
+<div class="dz-preview dz-file-preview">
+    <div class="dz-details">
+        <div class="dz-filename"><span data-dz-name></span></div>
+        <div class="dz-size" data-dz-size></div>
+        <img data-dz-thumbnail />
+    </div>
+    <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
+    <div class="dz-success-mark"><span>✔</span></div>
+    <div class="dz-error-mark"><span>✘</span></div>
+    <div class="dz-error-message"><span data-dz-errormessage></span></div>
+</div>
+EOT
+        ) ?>
+    };
 
 $dialog.jqdialog('option', 'buttons', [{}]);
 $dialogContainer.find('.ui-dialog-buttonset').remove();
+
+window.ccm_fileUploader.start(uploaderOptions);
 $dialog.on('dialogclose', function() {
-    if (uploadedFiles.length === 0) {
-        return;
-    }
-    <?php
-    if ($replacingFile === null) {
-        ?>
-        ConcreteEvent.publish('FileManagerAddFilesComplete', {files: uploadedFiles});
+    window.ccm_fileUploader.stop(uploaderOptions);
+    if (uploadedFiles.length > 0) {
         <?php
-    } else {
+        if ($replacingFile === null) {
+            ?>
+            ConcreteEvent.publish('FileManagerAddFilesComplete', {files: uploadedFiles});
+            <?php
+        } else {
+            ?>
+            ConcreteEvent.publish('FileManagerReplaceFileComplete', {files: uploadedFiles});
+            <?php
+        }
         ?>
-        ConcreteEvent.publish('FileManagerReplaceFileComplete', {files: uploadedFiles});
-        <?php
     }
-    ?>
 });
+
+function handleImportSuccessfull(files, isSingleUploadOperation) {
+    files.forEach(function(file) {
+        uploadedFiles.push(file);
+    });
+    if (isSingleUploadOperation) {
+        $dialog.jqdialog('close');
+    }
+}
 
 function handleImportResponse(response, isSingleUploadOperation) {
     if (!response) {
@@ -208,12 +237,9 @@ function handleImportResponse(response, isSingleUploadOperation) {
                     appendTo: document.body
                 });
             }
-            if (response.files && response.files.length) {
-                $.each(response.files, function() {
-                    uploadedFiles.push(this);
-                })
-                if (isSingleUploadOperation) {
-                    $dialog.jqdialog('close');
+            if (!failed) {
+                if (response.files && response.files.length) {
+                    handleImportSuccessfull(response.files);
                 }
             }
         }
@@ -260,63 +286,6 @@ $dialog.find('ul.nav-tabs a[data-tab]').on('click', function() {
     setTimeout(function() { refreshDialogButtons(); }, 0);
 });
 setTimeout(function() { refreshDialogButtons(); }, 0);
-
-//Setup upload tab
-var $dropzone = $dialog.find('#ccm-tab-content-local form').dropzone({
-    maxFiles: <?= $replacingFile === null ? 'null' : 1 ?>,
-    sending: function() {
-        $dialogContainer.find('.ui-dialog-buttonpane button').attr('disabled', 'disabled');
-    },
-    success: function(data, r) {
-        handleImportResponse(r, <?= $replacingFile ? 'true' : 'false' ?>);
-    },
-    <?php
-    if ($replacingFile) {
-        // We may need to allow people to re-try uploading a file if maxFiles === 1 and the upload of the file filed
-        ?>
-        error: function(files, message, xhr) {
-            this.defaultOptions.error.apply(this, arguments);
-            if (files) {
-                if (!(files instanceof Array)) {
-                    files = [files];
-                }
-                $.each(files, function(index, file) {
-                    if (file && file.accepted) {
-                        file.accepted = false;
-                    }
-                });
-            }
-        },
-        <?php
-    }
-    ?>
-    chunksUploaded: function (file, done) {
-        if (file.xhr.response) {
-            handleImportResponse(JSON.parse(file.xhr.response), <?= $replacingFile ? 'true' : 'false' ?>);
-        }
-        done();
-    },
-    queuecomplete: function() {
-        refreshDialogButtons();
-    },
-    chunking: <?= $isChunkingEnabled ? 'true' : 'false' ?>,
-    chunkSize: <?= $chunkSize ?>,
-    retryChunks: <?= $isChunkingEnabled ? 'true' : 'false' ?>,
-    previewTemplate: <?= json_encode(<<<'EOT'
-<div class="dz-preview dz-file-preview">
-    <div class="dz-details">
-        <div class="dz-filename"><span data-dz-name></span></div>
-        <div class="dz-size" data-dz-size></div>
-        <img data-dz-thumbnail />
-    </div>
-    <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
-    <div class="dz-success-mark"><span>✔</span></div>
-    <div class="dz-error-mark"><span>✘</span></div>
-    <div class="dz-error-message"><span data-dz-errormessage></span></div>
-</div>
-EOT
-        ) ?>
-});
 
 // Setup incoming tab
 <?php


### PR DESCRIPTION
This is a fix for #7916 alternative to #7921

We basically have a new JavaScript global object (`ccm_fileUploader`) that we can use to upload files via Dropzone.

When we have the file manager, we tell `ccm_fileUploader` to use the whole page as a drop zone, without a place where upload progress should be reported (we'll use only NProgress).

When we open the `Add Files` dialog, we (re)initialize the Dropzone, so that upload progress is reported in that dialog (but the drop zone is still the whole page).

When we close the  `Add Files` dialog, we (re)initialize the Dropzone as it was before opening the dialog.