### PR TITLE
5.7 Upgrade FIX: Use default site object when importing single pages

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
@@ -2,7 +2,7 @@
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Page\Single;
-use Concrete\Core\Permission\Category;
+use Concrete\Core\Support\Facade\Application;
 
 class ImportSinglePageStructureRoutine extends AbstractRoutine implements SpecifiableHomePageRoutineInterface
 {
@@ -20,6 +20,8 @@ class ImportSinglePageStructureRoutine extends AbstractRoutine implements Specif
     {
 
         if (isset($sx->singlepages)) {
+            $app = Application::getFacadeApplication();
+            $defaultSite = $app->make('site')->getDefault();
             foreach ($sx->singlepages->page as $p) {
                 $pkg = static::getPackageObject($p['package']);
 
@@ -37,6 +39,10 @@ class ImportSinglePageStructureRoutine extends AbstractRoutine implements Specif
                     } else {
                         $home = \Page::getByID(\Page::getHomePageID());
                         $siteTree = $home->getSiteTreeObject();
+                    }
+
+                    if (is_null($siteTree)) {
+                        $siteTree = $defaultSite;
                     }
 
                     $spl = Single::createPageInTree($p['path'], $siteTree, $root, $pkg);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
@@ -41,7 +41,7 @@ class ImportSinglePageStructureRoutine extends AbstractRoutine implements Specif
                         $siteTree = $home->getSiteTreeObject();
                     }
 
-                    if (is_null($siteTree)) {
+                    if ($siteTree === null) {
                         $siteTree = $defaultSite;
                     }
 


### PR DESCRIPTION
Essentially this is what I was doing in #7912 but I broke the tests, so re-worked it and then it didnt work on the 5.7 upgrade at a different part.

So now when importing single pages it will use the site default if it cant get the relevant site tree from the page object.

Also removed the unused category declaration 

