### PR TITLE
Fix permission checks of global areas

### DIFF
--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -56,7 +56,6 @@ if (isset($neutralStack)) {
         $a = Area::get($stackToEdit, STACKS_AREA_NAME);
         $cpc = new Permissions($stackToEdit);
         $cpcNeutral = $stackToEdit === $neutralStack ? $cpc : new Permissions($neutralStack);
-        $areaPermissions = new Permissions($a);
         $showApprovalButton = false;
         $hasPendingPageApproval = false;
         $workflowList = PageWorkflowProgress::getList($stackToEdit);
@@ -83,7 +82,7 @@ if (isset($neutralStack)) {
             <div class="container-fluid">
                 <ul class="nav navbar-nav small">
                     <?php
-                    if ($cpc->canEditPageContents() && $areaPermissions->canAddBlocks()) {
+                    if ($cpc->canAddBlocks()) {
                         ?>
                         <li class="dropdown">
                             <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?=t('Add')?> <span class="caret"></span></a>

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -294,7 +294,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      */
     public function getPermissionResponseClassName()
     {
-        return '\\Concrete\\Core\\Permission\\Response\\PageResponse';
+        return $this->getPageTypeHandle() === STACKS_PAGE_TYPE ? 'Concrete\\Core\\Permission\\Response\\StackResponse' : '\\Concrete\\Core\\Permission\\Response\\PageResponse';
     }
 
     /**

--- a/concrete/src/Permission/Checker.php
+++ b/concrete/src/Permission/Checker.php
@@ -2,6 +2,9 @@
 
 namespace Concrete\Core\Permission;
 
+use Concrete\Core\Area\Area;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Stack\Stack;
 use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Permission\Response\Response as PermissionResponse;
 use Concrete\Core\Support\Facade\Application;
@@ -27,6 +30,17 @@ class Checker
      */
     public function __construct($object = false)
     {
+        if ($object instanceof Area) {
+            $areaPage = $object->getAreaCollectionObject();
+            if ($areaPage instanceof Page && $areaPage->getPageTypeHandle() === STACKS_PAGE_TYPE) {
+                $object = $areaPage;
+            } elseif ($object->isGlobalArea()) {
+                $stack = Stack::getByName($object->getAreaHandle());
+                if ($stack) {
+                    $object = $stack;
+                }
+            }
+        }
         if ($object) {
             $this->response = PermissionResponse::getResponse($object);
             $r = $this->response->testForErrors();

--- a/concrete/src/Permission/Response/StackResponse.php
+++ b/concrete/src/Permission/Response/StackResponse.php
@@ -1,6 +1,96 @@
 <?php
+
 namespace Concrete\Core\Permission\Response;
 
+use Concrete\Core\Block\Block;
+use Concrete\Core\Permission\Category;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
+
+/**
+ * Stacks and global area permissions are actually "page" permissions.
+ * So, we need to translate the "area" permission keys to the "page" permission keys.
+ */
 class StackResponse extends PageResponse
 {
+    public function canAddBlocks()
+    {
+        return $this->validate('edit_page_contents');
+    }
+
+    public function canAddStacks()
+    {
+        return $this->validate('edit_page_contents');
+    }
+
+    public function canAddStack()
+    {
+        return $this->validate('edit_page_contents');
+    }
+
+    public function canAddLayout()
+    {
+        return $this->validate('edit_page_contents');
+    }
+
+    /**
+     * @param \Concrete\Core\Block\Block|\Concrete\Core\Block\BlockType\BlockType $blockTypeOrBlock
+     *
+     * @return bool
+     */
+    public function canAddBlock($blockTypeOrBlock)
+    {
+        if ($blockTypeOrBlock instanceof Block) {
+            $blockType = $blockTypeOrBlock->getBlockTypeObject();
+        } else {
+            $blockType = $blockTypeOrBlock;
+        }
+        switch ($blockType->getBlockTypeHandle()) {
+            case BLOCK_HANDLE_LAYOUT_PROXY:
+                return $this->canAddLayout();
+            case BLOCK_HANDLE_PAGE_TYPE_OUTPUT_PROXY:
+                return $this->canAddBlocks();
+        }
+        $pkc = Category::getByHandle('area');
+        $pk = $pkc->getPermissionKeyByHandle('add_block_to_area');
+        $pk->setPermissionObject($this->object->getArea(STACKS_AREA_NAME));
+
+        return $pk->validate($blockTypeOrBlock);
+    }
+
+    public function canViewAreaControls()
+    {
+        $app = Application::getFacadeApplication();
+        $u = $app->make(User::class);
+
+        return
+            $u->isSuperUser() ||
+            $this->canEditPageContents() ||
+            $this->canEditPagePermissions()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Permission\Response\Response::validate()
+     */
+    public function validate($permissionHandle, $args = [])
+    {
+        static $map = [
+            'add_block_to_area' => 'edit_page_contents',
+            'add_layout_to_area' => 'edit_page_contents',
+            'add_stack_to_area' => 'edit_page_contents',
+            'delete_area_contents' => 'edit_page_contents',
+            'edit_area_contents' => 'edit_page_contents',
+            'edit_area_design' => 'edit_page_properties',
+            'edit_area_permissions' => 'edit_page_permissions',
+            'schedule_area_contents_guest_access' => 'schedule_page_contents_guest_access',
+            'view_area' => 'view_page',
+        ];
+
+        $pagePermissionHandle = isset($map[$permissionHandle]) ? $map[$permissionHandle] : $permissionHandle;
+
+        return parent::validate($pagePermissionHandle, $args);
+    }
 }


### PR DESCRIPTION
Global areas (and stacks) act both like pages (for example they have versions) and like regular areas (for example they accept blocks).

When we fine-tune their access, we check their permission keys.
concrete5 permissions keys are grouped in permission categories.
We have the `page` category and the `area` category (well, there's also a `stack` category but I don't think it's currently used).

The closest applicable category for stacks and global areas is the `page` category, and that's the one currently used in the dashboard page where we manage them.

BTW we should also check the correct category when we edit pages, and that's what this PR implements.

Fix #7929