### PR TITLE
FIX long events were not properly fetched

### DIFF
--- a/concrete/blocks/calendar/controller.php
+++ b/concrete/blocks/calendar/controller.php
@@ -131,7 +131,7 @@ class Controller extends BlockController
                     $list->filterByAttribute($ak->getAttributeKeyHandle(), $this->filterByTopicID);
                 }
             }
-            $list->filterByStartTimeAfter(strtotime($start));
+            $list->filterByEndTimeAfter(strtotime($start));
             $list->filterByStartTimeBefore(strtotime($end));
             $results = $list->getResults();
 


### PR DESCRIPTION
Proposal to fix #7993 
When creating long events (multiple days) that begin in one month and end in another, they are only displayed on the month of the beginning day.
Solution : the events have to _end after_ the end of the period, instead of _starting after_ the beginning of the period.
