### PR TITLE
Removing query string from FontAwesome font paths, this fixes IE issues

### DIFF
--- a/concrete/css/build/vendor/font-awesome/path.less
+++ b/concrete/css/build/vendor/font-awesome/path.less
@@ -3,12 +3,12 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url('@{fa-font-path}/fontawesome-webfont.eot?v=@{fa-version}');
-  src: url('@{fa-font-path}/fontawesome-webfont.eot?#iefix&v=@{fa-version}') format('embedded-opentype'),
-    url('@{fa-font-path}/fontawesome-webfont.woff2?v=@{fa-version}') format('woff2'),
-    url('@{fa-font-path}/fontawesome-webfont.woff?v=@{fa-version}') format('woff'),
-    url('@{fa-font-path}/fontawesome-webfont.ttf?v=@{fa-version}') format('truetype'),
-    url('@{fa-font-path}/fontawesome-webfont.svg?v=@{fa-version}#fontawesomeregular') format('svg');
+  src: url('@{fa-font-path}/fontawesome-webfont.eot');
+  src: url('@{fa-font-path}/fontawesome-webfont.eot') format('embedded-opentype'),
+    url('@{fa-font-path}/fontawesome-webfont.woff2') format('woff2'),
+    url('@{fa-font-path}/fontawesome-webfont.woff') format('woff'),
+    url('@{fa-font-path}/fontawesome-webfont.ttf') format('truetype'),
+    url('@{fa-font-path}/fontawesome-webfont.svg') format('svg');
   // src: url('@{fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
We are experiencing issues with old versions of IE and FontAwesome, looks like the problem is the query string in the path. 