### PR TITLE
Prevent Express entry detail pages are ignored from search engines

### DIFF
--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -13,6 +13,7 @@ use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Search\Result\ItemColumn;
 use Concrete\Core\Support\Facade\Express;
 use Concrete\Core\Support\Facade\Facade;
+use Concrete\Core\Url\SeoCanonical;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Controller extends BlockController
@@ -118,6 +119,11 @@ class Controller extends BlockController
                 /** @var Seo $seo */
                 $seo = $this->app->make('helper/seo');
                 $seo->addTitleSegmentBefore($entry->getLabel());
+
+                /** @var SeoCanonical $canonical */
+                $canonical = $this->app->make(SeoCanonical::class);
+                $canonical->setPathArguments(['view_express_entity', $exEntryID]);
+
                 $this->set('entry', $entry);
                 $this->view();
             }

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -4,8 +4,10 @@ namespace Concrete\Block\PageList;
 use BlockType;
 use CollectionAttributeKey;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Page\Feed;
 use Concrete\Core\Tree\Node\Node;
+use Concrete\Core\Url\SeoCanonical;
 use Database;
 use Page;
 use Core;
@@ -285,8 +287,14 @@ class Controller extends BlockController
             $topicObj = Topic::getByID(intval($treeNodeID));
             if (is_object($topicObj) && $topicObj instanceof Topic) {
                 $this->list->filterByTopic(intval($treeNodeID));
-                $seo = Core::make('helper/seo');
+
+                /** @var Seo $seo */
+                $seo = $this->app->make('helper/seo');
                 $seo->addTitleSegment($topicObj->getTreeNodeDisplayName());
+
+                /** @var SeoCanonical $canonical */
+                $canonical = $this->app->make(SeoCanonical::class);
+                $canonical->setPathArguments(['topic', $treeNodeID, $topic]);
             }
         }
         $this->view();
@@ -294,8 +302,14 @@ class Controller extends BlockController
 
     public function action_filter_by_tag($tag = false)
     {
-        $seo = Core::make('helper/seo');
+        /** @var Seo $seo */
+        $seo = $this->app->make('helper/seo');
         $seo->addTitleSegment($tag);
+
+        /** @var SeoCanonical $canonical */
+        $canonical = $this->app->make(SeoCanonical::class);
+        $canonical->setPathArguments(['tag', $tag]);
+
         $this->list->filterByTags(h($tag));
         $this->view();
     }
@@ -322,9 +336,14 @@ class Controller extends BlockController
             $this->list->filterByPublicDate($start, '>=');
             $this->list->filterByPublicDate($end, '<=');
 
-            $seo = Core::make('helper/seo');
+            /** @var Seo $seo */
+            $seo = $this->app->make('helper/seo');
             $date = ucfirst(\Punic\Calendar::getMonthName($month, 'wide', '', true).' '.$year);
             $seo->addTitleSegment($date);
+
+            /** @var SeoCanonical $canonical */
+            $canonical = $this->app->make(SeoCanonical::class);
+            $canonical->setPathArguments([$year, $month]);
         }
         $this->view();
     }

--- a/concrete/src/Url/SeoCanonical.php
+++ b/concrete/src/Url/SeoCanonical.php
@@ -35,6 +35,13 @@ class SeoCanonical
     protected $excludedQuerystringParameters;
 
     /**
+     * The list of path arguments to be included in canonical URLs.
+     *
+     * @var string[]
+     */
+    protected $pathArguments = [];
+
+    /**
      * Initialize the instance.
      *
      * @param ResolverManagerInterface $resolver the instance of the class that builds page URLs
@@ -69,7 +76,11 @@ class SeoCanonical
                 if (!empty($originalCID) && $originalCID != $cID) {
                     $result = $this->getPageCanonicalURL($cID, $querystring);
                 } else {
-                    $result = $this->resolver->resolve([$page]);
+                    $args = [$page];
+                    if ($pathArguments = $this->getPathArguments()) {
+                        $args = array_merge($args, $pathArguments);
+                    }
+                    $result = $this->resolver->resolve($args);
                     $query = null;
                     if ($querystring instanceof Query) {
                         $query = clone $querystring;
@@ -122,5 +133,25 @@ class SeoCanonical
         }
 
         return $result;
+    }
+
+    /**
+     * Get path arguments to append canonical URLs
+     *
+     * @return string[]|null
+     */
+    public function getPathArguments()
+    {
+        return $this->pathArguments;
+    }
+
+    /**
+     * Set path arguments to append canonical URLs
+     *
+     * @param string[] $pathArguments
+     */
+    public function setPathArguments($pathArguments)
+    {
+        $this->pathArguments = $pathArguments;
     }
 }

--- a/concrete/src/Url/UrlServiceProvider.php
+++ b/concrete/src/Url/UrlServiceProvider.php
@@ -52,5 +52,6 @@ class UrlServiceProvider extends Provider
                 $config = $site->getConfigRepository();
                 return $config->get('seo.canonical_tag.excluded_querystring_parameters');
             });
+        $this->app->singleton(SeoCanonical::class, SeoCanonical::class);
     }
 }


### PR DESCRIPTION
This pull request includes:

* Mark SeoCanonical helper as a singleton
* Make it enable to append path arguments to canonical URL
* Append block action parameters to canonical URL from some block types

See also #7740 
