### PR TITLE
Cache page attribute value per request

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -202,6 +202,13 @@ return [
         'pages' => false,
 
         /*
+         * Cache Page Attributes
+         *
+         * @var bool
+         */
+        'page_attributes' => false,
+
+        /*
          * Use Doctrine development mode
          *
          * @var bool

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -325,6 +325,28 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         }
     }
 
+    public function getAttribute($ak, $mode = false)
+    {
+        $app = Facade::getFacadeApplication();
+        $cache = $app->make('cache/request');
+        $item = $cache->getItem(sprintf(
+            '/page/%s/%s/attribute/%s/%s',
+            (int) $this->getCollectionID(),
+            (int) $this->getVersionID(),
+            'ak_' . (is_object($ak) ? $ak->getAttributeKeyHandle() : $ak),
+            $mode?:'default'
+        ));
+
+        if (!$item->isMiss()) {
+            return $item->get();
+        } else {
+            $v = parent::getAttribute($ak, $mode);
+            $cache->save($item->set($v));
+
+            return $v;
+        }
+    }
+
     /**
      * Is this version approved?
      *

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -328,6 +328,10 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
     public function getAttribute($ak, $mode = false)
     {
         $app = Facade::getFacadeApplication();
+        if (!$app['config']->get('concrete.cache.page_attributes')) {
+            return parent::getAttribute($ak, $mode);
+        }
+
         $cache = $app->make('cache/request');
         $item = $cache->getItem(sprintf(
             '/page/%s/%s/attribute/%s/%s',


### PR DESCRIPTION
On a big site when we have a large number of attributes and pages, the number of queries per request will be very important as well as the load time.

So what i suggest here is to cache attribute value to improve load time