### PR TITLE
Include page aliases in page search result

### DIFF
--- a/concrete/elements/pages/search.php
+++ b/concrete/elements/pages/search.php
@@ -6,7 +6,7 @@ $form = Loader::helper('form');
 
 <script type="text/template" data-template="search-results-table-body">
 <% _.each(items, function (page) {%>
-<tr data-launch-search-menu="<%=page.cID%>" data-page-id="<%=page.cID%>" data-page-name="<%-page.cvName%>">
+<tr data-launch-search-menu="<%=page.cPointerID||page.cID%>" data-page-id="<%=page.cID%>" data-page-name="<%-page.cvName%>" title="<%-page.link%>">
     <td><span class="ccm-search-results-checkbox"><input type="checkbox" class="ccm-flat-checkbox" data-search-checkbox="individual" value="<%=page.cID%>" /></span></td>
     <% for (i = 0; i < page.columns.length; i++) {
         var column = page.columns[i];

--- a/concrete/src/Page/Search/Result/Item.php
+++ b/concrete/src/Page/Search/Result/Item.php
@@ -23,7 +23,8 @@ class Item extends SearchResultItem
 
     protected function populateDetails($item)
     {
-        $this->cID = $item->getCollectionID();
+        $this->cID = $item->isAliasPage() ? $item->getCollectionPointerOriginalID() : $item->getCollectionID();
+        $this->cPointerID = $item->getCollectionPointerID();
         $this->link = $item->getCollectionLink();
         $cp = new Permissions($item);
         $this->canEditPageProperties = $cp->canEditPageProperties();

--- a/concrete/src/Page/Search/SearchProvider.php
+++ b/concrete/src/Page/Search/SearchProvider.php
@@ -58,6 +58,7 @@ class SearchProvider extends AbstractSearchProvider
     {
         $site = \Core::make('site')->getActiveSiteForEditing();
         $list = new PageList();
+        $list->includeAliases();
         $list->setSiteTreeObject($site);
         return $list;
     }


### PR DESCRIPTION
It's important to include page aliases within search result, otherwise we can't choose page aliases from page selector espacially for Big sites where isn't possible to find the page from Regular Sitemap