### PR TITLE
Upgrade dependency patches to version 1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "require": {
     "wikimedia/composer-merge-plugin": "~1.3",
-    "concrete5/dependency-patches": "^1.3.0"
+    "concrete5/dependency-patches": "^1.5.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f5c41b6f84eb5c87a665a0dfecd1046",
+    "content-hash": "24aaceca05d8e7af8d0e86b188badb51",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -50,16 +50,16 @@
         },
         {
             "name": "concrete5/dependency-patches",
-            "version": "1.3.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5/dependency-patches.git",
-                "reference": "18e19bac383109b3ae05c6197ff955d045a84166"
+                "reference": "ab8d9078c862d0decf90dbca90de411fbb987fa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/18e19bac383109b3ae05c6197ff955d045a84166",
-                "reference": "18e19bac383109b3ae05c6197ff955d045a84166",
+                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/ab8d9078c862d0decf90dbca90de411fbb987fa7",
+                "reference": "ab8d9078c862d0decf90dbca90de411fbb987fa7",
                 "shasum": ""
             },
             "require": {
@@ -68,6 +68,9 @@
             "type": "library",
             "extra": {
                 "patches": {
+                    "doctrine/annotations:1.2.7": {
+                        "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
+                    },
                     "doctrine/orm:2.5.14": {
                         "Fix UnitOfWork::createEntity()": "doctrine/orm/UnitOfWork-createEntity-continue.patch"
                     },
@@ -81,7 +84,8 @@
                         "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
                     },
                     "tedivm/jshrink:1.1.0": {
-                        "Fix continue switch in FileGenerator and MethodReflection": "tedivm/jshrink/fix-minifier-loop.patch"
+                        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
+                        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
                     },
                     "zendframework/zend-code:2.6.3": {
                         "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
@@ -104,14 +108,14 @@
             "authors": [
                 {
                     "name": "Michele Locati",
+                    "role": "author",
                     "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io",
-                    "role": "author"
+                    "homepage": "https://mlocati.github.io"
                 }
             ],
             "description": "Patches required for concrete5 dependencies",
             "homepage": "https://github.com/concrete5/dependency-patches",
-            "time": "2019-05-29T16:31:38+00:00"
+            "time": "2019-07-29T08:25:31+00:00"
         },
         {
             "name": "concrete5/doctrine-xml",
@@ -424,6 +428,16 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.3.x-dev"
+                },
+                "patches_applied": {
+                    "hash": "82e8d7bd5d0530366e7da28f81a2cef0f28bab55",
+                    "list": [
+                        {
+                            "from-package": "concrete5/dependency-patches 1.5.0",
+                            "path": "doctrine/annotations/access-array-offset-on-null.patch",
+                            "description": "Fix access array offset on value of type null"
+                        }
+                    ]
                 }
             },
             "autoload": {
@@ -1039,7 +1053,7 @@
                     "hash": "f03553f596500df8083abdd1cd87cd1916d1a3f4",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "doctrine/orm/UnitOfWork-createEntity-continue.patch",
                             "description": "Fix UnitOfWork::createEntity()"
                         }
@@ -3686,7 +3700,7 @@
                     "hash": "43699395013691839330f8406ee49fa752c163fb",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
                             "description": "Fix minus in regular expressions"
                         }
@@ -4867,12 +4881,17 @@
             "type": "library",
             "extra": {
                 "patches_applied": {
-                    "hash": "b16ca9edf74b2527c4f02cd8f69c7ad1e452545c",
+                    "hash": "c8ec7f9d85bbbe7d89dd1fe73ea17f64a508e3f9",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "tedivm/jshrink/fix-minifier-loop.patch",
-                            "description": "Fix continue switch in FileGenerator and MethodReflection"
+                            "description": "Fix continue switch in Minifier"
+                        },
+                        {
+                            "from-package": "concrete5/dependency-patches 1.5.0",
+                            "path": "tedivm/jshrink/update-upstream-1.3.2.patch",
+                            "description": "Update to upstream version 1.3.2"
                         }
                     ]
                 }
@@ -5415,7 +5434,7 @@
                     "hash": "43aec57a6422c48c002031806c8a8ca01b6208cf",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "zendframework/zend-code/switch-continue.patch",
                             "description": "Fix continue switch in FileGenerator and MethodReflection"
                         }
@@ -5634,7 +5653,7 @@
                     "hash": "b1172d4359d8b116dcf51b148427b53e41d1ae2a",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "zendframework/zend-http/no-x-original-url-x-rewrite.patch",
                             "description": "Remove support for the X-Original-Url and X-Rewrite-Url headers"
                         }
@@ -5873,7 +5892,7 @@
                     "hash": "2eef0fc6a76db7a14e55b9d0717ffd9092bce7ce",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch",
                             "description": "Fix idn_to_ascii deprecation warning"
                         }
@@ -6047,7 +6066,7 @@
                     "hash": "f247c9d47f2ba4ae8d9dfe6d1a25c8627e377753",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch",
                             "description": "Fix ArrayObject::unserialize()"
                         }
@@ -6174,7 +6193,7 @@
                     "hash": "37d53a3bf7979793505330148334c2e97b2f7a0a",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch",
                             "description": "Fix idn_to_ascii/idn_to_utf8 deprecation warning"
                         }
@@ -6926,7 +6945,7 @@
                     "hash": "b230cedd50b7175de81a87b2ec86ad380ee748f9",
                     "list": [
                         {
-                            "from-package": "concrete5/dependency-patches 1.3.0",
+                            "from-package": "concrete5/dependency-patches 1.5.0",
                             "path": "phpunit/phpunit/Getopt-each.patch",
                             "description": "Avoid each() in Getopt"
                         }
@@ -7523,6 +7542,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
+        "ext-pdo": "*",
         "php": ">=5.5.9"
     },
     "platform-dev": [],


### PR DESCRIPTION
Changelog:
- [1.3.0 → 1.4.0](https://github.com/concrete5/dependency-patches/releases/tag/1.4.0)
- [1.4.0 → 1.5.0](https://github.com/concrete5/dependency-patches/releases/tag/1.5.0)
