### PR TITLE
Include page aliases in page search result

### DIFF
--- a/concrete/elements/pages/search.php
+++ b/concrete/elements/pages/search.php
@@ -11,7 +11,7 @@ $form = Loader::helper('form');
     <% for (i = 0; i < page.columns.length; i++) {
         var column = page.columns[i];
         if (column.key == 'cv.cvName') { %>
-            <td class="ccm-search-results-name"><%-column.value%></td>
+            <td class="ccm-search-results-name"><%-column.value%><%=page.cPointerID ? ' <i class="fa fa-sign-in"></i>' : ''%></td>
         <% } else { %>
             <td><%-column.value%></td>
         <% } %>

--- a/concrete/elements/pages/search.php
+++ b/concrete/elements/pages/search.php
@@ -6,7 +6,7 @@ $form = Loader::helper('form');
 
 <script type="text/template" data-template="search-results-table-body">
 <% _.each(items, function (page) {%>
-<tr data-launch-search-menu="<%=page.cID%>" data-page-id="<%=page.cID%>" data-page-name="<%-page.cvName%>">
+<tr data-launch-search-menu="<%=page.cPointerID||page.cID%>" data-page-id="<%=page.cID%>" data-page-name="<%-page.cvName%>" title="<%-page.link%>">
     <td><span class="ccm-search-results-checkbox"><input type="checkbox" class="ccm-flat-checkbox" data-search-checkbox="individual" value="<%=page.cID%>" /></span></td>
     <% for (i = 0; i < page.columns.length; i++) {
         var column = page.columns[i];

--- a/concrete/src/Page/Search/Field/Field/IncludePageAliasesField.php
+++ b/concrete/src/Page/Search/Field/Field/IncludePageAliasesField.php
@@ -1,0 +1,42 @@
+<?php
+namespace Concrete\Core\Page\Search\Field\Field;
+
+use Concrete\Core\Search\Field\AbstractField;
+use Concrete\Core\Search\ItemList\ItemList;
+
+class IncludePageAliasesField extends AbstractField
+{
+    protected $requestVariables = [
+        'includeAliases',
+    ];
+
+    public function getKey()
+    {
+        return 'include_page_aliases';
+    }
+
+    public function getDisplayName()
+    {
+        return t('Include Page Aliases');
+    }
+
+    /**
+     * @param \Concrete\Core\Page\PageList $list
+     */
+    public function filterList(ItemList $list)
+    {
+        if ($this->data['includeAliases'] === '1') {
+            $list->includeAliases();
+        }
+    }
+
+    public function renderSearchField()
+    {
+        $form = \Core::make('helper/form');
+        $html = '<div>';
+        $html .= '<div class="radio"><label>' . $form->radio('includeAliases', 0, $this->data['includeAliases']) . ' ' . t('No') . '</label></div>';
+        $html .= '<div class="radio"><label>' . $form->radio('includeAliases', 1, $this->data['includeAliases']) . ' ' . t('Yes') . '</label></div>';
+        $html .= '</div>';
+        return $html;
+    }
+}

--- a/concrete/src/Page/Search/Field/Manager.php
+++ b/concrete/src/Page/Search/Field/Manager.php
@@ -6,6 +6,7 @@ use Concrete\Core\Page\Search\Field\Field\ContainsBlockTypeField;
 use Concrete\Core\Page\Search\Field\Field\DateAddedField;
 use Concrete\Core\Page\Search\Field\Field\DateLastModifiedField;
 use Concrete\Core\Page\Search\Field\Field\DatePublicField;
+use Concrete\Core\Page\Search\Field\Field\IncludePageAliasesField;
 use Concrete\Core\Page\Search\Field\Field\NumberOfChildrenField;
 use Concrete\Core\Page\Search\Field\Field\PageTemplateField;
 use Concrete\Core\Page\Search\Field\Field\PageTypeField;
@@ -37,6 +38,7 @@ class Manager extends FieldManager
             new NumberOfChildrenField(),
             new PageTemplateField(),
             new ThemeField(),
+            new IncludePageAliasesField(),
             new VersionStatusField(),
             new PermissionsInheritanceField(),
             new DateLastModifiedField(),

--- a/concrete/src/Page/Search/Result/Item.php
+++ b/concrete/src/Page/Search/Result/Item.php
@@ -23,7 +23,8 @@ class Item extends SearchResultItem
 
     protected function populateDetails($item)
     {
-        $this->cID = $item->getCollectionID();
+        $this->cID = $item->isAliasPage() ? $item->getCollectionPointerOriginalID() : $item->getCollectionID();
+        $this->cPointerID = $item->getCollectionPointerID();
         $this->link = $item->getCollectionLink();
         $cp = new Permissions($item);
         $this->canEditPageProperties = $cp->canEditPageProperties();

--- a/concrete/src/Page/Search/SearchProvider.php
+++ b/concrete/src/Page/Search/SearchProvider.php
@@ -58,7 +58,6 @@ class SearchProvider extends AbstractSearchProvider
     {
         $site = \Core::make('site')->getActiveSiteForEditing();
         $list = new PageList();
-        $list->includeAliases();
         $list->setSiteTreeObject($site);
         return $list;
     }

--- a/concrete/src/Page/Search/SearchProvider.php
+++ b/concrete/src/Page/Search/SearchProvider.php
@@ -58,6 +58,7 @@ class SearchProvider extends AbstractSearchProvider
     {
         $site = \Core::make('site')->getActiveSiteForEditing();
         $list = new PageList();
+        $list->includeAliases();
         $list->setSiteTreeObject($site);
         return $list;
     }


### PR DESCRIPTION
It's important to include page aliases within search result, otherwise we can't choose page aliases from page selector espacially for Big sites where isn't possible to find the page from Regular Sitemap