### PR TITLE
Add back "Drop files here or click to upload." to drop zone

### DIFF
--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -30,6 +30,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <div class="ccm-tab-content" id="ccm-tab-content-local">
         <form class="dropzone">
+            <div class="dz-default dz-message"><span><?= t('Drop files here or click to upload.') ?></span></div>
         </form>
     </div>
 
@@ -195,7 +196,6 @@ EOT
 
 $dialog.jqdialog('option', 'buttons', [{}]);
 $dialogContainer.find('.ui-dialog-buttonset').remove();
-
 window.ccm_fileUploader.start(uploaderOptions);
 $dialog.on('dialogclose', function() {
     window.ccm_fileUploader.stop(uploaderOptions);


### PR DESCRIPTION
Fix #8010

We need to manually add the message because now the drop zone is the whole page and not just the area in the "Add Files" dialog (so [this check](https://github.com/enyo/dropzone/blob/v5.3.0/dist/dropzone.js#L1190) now fails because `this.element` is `body` and not the dropzone `form`).