### PR TITLE
PageTypeDefaults::SetupOnChildPages: Make Update forked blocks optional

### DIFF
--- a/concrete/controllers/dialog/block/aliasing.php
+++ b/concrete/controllers/dialog/block/aliasing.php
@@ -81,7 +81,8 @@ class Aliasing extends BackendInterfaceBlockController
                         echo json_encode($obj);
                         $this->app->shutdown();
                     } else {
-                        $queue = $this->block->queueForDefaultsAliasing($_POST['addBlock'], $_POST['updateForkedBlocks'], $queue);
+                        $r = $this->request->request;
+                        $queue = $this->block->queueForDefaultsAliasing($r->get('addBlock'), $r->get('updateForkedBlocks'), $queue);
                     }
 
                     $totalItems = $queue->count();
@@ -144,7 +145,8 @@ class Aliasing extends BackendInterfaceBlockController
     protected function validateAction()
     {
         if (parent::validateAction()) {
-            if (!$_POST['addBlock'] && !$_POST['updateForkedBlocks']) {
+            $r = $this->request->request;
+            if (!$r->get('addBlock') && !$r->get('updateForkedBlocks')) {
                 $this->error->add(t('You need to select at least one action'));
             } else {
                 return true;

--- a/concrete/controllers/dialog/block/aliasing.php
+++ b/concrete/controllers/dialog/block/aliasing.php
@@ -15,10 +15,12 @@ class Aliasing extends BackendInterfaceBlockController
     {
         $ct = Type::getByDefaultsPage($this->page);
         $template = Template::getByID($this->page->getPageTemplateID());
+        $site = $this->app->make('site')->getActiveSiteForEditing();
 
         $pl = new PageList();
         $pl->filterByPageTypeID($ct->getPageTypeID());
         $pl->filterByPageTemplate($template);
+        $pl->filterBySite($site);
         $pl->ignorePermissions();
         $this->set('total', $pl->getTotalResults());
     }
@@ -79,7 +81,7 @@ class Aliasing extends BackendInterfaceBlockController
                         echo json_encode($obj);
                         $this->app->shutdown();
                     } else {
-                        $queue = $this->block->queueForDefaultsAliasing($_POST['addBlock'], $queue);
+                        $queue = $this->block->queueForDefaultsAliasing($_POST['addBlock'], $_POST['updateForkedBlocks'], $queue);
                     }
 
                     $totalItems = $queue->count();
@@ -138,6 +140,19 @@ class Aliasing extends BackendInterfaceBlockController
         }
     }
     */
+
+    protected function validateAction()
+    {
+        if (parent::validateAction()) {
+            if (!$_POST['addBlock'] && !$_POST['updateForkedBlocks']) {
+                $this->error->add(t('You need to select at least one action'));
+            } else {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     protected function canAccess()
     {

--- a/concrete/controllers/dialog/block/aliasing.php
+++ b/concrete/controllers/dialog/block/aliasing.php
@@ -15,13 +15,13 @@ class Aliasing extends BackendInterfaceBlockController
     {
         $ct = Type::getByDefaultsPage($this->page);
         $template = Template::getByID($this->page->getPageTemplateID());
-        $site = $this->app->make('site')->getActiveSiteForEditing();
 
         $pl = new PageList();
+        $pl->setSiteTreeToAll();
+        $pl->ignorePermissions();
         $pl->filterByPageTypeID($ct->getPageTypeID());
         $pl->filterByPageTemplate($template);
-        $pl->filterBySite($site);
-        $pl->ignorePermissions();
+
         $this->set('total', $pl->getTotalResults());
     }
 

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1862,11 +1862,12 @@ EOT
      * Populate the queue to be used to add/update blocks of the pages of a specific type.
      *
      * @param bool $addBlock add this block to the pages where this block does not exist? If false, we'll only update blocks that already exist
+     * @param bool $updateForkedBlocks
      * @param \ZendQueue\Queue $queue The queue to add the messages too (it will be emptied before adding the new messages)
      *
      * @return \ZendQueue\Queue
      */
-    public function queueForDefaultsAliasing($addBlock, $queue)
+    public function queueForDefaultsAliasing($addBlock, $updateForkedBlocks, $queue)
     {
         $records = [];
         $db = \Database::connection();
@@ -1901,7 +1902,7 @@ EOT
                     $row['cID'], $row['cvID'], $cbRelationID,
                 ]);
 
-                if ($r2['bID'] || (!$r2['bID'] && $addBlock)) {
+                if (($r2['bID'] && $updateForkedBlocks) || (!$r2['bID'] && $addBlock)) {
                     // Ok, so either this block doesn't appear on the page at all, but addBlock set to true,
                     // or, the block appears on the page and it is forked. Either way we're going to add it to the page.
 

--- a/concrete/views/dialogs/block/aliasing.php
+++ b/concrete/views/dialogs/block/aliasing.php
@@ -11,21 +11,26 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
 
     <form method="post" id="ccmBlockMasterCollectionForm" data-dialog-form-processing="progressive" data-dialog-form="master-collection-alias" action="<?=$controller->action('submit')?>">
 
-    <p><?=t('This block will be added to all pages of this type. If it has been previously added it will be updated – even if the block on the child page has been forked from this block.')?></p>
+        <p><?=t('This block will be added to all pages of this type. If it has been previously added it will be updated.')?></p>
 
-    <div class="form-group">
-        <label class="control-label"><?=t('If this block does not appear on a page of this type')?></label>
-        <div class="radio"><label><input type="radio" name="addBlock" value="1" checked> <?=t('Add a new instance of the block to the page.')?></label></div>
-        <div class="radio"><label><input type="radio" name="addBlock" value="0"> <?=t('Keep this block off that page.')?></label></div>
-    </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('If this block does not appear on a page of this type')?></label>
+            <div class="radio"><label><input type="radio" name="addBlock" value="1" checked> <?=t('Add a new instance of the block to the page.')?></label></div>
+            <div class="radio"><label><input type="radio" name="addBlock" value="0"> <?=t('Keep this block off that page.')?></label></div>
+        </div>
+
+        <div class="form-group">
+            <label class="control-label"><?=t('Would you like to update forked blocks?')?></label>
+            <div class="radio"><label><input type="radio" name="updateForkedBlocks" value="1"> <?=t('Yes')?></label></div>
+            <div class="radio"><label><input type="radio" name="updateForkedBlocks" value="0" checked> <?=t('No')?></label></div>
+        </div>
 
         <div data-dialog-form-element="progress-bar"></div>
 
-
-    <div class="dialog-buttons">
-        <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
-        <button class="btn btn-primary pull-right" data-dialog-action="submit"><?=t('Save')?></button>
-    </div>
+        <div class="dialog-buttons">
+            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
+            <button class="btn btn-primary pull-right" data-dialog-action="submit"><?=t('Save')?></button>
+        </div>
 
     </form>
 


### PR DESCRIPTION
There are some cases where we don't want to update old blocks and we need only to add new ones.
![SetupOnChildPages](https://user-images.githubusercontent.com/13836863/62061568-561d4580-b21f-11e9-9d1c-bfb64dfe9526.png)
