### PR TITLE
Remove selected_hidden juggling, just merge them into selected plugins

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -8,6 +8,7 @@ use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Theme\Theme as PageTheme;
 use Concrete\Core\Site\Config\Liaison as Repository;
+use Concrete\Core\Site\Service;
 use Concrete\Core\Utility\Service\Identifier;
 use Page;
 use Permissions;
@@ -75,19 +76,25 @@ class CkeditorEditor implements EditorInterface
     protected $app;
 
     /**
+     * @var \Concrete\Core\Site\Service
+     */
+    private $site;
+
+    /**
      * Initialize the instance.
      *
      * @param Repository $config
      * @param PluginManager $pluginManager
      * @param array $styles
      */
-    public function __construct(Repository $config, PluginManager $pluginManager, $styles, Application $app)
+    public function __construct(Repository $config, Service $site, PluginManager $pluginManager, $styles, Application $app)
     {
         $this->config = $config;
         $this->pluginManager = $pluginManager;
         $this->assets = ResponseAssetGroup::get();
         $this->styles = $styles;
         $this->app = $app;
+        $this->site = $site;
     }
 
     /**
@@ -304,19 +311,19 @@ EOL;
         $this->config->save('editor.concrete.enable_filemanager', (bool) $request->request->get('enable_filemanager'));
         $this->config->save('editor.concrete.enable_sitemap', (bool) $request->request->get('enable_sitemap'));
 
-        $selected = (array) $this->config->get('editor.ckeditor4.plugins.selected_hidden', []);
+        // Load in selected_hidden plugins from the default site
+        $defaultConfig = $this->site->getDefault()->getConfigRepository();
+        $selected = (array) $defaultConfig->get('editor.ckeditor4.plugins.selected_hidden', []);
+
+        // Merge in plugins selected in the dashboard form
         $post = $request->request->get('plugin');
         if (is_array($post)) {
             $selected = array_merge($selected, $post);
         }
-        $plugins = [];
-        foreach ($selected as $plugin) {
-            if ($this->pluginManager->isAvailable($plugin)) {
-                $plugins[] = $plugin;
-            }
-        }
 
-        $this->config->save('editor.ckeditor4.plugins.selected', $plugins);
+        // Filter out plugins that aren't available
+        $selected = array_filter($selected, [$this->pluginManager, 'isAvailable']);
+        $this->config->save('editor.ckeditor4.plugins.selected', $selected);
     }
 
     /**

--- a/concrete/src/Editor/EditorServiceProvider.php
+++ b/concrete/src/Editor/EditorServiceProvider.php
@@ -377,14 +377,8 @@ class EditorServiceProvider extends ServiceProvider
                 $defaultConfig = $siteService->getDefault()->getConfigRepository();
             }
 
-            // Load in default selected plugins and hidden plugins
+            // Load in default selected plugins
             $selectedPlugins = (array) $defaultConfig->get('editor.ckeditor4.plugins.selected_default', []);
-        }
-
-        // Load in local site selected hidden
-        if ($activeSite->getSiteHandle() !== 'default') {
-            $selectedHidden = (array) $config->get('editor.ckeditor4.plugins.selected_hidden', []);
-            $selectedPlugins = array_merge($selectedPlugins, $selectedHidden);
         }
 
         return $selectedPlugins;

--- a/concrete/src/Editor/EditorServiceProvider.php
+++ b/concrete/src/Editor/EditorServiceProvider.php
@@ -377,8 +377,9 @@ class EditorServiceProvider extends ServiceProvider
                 $defaultConfig = $siteService->getDefault()->getConfigRepository();
             }
 
-            // Load in default selected plugins
+            // Load in default selected plugins and hidden selected plugins
             $selectedPlugins = (array) $defaultConfig->get('editor.ckeditor4.plugins.selected_default', []);
+            $selectedPlugins = array_merge($selectedPlugins, (array) $defaultConfig->get('editor.ckeditor4.plugins.selected_hidden', []));
         }
 
         return $selectedPlugins;


### PR DESCRIPTION
This PR fixes some issues with #7871. Instead of trying to track the `selected_hidden` values separately, let's just store them in the `selected` array when you configure them in the dashboard.