### PR TITLE
Add test for Section::registerDuplicate

### DIFF
--- a/tests/tests/Multilingual/SectionTest.php
+++ b/tests/tests/Multilingual/SectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Tests\Multilingual;
 
+use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\TestHelpers\Page\PageTestCase;
 
 class SectionTest extends PageTestCase
@@ -10,6 +11,8 @@ class SectionTest extends PageTestCase
     {
         parent::setUp();
 
+        $this->app->make('cache/request')->disable();
+
         // get entity manager from database connection
         $em = $this->connection()->getEntityManager();
 
@@ -17,7 +20,7 @@ class SectionTest extends PageTestCase
         $service = new \Concrete\Core\Localization\Locale\Service($em);
 
         // get current site
-        $site = \Core::make('site')->getSite();
+        $site = $this->app->make('site')->getSite();
 
         // get page template "full"
         $template = \Concrete\Core\Page\Template::getByHandle('full');
@@ -25,6 +28,9 @@ class SectionTest extends PageTestCase
         // add locale with home page
         $locale = $service->add($site, 'de', 'CH');
         $service->addHomePage($locale, $template, 'Second language', 'chde');
+
+        // refresh site entity from the database
+        $em->refresh($site);
     }
 
     public function testGetByLocale()
@@ -45,5 +51,47 @@ class SectionTest extends PageTestCase
         // check section
         $this->assertNotFalse($section, 'Unable to load Section by language');
         $this->assertEquals('de_CH', $section->getLocale());
+    }
+
+    public function testMultilingualEnabled()
+    {
+        $enabled = $this->app->make('multilingual/detector')->isEnabled();
+        $this->assertTrue($enabled);
+    }
+
+    public function testRegisterDuplicate()
+    {
+        $default = Section::getDefaultSection();
+        $second = Section::getByLocale('de_CH');
+
+        // Create two pages in the same language section
+        $oldPage = self::createPage('Old Page', $default);
+        $newPage = self::createPage('New Page', $default);
+
+        Section::registerPage($oldPage);
+        Section::registerDuplicate($newPage, $oldPage);
+
+        // When duplicating a page within the same language tree, a new mpRelationID should created for a new page.
+        $this->assertNotEquals(
+            Section::getMultilingualPageRelationID($oldPage->getCollectionID()),
+            Section::getMultilingualPageRelationID($newPage->getCollectionID()),
+            'A page duplicated in the same locale, but did not created new mpRelationID.'
+        );
+
+        // Create a page in the second locale
+        $newPageInSecondLocale = self::createPage('New Page in Second Locale', $second);
+
+        Section::registerDuplicate($newPageInSecondLocale, $oldPage);
+
+        // If you duplicate a page into a different language tree, it should get the same mpRelationID.
+        $this->assertEquals(
+            Section::getMultilingualPageRelationID($oldPage->getCollectionID()),
+            Section::getMultilingualPageRelationID($newPageInSecondLocale->getCollectionID()),
+            'Two pages are related between two locales, but we could not get same mpRelationID.'
+        );
+
+        $oldPage->delete();
+        $newPage->delete();
+        $newPageInSecondLocale->delete();
     }
 }

--- a/tests/tests/Multilingual/SectionTest.php
+++ b/tests/tests/Multilingual/SectionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Tests\Multilingual;
 
 use Concrete\Core\Multilingual\Page\Section\Section;
@@ -59,6 +58,11 @@ class SectionTest extends PageTestCase
         $this->assertTrue($enabled);
     }
 
+    /**
+     * This test will check if c5 can duplicate a page on the multilingual site correctly.
+     *
+     * @see https://github.com/concrete5/concrete5/issues/7430
+     */
     public function testRegisterDuplicate()
     {
         $default = Section::getDefaultSection();
@@ -66,10 +70,7 @@ class SectionTest extends PageTestCase
 
         // Create two pages in the same language section
         $oldPage = self::createPage('Old Page', $default);
-        $newPage = self::createPage('New Page', $default);
-
-        Section::registerPage($oldPage);
-        Section::registerDuplicate($newPage, $oldPage);
+        $newPage = $oldPage->duplicate($default);
 
         // When duplicating a page within the same language tree, a new mpRelationID should created for a new page.
         $this->assertNotEquals(
@@ -79,9 +80,7 @@ class SectionTest extends PageTestCase
         );
 
         // Create a page in the second locale
-        $newPageInSecondLocale = self::createPage('New Page in Second Locale', $second);
-
-        Section::registerDuplicate($newPageInSecondLocale, $oldPage);
+        $newPageInSecondLocale = $oldPage->duplicate($second);
 
         // If you duplicate a page into a different language tree, it should get the same mpRelationID.
         $this->assertEquals(


### PR DESCRIPTION
Added a new unit test for #8014

This test failed before #8014 merged, because a new `mpRelationID` is not generated when the page copied in the same language tree.

```
$ composer test -- --filter testRegisterDuplicate
> phpunit '--filter' 'testRegisterDuplicate'
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:        PHP 7.2.20
Configuration:  /path/to/concrete5/phpunit.xml

F

Time: 16.43 seconds, Memory: 38.25MB

There was 1 failure:

1) Concrete\Tests\Multilingual\SectionTest::testRegisterDuplicate
A page duplicated in the same locale, but did not created new mpRelationID.
Failed asserting that '1' is not equal to <string:1>.

/path/to/concrete5/tests/tests/Multilingual/SectionTest.php:78

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
Script phpunit handling the test event returned with error code 1
```

This test still failed after #8014 merged, due to sql error.

```
$ composer test -- --filter testRegisterDuplicate
> phpunit '--filter' 'testRegisterDuplicate'
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:        PHP 7.2.20
Configuration:  /path/to/concrete5/phpunit.xml

E

Time: 8.28 seconds, Memory: 38.25MB

There was 1 error:

1) Concrete\Tests\Multilingual\SectionTest::testRegisterDuplicate
Doctrine\DBAL\Exception\UniqueConstraintViolationException: An exception occurred while executing 'insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)' with params ["2", 4, "en_US", "en"]:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:66
/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:128
/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:855
/path/to/concrete5/concrete/src/Database/Connection/Connection.php:96
/path/to/concrete5/concrete/src/Multilingual/Page/Section/Section.php:354
/path/to/concrete5/tests/tests/Multilingual/SectionTest.php:72

Caused by
Doctrine\DBAL\Driver\PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:107
/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:849
/path/to/concrete5/concrete/src/Database/Connection/Connection.php:96
/path/to/concrete5/concrete/src/Multilingual/Page/Section/Section.php:354
/path/to/concrete5/tests/tests/Multilingual/SectionTest.php:72

Caused by
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:105
/path/to/concrete5/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:849
/path/to/concrete5/concrete/src/Database/Connection/Connection.php:96
/path/to/concrete5/concrete/src/Multilingual/Page/Section/Section.php:354
/path/to/concrete5/tests/tests/Multilingual/SectionTest.php:72

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
Script phpunit handling the test event returned with error code 2
```