### PR TITLE
Fix Japanese address formatting

### DIFF
--- a/concrete/src/Localization/Service/AddressFormat.php
+++ b/concrete/src/Localization/Service/AddressFormat.php
@@ -154,6 +154,7 @@ class AddressFormat
         $options = [];
         if (!empty($locale)) {
             $options['locale'] = $this->convertLocale($locale);
+            $address = $address->withLocale($options['locale']);
         }
         if (isset($this->options['subdivision_names'])) {
             $options['subdivision_names'] = $this->options['subdivision_names'];

--- a/tests/tests/Localization/Service/AddressFormatTest.php
+++ b/tests/tests/Localization/Service/AddressFormatTest.php
@@ -228,6 +228,31 @@ class AddressFormatTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests Japanese addresses as they are formatted differently.
+     */
+    public function testJapaneseFormatting()
+    {
+        $formatted = $this->addressFormat->format(
+            [
+                'address1' => '１丁目１３番地',
+                'city' => '千代田区',
+                'state_province' => '東京都',
+                'country' => 'JP',
+                'postal_code' => '101-0054',
+            ],
+            'text',
+            'ja_JP'
+        );
+        $expected = '日本' . "\n" .
+            '〒101-0054' . "\n" .
+            '東京都千代田区' . "\n" .
+            '１丁目１３番地'
+        ;
+
+        $this->assertEquals($expected, $formatted);
+    }
+
+    /**
      * Tests the text formatting of addresses in case the locale is not
      * specifically defined for the `AddressFormat::format()` method.
      */


### PR DESCRIPTION
As reported at https://github.com/concrete5/concrete5/issues/7943#issuecomment-516224778, the Japanese address formats differently which means the address object also needs to know its locale.

This fixes the linked issue reported by @hissy.