### PR TITLE
PermissionablePagination: make maxResultsToProcessAtOnce configurable

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1111,6 +1111,11 @@ return [
             'size_min' => -50,
             'size_max' => 200,
         ],
+        /*
+         * Process more than 1000 results in one result set will slow down your site,
+         * if you're not sure of what you are doing use PagerPagination or disable permission.
+         */
+        'permissionable_pagination_max_results' => 1000,
     ],
 
     'page' => [

--- a/concrete/src/Search/Pagination/PermissionablePagination.php
+++ b/concrete/src/Search/Pagination/PermissionablePagination.php
@@ -2,22 +2,21 @@
 namespace Concrete\Core\Search\Pagination;
 
 use Concrete\Core\Search\ItemList\ItemList;
+use Concrete\Core\Support\Facade\Facade;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 
 /**
- * Processes a thousand requests and builds pagination out of them.
- * This is slow on larger sites, but will yield accurate pagination even with permissions
- * Caveat: The most you can process in one result set is 1000 results. Otherwise, use PagerPagination
- * or disable permissions.
+ * Processes requests and builds pagination out of them.
  */
 class PermissionablePagination extends Pagination
 {
-    protected $maxResultsToProcessAtOnce = 1000;
 
     public function __construct(ItemList $itemList)
     {
-        $itemList->getQueryObject()->setMaxResults($this->maxResultsToProcessAtOnce);
+        $app = Facade::getFacadeApplication();
+        $maxResultsToProcessAtOnce = $app['config']->get('concrete.limits.permissionable_pagination_max_results');
+        $itemList->getQueryObject()->setMaxResults($maxResultsToProcessAtOnce);
         $results = $itemList->getResults();
         $adapter = new ArrayAdapter($results);
         $this->list = $itemList;

--- a/concrete/src/Search/Pagination/PermissionablePagination.php
+++ b/concrete/src/Search/Pagination/PermissionablePagination.php
@@ -11,12 +11,13 @@ use Pagerfanta\Pagerfanta;
  */
 class PermissionablePagination extends Pagination
 {
+    protected $maxResultsToProcessAtOnce;
 
     public function __construct(ItemList $itemList)
     {
         $app = Facade::getFacadeApplication();
-        $maxResultsToProcessAtOnce = $app['config']->get('concrete.limits.permissionable_pagination_max_results');
-        $itemList->getQueryObject()->setMaxResults($maxResultsToProcessAtOnce);
+        $this->maxResultsToProcessAtOnce = $app['config']->get('concrete.limits.permissionable_pagination_max_results');
+        $itemList->getQueryObject()->setMaxResults($this->maxResultsToProcessAtOnce);
         $results = $itemList->getResults();
         $adapter = new ArrayAdapter($results);
         $this->list = $itemList;


### PR DESCRIPTION
For BIG sites with more than 20000 pages we can't limit for 1000 results and also we still need permissions, so it could be better to give the ability to change this limit