### PR TITLE
Use the core email validator instead of the vendor one

### DIFF
--- a/concrete/src/Form/Service/DestinationPicker/EmailPicker.php
+++ b/concrete/src/Form/Service/DestinationPicker/EmailPicker.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Form\Service\DestinationPicker;
 
 use ArrayAccess;
 use Concrete\Core\Form\Service\Form;
-use Egulias\EmailValidator\EmailValidator;
+use Concrete\Core\Validator\String\EmailValidator;
 
 /**
  * A picker for DestinationPicker that allows users specify an email address.
@@ -92,8 +92,8 @@ class EmailPicker implements PickerInterface
                     }
                 }
                 if ($postValue !== null) {
-                    $emailValidator = new EmailValidator();
-                    if (!$emailValidator->isValid($postValue, !empty($options['checkDNS']), !empty($options['strict']))) {
+                    $emailValidator = new EmailValidator(!empty($options['checkDNS']), !empty($options['strict']));
+                    if (!$emailValidator->isValid($postValue)) {
                         $postValue = null;
                         if ($errors !== null) {
                             if ((string) $fieldDisplayName === '') {


### PR DESCRIPTION
We have a pretty nice email validator class: what about using it instead of the vendor one?

This will simplify upgrading the vendor email validator when we'll switch to concrete5 version 9.