### PR TITLE
Fix initialization of menu item controllers

### DIFF
--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -89,7 +89,7 @@ class Item implements ItemInterface
                 DIRNAME_MENU_ITEMS . '/' . $handle . '/' . FILENAME_CONTROLLER,
                 $this->pkgHandle
             );
-            $this->setController(\Core::make($class, [$this]));
+            $this->setController(\Core::make($class));
         }
 
         return $this->controller;


### PR DESCRIPTION
[Menu Item controllers](https://github.com/concrete5/concrete5/blob/8.5.1/concrete/src/Application/UserInterface/Menu/Item/Controller.php) doesn't have a `__constructor`, when creating a new instance of them, the `__constructor` of their [parent class](https://github.com/concrete5/concrete5/blob/8.5.1/concrete/src/Controller/AbstractController.php#L57]) is called.
That `__constructor` doesn't have any parameter, so the Container will throw a `Undefined offset: 0` warning [here](https://github.com/illuminate/container/blob/v5.2.45/Container.php#L877).

We have 2 solutions:
1. add a `__constructor` to the Menu Item controller, accepting a Menu Item instance (but it's useless since we already call `setMenuItem` later on, in the `setController` method)
2. remove the parameter when creating the controller instance.

In this PR I implement 2.

Ref. #4723