### PR TITLE
Allow specify the PHP version for coding style

### DIFF
--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -25,6 +25,7 @@ class PhpCodingStyleCommand extends Command
 c5:phpcs
 {--no-cache : Specify this flag to turn off the coding style cache}
 {--webroot={$defaultWebRoot} : Specify the webroot (use - to auto-detect it)}
+{--p|php= : The minimum PHP version }
 {action : Either "fix" or "check"}
 {path*  : The path to one or more files or directories }
 EOT
@@ -64,7 +65,10 @@ EOT
             }
             $fixer->getOptions()->setWebRoot($webroot);
         }
-        $fixer->getOptions()->setIsCacheDisabled($this->input->getOption('no-cache'));
+        $fixer->getOptions()
+            ->setIsCacheDisabled($this->input->getOption('no-cache'))
+            ->setMinimumPhpVersion($this->input->getOption('php'))
+        ;
         list($counters, $changes, $errors) = $fixer->fix($this->input, $this->output, $splFileInfos, $dryRun);
         /* @var array $counters */
         /* @var array $changes */

--- a/concrete/src/Support/CodingStyle/PhpFixerOptions.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerOptions.php
@@ -114,6 +114,13 @@ class PhpFixerOptions
     private $isCacheDisabled = false;
 
     /**
+     * The minimum PHP version.
+     *
+     * @var string
+     */
+    private $minimumPhpVersion = '';
+
+    /**
      * Initialize the instance.
      *
      * @param \Concrete\Core\Config\Repository\Repository $config
@@ -545,6 +552,30 @@ class PhpFixerOptions
     public function setIsCacheDisabled($value)
     {
         $this->isCacheDisabled = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the minimum PHP version.
+     *
+     * @return string empty string if the default one
+     */
+    public function getMinimumPhpVersion()
+    {
+        return $this->minimumPhpVersion;
+    }
+
+    /**
+     * Set the minimum PHP version.
+     *
+     * @param string $value empty string if the default one
+     *
+     * @return $this
+     */
+    public function setMinimumPhpVersion($value)
+    {
+        $this->minimumPhpVersion = (string) $value;
 
         return $this;
     }

--- a/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
@@ -56,10 +56,11 @@ class PhpFixerRuleResolver
      *
      * @param int $flags A combination of PhpFixer::FLAG_... flags.
      * @param bool $onlyAvailableOnes return only the available rules
+     * @param string $minimumPhpVersion the minimum PHP version that the files to be checked/fixed must be compatible with
      *
      * @return array
      */
-    public function getRules($flags, $onlyAvailableOnes)
+    public function getRules($flags, $onlyAvailableOnes, $minimumPhpVersion = '')
     {
         $flags = (int) $flags;
 
@@ -424,7 +425,7 @@ class PhpFixerRuleResolver
         $rules = $invariantRules + [
             // PHP arrays should be declared using the configured syntax.
             'array_syntax' => [
-                'syntax' => $hasFlag(PhpFixer::FLAG_OLDPHP) ? 'long' : 'short',
+                'syntax' => ($minimumPhpVersion !== '' && version_compare($minimumPhpVersion, '5.4') < 0) || $hasFlag(PhpFixer::FLAG_OLDPHP) ? 'long' : 'short',
             ],
 
             // Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.
@@ -436,7 +437,7 @@ class PhpFixerRuleResolver
             'braces' => $hasFlag(PhpFixer::FLAG_PHPONLY) ? ['allow_single_line_closure' => true] : false,
 
             // Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant.
-            'dir_constant' => $hasFlag(PhpFixer::FLAG_OLDPHP) ? false : true,
+            'dir_constant' => ($minimumPhpVersion !== '' && version_compare($minimumPhpVersion, '5.3') < 0) || $hasFlag(PhpFixer::FLAG_OLDPHP) ? false : true,
 
             // Code MUST use configured indentation type.
             'indentation_type' => $hasFlag(PhpFixer::FLAG_PHPONLY) ? true : false,
@@ -445,7 +446,7 @@ class PhpFixerRuleResolver
             'linebreak_after_opening_tag' => $hasFlag(PhpFixer::FLAG_PHPONLY) ? true : false,
 
             // Replace short-echo `<?=` with long format `<?php echo` syntax.
-            'no_short_echo_tag' => $hasFlag(PhpFixer::FLAG_OLDPHP) ? true : false,
+            'no_short_echo_tag' => ($minimumPhpVersion !== '' && version_compare($minimumPhpVersion, '5.4') < 0) || $hasFlag(PhpFixer::FLAG_OLDPHP) ? true : false,
 
             // Class names should match the file name.
             'psr4' => $hasFlag(PhpFixer::FLAG_PSR4CLASS) ? true : false,

--- a/concrete/src/Support/CodingStyle/PhpFixerRunner.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerRunner.php
@@ -142,7 +142,7 @@ class PhpFixerRunner
      */
     protected function applyStep(PhpFixerOptions $options, Traversable $finder, $flags, $dryRun)
     {
-        $rules = $this->ruleResolver->getRules($flags, true);
+        $rules = $this->ruleResolver->getRules($flags, true, $options->getMinimumPhpVersion());
         $fixers = $this->ruleResolver->getFixers($rules);
 
         $linter = new Linter();


### PR DESCRIPTION
What about letting users to specify the minimum PHP version that the code should support?
For example, this would be useful when checking/fixing code of packages that are compatible with concrete5 version 5.7 (that supported PHP 5.3), where we can't use short echo tags, __DIR__ constant, short array syntax, ...