### PR TITLE
Fix: calendar feed parameter and validation

### DIFF
--- a/concrete/routes/rss.php
+++ b/concrete/routes/rss.php
@@ -6,5 +6,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
  */
 $router->get('/rss/{identifier}', 'Concrete\Controller\Feed::output')
     ->setName('rss');
-$router->get('/ccm/calendar/feed/{identifier}', 'Concrete\Controller\CalendarFeed::view')
-    ->setName('calendar_rss');
+$router->get('/ccm/calendar/feed/{calendar_id}', 'Concrete\Controller\CalendarFeed::view')
+    ->setName('calendar_rss')
+    ->setRequirements(['calendar_id' => '[0-9]+']);
+


### PR DESCRIPTION
The name of the parameter passed to
Concrete\Controller\CalendarFeed::view is `calendar_id`, so `identifier`
is not being passed. Additionally, passing a non-numeric value throws
an exceptions, so adding `setRequirements` back will validate the
input. It was taken out when this was refactored in [20eb23ca339](https://github.com/concrete5/concrete5/commit/20eb23ca33948bda4b49f8a063b627c12fc0f17c#diff-85b456d955834f4fda0553a19acaa95aR658) (line 658).
