### PR TITLE
 Exclude "online" tests by default

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,4 +24,9 @@
             <directory suffix="page_theme.php">concrete/themes/</directory>
         </whitelist>
     </filter>
+    <groups>
+        <exclude>
+            <group>online</group>
+        </exclude>
+    </groups>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,6 @@
 <phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/sebastianbergmann/phpunit/4.8.36/phpunit.xsd"
         bootstrap="./tests/bootstrap.php"
         colors="true"
         convertErrorsToExceptions="true"
@@ -7,7 +9,8 @@
         backupGlobals="false"
         backupStaticAttributes="false"
         verbose="true"
-        processIsolation="false">
+        processIsolation="false"
+>
     <testsuites>
         <testsuite name="Tests">
             <directory>tests/tests/</directory>

--- a/tests/tests/Http/HttpClientTest.php
+++ b/tests/tests/Http/HttpClientTest.php
@@ -21,14 +21,14 @@ class HttpClientTest extends PHPUnit_Framework_TestCase
     private static $app;
 
     /**
-     * @var string|null
+     * @var string
      */
     private static $testRemoteURI;
 
     public static function setUpBeforeClass()
     {
         self::$app = Application::getFacadeApplication();
-        self::$testRemoteURI = getenv('CONCRETE5TESTS_TEST_REMOTE_URI') ?: null;
+        self::$testRemoteURI = getenv('CONCRETE5TESTS_TEST_REMOTE_URI') ?: 'https://www.concrete5.org/';
     }
 
     public function testAdapterKind()
@@ -138,12 +138,11 @@ class HttpClientTest extends PHPUnit_Framework_TestCase
      * @param mixed $caFile
      * @param mixed $caPath
      * @param mixed $shouldBeOK
+     *
+     * @group online
      */
     public function testSSLOptions($adapterClass, $caFile, $caPath, $shouldBeOK)
     {
-        if (self::$testRemoteURI === null) {
-            $this->markTestSkipped('Skipping calls to remote URIs');
-        }
         $this->checkValidAdapter($adapterClass, true);
 
         $factory = self::$app->make(HttpClientFactory::class);
@@ -162,7 +161,7 @@ class HttpClientTest extends PHPUnit_Framework_TestCase
         }
         $this->assertTrue($error === null, 'sslverifypeer turned off should always succeed (error: ' . ($error ? $error->getMessage() : '') . ')');
 
-        if ($shouldBeOK && $caPath == $certsFolder = self::SKIP_VALID_CERTS) {
+        if ($shouldBeOK && $caPath === self::SKIP_VALID_CERTS) {
             $this->markTestSkipped('Unable to find a local folder containing CA certificates');
         }
         $client = $factory->createFromOptions([


### PR DESCRIPTION
We have some tests that performs remote URL calls, and are marked as skipped unless we define a `CONCRETE5TESTS_TEST_REMOTE_URI` environment variable.

This makes the output of phpunit more verbose than necessary, since it displays a few tests marked as skipped (because the above variable is not set).

So, what about excluding those tests by default?