### PR TITLE
Allow email sending enable/disable from the dashboard

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/mail/method.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method.php
@@ -14,6 +14,7 @@ class Method extends DashboardPageController
     {
         if ($this->token->validate('save_settings')) {
             $config = $this->app->make('config');
+            $config->save('concrete.email.enabled', (bool) $this->post('EMAIL_ENABLED'));
             $config->save('concrete.mail.method', strtolower($this->post('MAIL_SEND_METHOD')));
             if ($this->post('MAIL_SEND_METHOD') == 'SMTP') {
                 $config->save('concrete.mail.methods.smtp.server', $this->post('MAIL_SEND_METHOD_SMTP_SERVER'));

--- a/concrete/single_pages/dashboard/system/mail/method.php
+++ b/concrete/single_pages/dashboard/system/mail/method.php
@@ -14,6 +14,19 @@ $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('E
 
     <fieldset>
         <div class="form-group">
+            <?= $form->label('EMAIL_ENABLED', t('Email Sending')) ?>
+            <div class="radio">
+                <label><?= $form->radio('EMAIL_ENABLED', false, strtoupper($config->get('concrete.email.enabled'))) ?><span><?= t('Disabled') ?></span></label>
+            </div>
+            <div class="radio">
+                <label><?= $form->radio('EMAIL_ENABLED', true, strtoupper($config->get('concrete.email.enabled'))) ?><span><?= t('Enabled') ?></span></label>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <div class="form-group">
+            <?= $form->label('MAIL_SEND_METHOD', t('Email Sending Method')) ?>
             <div class="radio">
                 <label><?= $form->radio('MAIL_SEND_METHOD', 'PHP_MAIL', strtoupper($config->get('concrete.mail.method'))) ?><span><?= t('Default PHP Mail Function') ?></span></label>
             </div>

--- a/concrete/single_pages/dashboard/system/mail/method.php
+++ b/concrete/single_pages/dashboard/system/mail/method.php
@@ -16,10 +16,10 @@ $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('E
         <div class="form-group">
             <?= $form->label('EMAIL_ENABLED', t('Email Sending')) ?>
             <div class="radio">
-                <label><?= $form->radio('EMAIL_ENABLED', false, strtoupper($config->get('concrete.email.enabled'))) ?><span><?= t('Disabled') ?></span></label>
+                <label><?= $form->radio('EMAIL_ENABLED', false, $config->get('concrete.email.enabled')) ?><span><?= t('Disabled') ?></span></label>
             </div>
             <div class="radio">
-                <label><?= $form->radio('EMAIL_ENABLED', true, strtoupper($config->get('concrete.email.enabled'))) ?><span><?= t('Enabled') ?></span></label>
+                <label><?= $form->radio('EMAIL_ENABLED', true, $config->get('concrete.email.enabled')) ?><span><?= t('Enabled') ?></span></label>
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
How about allowing users to enable/disable email sending from the dashboard?

**Before**
![Screen Shot 2019-08-08 at 19 48 12](https://user-images.githubusercontent.com/2462951/62697434-a3669780-ba15-11e9-8a72-5b284b1fd1a6.png)


**After**
![Screen Shot 2019-08-08 at 19 47 51](https://user-images.githubusercontent.com/2462951/62697438-a792b500-ba15-11e9-9c33-1d059518d8ca.png)
