### PR TITLE
Cookie is not an alias

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -33,7 +33,6 @@ return [
         'ConversationFlagType' => '\Concrete\Core\Conversation\FlagType\FlagType',
         'ConversationMessage' => '\Concrete\Core\Conversation\Message\Message',
         'ConversationRatingType' => '\Concrete\Core\Conversation\Rating\Type',
-        'Cookie' => '\Concrete\Core\Cookie\Cookie',
         'Environment' => '\Concrete\Core\Foundation\Environment',
         'FacebookAuthenticationTypeController' => '\Concrete\Authentication\Facebook\Controller',
         'File' => '\Concrete\Core\File\File',

--- a/tests/tests/Config/ValuesTest.php
+++ b/tests/tests/Config/ValuesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Concrete\Tests\Config;
+
+use PHPUnit_Framework_TestCase;
+
+class ValuesTest extends PHPUnit_Framework_TestCase
+{
+    public function provideConfiguredAliases()
+    {
+        $config = app('config');
+        $result = [];
+        foreach ($config->get('app.aliases') as $alias => $actualClass) {
+            $result[] = ['app.aliases', $alias, $actualClass];
+        }
+        foreach ($config->get('app.facades') as $alias => $actualClass) {
+            $result[] = ['app.facades', $alias, $actualClass];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @dataProvider provideConfiguredAliases
+     *
+     * @param string $configKey
+     * @param string $alias
+     * @param string $classFromConfig
+     */
+    public function testConfiguredAliases($configKey, $alias, $classFromConfig)
+    {
+        $alias = ltrim($alias, '\\');
+        $classFromConfig = ltrim($classFromConfig, '\\');
+        $this->assertTrue(class_exists($alias, true));
+        $actualClass = (new \ReflectionClass($alias))->getName();
+        $this->assertSame($classFromConfig, $actualClass, "Accordingly to {$configKey}, {$alias} should resolve to {$classFromConfig}, but it resolves to {$actualClass}");
+    }
+}


### PR DESCRIPTION
`Cookie` is present in the configuration both [as an alias](https://github.com/concrete5/concrete5/blob/7deb96e2ce02b172427b5123bd2143779bb38293/concrete/config/app.php#L36) and [as a facade](https://github.com/concrete5/concrete5/blob/7deb96e2ce02b172427b5123bd2143779bb38293/concrete/config/app.php#L165).

What we need is the facade, the alias is never loaded (because the facade is initialized first, the class alias autoloader will never use that value). Indeed, running this code
```php
echo get_class(new \Cookie());
```
outputs
```
Concrete\Core\Support\Facade\Cookie
```


I also added a test so that we won't have an issue like this anymore.