### PR TITLE
fix delete draft desktop draft list block

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -163,6 +163,13 @@ module.exports = function(grunt) {
             ]
         },
 
+        draftlist: {
+            dest: '<%= DIR_BASE %>/concrete/js/draft-list.js',
+            src: [
+                '<%= DIR_BASE %>/concrete/js/build/core/blocks/draft-list.js',
+            ]
+        },
+
         express: {
             dest: '<%= DIR_BASE %>/concrete/js/express.js',
             src: [

--- a/concrete/blocks/desktop_draft_list/controller.php
+++ b/concrete/blocks/desktop_draft_list/controller.php
@@ -2,13 +2,14 @@
 namespace Concrete\Block\DesktopDraftList;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\PageList;
 use Concrete\Core\User\UserInfo;
 use Permissions;
 use URL;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
@@ -57,6 +58,11 @@ class Controller extends BlockController
         parent::save($args);
     }
 
+    public function registerViewAssets($outputContent = '')
+    {
+        $this->requireAsset('core/draft_list');
+    }
+
     public function view()
     {
         $myDrafts = [];
@@ -103,7 +109,7 @@ class Controller extends BlockController
                     }
                     $deleteLink = null;
                     if ($dp->canDeletePage()) {
-                        $deleteLink = URL::to('/ccm/system/dialogs/page/delete') . '?cID=' . $draft->getCollectionID();
+                        $deleteLink = URL::to('/ccm/system/dialogs/page/delete_from_sitemap') . '?cID=' . $draft->getCollectionID();
                     }
                     $myDrafts[] = [
                         'link' => $navigation->getLinkToCollection($draft),
@@ -119,5 +125,13 @@ class Controller extends BlockController
         $this->set('drafts', $myDrafts);
         $this->set('showPagination', $showPagination);
         $this->set('pagination', $pagination);
+    }
+
+    public function action_reload_drafts()
+    {
+        $b = $this->getBlockObject();
+        $bv = new BlockView($b);
+        $bv->render('view');
+        $this->app->shutdown();
     }
 }

--- a/concrete/blocks/desktop_draft_list/controller.php
+++ b/concrete/blocks/desktop_draft_list/controller.php
@@ -82,10 +82,6 @@ class Controller extends BlockController
                 $list->setItemsPerPage((!empty($this->draftsPerPage)) ? $this->draftsPerPage : $this->defaultDraftsPerPage);
                 $pagination = $list->getPagination();
                 $drafts = $pagination->getCurrentPageResults();
-                if ($pagination->haveToPaginate()) {
-                    $showPagination = true;
-                    $pagination = $pagination->renderDefaultView();
-                }
             }
         }
 
@@ -123,7 +119,6 @@ class Controller extends BlockController
             }
         }
         $this->set('drafts', $myDrafts);
-        $this->set('showPagination', $showPagination);
         $this->set('pagination', $pagination);
     }
 

--- a/concrete/blocks/desktop_draft_list/controller.php
+++ b/concrete/blocks/desktop_draft_list/controller.php
@@ -66,7 +66,6 @@ class Controller extends BlockController
     public function view()
     {
         $myDrafts = [];
-        $showPagination = false;
         $pagination = null;
         $site = $this->app->make('site')->getSite();
         if (is_object($site)) {

--- a/concrete/blocks/desktop_draft_list/view.php
+++ b/concrete/blocks/desktop_draft_list/view.php
@@ -24,16 +24,20 @@
             <?php
     } ?>
             <?php
-                if ($showPagination) {
-                    echo $pagination;
-                } ?>
+            if ($pagination && $pagination->haveToPaginate()) {
+                $pagination->setBaseURL($view->action('reload_drafts')); ?>
+                <div class="ccm-search-results-pagination">
+                    <?= $pagination->renderDefaultView(); ?>
+                </div>
+                <?php
+            } ?>
         </div>
     <?php
 } else {
-                    ?>
+                ?>
         <p><?= t('There are no drafts.'); ?></p>
     <?php
-                } ?>
+            } ?>
 </div>
 
 <script type="text/javascript">

--- a/concrete/blocks/desktop_draft_list/view.php
+++ b/concrete/blocks/desktop_draft_list/view.php
@@ -1,27 +1,45 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+
 <div class="ccm-block-desktop-draft-list">
-    <h3><?= t('Page Drafts'); ?></h3>
-    <?php if (!empty($drafts)) { ?>
+    <h3><?= t('Page Drafts'); ?>
+        <i class="ccm-block-desktop-draft-list-for-me-loader fa fa-refresh fa-spin pull-right hidden"></i>
+    </h3>
+    <?php if (!empty($drafts)) {
+    ?>
         <div class="draft-list">
-            <?php foreach ($drafts as $draft) { ?>
+            <?php foreach ($drafts as $draft) {
+        ?>
                 <div class="draft-list-item">
                     <a href="<?= $draft['link']; ?>">
                         <?= t('%s created by %s on %s', $draft['name'], $draft['user'], $draft['dateAdded']); ?>
                     </a>
-                    <?php if (!empty($draft['deleteLink'])) { ?>
+                    <?php if (!empty($draft['deleteLink'])) {
+            ?>
                         <a class="dialog-launch btn btn-danger btn-xs" href="<?= $draft['deleteLink']; ?>" dialog-modal="true" dialog-title="<?= t('Delete Draft'); ?>" dialog-width="400" dialog-height="250">
                             <?= t('Delete Draft'); ?>
                         </a>
-                    <?php } ?>
+                    <?php
+        } ?>
                 </div>
-            <?php } ?>
+            <?php
+    } ?>
             <?php
                 if ($showPagination) {
                     echo $pagination;
-                }
-            ?>
+                } ?>
         </div>
-    <?php } else { ?>
+    <?php
+} else {
+                    ?>
         <p><?= t('There are no drafts.'); ?></p>
-    <?php } ?>
+    <?php
+                } ?>
 </div>
+
+<script type="text/javascript">
+    $(function() {
+        $('div.ccm-block-desktop-draft-list').concreteDraftList({
+            reloadUrl:'<?= $view->action('reload_drafts'); ?>'
+        });
+    });
+</script>

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -645,7 +645,7 @@ return [
             ['javascript', 'js/notification.js', ['minify' => false]],
         ],
         'core/draft_list' => [
-            ['javascript', 'js/build/core/blocks/draft_list.js', ['minify' => false]],
+            ['javascript', 'js/draft-list.js', ['minify' => false]],
         ],
         'core/tree' => [
             ['javascript', 'js/tree.js', ['minify' => false]],

--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -644,6 +644,9 @@ return [
         'core/notification' => [
             ['javascript', 'js/notification.js', ['minify' => false]],
         ],
+        'core/draft_list' => [
+            ['javascript', 'js/build/core/blocks/draft_list.js', ['minify' => false]],
+        ],
         'core/tree' => [
             ['javascript', 'js/tree.js', ['minify' => false]],
         ],
@@ -752,6 +755,12 @@ return [
         'core/notification' => [
             [
                 ['javascript', 'core/notification'],
+            ],
+        ],
+        'core/draft_list' => [
+            [
+                ['javascript', 'core/draft_list'],
+                ['javascript', 'core/events'],
             ],
         ],
         'core/colorpicker' => [

--- a/concrete/js/build/core/blocks/draft-list.js
+++ b/concrete/js/build/core/blocks/draft-list.js
@@ -1,4 +1,5 @@
 /* jshint unused:vars, undef:true, browser:true, jquery:true */
+/* global ConcreteEvent */
 
 ;(function(global, $) {
     'use strict';

--- a/concrete/js/build/core/blocks/draft_list.js
+++ b/concrete/js/build/core/blocks/draft_list.js
@@ -1,0 +1,73 @@
+/* jshint unused:vars, undef:true, browser:true, jquery:true */
+
+;(function(global, $) {
+    'use strict';
+
+    function ConcreteDraftList($element, options) {
+        var my = this;
+        options = $.extend({}, options);
+
+        my.$element = $element;
+        my.options = options;
+
+        ConcreteEvent.unsubscribe('SitemapDeleteRequestComplete');
+        ConcreteEvent.subscribe('SitemapDeleteRequestComplete', function (e) {
+            my.hideLoader();
+            $.concreteAjax({
+                dataType: 'html',
+                url: my.options.reloadUrl,
+                method: 'get',
+                success: function (r) {
+                    my.$element.replaceWith(r);
+                },
+                complete: function() {
+                    my.hideLoader();
+                }
+            });
+        });
+
+        my.$element.on('click', 'div.ccm-pagination-wrapper a', function(e) {
+            e.preventDefault();
+            my.showLoader();
+            window.scrollTo(0, 0);
+            $.concreteAjax({
+                loader: false,
+                dataType: 'html',
+                url: $(this).attr('href'),
+                method: 'get',
+                success: function(r) {
+                    my.$element.replaceWith(r);
+                },
+                complete: function() {
+                    my.hideLoader();
+                }
+            });
+
+        });
+
+        my.$element.find('.dialog-launch').dialog();
+    }
+
+    ConcreteDraftList.prototype = {
+        showLoader: function() {
+            var my = this;
+            my.$element.find('.ccm-block-desktop-draft-list-for-me-loader').removeClass('hidden');
+        },
+
+        hideLoader: function() {
+            var my = this;
+            my.$element.find('.ccm-block-desktop-draft-list-for-me-loader').addClass('hidden');
+        }
+
+    };
+
+    // jQuery Plugin
+    $.fn.concreteDraftList = function(options) {
+        return $.each($(this), function(i, obj) {
+            new ConcreteDraftList($(this), options);
+        });
+    };
+
+    global.ConcreteDraftList = ConcreteDraftList;
+
+})(this, jQuery);


### PR DESCRIPTION
This pull request fixes The issue related to the redirection to home page after the delete of a draft page in desktop draft list block
**Before fix**
![before-fix](https://user-images.githubusercontent.com/41285951/63158902-90a62100-c01a-11e9-88d8-a4087826fa19.gif)
**After fix**
![after-fix](https://user-images.githubusercontent.com/41285951/63251553-41f0c500-c26e-11e9-9ce5-b081ffdfb8fe.gif)

