### PR TITLE
Always register class aliases

### DIFF
--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -293,11 +293,14 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
     private function initializeClassAliases(Repository $config)
     {
         $list = ClassAliasList::getInstance();
-        $list->registerMultiple($config->get('app.aliases'));
+        $aliases = $config->get('app.aliases');
+        $list->registerMultiple($aliases);
         $list->registerMultiple($config->get('app.facades'));
 
-        // Autoload some aliases to prevent typehinting errors
-        class_exists('\Request');
+        // Autoload aliases to prevent typehinting errors
+        foreach (array_keys($aliases) as $alias) {
+            class_exists($alias);
+        }
         if (version_compare(PHP_VERSION, '7.2.0alpha1') < 0) {
             $list->register('Concrete\Core\Foundation\Object', 'Concrete\Core\Foundation\ConcreteObject');
         }


### PR DESCRIPTION
Let's assume we have this code

```php
function foo(\Area $bar) {}

foo(new \Concrete\Core\Area\Area());
```

In the [configuration](https://github.com/concrete5/concrete5/blob/0a610c77e472c8439acbd48a445d1548d965e6b4/concrete/config/app.php#L14), `\Area` is an alias of `\Concrete\Core\Area\Area`.

The problem is that, if `\Area` has not already been autoloaded, PHP throws the following error:

```
Uncaught TypeError: Argument 1 passed to foo() must be an instance of Area,
instance of Concrete\Core\Area\Area given
```

(This is the reason of #8060).

In #8068 we remove all the alias usage from the core, but 3rd party code would still be affected by this issue.

So, IMHO the solution is to always load class aliases...