### PR TITLE
Improve persistent login cookie

### DIFF
--- a/concrete/authentication/concrete/db.xml
+++ b/concrete/authentication/concrete/db.xml
@@ -9,7 +9,7 @@
       <autoincrement/>
       <key/>
     </field>
-    <field name="token" type="string" size="32"/>
+    <field name="token" type="string" size="64"/>
     <field name="uID" type="integer" size="10"/>
     <field name="validThrough" type="integer" size="10"/>
     <index name="token">

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2a2',
     'version_installed' => '8.5.2a2',
-    'version_db' => '20190817000000', // the key of the latest database migration
+    'version_db' => '20190822160700', // the key of the latest database migration
  
     /*
      * Installation status

--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller;
 
 use Concrete\Core\Cache\Cache;
 use Concrete\Core\Controller\Controller;
+use Concrete\Core\Encryption\PasswordHasher;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Install\ConnectionOptionsPreconditionInterface;
@@ -18,7 +19,6 @@ use Concrete\Core\Localization\Translation\Remote\ProviderInterface as RemoteTra
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\View\View;
 use Exception;
-use Hautelook\Phpass\PasswordHash;
 use Punic\Comparer as PunicComparer;
 use stdClass;
 
@@ -325,11 +325,11 @@ class Install extends Controller
                 $configuration['session-handler'] = $post->get('sessionHandler');
                 $options->setConfiguration($configuration);
 
-                $hasher = new PasswordHash($config->get('concrete.user.password.hash_cost_log2'), $config->get('concrete.user.password.hash_portable'));
+                $hasher = $this->app->make(PasswordHasher::class);
                 $options
                     ->setPrivacyPolicyAccepted($post->get('privacy') == '1' ? true : false)
                     ->setUserEmail($post->get('uEmail'))
-                    ->setUserPasswordHash($hasher->HashPassword($post->get('uPassword')))
+                    ->setUserPasswordHash($hasher->hashPassword($post->get('uPassword')))
                     ->setStartingPointHandle($post->get('SAMPLE_CONTENT'))
                     ->setSiteName($post->get('SITE'))
                     ->setSiteLocaleId($post->get('siteLocaleLanguage') . '_' . $post->get('siteLocaleCountry'))

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -9,7 +9,6 @@ use Concrete\Core\User\User;
 use Page;
 use Controller;
 use Concrete\Core\Support\Facade\Application;
-use Hautelook\Phpass\PasswordHash;
 
 abstract class AuthenticationTypeController extends Controller implements LoggerAwareInterface,
     AuthenticationTypeControllerInterface
@@ -57,19 +56,4 @@ abstract class AuthenticationTypeController extends Controller implements Logger
      * @return string
      */
     abstract public function getHandle();
-
-    /**
-     * Get an instance of a PasswordHash to be used to has the access token.
-     *
-     * @return \Hautelook\Phpass\PasswordHash
-     */
-    protected function getHasher()
-    {
-        $config = $this->app->make('config');
-
-        return new PasswordHash(
-            $config->get('concrete.user.password.hash_cost_log2'),
-            $config->get('concrete.user.password.hash_portable')
-        );
-    }
 }

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -9,6 +9,7 @@ use Concrete\Core\User\User;
 use Page;
 use Controller;
 use Concrete\Core\Support\Facade\Application;
+use Hautelook\Phpass\PasswordHash;
 
 abstract class AuthenticationTypeController extends Controller implements LoggerAwareInterface,
     AuthenticationTypeControllerInterface
@@ -56,4 +57,19 @@ abstract class AuthenticationTypeController extends Controller implements Logger
      * @return string
      */
     abstract public function getHandle();
+
+    /**
+     * Get an instance of a PasswordHash to be used to has the access token.
+     *
+     * @return \Hautelook\Phpass\PasswordHash
+     */
+    protected function getHasher()
+    {
+        $config = $this->app->make('config');
+
+        return new PasswordHash(
+            $config->get('concrete.user.password.hash_cost_log2'),
+            $config->get('concrete.user.password.hash_portable')
+        );
+    }
 }

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Cache\Cache;
 use Concrete\Core\Console\Command;
+use Concrete\Core\Encryption\PasswordHasher;
 use Concrete\Core\Install\ConnectionOptionsPreconditionInterface;
 use Concrete\Core\Install\Installer;
 use Concrete\Core\Install\PreconditionResult;
@@ -14,7 +15,6 @@ use Concrete\Core\Support\Facade\Application;
 use Database;
 use DateTimeZone;
 use Exception;
-use Hautelook\Phpass\PasswordHash;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -708,7 +708,7 @@ EOT
     {
         $app = Application::getFacadeApplication();
         $config = $app->make('config');
-        $hasher = new PasswordHash($config->get('concrete.user.password.hash_cost_log2'), $config->get('concrete.user.password.hash_portable'));
+        $hasher = $app->make(PasswordHasher::class);
         $installer = $app->make(Installer::class);
         $installer->getOptions()
             ->setConfiguration([
@@ -735,7 +735,7 @@ EOT
             ->setStartingPointHandle($options['starting-point'])
             ->setSiteName($options['site'])
             ->setUserEmail($options['admin-email'])
-            ->setUserPasswordHash($hasher->HashPassword($options['admin-password']))
+            ->setUserPasswordHash($hasher->hashPassword($options['admin-password']))
             ->setServerTimeZoneId($options['timezone'])
         ;
 

--- a/concrete/src/Encryption/PasswordHasher.php
+++ b/concrete/src/Encryption/PasswordHasher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Concrete\Core\Encryption;
+
+use Concrete\Core\Config\Repository\Repository;
+use Hautelook\Phpass\PasswordHash;
+
+class PasswordHasher
+{
+    /**
+     * @var \Hautelook\Phpass\PasswordHash
+     */
+    private $phpassPasswordHash;
+
+    /**
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     */
+    public function __construct(Repository $config)
+    {
+        $this->phpassPasswordHash = new PasswordHash(
+            $config->get('concrete.user.password.hash_cost_log2'),
+            $config->get('concrete.user.password.hash_portable')
+        );
+    }
+
+    /**
+     * Create a hash for a plain password.
+     *
+     * @param string $password
+     *
+     * @return string
+     */
+    public function hashPassword($password)
+    {
+        return $this->phpassPasswordHash->HashPassword($password);
+    }
+
+    /**
+     * Check if a password corresponds to a stored hash previosly created with the hashPassword() method.
+     *
+     * @param string $password
+     * @param string $storedHash
+     */
+    public function checkPassword($password, $storedHash)
+    {
+        return $this->phpassPasswordHash->CheckPassword($password, $storedHash);
+    }
+}

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -31,7 +31,6 @@ use Doctrine\ORM\Tools\Setup;
 use Exception;
 use Group;
 use GroupTree;
-use Hautelook\Phpass\PasswordHash;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use Package as BasePackage;
 use Page;

--- a/concrete/src/Session/SessionValidator.php
+++ b/concrete/src/Session/SessionValidator.php
@@ -11,6 +11,7 @@ use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
 use Concrete\Core\Permission\IPService;
+use Concrete\Core\User\PersistentAuthentication\CookieService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
 
@@ -164,9 +165,14 @@ class SessionValidator implements SessionValidatorInterface, LoggerAwareInterfac
      */
     public function hasActiveSession()
     {
-        $cookie = $this->app['cookie'];
+        if ($this->app['cookie']->has($this->config->get('concrete.session.name'))) {
+            return true;
+        }
+        if ($this->app->make(CookieService::class)->getCookie() !== null) {
+            return true;
+        }
 
-        return $cookie->has($this->config->get('concrete.session.name')) || $cookie->has('ccmAuthUserHash');
+        return false;
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20190822160700.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190822160700.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+
+class Version20190822160700 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeSchema()
+     */
+    public function upgradeSchema(Schema $schema)
+    {
+        $this->fixCookieTable($schema);
+    }
+
+    protected function fixCookieTable(Schema $schema)
+    {
+        if (!$schema->hasTable('authTypeConcreteCookieMap')) {
+            return;
+        }
+        $table = $schema->getTable('authTypeConcreteCookieMap');
+        if (!$table->hasColumn('token')) {
+            return;
+        }
+        $column = $table->getColumn('token');
+        if ($column->getType()->getName() !== Type::STRING) {
+            return;
+        }
+        if ($column->getLength() >= 64) {
+            return;
+        }
+        $column->setLength(64);
+    }
+}

--- a/concrete/src/User/PersistentAuthentication/CookieService.php
+++ b/concrete/src/User/PersistentAuthentication/CookieService.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Concrete\Core\User\PersistentAuthentication;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Cookie\CookieJar;
+
+class CookieService
+{
+    /**
+     * The name of the cookie to be used to remember the currently logged in user.
+     *
+     * @var string
+     */
+    const COOKIE_NAME = 'ccmAuthUserHash';
+
+    /**
+     * @var \Concrete\Core\Cookie\CookieJar
+     */
+    protected $cookieJar;
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Cookie\CookieJar $cookieJar
+     * @param \Concrete\Core\Config\Repository\Repository $config
+     */
+    public function __construct(CookieJar $cookieJar, Repository $config)
+    {
+        $this->cookieJar = $cookieJar;
+        $this->config = $config;
+    }
+
+    /**
+     * Get the authentication data corrently contained in the cookie jar.
+     *
+     * @return \Concrete\Core\User\PersistentAuthentication\CookieValue|null
+     */
+    public function getCookie()
+    {
+        if (!$this->cookieJar->has(static::COOKIE_NAME)) {
+            return null;
+        }
+        $rawValue = $this->cookieJar->get(static::COOKIE_NAME);
+
+        return $this->unserializeCookieValue($rawValue);
+    }
+
+    /**
+     * Set (or delete) the authentication cookie.
+     *
+     * @param \Concrete\Core\User\PersistentAuthentication\CookieValue|null $value
+     */
+    public function setCookie(CookieValue $value = null)
+    {
+        if ($value === null) {
+            $this->deleteCookie();
+
+            return;
+        }
+        $this->cookieJar->getResponseCookies()->addCookie(
+            // $name
+            static::COOKIE_NAME,
+            // $value
+            $this->serializeCookieValue($value),
+            // $expire
+            time() + (int) $this->config->get('concrete.session.remember_me.lifetime'),
+            // $path
+            DIR_REL . '/',
+            // $domain
+            $this->config->get('concrete.session.cookie.cookie_domain'),
+            // $secure
+            $this->config->get('concrete.session.cookie.cookie_secure'),
+            // $httpOnly
+            $this->config->get('concrete.session.cookie.cookie_httponly')
+        );
+    }
+
+    /**
+     * Delete the authentication cookie.
+     */
+    public function deleteCookie()
+    {
+        $this->cookieJar->getResponseCookies()->clear(static::COOKIE_NAME);
+    }
+
+    /**
+     * @param \Concrete\Core\User\PersistentAuthentication\CookieValue $value
+     *
+     * @return string
+     */
+    protected function serializeCookieValue(CookieValue $value)
+    {
+        return implode(':', [$value->getUserID(), $value->getAuthenticationTypeHandle(), $value->getToken()]);
+    }
+
+    /**
+     * @param string|mixed $rawValue
+     *
+     * @return \Concrete\Core\User\PersistentAuthentication\CookieValue|null
+     */
+    protected function unserializeCookieValue($rawValue)
+    {
+        if (!is_string($rawValue)) {
+            return null;
+        }
+        $chunks = explode(':', $rawValue);
+        if (count($chunks) !== 3) {
+            return null;
+        }
+        list($userID, $authenticationTypeHandle, $token) = $chunks;
+        if (($userID = (int) $userID) < 1 || $authenticationTypeHandle === '') {
+            return null;
+        }
+
+        return new CookieValue($userID, $authenticationTypeHandle, $token);
+    }
+}

--- a/concrete/src/User/PersistentAuthentication/CookieValue.php
+++ b/concrete/src/User/PersistentAuthentication/CookieValue.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Concrete\Core\User\PersistentAuthentication;
+
+class CookieValue
+{
+    /**
+     * The user ID.
+     *
+     * @var int
+     */
+    private $userID;
+
+    /**
+     * The handle of the authentication type.
+     *
+     * @var string
+     */
+    private $authenticationTypeHandle;
+
+    /**
+     * The unique token identifier.
+     *
+     * @var string
+     */
+    private $token;
+
+    /**
+     * @param int $userID The user ID
+     * @param string $authenticationTypeHandle the authentication type handle
+     * @param string $token the unique token identifier
+     */
+    public function __construct($userID, $authenticationTypeHandle, $token)
+    {
+        $this->userID = $userID;
+        $this->authenticationTypeHandle = $authenticationTypeHandle;
+        $this->token = $token;
+    }
+
+    /**
+     * Get the user ID.
+     *
+     * @return int
+     */
+    public function getUserID()
+    {
+        return $this->userID;
+    }
+
+    /**
+     * Get the handle of the authentication type.
+     *
+     * @return string
+     */
+    public function getAuthenticationTypeHandle()
+    {
+        return $this->authenticationTypeHandle;
+    }
+
+    /**
+     * Get the unique token identifier.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+}

--- a/concrete/src/User/RegistrationService.php
+++ b/concrete/src/User/RegistrationService.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\User;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Encryption\PasswordHasher;
 use Concrete\Core\Entity\User\User as UserEntity;
 use Concrete\Core\Entity\User\UserSignup;
 use Concrete\Core\Logging\Channels;
@@ -12,7 +13,6 @@ use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\User\Event\AddUser;
 use Concrete\Core\User\Event\UserInfoWithPassword;
 use Doctrine\ORM\EntityManagerInterface;
-use Hautelook\Phpass\PasswordHash;
 
 class RegistrationService implements RegistrationServiceInterface
 {
@@ -74,8 +74,7 @@ class RegistrationService implements RegistrationServiceInterface
             return false;
         }
 
-        $config = $this->application->make('config');
-        $hasher = new PasswordHash($config->get('concrete.user.password.hash_cost_log2'), $config->get('concrete.user.password.hash_portable'));
+        $hasher = $this->application->make(PasswordHasher::class);
 
         if (isset($data['uIsValidated']) && $data['uIsValidated'] == 1) {
             $uIsValidated = 1;
@@ -92,7 +91,7 @@ class RegistrationService implements RegistrationServiceInterface
         }
 
         $password_to_insert = isset($data['uPassword']) ? $data['uPassword'] : null;
-        $hash = $hasher->HashPassword($password_to_insert);
+        $hash = $hasher->hashPassword($password_to_insert);
 
         $uDefaultLanguage = null;
         if (isset($data['uDefaultLanguage']) && $data['uDefaultLanguage'] != '') {

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -8,6 +8,7 @@ use Concrete\Core\Attribute\Key\UserKey;
 use Concrete\Core\Attribute\ObjectInterface as AttributeObjectInterface;
 use Concrete\Core\Attribute\ObjectTrait;
 use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Encryption\PasswordHasher;
 use Concrete\Core\Entity\Attribute\Value\UserValue;
 use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Entity\User\User as UserEntity;
@@ -501,7 +502,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
                 if (isset($data['uPasswordConfirm']) && $data['uPassword'] === $data['uPasswordConfirm']) {
                     $passwordChangedOn = $this->application->make('date')->getOverridableNow();
                     $fields[] = 'uPassword = ?';
-                    $values[] = $this->getUserObject()->getUserPasswordHasher()->HashPassword($data['uPassword']);
+                    $values[] = $this->application->make(PasswordHasher::class)->hashPassword($data['uPassword']);
                     $fields[] = 'uLastPasswordChange = ?';
                     $values[] = $passwordChangedOn;
                     if (isset($data['uIsPasswordReset'])) {


### PR DESCRIPTION
This pull request:
1. fixes #8056 by hashing the token used to login (we need to have a larger `authTypeConcreteCookieMap`.`token` field)
2. introduces a couple of classes (in the `Concrete\Core\User\PersistentAuthentication` namespace) to make it easier and safer to get/set/delete the persistent login cookie
3. fixes a bug where *all* the stored records have increased `validThrough` when a user logs in via the persistent cookie ([here's the buggy line](https://github.com/concrete5/concrete5/blob/9fb82b3ee65c0863027dc0772a43ea54831b0b3e/concrete/authentication/concrete/controller.php#L64)) (!).
4. uses the `concrete.session.remember_me.lifetime` configuration key instead of the hard-coded `2 weeks` (see [here](https://github.com/concrete5/concrete5/blob/9fb82b3ee65c0863027dc0772a43ea54831b0b3e/concrete/authentication/concrete/controller.php#L63) and [here](https://github.com/concrete5/concrete5/blob/9fb82b3ee65c0863027dc0772a43ea54831b0b3e/concrete/authentication/concrete/controller.php#L83)).