### PR TITLE
Always register class aliases - v2

### DIFF
--- a/concrete/src/Foundation/ClassAliasList.php
+++ b/concrete/src/Foundation/ClassAliasList.php
@@ -6,6 +6,14 @@ class ClassAliasList
     private static $loc = null;
     public $aliases = array();
 
+    /**
+     * List of class aliases to be resolved as soon as possible.
+     * @deprecated it will be removed in future versions
+     *
+     * @var string[]
+     */
+    private $requiredAliases = [];
+
     public function getRegisteredAliases()
     {
         return $this->aliases;
@@ -29,6 +37,39 @@ class ClassAliasList
     {
         foreach ($array as $alias => $class) {
             $this->register($alias, $class);
+        }
+    }
+
+    /**
+     * Register a class alias to be resolved as soon as possible.
+     * @deprecated Don't use this method: it will be removed in future versions (use register)
+     * @param string $alias
+     * @param string $class
+     */
+    public function registerRequired($alias, $class)
+    {
+        $this->register($alias, $class);
+        $this->requiredAliases[] = $alias;
+    }
+
+    /**
+     * Register a list of class aliases to be pre-resolved as soon as possible.
+     * @deprecated Don't use this method: it will be removed in future versions (use registerMultiple)
+     */
+    public function registerMultipleRequired($array)
+    {
+        $this->registerMultiple($array);
+        $this->requiredAliases = array_merge($this->requiredAliases, array_keys($array));
+    }
+
+    /**
+     * Pre-load the class aliases marked as required.
+     * @deprecated Don't use this method: it will be removed in future versions.
+     */
+    public function resolveRequired()
+    {
+        foreach ($this->requiredAliases as $requiredAlias) {
+            class_exists($requiredAlias);
         }
     }
 }

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -293,7 +293,7 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
     private function initializeClassAliases(Repository $config)
     {
         $list = ClassAliasList::getInstance();
-        $list->registerMultiple($config->get('app.aliases'));
+        $list->registerMultipleRequired($config->get('app.aliases'));
         $list->registerMultiple($config->get('app.facades'));
 
         // Autoload aliases to prevent typehinting errors

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Foundation\Runtime\Run;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Foundation\ClassAliasList;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Http\ResponseFactoryInterface;
@@ -88,6 +89,13 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
                 // We do this because we don't want the entity manager to be loaded and we
                 // want to give packages an opportunity to replace classes and load new classes
                 'setupPackages',
+
+                // Pre-load class aliases
+                // This is needed to avoid the problem of calling functions that accept a class alias as a parameter,
+                // but that alias isn't still auto-loaded. For example, that would result in the following error:
+                // Argument 1 passed to functionName() must be an instance of Area, instance of Concrete\Core\Area\Area given.
+                // Don't use this method: it will be removed in future concrete5 versions
+                'preloadClassAliases',
 
                 // Load site specific timezones. Has to come after packages because it
                 // instantiates the site service, which sometimes packages need to override.
@@ -249,6 +257,19 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
     protected function setupPackages()
     {
         $this->app->setupPackages();
+    }
+
+    /**
+     * Pre-load class aliases
+     * This is needed to avoid the problem of calling functions that accept a class alias as a parameter,
+     * but that alias isn't still auto-loaded. For example, that would result in the following error:
+     * Argument 1 passed to functionName() must be an instance of Area, instance of Concrete\Core\Area\Area given.
+     *
+     * @deprecated Don't use this method: it will be removed in future concrete5 versions
+     */
+    protected function preloadClassAliases()
+    {
+        ClassAliasList::getInstance()->resolveRequired();
     }
 
     /**


### PR DESCRIPTION
In order to fix #8060, I suggested #8080 which pre-loaded the class aliases.

But that pre-loading happened too early, so it has been reverted by #8093 and #8060 was solved by #8096.

Since the core is moving away from class aliases, 3rd party code (and some parts of the core) may still be affected by problems like #8060, so we need to pre-load the class aliases.

That's what's done in this PR, which is like #8080, but the pre-loading is done later (that is, after `application/bootstrap/autoload.php`, `application/bootstrap/start.php`, `application/bootstrap/app.php`, and packages `on_start` methods).