### PR TITLE
Resolve #8101

### DIFF
--- a/concrete/src/Attribute/Category/AbstractCategory.php
+++ b/concrete/src/Attribute/Category/AbstractCategory.php
@@ -146,7 +146,9 @@ abstract class AbstractCategory implements CategoryInterface, StandardSearchInde
         $item = $cache->getItem(sprintf('/attribute/%s/handle/%s', $category, $handle));
         if (!$item->isMiss()) {
             $key = $item->get();
-        } else {
+        }
+
+        if (!is_object($key)) {
             $key = $this->getAttributeKeyRepository()->findOneBy([
                 'akHandle' => $handle,
             ]);
@@ -171,12 +173,14 @@ abstract class AbstractCategory implements CategoryInterface, StandardSearchInde
         $item = $cache->getItem(sprintf('/attribute/%s/id/%s', $category, $akID));
         if (!$item->isMiss()) {
             $key = $item->get();
-        } else {
-            $key = $this->getAttributeKeyRepository()->findOneBy([
-                'akID' => $akID,
-            ]);
-            $cache->save($item->set($key));
         }
+
+	    if (!is_object($key)) {
+		    $key = $this->getAttributeKeyRepository()->findOneBy([
+			    'akID' => $akID,
+		    ]);
+		    $cache->save($item->set($key));
+	    }
 
         return $key;
     }


### PR DESCRIPTION
It appears that the cause of https://github.com/concrete5/concrete5/issues/8101 is that when the attributes are created they are saved to the cache as null, so when the attribute set is created and tries to get that attribute key to connect it, the attribute key is "found" in the cache, but is null.