### PR TITLE
Strip out bad data from IE

### DIFF
--- a/concrete/attributes/number/controller.php
+++ b/concrete/attributes/number/controller.php
@@ -87,6 +87,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     public function createAttributeValue($value)
     {
         $av = new NumberValue();
+		$value = $value === null ? null : preg_replace("/[^0-9]./", '', $value);
         $av->setValue($value);
 
         return $av;


### PR DESCRIPTION
Most browsers only let you submit numbers. However, IE allows you to submit values including non-numeric data including commas causing an exception. This filters out everything except numbers, decimals, and null.