### PR TITLE
Add a config key to support script-specific locales

### DIFF
--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -137,6 +137,7 @@ return [
                 'use_browser_detected_locale' => false,
                 'default_source_locale' => 'en_US',
                 'always_track_user_locale' => true,
+                'support_script_specific_locale' => false,
             ],
             'seo' => [
                 'canonical_tag' => [

--- a/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
@@ -58,6 +58,7 @@ class Setup extends DashboardSitePageController
             }
         }
         $this->set('mlLink', $mlLink);
+        $this->set('supportScriptSpecificLocale', $siteConfig->get('multilingual.support_script_specific_locale'));
     }
 
     public function get_countries_for_language()
@@ -157,6 +158,7 @@ class Setup extends DashboardSitePageController
                 }
                 $siteConfig->save('multilingual.default_source_locale', $defaultSourceLocale);
                 $siteConfig->save('multilingual.always_track_user_locale', $this->post('alwaysTrackUserLocale') ? true : false);
+                $siteConfig->save('multilingual.support_script_specific_locale', $this->post('supportScriptSpecificLocale') ? true : false);
                 $this->flash('success', t('Default Section settings updated.'));
                 $this->redirect('/dashboard/system/multilingual/setup', 'view');
             } else {

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -157,6 +157,15 @@ foreach ($locales as $locale) {
             <?= $form->select('defaultSourceCountry', array_merge(['' => t('*** Undetermined country')], $countries), $defaultSourceCountry) ?>
         </div>
     </div>
+    <div class="form-group">
+        <label class="control-label"><?= t('Advanced') ?></label>
+        <div class="checkbox">
+            <label>
+                <?= $form->checkbox('supportScriptSpecificLocale', 1, $supportScriptSpecificLocale) ?>
+                <span><?= t('Support script-specific locale.') ?> <i class="launch-tooltip control-label fa fa-question-circle" title="<?= h(t('Make it enable to choose script-specific languages (eg "Simplified Chinese") for site locale.')) ?>"></i></span>
+            </label>
+        </div>
+    </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <?php $token->output('set_default') ?>

--- a/concrete/src/Localization/Service/LanguageList.php
+++ b/concrete/src/Localization/Service/LanguageList.php
@@ -1,12 +1,16 @@
 <?php
 namespace Concrete\Core\Localization\Service;
 
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
 use Punic\Language;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-class LanguageList
+class LanguageList implements ApplicationAwareInterface
 {
+    use ApplicationAwareTrait;
+
     /**
      * Returns an associative array with the locale code as the key and the translated language name as the value.
      *
@@ -14,7 +18,13 @@ class LanguageList
      */
     public function getLanguageList()
     {
-        $languages = Language::getAll(true, true);
+        $excludeScriptSpecific = true;
+        $site = $this->app->make('site')->getActiveSiteForEditing();
+        if (is_object($site)) {
+            $siteConfig = $site->getConfigRepository();
+            $excludeScriptSpecific = !$siteConfig->get('multilingual.support_script_specific_locale');
+        }
+        $languages = Language::getAll(true, $excludeScriptSpecific);
 
         return $languages;
     }


### PR DESCRIPTION
Issue: You can not set "Simplified Chinese" or "Traditional Chinese" for multilingual section.

Chinese people living in mainland China uses Simplified Chinese, and people living in outside of the mainland (e.g. Hong-kong, Taiwan, Macau) uses Traditional Chinese. It's a very important difference. So, let's make it enable to choose these type of locale. I tested the multilingual sections with "Simplified Chinese" and "Traditional Chinese", and there's no problem.

Q. Why script-specific languages originally excluded?
A. There was no reason. See:
https://github.com/concrete5/concrete5/commit/a66e1507d4784d9f777cfac031ff74dd8efe246c#commitcomment-35135337