### PR TITLE
Preload class aliases also when concrete5 is not installed

### DIFF
--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -118,6 +118,7 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
             ]);
         } else {
             $this->initializeSystemTimezone();
+            $this->preloadClassAliases();
         }
 
         // Create the request to use


### PR DESCRIPTION
This PR fixes the same issue as #8109, but in a more general way (we may also have the same issue with Blocks and any other aliased class).