### PR TITLE
Fix migration from 5.7 when there's no multilingual section

### DIFF
--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -302,6 +302,9 @@ class Service
         }
         if (!$cID) {
             $cID = (int) Page::getHomePageID();
+            if ($cID === 0) {
+                $cID = HOME_CID;
+            }
         }
         $tree->setSiteHomePageID($cID);
         $tree->setLocale($locale);


### PR DESCRIPTION
After the migration from version 5.7.5.9, a site became broken.

The browser stops with this error:

> [E_WARNING] Creating default object from empty value

At this line of Page::getFromRequest():

> $c->cPathFetchIsCanonical = true;

If force PHP to ignore this E_WARNING, the execution stops anyway with this error:
```
Argument 1 passed to
Concrete\Core\Http\ResponseFactory::collection()
must be an instance of
Concrete\Core\Page\Collection\Collection, instance of stdClass given,
called in src/Http/DefaultDispatcher.php on line 130
```

Inspecting the cause of this, I found that the change in this PR fixes the migration.
