### PR TITLE
Revert "Add a config key to support script-specific locales"

### DIFF
--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -137,7 +137,6 @@ return [
                 'use_browser_detected_locale' => false,
                 'default_source_locale' => 'en_US',
                 'always_track_user_locale' => true,
-                'support_script_specific_locale' => false,
             ],
             'seo' => [
                 'canonical_tag' => [

--- a/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
@@ -58,7 +58,6 @@ class Setup extends DashboardSitePageController
             }
         }
         $this->set('mlLink', $mlLink);
-        $this->set('supportScriptSpecificLocale', $siteConfig->get('multilingual.support_script_specific_locale'));
     }
 
     public function get_countries_for_language()
@@ -158,7 +157,6 @@ class Setup extends DashboardSitePageController
                 }
                 $siteConfig->save('multilingual.default_source_locale', $defaultSourceLocale);
                 $siteConfig->save('multilingual.always_track_user_locale', $this->post('alwaysTrackUserLocale') ? true : false);
-                $siteConfig->save('multilingual.support_script_specific_locale', $this->post('supportScriptSpecificLocale') ? true : false);
                 $this->flash('success', t('Default Section settings updated.'));
                 $this->redirect('/dashboard/system/multilingual/setup', 'view');
             } else {

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -157,15 +157,6 @@ foreach ($locales as $locale) {
             <?= $form->select('defaultSourceCountry', array_merge(['' => t('*** Undetermined country')], $countries), $defaultSourceCountry) ?>
         </div>
     </div>
-    <div class="form-group">
-        <label class="control-label"><?= t('Advanced') ?></label>
-        <div class="checkbox">
-            <label>
-                <?= $form->checkbox('supportScriptSpecificLocale', 1, $supportScriptSpecificLocale) ?>
-                <span><?= t('Support script-specific locale.') ?> <i class="launch-tooltip control-label fa fa-question-circle" title="<?= h(t('Make it enable to choose script-specific languages (eg "Simplified Chinese") for site locale.')) ?>"></i></span>
-            </label>
-        </div>
-    </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <?php $token->output('set_default') ?>

--- a/concrete/src/Localization/Service/LanguageList.php
+++ b/concrete/src/Localization/Service/LanguageList.php
@@ -1,16 +1,12 @@
 <?php
 namespace Concrete\Core\Localization\Service;
 
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Punic\Language;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-class LanguageList implements ApplicationAwareInterface
+class LanguageList
 {
-    use ApplicationAwareTrait;
-
     /**
      * Returns an associative array with the locale code as the key and the translated language name as the value.
      *
@@ -18,13 +14,7 @@ class LanguageList implements ApplicationAwareInterface
      */
     public function getLanguageList()
     {
-        $excludeScriptSpecific = true;
-        $site = $this->app->make('site')->getActiveSiteForEditing();
-        if (is_object($site)) {
-            $siteConfig = $site->getConfigRepository();
-            $excludeScriptSpecific = !$siteConfig->get('multilingual.support_script_specific_locale');
-        }
-        $languages = Language::getAll(true, $excludeScriptSpecific);
+        $languages = Language::getAll(true, true);
 
         return $languages;
     }


### PR DESCRIPTION
This reverts #8128 – unfortunately it completely broke installation and will have to be reworked. 