### PR TITLE
FAQ block controller did not call LinkAbstractor when editing rich te…

### DIFF
--- a/concrete/blocks/faq/controller.php
+++ b/concrete/blocks/faq/controller.php
@@ -42,7 +42,14 @@ class Controller extends BlockController
     public function edit()
     {
         $db = $this->app->make('database')->connection();
-        $query = $db->fetchAll('SELECT * FROM btFaqEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        $rows = $db->fetchAll('SELECT * FROM btFaqEntries WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+
+        $query = [];
+        foreach ($rows as $q) {
+            $q['description'] = LinkAbstractor::translateFromEditMode($q['description']);
+            $query[] = $q;
+        }
+
         $this->set('rows', $query);
     }
 


### PR DESCRIPTION
If you dropped an image into the rich text description of an FAQ entry, when you went back to edit the entry, the image didn't show up. Added LinkAbstractor::translateFromEditMode() on each description which is what the content block does.