### PR TITLE
Avoid DBAL Migrations 1.8

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -36,7 +36,7 @@
     "symfony/routing": "3.*",
     "symfony/http-kernel": "3.4.*",
     "doctrine/orm": "~2.5",
-    "doctrine/migrations": "1.*",
+    "doctrine/migrations": "1.* <1.8",
     "league/flysystem": "1.*",
     "symfony/event-dispatcher": "3.*",
     "symfony/serializer": "3.*",


### PR DESCRIPTION
The only change between version 1.7.2 and 1.8.1 is a class alias (introduced in 1.8.1) and a `trigger_error` (that breaks sites where E_DEPRECATED is not accepted) (see [here](https://github.com/doctrine/migrations/compare/v1.7.1...v1.8.1)).

So, what about limiting the maximum version to 1.7.x?