### PR TITLE
Don't ask to preserve old page path of external URLs

### DIFF
--- a/concrete/src/Workflow/Request/MovePageRequest.php
+++ b/concrete/src/Workflow/Request/MovePageRequest.php
@@ -75,7 +75,7 @@ class MovePageRequest extends PageRequest
         $dc = Page::getByID($this->targetCID);
         if (is_object($c) && is_object($dc) && (!$c->isError()) && (!$dc->isError())) {
             if ($c->canMoveCopyTo($dc)) {
-                if ($this->saveOldPagePath) {
+                if (!$c->isExternalLink() && $this->saveOldPagePath) {
                     // retain old page path.
                     $path = $c->getCollectionPathObject();
                     if (is_object($path)) {

--- a/concrete/views/dialogs/page/drag_request.php
+++ b/concrete/views/dialogs/page/drag_request.php
@@ -74,12 +74,18 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                      }
                      ?>
                 </label>
-                <div class="checkbox" style="margin: 0 0 0 20px">
-                    <label>
-                        <input type="checkbox" name="saveOldPagePath" value="1" />
-                        <?= t('Save old page path') ?>
-                    </label>
-                </div>
+                <?php
+                if (!$singleOriginalPage->isExternalLink()) {
+                    ?>
+                    <div class="checkbox" style="margin: 0 0 0 20px">
+                        <label>
+                            <input type="checkbox" name="saveOldPagePath" value="1" />
+                            <?= t('Save old page path') ?>
+                        </label>
+                    </div>
+                    <?php
+                }
+                ?>
             </div>
         </div>
         <?php


### PR DESCRIPTION
When moving an external URL in the sitemap, we are currently asked if we want to preserve the old page path.

This doesn't make sense, since external URLs don't have page paths.