### PR TITLE
Add is_object($c) check on page list block

### DIFF
--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -8,7 +8,7 @@ $th = Core::make('helper/text');
 /** @var \Concrete\Core\Localization\Service\Date $dh */
 $dh = Core::make('helper/date');
 
-if ($c->isEditMode() && $controller->isBlockEmpty()) {
+if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
     ?>
     <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Page List Block.') ?></div>
     <?php


### PR DESCRIPTION
One of our client's project we got the following error-

```
Error thrown with message "Call to a member function isEditMode() on null"
```

Let's add the `is_object($c)` to avoid this error.