### PR TITLE
Fix for importing images

### DIFF
--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/ImageRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/ImageRoutine.php
@@ -17,6 +17,13 @@ class ImageRoutine extends AbstractRegularExpressionRoutine
 
     public function getItem($identifier)
     {
-        return new ImageItem($identifier);
+        $prefix = null;
+        $filename = null;
+        if (strpos($identifier, ':') > -1) {
+            list($prefix, $filename) = explode(':', $identifier);
+        } else {
+            $filename = $identifier;
+        }
+        return new ImageItem($filename, $prefix);
     }
 }


### PR DESCRIPTION
Image imports are not matched up correctly due to prefix not being parsed in getItem method.
https://github.com/concrete5/addon_migration_tool/issues/78

*Check these before submitting new pull requests*

- [x ] I read the __guidelines for contributing__ linked above  

- [ x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!