### PR TITLE
Express Form - Email notification, check file object

### DIFF
--- a/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
+++ b/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
@@ -102,8 +102,10 @@ class FormBlockSubmissionEmailNotification extends AbstractFormBlockSubmissionNo
                 foreach ($this->getAttributeValues($entry) as $attributeValue) {
                     if ($attributeValue->getAttributeTypeObject()->getAttributeTypeHandle() == "image_file") {
                         $file = $attributeValue->getValue();
-                        $files[] = $file;
-                        $mh->addAttachment($file);
+                        if ($file) {
+                            $files[] = $file;
+                            $mh->addAttachment($file);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
An issue occurs if:
- An Express Form is added
- With email notifications
- With an image_file attribute that's not required
- and it's submitted without a file

Fix: check for valid object, before trying to add it as an attachment.