### PR TITLE
Delete 'show video infomation' option and change option name of showing related videos

### DIFF
--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -1,10 +1,9 @@
 <?php
-
 namespace Concrete\Block\Youtube;
 
 use Concrete\Core\Block\BlockController;
 
-class controller extends BlockController
+class Controller extends BlockController
 {
     protected $btTable = 'btYouTube';
     protected $btInterfaceWidth = '400';
@@ -60,11 +59,11 @@ class controller extends BlockController
             $this->set('youtubeDomain', 'www.youtube.com');
         }
 
-        if (false !== strpos($videoID, ',')) {
+        if (strpos($videoID, ',') !== false) {
             $this->set('playlist', $videoID);
         }
 
-        if (1 == $this->startTimeEnabled && ('0' === $this->startTime || $this->startTime)) {
+        if ($this->startTimeEnabled == 1 && ($this->startTime === '0' || $this->startTime)) {
             $this->set('startSeconds', $this->convertStringToSeconds($this->startTime));
         } elseif (!empty($params['t'])) {
             $this->set('startSeconds', $this->convertStringToSeconds($params['t']));
@@ -77,21 +76,21 @@ class controller extends BlockController
     public function convertStringToSeconds($string)
     {
         if (preg_match_all('/(\d+)(h|m|s)/i', $string, $matches)) {
-            $h = (false !== ($key = array_search('h', $matches[2]))) ? (int) $matches[1][$key] : 0;
-            $m = (false !== ($key = array_search('m', $matches[2]))) ? (int) $matches[1][$key] : 0;
-            $s = (false !== ($key = array_search('s', $matches[2]))) ? (int) $matches[1][$key] : 0;
+            $h = (($key = array_search('h', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
+            $m = (($key = array_search('m', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
+            $s = (($key = array_search('s', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
             $seconds = ($h * 3600) + ($m * 60) + $s;
         } else {
             $pieces = array_reverse(explode(':', $string));
             $seconds = 0;
-            $multipliers = array(1, 60, 3600);
+            $multipliers = [1, 60, 3600];
             foreach ($multipliers as $key => $multiplier) {
-                if (\array_key_exists($key, $pieces)) {
+                if (array_key_exists($key, $pieces)) {
                     $seconds += (int) $pieces[$key] * $multiplier;
                 }
             }
         }
-        if (0 === $seconds || $seconds > 0) {
+        if ($seconds === 0 || $seconds > 0) {
             return $seconds;
         }
 
@@ -100,7 +99,7 @@ class controller extends BlockController
 
     public function save($data)
     {
-        $data += array(
+        $data += [
             'title' => '',
 
             'videoURL' => '',
@@ -123,9 +122,9 @@ class controller extends BlockController
             'startTime' => '',
 
             'noCookie' => false,
-        );
+        ];
 
-        $args = array(
+        $args = [
             'title' => trim($data['title']),
 
             'videoURL' => trim($data['videoURL']),
@@ -147,17 +146,17 @@ class controller extends BlockController
             'startTime' => trim($data['startTime']),
 
             'noCookie' => $data['noCookie'] ? 1 : 0,
-        );
-        if ('fixed' === $args['sizing']) {
-            $args += array(
+        ];
+        if ($args['sizing'] === 'fixed') {
+            $args += [
                 'vWidth' => trim($data['vWidth']),
                 'vHeight' => trim($data['vHeight']),
-            );
+            ];
         } else {
-            $args += array(
+            $args += [
                 'vWidth' => '',
                 'vHeight' => '',
-            );
+            ];
         }
 
         parent::save($args);

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Concrete\Block\Youtube;
 
 use Concrete\Core\Block\BlockController;
 
-class Controller extends BlockController
+class controller extends BlockController
 {
     protected $btTable = 'btYouTube';
     protected $btInterfaceWidth = '400';
@@ -59,11 +60,11 @@ class Controller extends BlockController
             $this->set('youtubeDomain', 'www.youtube.com');
         }
 
-        if (strpos($videoID, ',') !== false) {
+        if (false !== strpos($videoID, ',')) {
             $this->set('playlist', $videoID);
         }
 
-        if ($this->startTimeEnabled == 1 && ($this->startTime === '0' || $this->startTime)) {
+        if (1 == $this->startTimeEnabled && ('0' === $this->startTime || $this->startTime)) {
             $this->set('startSeconds', $this->convertStringToSeconds($this->startTime));
         } elseif (!empty($params['t'])) {
             $this->set('startSeconds', $this->convertStringToSeconds($params['t']));
@@ -76,21 +77,21 @@ class Controller extends BlockController
     public function convertStringToSeconds($string)
     {
         if (preg_match_all('/(\d+)(h|m|s)/i', $string, $matches)) {
-            $h = (($key = array_search('h', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
-            $m = (($key = array_search('m', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
-            $s = (($key = array_search('s', $matches[2])) !== false) ? (int) $matches[1][$key] : 0;
+            $h = (false !== ($key = array_search('h', $matches[2]))) ? (int) $matches[1][$key] : 0;
+            $m = (false !== ($key = array_search('m', $matches[2]))) ? (int) $matches[1][$key] : 0;
+            $s = (false !== ($key = array_search('s', $matches[2]))) ? (int) $matches[1][$key] : 0;
             $seconds = ($h * 3600) + ($m * 60) + $s;
         } else {
             $pieces = array_reverse(explode(':', $string));
             $seconds = 0;
-            $multipliers = [1, 60, 3600];
+            $multipliers = array(1, 60, 3600);
             foreach ($multipliers as $key => $multiplier) {
-                if (array_key_exists($key, $pieces)) {
+                if (\array_key_exists($key, $pieces)) {
                     $seconds += (int) $pieces[$key] * $multiplier;
                 }
             }
         }
-        if ($seconds === 0 || $seconds > 0) {
+        if (0 === $seconds || $seconds > 0) {
             return $seconds;
         }
 
@@ -99,7 +100,7 @@ class Controller extends BlockController
 
     public function save($data)
     {
-        $data += [
+        $data += array(
             'title' => '',
 
             'videoURL' => '',
@@ -122,9 +123,9 @@ class Controller extends BlockController
             'startTime' => '',
 
             'noCookie' => false,
-        ];
+        );
 
-        $args = [
+        $args = array(
             'title' => trim($data['title']),
 
             'videoURL' => trim($data['videoURL']),
@@ -146,17 +147,17 @@ class Controller extends BlockController
             'startTime' => trim($data['startTime']),
 
             'noCookie' => $data['noCookie'] ? 1 : 0,
-        ];
-        if ($args['sizing'] === 'fixed') {
-            $args += [
+        );
+        if ('fixed' === $args['sizing']) {
+            $args += array(
                 'vWidth' => trim($data['vWidth']),
                 'vHeight' => trim($data['vHeight']),
-            ];
+            );
         } else {
-            $args += [
+            $args += array(
                 'vWidth' => '',
                 'vHeight' => '',
-            ];
+            );
         }
 
         parent::save($args);

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -108,7 +108,6 @@ class Controller extends BlockController
             'vHeight' => null,
             'vWidth' => null,
 
-            'showinfo' => false,
             'controls' => false,
             'modestbranding' => false,
             'showCaptions' => false,
@@ -132,7 +131,6 @@ class Controller extends BlockController
 
             'sizing' => $data['sizing'],
 
-            'showinfo' => $data['showinfo'] ? 1 : 0,
             'controls' => $data['controls'] ? 1 : 0,
             'modestbranding' => $data['modestbranding'] ? 1 : 0,
             'showCaptions' => $data['showCaptions'] ? 1 : 0,

--- a/concrete/blocks/youtube/db.xml
+++ b/concrete/blocks/youtube/db.xml
@@ -39,10 +39,6 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="showinfo" type="boolean">
-      <default value="0"/>
-      <notnull/>
-    </field>
     <field name="showCaptions" type="boolean">
       <default value="0"/>
       <notnull/>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -13,16 +13,16 @@ if (empty($sizing)) {
 ?>
 
 <?php
-echo Core::make('helper/concrete/ui')->tabs(array(
-    array('video', t('Video'), true),
-    array('settings', t('Settings')),
-));
+echo Core::make('helper/concrete/ui')->tabs([
+    ['video', t('Video'), true],
+    ['settings', t('Settings')],
+]);
 ?>
 
 <div class="ccm-tab-content" id="ccm-tab-content-video">
     <div class="form-group">
         <label class="control-label"><?php echo t('YouTube URL'); ?></label>
-        <?php echo $form->text('videoURL', isset($videoURL) ? $videoURL : '', array('required' => 'required')); ?>
+        <?php echo $form->text('videoURL', isset($videoURL) ? $videoURL : '', ['required' => 'required']); ?>
     </div>
     <div class="form-group">
         <label class="control-label"><?=t('Size'); ?></label>
@@ -45,7 +45,7 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             </label>
         </div>
     </div>
-    <div id="fixedsizes" class="<?php echo 'fixed' == $sizing ? '' : 'hidden'; ?>">
+    <div id="fixedsizes" class="<?php echo $sizing == 'fixed' ? '' : 'hidden'; ?>">
         <div class="form-group">
             <label class="control-label"><?php echo t('Width'); ?></label>
             <div class="input-group">
@@ -77,8 +77,8 @@ echo Core::make('helper/concrete/ui')->tabs(array(
                     <div class="checkbox">
                         <label>
                             <?php
-                            $disabledattr = array();
-                            if (isset($color) && 'white' == $color) {
+                            $disabledattr = [];
+                            if (isset($color) && $color == 'white') {
                                 $disabledattr['disabled'] = 'disabled';
                             }
                             echo $form->checkbox('modestbranding', 1, (isset($modestbranding) ? $modestbranding : true), $disabledattr); ?>
@@ -89,9 +89,9 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             </div>
 
             <div class="col-xs-6">
-                <div class="form-group controls-only <?php echo isset($controls) && 0 == $controls ? 'hidden' : ''; ?>">
+                <div class="form-group controls-only <?php echo isset($controls) && $controls == 0 ? 'hidden' : ''; ?>">
                     <?php  echo $form->label('color', t('Progress Bar Color')); ?>
-                    <?php  echo $form->select('color', array('red' => t('Red'), 'white' => t('White')), isset($color) ? $color : null); ?>
+                    <?php  echo $form->select('color', ['red' => t('Red'), 'white' => t('White')], isset($color) ? $color : null); ?>
                 </div>
             </div>
         </div>
@@ -107,7 +107,7 @@ echo Core::make('helper/concrete/ui')->tabs(array(
             </div>
             <div class="checkbox">
                 <label>
-                    <?php echo $form->checkbox('iv_load_policy', 1, isset($iv_load_polict) && 3 == $iv_load_policy); ?>
+                    <?php echo $form->checkbox('iv_load_policy', 1, isset($iv_load_polict) && $iv_load_policy == 3); ?>
                     <?php echo t('Hide annotations by default'); ?>
                 </label>
             </div>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -13,16 +13,16 @@ if (empty($sizing)) {
 ?>
 
 <?php
-echo Core::make('helper/concrete/ui')->tabs([
-    ['video', t('Video'), true],
-    ['settings', t('Settings')],
-]);
+echo Core::make('helper/concrete/ui')->tabs(array(
+    array('video', t('Video'), true),
+    array('settings', t('Settings')),
+));
 ?>
 
 <div class="ccm-tab-content" id="ccm-tab-content-video">
     <div class="form-group">
         <label class="control-label"><?php echo t('YouTube URL'); ?></label>
-        <?php echo $form->text('videoURL', isset($videoURL) ? $videoURL : '', ['required' => 'required']); ?>
+        <?php echo $form->text('videoURL', isset($videoURL) ? $videoURL : '', array('required' => 'required')); ?>
     </div>
     <div class="form-group">
         <label class="control-label"><?=t('Size'); ?></label>
@@ -45,7 +45,7 @@ echo Core::make('helper/concrete/ui')->tabs([
             </label>
         </div>
     </div>
-    <div id="fixedsizes" class="<?php echo $sizing == 'fixed' ? '' : 'hidden'; ?>">
+    <div id="fixedsizes" class="<?php echo 'fixed' == $sizing ? '' : 'hidden'; ?>">
         <div class="form-group">
             <label class="control-label"><?php echo t('Width'); ?></label>
             <div class="input-group">
@@ -77,8 +77,8 @@ echo Core::make('helper/concrete/ui')->tabs([
                     <div class="checkbox">
                         <label>
                             <?php
-                            $disabledattr = [];
-                            if (isset($color) && $color == 'white') {
+                            $disabledattr = array();
+                            if (isset($color) && 'white' == $color) {
                                 $disabledattr['disabled'] = 'disabled';
                             }
                             echo $form->checkbox('modestbranding', 1, (isset($modestbranding) ? $modestbranding : true), $disabledattr); ?>
@@ -89,9 +89,9 @@ echo Core::make('helper/concrete/ui')->tabs([
             </div>
 
             <div class="col-xs-6">
-                <div class="form-group controls-only <?php echo isset($controls) && $controls == 0 ? 'hidden' : ''; ?>">
+                <div class="form-group controls-only <?php echo isset($controls) && 0 == $controls ? 'hidden' : ''; ?>">
                     <?php  echo $form->label('color', t('Progress Bar Color')); ?>
-                    <?php  echo $form->select('color', ['red' => t('Red'), 'white' => t('White')], isset($color) ? $color : null); ?>
+                    <?php  echo $form->select('color', array('red' => t('Red'), 'white' => t('White')), isset($color) ? $color : null); ?>
                 </div>
             </div>
         </div>
@@ -107,7 +107,7 @@ echo Core::make('helper/concrete/ui')->tabs([
             </div>
             <div class="checkbox">
                 <label>
-                    <?php echo $form->checkbox('iv_load_policy', 1, isset($iv_load_polict) && $iv_load_policy == 3); ?>
+                    <?php echo $form->checkbox('iv_load_policy', 1, isset($iv_load_polict) && 3 == $iv_load_policy); ?>
                     <?php echo t('Hide annotations by default'); ?>
                 </label>
             </div>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -70,12 +70,6 @@ echo Core::make('helper/concrete/ui')->tabs([
                 <div class="form-group">
                     <div class="checkbox">
                         <label>
-                            <?php echo $form->checkbox('showinfo', 1, (isset($showinfo) ? $showinfo : true)); ?>
-                            <?php echo t('Show video information'); ?>
-                        </label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
                             <?php echo $form->checkbox('controls', 1, (isset($controls) ? $controls : true)); ?>
                             <?php echo t('Show controls'); ?>
                         </label>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -102,7 +102,7 @@ echo Core::make('helper/concrete/ui')->tabs([
             <div class="checkbox">
                 <label>
                     <?php echo $form->checkbox('rel', 1, !empty($rel)); ?>
-                    <?php echo t('Show related videos when playback ends'); ?>
+                    <?php echo t('Show related videos from different channels when playback ends'); ?>
                 </label>
             </div>
             <div class="checkbox">

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -4,23 +4,23 @@ $responsiveClass = 'youtubeBlockResponsive16by9';
 $sizeDisabled = '';
 
 if ($vWidth && $vHeight) {
-    $sizeargs = 'width="' . $vWidth . '" height="' . $vHeight . '"';
-    $sizeDisabled = 'style="width:' . $vWidth . 'px; height:' . $vHeight . 'px"';
+    $sizeargs = 'width="'.$vWidth.'" height="'.$vHeight.'"';
+    $sizeDisabled = 'style="width:'.$vWidth.'px; height:'.$vHeight.'px"';
     $responsiveClass = '';
-} elseif ($sizing == '4:3') {
+} elseif ('4:3' == $sizing) {
     $responsiveClass = 'youtubeBlockResponsive4by3';
 }
 
-$params = [];
+$params = array();
 
 if (isset($playlist)) {
-    $params[] = 'playlist=' . $playlist;
+    $params[] = 'playlist='.$playlist;
     $videoID = '';
 }
 
 if ($playListID) {
     $params[] = 'listType=playlist';
-    $params[] = 'list=' . $playListID;
+    $params[] = 'list='.$playListID;
 }
 
 if (isset($autoplay) && $autoplay) {
@@ -28,23 +28,23 @@ if (isset($autoplay) && $autoplay) {
 }
 
 if (isset($color) && $color) {
-    $params[] = 'color=' . $color;
+    $params[] = 'color='.$color;
 }
 
-if (isset($controls) && $controls != '') {
-    $params[] = 'controls=' . $controls;
+if (isset($controls) && '' != $controls) {
+    $params[] = 'controls='.$controls;
 }
 
-$params[] = 'hl=' . Localization::activeLanguage();
+$params[] = 'hl='.Localization::activeLanguage();
 
 if (isset($iv_load_policy) && $iv_load_policy > 0) {
-    $params[] = 'iv_load_policy=' . $iv_load_policy;
+    $params[] = 'iv_load_policy='.$iv_load_policy;
 }
 
 if (isset($loopEnd) && $loopEnd) {
     $params[] = 'loop=1';
-    if (!isset($playlist) && $videoID !== '') {
-        $params[] = 'playlist=' . $videoID;
+    if (!isset($playlist) && '' !== $videoID) {
+        $params[] = 'playlist='.$videoID;
     }
 }
 
@@ -60,14 +60,14 @@ if (isset($rel) && $rel) {
 
 if (isset($showCaptions) && $showCaptions) {
     $params[] = 'cc_load_policy=1';
-    $params[] = 'cc_lang_pref=' . Localization::activeLanguage();
+    $params[] = 'cc_lang_pref='.Localization::activeLanguage();
 }
 
 if (!empty($startSeconds)) {
-    $params[] = 'start=' . $startSeconds;
+    $params[] = 'start='.$startSeconds;
 }
 
-$paramstring = '?' . implode('&', $params);
+$paramstring = '?'.implode('&', $params);
 
 if (Page::getCurrentPage()->isEditMode()) {
     $loc = Localization::getInstance();

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -4,23 +4,23 @@ $responsiveClass = 'youtubeBlockResponsive16by9';
 $sizeDisabled = '';
 
 if ($vWidth && $vHeight) {
-    $sizeargs = 'width="'.$vWidth.'" height="'.$vHeight.'"';
-    $sizeDisabled = 'style="width:'.$vWidth.'px; height:'.$vHeight.'px"';
+    $sizeargs = 'width="' . $vWidth . '" height="' . $vHeight . '"';
+    $sizeDisabled = 'style="width:' . $vWidth . 'px; height:' . $vHeight . 'px"';
     $responsiveClass = '';
-} elseif ('4:3' == $sizing) {
+} elseif ($sizing == '4:3') {
     $responsiveClass = 'youtubeBlockResponsive4by3';
 }
 
-$params = array();
+$params = [];
 
 if (isset($playlist)) {
-    $params[] = 'playlist='.$playlist;
+    $params[] = 'playlist=' . $playlist;
     $videoID = '';
 }
 
 if ($playListID) {
     $params[] = 'listType=playlist';
-    $params[] = 'list='.$playListID;
+    $params[] = 'list=' . $playListID;
 }
 
 if (isset($autoplay) && $autoplay) {
@@ -28,23 +28,23 @@ if (isset($autoplay) && $autoplay) {
 }
 
 if (isset($color) && $color) {
-    $params[] = 'color='.$color;
+    $params[] = 'color=' . $color;
 }
 
-if (isset($controls) && '' != $controls) {
-    $params[] = 'controls='.$controls;
+if (isset($controls) && $controls != '') {
+    $params[] = 'controls=' . $controls;
 }
 
-$params[] = 'hl='.Localization::activeLanguage();
+$params[] = 'hl=' . Localization::activeLanguage();
 
 if (isset($iv_load_policy) && $iv_load_policy > 0) {
-    $params[] = 'iv_load_policy='.$iv_load_policy;
+    $params[] = 'iv_load_policy=' . $iv_load_policy;
 }
 
 if (isset($loopEnd) && $loopEnd) {
     $params[] = 'loop=1';
-    if (!isset($playlist) && '' !== $videoID) {
-        $params[] = 'playlist='.$videoID;
+    if (!isset($playlist) && $videoID !== '') {
+        $params[] = 'playlist=' . $videoID;
     }
 }
 
@@ -60,14 +60,14 @@ if (isset($rel) && $rel) {
 
 if (isset($showCaptions) && $showCaptions) {
     $params[] = 'cc_load_policy=1';
-    $params[] = 'cc_lang_pref='.Localization::activeLanguage();
+    $params[] = 'cc_lang_pref=' . Localization::activeLanguage();
 }
 
 if (!empty($startSeconds)) {
-    $params[] = 'start='.$startSeconds;
+    $params[] = 'start=' . $startSeconds;
 }
 
-$paramstring = '?'.implode('&', $params);
+$paramstring = '?' . implode('&', $params);
 
 if (Page::getCurrentPage()->isEditMode()) {
     $loc = Localization::getInstance();

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -58,12 +58,6 @@ if (isset($rel) && $rel) {
     $params[] = 'rel=0';
 }
 
-if (isset($showinfo) && $showinfo) {
-    $params[] = 'showinfo=1';
-} else {
-    $params[] = 'showinfo=0';
-}
-
 if (isset($showCaptions) && $showCaptions) {
     $params[] = 'cc_load_policy=1';
     $params[] = 'cc_lang_pref=' . Localization::activeLanguage();

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2',
     'version_installed' => '8.5.2',
-    'version_db' => '20190925072210', // the key of the latest database migration
+    'version_db' => '20191002000000', // the key of the latest database migration
  
     /*
      * Installation status

--- a/concrete/src/Updater/Migrations/Migrations/Version20191002000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20191002000000.php
@@ -1,0 +1,14 @@
+<?php
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20190826000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        /* Refresh youtube block */
+        $this->refreshBlockType('youtube');
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20191002000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20191002000000.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Updater\Migrations\Migrations;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20190826000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20191002000000 extends AbstractMigration implements RepeatableMigrationInterface
 {
     public function upgradeDatabase()
     {


### PR DESCRIPTION
I deleted showinfo setting because youtube IFrame Player API got it deprecated.
https://developers.google.com/youtube/player_parameters#showinfo

Also, I've changed setting's option name because each parameter function has been changed.
https://developers.google.com/youtube/player_parameters#rel

Fixes #8158