### PR TITLE
#8158 - Updating depreciated Youtube API

### DIFF
--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -108,7 +108,6 @@ class Controller extends BlockController
             'vHeight' => null,
             'vWidth' => null,
 
-            'showinfo' => false,
             'controls' => false,
             'modestbranding' => false,
             'showCaptions' => false,
@@ -132,7 +131,6 @@ class Controller extends BlockController
 
             'sizing' => $data['sizing'],
 
-            'showinfo' => $data['showinfo'] ? 1 : 0,
             'controls' => $data['controls'] ? 1 : 0,
             'modestbranding' => $data['modestbranding'] ? 1 : 0,
             'showCaptions' => $data['showCaptions'] ? 1 : 0,

--- a/concrete/blocks/youtube/db.xml
+++ b/concrete/blocks/youtube/db.xml
@@ -39,10 +39,6 @@
       <default value="0"/>
       <notnull/>
     </field>
-    <field name="showinfo" type="boolean">
-      <default value="0"/>
-      <notnull/>
-    </field>
     <field name="showCaptions" type="boolean">
       <default value="0"/>
       <notnull/>

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -108,7 +108,11 @@ echo Core::make('helper/concrete/ui')->tabs([
             <div class="checkbox">
                 <label>
                     <?php echo $form->checkbox('rel', 1, !empty($rel)); ?>
-                    <?php echo t('Show related videos when playback ends'); ?>
+                    <?php echo t('Show related videos from other channels'); ?>
+                    <?php echo sprintf(
+                    '<i class="launch-tooltip fa fa-exclamation-circle z-indexable z-1000" data-toggle="tooltip" data-placement="bottom" title="%s"></i>',
+                    t('Disabling this will show related videos from the same channel as the video')
+                    ); ?>
                 </label>
             </div>
             <div class="checkbox">

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -58,12 +58,6 @@ if (isset($rel) && $rel) {
     $params[] = 'rel=0';
 }
 
-if (isset($showinfo) && $showinfo) {
-    $params[] = 'showinfo=1';
-} else {
-    $params[] = 'showinfo=0';
-}
-
 if (isset($showCaptions) && $showCaptions) {
     $params[] = 'cc_load_policy=1';
     $params[] = 'cc_lang_pref=' . Localization::activeLanguage();

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2',
     'version_installed' => '8.5.2',
-    'version_db' => '20190925072210', // the key of the latest database migration
+    'version_db' => '20191003000327', // the key of the latest database migration
  
     /*
      * Installation status

--- a/concrete/src/Updater/Migrations/Migrations/Version20191003000327.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20191003000327.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+/**
+ * Removes showinfo (Youtube ingore it now)
+ * Updates the show related videos description (Youtube always show related videos)
+ * https://developers.google.com/youtube/player_parameters?hl=en#rel
+ * @see https://github.com/concrete5/concrete5/issues/8158
+ */
+class Version20191003000327 extends AbstractMigration  implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshBlockType('youtube');
+    }
+}


### PR DESCRIPTION
We are removing showinfo as it no longer is used by youtube
https://developers.google.com/youtube/player_parameters?hl=en#showinfo

Updating show related videos description as it no longer disables related videos
https://developers.google.com/youtube/player_parameters?hl=en#rel