### PR TITLE
Fix file manager issue with number of items per page

### DIFF
--- a/concrete/controllers/search/file_folder.php
+++ b/concrete/controllers/search/file_folder.php
@@ -92,7 +92,6 @@ class FileFolder extends AbstractController
 
             if ($itemsPerPage) {
                 $list->setItemsPerPage($itemsPerPage);
-                $provider->setItemsPerPageSession($itemsPerPage);
             }
 
             if (count($filters)) {


### PR DESCRIPTION
This issue https://github.com/concrete5/concrete5/issues/7316 actually isn't being fixed.

The following code block always returns the value from the session and doesn't read the config value.

https://github.com/concrete5/concrete5/blob/1e62ebe56250c1ffc5bc552aae44526ce91a4c56/concrete/src/File/Search/SearchProvider.php#L119-L127


