### PR TITLE
Return a Response instead of dying when saving a block

### DIFF
--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -47,6 +47,7 @@ class Edit extends BackendInterfaceBlockController
     public function submit()
     {
         if ($this->validateAction() && $this->canAccess()) {
+            $app = Application::getFacadeApplication();
             $b = $this->getBlockToEdit();
             $e = $this->validateBlock($b);
             $pr = $this->getEditResponse($b, $e);
@@ -63,11 +64,10 @@ class Edit extends BackendInterfaceBlockController
                 $formatter = new JsonFormatter($e);
                 $response = $formatter->asArray();
                 $response['newbID'] = intval($b->getBlockID());
-                $app = Application::getFacadeApplication();
                 return $app->make(ResponseFactoryInterface::class)->create(json_encode($response));
             }
 
-            $pr->outputJSON();
+            return $app->make(ResponseFactoryInterface::class)->json($pr);
         }
     }
 


### PR DESCRIPTION
When we save a block, we call the outputJSON method of EditResponse.

This works, but normal request &rarr; response flow is broken (for example, middlewares are not executed).

What about switching to the standard way (that is, returning a Response instance)?