### PR TITLE
Check the regular expressions in the Google authentication type

### DIFF
--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -80,8 +80,8 @@ class Controller extends GenericOauth2TypeController
             $blacklist[] = $decoded;
         }
 
-        $config->save('auth.google.email_filters.whitelist', array_values(array_filter($whitelist)));
-        $config->save('auth.google.email_filters.blacklist', array_values(array_filter($blacklist)));
+        $config->save('auth.google.email_filters.whitelist', $whitelist);
+        $config->save('auth.google.email_filters.blacklist', $blacklist);
     }
 
     public function edit()

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -51,10 +51,6 @@ class Controller extends GenericOauth2TypeController
     public function saveAuthenticationType($args)
     {
         $config = $this->app->make('config');
-        $config->save('auth.google.appid', $args['apikey']);
-        $config->save('auth.google.secret', $args['apisecret']);
-        $config->save('auth.google.registration.enabled', (bool) $args['registration_enabled']);
-        $config->save('auth.google.registration.group', intval($args['registration_group'], 10));
 
         $stringsValidator = $this->app->make(Strings::class);
 
@@ -80,6 +76,10 @@ class Controller extends GenericOauth2TypeController
             $blacklist[] = $decoded;
         }
 
+        $config->save('auth.google.appid', $args['apikey']);
+        $config->save('auth.google.secret', $args['apisecret']);
+        $config->save('auth.google.registration.enabled', (bool) $args['registration_enabled']);
+        $config->save('auth.google.registration.group', (int) $args['registration_group']);
         $config->save('auth.google.email_filters.whitelist', $whitelist);
         $config->save('auth.google.email_filters.blacklist', $blacklist);
     }

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -6,9 +6,11 @@ defined('C5_EXECUTE') or die('Access Denied');
 use Concrete\Core\Authentication\LoginException;
 use Concrete\Core\Authentication\Type\Google\Factory\GoogleServiceFactory;
 use Concrete\Core\Authentication\Type\OAuth\OAuth2\GenericOauth2TypeController;
+use Concrete\Core\Error\UserMessageException;
 use OAuth\OAuth2\Service\Google;
 use Concrete\Core\User\User;
 use Concrete\Core\Routing\RedirectResponse;
+use Concrete\Core\Utility\Service\Validation\Strings;
 
 class Controller extends GenericOauth2TypeController
 {
@@ -54,14 +56,28 @@ class Controller extends GenericOauth2TypeController
         $config->save('auth.google.registration.enabled', (bool) $args['registration_enabled']);
         $config->save('auth.google.registration.group', intval($args['registration_group'], 10));
 
+        $stringsValidator = $this->app->make(Strings::class);
+
         $whitelist = [];
-        foreach (explode(PHP_EOL, $args['whitelist']) as $entry) {
+        foreach (preg_split('/\s*[\r\n]\s*/', array_get($args, 'whitelist', ''), -1, PREG_SPLIT_NO_EMPTY) as $entry) {
+            if (!$stringsValidator->isValidRegex($entry)) {
+                throw new UserMessageException(t('The regular expression "%s" is not valid.', $entry));
+            }
             $whitelist[] = trim($entry);
         }
 
         $blacklist = [];
-        foreach (explode(PHP_EOL, $args['blacklist']) as $entry) {
-            $blacklist[] = json_decode(trim($entry), true);
+        foreach (preg_split('/\s*[\r\n]\s*/', array_get($args, 'blacklist', ''), -1, PREG_SPLIT_NO_EMPTY) as $entry) {
+            set_error_handler(function () {}, -1);
+            $decoded = @json_decode($entry, true);
+            restore_error_handler();
+            if (!is_array($decoded) || !isset($decoded[0])) {
+                throw new UserMessageException(t('The black list line "%s" is not valid.', $entry));
+            }
+            if (!$stringsValidator->isValidRegex($decoded[0])) {
+                throw new UserMessageException(t('The regular expression "%s" is not valid.', $entry));
+            }
+            $blacklist[] = $decoded;
         }
 
         $config->save('auth.google.email_filters.whitelist', array_values(array_filter($whitelist)));

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -63,7 +63,7 @@ class Controller extends GenericOauth2TypeController
             if (!$stringsValidator->isValidRegex($entry)) {
                 throw new UserMessageException(t('The regular expression "%s" is not valid.', $entry));
             }
-            $whitelist[] = trim($entry);
+            $whitelist[] = $entry;
         }
 
         $blacklist = [];

--- a/concrete/authentication/google/type_form.php
+++ b/concrete/authentication/google/type_form.php
@@ -1,4 +1,16 @@
-<?php defined('C5_EXECUTE') or die('Access denied.'); ?>
+<?php
+
+defined('C5_EXECUTE') or die('Access denied.');
+
+/**
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\User\Group\Group[] $groups
+ * @var string $apikey
+ * @var string $apisecret
+ * @var string[] $blacklist
+ * @var string[] $whitelist
+ */
+?>
 
 <div class='form-group'>
     <?= $form->label('apikey', t('App ID')) ?>
@@ -15,32 +27,23 @@
 </div>
 <div class='form-group'>
     <div class="input-group">
-        <label type="checkbox">
-            <input type="checkbox" name="registration_enabled" value="1" <?= \Config::get(
-                'auth.google.registration.enabled',
-                false) ? 'checked' : '' ?>>
+        <label>
+            <?= $form->checkbox('registration_enabled', '1', Config::get('auth.google.registration.enabled')) ?>
             <span style="font-weight:normal"><?= t('Allow automatic registration') ?></span>
         </label>
     </div>
 </div>
 <div class='form-group registration-group'>
     <label for="registration_group" class="control-label"><?= t('Group to enter on registration') ?></label>
-    <select name="registration_group" class="form-control">
-        <option value="0"><?= t("None") ?></option>
-        <?php
-        /** @var \Group $group */
-        foreach ($groups as $group) {
-            ?>
-            <option value="<?= $group->getGroupID() ?>" <?= intval($group->getGroupID(), 10) === intval(
-                \Config::get('auth.google.registration.group', false),
-                10) ? 'selected' : '' ?>>
-                <?= $group->getGroupDisplayName(false) ?>
-            </option>
-        <?php
-
-        }
-        ?>
-    </select>
+    <?php
+    $optionValues = [
+        '0' => t('None'),
+    ];
+    foreach ($groups as $group) {
+        $optionValues[$group->getGroupID()] = $group->getGroupDisplayName(false);
+    }
+    echo $form->select('registration_group', $optionValues, (int) Config::get('auth.google.registration.group'));
+    ?>
 </div>
 
 <h4><?= t('Domain Filtering') ?></h4>
@@ -50,20 +53,16 @@
         'For example user@example.com would filter against "example.com".') ?></p>
 
 <div class="form-group">
-    <label for="whitelist">
-        <?= t('Domain Whitelist regex') ?>
-    </label>
+    <?= $form->label('whitelist', t('Domain Whitelist regex')) ?>
     <span class="help-block"><?= t(
             'One per line, to whitelist all %s domains: %s',
             '<code>concrete5.org</code>',
             '<code>~^concrete5\\.org$~i</code>') ?></span>
-    <textarea type="text" name="whitelist" class="form-control"><?= implode("\n", (array) $whitelist) ?></textarea>
+    <?= $form->textarea('whitelist', implode("\n", (array) $whitelist)) ?>
 </div>
 
 <div class="form-group">
-    <label for="whitelist">
-        <?= t('Domain Blacklist regex') ?>
-    </label>
+    <?= $form->label('blacklist', t('Domain Blacklist regex')) ?>
     <span class="help-block"><?= t('One per line') ?></span>
     <span class="help-block"><?= t(
             'Format: %s.',
@@ -71,7 +70,7 @@
     <span class="help-block"><?= t(
             'To disallow everything other than whitelist: %s.',
             sprintf('<code>[ "~.*~", "%s" ]</code>', t('Invalid domain.'))) ?></span>
-    <textarea type="text" name="blacklist" class="form-control"><?= implode("\n", $blacklist) ?></textarea>
+    <?= $form->textarea('blacklist', implode("\n", $blacklist)) ?>
 </div>
 
 <div class="alert alert-info">

--- a/concrete/authentication/google/type_form.php
+++ b/concrete/authentication/google/type_form.php
@@ -57,7 +57,7 @@
             'One per line, to whitelist all %s domains: %s',
             '<code>concrete5.org</code>',
             '<code>~^concrete5\\.org$~i</code>') ?></span>
-    <textarea type="text" name="whitelist" class="form-control"><?= implode(PHP_EOL, (array) $whitelist) ?></textarea>
+    <textarea type="text" name="whitelist" class="form-control"><?= implode("\n", (array) $whitelist) ?></textarea>
 </div>
 
 <div class="form-group">
@@ -71,7 +71,7 @@
     <span class="help-block"><?= t(
             'To disallow everything other than whitelist: %s.',
             sprintf('<code>[ "~.*~", "%s" ]</code>', t('Invalid domain.'))) ?></span>
-    <textarea type="text" name="blacklist" class="form-control"><?= implode(PHP_EOL, $blacklist) ?></textarea>
+    <textarea type="text" name="blacklist" class="form-control"><?= implode("\n", $blacklist) ?></textarea>
 </div>
 
 <div class="alert alert-info">

--- a/concrete/controllers/single_page/dashboard/system/registration/authentication.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/authentication.php
@@ -122,7 +122,8 @@ class Authentication extends DashboardPageController
             $this->redirect('dashboard/system/registration/authentication/');
             exit;
         }
-        $this->view();
+
+        return $this->error->has() ? $this->edit($atid) : $this->view();
     }
 
     public function edit($atid)

--- a/concrete/src/Utility/Service/Validation/Strings.php
+++ b/concrete/src/Utility/Service/Validation/Strings.php
@@ -172,4 +172,30 @@ class Strings
 
         return strlen(trim(preg_replace('/([a-zA-Z0-9]*)/', '', $str)));
     }
+
+    /**
+     * Check if a variable contains a valid regular expression.
+     *
+     * @param string|mixed $pattern the variable to be checked
+     * @param bool $includesDelimiters set to TRUE if $pattern should contain delimiters, FALSE if we need to add them
+     *
+     * @return bool
+     */
+    public function isValidRegex($pattern, $includesDelimiters = true)
+    {
+        if (!is_string($pattern)) {
+            return false;
+        }
+        if ($pattern === '') {
+            return $includesDelimiters ? false : true;
+        }
+        if (!$includesDelimiters) {
+            $pattern = "/{$pattern}/";
+        }
+        set_error_handler(function () {}, -1);
+        $result = @preg_match($pattern, 'X');
+        restore_error_handler();
+
+        return $result !== false;
+    }
 }

--- a/tests/tests/Utility/Service/Validation/StringsTest.php
+++ b/tests/tests/Utility/Service/Validation/StringsTest.php
@@ -238,6 +238,34 @@ class StringsTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function isValidRegexProvider()
+    {
+        return [
+            [false, null, false],
+            [false, null, true],
+            [false, $this, false],
+            [false, $this, true],
+            [false, [], false],
+            [false, [], true],
+            [false, 1, false],
+            [false, 1, true],
+            [true, '', false],
+            [false, '', true],
+            [true, '//', true],
+            [false, '(', true],
+            [false, '(', false],
+            [true, 'Test', false],
+            [false, 'Test', true],
+            [true, '/Test/', true],
+            [false, '+', false],
+            [false, '+', true],
+            [false, '/+/', true],
+            [true, '.+', false],
+            [false, '.+', true],
+            [true, '/.+/', true],
+        ];
+    }
+
     /**
      * @dataProvider emailDataProvider
      *
@@ -351,5 +379,17 @@ class StringsTest extends PHPUnit_Framework_TestCase
     public function testContainsSymbol($expected, $string)
     {
         $this->assertEquals($expected, $this->object->containsSymbol($string));
+    }
+
+    /**
+     * @dataProvider isValidRegexProvider
+     *
+     * @param bool $expected
+     * @param string|mixed $pattern
+     * @param bool $includesDelimiters
+     */
+    public function testIsValidRegex($expected, $pattern, $includesDelimiters)
+    {
+        $this->assertSame($expected, $this->object->isValidRegex($pattern, $includesDelimiters));
     }
 }


### PR DESCRIPTION
If users insert invalid regular expressions in the configuration of the Google authentication type, concrete5 accepts this invalid configuration but, upon login via Google, site visitors see an ugly error message (for example: `preg_match(): Delimiter must not be alphanumeric or backslash`).

So, what about adding some checks to the configuration?