### PR TITLE
Fix indexing stuff

### DIFF
--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -1,15 +1,14 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
 
-use Concrete\Core\Attribute\AttributeKeyInterface;
 use CommunityTranslation\Notification\CategoryInterface;
-use Concrete\Core\Support\Facade\Application;
-use Concrete\Core\Page;
+use Concrete\Core\Attribute\AttributeKeyInterface;
 use Concrete\Core\Attribute\SetFactory;
 use Concrete\Core\Attribute\StandardSetManager;
+use Concrete\Core\Page;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
  * @var Concrete\Core\Url\UrlImmutable $action
@@ -82,7 +81,7 @@ if ($key !== null) {
                 <?= $form->label('asID', t('Set')) ?>
                 <div class="controls">
                     <?php
-                    $sel = array('0' => t('** None'));
+                    $sel = ['0' => t('** None')];
                     $sets = $category->getSetManager()->getAttributeSets();
                     foreach ($sets as $as) {
                         $sel[$as->getAttributeSetID()] = $as->getAttributeSetDisplayName();
@@ -140,7 +139,7 @@ if ($key !== null) {
         echo $form->hidden('akCategoryID', $category->getCategoryEntity()->getAttributeKeyCategoryID());
         View::element(
             'attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
-            array('key' => $key),
+            ['key' => $key],
             $category->getCategoryEntity()->getPackageID() ? $category->getCategoryEntity()->getPackageHandle() : null
         );
     }

--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -107,6 +107,28 @@ if ($key !== null) {
                 <label>
                     <?= $form->checkbox('akIsSearchable', 1, $key === null || $key->isAttributeKeySearchable()) ?>
                     <?= t('Field available in advanced search.') ?>
+                    <?php
+                    if ($key && $key->isAttributeKeySearchable()) {
+                        ?>
+                        <div class="alert alert-danger small hide" id="akIsSearchable-warning">
+                            <?= t(
+                                'WARNING: you will need to re-run the %s automated job if you uncheck this value, save the attribute, and then re-check this value',
+                                '<strong>' . t('Index Search Engine - All') . '</strong>'
+                            ) ?>
+                        </div>
+                        <script>
+                        $(document).ready(function() {
+                            $('#akIsSearchable')
+                                .on('change', function() {
+                                    $('#akIsSearchable-warning').toggleClass('hide', $(this).is(':checked'))
+                                })
+                                .trigger('change')
+                            ;
+                        });
+                        </script>
+                        <?php
+                    }
+                    ?>
                 </label>
             </div>
         </div>

--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -29,9 +29,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
         echo $form->hidden('akID', $key->getAttributeKeyID());
     }
     ?>
-
-
     <fieldset>
+
         <legend><?= t('%s: Basic Details', $type->getAttributeTypeDisplayName()) ?></legend>
 
         <div class="form-group">
@@ -42,7 +41,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
             </div>
         </div>
 
-
         <div class="form-group">
             <?= $form->label('akName', t('Name')) ?>
             <div class="input-group">
@@ -51,23 +49,25 @@ defined('C5_EXECUTE') or die("Access Denied.");
             </div>
         </div>
 
-        <?php if ($category && $category->getSetManager()->allowAttributeSets() == \Concrete\Core\Attribute\StandardSetManager::ASET_ALLOW_SINGLE) {
-    ?>
+        <?php
+        if ($category && $category->getSetManager()->allowAttributeSets() == \Concrete\Core\Attribute\StandardSetManager::ASET_ALLOW_SINGLE) {
+            ?>
             <div class="form-group">
                 <?= $form->label('asID', t('Set')) ?>
                 <div class="controls">
                     <?php
                     $sel = array('0' => t('** None'));
-    $sets = $category->getSetManager()->getAttributeSets();
-    foreach ($sets as $as) {
-        $sel[$as->getAttributeSetID()] = $as->getAttributeSetDisplayName();
-    }
-    echo $form->select('asID', $sel, $asID);
-    ?>
+                    $sets = $category->getSetManager()->getAttributeSets();
+                    foreach ($sets as $as) {
+                        $sel[$as->getAttributeSetID()] = $as->getAttributeSetDisplayName();
+                    }
+                    echo $form->select('asID', $sel, $asID);
+                    ?>
                 </div>
             </div>
-        <?php 
-} ?>
+            <?php
+        }
+        ?>
 
         <div class="form-group">
             <label class="control-label"><?= t('Searchable') ?></label>
@@ -77,56 +77,63 @@ defined('C5_EXECUTE') or die("Access Denied.");
             $advanced_label = t('Field available in advanced search.');
 
             ?>
-            <div class="checkbox"><label><?= $form->checkbox('akIsSearchableIndexed', 1,
-                        !empty($akIsSearchableIndexed)) ?> <?= $keyword_label ?></label></div>
-            <div class="checkbox"><label><?= $form->checkbox('akIsSearchable', 1,
-                        $akIsSearchable) ?> <?= $advanced_label ?></label></div>
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('akIsSearchableIndexed', 1, !empty($akIsSearchableIndexed)) ?>
+                    <?= $keyword_label ?>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('akIsSearchable', 1, $akIsSearchable) ?>
+                    <?= $advanced_label ?>
+                </label>
+            </div>
         </div>
 
     </fieldset>
 
-    <?= $form->hidden('atID', $type->getAttributeTypeID()) ?>
-    <?php if ($category && $category instanceof \Concrete\Core\Attribute\Category\StandardCategoryInterface) {
-    ?>
-        <?= $form->hidden('akCategoryID', $category->getCategoryEntity()->getAttributeKeyCategoryID());
-    ?>
+    <?php
+    echo $form->hidden('atID', $type->getAttributeTypeID());
 
-        <?php
-
+    if ($category && $category instanceof \Concrete\Core\Attribute\Category\StandardCategoryInterface) {
+        echo $form->hidden('akCategoryID', $category->getCategoryEntity()->getAttributeKeyCategoryID());
         if ($category->getCategoryEntity()->getPackageID() > 0) {
-            @Loader::packageElement('attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
-                $category->getCategoryEntity()->getPackageHandle(), array('key' => $key));
+            @Loader::packageElement(
+                'attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
+                $category->getCategoryEntity()->getPackageHandle(),
+                array('key' => $key)
+            );
         } else {
-            @Loader::element('attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
-                array('key' => isset($key) ? $key : null));
+            @Loader::element(
+                'attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
+                array('key' => isset($key) ? $key : null)
+            );
         }
-    ?>
+    }
+    $valt->output('add_or_update_attribute');
+    $type->render(new \Concrete\Core\Attribute\Context\AttributeTypeSettingsContext(), isset($key) ? $key : null);
 
-    <?php 
-} ?>
-
-    <?= $valt->output('add_or_update_attribute') ?>
-    <?php $type->render(new \Concrete\Core\Attribute\Context\AttributeTypeSettingsContext(), isset($key) ? $key : null); ?>
-
-    <?php if (!isset($back)) {
-    $back = URL::page($c);
-}
+    if (!isset($back)) {
+        $back = URL::page($c);
+    }
     ?>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <a href="<?= $back ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
-            <?php if (isset($key) && is_object($key)) {
-    ?>
+            <?php
+            if (isset($key) && is_object($key)) {
+                ?>
                 <button type="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button>
-            <?php 
-} else {
-    ?>
+                <?php
+            } else {
+                ?>
                 <button type="submit" class="btn btn-primary pull-right"><?= t('Add') ?></button>
-            <?php 
-} ?>
+                <?php
+            }
+            ?>
         </div>
     </div>
-
 
 </form>

--- a/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
@@ -1,11 +1,17 @@
 <?php
+
 namespace Concrete\Core\Attribute\Category\SearchIndexer;
 
 use Concrete\Core\Entity\Express\Entity;
 
 class ExpressSearchIndexer extends StandardSearchIndexer
 {
-
+    /**
+     * Update (if needed) the name of the index table ater the express entity changed (for example because its handle changed).
+     *
+     * @param \Concrete\Core\Entity\Express\Entity $previousEntity
+     * @param \Concrete\Core\Entity\Express\Entity $newEntity
+     */
     public function updateRepository(Entity $previousEntity, Entity $newEntity)
     {
         $previousTable = $previousEntity->getAttributeKeyCategory()->getIndexedSearchTable();
@@ -13,6 +19,5 @@ class ExpressSearchIndexer extends StandardSearchIndexer
         if ($this->connection->tableExists($previousTable)) {
             $this->connection->execute(sprintf('alter table %s rename %s', $previousTable, $newTable));
         }
-
     }
 }

--- a/concrete/src/Attribute/Category/SearchIndexer/LegacySearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/LegacySearchIndexer.php
@@ -1,19 +1,20 @@
 <?php
+
 namespace Concrete\Core\Attribute\Category\SearchIndexer;
 
-use Concrete\Core\Attribute\AttributeKeyInterface;
 use Concrete\Core\Attribute\AttributeValueInterface;
 use Concrete\Core\Attribute\Category\CategoryInterface;
-use Concrete\Core\Database\Connection\Connection;
-use Concrete\Core\Entity\Attribute\Value\Value;
-use Doctrine\DBAL\Schema\Schema;
 
 class LegacySearchIndexer extends \Concrete\Core\Attribute\Category\SearchIndexer\StandardSearchIndexer
 {
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\StandardSearchIndexer::indexEntry()
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\SearchIndexerInterface::indexEntry()
+     */
     public function indexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject)
     {
         return false; // happens in the deprecated saveAttributeForm method
     }
-
 }

--- a/concrete/src/Attribute/Category/SearchIndexer/SearchIndexerInterface.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/SearchIndexerInterface.php
@@ -1,50 +1,47 @@
 <?php
+
 namespace Concrete\Core\Attribute\Category\SearchIndexer;
 
 use Concrete\Core\Attribute\AttributeKeyInterface;
 use Concrete\Core\Attribute\AttributeValueInterface;
 use Concrete\Core\Attribute\Category\CategoryInterface;
-use Concrete\Core\Entity\Attribute\Value\Value;
 
+/**
+ * Interface that all the classes that handle the search index of attribute categories must implement.
+ */
 interface SearchIndexerInterface
 {
     /**
-     * @param CategoryInterface $category
-     * @return void
+     * Create the database table where the data of the indexed attributes will be stored.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
      */
     public function createRepository(CategoryInterface $category);
 
     /**
-     * @param CategoryInterface $category
-     * @param AttributeKeyInterface $key
+     * Create or update the column that contains the indexed data of a specific attribute.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeKeyInterface $key
      * @param string|null $previousHandle
-     * @return void
      */
     public function updateRepositoryColumns(CategoryInterface $category, AttributeKeyInterface $key, $previousHandle = null);
 
-    /*
-     * This was added in v8.2 but we can't assume that everyone has implemented this yet.
-     * Uncomment this in the future when we are sure we won't break anything
-     *
-     * @param CategoryInterface $category
-     * @param AttributeKeyInterface $key
-     * @return void
-     */
-//     public function refreshRepositoryColumns(CategoryInterface $category, AttributeKeyInterface $key);
-
     /**
-     * @param CategoryInterface $category
-     * @param AttributeValueInterface $attributeValue
-     * @param mixed $subject
-     * @return void
+     * Store in the index table the value of an attribute of an item.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeValueInterface $attributeValue
+     * @param object $subject The item owning the attribute value
      */
     public function indexEntry(CategoryInterface $category, AttributeValueInterface $attributeValue, $subject);
 
     /**
-     * @param CategoryInterface $category
-     * @param AttributeValueInterface $attributeValue
-     * @param mixed $subject
-     * @return void
+     * Remove from the index table the value of an attribute of an item.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeValueInterface $attributeValue
+     * @param object $subject The item owning the attribute value
      */
     public function clearIndexEntry(CategoryInterface $category, AttributeValueInterface $attributeValue, $subject);
 }

--- a/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Attribute\Category\SearchIndexer;
 
 use Concrete\Core\Attribute\AttributeKeyInterface;
@@ -9,22 +10,26 @@ use Doctrine\DBAL\Schema\Schema;
 
 class StandardSearchIndexer implements SearchIndexerInterface
 {
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
     protected $connection;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param \Concrete\Core\Database\Connection\Connection $connection
+     */
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
     }
 
-    protected function isValid(CategoryInterface $category)
-    {
-        if (!($category instanceof StandardSearchIndexerInterface)) {
-            throw new \Exception(t('Category %s must implement StandardSearchIndexerInterface.'), $category->getCategoryEntity()->getAttributeCategoryHandle());
-        }
-
-        return true;
-    }
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\SearchIndexerInterface::indexEntry()
+     */
     public function indexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject)
     {
         if ($this->isValid($category)) {
@@ -33,6 +38,11 @@ class StandardSearchIndexer implements SearchIndexerInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\SearchIndexerInterface::clearIndexEntry()
+     */
     public function clearIndexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject)
     {
         if ($this->isValid($category)) {
@@ -41,6 +51,11 @@ class StandardSearchIndexer implements SearchIndexerInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\SearchIndexerInterface::createRepository()
+     */
     public function createRepository(CategoryInterface $category)
     {
         $schema = new Schema([], [], $this->connection->getSchemaManager()->createSchemaConfig());
@@ -81,6 +96,11 @@ class StandardSearchIndexer implements SearchIndexerInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Category\SearchIndexer\SearchIndexerInterface::updateRepositoryColumns()
+     */
     public function updateRepositoryColumns(CategoryInterface $category, AttributeKeyInterface $key, $previousHandle = null)
     {
         if ($this->isValid($category)) {
@@ -89,11 +109,35 @@ class StandardSearchIndexer implements SearchIndexerInterface
         }
     }
 
+    /**
+     * @deprecated use the updateRepositoryColumns() method
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeKeyInterface $key
+     */
     public function refreshRepositoryColumns(CategoryInterface $category, AttributeKeyInterface $key)
     {
         if ($this->isValid($category)) {
             $attributeIndexer = $key->getSearchIndexer();
             $attributeIndexer->refreshSearchIndexKeyColumns($category, $key);
         }
+    }
+
+    /**
+     * Check if a category is correctly configured to handle indexing stuff.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     *
+     * @throws \Exception in case of errors
+     *
+     * @return bool
+     */
+    protected function isValid(CategoryInterface $category)
+    {
+        if (!($category instanceof StandardSearchIndexerInterface)) {
+            throw new \Exception(t('Category %s must implement StandardSearchIndexerInterface.'), $category->getCategoryEntity()->getAttributeCategoryHandle());
+        }
+
+        return true;
     }
 }

--- a/concrete/src/Attribute/Key/Listener.php
+++ b/concrete/src/Attribute/Key/Listener.php
@@ -1,19 +1,30 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key;
 
+use Concrete\Core\Attribute\Key\SearchIndexer\SearchIndexerInterface;
 use Concrete\Core\Entity\Attribute\Key\Key as AttributeKey;
-use Concrete\Core\Entity\Express\Entity;
-use Concrete\Core\Tree\Node\Node;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
 class Listener
 {
-
+    /**
+     * @param \Concrete\Core\Entity\Attribute\Key\Key $key
+     * @param \Doctrine\ORM\Event\LifecycleEventArgs $event
+     */
     public function preRemove(AttributeKey $key, LifecycleEventArgs $event)
     {
         $em = $event->getEntityManager();
         $category = $key->getAttributeCategory();
 
+        // Remove the index column(s), if any
+        if ($key->isAttributeKeySearchable()) {
+            $indexer = $key->getSearchIndexer();
+            if ($indexer instanceof SearchIndexerInterface) {
+                $key->setIsAttributeKeySearchable(false);
+                $indexer->updateSearchIndexKeyColumns($category, $key);
+            }
+        }
         // Delete the category key record
         $category->deleteKey($key);
 
@@ -23,11 +34,9 @@ class Listener
 
         // Delete from any attribute sets
         $r = $em->getRepository('\Concrete\Core\Entity\Attribute\SetKey');
-        $setKeys = $r->findBy(array('attribute_key' => $key));
+        $setKeys = $r->findBy(['attribute_key' => $key]);
         foreach ($setKeys as $setKey) {
             $em->remove($setKey);
         }
     }
-
-
 }

--- a/concrete/src/Attribute/Key/SearchIndexer/SearchIndexerInterface.php
+++ b/concrete/src/Attribute/Key/SearchIndexer/SearchIndexerInterface.php
@@ -1,15 +1,40 @@
 <?php
+
 namespace Concrete\Core\Attribute\Key\SearchIndexer;
 
 use Concrete\Core\Attribute\AttributeKeyInterface;
 use Concrete\Core\Attribute\AttributeValueInterface;
 use Concrete\Core\Attribute\Category\CategoryInterface;
 
+/**
+ * Interface that all the classes that handle the search index of attribute keys must implement.
+ */
 interface SearchIndexerInterface
 {
+    /**
+     * Create or update the column that contains the indexed data of a specific attribute.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeKeyInterface $key
+     * @param string|null $previousHandle
+     */
+    public function updateSearchIndexKeyColumns(CategoryInterface $category, AttributeKeyInterface $key, $previousHandle);
 
-    function clearIndexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject);
-    function indexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject);
-    function updateSearchIndexKeyColumns(CategoryInterface $category, AttributeKeyInterface $key, $previousHandle);
+    /**
+     * Store in the index table the value of an attribute of an item.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeValueInterface $value
+     * @param object $subject The item owning the attribute value
+     */
+    public function indexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject);
 
+    /**
+     * Remove from the index table the value of an attribute of an item.
+     *
+     * @param \Concrete\Core\Attribute\Category\CategoryInterface $category
+     * @param \Concrete\Core\Attribute\AttributeValueInterface $value
+     * @param object $subject The item owning the attribute value
+     */
+    public function clearIndexEntry(CategoryInterface $category, AttributeValueInterface $value, $subject);
 }

--- a/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
@@ -77,9 +77,7 @@ class StandardSearchIndexer implements SearchIndexerInterface
         $diff = $comparator->diffTable($fromTable, $toTable);
         if ($diff !== false) {
             $sql = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
-            $arr = [];
             foreach ($sql as $q) {
-                $arr[] = $q;
                 $this->connection->exec($q);
             }
         }
@@ -152,9 +150,7 @@ class StandardSearchIndexer implements SearchIndexerInterface
         $diff = $comparator->diffTable($fromTable, $toTable);
         if ($diff !== false) {
             $sql = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
-            $arr = [];
             foreach ($sql as $q) {
-                $arr[] = $q;
                 $this->connection->exec($q);
             }
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170316000000.php
@@ -41,7 +41,7 @@ class Version20170316000000 extends AbstractMigration implements RepeatableMigra
                 // Refresh the column from the attribute's search index definition if we can
                 // (we don't require this method in the interface yet)
                 try {
-                    $category->getSearchIndexer()->refreshRepositoryColumns($category, $key);
+                    $category->getSearchIndexer()->updateRepositoryColumns($category, $key);
                 } catch (\Exception $e) {
                 }
             }


### PR DESCRIPTION
Included in this pull request:
- added some PHPDoc
- deprecate the `refreshSearchIndexKeyColumns()` method of the attribute key `StandardSearchIndexer`: it's not part of `SearchIndexerInterface`, what it does has been integrated into the `updateSearchIndexKeyColumns()` method
- deprecate the `refreshRepositoryColumns()` method of the category `StandardSearchIndexer`: it's not part of `SearchIndexerInterface`, what it does has been integrated into the `updateRepositoryColumns()` method
- fix the logic of `updateSearchIndexKeyColumns`:
   - fix #5552
   - fix #6562
   - fix #7859

To be noted: with this PR, when users uncheck the `Field available in advanced search` option, the columns in the index table are dropped. The reasons for this are:
- we avoid having useless columns (see for example #8001)
- if people uncheck the option, then update some data, then re-check the option, we'd still need to re-index the contents (otherwise we risk to have wrong results)

In order to help people avoid unchecking this option by mistake, I added f4e4e82207.