### PR TITLE
Minor fix - return default column set using the provider

### DIFF
--- a/concrete/src/Page/Search/ColumnSet/ColumnSet.php
+++ b/concrete/src/Page/Search/ColumnSet/ColumnSet.php
@@ -32,6 +32,6 @@ class ColumnSet extends Set
             return $columns;
         }
 
-        return new DefaultSet();
+        return $provider->getDefaultColumnSet();
     }
 }


### PR DESCRIPTION
Let's use- 

```
return $provider->getDefaultColumnSet();
```

instead of 

```
return new DefaultSet();
```

### Reason-

Override of the  `SearchProvider` & `DefaultSet` class doesn't work properly because of this `return new DefaultSet();`. It requires one more class override only because of this line.

https://github.com/concrete5/concrete5/blob/80dfd7d8fc9bfa305a703c1aa1e71f6fd2694c5b/concrete/src/Page/Search/ColumnSet/ColumnSet.php#L21-L36

