### PR TITLE
Fix token error on flag_conversation_message

### DIFF
--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -141,6 +141,7 @@ class Controller extends BlockController implements ConversationFeatureInterface
             $this->set('addMessageToken', $addMessageToken);
             $this->set('editMessageToken', $tokenHelper->generate('edit_conversation_message'));
             $this->set('deleteMessageToken', $tokenHelper->generate('delete_conversation_message'));
+            $this->set('flagMessageToken', $tokenHelper->generate('flag_conversation_message'));
             $this->set('cID', Page::getCurrentPage()->getCollectionID());
             $this->set('users', $this->getActiveUsers(true));
             $this->set('maxFilesGuest', $fileSettings['maxFilesGuest']);

--- a/concrete/blocks/core_conversation/view.php
+++ b/concrete/blocks/core_conversation/view.php
@@ -29,6 +29,7 @@ if (is_object($conversation)) { ?>
             addMessageToken: '<?=$addMessageToken?>',
             editMessageToken: '<?=$editMessageToken?>',
             deleteMessageToken: '<?=$deleteMessageToken?>',
+            flagMessageToken: '<?=$flagMessageToken?>',
             displayMode: '<?=$displayMode?>',
             addMessageLabel: '<?=$addMessageLabel?>',
             paginate: <?=$paginate?>,

--- a/concrete/js/build/core/conversations/conversations.js
+++ b/concrete/js/build/core/conversations/conversations.js
@@ -72,7 +72,8 @@
                 uninitialized: true,
                 deleteMessageToken: null,
                 addMessageToken: null,
-                editMessageToken: null
+                editMessageToken: null,
+                flagMessageToken: null
             }, options);
 
             var enablePosting = (obj.options.addMessageToken != '') ? 1 : 0;
@@ -598,6 +599,9 @@
             var obj = this;
             obj.publish('conversationBeforeFlagMessage', { msgID: msgID });
             var formArray = [{
+                'name': 'token',
+                'value': obj.options.flagMessageToken
+            },{
                 'name': 'cnvMessageID',
                 'value': msgID
             }];


### PR DESCRIPTION
On set a message as spam, token error is issued, because the form does not send a token.