### PR TITLE
Fix document library block error when file node type is other than File or FileFolder

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -6,20 +6,16 @@ use Concrete\Core\Attribute\Key\FileKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Entity\File\Version;
-use Concrete\Core\File\FileList;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\File\FolderItemList;
 use Concrete\Core\File\Importer;
 use Concrete\Core\File\Set\Set;
 use Concrete\Core\File\Set\SetList;
 use Concrete\Core\File\Type\Type;
-use Concrete\Core\Form\Service\Widget\Attribute;
 use Concrete\Core\Http\ResponseFactory;
-use Concrete\Core\Site\Service;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\File;
 use Concrete\Core\Tree\Node\Type\FileFolder;
-use Concrete\Core\Url\Resolver\Manager\ResolverManager;
 use Concrete\Core\Url\UrlImmutable;
 use Concrete\Core\User\User;
 use Core;
@@ -27,13 +23,12 @@ use FileAttributeKey;
 
 class Controller extends BlockController
 {
-
-    protected $btInterfaceWidth = "640";
-    protected $btInterfaceHeight = "400";
+    protected $btInterfaceWidth = '640';
+    protected $btInterfaceHeight = '400';
     protected $btTable = 'btDocumentLibrary';
-    protected $fileAttributes = array();
+    protected $fileAttributes = [];
 
-    /** @var null|FileFolder */
+    /** @var FileFolder|null */
     protected $rootNode = null;
 
     /** @var int */
@@ -41,12 +36,12 @@ class Controller extends BlockController
 
     public function getBlockTypeDescription()
     {
-        return t("Add a searchable document library to a page.");
+        return t('Add a searchable document library to a page.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Document Library");
+        return t('Document Library');
     }
 
     public function action_navigate($blockID, $folderID = 0)
@@ -106,7 +101,7 @@ class Controller extends BlockController
         $fsl = new SetList();
         $fsl->filterByType(Set::TYPE_PUBLIC);
         $r = $fsl->get();
-        $sets = array();
+        $sets = [];
         foreach ($r as $fs) {
             $fsp = new \Permissions($fs);
             if ($fsp->canSearchFiles()) {
@@ -115,27 +110,27 @@ class Controller extends BlockController
         }
         $this->set('fileSets', $sets);
 
-        $searchProperties = array(
+        $searchProperties = [
             'date' => t('Date Posted'),
             'type' => t('File Type'),
-            'extension' => t('File Extension')
-        );
+            'extension' => t('File Extension'),
+        ];
         foreach ($this->fileAttributes as $ak) {
             $searchProperties['ak_' . $ak->getAttributeKeyID()] = $ak->getAttributeKeyDisplayName();
         }
         $this->set('searchProperties', $searchProperties);
 
-        $orderByOptions = array(
+        $orderByOptions = [
             'title' => t('Title'),
             'set' => tc('Order of a set', 'Set Order'),
             'date' => t('Date Posted'),
-            'filename' => t('Filename')
-        );
+            'filename' => t('Filename'),
+        ];
         foreach ($this->fileAttributes as $ak) {
             $orderByOptions['ak_' . $ak->getAttributeKeyID()] = $ak->getAttributeKeyDisplayName();
         }
         $this->set('orderByOptions', $orderByOptions);
-        $viewProperties = array(
+        $viewProperties = [
             'thumbnail' => t('Thumbnail'),
             'filename' => t('Filename'),
             'tags' => t('Tags'),
@@ -143,13 +138,13 @@ class Controller extends BlockController
             'extension' => t('Extension'),
             'size' => t('Size'),
             'description' => t('Description'),
-        );
+        ];
         foreach ($this->fileAttributes as $ak) {
             $viewProperties['ak_' . $ak->getAttributeKeyID()] = $ak->getAttributeKeyDisplayName();
         }
         $this->set('viewProperties', $viewProperties);
 
-        $expandableProperties = array(
+        $expandableProperties = [
             'image' => t('Image'),
             'description' => t('Description'),
             'tags' => t('Tags'),
@@ -157,23 +152,22 @@ class Controller extends BlockController
             'date' => t('Date Posted'),
             'extension' => t('Extension'),
             'size' => t('Size'),
-        );
+        ];
         foreach ($this->fileAttributes as $ak) {
             $expandableProperties['ak_' . $ak->getAttributeKeyID()] = $ak->getAttributeKeyDisplayName();
         }
         $this->set('expandableProperties', $expandableProperties);
-
     }
 
     public function edit()
     {
         $this->loadData();
-        $this->set('selectedSets', (array)json_decode($this->setIds));
-        $this->set('searchPropertiesSelected', (array)json_decode($this->searchProperties));
-        $viewPropertiesDoNotDisplay = array();
-        $viewPropertiesDisplay = array();
-        $viewPropertiesDisplaySortable = array();
-        $viewProperties = (array)json_decode($this->viewProperties);
+        $this->set('selectedSets', (array) json_decode($this->setIds));
+        $this->set('searchPropertiesSelected', (array) json_decode($this->searchProperties));
+        $viewPropertiesDoNotDisplay = [];
+        $viewPropertiesDisplay = [];
+        $viewPropertiesDisplaySortable = [];
+        $viewProperties = (array) json_decode($this->viewProperties);
         foreach ($viewProperties as $key => $type) {
             switch ($type) {
                 case -1:
@@ -185,13 +179,12 @@ class Controller extends BlockController
                 case 5:
                     $viewPropertiesDisplaySortable[] = $key;
                     break;
-
             }
         }
         $this->set('viewPropertiesDoNotDisplay', $viewPropertiesDoNotDisplay);
         $this->set('viewPropertiesDisplay', $viewPropertiesDisplay);
         $this->set('viewPropertiesDisplaySortable', $viewPropertiesDisplaySortable);
-        $this->set('expandablePropertiesSelected', (array)json_decode($this->expandableProperties));
+        $this->set('expandablePropertiesSelected', (array) json_decode($this->expandableProperties));
     }
 
     public function getSortColumnKey($key, $retrieve = 'filelist')
@@ -203,7 +196,6 @@ class Controller extends BlockController
                 if (is_object($ak)) {
                     return 'ak_' . $ak->getAttributeKeyHandle();
                 }
-
             } else {
                 $akHandle = substr($key, 3);
                 $ak = FileKey::getByHandle($akHandle);
@@ -213,7 +205,7 @@ class Controller extends BlockController
             }
         }
 
-        $properties = array(
+        $properties = [
             'title' => 'fv.fvTitle',
             'filename' => 'fv.fvFilename',
             'tags' => 'fv.fvTags',
@@ -221,7 +213,7 @@ class Controller extends BlockController
             'extension' => 'fv.fvExtension',
             'size' => 'fv.fvSize',
             'description' => 'fv.fvDescription',
-        );
+        ];
 
         foreach ($properties as $block => $filelist) {
             if ($retrieve == 'filelist' && $key == $block) {
@@ -239,18 +231,18 @@ class Controller extends BlockController
         $this->loadData();
         $this->set('setMode', 'any');
         $this->set('enableSearch', 0);
-        $this->set('selectedSets', array());
-        $this->set('searchPropertiesSelected', array());
-        $this->set('expandablePropertiesSelected', array());
-        $viewPropertiesDoNotDisplay = array();
+        $this->set('selectedSets', []);
+        $this->set('searchPropertiesSelected', []);
+        $this->set('expandablePropertiesSelected', []);
+        $viewPropertiesDoNotDisplay = [];
         foreach ($this->get('viewProperties') as $key => $name) {
-            if (!in_array($key, array('filename', 'size', 'date', 'thumbnail'))) {
+            if (!in_array($key, ['filename', 'size', 'date', 'thumbnail'])) {
                 $viewPropertiesDoNotDisplay[] = $key;
             }
         }
         $this->set('viewPropertiesDoNotDisplay', $viewPropertiesDoNotDisplay);
-        $this->set('viewPropertiesDisplay', array('thumbnail'));
-        $this->set('viewPropertiesDisplaySortable', array('filename', 'size', 'date'));
+        $this->set('viewPropertiesDisplay', ['thumbnail']);
+        $this->set('viewPropertiesDisplaySortable', ['filename', 'size', 'date']);
         $this->set('displayLimit', 20);
         $this->set('downloadFileMethod', 'browser');
         $this->set('heightMode', 'auto');
@@ -310,8 +302,8 @@ class Controller extends BlockController
 
     protected function getTableColumns($results)
     {
-        $viewProperties = (array)json_decode($this->viewProperties);
-        $return = array();
+        $viewProperties = (array) json_decode($this->viewProperties);
+        $return = [];
         if (array_key_exists('thumbnail', $viewProperties) && $viewProperties['thumbnail'] > -1) {
             $return[] = 'thumbnail';
         }
@@ -340,7 +332,7 @@ class Controller extends BlockController
             }
         }
 
-        $expandableProperties = (array)json_decode($this->expandableProperties);
+        $expandableProperties = (array) json_decode($this->expandableProperties);
         if (count($expandableProperties)) {
             $return[] = 'details';
         }
@@ -350,21 +342,23 @@ class Controller extends BlockController
 
     protected function getTableExpandableProperties()
     {
-        $expandableProperties = (array)json_decode($this->expandableProperties);
-        $return = array();
+        $expandableProperties = (array) json_decode($this->expandableProperties);
+        $return = [];
         foreach ($expandableProperties as $key) {
             $return[] = $key;
         }
+
         return $return;
     }
 
     protected function getTableSearchProperties()
     {
-        $searchProperties = (array)json_decode($this->searchProperties);
-        $return = array();
+        $searchProperties = (array) json_decode($this->searchProperties);
+        $return = [];
         foreach ($searchProperties as $key) {
             $return[] = $key;
         }
+
         return $return;
     }
 
@@ -377,7 +371,7 @@ class Controller extends BlockController
                 return t('Detail Image');
             case 'edit_properties':
             case 'details':
-                return "";
+                return '';
             case 'thumbnail':
                 return t('Thumbnail');
             case 'filename':
@@ -416,6 +410,7 @@ class Controller extends BlockController
         if ($orderBy && $orderBy == $key) {
             $class .= ' ccm-block-document-library-active-sort-' . $order;
         }
+
         return $class;
     }
 
@@ -434,6 +429,7 @@ class Controller extends BlockController
             $query['dir'] = $order;
             $url = $url->setQuery($query);
         }
+
         return $url;
     }
 
@@ -445,7 +441,8 @@ class Controller extends BlockController
         if ($key == 'details') {
             return false;
         }
-        $viewProperties = (array)json_decode($this->viewProperties);
+        $viewProperties = (array) json_decode($this->viewProperties);
+
         return isset($viewProperties[$key]) && $viewProperties[$key] == 5;
     }
 
@@ -455,22 +452,25 @@ class Controller extends BlockController
             case 'type':
                 $form = \Core::make('helper/form');
                 $t1 = Type::getTypeList();
-                $types = array('' => t('** File type'));
+                $types = ['' => t('** File type')];
                 foreach ($t1 as $value) {
                     $types[$value] = Type::getGenericTypeText($value);
                 }
-                return $form->select('type', $types, array('style' => 'width: 120px'));
+
+                return $form->select('type', $types, ['style' => 'width: 120px']);
             case 'extension':
                 $form = \Core::make('helper/form');
                 $ext1 = Type::getUsedExtensionList();
-                $extensions = array('' => t('** File Extension'));
+                $extensions = ['' => t('** File Extension')];
                 foreach ($ext1 as $value) {
                     $extensions[$value] = $value;
                 }
-                return $form->select('extension', $extensions, array('style' => 'width: 120px'));
+
+                return $form->select('extension', $extensions, ['style' => 'width: 120px']);
             case 'date':
                 $wdt = \Core::make('helper/form/date_time');
-                print $wdt->translate($_REQUEST['date_from']);
+                echo $wdt->translate($_REQUEST['date_from']);
+
                 return $wdt->datetime('date_from', $wdt->translate('date_from', $_REQUEST),
                         true) . t('to') . $wdt->datetime('date_to', $wdt->translate('date_to', $_REQUEST), true);
             default:
@@ -491,7 +491,7 @@ class Controller extends BlockController
         $table = $category->getIndexedSearchTable();
         $query->leftJoin('fv', $table, 'fis', 'fv.fID = fis.fID');
 
-        $searchProperties = (array)json_decode($this->searchProperties);
+        $searchProperties = (array) json_decode($this->searchProperties);
         foreach ($searchProperties as $column) {
             switch ($column) {
                 case 'type':
@@ -539,6 +539,7 @@ class Controller extends BlockController
                     break;
             }
         }
+
         return $list;
     }
 
@@ -557,7 +558,6 @@ class Controller extends BlockController
 
                 $im = Core::make('helper/image');
                 if ($file->getTypeObject()->getGenericType() == Type::T_IMAGE && $this->maxThumbWidth && $this->maxThumbHeight) {
-
                     $thumb = $im->getThumbnail(
                         $file,
                         $this->maxThumbWidth,
@@ -603,7 +603,7 @@ class Controller extends BlockController
                 return $file->getTags();
                 break;
             case 'date':
-                return Core::make("date")->formatDate($file->getDateAdded(), false);
+                return Core::make('date')->formatDate($file->getDateAdded(), false);
                 break;
             case 'extension':
                 return $file->getExtension();
@@ -626,7 +626,7 @@ class Controller extends BlockController
 
     public function action_upload($bID = false)
     {
-        $files = array();
+        $files = [];
         if ($this->bID == $bID) {
             $fp = \FilePermissions::getGlobal();
             $cf = \Loader::helper('file');
@@ -647,7 +647,7 @@ class Controller extends BlockController
                                     $fs->addFileToSet($file);
                                 }
                             }
-                            /** @var \Concrete\Core\Entity\File\File $file */
+                            /* @var \Concrete\Core\Entity\File\File $file */
                             $files[] = $file;
                         }
                     }
@@ -664,7 +664,6 @@ class Controller extends BlockController
         $r = new \Concrete\Core\File\EditResponse();
         $r->setFiles($files);
         $r->outputJSON();
-
     }
 
     protected function setupFolderFileFolderFilter(FolderItemList $list)
@@ -843,6 +842,7 @@ class Controller extends BlockController
 
     /**
      * @param bool $realRoot
+     *
      * @return FileFolder
      */
     private function getRootFolder($realRoot = false)
@@ -856,12 +856,12 @@ class Controller extends BlockController
         }
 
         $filesystem = $this->app->make(Filesystem::class);
+
         return $filesystem->getRootFolder();
     }
 
     private function getFolderColumnValue($key, FileFolder $folder)
     {
-
         switch ($key) {
             case 'thumbnail':
             case 'image':
@@ -871,7 +871,7 @@ class Controller extends BlockController
                 );
             case 'title':
                 $view = new BlockView($this->getBlockObject());
-                /** @var UrlImmutable $action */ 
+                /** @var UrlImmutable $action */
                 $action = $this->getActionURL('navigate');
                 $actionPath = $action->getPath();
                 $actionPath->append($folder->getTreeNodeID());
@@ -884,7 +884,7 @@ class Controller extends BlockController
                 return [];
                 break;
             case 'date':
-                return $this->app->make("date")->formatDate($folder->getDateCreated(), false);
+                return $this->app->make('date')->formatDate($folder->getDateCreated(), false);
             case 'extension':
             case 'size':
             case 'description':
@@ -926,20 +926,21 @@ class Controller extends BlockController
     /**
      * @param FolderItemList $list
      * @param string $keywords
+     *
      * @return \Concrete\Core\File\FolderItemList
      */
     private function setupKeywordSearch(FolderItemList $list, $keywords)
     {
         $this->enableSubFolderSearch($list);
         $query = $list->getQueryObject();
-        $expressions = array(
+        $expressions = [
             $query->expr()->like('fv.fvFilename', ':keywords'),
             $query->expr()->like('fv.fvDescription', ':keywords'),
             $query->expr()->like('fv.fvTitle', ':keywords'),
             $query->expr()->like('fv.fvTags', ':keywords'),
             $query->expr()->like('fv.fvTags', ':keywords'),
             $query->expr()->like('n.treeNodeName', ':keywords'),
-        );
+        ];
 
         $keys = FileAttributeKey::getSearchableIndexedList();
         foreach ($keys as $ak) {
@@ -952,5 +953,4 @@ class Controller extends BlockController
 
         return $list;
     }
-
 }

--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -548,6 +548,8 @@ class Controller extends BlockController
             $file = $file->getTreeNodeFileObject();
         } elseif ($file instanceof FileFolder) {
             return $this->getFolderColumnValue($key, $file);
+        } else {
+            return false;
         }
 
         switch ($key) {


### PR DESCRIPTION
Document library block returns`Call to undefined method` error when the `$file` tree node type is other than `File` or `FileFolder`.
In my case, it was `\Concrete\Core\Tree\Node\Type\SearchPreset`.

https://github.com/concrete5/concrete5/blob/f8424aeeb7514c2e63ec746b6ea175e2b85e64f1/concrete/blocks/document_library/controller.php#L547-L551

This PR fixes the issue.