### PR TITLE
Fix #8218 - save_avatar uses the incorrect ccm_token

### DIFF
--- a/build/components/avatar/Cropper.js
+++ b/build/components/avatar/Cropper.js
@@ -27,6 +27,8 @@ export default {
             imageWidth: 0,
             saving: false,
             currentimage: null,
+            hasError: false,
+            errorMessage: '',
         }
     },
 
@@ -41,7 +43,14 @@ export default {
         this.setupUploading();
     },
     methods: {
-
+        setError(error) {
+            this.hasError = true;
+            this.errorMessage = error;
+        },
+        clearError() {
+            this.hasError = false;
+            this.errorMessage = '';
+        },
         /**
          * Setup dropzone for uploading
          */
@@ -78,18 +87,26 @@ export default {
                     });
 
                     this.on('success', function(event, data) {
-                        component.currentimage = data.avatar;
+                        if (!component.hasError) {
+                            component.currentimage = data.avatar;
+                        }
+
                     });
 
-                    this.on('complete', function() {
-                        component.saving = false;
-                        component.img = null;
-                        component.dropzone.destroy();
-                        component.dropzone = null;
+                    this.on('error', function (event, data) {
+                        component.setError(data.message);
+                        component.currentimage = component.src;
+                    })
 
-                        setTimeout(function() {
-                            component.setupUploading();
-                        }, 0);
+                    this.on('complete', function() {
+                            component.saving = false;
+                            component.img = null;
+                            component.dropzone.destroy();
+                            component.dropzone = null;
+
+                            setTimeout(function () {
+                                component.setupUploading();
+                            }, 0);
                     });
                 },
 
@@ -165,7 +182,9 @@ export default {
             if (window.confirm('Are you sure you want to quit?')) {
                 this.done.call(this.dropzone, 'Cancelled upload.');
                 this.img = null;
+                this.saving = false
                 this.dropzone.destroy();
+                this.clearError()
                 this.dropzone = null;
                 this.setupUploading();
             }

--- a/build/components/avatar/Cropper.vue
+++ b/build/components/avatar/Cropper.vue
@@ -30,6 +30,9 @@
             <a class="ccm-avatar-cancel" :style="{width: width / 2 + 'px'}" @click="handleCancel"></a>
         </div>
         <canvas ref="canvas" style="height: 0px"></canvas>
+        <div v-if="hasError" class="alert alert-danger">
+            {{errorMessage}}
+        </div>
     </div>
 </template>
 

--- a/concrete/controllers/single_page/account/avatar.php
+++ b/concrete/controllers/single_page/account/avatar.php
@@ -24,8 +24,10 @@ class Avatar extends AccountProfileEditPageController
         ];
         $this->view();
         $token = $this->app->make('token');
-        if (!$token->validate('avatar/save_avatar')) {
-            $this->redirect('/profile/avatar', 'token');
+        if (!$token->validate('avatar/save_avatar', $this->request->query->get('ccm_token'))) {
+            $result['error'] = true;
+            $result['message'] = $token->getErrorMessage();
+            return new JsonResponse($result, 400);
         }
 
         /** @var UserInfo $profile */

--- a/concrete/controllers/single_page/account/avatar.php
+++ b/concrete/controllers/single_page/account/avatar.php
@@ -3,8 +3,9 @@ namespace Concrete\Controller\SinglePage\Account;
 
 use Concrete\Controller\SinglePage\Account\EditProfile as AccountProfileEditPageController;
 use Concrete\Core\User\UserInfo;
-use Imagine\Image\Palette\Color\RGB;
+use Imagine\Image\Palette\RGB;
 use Imagine\Image\Point;
+use Imagine\Image\ImagineInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Avatar extends AccountProfileEditPageController
@@ -20,36 +21,61 @@ class Avatar extends AccountProfileEditPageController
     {
         $result = [
             'success' => false,
-            'avatar' => null
+            'avatar' => null,
         ];
         $this->view();
         $token = $this->app->make('token');
         if (!$token->validate('avatar/save_avatar', $this->request->query->get('ccm_token'))) {
             $result['error'] = true;
             $result['message'] = $token->getErrorMessage();
+
             return new JsonResponse($result, 400);
         }
 
-        /** @var UserInfo $profile */
+        /** @var UserInfo */
         $profile = $this->get('profile');
 
-        /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
+        /** @var \Symfony\Component\HttpFoundation\File\UploadedFile */
         $file = $this->request->files->get('file');
         if ($file) {
-            $image = \Image::open($file->getPathname());
+            try {
+                /** @var ImagineInterface $imagine */
+                $imagine = $this->app->make(ImagineInterface::class);
+                $image = $imagine->open($file->getPathname());
 
-            $palette = new \Imagine\Image\Palette\RGB();
+                $palette = new RGB();
 
-            // Give our image a white background
-            $canvas = \Image::create($image->getSize(), $palette->color('fff'));
-            $canvas->paste($image, new Point(0, 0));
+                // Give our image a white background
+                $canvas = $imagine->create($image->getSize(), $palette->color('fff'));
+                $canvas->paste($image, new Point(0, 0));
 
-            // Update the avatar
-            $profile->updateUserAvatar($canvas);
+                // Update the avatar
+                $profile->updateUserAvatar($canvas);
 
-            // Update the result
-            $result['success'] = true;
-            $result['avatar'] = $profile->getUserAvatar()->getPath() . '?' . time();
+                // Update the result
+                $result['success'] = true;
+                $result['avatar'] = $profile->getUserAvatar()->getPath() . '?' . time();
+            } catch (\Exception $error) {
+                if ($this->app->make('config')->get('concrete.log.errors')) {
+                    $logger = $this->app->make('log/exceptions');
+                    $logger->emergency(
+                        t(
+                            "Exception Occurred: %s:%d %s (%d)\n",
+                            $error->getFile(),
+                            $error->getLine(),
+                            $error->getMessage(),
+                            $error->getCode()
+                        ),
+                        [$error]
+                    );
+                }
+
+                $result['error'] = true;
+                $result['message'] = t('Error while setting profile picture.');
+            }
+        } else {
+            $result['error'] = true;
+            $result['message'] = t('Error while uploading file.');
         }
 
         return new JsonResponse($result, $result['success'] ? 200 : 400);
@@ -68,11 +94,14 @@ class Avatar extends AccountProfileEditPageController
         if (!is_object($profile) || $profile->getUserID() < 1) {
             return false;
         }
+        $thumbnail = $this->request->request->get('thumbnail');
 
-        if (isset($_POST['thumbnail']) && strlen($_POST['thumbnail'])) {
-            $thumb = base64_decode($_POST['thumbnail']);
-            $image = \Image::load($thumb);
+        if ($thumbnail) {
+            $thumb = base64_decode($thumbnail);
+            $image = $this->app->make(ImagineInterface::class)->load($thumb);
             $profile->updateUserAvatar($image);
+        } else {
+            return false;
         }
 
         $this->redirect('/account/avatar', 'saved');
@@ -98,9 +127,8 @@ class Avatar extends AccountProfileEditPageController
         }
         if (!$this->error->has()) {
             $profile = $this->get('profile');
-            $av = $this->get('av');
 
-            $service = \Core::make('user/avatar');
+            $service = $this->app->make('user/avatar');
             $service->removeAvatar($profile);
             $this->redirect('/account/avatar', 'deleted');
         }


### PR DESCRIPTION
This PR fixes (#8218) the save_avatar not using the ccm_token supplied in the query string.
Essentially /ccm/assets/localization/dropzone/js adds ccm_token to the parameters by default and this causes issues with the validation

I've also added error handling and logging if anything goes wrong with the avatar upload. It will now display an error message if the token is invalid or something goes wrong during upload and will also reset the visuals to the previous source.

I've updated the controller a bit but i'm not sure if we need save_thumb anymore but i've kept it for bc (if people are using a custom pages)