### PR TITLE
Fixing #8206 and #8150 : Issues with userGroups and inGroup()

### DIFF
--- a/concrete/controllers/backend/user.php
+++ b/concrete/controllers/backend/user.php
@@ -50,7 +50,7 @@ class User extends Controller
                 foreach ($users as $ui) {
                     $uo = $ui->getUserObject();
                     if ($task == 'add') {
-                        if (!$uo->inGroup($g)) {
+                        if (!$uo->inExactGroup($g)) {
                             $uo->enterGroup($g);
                             $obj = new stdClass();
                             $obj->gDisplayName = $g->getGroupDisplayName();
@@ -59,7 +59,7 @@ class User extends Controller
                             $r->setAdditionalDataAttribute('groups', array($obj));
                         }
                     } else {
-                        if ($uo->inGroup($g)) {
+                        if ($uo->inExactGroup($g)) {
                             $uo->exitGroup($g);
                             $obj = new stdClass();
                             $obj->gID = $g->getGroupID();

--- a/concrete/controllers/dialog/user/bulk/group.php
+++ b/concrete/controllers/dialog/user/bulk/group.php
@@ -97,10 +97,10 @@ class Group extends BackendInterfaceController
 
                 $uo = $ui->getUserObject();
 
-                if ('add' == $function && $uo->inGroup($group)) {
+                if ('add' == $function && $uo->inExactGroup($group)) {
                     continue;
                 }
-                if ('remove' == $function && !$uo->inGroup($group)) {
+                if ('remove' == $function && !$uo->inExactGroup($group)) {
                     continue;
                 }
 

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -717,7 +717,7 @@ class User extends ConcreteObject
     }
 
     /**
-     * Return true if user is in Group or any of this groups children
+     * Return true if user is in Group or any of this groups children.
      *
      * @param Group $g
      *
@@ -749,9 +749,10 @@ class User extends ConcreteObject
 
     /**
      * Return true if user is in this Group.
-     * Does not check if user is a member of children
+     * Does not check if user is a member of children.
      *
      * @param Group $g
+     *
      * @return bool
      */
     public function inExactGroup($g)

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -744,7 +744,7 @@ class User extends ConcreteObject
             ->setMaxResults(1);
         $results = $query->execute()->fetchColumn();
 
-        return $results;
+        return (bool) $results;
     }
 
     /**
@@ -769,7 +769,7 @@ class User extends ConcreteObject
             ->setMaxResults(1);
         $results = $query->execute()->fetchColumn();
 
-        return $results;
+        return (bool) $results;
     }
 
     /**

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -150,7 +150,7 @@ class GroupTest extends UserTestCase
         $this->assertTrue($userA->inGroup($group3));
         $this->assertTrue($userA->inGroup($group2));
         $this->assertTrue($userA->inGroup($group1));
-        $this->assertFalse($userB->inGroup($group4));
+        $this->assertFalse($userA->inGroup($group4));
         $userB = $userB->getUserObject();
 
         $this->assertFalse($userB->inGroup($group3));
@@ -271,28 +271,28 @@ class GroupTest extends UserTestCase
         // Check they are a member of group 1
         $this->assertTrue($fuu1->inGroup($group1));
         // Check they are not a member of similar group path
-        $this->assertFalse($fui1->inGroup($group2));
+        $this->assertFalse($fuu1->inGroup($group2));
 
         $this->assertTrue($fuu2->inExactGroup($group1));
         // Check they are a member of group 1
         $this->assertTrue($fuu2->inGroup($group1));
         // Check they are not a member of any children
-        $this->assertFalse($fui2->inGroup($group2));
-        $this->assertFalse($fui3->inGroup($group3));
+        $this->assertFalse($fuu2->inGroup($group2));
+        $this->assertFalse($fuu3->inGroup($group3));
 
         // Check they are a member of group 1 from child only
         $this->assertFalse($fuu3->inExactGroup($group1));
         $this->assertTrue($fuu3->inGroup($group1));
         // Check they are not a member of any children
-        $this->assertTrue($fui3->inGroup($group2));
-        $this->assertFalse($fui3->inGroup($group3));
+        $this->assertTrue($fuu3->inGroup($group2));
+        $this->assertFalse($fuu3->inGroup($group3));
 
         // Check they are a member of group 1
         $this->assertTrue($fuu4->inExactGroup($group1));
         $this->assertTrue($fuu4->inGroup($group1));
         // Check they are not a member of any children
-        $this->assertFalse($fui4->inGroup($group2));
-        $this->assertTrue($fui4->inGroup($group3));
+        $this->assertFalse($fuu4->inGroup($group2));
+        $this->assertTrue($fuu4->inGroup($group3));
 
     }
 }

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -241,4 +241,55 @@ class GroupTest extends UserTestCase
         $results = $list6->getResults();
         $this->assertEquals(8, count($results));
     }
+
+    public function testParentChildGroups()
+    {
+
+        $group1 = Group::add('User Group', 'This is a parent test group 1');
+        $group2 = Group::add('User Group Child', 'This is a child test group 1', $group1);
+        $group3 = Group::add('User Group Child 2', 'This is a child test group 2', $group1);
+
+        $fui1 = $this->createUser('groupuser1', 'groupuser1@concrete5.org');
+        $fui2 = $this->createUser('groupuser2', 'groupuser2@concrete5.org');
+        $fui3 = $this->createUser('groupuser3', 'groupuser3@concrete5.org');
+        $fui4 = $this->createUser('groupuser4', 'groupuser4@concrete5.org');
+        $fuu1 = $fui1->getUserObject();
+        $fuu1->enterGroup($group3);
+        $fuu2 = $fui2->getUserObject();
+        $fuu2->enterGroup($group1);
+        $fuu3 = $fui3->getUserObject();
+        $fuu3->enterGroup($group2);
+        $fuu4 = $fui4->getUserObject();
+        $fuu4->enterGroup($group3);
+        $fuu4->enterGroup($group1);
+
+        //Check they aren exclusively in group 1
+        $this->assertFalse($fuu1->isInExactGroup($group1));
+        // Check they are a member of group 1
+        $this->assertTrue($fuu1->isInGroup($group1));
+        // Check they are not a member of similar group path
+        $this->assertFalse($fui1->isInGroup($group2));
+
+        $this->assertTrue($fuu2->isInExactGroup($group1));
+        // Check they are a member of group 1
+        $this->assertTrue($fuu2->isInGroup($group1));
+        // Check they are not a member of any children
+        $this->assertFalse($fui2->isInGroup($group2));
+        $this->assertFalse($fui3->isInGroup($group3));
+
+        // Check they are a member of group 1 from child only
+        $this->assertFalse($fuu3->isInExactGroup($group1));
+        $this->assertTrue($fuu3->isInGroup($group1));
+        // Check they are not a member of any children
+        $this->assertTrue($fui3->isInGroup($group2));
+        $this->assertFalse($fui3->isInGroup($group3));
+
+        // Check they are a member of group 1
+        $this->assertTrue($fuu4->isInExactGroup($group1));
+        $this->assertTrue($fuu4->isInGroup($group1));
+        // Check they are not a member of any children
+        $this->assertFalse($fui4->isInGroup($group2));
+        $this->assertTrue($fui4->isInGroup($group3));
+
+    }
 }


### PR DESCRIPTION
This pr fixes parent groups not being able to be added after a child has been added due to their path names being the same. #8150
It also adds a new inExactGroup() function for this behaviour. This means that the previous behaviour of inGroup(), which returns true if in the user is in the group or any child groups, are not affected by this change.
This pr also fixes the issue where Groups with similar names return true for inGroup() #8206. For example
A user in group named ("Paying members 1") would return true for being a member of ("Paying members 100")

This PR also adds some new tests to address the issues above, such as testing for similar named groups, testing for inExactGroup vs inGroup