### PR TITLE
Update OAuth password check to use PasswordHasher class

### DIFF
--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -13,6 +13,7 @@ use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User as UserObject;
 use Concrete\Core\Validation\CSRF\Token;
 use Concrete\Core\View\View;
@@ -180,8 +181,11 @@ final class Controller implements LoggerAwareInterface
             /** @var User $user */
             $user = $userRepository->findOneBy([$emailLogin ? 'uEmail' : 'uName' => $user]);
 
+            $app = Application::getFacadeApplication();
+            $hasher = $app->make(\Concrete\Core\Encryption\PasswordHasher::class);
+
             // User successfully logged in
-            if ($user && $user->getUserID() && password_verify($password, $user->getUserPassword())) {
+            if ($user && $user->getUserID() && $hasher->checkPassword($password, $user->getUserPassword())) {
 
                 $userInfo = $this->entityManager->find(User::class, $user->getUserID());
                 $request->setUser($userInfo);


### PR DESCRIPTION
This updates the OAuth login controller to use concrete5's PasswordHasher class to check the password, instead of the native password_verify function. This ensures that the same password hashing types that are supported via the standard concrete5 login are also supported for external/API logins.