### PR TITLE
Add phone and email to social links

### DIFF
--- a/concrete/src/Sharing/SocialNetwork/ServiceList.php
+++ b/concrete/src/Sharing/SocialNetwork/ServiceList.php
@@ -27,6 +27,8 @@ class ServiceList
             ['skype', 'Skype', 'skype'],
             ['vk', 'Vkontakte', 'vk'],
             ['personal_website', 'Personal Website', 'external-link'],
+            ['email', 'Email', 'envelope'],
+            ['phone', 'Phone', 'phone-square'],
         ];
 
         // if additional social media services have been defined in custom config, append to built-in list or override


### PR DESCRIPTION
Phone URLs should start with `tel:`, email URLs should start with `mailto:`