### PR TITLE
Don't check POSIX permissions of API public key on Windows

### DIFF
--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -29,7 +29,7 @@ use League\OAuth2\Server\ResourceServer;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use phpseclib\Crypt\RSA;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
-use Zend\Http\Header\Authorization;
+use League\OAuth2\Server\CryptKey;
 
 class ApiServiceProvider extends ServiceProvider
 {
@@ -129,9 +129,10 @@ class ApiServiceProvider extends ServiceProvider
         // The ResourceServer deals with authenticating requests, in other words validating tokens
         $this->app->when(ResourceServer::class)->needs('$publicKey')->give($this->getKey(self::KEY_PUBLIC));
         $this->app->bind(ResourceServer::class, function() {
+            $cryptKey = new CryptKey($this->getKey(self::KEY_PUBLIC), null, DIRECTORY_SEPARATOR !== '\\');
             return $this->app->build(ResourceServer::class, [
                 $this->app->make(AccessTokenRepositoryInterface::class),
-                $this->getKey(self::KEY_PUBLIC),
+                $cryptKey,
                 $this->app->make(DefaultValidator::class)
             ]);
         });

--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -127,7 +127,6 @@ class ApiServiceProvider extends ServiceProvider
     protected function registerAuthorizationServer()
     {
         // The ResourceServer deals with authenticating requests, in other words validating tokens
-        $this->app->when(ResourceServer::class)->needs('$publicKey')->give($this->getKey(self::KEY_PUBLIC));
         $this->app->bind(ResourceServer::class, function() {
             $cryptKey = new CryptKey($this->getKey(self::KEY_PUBLIC), null, DIRECTORY_SEPARATOR !== '\\');
             return $this->app->build(ResourceServer::class, [


### PR DESCRIPTION
When initializing the ResourceServer class, we pass the actual public key (in RSA format, that is a string that starts with `-----BEGIN PUBLIC KEY-----`).

In this case, the `league/oauth2-server` component saves this public key to file, and sets its file permissions to 0600 (see [here](https://github.com/thephpleague/oauth2-server/blob/5.1.6/src/ResourceServer.php#L50), [here](https://github.com/thephpleague/oauth2-server/blob/master/src/CryptKey.php#L40) and [here](https://github.com/thephpleague/oauth2-server/blob/master/src/CryptKey.php#L93)).

Under Windows, it all works, but reading back the configured permissions always return 0666, so [this check](https://github.com/thephpleague/oauth2-server/blob/master/src/CryptKey.php#L58) always fail.

The solution is to create the `CryptKey` instance on our own, skipping the permission check if we're on Windows (`$keyPermissionsCheck = DIRECTORY_SEPARATOR !== '\\'`).