### PR TITLE
Allow the AuthorFormatter class to be overriden

### DIFF
--- a/concrete/src/Conversation/Message/Author.php
+++ b/concrete/src/Conversation/Message/Author.php
@@ -85,8 +85,6 @@ class Author
      */
     public function getFormatter()
     {
-        $formatter = new AuthorFormatter($this);
-
-        return $formatter;
+        return \Core::make(AuthorFormatter::class, [$this]);
     }
 }


### PR DESCRIPTION
this allows something such as the following to work in app.php

Core::bind(\Concrete\Core\Conversation\Message\AuthorFormatter::class, function($app, $params) {
    return new \Application\MySite\Conversation\Message\AuthorFormatter($params[0]);
});

the use-case in this circumstance was to allow a custom User attribute to be used as the display name for members who have posted on the site

addresses #8231 