### PR TITLE
Fix failing orm:validate-schema check. Invalid orm schema in Oauth2\Scope

### DIFF
--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -26,16 +26,6 @@ class Scope implements ScopeEntityInterface
     protected $description = '';
 
     /**
-     * @ORM\ManyToMany(targetEntity="AuthCode", mappedBy="scopes")
-     */
-    protected $codes;
-
-    /**
-     * @ORM\ManyToMany(targetEntity="AccessToken", mappedBy="scopes")
-     */
-    protected $tokens;
-
-    /**
      * {@inheritdoc}
      *
      * @see \League\OAuth2\Server\Entities\ScopeEntityInterface::getIdentifier()


### PR DESCRIPTION
Fixes invalid orm schema check.

> ./concrete/bin/concrete5 -- 'orm:validate-schema'
[Mapping]  FAIL - The entity-class 'Concrete\Core\Entity\OAuth\Scope' mapping is invalid:
* The association Concrete\Core\Entity\OAuth\Scope#codes refers to the owning side field Concrete\Core\Entity\OAuth\AuthCode#scopes which is not defined as association, but as field.
* The association Concrete\Core\Entity\OAuth\Scope#codes refers to the owning side field Concrete\Core\Entity\OAuth\AuthCode#scopes which does not exist.
* The association Concrete\Core\Entity\OAuth\Scope#tokens refers to the owning side field Concrete\Core\Entity\OAuth\AccessToken#scopes which is not defined as association, but as field.
* The association Concrete\Core\Entity\OAuth\Scope#tokens refers to the owning side field Concrete\Core\Entity\OAuth\AccessToken#scopes which does not exist.

The Scope entity had invalid ManyToMany references to OAuth\AccessToken and OAuth\AuthCode entities. Since the references were not valid, doctrine has not generated any database column. So there should be no need for generating a migration. (See the image)

![oauth_scopes](https://user-images.githubusercontent.com/995643/68287497-1ae2ac00-0083-11ea-8c59-8cb3678a5c65.png)
