### PR TITLE
add possibility to execute concrete5 cli with shorter composer command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     ],
     "post-create-project-cmd": [
       "composer config --unset platform.php"
-    ]
+    ],
+    "ccm": "./concrete/bin/concrete5 --"
   }
 }


### PR DESCRIPTION
Old command: `./concrete5/bin/concrete5 list`
New possibility: `composer ccm list` or `composer ccm c5:info`

I think `ccm` for the shortening of './concrete/bin/concrete5' is better than something like "c5". Otherwise, the command would look like this, which looks odd.

`composer c5 c5:info`