### PR TITLE
Improve Connection::isCollationSupportedForKeys()

### DIFF
--- a/concrete/src/Database/Connection/Connection.php
+++ b/concrete/src/Database/Connection/Connection.php
@@ -531,8 +531,14 @@ class Connection extends \Doctrine\DBAL\Connection
             return false;
         }
         try {
-            $sm->dropTable($tableName);
+            $this->insert($tableName, [$column->getName() => str_repeat('a', (int) $fieldLength)]);
         } catch (Exception $x) {
+            return false;
+        } finally {
+            try {
+                $sm->dropTable($tableName);
+            } catch (Exception $x) {
+            }
         }
 
         return true;


### PR DESCRIPTION
It [has been reported](https://concrete5.slack.com/archives/CDJ4G93C3/p1573130889307700) that the function returns TRUE even if the DB
doesn't actually support keys in the specified length.

This change may hopefully fix this issue.