### PR TITLE
Make it enable to customize file menu

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1881,7 +1881,7 @@ class Version implements ObjectInterface
         $r->fileName = $this->getFileName();
         $r->resultsThumbnailImg = $this->getListingThumbnailImage();
         $r->fID = $this->getFileID();
-        $r->treeNodeMenu = new Menu($this->getfile());
+        $r->treeNodeMenu = app(Menu::class, [$this->getfile()]);
 
         return $r;
     }

--- a/concrete/src/Tree/Node/Type/File.php
+++ b/concrete/src/Tree/Node/Type/File.php
@@ -41,7 +41,7 @@ class File extends TreeNode
     {
         $file = $this->getTreeNodeFileObject();
         if (is_object($file)) {
-            return new Menu($file);
+            return app(Menu::class, [$file]);
         }
     }
 


### PR DESCRIPTION
Let's make it enable to customize the file menu from application or custom packages!

After this pull request is merged, we can add a custom menu item like this:

```php
$app->bind(\Concrete\Core\File\Menu::class, function ($app, $params) {
    $menu = new \Concrete\Core\File\Menu($params[0]);
    $menu->addItem(new \Concrete\Core\Application\UserInterface\ContextMenu\Item\LinkItem('#', 'Rescan', [
        'data-file-manager-action' => 'rescan',
        'data-file-id' => $params[0]->getFileID(),
    ]));

    return $menu;
});
```