### PR TITLE
[Bugfix] The folder name is null when you create it with name '0'

### DIFF
--- a/concrete/controllers/dialog/tree/node/category/add.php
+++ b/concrete/controllers/dialog/tree/node/category/add.php
@@ -16,6 +16,7 @@ class Add extends Node
     {
         $node = $this->getNode();
         $np = new \Permissions($node);
+
         return $np->canAddCategoryTreeNode();
     }
 
@@ -33,6 +34,7 @@ class Add extends Node
         if ($category instanceof ExpressEntryCategory) {
             return ExpressEntryCategory::class;
         }
+
         return Category::class;
     }
 
@@ -70,6 +72,7 @@ class Add extends Node
             }
             $category = $class::add($title, $parent);
             $r = $category->getTreeNodeJSON();
+
             return new JsonResponse($r);
         } else {
             return new JsonResponse($error);

--- a/concrete/controllers/dialog/tree/node/category/add.php
+++ b/concrete/controllers/dialog/tree/node/category/add.php
@@ -2,6 +2,7 @@
 namespace Concrete\Controller\Dialog\Tree\Node\Category;
 
 use Concrete\Controller\Dialog\Tree\Node;
+use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Tree\Node\NodeType;
 use Concrete\Core\Tree\Node\Type\Category;
 use Concrete\Core\Tree\Node\Type\ExpressEntryCategory;
@@ -37,15 +38,17 @@ class Add extends Node
 
     public function add_category_node()
     {
-        $token = \Core::make('token');
-        $error = \Core::make('error');
+        $app = Facade::getFacadeApplication();
+        $token = $app->make('token');
+        $error = $app->make('error');
+        $vsh = $app->make('helper/validation/strings');
         $parent = $this->getNode();
         if (!$token->validate('add_category_node')) {
             $error->add($token->getErrorMessage());
         }
 
         $title = $_POST['treeNodeCategoryName'];
-        if (!$title) {
+        if (!$vsh->notempty($title)) {
             $error->add(t('Invalid title for category'));
         }
 

--- a/concrete/controllers/dialog/tree/node/category/edit.php
+++ b/concrete/controllers/dialog/tree/node/category/edit.php
@@ -2,6 +2,7 @@
 namespace Concrete\Controller\Dialog\Tree\Node\Category;
 
 use Concrete\Controller\Dialog\Tree\Node;
+use Concrete\Core\Support\Facade\Facade;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Edit extends Node
@@ -23,15 +24,17 @@ class Edit extends Node
 
     public function update_category_node()
     {
-        $token = \Core::make('token');
-        $error = \Core::make('error');
+        $app = Facade::getFacadeApplication();
+        $token = $app->make('token');
+        $error = $app->make('error');
+        $vsh = $app->make('helper/validation/strings');
         $node = $this->getNode();
         if (!$token->validate('update_category_node')) {
             $error->add($token->getErrorMessage());
         }
 
         $title = $_POST['treeNodeCategoryName'];
-        if (!$title) {
+        if (!$vsh->notempty($title)) {
             $error->add(t('Invalid title for category'));
         }
 

--- a/concrete/controllers/dialog/tree/node/category/edit.php
+++ b/concrete/controllers/dialog/tree/node/category/edit.php
@@ -13,6 +13,7 @@ class Edit extends Node
     {
         $node = $this->getNode();
         $np = new \Permissions($node);
+
         return $np->canEditTreeNode();
     }
 
@@ -41,6 +42,7 @@ class Edit extends Node
         if (!$error->has()) {
             $node->setTreeNodeName($title);
             $r = $node->getTreeNodeJSON();
+
             return new JsonResponse($r);
         } else {
             return new JsonResponse($error);

--- a/concrete/src/Tree/Node/Type/Category.php
+++ b/concrete/src/Tree/Node/Type/Category.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Tree\Node\Type;
 
+use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Tree\Node\Node as TreeNode;
 use Concrete\Core\Tree\Node\Type\Formatter\CategoryListFormatter;
 use Concrete\Core\Tree\Node\Type\Menu\CategoryMenu;
@@ -40,7 +41,9 @@ class Category extends TreeNode
 
     public function getTreeNodeDisplayName($format = 'html')
     {
-        if ($this->getTreeNodeName()) {
+        $app = Facade::getFacadeApplication();
+        $vsh = $app->make('helper/validation/strings');
+        if ($vsh->notempty($this->getTreeNodeName())) {
             $name = tc($this->getTreeNodeTranslationContext(), $this->getTreeNodeName());
             switch ($format) {
                 case 'html':

--- a/concrete/src/Tree/Node/Type/Category.php
+++ b/concrete/src/Tree/Node/Type/Category.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Core\Tree\Node\Type;
 
 use Concrete\Core\Support\Facade\Facade;


### PR DESCRIPTION
### Summary-
This PR contains the following-
- [Fix] The folder name is null when you create it with name '0'
- Allow add/edit tree node category/folder name to '0'

### Detail-
Now it doesn't show up the folder name if you save it with `0`.
I was wondering should we allow to add the folders with the name `0` or not. 

But as (@hissy suggested) we're allowing the page names with `0`, we should allow the folder name as well. 
https://github.com/concrete5/concrete5/pull/3856