### PR TITLE
Introduce show password icon for pass flds

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -132,6 +132,7 @@ module.exports = function(grunt) {
                 '<%= DIR_BASE %>/concrete/js/build/core/app/help/guides/dashboard.js',
                 '<%= DIR_BASE %>/concrete/js/build/core/app/help/guides/location-panel.js',
                 '<%= DIR_BASE %>/concrete/js/build/core/app/heartbeat.js',
+                '<%= DIR_BASE %>/concrete/js/build/core/app/show-password.js',
                 // Edit Mode
                 '<%= DIR_BASE %>/concrete/js/build/core/app/edit-mode/editmode.js',
                 '<%= DIR_BASE %>/concrete/js/build/core/app/edit-mode/block.js',

--- a/concrete/css/build/core/app/dialog.less
+++ b/concrete/css/build/core/app/dialog.less
@@ -139,6 +139,10 @@ div.ui-dialog {
       padding-right: 26px;
       margin-left: -26px;
       margin-right: -26px;
+
+      .show-password {
+        right: 26px;
+      }
     }
 
     div.well {

--- a/concrete/css/build/core/app/forms.less
+++ b/concrete/css/build/core/app/forms.less
@@ -43,5 +43,15 @@
     color: #888;
   }
 
-
+  // Show Password icon
+  .show-password {
+    pointer-events: auto;
+    cursor: pointer;
+  }
+  div.ui-dialog .ui-dialog-content div.form-group {
+    .show-password {
+      right: 26px;
+    }
+  }
+   
 }

--- a/concrete/js/build/core/app/show-password.js
+++ b/concrete/js/build/core/app/show-password.js
@@ -1,0 +1,9 @@
+/* Toggle Password Visibility */
+;(function(global, $) {
+    "use strict";
+    $('.show-password').on('click', function() {
+        $(this).toggleClass('fa-eye-slash').siblings('input').focus().attr('type', function(index, attrVal){
+            return attrVal == 'password' ? 'text' : 'password';
+        });
+    });        
+})(this, jQuery);

--- a/concrete/single_pages/dashboard/users/add.php
+++ b/concrete/single_pages/dashboard/users/add.php
@@ -14,12 +14,10 @@ $ih = Loader::helper('concrete/ui');
 			</div>
 		</div>
 
-		<div class="form-group">
+		<div class="form-group has-feedback">
 			<label for="uPassword" class="control-label"><?php echo t('Password'); ?></label>
-			<div class="input-group">
-				<?php echo $form->password('uPassword', array('autocomplete' => 'off')); ?>
-				<span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
-			</div>
+			<?php echo $form->password('uPassword', array('autocomplete' => 'off')); ?>
+			<span class="fa fa-eye form-control-feedback show-password"></span
 		</div>
 
 		<div class="form-group">

--- a/concrete/single_pages/dashboard/users/add.php
+++ b/concrete/single_pages/dashboard/users/add.php
@@ -17,7 +17,7 @@ $ih = Loader::helper('concrete/ui');
 		<div class="form-group has-feedback">
 			<label for="uPassword" class="control-label"><?php echo t('Password'); ?></label>
 			<?php echo $form->password('uPassword', array('autocomplete' => 'off')); ?>
-			<span class="fa fa-eye form-control-feedback show-password"></span
+			<span class="fa fa-eye form-control-feedback show-password"></span>
 		</div>
 
 		<div class="form-group">

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -238,14 +238,16 @@ if (isset($user) && is_object($user)) {
                 <form data-dialog-form="change-password" action="<?= $view->action('change_password', $user->getUserID()) ?>">
                     <?= $token->output('change_password') ?>
 
-                    <div class="form-group">
+                    <div class="form-group has-feedback">
                         <?= $form->label('uPassword', t('Password')) ?>
                         <?= $form->password('uPassword', ['autocomplete' => 'off']) ?>
+                        <span class="fa fa-eye form-control-feedback show-password"></span>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group has-feedback">
                         <?= $form->label('uPasswordConfirm', t('Confirm Password')) ?>
                         <?= $form->password('uPasswordConfirm', ['autocomplete' => 'off']) ?>
+                        <span class="fa fa-eye form-control-feedback show-password"></span>
                     </div>
 
                     <div class="dialog-buttons">

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -416,17 +416,17 @@ switch ($installStep) {
                                             </div>
                                         </div>
                                         <div class="col-md-6">
-                                            <div class="form-group">
-                                                <label for="uPassword"
-                                                       class="control-label"><?= t('Administrator Password') ?></label>
+                                            <div class="form-group has-feedback">
+                                                <label for="uPassword" class="control-label"><?= t('Administrator Password') ?></label>
                                                 <?= $form->password('uPassword', $passwordAttributes) ?>
+                                                <span class="fa fa-eye form-control-feedback show-password"></span>
                                             </div>
                                         </div>
                                         <div class="col-md-6">
-                                            <div class="form-group">
-                                                <label for="uPassword"
-                                                       class="control-label"><?= t('Confirm Password') ?></label>
+                                            <div class="form-group has-feedback">
+                                                <label for="uPassword" class="control-label"><?= t('Confirm Password') ?></label>
                                                 <?= $form->password('uPasswordConfirm', $passwordAttributes) ?>
+                                                <span class="fa fa-eye form-control-feedback show-password"></span>
                                             </div>
                                         </div>
                                     </div>
@@ -483,10 +483,11 @@ switch ($installStep) {
                                             </div>
                                         </div>
                                         <div class="col-md-6">
-                                            <div class="form-group">
+                                            <div class="form-group has-feedback">
                                                 <label class="control-label"
                                                        for="DB_PASSWORD"><?= t('MySQL Password') ?></label>
                                                 <?= $form->password('DB_PASSWORD', ['autocomplete' => 'off']) ?>
+                                                <span class="fa fa-eye form-control-feedback show-password"></span>
                                             </div>
                                         </div>
                                         <div class="col-md-6">


### PR DESCRIPTION
The `grunt` command should be executed to regenerate `app.js` & `app.css`.

![show-password-presentation](https://user-images.githubusercontent.com/7886999/68927971-3e51d900-079e-11ea-9640-f85eab637f4e.gif)
