### PR TITLE
Edit page aliases

### DIFF
--- a/build/foundation/js/cms/sitemap/search.js
+++ b/build/foundation/js/cms/sitemap/search.js
@@ -3,6 +3,10 @@ var DIALOGS = {
     externalLink: {
         width: 350,
         height: 270
+    },
+    alias: {
+        width: 350,
+        height: 270
     }
 };
 
@@ -148,6 +152,9 @@ var ConcretePageAjaxSearchMenu = {
                             '<li><a data-action="delete-forever" href="javascript:void(0)">' + ccmi18n_sitemap.deletePageForever + '</a></li>',
                         '<% } else if (item.cAlias == \'LINK\' || item.cAlias == \'POINTER\') { %>',
                             '<li><a href="<%- item.link %>">' + ccmi18n_sitemap.visitExternalLink + '</a></li>',
+                            '<% if (item.cAlias == \'POINTER\' && item.canEditPageProperties) { %>',
+                                '<li><a class="dialog-launch" dialog-width="' + DIALOGS.alias.width + '" dialog-height="' + DIALOGS.alias.height + '" dialog-title="' + ccmi18n_sitemap.editAlias + '" dialog-modal="false" dialog-append-buttons="true" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/edit_alias?cID=<%=item.cID%>">' + ccmi18n_sitemap.editAlias + '</a></li>',
+                            '<% } %>',
                             '<% if (item.cAlias == \'LINK\' && item.canEditPageProperties) { %>',
                                 '<li><a class="dialog-launch" dialog-width="' + DIALOGS.externalLink.width + '" dialog-height="' + DIALOGS.externalLink.height + '" dialog-title="' + ccmi18n_sitemap.editExternalLink + '" dialog-modal="false" dialog-append-buttons="true" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/edit_external?cID=<%=item.cID%>">' + ccmi18n_sitemap.editExternalLink + '</a></li>',
                                 '<li><a class="dialog-launch" dialog-on-close="ConcreteSitemap.exitEditMode(<%=item.cID%>)" dialog-width="90%" dialog-height="70%" dialog-modal="false" dialog-title="' + ccmi18n_sitemap.pageAttributesTitle + '" href="' + CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/attributes?cID=<%=item.cID%>">' + ccmi18n_sitemap.pageAttributes + '</a></li>',

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,8 +8,8 @@ return [
      */
     'version' => '9.0.0a1',
     'version_installed' => '9.0.0a1',
-    'version_db' => '20191029175713', // the key of the latest database migration
- 
+    'version_db' => '20200116115000', // the key of the latest database migration
+
     /*
      * Installation status
      *

--- a/concrete/controllers/dialog/page/edit_alias.php
+++ b/concrete/controllers/dialog/page/edit_alias.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Concrete\Controller\Dialog\Page;
+
+use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\EditResponse;
+
+class EditAlias extends BackendInterfacePageController
+{
+    protected $viewPath = '/dialogs/page/edit_alias';
+
+    public function view()
+    {
+        $this->set('form', $this->app->make('helper/form'));
+        $this->set('customAliasName', $this->page->getCustomAliasName());
+        $this->set('aliasHandle', $this->page->getAliasHandle());
+    }
+
+    public function submit()
+    {
+        if ($this->validateAction()) {
+            $data = [];
+            $customAliasName = $this->request->request->get('customAliasName');
+            if (is_string($customAliasName)) {
+                $data['customAliasName'] = trim($customAliasName);
+            }
+            $aliasHandle = $this->request->request->get('aliasHandle');
+            if (is_string($aliasHandle) && ($aliasHandle = trim($aliasHandle)) !== '') {
+                $data['aliasHandle'] = $aliasHandle;
+            }
+            $this->page->updateCollectionAlias($data);
+            $pr = new EditResponse();
+            $pr->setMessage(t('Alias updated.'));
+            $pr->setPage($this->page);
+
+            return $this->app->make(ResponseFactoryInterface::class)->json($pr);
+        }
+    }
+
+    protected function canAccess()
+    {
+        return $this->permissions->canEditPageProperties() && $this->page->isAliasPage();
+    }
+}

--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -143,6 +143,7 @@ var ccmi18n_sitemap = ' . json_encode([
                 'pageLocationTitle' => t('Location'),
                 'visitExternalLink' => t('Visit'),
                 'editExternalLink' => t('Edit External Link'),
+                'editAlias' => t('Edit Alias'),
                 'deleteExternalLink' => t('Delete'),
                 'copyProgressTitle' => t('Copy Progress'),
                 'addExternalLink' => t('Add External Link'),

--- a/concrete/routes/dialogs/pages.php
+++ b/concrete/routes/dialogs/pages.php
@@ -32,6 +32,8 @@ $router->all('/design/css', 'Design\Css::view');
 $router->all('/design/css/get', 'Design\Css::getCss');
 $router->all('/design/css/set', 'Design\Css::setCss');
 $router->all('/design/css/submit', 'Design\Css::submit');
+$router->all('/edit_alias', 'EditAlias::view');
+$router->all('/edit_alias/submit', 'EditAlias::submit');
 $router->all('/edit_external', 'EditExternal::view');
 $router->all('/edit_external/submit', 'EditExternal::submit');
 $router->all('/location', 'Location::view');

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -54,6 +54,7 @@ use PageType;
 use Queue;
 use Request;
 use Session;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use UserInfo;
 
 /**
@@ -144,6 +145,20 @@ class Page extends Collection implements CategoryMemberInterface,
      * @var int|null
      */
     protected $siteTreeID;
+
+    /**
+     * The custom name of the alias page.
+     *
+     * @var string|null NULL if the page is not an alias, empty string if we should use the name of the aliased page, the custom alias name otherwise.
+     */
+    private $customAliasName;
+
+    /**
+     * The handle of the alias page
+     *
+     * @var string|null NULL if the page is not an alias, the alias handle otherwise.
+     */
+    private $aliasHandle;
 
     /**
      * Whether this page has a custom summary template collection assigned to it. If null/false,
@@ -910,7 +925,7 @@ class Page extends Collection implements CategoryMemberInterface,
 
         $data = [
             'handle' => $handle,
-            'name' => $this->getCollectionName(),
+            'name' => '',
         ];
         $cobj = parent::addCollection($data);
         $newCID = $cobj->getCollectionID();
@@ -930,6 +945,61 @@ class Page extends Collection implements CategoryMemberInterface,
         $pe = new Event(\Page::getByID($newCID));
         Events::dispatch('on_page_alias_add', $pe);
         return $newCID;
+    }
+
+    /**
+     * Update the alias details.
+     *
+     * @param array $data Supported keys:
+     * <ul>
+     *     <li>string <code>customAliasName</code> empty string to use the name of the aliased page</li>
+     *     <li>string <code>aliasHandle</code> the URL slug of the alias</li>
+     * </ul>
+     */
+    public function updateCollectionAlias(array $data)
+    {
+        if (!$this->isAliasPage()) {
+            return;
+        }
+        $app = Application::getFacadeApplication();
+        $data += [
+            'customAliasName' => null,
+            'aliasHandle' => '',
+        ];
+        $cSet = [];
+        $cvSet = [];
+        if ((string) $data['aliasHandle'] !== '') {
+            $cSet['cHandle'] = $data['aliasHandle'];
+            $cvSet['cvHandle'] = $data['aliasHandle'];
+        }
+        if ($data['customAliasName'] !== null) {
+            $cvSet['cvName'] = $data['customAliasName'];
+        }
+        $db = $app->make(Connection::class);
+        if ($cSet !== []) {
+            $db->update(
+                'Collections',
+                $cSet,
+                ['cID' => $this->getCollectionPointerOriginalID()]
+            );
+        }
+        if ($cvSet !== []) {
+            $db->update(
+                'CollectionVersions',
+                $cvSet,
+                ['cID' => $this->getCollectionPointerOriginalID()]
+            );
+        }
+        if ($data['customAliasName'] !== null) {
+            $this->customAliasName = $data['customAliasName'];
+        }
+        if ((string) $data['aliasHandle'] !== '') {
+            $this->aliasHandle = $data['aliasHandle'];
+            $this->rescanCollectionPath();
+        }
+        $pe = new Event($this);
+        $eventDispatcher = $app->make(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch('on_page_alias_edit', $pe);
     }
 
     /**
@@ -1623,11 +1693,36 @@ class Page extends Collection implements CategoryMemberInterface,
      */
     public function getCollectionName()
     {
+        $customAliasName = (string) $this->getCustomAliasName();
+        if ($customAliasName !== '') {
+            return $customAliasName;
+        }
+
         if (isset($this->vObj)) {
             return isset($this->vObj->cvName) ? $this->vObj->cvName : null;
         }
 
         return isset($this->cvName) ? $this->cvName : null;
+    }
+
+    /**
+     * Get the custom name of the alias page.
+     *
+     * @return string|null NULL if the page is not an alias, empty string if we should use the name of the aliased page, the custom alias name otherwise.
+     */
+    public function getCustomAliasName()
+    {
+        return $this->customAliasName;
+    }
+
+    /**
+     * Get the handle of the alias page
+     *
+     * @return string|null NULL if the page is not an alias, the alias handle otherwise
+     */
+    public function getAliasHandle()
+    {
+        return $this->aliasHandle;
     }
 
     /**
@@ -3794,18 +3889,22 @@ EOT
     {
         $db = Database::connection();
 
-        $q0 = 'select Pages.cID, Pages.pkgID, Pages.siteTreeID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsDraft, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Pages.ptID, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ';
-        //$q2 = "select cParentID, cPointerID, cPath, Pages.cID from Pages left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
+        $fields = 'Pages.cID, Pages.pkgID, Pages.siteTreeID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsDraft, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Pages.ptID, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom, Collections.cHandle';
+        $from = 'Pages INNER JOIN Collections ON Pages.cID = Collections.cID LEFT JOIN PagePaths ON (Pages.cID = PagePaths.cID AND PagePaths.ppIsCanonical = 1)';
 
-        $row = $db->fetchAssoc($q0 . $where, [$cInfo]);
+        $row = $db->fetchAssoc("SELECT {$fields} FROM {$from} {$where}", [$cInfo]);
         if ($row !== false && $row['cPointerID'] > 0) {
             $originalRow = $row;
-            $row = $db->fetchAssoc($q0 . 'where Pages.cID = ?', [$row['cPointerID']]);
+            $row = $db->fetchAssoc("SELECT {$fields}, CollectionVersions.cvName FROM {$from} LEFT JOIN CollectionVersions ON CollectionVersions.cID = ? WHERE Pages.cID = ? LIMIT 1", [$row['cID'], $row['cPointerID']]);
         } else {
             $originalRow = null;
         }
 
         if ($row !== false) {
+            if ($originalRow !== null) {
+                $this->customAliasName = (string) $row['cvName'];
+                unset($row['cvName']);
+            }
             foreach ($row as $key => $value) {
                 $this->{$key} = $value;
             }
@@ -3817,6 +3916,7 @@ EOT
                 $this->cPath = $originalRow['cPath'];
                 $this->cParentID = $originalRow['cParentID'];
                 $this->cDisplayOrder = $originalRow['cDisplayOrder'];
+                $this->aliasHandle = (string) $originalRow['cHandle'];
             }
             $this->isMasterCollection = $row['cIsTemplate'];
             $this->loadError(false);
@@ -3901,7 +4001,9 @@ EOT
         $cID = ($this->getCollectionPointerOriginalID() > 0) ? $this->getCollectionPointerOriginalID() : $this->cID;
         /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
         $stringValidator = Core::make('helper/validation/strings');
-        if ($stringValidator->notempty($this->getCollectionHandle())) {
+        if ($stringValidator->notempty($this->getAliasHandle())) {
+            $path .= $this->getAliasHandle();
+        } elseif ($stringValidator->notempty($this->getCollectionHandle())) {
             $path .= $this->getCollectionHandle();
         } elseif (!$this->isHomePage()) {
             $path .= $cID;

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -956,7 +956,7 @@ class Page extends Collection implements CategoryMemberInterface,
      *     <li>string <code>aliasHandle</code> the URL slug of the alias</li>
      * </ul>
      */
-    public function updateCollectionAlias(array $data)
+    public function updateCollectionAlias(array $data): void
     {
         if (!$this->isAliasPage()) {
             return;
@@ -1710,7 +1710,7 @@ class Page extends Collection implements CategoryMemberInterface,
      *
      * @return string|null NULL if the page is not an alias, empty string if we should use the name of the aliased page, the custom alias name otherwise.
      */
-    public function getCustomAliasName()
+    public function getCustomAliasName(): ?string
     {
         return $this->customAliasName;
     }
@@ -1720,7 +1720,7 @@ class Page extends Collection implements CategoryMemberInterface,
      *
      * @return string|null NULL if the page is not an alias, the alias handle otherwise
      */
-    public function getAliasHandle()
+    public function getAliasHandle(): ?string
     {
         return $this->aliasHandle;
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20200116115000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200116115000.php
@@ -28,7 +28,7 @@ class Version20200116115000 extends AbstractMigration implements RepeatableMigra
      *
      * @return bool
      */
-    private function shouldUpdateCollectionVersions()
+    private function shouldUpdateCollectionVersions(): bool
     {
         $config = $this->app->make('config');
         $lastPerformedMigrationID = (string) $config->get('concrete.version_db_installed');
@@ -44,7 +44,7 @@ class Version20200116115000 extends AbstractMigration implements RepeatableMigra
      * Clear the cvName field of the CollectionVersions table for aliases,
      * so that concrete5 knows that users want the current name of the aliased page.
      */
-    private function updateCollectionVersions()
+    private function updateCollectionVersions(): void
     {
         $this->connection->executeUpdate(
             <<<'EOT'

--- a/concrete/src/Updater/Migrations/Migrations/Version20200116115000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200116115000.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20200116115000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        if ($this->shouldUpdateCollectionVersions()) {
+            $this->updateCollectionVersions();
+        }
+    }
+
+    /**
+     * Should we update the CollectionVersions database table?
+     *
+     * This is needed if we are re-executing this migration.
+     *
+     * @return bool
+     */
+    private function shouldUpdateCollectionVersions()
+    {
+        $config = $this->app->make('config');
+        $lastPerformedMigrationID = (string) $config->get('concrete.version_db_installed');
+        if ($lastPerformedMigrationID === '') {
+            return true;
+        }
+        $thisMigrationID = preg_replace('/.*Version(\d+)$/', '${1}', __CLASS__);
+
+        return $thisMigrationID > $lastPerformedMigrationID;
+    }
+
+    /**
+     * Clear the cvName field of the CollectionVersions table for aliases,
+     * so that concrete5 knows that users want the current name of the aliased page.
+     */
+    private function updateCollectionVersions()
+    {
+        $this->connection->executeUpdate(
+            <<<'EOT'
+UPDATE
+    CollectionVersions
+    INNER JOIN Pages ON CollectionVersions.cID = Pages.cID
+SET
+    CollectionVersions.cvName = ''
+WHERE
+    Pages.cPointerID IS NOT NULL
+    AND Pages.cPointerID <> 0
+EOT
+            );
+    }
+}

--- a/concrete/views/dialogs/page/edit_alias.php
+++ b/concrete/views/dialogs/page/edit_alias.php
@@ -1,0 +1,39 @@
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Controller\Dialog\Page\EditAlias $controller
+ * @var Concrete\Core\View\DialogView $view
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var string $customAliasName
+ * @var string $aliasHandle
+ **/
+
+?>
+<div class="ccm-ui">
+    <form class="form-stacked" data-dialog-form="edit-alias" method="post" action="<?= $controller->action('submit') ?>">
+        <div class="form-group">
+            <?= $form->label('customAliasName', t('Name')) ?>
+            <?= $form->text('customAliasName', $customAliasName, ['autofocus' => 'autofocus', 'placeholder' => t('Empty: use name of aliased page')]) ?>
+        </div>
+        <div class="form-group">
+            <?= $form->label('aliasHandle', t('URL Slug'), ['class' => 'launch-tooltip', 'title' => t('This page must always be available from at least one URL. This is that URL.')]) ?>
+            <?= $form->text('aliasHandle', $aliasHandle, ['required' => 'required', 'maxlength' => 255]) ?>
+        </div>
+        <div class="dialog-buttons">
+            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+            <button type="button" data-dialog-action="submit" class="btn btn-primary pull-right"><?= t('Save') ?></button>
+        </div>
+    </form>
+</div>
+
+<script>
+$(document).ready(function() {
+    ConcreteEvent.unsubscribe('AjaxFormSubmitSuccess.ccmSitemapAliasSaved');
+    ConcreteEvent.subscribe('AjaxFormSubmitSuccess.ccmSitemapAliasSaved', function(e, data) {
+        if (data.form === 'edit-alias') {
+            ConcreteEvent.publish('SitemapUpdatePageRequestComplete', {'cID': data.response.cID});
+        }
+    });
+});
+</script>


### PR DESCRIPTION
When we create page aliases, it's not possible to change neither their name nor their URL slug.
(It's maybe the first issue I submitted to @aembler something like 9/10 years ago, IIRC via an email message - and he agreed it's something that should be fixed).

With this PR, users will be (finally :wink:) able to edit page aliases:

![edit-aliases](https://user-images.githubusercontent.com/928116/69161440-741ef680-0aeb-11ea-8b75-e0ff7c1abe6d.gif)
