### PR TITLE
Fix block edit Access Denied issue #8261

### DIFF
--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -47,12 +47,13 @@ class Edit extends BackendInterfaceBlockController
     public function submit()
     {
         if ($this->validateAction() && $this->canAccess()) {
+            $app = Application::getFacadeApplication();
+
             // validate the request
             $e = $this->validateBlock($this->block);
             if ($e instanceof ErrorList && $e->has()) {
                 $formatter = new JsonFormatter($e);
                 $response = $formatter->asArray();
-                $app = Application::getFacadeApplication();
                 return $app->make(ResponseFactoryInterface::class)->create(json_encode($response));
             }
 
@@ -62,7 +63,7 @@ class Edit extends BackendInterfaceBlockController
             $b->update($_POST);
             $event = new BlockEdit($b, $this->page);
             Events::dispatch('on_block_edit', $event);
-            $pr->outputJSON();
+            return $app->make(ResponseFactoryInterface::class)->json($pr);
         }
     }
 

--- a/concrete/controllers/dialog/block/edit.php
+++ b/concrete/controllers/dialog/block/edit.php
@@ -47,27 +47,22 @@ class Edit extends BackendInterfaceBlockController
     public function submit()
     {
         if ($this->validateAction() && $this->canAccess()) {
-            $app = Application::getFacadeApplication();
-            $b = $this->getBlockToEdit();
-            $e = $this->validateBlock($b);
-            $pr = $this->getEditResponse($b, $e);
-
-            if (!is_object($e) || ($e instanceof ErrorList && !$e->has())) {
-                // we can update the block that we're submitting
-                $b->update($_POST);
-                $event = new BlockEdit($b, $this->page);
-                Events::dispatch('on_block_edit', $event);
-            }
-
-            // the block has a new id at this point, we have to pass it to the view
+            // validate the request
+            $e = $this->validateBlock($this->block);
             if ($e instanceof ErrorList && $e->has()) {
                 $formatter = new JsonFormatter($e);
                 $response = $formatter->asArray();
-                $response['newbID'] = intval($b->getBlockID());
+                $app = Application::getFacadeApplication();
                 return $app->make(ResponseFactoryInterface::class)->create(json_encode($response));
             }
 
-            return $app->make(ResponseFactoryInterface::class)->json($pr);
+            // create a new version of the block
+            $b = $this->getBlockToEdit();
+            $pr = $this->getEditResponse($b);
+            $b->update($_POST);
+            $event = new BlockEdit($b, $this->page);
+            Events::dispatch('on_block_edit', $event);
+            $pr->outputJSON();
         }
     }
 


### PR DESCRIPTION
Potential fix for https://github.com/concrete5/concrete5/issues/8261, essentially I've moved `$b = $this->getBlockToEdit();` to after the block passes validation, as that function creates a new version of the block, and I can't think of a reason why we would want a new version until we've successfully validated and can save the block. If I'm wrong please let me know. 😃 