### PR TITLE
Add Page::getCollectionDisplayName()

### DIFF
--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -38,7 +38,7 @@ class Controller extends AttributeTypeController
         $cID = $this->getAttributeValue()->getValue();
         $page = Page::getByID($cID, 'ACTIVE');
         if (is_object($page) && !$page->isError()) {
-            return t('<a href="%s">%s</a>', $page->getCollectionLink(), $page->getCollectionName());
+            return t('<a href="%s">%s</a>', $page->getCollectionLink(), $page->getCollectionDisplayName());
         }
     }
 

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -446,7 +446,7 @@ class Controller extends BlockController
                     $tc1 = Page::getByID($cParentID, "ACTIVE");
                 }
                 $niRow = array();
-                $niRow['cvName'] = $tc1->getCollectionName();
+                $niRow['cvName'] = $tc1->getCollectionDisplayName();
                 $niRow['cID'] = $cParentID;
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
                 $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc1);
@@ -461,7 +461,7 @@ class Controller extends BlockController
 
             if ($displayHeadPage) {
                 $niRow = array();
-                $niRow['cvName'] = $tc1->getCollectionName();
+                $niRow['cvName'] = $tc1->getCollectionDisplayName();
                 $niRow['cID'] = $row['cID'];
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
                 $niRow['cPath'] = $tc1->getCollectionPath();
@@ -588,7 +588,7 @@ class Controller extends BlockController
 
                     if ($displayPage) {
                         $niRow = array();
-                        $niRow['cvName'] = $tc->getCollectionName();
+                        $niRow['cvName'] = $tc->getCollectionDisplayName();
                         $niRow['cID'] = $row['cID'];
                         $niRow['cvDescription'] = $tc->getCollectionDescription();
                         $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc);
@@ -603,7 +603,7 @@ class Controller extends BlockController
                         $sorted_array[$niRow['cID']] = $ni;
 
                         $_c = $ni->getCollectionObject();
-                        $object_name = $_c->getCollectionName();
+                        $object_name = $_c->getCollectionDisplayName();
                         $navObjectNames[$niRow['cID']] = $object_name;
                     }
                 }

--- a/concrete/blocks/desktop_draft_list/controller.php
+++ b/concrete/blocks/desktop_draft_list/controller.php
@@ -90,7 +90,7 @@ class Controller extends BlockController
             foreach ($drafts as $draft) {
                 $dp = new Permissions($draft);
                 if ($dp->canEditPageContents()) {
-                    $draftName = $draft->getCollectionName();
+                    $draftName = $draft->getCollectionDisplayName();
                     if (empty($draftName)) {
                         $draftName = t('(Untitled)');
                     }

--- a/concrete/blocks/discussion/view.php
+++ b/concrete/blocks/discussion/view.php
@@ -57,7 +57,7 @@ if (is_object($discussion)) {
 }
     ?>
 
-		<h3><?=$c->getCollectionName()?></h3>
+		<h3><?=h($c->getCollectionDisplayName())?></h3>
 	
 		<?php if (count($topics)) {
     ?>
@@ -84,7 +84,7 @@ if (is_object($discussion)) {
 					<?=t2('<em>%s</em> Reply', '<em>%s</em> Replies', $replies)?>
 				</div>
 				<div class="ccm-discussion-topic-details">
-					<h3><a href="<?=Loader::helper('navigation')->getLinkToCollection($t)?>"><?=$t->getCollectionName()?></a></h3>
+					<h3><a href="<?=Loader::helper('navigation')->getLinkToCollection($t)?>"><?=h($t->getCollectionDisplayName())?></a></h3>
 					<p><?=t(/*i18n: %s is a date/time*/'Topic Posted on %s.', $dh->formatDateTime($t->getCollectionDatePublic(), true))?>
 					<?php if ($replies > 0) {
     ?>

--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -98,7 +98,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         if (!isset($renderer)) {
             $page = $this->block->getBlockCollectionObject();
             $this->app->make('log')
-                ->warning(t('Form block on page %s (ID: %s) could not be loaded. Its express object or express form no longer exists.', $page->getCollectionName(), $page->getCollectionID()));
+                ->warning(t('Form block on page %s (ID: %s) could not be loaded. Its express object or express form no longer exists.', $page->getCollectionDisplayName(), $page->getCollectionID()));
         }
     }
 
@@ -110,7 +110,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
     public function add()
     {
-        $this->set('formName', $this->request->getCurrentPage()->getCollectionName());
+        $this->set('formName', $this->request->getCurrentPage()->getCollectionDisplayName());
         $this->set('submitLabel', t('Submit'));
         $this->set('thankyouMsg', t('Thanks!'));
         $this->edit();

--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -77,7 +77,7 @@ class Controller extends BlockController
         $nextCollection = $this->getNextCollection();
         if (is_object($nextCollection) && !$nextCollection->isError()) {
             $nextLinkURL = $nextCollection->getCollectionLink();
-            $nextLinkText = $nextCollection->getCollectionName();
+            $nextLinkText = $nextCollection->getCollectionDisplayName();
         }
 
         $this->set('nextCollection', $nextCollection);
@@ -92,7 +92,7 @@ class Controller extends BlockController
 
         if (is_object($previousCollection) && !$previousCollection->isError()) {
             $previousLinkURL = $previousCollection->getCollectionLink();
-            $previousLinkText = $previousCollection->getCollectionName();
+            $previousLinkText = $previousCollection->getCollectionDisplayName();
         }
 
         $this->set('previousCollection', $previousCollection);

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -58,7 +58,7 @@ class Controller extends BlockController
         $content = "";
         switch ($this->attributeHandle) {
             case "rpv_pageName":
-                $content = h($c->getCollectionName());
+                $content = h($c->getCollectionDisplayName());
                 break;
             case "rpv_pageDescription":
                 $content = nl2br(h($c->getCollectionDescription()));

--- a/concrete/blocks/page_list/templates/thumbnail_grid/view.php
+++ b/concrete/blocks/page_list/templates/thumbnail_grid/view.php
@@ -14,7 +14,7 @@ $c = Page::getCurrentPage();
 
     <?php foreach ($pages as $page):
 
-        $title = $th->entities($page->getCollectionName());
+        $title = $th->entities($page->getCollectionDisplayName());
         $url = $nh->getLinkToCollection($page);
         $target = ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) ? '_blank' : $page->getAttribute('nav_target');
         $target = empty($target) ? '_self' : $target;

--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -53,7 +53,7 @@ if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
                 // Prepare data for each page being listed...
                 $buttonClasses = 'ccm-block-page-list-read-more';
                 $entryClasses = 'ccm-block-page-list-page-entry';
-                $title = $page->getCollectionName();
+                $title = $page->getCollectionDisplayName();
                 if ($page->getCollectionPointerExternalLink() != '') {
                     $url = $page->getCollectionPointerExternalLink();
                     if ($page->openCollectionPointerExternalLinkInNewWindow()) {

--- a/concrete/blocks/page_title/controller.php
+++ b/concrete/blocks/page_title/controller.php
@@ -38,7 +38,7 @@ class Controller extends BlockController
         } else {
             $p = Page::getCurrentPage();
             if ($p instanceof Page) {
-                $title = $p->getCollectionName();
+                $title = $p->getCollectionDisplayName();
                 if (!strlen($title) && $p->isMasterCollection()) {
                     $title = '[' . t('Page Title') . ']';
                 }

--- a/concrete/blocks/search/view.php
+++ b/concrete/blocks/search/view.php
@@ -41,7 +41,7 @@ if (!isset($query) || !is_string($query)) {
                 foreach ($results as $r) {
                     $currentPageBody = $this->controller->highlightedExtendedMarkup($r->getPageIndexContent(), $query);
                     ?><div class="searchResult">
-                        <h3><a href="<?=$r->getCollectionLink()?>"><?=$r->getCollectionName()?></a></h3>
+                        <h3><a href="<?=$r->getCollectionLink()?>"><?=h($r->getCollectionDisplayName())?></a></h3>
                         <p><?php
                             if ($r->getCollectionDescription()) {
                                 echo $this->controller->highlightedMarkup($tt->shortText($r->getCollectionDescription()), $query);

--- a/concrete/controllers/backend/intelligent_search.php
+++ b/concrete/controllers/backend/intelligent_search.php
@@ -36,7 +36,7 @@ class IntelligentSearch extends UserInterface
             $obj = new \stdClass();
             $obj->href = $nh->getLinkToCollection($c);
             $obj->cID = $c->getCollectionID();
-            $obj->name = $c->getCollectionName();
+            $obj->name = $c->getCollectionDisplayName();
             $results[] = $obj;
         }
         echo json_encode($results);

--- a/concrete/controllers/backend/page/multilingual.php
+++ b/concrete/controllers/backend/page/multilingual.php
@@ -68,7 +68,7 @@ class Multilingual extends Page
             Section::relatePage($this->page, $destPage, $ms->getLocale());
             $ih = Core::make('multilingual/interface/flag');
             $icon = (string) $ih->getSectionFlagIcon($ms);
-            $pr->setAdditionalDataAttribute('name', $destPage->getCollectionName());
+            $pr->setAdditionalDataAttribute('name', $destPage->getCollectionDisplayName());
             $pr->setAdditionalDataAttribute('link', $destPage->getCollectionLink());
             $pr->setAdditionalDataAttribute('icon', $icon);
             $pr->setMessage(t('Page assigned.'));
@@ -124,7 +124,7 @@ class Multilingual extends Page
                     $ih = Core::make('multilingual/interface/flag');
                     $icon = (string) $ih->getSectionFlagIcon($ms);
                     $pr->setPage($newPage);
-                    $pr->setAdditionalDataAttribute('name', $newPage->getCollectionName());
+                    $pr->setAdditionalDataAttribute('name', $newPage->getCollectionDisplayName());
                     $pr->setAdditionalDataAttribute('link', $newPage->getCollectionLink());
                     $pr->setAdditionalDataAttribute('icon', $icon);
                 }

--- a/concrete/controllers/dialog/page/drag_request.php
+++ b/concrete/controllers/dialog/page/drag_request.php
@@ -174,7 +174,7 @@ class DragRequest extends UserInterfaceController
         $destipationPage = $dragRequestData->getDestinationPage();
         foreach ($dragRequestData->getOriginalPages() as $originalPage) {
             $newCIDs[] = $originalPage->addCollectionAlias($destipationPage);
-            $successMessages[] = t('"%1$s" was successfully aliased beneath "%2$s".', $originalPage->getCollectionName(), $destipationPage->getCollectionName());
+            $successMessages[] = t('"%1$s" was successfully aliased beneath "%2$s".', $originalPage->getCollectionDisplayName(), $destipationPage->getCollectionDisplayName());
         }
         $this->setNewPagesDisplayOrder($dragRequestData, $newCIDs);
 
@@ -201,7 +201,7 @@ class DragRequest extends UserInterfaceController
                 throw new UserMessageException(t('An error occurred while attempting the copy operation.'));
             }
             $newCIDs[] = $newPage->getCollectionID();
-            $successMessages[] = t('"%1$s" was successfully copied beneath "%2$s".', $originalPage->getCollectionName(), $destipationPage->getCollectionName());
+            $successMessages[] = t('"%1$s" was successfully copied beneath "%2$s".', $originalPage->getCollectionDisplayName(), $destipationPage->getCollectionDisplayName());
         }
         $this->setNewPagesDisplayOrder($dragRequestData, $newCIDs);
 
@@ -228,9 +228,9 @@ class DragRequest extends UserInterfaceController
             $r = $pkr->trigger();
             $newCIDs[] = $originalPage->getCollectionID();
             if ($r instanceof \Concrete\Core\Workflow\Progress\Response) {
-                $successMessages[] = t('"%1$s" was moved beneath "%2$s".', $originalPage->getCollectionName(), $destipationPage->getCollectionName());
+                $successMessages[] = t('"%1$s" was moved beneath "%2$s".', $originalPage->getCollectionDisplayName(), $destipationPage->getCollectionDisplayName());
             } else {
-                $successMessages[] = t('Your request to move "%1$s" beneath "%2$s" has been stored. Someone with approval rights will have to activate the change.', $originalPage->getCollectionName(), $destipationPage->getCollectionName());
+                $successMessages[] = t('Your request to move "%1$s" beneath "%2$s" has been stored. Someone with approval rights will have to activate the change.', $originalPage->getCollectionDisplayName(), $destipationPage->getCollectionDisplayName());
             }
         }
         $this->setNewPagesDisplayOrder($dragRequestData, $newCIDs);
@@ -256,13 +256,13 @@ class DragRequest extends UserInterfaceController
         $cloner = $this->app->make(Cloner::class);
         $clonerOptions = $this->app->build(ClonerOptions::class)
             ->setForceUnapproved(true)
-            ->setVersionComments(t('Contents copied from %s', $originalPage->getCollectionName()))
+            ->setVersionComments(t('Contents copied from %s', $originalPage->getCollectionDisplayName()))
         ;
         $newVersion = $cloner->cloneCollectionVersion($originalVersion, $dragRequestData->getDestinationPage(), $clonerOptions);
 
         return $this->buildOperationCompletedResponse(
             [$newVersion->getCollectionID()],
-            [t('The contents of "%1$s" has been copied to "%2$s".', $originalPage->getCollectionName(), $dragRequestData->getDestinationPage()->getCollectionName())]
+            [t('The contents of "%1$s" has been copied to "%2$s".', $originalPage->getCollectionDisplayName(), $dragRequestData->getDestinationPage()->getCollectionDisplayName())]
         );
     }
 

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -257,7 +257,7 @@ class Stacks extends DashboardPageController
                 $breadcrumb[] = [
                     'id' => $item->getCollectionID(),
                     'active' => $item->getCollectionID() == $page->getCollectionID(),
-                    'name' => $item->getCollectionName(),
+                    'name' => $item->getCollectionDisplayName(),
                     'url' => \URL::to('/dashboard/blocks/stacks', 'view_details', $item->getCollectionID()),
                 ];
             }
@@ -619,7 +619,7 @@ class Stacks extends DashboardPageController
             $moveFolder->getPage()->move($destinationPage);
         }
         JsonResponse::create(
-            t2('%d item has been moved under the folder %s', '%d items have been moved under the folder %s', count($sourceIDs), count($sourceIDs), h($destinationPage->getCollectionName()))
+            t2('%d item has been moved under the folder %s', '%d items have been moved under the folder %s', count($sourceIDs), count($sourceIDs), h($destinationPage->getCollectionDisplayName()))
         )->send();
         exit;
     }

--- a/concrete/controllers/single_page/dashboard/system/basics/multilingual.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/multilingual.php
@@ -24,7 +24,7 @@ class Multilingual extends DashboardPageController
             $cp = new Checker($mlPage);
             if ($cp->canViewPage()) {
                 $mlLink = [
-                    t($mlPage->getCollectionName()),
+                    $mlPage->getCollectionDisplayName(),
                     $mlPage->getCollectionLink(),
                 ];
             }

--- a/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
@@ -52,7 +52,7 @@ class Setup extends DashboardSitePageController
             $cp = new Checker($mlPage);
             if ($cp->canViewPage()) {
                 $mlLink = [
-                    t($mlPage->getCollectionName()),
+                    $mlPage->getCollectionDisplayName(),
                     $mlPage->getCollectionLink(),
                 ];
             }

--- a/concrete/controllers/single_page/dashboard/system/seo/bulk.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/bulk.php
@@ -104,7 +104,7 @@ class Bulk extends DashboardPageController
         }
         $titleFormat = $this->app->make('config')->get('concrete.seo.title_format');
         $siteName = $this->getSiteNameForPage($c);
-        if (trim(sprintf($titleFormat, $siteName, $c->getCollectionName())) != trim($this->post('meta_title')) && $this->post('meta_title')) {
+        if (trim(sprintf($titleFormat, $siteName, $c->getCollectionDisplayName())) != trim($this->post('meta_title')) && $this->post('meta_title')) {
             $c->setAttribute('meta_title', trim($this->post('meta_title')));
         }
 

--- a/concrete/elements/account/menu.php
+++ b/concrete/elements/account/menu.php
@@ -47,7 +47,7 @@ $url = $app->make('url/manager');
                     }
                 }
                 foreach ($categories as $cc) {
-                    ?><li><a href="<?=$url->resolve([$cc])?>"><?=h(t($cc->getCollectionName()))?></a></li><?php
+                    ?><li><a href="<?=$url->resolve([$cc])?>"><?=h($cc->getCollectionDisplayName())?></a></li><?php
                 }
             ?>
             <li class="divider"></li>

--- a/concrete/elements/dashboard/mobile_menu.php
+++ b/concrete/elements/dashboard/mobile_menu.php
@@ -13,7 +13,7 @@
                 $children = $view->controller->getChildPages($page);
                 ?>
                 <li class="<?=$view->controller->getMenuItemClass($page)?>">
-                    <a href="<?=$page->getCollectionLink()?>"><?=t($page->getCollectionName())?></a>
+                    <a href="<?=$page->getCollectionLink()?>"><?=$page->getCollectionDisplayName()?></a>
                     <?php
                     if ($children) {
                         echo '<i class="fa fa-caret-down drop-down-toggle"></i>';

--- a/concrete/elements/dashboard/welcome.php
+++ b/concrete/elements/dashboard/welcome.php
@@ -63,7 +63,7 @@ if (Config::get('concrete.white_label.background_image') !== 'none' && !Config::
                     <li <?php if ($c->getCollectionPath() == '/dashboard/welcome') {?>class="active"<?php } ?>><a href="<?=URL::to('/dashboard/welcome')?>"><?=t('Welcome')?></a></li>
                     <?php foreach($nav as $page) { ?>
                         <li <?php if ($page->getCollectionID() == $c->getCollectionID()) {?>class="active"<?php } ?>>
-                            <a href="<?=$page->getCollectionLink()?>"><?=t($page->getCollectionName())?></a>
+                            <a href="<?=$page->getCollectionLink()?>"><?=h($page->getCollectionDisplayName())?></a>
                         </li>
                     <?php } ?>
                     <li><a href="<?=URL::to('/account')?>"><?=t('My Account')?></a></li>

--- a/concrete/elements/files/properties.php
+++ b/concrete/elements/files/properties.php
@@ -78,7 +78,7 @@ if ($downloadUrl !== $url) {
     $oc = $f->getOriginalPageObject();
     if (is_object($oc)) {
         $fileManager = Page::getByPath('/dashboard/files/search');
-        $ocName = $oc->getCollectionName();
+        $ocName = $oc->getCollectionDisplayName();
         if (is_object($fileManager) && !$fileManager->isError()) {
             if ($fileManager->getCollectionID() == $oc->getCollectionID()) {
                 $ocName = t('Dashboard File Manager');
@@ -88,7 +88,7 @@ if ($downloadUrl !== $url) {
         <div class="row">
             <div class="col-md-3"><p><?= t('Page Added To') ?></p></div>
             <div class="col-md-9"><p><a href="<?= Loader::helper('navigation')->getLinkToCollection($oc) ?>"
-                                        target="_blank"><?= $ocName ?></a></p></div>
+                                        target="_blank"><?= h($ocName) ?></a></p></div>
         </div>
     <?php
     }

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -49,7 +49,7 @@ if (is_object($c)) {
      * We can set a title 3 ways:
      * 1. It comes through programmatically as $pageTitle. If this is the case then we pass it through, no questions asked
      * 2. It comes from meta title
-     * 3. It comes from getCollectionName()
+     * 3. It comes from getCollectionDisplayName()
      * In the case of 3, we also pass it through page title format.
      */
     if ($pageTitle === null) {
@@ -58,10 +58,7 @@ if (is_object($c)) {
         if (!is_string($pageTitle) || $pageTitle === '') {
             $seo = $app->make('helper/seo');
             if (!$seo->hasCustomTitle()) {
-                $pageTitle = $c->getCollectionName();
-                if ($c->isSystemPage()) {
-                    $pageTitle = t($pageTitle);
-                }
+                $pageTitle = $c->getCollectionDisplayName();
                 $seo->addTitleSegmentBefore($pageTitle);
             }
             $seo->setSiteName(tc('SiteName', $site->getSiteName()));

--- a/concrete/elements/navigation/menu.php
+++ b/concrete/elements/navigation/menu.php
@@ -17,7 +17,7 @@ if (!empty($top)) {
                         $next = ($i + 1 < $n) ? $pages[$i + 1] : null;
                         ?>
                         <li class="<?=$view->controller->getMenuItemClass($page)?>">
-                            <a href="<?=$page->getCollectionLink()?>"><?=t($page->getCollectionName())?></a>
+                            <a href="<?=$page->getCollectionLink()?>"><?=h($page->getCollectionDisplayName())?></a>
                             <?php
                             if ($view->controller->displayChildPages($page)) {
                                 $children = $view->controller->getChildPages($page);

--- a/concrete/elements/package/single_pages_item_list.php
+++ b/concrete/elements/package/single_pages_item_list.php
@@ -8,7 +8,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <?php foreach ($category->getItems($package) as $page) {
         ?>
         <li class="clearfix row">
-            <span class="col-sm-2"><a href="<?=$page->getCollectionLink()?>"><?=$page->getCollectionName()?></a></span>
+            <span class="col-sm-2"><a href="<?=$page->getCollectionLink()?>"><?=h($page->getCollectionDisplayName())?></a></span>
             <span class="col-sm-3"><code><?=$page->getCollectionPath()?></code></span>
             <span class="col-sm-5"><?=$page->getCollectionDescription()?></span>
         </li>

--- a/concrete/elements/page_types/target_types/form/page_type.php
+++ b/concrete/elements/page_types/target_types/form/page_type.php
@@ -53,10 +53,10 @@ if (is_object($pagetype) && $pagetype->getPageTypePublishTargetTypeID() == $conf
 					if (is_array($trail)) {
 						$trail = array_reverse($trail);
 						for ($i = 0; $i < count($trail); $i++) {
-							$label .= $trail[$i]->getCollectionName() . ' &gt; ';
+						    $label .= h($trail[$i]->getCollectionDisplayName()) . ' &gt; ';
 						}
 					}
-					$label .= $p->getCollectionName();
+					$label .= $p->getCollectionDisplayName();
 					$options[$p->getCollectionID()] = $label;
                 }
             }
@@ -64,7 +64,7 @@ if (is_object($pagetype) && $pagetype->getPageTypePublishTargetTypeID() == $conf
         } elseif (count($pages) == 1) {
             $p = $pages[0];
             echo $form->hidden('cParentID', $p->getCollectionID());
-            echo t('This page will be published beneath "%s."', $p->getCollectionName());
+            echo t('This page will be published beneath "%s."', h($p->getCollectionDisplayName()));
         }
     }
 }

--- a/concrete/elements/page_types/target_types/form/parent_page.php
+++ b/concrete/elements/page_types/target_types/form/parent_page.php
@@ -10,6 +10,6 @@ if (is_object($pagetype) && $pagetype->getPageTypePublishTargetTypeID() == $conf
     $cID = $configuredTarget->getParentPageID();
     $pc = Page::getByID($cID, 'ACTIVE');
     ?>
-<span class="checkbox"><?=t('This page will be published beneath <a href="%s">%s</a>.', Loader::helper('navigation')->getLinkToCollection($pc), $pc->getCollectionName())?></label>
+<span class="checkbox"><?=t('This page will be published beneath <a href="%s">%s</a>.', Loader::helper('navigation')->getLinkToCollection($pc), h($pc->getCollectionDisplayName()))?></label>
 <?php 
 } ?>

--- a/concrete/elements/panels/dashboard.php
+++ b/concrete/elements/panels/dashboard.php
@@ -35,7 +35,7 @@ foreach ($parents as $pc) {
     if ($cp->canViewPage()) {
         ?>
 					<li <?php if ($active) {
-    ?>class="nav-selected"<?php } ?>><a href="<?=Loader::helper('navigation')->getLinkToCollection($cc)?>"><?=t($cc->getCollectionName())?></a></li>
+    ?>class="nav-selected"<?php } ?>><a href="<?=Loader::helper('navigation')->getLinkToCollection($cc)?>"><?=h($cc->getCollectionDisplayName())?></a></li>
 
 			<?php
 		$next = $nav[$i + 1];

--- a/concrete/elements/workflow/progress/categories/page/pending.php
+++ b/concrete/elements/workflow/progress/categories/page/pending.php
@@ -26,7 +26,7 @@ $noitems = true;
             $noitems = false;
             ?>
 <tr class="ccm-workflow-waiting-for-me-row<?=$wp->getWorkflowProgressID()?>">
-	<td><?=$p->getCollectionName()?></td>
+	<td><?=h($p->getCollectionDisplayName())?></td>
 	<td><a href="<?=Loader::helper('navigation')->getLinkToCollection($p)?>"><?=$p->getCollectionPath()?></a>
 	<td><?=$dh->formatDateTime($wp->getWorkflowProgressDateLastAction(), true)?></td>
 	<td><a href="javascript:void(0)" title="<?=t('Click for history.')?>" onclick="$(this).parentsUntil('tr').parent().next().show()"><?=$wf->getWorkflowProgressStatusDescription($wp)?></a></td>

--- a/concrete/single_pages/account/avatar.php
+++ b/concrete/single_pages/account/avatar.php
@@ -8,7 +8,7 @@ $save_url = $save_url->setQuery(array(
 
 
 <div vue-enabled>
-<h2><?=$c->getCollectionName()?></h2>
+<h2><?=h($c->getCollectionDisplayName())?></h2>
 
 	<p><?php echo t('Change the picture attached to my posts.')?></p>
 

--- a/concrete/single_pages/account/edit_profile.php
+++ b/concrete/single_pages/account/edit_profile.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
-<h2><?= t($c->getCollectionName()); ?></h2>
+<h2><?= h($c->getCollectionDisplayName()) ?></h2>
 
 <form method="post" action="<?= $view->action('save'); ?>" enctype="multipart/form-data">
 	<?php $valt->output('profile_edit'); ?>

--- a/concrete/single_pages/account/messages.php
+++ b/concrete/single_pages/account/messages.php
@@ -3,7 +3,7 @@
 $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
 ?>
 
-<h2><?=$c->getCollectionName(); ?></h2>
+<h2><?= h($c->getCollectionDisplayName()) ?></h2>
 
 	<?php switch ($this->controller->getTask()) {
         case 'view_message': ?>

--- a/concrete/single_pages/dashboard/blocks/stacks/detail.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/detail.php
@@ -5,7 +5,7 @@
 <div class="ccm-pane">
 
 
-	<div class="ccm-pane-header"><h3><?=$c->getCollectionName()?></h3></div>
+	<div class="ccm-pane-header"><h3><?=h($c->getCollectionDisplayName())?></h3></div>
 	<div class="ccm-pane-body clearfix" id="ccm-stack-container">
 	<?php $a = new Area(STACKS_AREA_NAME); $a->display($c); ?>
 	</div>

--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -27,7 +27,7 @@ if (isset($neutralStack)) {
             <a href="<?=$view->action('view_details', $neutralStack->getCollectionParentID())?>" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?=t("Back to Stacks")?></a>
         <?php } ?>
     </div>
-    <p class="lead"><?=h($neutralStack->getCollectionName())?></p>
+    <p class="lead"><?=h($neutralStack->getCollectionDisplayName())?></p>
     <?php
     if ($stackToEdit === null) {
         ?>
@@ -346,7 +346,7 @@ $(function() {
                             ?>
                             <tr class="<?=$formatter->getSearchResultsClass()?>" data-details-url="<?=$view->url('/dashboard/blocks/stacks', 'view_details', $st->getCollectionID())?>" data-collection-id="<?=$st->getCollectionID()?>">
                                 <td class="ccm-search-results-icon"><?=$formatter->getIconElement()?></td>
-                                <td class="ccm-search-results-name"><?=h($st->getCollectionName())?></td>
+                                <td class="ccm-search-results-name"><?=h($st->getCollectionDisplayName())?></td>
                                 <td><?=$dh->formatDateTime($st->getCollectionDateAdded())?></td>
                                 <td class="ccm-search-results-menu-launcher">
                                     <?php if ($st->getCollectionTypeHandle() == STACK_CATEGORY_PAGE_TYPE) { ?>

--- a/concrete/single_pages/dashboard/composer/drafts.php
+++ b/concrete/single_pages/dashboard/composer/drafts.php
@@ -23,10 +23,10 @@ $num = 0;
         $pdr = new Permissions($dr);
         if ($pdr->canEditPage()) {
             ++$num;
-            $pageName = ($dr->getCollectionName()) ? $dr->getCollectionName() : t('(Untitled Page)');
+            $pageName = $dr->getCollectionDisplayName() ?: t('(Untitled Page)');
             ?>
 	<tr>
-		<td><a href="<?=$view->url('/dashboard/composer/write', 'draft', $dr->getCollectionID())?>"><?=$pageName?></a></td>
+		<td><a href="<?=$view->url('/dashboard/composer/write', 'draft', $dr->getCollectionID())?>"><?=h($pageName)?></a></td>
 		<td><?php
         $ui = UserInfo::getByID($dr->getCollectionUserID());
             if (is_object($ui)) {

--- a/concrete/single_pages/dashboard/pages/single.php
+++ b/concrete/single_pages/dashboard/pages/single.php
@@ -55,7 +55,7 @@ echo Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Sing
     }
     ?>
 					<tr>
-						<td style="width: 30%"><a href="<?=URL::to($p)?>"><?php echo $p->getCollectionName()?></a></td>
+						<td style="width: 30%"><a href="<?=URL::to($p)?>"><?= h($p->getCollectionDisplayName()) ?></a></td>
 						<td style="width: 40%"><?php echo $p->getCollectionPath()?></td>
 						<td style="width: 30%"><?php echo $packageName;
     ?></td>

--- a/concrete/single_pages/dashboard/system/files/thumbnails.php
+++ b/concrete/single_pages/dashboard/system/files/thumbnails.php
@@ -89,7 +89,7 @@ if (isset($type)) {
                             $optionsPageName = t('Image Options');
                             $optionsPage = Page::getByPath('/dashboard/system/files/image_uploading');
                             if ($optionsPage && !$optionsPage->isError()) {
-                                $optionsPageName = h(t($optionsPage->getCollectionName()));
+                                $optionsPageName = h($optionsPage->getCollectionDisplayName());
                                 $optionsPagePermissions = new Checker($optionsPage);
                                 if ($optionsPagePermissions->canViewPage()) {
                                     $optionsPageName = '<a href="' . h($optionsPage->getCollectionLink()) . '" target="_blank">' . $optionsPageName . '</a>';

--- a/concrete/single_pages/dashboard/system/multilingual/page_report.php
+++ b/concrete/single_pages/dashboard/system/multilingual/page_report.php
@@ -108,7 +108,7 @@ if (count($sections) > 0) {
                             ?>
                             <tr>
                                 <td>
-                                    <a href="<?= $pc->getCollectionLink() ?>"><?= $pc->getCollectionName() ?></a>
+                                    <a href="<?= $pc->getCollectionLink() ?>"><?= h($pc->getCollectionDisplayName()) ?></a>
                                     <div><small><?= $pc->getCollectionPath() ?></small></div>
                                 </td>
                                 <?php
@@ -124,7 +124,7 @@ if (count($sections) > 0) {
                                                     $cID = $sc->getTranslatedPageID($pc);
                                                     if ($cID) {
                                                         $p = Page::getByID($cID);
-                                                        echo '<a href="' . $nav->getLinkToCollection($p) . '">' . $p->getCollectionName() . '</a>';
+                                                        echo '<a href="' . $nav->getLinkToCollection($p) . '">' . h($p->getCollectionDisplayName()) . '</a>';
                                                     } elseif ($cID === '0') {
                                                         echo t('Ignored');
                                                     }

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -30,7 +30,7 @@ $app = Concrete\Core\Support\Facade\Application::getFacadeApplication();
             <td>
                 <?php
                 if (is_object($home)) {
-                    ?><a href="<?= $home->getCollectionLink() ?>"><?= $home->getCollectionName() ?></a><?php
+                    ?><a href="<?= $home->getCollectionLink() ?>"><?= h($home->getCollectionDisplayName()) ?></a><?php
                 } else {
                     ?><span class="text-warning"><?= t('None Created.') ?></span><?php
                 }

--- a/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -92,7 +92,7 @@ if ($this->controller->getTask() == 'translate_po') {
                         foreach ($pages as $pc) {
                             $pcl = \Concrete\Core\Multilingual\Page\Section\Section::getByID($pc->getCollectionID()); ?><tr>
                                 <td><?php echo $ch->getSectionFlagIcon($pc); ?></td>
-                                <td><a href="<?php echo $nav->getLinkToCollection($pc); ?>"><?php echo $pc->getCollectionName(); ?></a></td>
+                                <td><a href="<?php echo $nav->getLinkToCollection($pc); ?>"><?= h($pc->getCollectionDisplayName()) ?></a></td>
                                 <td style="white-space: nowrap">
                                     <?php
                                     echo $pc->getLocale();

--- a/concrete/single_pages/dashboard/system/seo/bulk.php
+++ b/concrete/single_pages/dashboard/system/seo/bulk.php
@@ -123,13 +123,13 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
             $cID = $cobj->getCollectionID();
             ?>
             <div class="row page-title">
-                <legend><?php echo $cobj->getCollectionName() ?></legend>
+                <legend><?= h($cobj->getCollectionDisplayName()) ?></legend>
             </div>
             <div class="ccm-seoRow-<?php echo $cID; ?> ccm-seo-rows <?php echo $i % 2 == 0 ? 'even' : '' ?> row">
                 <div class="col-md-3 col-md-offset-1 seo-page-details">
                     <strong><?php echo t('Page Name'); ?></strong>
                     <br/>
-                    <?php echo $cobj->getCollectionName() ? $cobj->getCollectionName() : ''; ?>
+                    <?= h($cobj->getCollectionDisplayName()) ?>
                     <br/>
                     <br/>
                     <strong><?php echo t('Page Type'); ?></strong>
@@ -145,7 +145,7 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
                 <div class="col-md-7 seo-page-edit">
                     <div class="form-group">
                         <label class="control-label"><?php echo t('Meta Title'); ?></label>
-                        <?php $seoPageTitle = $cobj->getCollectionName();
+                        <?php $seoPageTitle = $cobj->getCollectionDisplayName();
                         $seoPageTitle = htmlspecialchars($seoPageTitle, ENT_COMPAT, APP_CHARSET);
                         $autoTitle = sprintf(Config::get('concrete.seo.title_format'), $controller->getSiteNameForPage($cobj), $seoPageTitle);
                         $titleInfo = array('title' => $cID);

--- a/concrete/single_pages/dashboard/system/seo/view.php
+++ b/concrete/single_pages/dashboard/system/seo/view.php
@@ -7,7 +7,7 @@ foreach ($categories as $cat) {
     ?>
 
 	<div class="page-header">
-	<h3><a href="<?=Loader::helper('navigation')->getLinkToCollection($cat)?>"><?=$cat->getCollectionName()?></a>
+	<h3><a href="<?=Loader::helper('navigation')->getLinkToCollection($cat)?>"><?=h($cat->getCollectionDisplayName())?></a>
 	<small><?=$cat->getCollectionDescription()?></small>
 	</h3>
 	</div>
@@ -32,7 +32,7 @@ foreach ($categories as $cat) {
     ?>
 	
 	<div class="span4">
-		<a href="<?=Loader::helper('navigation')->getLinkToCollection($cat)?>"><?=$subcat->getCollectionName()?></a>
+		<a href="<?=Loader::helper('navigation')->getLinkToCollection($cat)?>"><?=h($subcat->getCollectionDisplayName())?></a>
 	</div>
 	
 	<?php 

--- a/concrete/single_pages/dashboard/system/view.php
+++ b/concrete/single_pages/dashboard/system/view.php
@@ -12,7 +12,7 @@ for ($i = 0; $i < count($categories); ++$i) {
     ?>
 
     <div class="col-md-4 ccm-dashboard-section-menu">
-        <h2><?=t($cat->getCollectionName())?></h2>
+        <h2><?=h($cat->getCollectionDisplayName())?></h2>
 
 
         <?php
@@ -35,7 +35,7 @@ for ($i = 0; $i < count($categories); ++$i) {
             <?php foreach ($show as $subcat) {
     ?>
 
-                <li><a href="<?=Loader::helper('navigation')->getLinkToCollection($subcat, false, true)?>"><i class="<?=$subcat->getAttribute('icon_dashboard')?>"></i> <?=t($subcat->getCollectionName())?></a></li>
+                <li><a href="<?=Loader::helper('navigation')->getLinkToCollection($subcat, false, true)?>"><i class="<?=$subcat->getAttribute('icon_dashboard')?>"></i> <?=h($subcat->getCollectionDisplayName())?></a></li>
 
             <?php 
 }

--- a/concrete/single_pages/dashboard/view.php
+++ b/concrete/single_pages/dashboard/view.php
@@ -13,7 +13,7 @@ for ($i = 0; $i < count($categories); ++$i) {
     ?>
 
         <div class="col-md-4 ccm-dashboard-section-menu">
-            <h2><?=t($cat->getCollectionName())?></h2>
+            <h2><?=h($cat->getCollectionDisplayName())?></h2>
 
 
             <?php
@@ -39,7 +39,7 @@ for ($i = 0; $i < count($categories); ++$i) {
             <?php foreach ($show as $subcat) {
     ?>
 
-            <li><a href="<?=Loader::helper('navigation')->getLinkToCollection($subcat, false, true)?>"><i class="<?=$subcat->getAttribute('icon_dashboard')?>"></i> <?=t($subcat->getCollectionName())?></a></li>
+            <li><a href="<?=Loader::helper('navigation')->getLinkToCollection($subcat, false, true)?>"><i class="<?=$subcat->getAttribute('icon_dashboard')?>"></i> <?=h($subcat->getCollectionDisplayName())?></a></li>
 
             <?php 
 }

--- a/concrete/src/Application/Service/Dashboard.php
+++ b/concrete/src/Application/Service/Dashboard.php
@@ -143,15 +143,15 @@ class Dashboard
                         $class = '';
                     }
 
-                    $relatedPages .= '<li class="' . $class . '"><a href="' . $nh->getLinkToCollection($sc) . '">' . t($sc->getCollectionName()) . '</a></li>';
+                    $relatedPages .= '<li class="' . $class . '"><a href="' . $nh->getLinkToCollection($sc) . '">' . h($sc->getCollectionDisplayName()) . '</a></li>';
                 }
 
                 if ($upToPage) {
                     $relatedPages .= '<li class="ccm-menu-separator"></li>';
-                    $relatedPages .= '<li><a href="' . $nh->getLinkToCollection($upToPage) . '">' . t('&lt; Back to %s', t($upToPage->getCollectionName())) . '</a></li>';
+                    $relatedPages .= '<li><a href="' . $nh->getLinkToCollection($upToPage) . '">' . t('&lt; Back to %s', h($upToPage->getCollectionDisplayName())) . '</a></li>';
                 }
                 $relatedPages .= '</ul>';
-                $navigateTitle = t($parent->getCollectionName());
+                $navigateTitle = $parent->getCollectionDisplayName();
             }
         }
 
@@ -192,7 +192,7 @@ class Dashboard
         $html .= '<li><a href="javascript:void(0)" onclick="CCMDashboard.closePane(this)"><i class="icon-remove"></i></a></li>';
         $html .= '</ul>';
         if (!$title) {
-            $title = $c->getCollectionName();
+            $title = h($c->getCollectionDisplayName());
         }
         $html .= '<h3>' . $title . '</h3>';
         $html .= '</div>';
@@ -249,18 +249,18 @@ class Dashboard
                 $ch2 = $page->getCollectionChildrenArray(true);
             } ?>
                 <div class="ccm-intelligent-search-results-module ccm-intelligent-search-results-module-onsite">
-                    <h1><?=t($page->getCollectionName())?></h1>
+                    <h1><?=h($page->getCollectionDisplayName())?></h1>
                     <ul class="ccm-intelligent-search-results-list">
                         <?php
                         if (count($ch2) == 0) {
                             ?>
-                            <li><a href="<?=$navHelper->getLinkTocollection($page)?>"><?=t($page->getCollectionName())?></a><span><?=t($page->getCollectionName())?> <?=t($page->getAttribute('meta_keywords'))?></span></li>
+                            <li><a href="<?=$navHelper->getLinkTocollection($page)?>"><?=h($page->getCollectionDisplayName())?></a><span><?=h($page->getCollectionDisplayName())?> <?=t($page->getAttribute('meta_keywords'))?></span></li>
                             <?php
 
                         }
             if ($page->getCollectionPath() == '/dashboard/system') {
                 ?>
-                            <li><a href="<?=$navHelper->getLinkTocollection($page)?>"><?=t('View All')?></a><span><?=t($page->getCollectionName())?> <?=t($page->getAttribute('meta_keywords'))?></span></li>
+                            <li><a href="<?=$navHelper->getLinkTocollection($page)?>"><?=t('View All')?></a><span><?=h($page->getCollectionDisplayName())?> <?=t($page->getAttribute('meta_keywords'))?></span></li>
                             <?php
 
             }
@@ -275,10 +275,10 @@ class Dashboard
                 }
 
                 ?>
-                    <li><a href="<?=$navHelper->getLinkTocollection($subpage)?>"><?=t($subpage->getCollectionName())?></a><span><?php if ($page->getCollectionPath() != '/dashboard/system') {
-    ?><?=t($page->getCollectionName())?> <?=t($page->getAttribute('meta_keywords'))?> <?php
+                    <li><a href="<?=$navHelper->getLinkTocollection($subpage)?>"><?=h($subpage->getCollectionDisplayName())?></a><span><?php if ($page->getCollectionPath() != '/dashboard/system') {
+    ?><?=h($page->getCollectionDisplayName())?> <?=t($page->getAttribute('meta_keywords'))?> <?php
 }
-                ?><?=t($subpage->getCollectionName())?> <?=t($subpage->getAttribute('meta_keywords'))?></span></li>
+                ?><?=h($subpage->getCollectionDisplayName())?> <?=t($subpage->getAttribute('meta_keywords'))?></span></li>
                     <?php
 
             } ?>

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -214,8 +214,10 @@ class Sitemap
             $numSubpages = (int) $c->getNumChildren();
         }
 
-        $cvName = ($c->getCollectionName() !== '') ? $c->getCollectionName() : '(No Title)';
-        $cvName = ($c->isSystemPage() || $cID == 1) ? t($cvName) : $cvName;
+        $cvName = $c->getCollectionDisplayName();
+        if ($cvName === '') {
+            $cvName = '(No Title)';
+        }
 
         $isInTrash = $c->isInTrash();
 

--- a/concrete/src/Application/Service/UserInterface.php
+++ b/concrete/src/Application/Service/UserInterface.php
@@ -152,7 +152,7 @@ class UserInterface
         if (method_exists($cnt, 'getQuickNavigationLinkHTML')) {
             return $cnt->getQuickNavigationLinkHTML();
         } else {
-            return '<a href="' . Core::make('helper/navigation')->getLinkToCollection($c) . '">' . $c->getCollectionName() . '</a>';
+            return '<a href="' . Core::make('helper/navigation')->getLinkToCollection($c) . '">' . h($c->getCollectionDisplayName()) . '</a>';
         }
     }
 
@@ -268,7 +268,7 @@ class UserInterface
                 $_c = $t[0];
             } else {
                 $_c = $t;
-                $name = $t->getCollectionName();
+                $name = $t->getCollectionDisplayName();
             }
 
             $href = Core::make('helper/navigation')->getLinkToCollection($_c);

--- a/concrete/src/Conversation/Message/Message.php
+++ b/concrete/src/Conversation/Message/Message.php
@@ -585,7 +585,7 @@ class Message extends ConcreteObject implements \Concrete\Core\Permission\Object
                 foreach ($users as $ui) {
                     $mail = Core::make('mail');
                     $mail->to($ui->getUserEmail());
-                    $mail->addParameter('title', $c->getCollectionName());
+                    $mail->addParameter('title', $c->getCollectionDisplayName());
                     $mail->addParameter('link', $c->getCollectionLink(true));
                     $mail->addParameter('poster', $formatter->getDisplayName());
                     $mail->addParameter('body', Core::make('helper/text')->prettyStripTags($cnvMessageBody));

--- a/concrete/src/Csv/Export/PageActivityExporter.php
+++ b/concrete/src/Csv/Export/PageActivityExporter.php
@@ -60,7 +60,7 @@ class PageActivityExporter extends AbstractExporter
 
         yield (int) $page->getCollectionID();
         yield (string) $page->getCollectionPath();
-        yield (string) $page->getCollectionName();
+        yield $page->getCollectionDisplayName();
         yield (int) $version->getVersionID();
         yield (string) $this->getLocalizedDate($version->getVersionDateApproved());
         yield (string) $version->getVersionComments();

--- a/concrete/src/Editor/PageNameSnippet.php
+++ b/concrete/src/Editor/PageNameSnippet.php
@@ -9,7 +9,7 @@ class PageNameSnippet extends Snippet
     {
         $c = Page::getCurrentPage();
         if (is_object($c)) {
-            return $c->getCollectionName();
+            return $c->getCollectionDisplayName();
         }
     }
 }

--- a/concrete/src/Entity/Page/Feed.php
+++ b/concrete/src/Entity/Page/Feed.php
@@ -488,7 +488,7 @@ class Feed
 
             foreach ($results as $p) {
                 $entry = $writer->createEntry();
-                $entry->setTitle($p->getCollectionName());
+                $entry->setTitle($p->getCollectionDisplayName());
                 $entry->setDateCreated(strtotime($p->getCollectionDatePublic()));
                 $content = $this->getPageFeedContent($p);
                 if (!$content) {

--- a/concrete/src/Form/Service/Widget/PageSelector.php
+++ b/concrete/src/Form/Service/Widget/PageSelector.php
@@ -72,7 +72,7 @@ EOL;
             $oc = Page::getByID($selectedCID);
             $cp = new Permissions($oc);
             if ($cp->canViewPage()) {
-                $cName = $oc->getCollectionName();
+                $cName = $oc->getCollectionDisplayName();
             }
         }
 

--- a/concrete/src/Package/ItemCategory/SinglePage.php
+++ b/concrete/src/Package/ItemCategory/SinglePage.php
@@ -18,7 +18,7 @@ class SinglePage extends AbstractCategory
 
     public function getItemName($page)
     {
-        return $page->getCollectionName();
+        return $page->getCollectionDisplayName();
     }
 
     public function renderList(Package $package)

--- a/concrete/src/Page/Controller/AccountPageController.php
+++ b/concrete/src/Page/Controller/AccountPageController.php
@@ -57,13 +57,4 @@ class AccountPageController extends CorePageController
         $this->set('error', $this->error);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @see \Concrete\Core\Page\Controller\PageController::useUserLocale()
-     */
-    public function useUserLocale()
-    {
-        return true;
-    }
 }

--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -108,14 +108,4 @@ class DashboardPageController extends PageController
     {
         return $this->entityManager;
     }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @see \Concrete\Core\Page\Controller\PageController::useUserLocale()
-     */
-    public function useUserLocale()
-    {
-        return true;
-    }
 }

--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -91,7 +91,7 @@ class DashboardPageController extends PageController
     {
         $pageTitle = $this->get('pageTitle');
         if (!$pageTitle) {
-            $this->set('pageTitle', t($this->c->getCollectionName()));
+            $this->set('pageTitle', $this->c->getCollectionDisplayName());
         }
         $dbConfig = $this->app->make('config/database');
         $this->set('showPrivacyPolicyNotice', !$dbConfig->get('app.privacy_policy_accepted'));

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -155,6 +155,9 @@ class PageController extends Controller
         }
     }
 
+    /**
+     * @return \Concrete\Core\Page\Page
+     */
     public function getPageObject()
     {
         return $this->c;
@@ -348,7 +351,7 @@ class PageController extends Controller
      */
     public function useUserLocale()
     {
-        return false;
+        return $this->getPageObject()->isPageTranslatable();
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1681,9 +1681,9 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     }
 
     /**
-     * Get the page name.
+     * Get the (untranslated) page name.
      *
-     * @return string
+     * @return string|null
      */
     public function getCollectionName()
     {
@@ -1692,6 +1692,21 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         }
 
         return isset($this->cvName) ? $this->cvName : null;
+    }
+
+    /**
+     * Get the (possibly translated) page name.
+     *
+     * @return string
+     */
+    public function getCollectionDisplayName()
+    {
+        $name = (string) $this->getCollectionName();
+        if ($this->isPageTranslatable()) {
+            $name = t($name);
+        }
+        
+        return $name;
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -325,7 +325,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public function getJSONObject()
     {
         $r = new \stdClass();
-        $r->name = $this->getCollectionName() !== '' ? $this->getCollectionName() : t('(No Title)');
+        $r->name = $this->getCollectionDisplayName() !== '' ? $this->getCollectionDisplayName() : t('(No Title)');
         if ($this->isAliasPage()) {
             $r->cID = $this->getCollectionPointerOriginalID();
         } else {
@@ -2985,7 +2985,7 @@ EOT
         $app = Facade::getFacadeApplication();
         $logger = $app->make('log/factory')->createLogger(Channels::CHANNEL_SITE_ORGANIZATION);
         $logger->notice(t('Page "%s" at path "%s" deleted',
-            $this->getCollectionName(),
+            $this->getCollectionDisplayName(),
             $this->getCollectionPath()
         ));
 
@@ -3053,7 +3053,7 @@ EOT
         $app = Facade::getFacadeApplication();
         $logger = $app->make('log/factory')->createLogger(Channels::CHANNEL_SITE_ORGANIZATION);
         $logger->notice(t('Page "%s" at path "%s" Moved to trash',
-            $this->getCollectionName(),
+            $this->getCollectionDisplayName(),
             $this->getCollectionPath()
         ));
 

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1695,6 +1695,16 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     }
 
     /**
+     * Check if this page can be (possibly) rendered in different languages depending on the current user/language.
+     *
+     * @return bool
+     */
+    public function isPageTranslatable()
+    {
+        return $this->isSystemPage() || $this->isGeneratedCollection();
+    }
+
+    /**
      * Get the collection ID for the aliased page (returns 0 unless used on an actual alias).
      *
      * @return int

--- a/concrete/src/Page/Relation/Formatter/SiblingFormatter.php
+++ b/concrete/src/Page/Relation/Formatter/SiblingFormatter.php
@@ -17,7 +17,7 @@ class SiblingFormatter implements FormatterInterface
     public function getDisplayName()
     {
         $page = $this->relation->getPageObject();
-        $title = sprintf('%s > %s', $page->getSiteTreeObject()->getDisplayName(), $page->getCollectionName());
+        $title = sprintf('%s > %s', $page->getSiteTreeObject()->getDisplayName(), $page->getCollectionDisplayName());
         return $title;
     }
 }

--- a/concrete/src/Page/Search/ColumnSet/Column/CollectionVersionColumn.php
+++ b/concrete/src/Page/Search/ColumnSet/Column/CollectionVersionColumn.php
@@ -21,7 +21,7 @@ class CollectionVersionColumn extends Column implements PagerColumnInterface
 
     public function getColumnCallback()
     {
-        return 'getCollectionName';
+        return 'getCollectionDisplayName';
     }
 
     public function filterListAtOffset(PagerProviderInterface $itemList, $mixed)
@@ -29,7 +29,7 @@ class CollectionVersionColumn extends Column implements PagerColumnInterface
         $query = $itemList->getQueryObject();
         $sort = $this->getColumnSortDirection() == 'desc' ? '<' : '>';
         $where = sprintf('(cv.cvName, p.cID) %s (:sortName, :sortID)', $sort);
-        $query->setParameter('sortName', $mixed->getCollectionName());
+        $query->setParameter('sortName', $mixed->getCollectionDisplayName());
         $query->setParameter('sortID', $mixed->getCollectionID());
         $query->andWhere($where);
     }

--- a/concrete/src/Page/Search/Result/Item.php
+++ b/concrete/src/Page/Search/Result/Item.php
@@ -34,6 +34,6 @@ class Item extends SearchResultItem
         $this->canEditPageType = $cp->canEditPageType();
         $this->canViewPageVersions = $cp->canViewPageVersions();
         $this->canDeletePage = $cp->canDeletePage();
-        $this->cvName = $item->getCollectionName();
+        $this->cvName = $item->getCollectionDisplayName();
     }
 }

--- a/concrete/src/Page/Sitemap/DragRequestData.php
+++ b/concrete/src/Page/Sitemap/DragRequestData.php
@@ -386,21 +386,21 @@ class DragRequestData
         $destinationPageID = $this->getDestinationPage()->getCollectionID();
         foreach ($this->getOriginalPages() as $originalPage) {
             if ($originalPage->getCollectionParentID() == $destinationPageID) {
-                return t('"%1$s" is already the parent page of "%2$s".', $this->getDestinationPage()->getCollectionName(), $originalPage->getCollectionName());
+                return t('"%1$s" is already the parent page of "%2$s".', $this->getDestinationPage()->getCollectionDisplayName(), $originalPage->getCollectionDisplayName());
             }
             $originalPageChecker = new Checker($originalPage);
             if (!$originalPageChecker->canMoveOrCopyPage()) {
-                return t('You don\'t have the permission move the page "%s".', $originalPage->getCollectionName());
+                return t('You don\'t have the permission move the page "%s".', $originalPage->getCollectionDisplayName());
             }
             if ($originalPage->getCollectionID() == $destinationPageID) {
-                return t('It\'s not possible to move the page "%s" under itself.', $originalPage->getCollectionName());
+                return t('It\'s not possible to move the page "%s" under itself.', $originalPage->getCollectionDisplayName());
             }
             if (in_array($destinationPageID, $originalPage->getCollectionChildrenArray())) {
-                return t('It\'s not possible to move the page "%s" under one of its child pages.', $originalPage->getCollectionName());
+                return t('It\'s not possible to move the page "%s" under one of its child pages.', $originalPage->getCollectionDisplayName());
             }
             $originalPageType = $originalPage->getPageTypeObject();
             if (!$destinationPageChecker->canAddSubpage($originalPageType)) {
-                return t('You do not have sufficient privileges to move the page "%1$s" under "%2$s".', $originalPage->getCollectionName(), $this->getDestinationPage()->getCollectionName());
+                return t('You do not have sufficient privileges to move the page "%1$s" under "%2$s".', $originalPage->getCollectionDisplayName(), $this->getDestinationPage()->getCollectionDisplayName());
             }
         }
 
@@ -421,11 +421,11 @@ class DragRequestData
         foreach ($this->getOriginalPages() as $originalPage) {
             $originalPageChecker = new Checker($originalPage);
             if (!$originalPageChecker->canMoveOrCopyPage()) {
-                return t('You don\'t have the permission to create an alias of the page "%s".', $originalPage->getCollectionName());
+                return t('You don\'t have the permission to create an alias of the page "%s".', $originalPage->getCollectionDisplayName());
             }
             $originalPageType = $originalPage->getPageTypeObject();
             if (!$destinationPageChecker->canAddSubpage($originalPageType)) {
-                return t('You do not have sufficient privileges to alias the page "%1$s" under "%2$s".', $originalPage->getCollectionName(), $this->getDestinationPage()->getCollectionName());
+                return t('You do not have sufficient privileges to alias the page "%1$s" under "%2$s".', $originalPage->getCollectionDisplayName(), $this->getDestinationPage()->getCollectionDisplayName());
             }
         }
 
@@ -443,11 +443,11 @@ class DragRequestData
         foreach ($this->getOriginalPages() as $originalPage) {
             $originalPageChecker = new Checker($originalPage);
             if (!$originalPageChecker->canMoveOrCopyPage()) {
-                return t('You don\'t have the permission copy the page "%s".', $originalPage->getCollectionName());
+                return t('You don\'t have the permission copy the page "%s".', $originalPage->getCollectionDisplayName());
             }
             $originalPageType = $originalPage->getPageTypeObject();
             if (!$destinationPageChecker->canAddSubpage($originalPageType)) {
-                return t('You do not have sufficient privileges to copy the page "%1$s" under "%2$s".', $originalPage->getCollectionName(), $this->getDestinationPage()->getCollectionName());
+                return t('You do not have sufficient privileges to copy the page "%1$s" under "%2$s".', $originalPage->getCollectionDisplayName(), $this->getDestinationPage()->getCollectionDisplayName());
             }
         }
 
@@ -469,10 +469,10 @@ class DragRequestData
         $somePageWithChildren = false;
         foreach ($this->getOriginalPages() as $originalPage) {
             if ($originalPage->getCollectionID() == $destinationPageID) {
-                return t('It\'s not possible to copy the page "%s" and its child pages under the page itself.', $originalPage->getCollectionName());
+                return t('It\'s not possible to copy the page "%s" and its child pages under the page itself.', $originalPage->getCollectionDisplayName());
             }
             if (in_array($destinationPageID, $originalPage->getCollectionChildrenArray())) {
-                return t('It\'s not possible to copy the page "%s" and its child pages under one of its child pages.', $originalPage->getCollectionName());
+                return t('It\'s not possible to copy the page "%s" and its child pages under one of its child pages.', $originalPage->getCollectionDisplayName());
             }
             if ($somePageWithChildren === false && !$originalPage->isAliasPageOrExternalLink() && $originalPage->getNumChildrenDirect() > 0) {
                 $somePageWithChildren = true;
@@ -508,7 +508,7 @@ class DragRequestData
         }
         $pc = new Checker($destinationPage);
         if (!$pc->canWrite()) {
-            return t('You don\'t have the permission to edit the contents of "%s".', $destinationPage->getCollectionName());
+            return t('You don\'t have the permission to edit the contents of "%s".', $destinationPage->getCollectionDisplayName());
         }
 
         return '';

--- a/concrete/src/Sharing/ShareThisPage/Service.php
+++ b/concrete/src/Sharing/ShareThisPage/Service.php
@@ -29,7 +29,7 @@ class Service extends SocialNetworkService
         }
 
         if (is_object($c) && !$c->isError()) {
-            $title = $c->getCollectionName();
+            $title = $c->getCollectionDisplayName();
         } else {
             $title = \Core::make('site')->getSite()->getSiteName();
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -1191,7 +1191,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
 
         foreach ($sections as $section) {
             $sectionPage = \Page::getByID($section['cID']);
-            $this->output(t('Migrating multilingual section: %s...', $sectionPage->getCollectionName()));
+            $this->output(t('Migrating multilingual section: %s...', $sectionPage->getCollectionDisplayName()));
             // Create a locale for this section
 
             if ($site->getDefaultLocale()->getLocale() != $section['msLanguage'] . '_' . $section['msCountry']) {
@@ -1214,7 +1214,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
 
                     // We actually do nothing in this case since this is all already set up automatically earlier.
                 } else {
-                    $this->output(t('Setting pages for section %s to site tree %s...', $sectionPage->getCollectionName(), $tree->getSiteTreeID()));
+                    $this->output(t('Setting pages for section %s to site tree %s...', $sectionPage->getCollectionDisplayName(), $tree->getSiteTreeID()));
                     $tree->setSiteHomePageID($section['cID']);
                     $em->persist($tree);
                     $em->flush();

--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -61,16 +61,16 @@ class ApprovePageRequest extends PageRequest
             if (!$this->isNewPageRequest()) {
                 // new version of existing page
                 $d->setEmailDescription(t("\"%s\" has pending changes and needs to be approved.\n\nVersion Comments: %s\n\nView the page here: %s.",
-                    $c->getCollectionName(), $comments, $link));
+                    $c->getCollectionDisplayName(), $comments, $link));
                 $d->setDescription(t("Version %s of Page <a target=\"_blank\" href=\"%s\">%s</a> submitted for Approval.", $this->cvID, $link,
-                    $c->getCollectionName()));
+                    $c->getCollectionDisplayName()));
                 $d->setInContextDescription(t("Page Version %s Submitted for Approval.", $this->cvID));
                 $d->setShortStatus(t("Pending Approval"));
             } else {
                 // Completely new page.
                 $d->setEmailDescription(t("New page created: \"%s\". This page requires approval.\n\nAuthor Comments: %s\n\nView the page here: %s.",
-                    $c->getCollectionName(), $comments, $link));
-                $d->setDescription(t("New Page: <a target=\"_blank\" href=\"%s\">%s</a>", $link, $c->getCollectionName()));
+                    $c->getCollectionDisplayName(), $comments, $link));
+                $d->setDescription(t("New Page: <a target=\"_blank\" href=\"%s\">%s</a>", $link, $c->getCollectionDisplayName()));
                 $d->setInContextDescription(t("New Page %s submitted for approval.", $this->cvID));
                 $d->setShortStatus(t("New Page"));
             }

--- a/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
@@ -33,9 +33,9 @@ class ChangePagePermissionsInheritanceRequest extends PageRequest
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending permission inheritance. View the page here: %s.", $c->getCollectionName(), $link));
+        $d->setEmailDescription(t("\"%s\" has pending permission inheritance. View the page here: %s.", $c->getCollectionDisplayName(), $link));
         $d->setInContextDescription(t("Page Submitted to Change Permission Inheritance to %s.", ucfirst(strtolower($this->inheritance))));
-        $d->setDescription(t("<a href=\"%s\">%s</a> submitted to change permission inheritance to %s.", $link, $c->getCollectionName(), ucfirst(strtolower($this->inheritance))));
+        $d->setDescription(t("<a href=\"%s\">%s</a> submitted to change permission inheritance to %s.", $link, $c->getCollectionDisplayName(), ucfirst(strtolower($this->inheritance))));
         $d->setShortStatus(t("Permission Inheritance Changes"));
 
         return $d;

--- a/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
@@ -38,9 +38,9 @@ class ChangePagePermissionsRequest extends PageRequest
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending permission changes. View the page here: %s.", $c->getCollectionName(), $link));
+        $d->setEmailDescription(t("\"%s\" has pending permission changes. View the page here: %s.", $c->getCollectionDisplayName(), $link));
         $d->setInContextDescription(t("Page Submitted for Permission Changes."));
-        $d->setDescription(t("<a href=\"%s\">%s</a> submitted for Permission Changes.", $link, $c->getCollectionName()));
+        $d->setDescription(t("<a href=\"%s\">%s</a> submitted for Permission Changes.", $link, $c->getCollectionDisplayName()));
         $d->setShortStatus(t("Permission Changes"));
 
         return $d;

--- a/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
@@ -34,13 +34,13 @@ class ChangeSubpageDefaultsInheritanceRequest extends PageRequest
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending sub-page permission inhiterance changes. View the page here: %s.", $c->getCollectionName(), $link));
+        $d->setEmailDescription(t("\"%s\" has pending sub-page permission inhiterance changes. View the page here: %s.", $c->getCollectionDisplayName(), $link));
         if ($this->inheritance == 0) {
             $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from page type."));
         } else {
             $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from parent."));
         }
-        $d->setDescription(t("<a href=\"%s\">%s</a> has pending sub-page permission inhiterance changes.", $link, $c->getCollectionName()));
+        $d->setDescription(t("<a href=\"%s\">%s</a> has pending sub-page permission inhiterance changes.", $link, $c->getCollectionDisplayName()));
         $d->setShortStatus(t("Sub-Page Inheritance Changes"));
 
         return $d;

--- a/concrete/src/Workflow/Request/DeletePageRequest.php
+++ b/concrete/src/Workflow/Request/DeletePageRequest.php
@@ -30,9 +30,9 @@ class DeletePageRequest extends PageRequest
             $item = t('stack');
         }
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has been marked for deletion. View the page here: %s.", $c->getCollectionName(), $link));
+        $d->setEmailDescription(t("\"%s\" has been marked for deletion. View the page here: %s.", $c->getCollectionDisplayName(), $link));
         $d->setInContextDescription(t("This %s has been marked for deletion. ", $item));
-        $d->setDescription(t("<a href=\"%s\">%s</a> has been marked for deletion. ", $link, $c->getCollectionName()));
+        $d->setDescription(t("<a href=\"%s\">%s</a> has been marked for deletion. ", $link, $c->getCollectionDisplayName()));
         $d->setShortStatus(t("Pending Delete"));
 
         return $d;

--- a/concrete/src/Workflow/Request/MovePageRequest.php
+++ b/concrete/src/Workflow/Request/MovePageRequest.php
@@ -41,9 +41,9 @@ class MovePageRequest extends PageRequest
         $target = Page::getByID($this->targetCID, 'ACTIVE');
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
         $targetLink = Loader::helper('navigation')->getLinkToCollection($target, true);
-        $d->setEmailDescription(t("\"%s\" is pending a move to beneath \"%s\". Source Page: %s. Target Page: %s.", $c->getCollectionName(), $target->getCollectionName(), $link, $targetLink));
-        $d->setInContextDescription(t("This page is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $targetLink, $target->getCollectionName()));
-        $d->setDescription(t("<a href=\"%s\">%s</a> is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $link, $c->getCollectionName(), $targetLink, $target->getCollectionName()));
+        $d->setEmailDescription(t("\"%s\" is pending a move to beneath \"%s\". Source Page: %s. Target Page: %s.", $c->getCollectionDisplayName(), $target->getCollectionDisplayName(), $link, $targetLink));
+        $d->setInContextDescription(t("This page is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $targetLink, $target->getCollectionDisplayName()));
+        $d->setDescription(t("<a href=\"%s\">%s</a> is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $link, $c->getCollectionDisplayName(), $targetLink, $target->getCollectionDisplayName()));
         $d->setShortStatus(t("Pending Move"));
 
         return $d;

--- a/concrete/src/Workflow/Request/UnapprovePageRequest.php
+++ b/concrete/src/Workflow/Request/UnapprovePageRequest.php
@@ -41,9 +41,9 @@ class UnapprovePageRequest extends PageRequest
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
         $v = $c->getVersionObject();
         if (is_object($v)) {
-            $d->setEmailDescription(t("Page unapproval requested for page: \"%s\".\n\nView the page here: %s.", $c->getCollectionName(), $link));
-            $d->setDescription(t("Page %s submitted for unapproval.", '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>'));
-            $d->setInContextDescription(t("Page %s submitted for unapproval.", $c->getCollectionName()));
+            $d->setEmailDescription(t("Page unapproval requested for page: \"%s\".\n\nView the page here: %s.", $c->getCollectionDisplayName(), $link));
+            $d->setDescription(t("Page %s submitted for unapproval.", '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionDisplayName() . '</a>'));
+            $d->setInContextDescription(t("Page %s submitted for unapproval.", $c->getCollectionDisplayName()));
             $d->setShortStatus(t("Page Version Unapproval"));
         }
 

--- a/concrete/themes/dashboard/core_stack.php
+++ b/concrete/themes/dashboard/core_stack.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 $this->inc('elements/header.php'); ?>
 
-<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper($c->getCollectionName())?>
+<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper($c->getCollectionDisplayName())?>
 
 <?php
 

--- a/concrete/tools/pages/autocomplete.php
+++ b/concrete/tools/pages/autocomplete.php
@@ -13,7 +13,7 @@ if ($valt->validate('quick_page_select_' . $_REQUEST['key'], $_REQUEST['token'])
     $pageNames = array();
     foreach ($pages as $c) {
         $obj = new stdClass();
-        $obj->label = $c->getCollectionName();
+        $obj->label = $c->getCollectionDisplayName();
         $obj->value = $c->getCollectionID();
         $pageNames[] = $obj;
     }

--- a/concrete/tools/pages/delete.php
+++ b/concrete/tools/pages/delete.php
@@ -106,7 +106,7 @@ foreach ($pages as $c) {
 		<?=$form->hidden('cID[]', $c->getCollectionID())?>
 
 		<tr>
-			<td class="ccm-page-list-name"><?=$c->getCollectionName()?></td>
+			<td class="ccm-page-list-name"><?=h($c->getCollectionDisplayName())?></td>
 			<td><?=$c->getPageTypeName()?></td>
 			<td><?=$dh->formatDateTime($c->getCollectionDatePublic())?></td>
 			<td><?php

--- a/concrete/views/dialogs/area/edit/permissions.php
+++ b/concrete/views/dialogs/area/edit/permissions.php
@@ -37,7 +37,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                     echo t(
                         /*i18n: %s is the name of a page */
                         'The following area permissions are inherited from an area set on %s.',
-                        '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $areac->getCollectionID() . '">' . h($areac->getCollectionName()) . '</a>'
+                        '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $areac->getCollectionID() . '">' . h($areac->getCollectionDisplayName()) . '</a>'
                     );
                 }
                 ?>

--- a/concrete/views/dialogs/page/drag_request.php
+++ b/concrete/views/dialogs/page/drag_request.php
@@ -37,9 +37,9 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
         echo t('What do you wish to do?');
     } else {
         if ($dragRequestData->getDragMode() === 'none') {
-            echo t('You selected to move/copy "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+            echo t('You selected to move/copy "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionDisplayName()), h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
         } else {
-            echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+            echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionDisplayName()), h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
         }
 
     }
@@ -68,9 +68,9 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                     <input type="radio" name="ctask" value="<?= $dragRequestData::OPERATION_MOVE ?>" />
                     <?php
                     if ($singleOriginalPage !== null) {
-                        echo t('<strong>Move</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+                        echo t('<strong>Move</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionDisplayName()), h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                      } else {
-                         echo t('<strong>Move</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionName()));
+                         echo t('<strong>Move</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                      }
                      ?>
                 </label>
@@ -99,9 +99,9 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                     <input type="radio" name="ctask" value="<?= $dragRequestData::OPERATION_ALIAS ?>" />
                     <?php
                     if ($singleOriginalPage !== null) {
-                        echo t('<strong>Alias</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+                        echo t('<strong>Alias</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionDisplayName()), h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                     } else {
-                        echo t('<strong>Alias</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionName()));
+                        echo t('<strong>Alias</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                     }
                     ?>
                 </label>
@@ -130,9 +130,9 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPY ?>" />
                                 <?php
                                 if ($singleOriginalPage !== null) {
-                                    echo h(t('Copy "%1$s" beneath "%2$s"', $singleOriginalPage->getCollectionName(), $dragRequestData->getDestinationPage()->getCollectionName()));
+                                    echo h(t('Copy "%1$s" beneath "%2$s"', $singleOriginalPage->getCollectionDisplayName(), $dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                                 } else {
-                                    echo h(t('Copy pages beneath "%s"', $dragRequestData->getDestinationPage()->getCollectionName()));
+                                    echo h(t('Copy pages beneath "%s"', $dragRequestData->getDestinationPage()->getCollectionDisplayName()));
                                 }
                                 ?>
                             </label>
@@ -144,7 +144,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                         <div class="checkbox">
                             <label>
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPYALL ?>" />
-                                <?= h(t('Copy "%1$s" and all its children beneath "%2$s"', $singleOriginalPage->getCollectionName(), $dragRequestData->getDestinationPage()->getCollectionName())) ?>
+                                <?= h(t('Copy "%1$s" and all its children beneath "%2$s"', $singleOriginalPage->getCollectionDisplayName(), $dragRequestData->getDestinationPage()->getCollectionDisplayName())) ?>
                             </label>
                         </div>
                         <?php
@@ -154,7 +154,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                         <div class="checkbox">
                             <label>
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPYVERSION ?>" />
-                                <?= h(t('Replace "%1$s" with a copy of "%2$s"', $dragRequestData->getDestinationPage()->getCollectionName(), $singleOriginalPage->getCollectionName())) ?>
+                                <?= h(t('Replace "%1$s" with a copy of "%2$s"', $dragRequestData->getDestinationPage()->getCollectionDisplayName(), $singleOriginalPage->getCollectionDisplayName())) ?>
                             </label>
                         </div>
                     </div>

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -104,7 +104,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 	<% if (parentID && parentID > 0) { %>
 	<ol class="breadcrumb">
 	  <li><a href="<%=parentLink%>" target="_blank"><%=parentName%></a></li>
-	  <li class="active"><?=$c->getCollectionName()?></li>
+	  <li class="active"><?=h($c->getCollectionDisplayName())?></li>
 	</ol>
 	<% } else { %>
 		<div class="breadcrumb">
@@ -152,7 +152,7 @@ $(function() {
 
 	$('#ccm-panel-detail-location-display').html(renderBreadcrumb({
 		parentLink: '<?=Loader::helper('navigation')->getLinkToCollection($parent);?>',
-		parentName: <?=json_encode($parent->getCollectionName())?>,
+		parentName: <?=json_encode($parent->getCollectionDisplayName())?>,
 		parentID: '<?=$cParentID?>'
 	}));
 

--- a/concrete/views/panels/details/page/permissions/advanced.php
+++ b/concrete/views/panels/details/page/permissions/advanced.php
@@ -46,7 +46,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                     echo t('This page inherits its permissions from:');
                 }
                 ?>
-                <a target="_blank" href="<?=URL::to($cpc)?>"><?=$cpc->getCollectionName()?></a>
+                <a target="_blank" href="<?=URL::to($cpc)?>"><?=h($cpc->getCollectionDisplayName())?></a>
             </div>
             <?php
         }

--- a/concrete/views/panels/page/relations.php
+++ b/concrete/views/panels/page/relations.php
@@ -32,7 +32,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                     <?php if ($relatedID && $currentSection->getCollectionID() != $m->getCollectionID()) {
         $relatedPage = Page::getByID($relatedID, 'RECENT');
         ?>
-                        <a href="<?=$relatedPage->getCollectionLink()?>"><?=$icon?> <?=$relatedPage->getCollectionName()?></a>
+                        <a href="<?=$relatedPage->getCollectionLink()?>"><?=$icon?> <?=h($relatedPage->getCollectionDisplayName())?></a>
                     <?php
     } else {
         ?>

--- a/concrete/views/panels/sitemap.php
+++ b/concrete/views/panels/sitemap.php
@@ -48,8 +48,8 @@
             <?php foreach ($drafts as $dc) {
                 ?>
                 <li><a href="<?=Loader::helper('navigation')->getLinkToCollection($dc)?>"><?php
-                        if ($dc->getCollectionName()) {
-                            echo $dc->getCollectionName() . ' ' . Core::make('date')->formatDateTime($dc->getCollectionDateAdded(), false);
+                        if ($dc->getCollectionDisplayName() !== '') {
+                            echo $dc->getCollectionDisplayName() . ' ' . Core::make('date')->formatDateTime($dc->getCollectionDateAdded(), false);
                         } else {
                             echo t('(Untitled)') . ' ' . Core::make('date')->formatDateTime($dc->getCollectionDateAdded(), false);
                         }


### PR DESCRIPTION
When displaying the page names when the current language is not English, we currently display page names in different ways:
- direct calls to `$page->getCollectionName()`, which returns the English name of pages (which is wrong for example in case of dashboard pages)
- calls to `t($page->getCollectionName())`, which tries to translate the English name of pages (which is wrong for example in case of regular site pages)
- calls to `$page->isSystemPage ? t($c->getCollectionName()) : $c->getCollectionName()`, which works for dashboard pages but not for single pages

So, what about adding `Page::getCollectionDisplayName()` and use it whenever we need to display page names?
