### PR TITLE
Allow users to customize the URL of the login page

### DIFF
--- a/concrete/authentication/concrete/change_password.php
+++ b/concrete/authentication/concrete/change_password.php
@@ -25,7 +25,7 @@ if (!empty($_error)) {
 <h4><?= t('Reset Password') ?></h4>
 <div class="help-block"><?= t('Enter your new password below.') ?></div>
 <div class="change-password">
-	<form method="post" action="<?= URL::to('/login', 'callback', $authType->getAuthenticationTypeHandle(), 'change_password', $uHash) ?>">
+	<form method="post" action="<?= h(app('helper/navigation')->getLoginUrl(['callback', $authType->getAuthenticationTypeHandle(), 'change_password', $uHash])) ?>">
 		<div class="form-group">
 			<label class="control-label" for="uPassword"><?= t('New Password') ?></label>
 			<input type="password" name="uPassword" id="uPassword" class="form-control" autocomplete="off"/>

--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -232,12 +232,12 @@ class Controller extends AuthenticationTypeController
                     //generate hash that'll be used to authenticate user, allowing them to change their password
                     $h = new ValidationHash();
                     $uHash = $h->add($oUser->getUserID(), intval(UVTYPE_CHANGE_PASSWORD), true);
-                    $changePassURL = View::url(
-                        '/login',
+                    $changePassURL = $this->app->make('helper/navigation')->getLoginUrl([
                         'callback',
                         $this->getAuthenticationType()->getAuthenticationTypeHandle(),
                         'change_password',
-                        $uHash);
+                        $uHash,
+                    ]);
 
                     $mh->addParameter('changePassURL', $changePassURL);
 
@@ -268,8 +268,10 @@ class Controller extends AuthenticationTypeController
             if ($error->has()) {
                 $this->set('error', $error);
             } else {
-                $this->redirect('/login', $this->getAuthenticationType()->getAuthenticationTypeHandle(),
-                    'password_sent');
+                $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+                    $this->getAuthenticationType()->getAuthenticationTypeHandle(),
+                    'password_sent',
+                ]));
             }
         }
     }
@@ -299,7 +301,10 @@ class Controller extends AuthenticationTypeController
                         $h->deleteKey('UserValidationHashes', 'uHash', $uHash);
                         $this->set('passwordChanged', true);
 
-                        $this->redirect('/login', $this->getAuthenticationType()->getAuthenticationTypeHandle(), 'password_changed');
+                        $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+                            $this->getAuthenticationType()->getAuthenticationTypeHandle(),
+                            'password_changed',
+                        ]));
                     } else {
                         $this->set('error', $e);
                     }
@@ -309,7 +314,10 @@ class Controller extends AuthenticationTypeController
                 return;
             }
         }
-        $this->redirect('/login', $this->getAuthenticationType()->getAuthenticationTypeHandle(), 'invalid_token');
+        $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+            $this->getAuthenticationType()->getAuthenticationTypeHandle(),
+            'invalid_token'
+        ]));
     }
 
     public function password_changed()
@@ -357,7 +365,10 @@ class Controller extends AuthenticationTypeController
             $user = $loginService->login($uName, $uPassword);
         } catch (UserPasswordResetException $e) {
             Session::set('uPasswordResetUserName', $this->post('uName'));
-            $this->redirect('/login/', $this->getAuthenticationType()->getAuthenticationTypeHandle(), 'required_password_upgrade');
+            $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+                $this->getAuthenticationType()->getAuthenticationTypeHandle(),
+                'required_password_upgrade',
+            ]));
         } catch (UserException $e) {
             $this->handleFailedLogin($loginService, $uName, $uPassword, $e);
         }
@@ -423,9 +434,18 @@ class Controller extends AuthenticationTypeController
             } else {
                 $mode = 'workflow';
             }
-            $this->redirect('/login/callback/concrete', 'email_validated', $mode);
+            $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+                'callback',
+                'concrete',
+                'email_validated',
+                $mode,
+            ]));
             exit;
         }
-        $this->redirect('/login/callback/concrete', 'invalid_token');
+        $this->redirect($this->app->make('helper/navigation')->getLoginUrl([
+            'callback',
+            'concrete',
+            'invalid_token',
+        ]));
     }
 }

--- a/concrete/authentication/concrete/forgot_password.php
+++ b/concrete/authentication/concrete/forgot_password.php
@@ -1,7 +1,7 @@
 <?php defined('C5_EXECUTE') or die('Access denied.'); ?>
 
 <div class="forgotPassword">
-	<form method="post" action="<?= URL::to('/login', 'callback', $authType->getAuthenticationTypeHandle(), 'forgot_password') ?>">
+	<form method="post" action="<?= h(app('helper/navigation')->getLoginUrl(['callback', $authType->getAuthenticationTypeHandle(), 'forgot_password'])) ?>">
 		<?php $token->output(); ?>
 		<h4><?= t('Forgot Your Password?') ?></h4>
 		<div class="ccm-message"><?= isset($intro_msg) ? $intro_msg : '' ?></div>

--- a/concrete/authentication/concrete/form.php
+++ b/concrete/authentication/concrete/form.php
@@ -4,7 +4,7 @@ $dh = Core::make('helper/date');  /* @var $dh \Concrete\Core\Localization\Servic
 /* @var Concrete\Core\Form\Service\Form $form */
 ?>
 
-<form method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()) ?>">
+<form method="post" action="<?= h(app('helper/navigation')->getLoginUrl(['authenticate', $this->getAuthenticationTypeHandle()])) ?>">
 
 	<div class="form-group">
 		<label class="control-label" for="uName"><?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('Username')?></label>
@@ -36,7 +36,7 @@ $dh = Core::make('helper/date');  /* @var $dh \Concrete\Core\Localization\Servic
 
 	<div class="form-group">
 		<button class="btn btn-primary"><?= t('Log in') ?></button>
-		<a href="<?= URL::to('/login', 'concrete', 'forgot_password')?>" class="btn pull-right"><?= t('Forgot Password') ?></a>
+		<a href="<?= h(app('helper/navigation')->getLoginUrl(['concrete', 'forgot_password']))?>" class="btn pull-right"><?= t('Forgot Password') ?></a>
 	</div>
 
 	<?php Core::make('helper/validation/token')->output('login_' . $this->getAuthenticationTypeHandle()); ?>

--- a/concrete/authentication/concrete/invalid_token.php
+++ b/concrete/authentication/concrete/invalid_token.php
@@ -5,7 +5,7 @@
 	<div class="help-block">
 		<?= t('The token you provided doesn\'t appear to be valid. Please paste the url exactly as it appears in the email or visit the forgot password page again to have a new token generated.') ?>
 	</div>
-	<a href="<?= URL::to('/login/callback/concrete') ?>" class="btn btn-block btn-primary">
+	<a href="<?= h(app('helper/navigation')->getLoginUrl(['callback', 'concrete'])) ?>" class="btn btn-block btn-primary">
 		<?= t('Continue') ?>
 	</a>
 </div>

--- a/concrete/authentication/concrete/password_sent.php
+++ b/concrete/authentication/concrete/password_sent.php
@@ -6,7 +6,7 @@
 	<div class="help-block">
 		<?= t('If there is an account associated with this email, instructions for resetting your password have been sent.') ?>
 	</div>
-	<a href="<?= URL::to('/login') ?>" class="btn btn-block btn-primary">
+	<a href="<?= h(app('helper/navigation')->getLoginUrl()) ?>" class="btn btn-block btn-primary">
 		<?= t('Go Back') ?>
 	</a>
 </div>

--- a/concrete/authentication/concrete/required_password_upgrade.php
+++ b/concrete/authentication/concrete/required_password_upgrade.php
@@ -2,7 +2,7 @@
 
 <div class="required-password-upgrade">
     <form method="post"
-          action="<?= URL::to('/login', 'callback', $authType->getAuthenticationTypeHandle(), 'required_password_upgrade') ?>">
+          action="<?= h(app('helper/navigation')->getLoginUrl(['callback', $authType->getAuthenticationTypeHandle(), 'required_password_upgrade'])) ?>">
 	    <?php $token->output(); ?>
         <h4><?= t('Required password upgrade') ?></h4>
         <div class="ccm-message"></div>

--- a/concrete/authentication/facebook/controller.php
+++ b/concrete/authentication/facebook/controller.php
@@ -120,7 +120,7 @@ class Controller extends GenericOauth2TypeController
     {
 
         if (!User::isLoggedIn()) {
-            $response = new RedirectResponse(\URL::to('/login'), 302);
+            $response = new RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(), 302);
             $response->send();
             exit;
         }

--- a/concrete/authentication/facebook/form.php
+++ b/concrete/authentication/facebook/form.php
@@ -20,7 +20,7 @@ if (isset($message)) {
 
 if (isset($show_email) && $show_email) {
     ?>
-    <form action="<?= \URL::to('/login/callback/facebook/handle_register') ?>">
+    <form action="<?= h(app('helper/navigation')->getLoginUrl(['callback', 'facebook', 'handle_register'])) ?>">
         <?php // It's best to show full name here for regional variations
         if (isset($fullName) && !empty($fullName)) {?>
         <span><?= t('Register an account for "%s"', $fullName) ?></span>

--- a/concrete/authentication/facebook/type_form.php
+++ b/concrete/authentication/facebook/type_form.php
@@ -5,7 +5,7 @@
     <p><?php echo t('<a href="%s" target="_blank">Click here</a> to obtain your access keys.', 'https://developers.facebook.com/apps/'); ?></p>
     <p><?php echo t('Add the "Facebook Login" product to a Facebook app.'); ?></p>
     <p><?php echo t('Set the "Valid OAuth redirect URIs" to: %s', ' <code>'.URL::to('/ccm/system/authentication/oauth2/facebook/callback').'</code>'); ?></p>
-    <p><?php echo t('Set the "Deauthorize Callback URL" to: %s', ' <code>'.URL::to('/login/callback/facebook/revoke').'</code>'); ?></p>
+    <p><?php echo t('Set the "Deauthorize Callback URL" to: %s', ' <code>'.h(app('helper/navigation')->getLoginUrl(['callback', 'facebook', 'revoke'])).'</code>'); ?></p>
 </div>
 
 <div class='form-group'>

--- a/concrete/authentication/google/controller.php
+++ b/concrete/authentication/google/controller.php
@@ -147,7 +147,7 @@ class Controller extends GenericOauth2TypeController
     {
 
         if (!User::isLoggedIn()) {
-            $response = new RedirectResponse(\URL::to('/login'), 302);
+            $response = new RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(), 302);
             $response->send();
             exit;
         }

--- a/concrete/authentication/google/form.php
+++ b/concrete/authentication/google/form.php
@@ -15,7 +15,7 @@ if (isset($message)) {
 
 if (isset($show_email) && $show_email) {
     ?>
-    <form action="<?= \URL::to('/login/callback/google/handle_register') ?>">
+    <form action="<?= h(app('helper/navigation')->getLoginUrl(['callback', 'google', 'handle_register'])) ?>">
         <?php
         // It's best to show full name here for regional variations of display order of names
         if (isset($fullName) && !empty($fullName)) {?>

--- a/concrete/authentication/twitter/controller.php
+++ b/concrete/authentication/twitter/controller.php
@@ -98,7 +98,7 @@ class Controller extends GenericOauth1aTypeController
     {
 
         if (!User::isLoggedIn()) {
-            $response = new RedirectResponse(\URL::to('/login'), 302);
+            $response = new RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(), 302);
             $response->send();
             exit;
         }

--- a/concrete/authentication/twitter/form.php
+++ b/concrete/authentication/twitter/form.php
@@ -15,7 +15,7 @@ if (isset($message)) {
 
 if (isset($show_email) && $show_email) {
     ?>
-    <form action="<?= \URL::to('/login/callback/twitter/handle_register') ?>">
+    <form action="<?= h(app('helper/navigation')->getLoginUrl(['callback', 'twitter', 'handle_register'])) ?>">
         <span><?= t('Register an account for "%s"', "@{$username}") ?></span>
         <hr />
         <div class="input-group">

--- a/concrete/blocks/survey/controller.php
+++ b/concrete/blocks/survey/controller.php
@@ -112,7 +112,7 @@ class Controller extends BlockController
 
         if ($this->requiresRegistration()) {
             if (!$u->isRegistered()) {
-                $this->redirect('/login');
+                $this->redirect($this->app->make('helper/navigation')->getLoginUrl());
             }
         }
 

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.2',
     'version_installed' => '8.5.2',
-    'version_db' => '20191002000000', // the key of the latest database migration
+    'version_db' => '20191121000000', // the key of the latest database migration
  
     /*
      * Installation status

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -612,6 +612,7 @@ return [
     'paths' => [
         'trash' => '/!trash',
         'drafts' => '/!drafts',
+        'login' => '/login'
     ],
     'icons' => [
         'page_template' => [

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -955,6 +955,13 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Login Page" path="/dashboard/system/registration/login" filename="/dashboard/system/registration/login.php" pagetype="" description="Set the URL of the login page." package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>login, security, url</value>
+                </attributekey>
+            </attributes>
+        </page>
 
         <page name="Email" path="/dashboard/system/mail" filename="/dashboard/system/mail/view.php" pagetype=""
               description="Control how your site send and processes mail." package="">

--- a/concrete/controllers/frontend/page_forbidden.php
+++ b/concrete/controllers/frontend/page_forbidden.php
@@ -13,7 +13,7 @@ class PageForbidden extends Controller
     {
         $u = new User();
         if (!$u->isRegistered() && Config::get('concrete.permissions.forward_to_login')) { //if they are not logged in, and we show guests the login...
-            $this->redirect('/login');
+            $this->redirect($this->app->make('helper/navigation')->getLoginUrl());
         }
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
@@ -122,7 +122,7 @@ class AutomatedLogout extends DashboardPageController
         $this->flash('error', t('All sessions have been invalidated. You must log back in to continue.'));
 
         // Redirect to the login page
-        return $this->factory->redirect($this->urls->resolve(['/login']));
+        return $this->factory->redirect($this->app->make('helper/navigation')->getLoginUrl());
     }
 
     /**

--- a/concrete/controllers/single_page/dashboard/system/registration/login.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/login.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Concrete\Controller\SinglePage\Dashboard\System\Registration;
+
+use Concrete\Core\Entity\Page\PagePath;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Utility\Service\Validation\Strings;
+use Doctrine\ORM\EntityManagerInterface;
+
+class Login extends DashboardPageController
+{
+    public function view()
+    {
+        $config = $this->app->make('config');
+
+        $this->set('loginUrl', $config->get('concrete.paths.login'));
+        $this->set('saveAction', $this->action('save'));
+    }
+
+    public function save()
+    {
+        if (!$this->token->validate('set-login-url')) {
+            $this->error->add($this->token->getErrorMessage());
+
+            return $this->view();
+        }
+        $newLoginUrl = $this->normalizeLoginUrl($this->request->request->get('loginUrl'));
+        if ($newLoginUrl === '') {
+            $this->error->add(t('Invalid URL of the login page'));
+
+            return $this->view();
+        }
+        $config = $this->app->make('config');
+        $oldLoginUrl = $config->get('concrete.paths.login');
+        $loginPage = Page::getByPath($oldLoginUrl);
+        if ($loginPage === null || $loginPage->isError()) {
+            $this->error->addHtml(t('Failed to get the page at the URL %s', '<code>' . h($oldLoginUrl) . '</code>'));
+
+            return $this->view();
+        }
+        $this->app->make(EntityManagerInterface::class)->transactional(function (EntityManagerInterface $em) use ($oldLoginUrl, $newLoginUrl, $loginPage, $config) {
+            $loginPage->clearPagePaths();
+            $newPagePath = new PagePath();
+            $newPagePath->setPagePath($newLoginUrl);
+            $newPagePath->setPageObject($loginPage);
+            $newPagePath->setPagePathIsCanonical(true);
+            $em->persist($newPagePath);
+            $em->flush();
+            $pageThemes = $config->get('app.theme_paths');
+            $loginPageTheme = array_get($pageThemes, $oldLoginUrl);
+            unset($pageThemes[$oldLoginUrl]);
+            if ($loginPageTheme !== null) {
+                $pageThemes[$newLoginUrl] = $loginPageTheme;
+            }
+            $config->save('app.theme_paths', $pageThemes);
+            $config->save('concrete.paths.login', $newLoginUrl);
+        });
+
+        $this->flash('success', t('Options successfully saved.'));
+
+        return $this->app->make(ResponseFactoryInterface::class)->redirect(
+            $this->action(''),
+            302
+        );
+    }
+
+    /**
+     * @param mixed $url
+     *
+     * @return string
+     */
+    protected function normalizeLoginUrl($url)
+    {
+        if (!is_string($url)) {
+            return '';
+        }
+        $vals = $this->app->make(Strings::class);
+        $chunks = [];
+        foreach (preg_split('%[/\s]+%', $url, -1, PREG_SPLIT_NO_EMPTY) as $chunk) {
+            if (!$vals->handle($chunk)) {
+                return '';
+            }
+            $chunks[] = $chunk;
+        }
+        if ($chunks === []) {
+            return '';
+        }
+
+        return '/' . implode('/', $chunks);
+    }
+}

--- a/concrete/controllers/single_page/dashboard/system/registration/postlogin.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/postlogin.php
@@ -14,7 +14,7 @@ class Postlogin extends DashboardPageController
         parent::__construct($c);
         $this->token = Loader::helper('validation/token');
 
-        //login redirection
+        // login redirection
         $this->set('site_login_redirect', Config::get('concrete.misc.login_redirect'));
         $this->set('login_redirect_cid', intval(Config::get('concrete.misc.login_redirect_cid')));
     }

--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -208,7 +208,7 @@ class Login extends PageController implements LoggerAwareInterface
         $this->app->make('director')->dispatch('on_user_login', $ue);
 
         return new RedirectResponse(
-            $this->app->make('url/manager')->resolve(['/login', 'login_complete'])
+            $this->app->make('helper/navigation')->getLoginUrl(['login_complete'])
         );
     }
 

--- a/concrete/controllers/single_page/members/profile.php
+++ b/concrete/controllers/single_page/members/profile.php
@@ -24,7 +24,7 @@ class Profile extends PublicProfilePageController
             $profile = UserInfo::getByID($u->getUserID());
         } else {
             $this->set('intro_msg', t('You must sign in order to access this page!'));
-            return $this->replace('/login');
+            return $this->replace($this->app->make('helper/navigation')->getLoginPath());
         }
         if (is_object($profile) && $profile->getUserID() == $u->getUserID()) {
             $canEdit = true;

--- a/concrete/controllers/single_page/page_forbidden.php
+++ b/concrete/controllers/single_page/page_forbidden.php
@@ -4,7 +4,6 @@ namespace Concrete\Controller\SinglePage;
 
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\PageController;
-use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\User\User;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,7 +39,7 @@ class PageForbidden extends PageController
         if ($user === null || !$user->isRegistered()) {
             $config = $this->app->make('config');
             if ($config->get('concrete.permissions.forward_to_login')) {
-                $destination = $this->app->make(ResolverManagerInterface::class)->resolve(['/login']);
+                $destination = $this->app->make('helper/navigation')->getLoginUrl();
                 $result = $this->app->make(ResponseFactoryInterface::class)->redirect($destination, Response::HTTP_FOUND);
             }
         }

--- a/concrete/elements/account/menu.php
+++ b/concrete/elements/account/menu.php
@@ -52,7 +52,7 @@ $url = $app->make('url/manager');
             ?>
             <li class="divider"></li>
             <li><a href="<?=$url->resolve(['/'])?>"><i class="fa fa-home"></i> <?=t('Home')?></a></li>
-            <li><a href="<?=$url->resolve(['/login', 'do_logout', $app->make('token')->generate('do_logout')])?>"><i class="fa fa-sign-out"></i> <?=t('Sign Out')?></a></li>
+            <li><a href="<?=h($app->make('helper/navigation')->getLogoutUrl())?>"><i class="fa fa-sign-out"></i> <?=t('Sign Out')?></a></li>
         </ul>
     </div>
 </div>

--- a/concrete/elements/conversation/message/add_form.php
+++ b/concrete/elements/conversation/message/add_form.php
@@ -122,7 +122,7 @@ $u = new User();
                 print '<p>';
                 echo ' ';
                 if (!$u->isRegistered()) {
-                    echo t('You must <a href="%s">sign in</a> to post to this conversation.', URL::to('/login'));
+                    echo t('You must <a href="%s">sign in</a> to post to this conversation.', h(app('helper/navigation')->getLoginUrl()));
                 } else {
                     echo t('You do not have permission to post this to conversation.');
                 }

--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -246,7 +246,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                         ?>
                         <li>
                             <i class="fa fa-sign-out mobile-leading-icon"></i>
-                            <a href="<?= URL::to('/login', 'do_logout', $valt->generate('do_logout')); ?>"><?= t('Sign Out'); ?></a>
+                            <a href="<?= h($app->make('helper/navigation')->getLogoutUrl()) ?>"><?= t('Sign Out'); ?></a>
                         </li>
                     </ul>
                 </div>
@@ -381,7 +381,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                 } else {
                     ?>
                     <li class="pull-right hidden-xs">
-                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-toggle="tooltip" data-placement="bottom" data-delay='{ "show": 500, "hide": 0 }' href="<?=URL::to('/login', 'logout', $valt->generate('logout'))?>" title="<?=t('Sign Out')?>">
+                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-toggle="tooltip" data-placement="bottom" data-delay='{ "show": 500, "hide": 0 }' href="<?=h($app->make('helper/navigation')->getLogoutUrl())?>" title="<?=t('Sign Out')?>">
                             <i class="fa fa-sign-out"></i><span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings"><?= tc('toolbar', 'Sign Out') ?></span>
                         </a>
                     </li>

--- a/concrete/elements/panels/dashboard.php
+++ b/concrete/elements/panels/dashboard.php
@@ -61,6 +61,6 @@ foreach ($parents as $pc) {
 	
 	<div class="ccm-panel-dashboard-footer">
 		<p><?=t('Logged in as <a href="%s">%s</a>', URL::to('/account'), $ui->getUserDisplayName());?>. </p>
-		<a href="<?=URL::to('/login', 'do_logout', Loader::helper('validation/token')->generate('do_logout'))?>"><?=t('Sign Out.')?></a>
+		<a href="<?=h(app('helper/navigation')->getLogoutUrl())?>"><?=t('Sign Out.')?></a>
 	</div>
 </section>

--- a/concrete/mail/user_registered_approval_complete.php
+++ b/concrete/mail/user_registered_approval_complete.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 
 $subject = $siteName.' '.t('Registration Approved');
-
+$loginUrl = app('helper/navigation')->getLoginUrl();
 /*
  * HTML BODY START
  */
@@ -12,7 +12,7 @@ ob_start();
 <h2><?= t('Welcome to') ?> <?= $siteName ?></h2>
 <?= t("Your registration has been approved. You can log into your new account here") ?>:<br />
 <br />
-<a href="<?= View::url('/login') ?>"><?= View::url('/login') ?></a>
+<a href="<?= h($loginUrl) ?>"><?= h($loginUrl) ?></a>
 <?php
 
 $bodyHTML = ob_get_clean();
@@ -30,7 +30,7 @@ ob_start();
 
 <?= t("Your registration has been approved. You can log into your new account here") ?>:
 
-<?= View::url('/login') ?>
+<?= $loginUrl ?>
 <?php
 
 $body = ob_get_clean();

--- a/concrete/mail/validate_user_email.php
+++ b/concrete/mail/validate_user_email.php
@@ -11,4 +11,4 @@ You must click the following URL in order to activate your account for %s:
 
 Thanks for your interest in %s
 
-", $site, View::url('/login', 'callback', 'concrete', 'v', $uHash), $site);
+", $site, app('helper/navigation')->getLoginUrl(['callback', 'concrete', 'v', $uHash]), $site);

--- a/concrete/single_pages/dashboard/system/registration/login.php
+++ b/concrete/single_pages/dashboard/system/registration/login.php
@@ -1,0 +1,31 @@
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Html\Service\Html $html
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Application\Service\UserInterface $interface
+ * @var string $loginUrl
+ * @var string $saveAction
+ */
+
+?>
+<form action="<?= $saveAction ?>" method="POST">
+    <?php $token->output('set-login-url') ?>
+    
+    <div class="form-group">
+        <?= $form->label('loginUrl', t('Relative URL of the login page')) ?>
+        <?= $form->text('loginUrl', $loginUrl, ['required' => 'required']) ?>
+    </div>
+
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <div class="pull-right">
+                <button class="btn btn-primary" type="submit"><?= t('Save') ?></button>
+            </div>
+        </div>
+    </div>
+    
+</form>

--- a/concrete/single_pages/login_oauth.php
+++ b/concrete/single_pages/login_oauth.php
@@ -60,7 +60,7 @@ $form = Loader::helper('form');
 			<div class='help-block'>
 				<?=t('Enter your email address below. We will send you instructions to reset your password.')?>
 			</div>
-			<form method="post" action="<?=$view->url('/login', 'forgot_password')?>" class="form-horizontal">
+			<form method="post" action="<?=h(app('helper/navigation')->getLoginUrl(['forgot_password']))?>" class="form-horizontal">
 				<div class='control-group'>
 					<label class='control-label' for='uEmail'><?=t('Email Address')?></label>
 					<div class='controls'>

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -47,7 +47,7 @@ abstract class AuthenticationTypeController extends Controller implements Logger
 
     public function completeAuthentication(User $u)
     {
-        $c = Page::getByPath('/login');
+        $c = Page::getByPath($this->app->make('helper/navigation')->getLoginPath());
         $controller = $c->getPageController();
         return $controller->finishAuthentication($this->getAuthenticationType(), $u);
     }

--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -88,7 +88,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         if ($error) {
             $this->markError($error);
         }
-        id(new \RedirectResponse(\URL::to('/login/callback/' . $this->getHandle() . '/handle_error')))->send();
+        id(new \RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(['callback', $this->getHandle(), 'handle_error'])))->send();
     }
 
     public function markError($error)
@@ -112,7 +112,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         if ($message) {
             $this->markSuccess($message);
         }
-        id(new \RedirectResponse(\URL::to('/login/callback/' . $this->getHandle() . '/handle_success')))->send();
+        id(new \RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(['callback', $this->getHandle(), 'handle_success'])))->send();
     }
 
     public function markSuccess($message)
@@ -214,7 +214,12 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
                 $flashbag->set('token', $this->getToken());
 
 
-                $response = \Redirect::to('/login/callback/' . $this->getHandle() . '/handle_register/', id(new Token())->generate($this->getHandle() . '_register'));
+                $response = \Redirect::to($this->app->make('helper/navigation')->getLoginUrl([
+                    'callback',
+                    $this->getHandle(),
+                    'handle_register',
+                    id(new Token())->generate($this->getHandle() . '_register'),
+                ]));
                 $response->send();
                 exit;
 
@@ -246,7 +251,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
 
         if (!$token_helper->validate($this->getHandle().'_register', $token) && !$token_helper->validate($this->getHandle().'_register') ||
             !$this->token) {
-            $this->redirect('/login/');
+            $this->redirect($this->app->make('helper/navigation')->getLoginUrl());
             exit;
         }
         if (\Request::request('uEmail', false)) {
@@ -580,7 +585,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     public function handle_detach_attempt()
     {
         if (!User::isLoggedIn()) {
-            $response = new RedirectResponse(\URL::to('/login'), 302);
+            $response = new \RedirectResponse($this->app->make('helper/navigation')->getLoginUrl(), 302);
             $response->send();
             exit;
         }

--- a/concrete/src/Html/Service/Navigation.php
+++ b/concrete/src/Html/Service/Navigation.php
@@ -5,7 +5,7 @@ use Database;
 use Page;
 use URL;
 use User;
-use Concrete\Core\Validation\CSRF\Token;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 
 class Navigation
 {
@@ -64,13 +64,55 @@ class Navigation
         return $this->getLinkToCollection($cObj);
     }
 
+    /**
+     * Get the path to the login page, relative to the concrete5 web root.
+     *
+     * @return string
+     */
+    public function getLoginPath()
+    {
+        return app('config')->get('concrete.paths.login');
+    }
+
+    /**
+     * Get the URL to the login page.
+     *
+     * @param array $arguments additional arguments for the login page.
+     *
+     * @return \Concrete\Core\Url\UrlImmutable
+     */
+    public function getLoginUrl(array $arguments = [])
+    {
+        array_unshift($arguments, $this->getLoginPath());
+
+        return app(ResolverManagerInterface::class)->resolve($arguments);
+    }
+
+    /**
+     * Get the URL to be visited to log out the current user.
+     *
+     * @return \Concrete\Core\Url\UrlImmutable
+     */
+    public function getLogoutUrl()
+    {
+        return $this->getLoginUrl([
+            'do_logout',
+            app('token')->generate('do_logout'),
+        ]);
+    }
+
+    /**
+     * Get an "<a>" HTML element pointing to the login page (if the user is not logged in) or to the URL that logs out the user.
+     *
+     * @return string
+     */
     public function getLogInOutLink()
     {
         if (!id(new User())->isLoggedIn()) {
-            $url = URL::to('/login');
+            $url = $this->getLoginUrl();
             $label = t('Log in');
         } else {
-            $url = URL::to('/login', 'do_logout', id(new Token())->generate('do_logout'));
+            $url = $this->getLogoutUrl();
             $label = t('Log out');
         }
 

--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -88,10 +88,10 @@ class DefaultDispatcher implements DispatcherInterface
             if ($user->isError()) {
                 switch ($user->getError()) {
                     case USER_SESSION_EXPIRED:
-                        return Redirect::to('/login', 'session_invalidated')->send();
+                        return Redirect::to($this->app->make('helper/navigation')->getLoginUrl(['session_invalidated']))->send();
                 }
             } elseif (!$isActive) {
-                return Redirect::to('/login', 'account_deactivated')->send();
+                return Redirect::to($this->app->make('helper/navigation')->getLoginUrl(['account_deactivated']))->send();
             } else {
                 $v = new View('/frontend/user_error');
                 $v->setViewTheme('concrete');

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -250,7 +250,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         }
 
         // maintenance mode
-        if ($collection->getCollectionPath() != '/login') {
+        if ($collection->getCollectionPath() !== $this->app->make('helper/navigation')->getLoginPath()) {
             $smm = $this->config->get('concrete.maintenance_mode');
             if ($smm == 1 && !Key::getByHandle('view_in_maintenance_mode')->validate() && ($_SERVER['REQUEST_METHOD'] != 'POST' || $this->app->make('token')->validate() == false)) {
                 $v = new View('/frontend/maintenance_mode');

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -641,7 +641,7 @@ class StartingPointPackage extends BasePackage
         );
 
         // login
-        $login = Page::getByPath('/login', 'RECENT');
+        $login = Page::getByPath($this->app->make('helper/navigation')->getLoginPath(), 'RECENT');
         $login->assignPermissions($g1, ['view_page']);
 
         // register

--- a/concrete/src/Page/Controller/AccountPageController.php
+++ b/concrete/src/Page/Controller/AccountPageController.php
@@ -18,7 +18,7 @@ class AccountPageController extends CorePageController
     {
         $u = new \User();
         if (!$u->isRegistered()) {
-            return $this->replace('/login');
+            return $this->replace($this->app->make('helper/navigation')->getLoginPath());
         }
         $profile = \UserInfo::getByID($u->getUserID());
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20191121000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20191121000000.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20191121000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->createSinglePage(
+            '/dashboard/system/registration/login',
+            'Login Page',
+            [
+                'meta_keywords' => 'login, security, url',
+            ]
+        );
+    }
+}

--- a/concrete/themes/concrete/elements/header.php
+++ b/concrete/themes/concrete/elements/header.php
@@ -57,7 +57,7 @@ $config = $site->getConfigRepository();
         <?php if ($showAccount) {
     ?>
         <li class="pull-right">
-            <a href="<?=URL::to('/login', 'do_logout', Loader::helper('validation/token')->generate('do_logout'))?>" title="<?=t('Sign Out')?>"><i class="fa fa-sign-out"></i>
+            <a href="<?=h(app('helper/navigation')->getLogoutUrl())?>" title="<?=t('Sign Out')?>"><i class="fa fa-sign-out"></i>
             <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings">
                 <?= tc('toolbar', 'Sign Out') ?>
             </span>

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -59,7 +59,7 @@ $large_font = (bool) $config->get('concrete.accessibility.toolbar_large_font');
                         ?>
                     </li>
                     <li>
-                        <i class="fa fa-sign-out mobile-leading-icon"></i><a href="<?= URL::to('/login', 'do_logout', $valt->generate('do_logout')); ?>"><?= t('Sign Out'); ?></a>
+                        <i class="fa fa-sign-out mobile-leading-icon"></i><a href="<?= h($app->make('helper/navigation')->getLogoutUrl()) ?>"><?= t('Sign Out'); ?></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
With this pull request, users will be able to customize the URL of the login page.

It's a bit hacky at the moment, but it works.

Here's how this can be done:

1. Open the `PagePaths` database table
2. Locate the record where the `cPath` field contains `/login`, and change `/login` to whatever you want (for example: `/enter`)
3. Edit the `/application/config/concrete.php` file and add these keys:
    ```php
    <?php
    
    return [
        'paths' => [
            'login' => '/enter',
        ],
    ];
    ```
4. Edit the `/application/config/app.php` file and add these keys:
    ```php
    <?php

    return [
        'theme_paths' => [
            '/enter' => [
                VIEW_CORE_THEME,
                VIEW_CORE_THEME_TEMPLATE_BACKGROUND_IMAGE,
            ],
        ],
    ];
    ```
