### PR TITLE
Fix issue #8118 - ckeditor javascript error when adding or editing a content block type

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -215,7 +215,6 @@ EOL;
             $identifier,
             [
                 'startupFocus' => true,
-                'disableAutoInline' => true,
             ]
         );
 
@@ -243,9 +242,7 @@ EOL;
      */
     public function outputEditorWithOptions($key, array $options = [], $content = null)
     {
-        $options += [
-            'disableAutoInline' => true,
-        ];
+        $options += [];
 
         $pluginManager = $this->getPluginManager();
         if ($pluginManager->isSelected('sourcearea')) {
@@ -275,9 +272,7 @@ EOL;
      */
     public function outputStandardEditorInitJSFunction()
     {
-        $options = [
-            'disableAutoInline' => true,
-        ];
+        $options = [];
 
         $pluginManager = $this->getPluginManager();
         if ($pluginManager->isSelected('sourcearea')) {
@@ -461,6 +456,7 @@ EOL;
 
         $html = <<<EOL
         <script type="text/javascript">
+        CKEDITOR.disableAutoInline = true;
         $(function() {
             var initEditor = {$jsFunc};
             initEditor('#{$identifier}');

--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -453,12 +453,11 @@ EOL;
     protected function getEditorScript($identifier, $options = [])
     {
         $jsFunc = $this->getEditorInitJSFunction($options);
-
         $html = <<<EOL
         <script type="text/javascript">
-        CKEDITOR.disableAutoInline = true;
         $(function() {
             var initEditor = {$jsFunc};
+            CKEDITOR.disableAutoInline = true;
             initEditor('#{$identifier}');
          });
         </script>


### PR DESCRIPTION
Fixes #8118 It seems the way in which the property "disableAutoInline = true" has to be set, has changed.

The way it was set, did not prevent ckeditor on creating a inline editor on elements with the `contenteditable` attribute set to `true`. According to the [documentation for v4](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#cfg-disableAutoInline) the property has to be set like this:

```javascript
CKEDITOR.disableAutoInline = true;
```

