### PR TITLE
Fix editing Rich Text attributes

### DIFF
--- a/concrete/attributes/textarea/controller.php
+++ b/concrete/attributes/textarea/controller.php
@@ -3,13 +3,14 @@ namespace Concrete\Attribute\Textarea;
 
 use Concrete\Core\Attribute\DefaultController;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
+use Concrete\Core\Attribute\XEditableConfigurableAttributeInterface;
 use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Entity\Attribute\Key\Settings\TextareaSettings;
 use Concrete\Core\Entity\Attribute\Value\Value\TextValue;
 use Core;
 use Database;
 
-class Controller extends DefaultController
+class Controller extends DefaultController implements XEditableConfigurableAttributeInterface
 {
 
     public function getIconFormatter()
@@ -175,4 +176,22 @@ class Controller extends DefaultController
         return TextareaSettings::class;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\XEditableConfigurableAttributeInterface::getXEditableOptions()
+     */
+    public function getXEditableOptions()
+    {
+        $this->load();
+        if ($this->akTextareaDisplayMode === 'rich_text') {
+            return [
+                'editableMode' => 'inline',
+                'onblur' => 'ignore',
+                'showbuttons' => 'bottom',
+            ];
+        }
+
+        return [];
+    }
 }

--- a/concrete/elements/attribute/editable_attribute.php
+++ b/concrete/elements/attribute/editable_attribute.php
@@ -1,6 +1,7 @@
 <?php
 
 use Concrete\Core\Attribute\CustomNoValueTextAttributeInterface;
+use Concrete\Core\Attribute\XEditableConfigurableAttributeInterface;
 
 /**
  * @var Concrete\Core\Entity\Attribute\Key\Key $ak
@@ -12,6 +13,7 @@ use Concrete\Core\Attribute\CustomNoValueTextAttributeInterface;
  * @var string $saveAction
  * @var string $display
  */
+$xeditableOptions = null;
 $display = null;
 $noValueDisplayHtml = '';
 if (isset($objects)) {
@@ -32,6 +34,9 @@ if (isset($objects)) {
         $attributeController = $ak->getController();
         if ($attributeController instanceof CustomNoValueTextAttributeInterface) {
             $noValueDisplayHtml = (string) $attributeController->getNoneTextDisplayValue();
+        }
+        if ($attributeController instanceof XEditableConfigurableAttributeInterface) {
+            $xeditableOptions = $attributeController->getXEditableOptions();
         }
     }
     $value = $object->getAttributeValueObject($ak);
@@ -70,7 +75,11 @@ $canEdit = $permissionsCallback($ak, isset($permissionsArguments) ? $permissions
                         data-type="concreteattribute"
                         data-placement="bottom"
                         <?php
-                        if ($ak->getAttributeTypeHandle() === 'textarea') {
+                        if ($xeditableOptions !== null) {
+                            foreach ($xeditableOptions as $xeditableOptionName => $xeditableOptionValue) {
+                                echo ' ', h("data-{$xeditableOptionName}"), '="', h($xeditableOptionValue), '"';
+                            }
+                        } elseif ($ak->getAttributeTypeHandle() === 'textarea') {
                             echo ' data-editableMode="inline" ';
                         }
                         if ($noValueDisplayHtml !== '') {

--- a/concrete/src/Attribute/XEditableConfigurableAttributeInterface.php
+++ b/concrete/src/Attribute/XEditableConfigurableAttributeInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\Core\Attribute;
+
+/**
+ * Attribute controllers should implement this interface to customize the X-Editable options.
+ */
+interface XEditableConfigurableAttributeInterface
+{
+    /**
+     * Return custom options for the X-Editable element.
+     *
+     * @see https://vitalets.github.io/x-editable/docs.html#editable
+     *
+     * @return array
+     */
+    public function getXEditableOptions();
+}


### PR DESCRIPTION
When editing a Rich Text attribute, the CKEditor instance is created inside an X-editable container.
When CKEditor opens a dialog (for example: add/edit link), and users click on it, X-editable tries to close the editor. This fails because of https://github.com/ckeditor/ckeditor4/issues/3686, but it shouldn't occur.

To solve this, we need to tell X-editable to not close the editor when users clicks outside the X-editable element.

Fix #8271.