### PR TITLE
Fix #7215 - Fixing draggable zone on filemanager to only accept file/folder nodes 

### DIFF
--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -108,6 +108,7 @@
             });
 
             my.$element.find('tr[data-file-manager-tree-node-type=file_folder], ol[data-search-navigation=breadcrumb] a[data-file-manager-tree-node]').droppable({
+                accept: '.ccm-search-results-folder, .ccm-search-results-file',
                 tolerance: 'pointer',
                 hoverClass: 'ccm-search-select-active-droppable',
                 drop: function(event, ui) {


### PR DESCRIPTION
Fixes #7215

This PR fixes permission window breaks if the drag-able area is located over the folder #7215

Essentially if a draggable ui element was over a folder node in the file manager (such as permission windows) then when dropped it would drop into both areas and cause a javascript error and break the permissions