### PR TITLE
Fix setting the emails subject a second time with an undefined variable

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -313,7 +313,6 @@ class Service
             $this->from($from[0], isset($from[1]) ? $from[1] : null);
         }
         $this->template = $template;
-        $this->subject = $subject;
         $this->body = (isset($body) && is_string($body)) ? $body : false;
         $this->bodyHTML = (isset($bodyHTML) && is_string($bodyHTML)) ? $bodyHTML : false;
     }

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -313,6 +313,11 @@ class Service
             $this->from($from[0], isset($from[1]) ? $from[1] : null);
         }
         $this->template = $template;
+
+        if (isset($subject)) {
+            $this->subject = $subject;
+        }
+
         $this->body = (isset($body) && is_string($body)) ? $body : false;
         $this->bodyHTML = (isset($bodyHTML) && is_string($bodyHTML)) ? $bodyHTML : false;
     }


### PR DESCRIPTION
In the `\Concrete\Core\Mail\Service::load()` method, the emails subject is set again, with for the most cases, a not defined variable. 

If the subject of a mail was set like the example below, the `load()` method will override the value of the subject again. The `$subject` may or may not be set with the `extract` function  shown [here](https://github.com/concrete5/concrete5/blob/f8424aeeb7514c2e63ec746b6ea175e2b85e64f1/concrete/src/Mail/Service.php#L296).

If the Mail\Service class has a proper setter for the Subject, which it does, it should be the only way in setting the emails subject.

```php
$mailHelper = $app->make('helper/mail')
$mailHelper->to('some@person.io);
// Set Subject
$mailHelper->setSubject('Some Title');
// Subject would be overridden under certain circumstances
$mailHelper->load('my_mail_template');

```