### PR TITLE
Fix #8265 - failing to add url upon drag/drop/paste

### DIFF
--- a/concrete/js/ckeditor4/core/concrete5uploadimage/plugin.js
+++ b/concrete/js/ckeditor4/core/concrete5uploadimage/plugin.js
@@ -22,9 +22,9 @@
                     xhr = data.fileLoader.xhr;
 
                 if (xhr.status == 200) {
-                    var files = jQuery.parseJSON(xhr.responseText);
-                    if (files.length > 0) {
-                        data.url = files[0].urlInline;
+                    var respObj = jQuery.parseJSON(xhr.responseText);
+                    if (respObj.files.length > 0) {
+                        data.url = respObj.files[0].urlInline;
                     }
                 } else {
                     data.message = xhr.responseText;


### PR DESCRIPTION
After the refactoring of the file import in 8.5.0.
You are unable to drag and drop or paste images into content blocks.

This is due to the response no longer returning an array but an object that contains the array of files.

This PR fixes that issue