### PR TITLE
Let concrete5 handle the session garbage collection

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -827,7 +827,14 @@ return [
             'database' => 1, // Use different Redis Databases - optional
         ],
         'save_path' => null,
+        // Minimum duration (in seconds) of an "unoutched" session
         'max_lifetime' => 7200,
+        // gc_probability and gc_divisor together define the probability to
+        // cleanup expided sessions ("garbage collection").
+        // Example: if gc_probability is 1 and gc_divisor is 100, on average we'll have 1 GC every 100 requests (1%)
+        // Example: if gc_probability is 5 and gc_divisor is 20, on average we'll have 1 GC every 20 requests (25%)
+        'gc_probability' => 1,
+        'gc_divisor' => 100,
         'cookie' => [
             'cookie_path' => false, // set a specific path here if you know it, otherwise it'll default to relative
             'cookie_lifetime' => 0,

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -178,8 +178,11 @@ class SessionFactory implements SessionFactoryInterface
         $storage = $app->make(NativeSessionStorage::class, [[], $handler]);
 
         // Initialize the storage with some options
-        $options = array_get($config, 'cookie', []);
-        $options['gc_maxlifetime'] = array_get($config, 'max_lifetime');
+        $options = array_get($config, 'cookie', []) + [
+            'gc_maxlifetime' => (int) array_get($config, 'max_lifetime') ?: (int) ini_get('session.gc_maxlifetime') ?: 7200,
+            'gc_probability' => (int) array_get($config, 'gc_probability') ?: (int) ini_get('session.gc_probability') ?: 1,
+            'gc_divisor' => (int) array_get($config, 'gc_divisor') ?: (int) ini_get('session.gc_divisor') ?: 100,
+        ];
 
         if (array_get($options, 'cookie_path', false) === false) {
             $options['cookie_path'] = $app['app_relative_path'] . '/';


### PR DESCRIPTION
Expired sessions are cleaned up in the so-called *garbage collection* (*GC* for short).

GC is called automatically at the startup of sessions (see [this PHP manual page](https://www.php.net/manual/en/sessionhandlerinterface.gc.php)), and it may or may not be performed accordingly to the value of the `session.gc_probability` and `session.gc_divisor` INI values.

At the moment, concrete5 doesn't handle these values, so PHP will use the ones configured in every system `php.ini` file.

If the system is misconfigured, we risk that GC never occurs, which leads to huge directories (or `Sessions` database tables if users use the database session handler).

So, what about adding explicit support to GC?
PS: in this PR we configure a default 1% GC probability (the PHP default one), but users can change it by setting the `concrete.session.gc_probability`/`concrete.session.gc_divisor` configuration keys.

Fix #8283