### PR TITLE
Make it so users can disable core middlewares

### DIFF
--- a/concrete/src/Http/HttpServiceProvider.php
+++ b/concrete/src/Http/HttpServiceProvider.php
@@ -43,7 +43,7 @@ class HttpServiceProvider extends ServiceProvider
             foreach ($config->get('app.middleware') as $middleware) {
                 if (is_array($middleware)) {
                     $server->addMiddleware($app->make($middleware['class']), $middleware['priority']);
-                } else {
+                } elseif ($middleware) {
                     $server->addMiddleware($app->make($middleware));
                 }
             }


### PR DESCRIPTION
Disabling core middlewares can only be done by creating "passthru" middlewares (as very well [described here](https://documentation.concrete5.org/tutorials/how-to-add-replace-or-remove-middleware)).

What about letting users to disable a middleware (for example `core_xframeoptions`) simply by writing this to the `application/config/app.php` file?

```php
return [
    'middleware' => [
        'core_xframeoptions' => false,
    ],
];
```