### PR TITLE
Make it so routes can echo their output

### DIFF
--- a/concrete/src/Routing/ClosureRouteAction.php
+++ b/concrete/src/Routing/ClosureRouteAction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Routing;
 
 use Concrete\Core\Http\Request;
@@ -7,11 +8,11 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
 class ClosureRouteAction implements RouteActionInterface
 {
-
     protected $callback;
 
     /**
      * ClosureRouteAction constructor.
+     *
      * @param $callback
      */
     public function __construct($callback)
@@ -28,15 +29,21 @@ class ClosureRouteAction implements RouteActionInterface
     {
         $resolver = new ArgumentResolver();
         $arguments = $resolver->getArguments($request, $this->callback);
+        ob_start();
         $response = call_user_func_array($this->callback, $arguments);
+        $echoedResponse = ob_get_contents();
+        ob_end_clean();
 
-        if (is_string($response)) {
-            $r = new Response();
-            $r->setContent($response);
-            return $r;
-        } else {
+        if ($response instanceof Response) {
             return $response;
         }
+        $r = new Response();
+        if (is_string($response)) {
+            $r->setContent($response);
+        } else {
+            $r->setContent($echoedResponse);
+        }
 
+        return $r;
     }
 }


### PR DESCRIPTION
In the [application/bootstrap/app.php](https://github.com/concrete5/concrete5/blob/8.5.2/application/bootstrap/app.php#L40) file we have an example where routes can send their output by simply calling `echo`.

BTW this currently doesn't work: we have this error:
```
Error thrown with message "Call to a member function has() on null"

Stacktrace:
#11 Error in concrete/src/Http/Middleware/FrameOptionsMiddleware.php:41
...
```

that's because middlewares expect a Response object, but we currently return `null`.

What about actually supporting the `echo` approach?

EDIT: fix #7750 (thanks @hissy)