### PR TITLE
Fix: check singleOriginalPage object

### DIFF
--- a/concrete/views/dialogs/page/drag_request.php
+++ b/concrete/views/dialogs/page/drag_request.php
@@ -75,7 +75,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                      ?>
                 </label>
                 <?php
-                if (!$singleOriginalPage->isExternalLink()) {
+                if ($singleOriginalPage && !$singleOriginalPage->isExternalLink()) {
                     ?>
                     <div class="checkbox" style="margin: 0 0 0 20px">
                         <label>


### PR DESCRIPTION
Breaks when moving multiple pages at once due to no check for `$singleOriginalPage` which is null in this case.