### PR TITLE
Fix replacing old 5.7 files

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -571,6 +571,10 @@ class File extends Controller
             $replacingFile = $this->getFileToBeReplaced();
             if ($replacingFile !== null) {
                 $folder = $replacingFile->getFileFolderObject();
+                // Fix for 5.7 files that had their parents set to their own file id
+                if ($folder instanceof \Concrete\Core\Tree\Node\Type\File) {
+                    $folder = $folder->getTreeNodeParentObject();
+                }
             } else {
                 $treeNodeID = $this->request->request->get('currentFolder');
                 if ($treeNodeID) {


### PR DESCRIPTION
Currently in version 8.5.x sites that have been upgraded from 5.7 sites, you can no longer replace files.

This is due to two reasons, the first (and the one this PR seeks to resolve) is that after @mlocati 's refactoring of the backend file handler we check for the folder of replacing files.

The second issue is that 5.7 files don't have a folder under the folderTreeNodeID column (they have their own fileNodeID)... in the migration it states that this was for some permissions issue.
https://github.com/concrete5/concrete5/blob/develop/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php#L37-L51
 Rather than modify existing databases and replacing the folderTreeNodeID with an actual folder.

Instead I went with the method of checking if the replacing file getFileFolderObject() returns a file entity get its parent.

*Note i could have edited the getFileFolderObject() function however this could have other effects for existing permissions*

Would appreciate @mlocati and @aembler input on this one

