### PR TITLE
Exclude octet streams from being logged

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -400,12 +400,12 @@ return [
             /*
              * Whitelist of loggable http content types
              * Supports wildcards
+             * Test: tests\Logging\HttpLoggableAwareTraitTest.php
              */
             'content-types' => [
-                'text/*',
-                'application/json',
-                'application/xml',
-                'application/*+xml'
+                '#^text/#i',
+                '#^application/json$#i',
+                '#^application/(.*\+)?xml$#i',
             ]
         ],
     ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -395,6 +395,19 @@ return [
                 'configuration' => [],
             ],
         ],
+
+        'http' => [
+            /*
+             * Whitelist of loggable http content types
+             * Supports wildcards
+             */
+            'content-types' => [
+                'text/*',
+                'application/json',
+                'application/xml',
+                'application/*+xml'
+            ]
+        ],
     ],
     'jobs' => [
         'enable_scheduling' => true,

--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -68,6 +68,14 @@ class Client extends ZendClient implements LoggerAwareInterface
             } else {
                 $shortBody = mb_substr($body, 0, 197) . '...';
             }
+
+            // If the content-type is an octet stream, don't log it.
+            $headers = array_change_key_case($response->getHeaders()->toArray());
+            if (array_key_exists('content-type', $headers) &&
+                $headers['content-type'] === 'application/octet-stream') {
+                $shortBody = 'of the content-type: application/octet-stream';
+            }
+
             $logger->debug(
                 'The response code was {statusCode} and the body was {shortBody}',
                 [

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Logging;
 
+use Concrete\Core\Support\Facade\Application;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Zend\Http\Request as ZendRequest;
@@ -77,10 +78,7 @@ trait HttpLoggableAwareTrait
 
             if (is_array($types)) {
                 foreach($types as $type) {
-                    $type = str_replace( '*' , '(.*)', $type);
-                    $search = '#^'.$type.'#i'  ;
-                    preg_match($search, $responseContentType, $matches);
-
+                    preg_match($type, $responseContentType, $matches);
                     if (count($matches)) {
                         $isLoggable = true;
                         break;
@@ -98,7 +96,8 @@ trait HttpLoggableAwareTrait
      */
     public function getLoggableContentTypes()
     {
-        $config = \Core::make('config');
+        $app = Application::getFacadeApplication();
+        $config = $app->make('config');
         return $config->get('concrete.log.http.content-types');
     }
 

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -78,8 +78,7 @@ trait HttpLoggableAwareTrait
 
             if (is_array($types)) {
                 foreach($types as $type) {
-                    preg_match($type, $responseContentType, $matches);
-                    if (count($matches)) {
+                    if (preg_match($type, $responseContentType)) {
                         $isLoggable = true;
                         break;
                     }

--- a/concrete/src/Logging/HttpLoggableAwareTrait.php
+++ b/concrete/src/Logging/HttpLoggableAwareTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Concrete\Core\Logging;
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Zend\Http\Request as ZendRequest;
+use Zend\Http\Response as ZendResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Class HttpLoggableAwareTrait
+ *
+ * Check if a http request or http response body can be logged (doesn't contain binary data)
+ */
+trait HttpLoggableAwareTrait
+{
+
+    /**
+     * Check if request body can be logged (is not binary)
+     *
+     * @param ZendRequest|SymfonyRequest|RequestInterface $request
+     * @return bool
+     */
+    public function isRequestBodyLoggable($request)
+    {
+        if ($request instanceof SymfonyRequest) {
+            $headers = array_change_key_case($request->headers->all());
+        } elseif ($request instanceof ZendRequest) {
+            $headers = array_change_key_case($request->getHeaders()->toArray());
+        } elseif ($request instanceof RequestInterface) {
+            $headers = array_change_key_case($request->getHeaders());
+        } else {
+            $headers = [];
+        }
+
+        return $this->isLoggable($headers, $this->getLoggableContentTypes());
+    }
+
+    /**
+     * Check if response body can be logged (is not binary)
+     *
+     * @param ZendResponse|SymfonyResponse|ResponseInterface $response
+     * @return bool
+     */
+    public function isResponseBodyLoggable($response)
+    {
+        if ($response instanceof SymfonyResponse) {
+            $headers =  array_change_key_case($response->headers->all());
+        } elseif ($response instanceof ZendResponse) {
+            $headers =  array_change_key_case($response->getHeaders()->toArray());
+        } elseif ($response instanceof ResponseInterface) {
+            $headers = array_change_key_case($response->getHeaders());
+        } else {
+            $headers = [];
+        }
+
+        return $this->isLoggable($headers, $this->getLoggableContentTypes());
+    }
+
+    /**
+     * Compare the headers of the request or response with the whitelist
+     * If the content type matches a entry in the whitelist,
+     * the response or request body can be logged
+     *
+     * @param array $headers
+     * @param array $types
+     * @return bool
+     */
+    public function isLoggable(array $headers, array $types)
+    {
+        $isLoggable = false;
+
+        if (array_key_exists('content-type', $headers)) {
+            $responseContentType = $headers['content-type'];
+
+            if (is_array($types)) {
+                foreach($types as $type) {
+                    $type = str_replace( '*' , '(.*)', $type);
+                    $search = '#^'.$type.'#i'  ;
+                    preg_match($search, $responseContentType, $matches);
+
+                    if (count($matches)) {
+                        $isLoggable = true;
+                        break;
+                    }
+                }
+            }
+        }
+        return $isLoggable;
+    }
+
+    /**
+     * Get whitelist of http content types which can be logged
+     *
+     * @return array
+     */
+    public function getLoggableContentTypes()
+    {
+        $config = \Core::make('config');
+        return $config->get('concrete.log.http.content-types');
+    }
+
+    /**
+     * Get content-type string from response
+     *
+     * @param ZendRequest|SymfonyRequest|RequestInterface $request
+     * @return string
+     */
+    public function getRequestContentType($request)
+    {
+        $contentType = '';
+
+        if ($request instanceof SymfonyRequest) {
+            $contentType =  array_change_key_case($request->headers->get('content-type'));
+        } elseif ($request instanceof ZendRequest) {
+            $headers =  array_change_key_case($request->getHeaders()->toArray());
+            if (array_key_exists('content-type', $headers)) {
+                $contentType = $headers['content-type'];
+            }
+        }
+        // PSR-7
+        elseif ($request instanceof RequestInterface) {
+            $contentType = $request->getHeader('content-type');
+        }
+        return $contentType;
+    }
+
+    /**
+     * Get content-type string from response
+     *
+     * @param ZendResponse|SymfonyResponse|ResponseInterface $response
+     * @return string
+     */
+    public function getResponseContentType($response)
+    {
+        $contentType = '';
+
+        if ($response instanceof SymfonyResponse) {
+            $contentType =  array_change_key_case($response->headers->get('content-type'));
+        } elseif ($response instanceof ZendResponse) {
+            $headers =  array_change_key_case($response->getHeaders()->toArray());
+            if (array_key_exists('content-type', $headers)) {
+                $contentType = $headers['content-type'];
+            }
+        }
+        // PSR-7
+        elseif ($response instanceof ResponseInterface) {
+            $contentType = $response->getHeader('content-type');
+        }
+
+        return $contentType;
+    }
+}

--- a/tests/tests/Logging/HttpLoggableAwareTraitTest.php
+++ b/tests/tests/Logging/HttpLoggableAwareTraitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Concrete\Tests\Logging;
+
+use Concrete\Core\Logging\HttpLoggableAwareTrait;
+use PHPUnit_Framework_TestCase;
+
+class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider routeDestinationProvider
+     *
+     * @return array
+     */
+    public function contentTypesProvider()
+    {
+        return [
+            // contentType, expected
+            // true = loggable http body types
+            [['content-type' => 'text/plain'], true],
+            [['content-type' => 'text/css'], true],
+            [['content-type' => 'text/html'], true],
+            [['content-type' => 'text/csv'], true],
+            [['content-type' => 'application/json'], true],
+            [['content-type' => 'application/xml'], true],
+            [['content-type' => 'application/rss+xml'], true],
+            // false
+            [['content-type' => 'application/rtf'], false],
+            [['content-type' => 'application/javascript'], false],
+            [['content-type' => 'image/png'], false],
+            [['content-type' => 'image/jpeg'], false]
+        ];
+    }
+
+    /**
+     * Stub config values from log -> http -> content-types
+     *
+     * @return array
+     */
+    public function getLoggableContentTypes()
+    {
+        return [
+            'text/*',
+            'application/json',
+            'application/xml',
+            'application/*+xml'
+        ];
+    }
+
+    /**
+     * @dataProvider contentTypesProvider
+     */
+    public function testIsLoggable($contentType, $expected)
+    {
+        $mockTrait = $this->getMockForTrait(HttpLoggableAwareTrait::class);
+        $mockTrait->expects($this->any())
+            ->method('getLoggableContentTypes')
+            ->willReturn($this->getLoggableContentTypes());
+
+        $this->assertEquals($expected, $mockTrait->isLoggable($contentType, $mockTrait->getLoggableContentTypes()));
+    }
+}

--- a/tests/tests/Logging/HttpLoggableAwareTraitTest.php
+++ b/tests/tests/Logging/HttpLoggableAwareTraitTest.php
@@ -40,10 +40,9 @@ class HttpLoggableAwareTraitTest extends PHPUnit_Framework_TestCase
     public function getLoggableContentTypes()
     {
         return [
-            'text/*',
-            'application/json',
-            'application/xml',
-            'application/*+xml'
+            '#^text/#i',
+            '#^application/json$#i',
+            '#^application/(.*\+)?xml$#i',
         ];
     }
 


### PR DESCRIPTION
Fix #8301  Something like this should prevent binary data from being logged, if the logging level is set to "debug". Maybe there is a better solution.