### PR TITLE
Use container to create CsvWriter instance

### DIFF
--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -106,7 +106,10 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
         return StreamedResponse::create(function () use ($entity, $me, $bom) {
             $entryList = new EntryList($entity);
 
-            $writer = new CsvWriter($this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'), new Date());
+            $writer = $this->app->make(CsvWriter::class, [
+                $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
+                new Date()
+            ]);
             echo $bom;
             $writer->insertHeaders($entity);
             $writer->insertEntryList($entryList);


### PR DESCRIPTION
It's currently impossible to overwrite the CsvWriter in a fashionable manner. If we boot the CsvWriter via the app container, like in this PR, we can rebind it in custom code.