### PR TITLE
Don't output email when it's invalid

### DIFF
--- a/concrete/src/Validator/String/EmailValidator.php
+++ b/concrete/src/Validator/String/EmailValidator.php
@@ -62,7 +62,7 @@ class EmailValidator extends AbstractTranslatableValidator
         $this->setErrorString(
             self::E_INVALID_ADDRESS,
             function (EmailValidator $validator, $code, $mixed) {
-                return t('The email address "%s" is not valid.', $mixed);
+                return t('Invalid email address.');
             }
         );
     }

--- a/tests/tests/Attribute/ValidationTest.php
+++ b/tests/tests/Attribute/ValidationTest.php
@@ -73,7 +73,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($error->has());
         $errors = $error->getList();
         $this->assertInstanceOf('\Concrete\Core\Error\ErrorList\Error\Error', $errors[0]);
-        $this->assertEquals('The email address "foo" is not valid.', (string) $errors[0]);
+        $this->assertEquals('Invalid email address.', (string) $errors[0]);
         $this->assertEquals(1, count($errors));
 
         $post['akID'][1]['value'] = 'test@test.com';


### PR DESCRIPTION
The EmailValidator validator class outputs the email address if it is valid. Let's output a generic message instead.