### PR TITLE
Fix height/width of edit folder permissions dialog

### DIFF
--- a/concrete/src/Tree/Menu/Item/EditPermissionsItem.php
+++ b/concrete/src/Tree/Menu/Item/EditPermissionsItem.php
@@ -2,6 +2,9 @@
 
 namespace Concrete\Core\Tree\Menu\Item;
 
+use HtmlObject\Element;
+use HtmlObject\Link;
+
 class EditPermissionsItem extends AbstractNodeItem
 {
 
@@ -23,5 +26,18 @@ class EditPermissionsItem extends AbstractNodeItem
     public function getItemName()
     {
         return t('Edit Permissions');
+    }
+
+    public function getItemElement()
+    {
+        $element = new Element('li');
+        $link = new Link('#', $this->getItemName());
+        $link->setAttribute('data-tree-action', $this->getAction());
+        $link->setAttribute('dialog-title', $this->getDialogTitle());
+        $link->setAttribute('data-tree-action-url', $this->getActionURL());
+        $link->setAttribute('dialog-width', '520');
+        $link->setAttribute('dialog-height', '450');
+        $element->appendChild($link);
+        return $element;
     }
 }

--- a/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
+++ b/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
@@ -112,6 +112,6 @@ class ContextMenuTest extends PHPUnit_Framework_TestCase
         $menu = new \Concrete\Core\Application\UserInterface\ContextMenu\Menu();
         $menu->addItem($item);
         $html = (string) $menu->getMenuElement();
-        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3">Edit Permissions</a></li></ul></div></div>', $html);
+        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3" width="520" dialog-height="450">Edit Permissions</a></li></ul></div></div>', $html);
     }
 }

--- a/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
+++ b/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
@@ -112,6 +112,6 @@ class ContextMenuTest extends PHPUnit_Framework_TestCase
         $menu = new \Concrete\Core\Application\UserInterface\ContextMenu\Menu();
         $menu->addItem($item);
         $html = (string) $menu->getMenuElement();
-        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3"  dialog-width="520" dialog-height="450">Edit Permissions</a></li></ul></div></div>', $html);
+        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3" dialog-width="520" dialog-height="450">Edit Permissions</a></li></ul></div></div>', $html);
     }
 }

--- a/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
+++ b/tests/tests/Application/UserInterface/ContextMenu/ContextMenuTest.php
@@ -112,6 +112,6 @@ class ContextMenuTest extends PHPUnit_Framework_TestCase
         $menu = new \Concrete\Core\Application\UserInterface\ContextMenu\Menu();
         $menu->addItem($item);
         $html = (string) $menu->getMenuElement();
-        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3" width="520" dialog-height="450">Edit Permissions</a></li></ul></div></div>', $html);
+        $this->assertEquals('<div class="popover fade"><div class="arrow"></div><div class="popover-inner"><ul class="dropdown-menu"><li><a href="#" data-tree-action="edit-node" dialog-title="Edit Permissions" data-tree-action-url="http://www.dummyco.com/path/to/server/index.php/ccm/system/dialogs/tree/node/permissions?treeNodeID=3"  dialog-width="520" dialog-height="450">Edit Permissions</a></li></ul></div></div>', $html);
     }
 }


### PR DESCRIPTION
Since edit folder permissions is a tree node item it doesnt have a width or height set on the dialog.
This PR adds a Height and Width to the edit folder permission dialog.
Fixes issue described in PR #8303