### PR TITLE
Fix to show User Attribute Options

### DIFF
--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -1,7 +1,7 @@
 <?php
 
-use CommunityTranslation\Notification\CategoryInterface;
 use Concrete\Core\Attribute\AttributeKeyInterface;
+use Concrete\Core\Attribute\Category\CategoryInterface;
 use Concrete\Core\Attribute\SetFactory;
 use Concrete\Core\Attribute\StandardSetManager;
 use Concrete\Core\Page;


### PR DESCRIPTION
"User Attribute Options" section is not displayed now because of the wrong class import made by @mlocati  at #8198 . Let's fix it.