### PR TITLE
Fix initializing CKEditor

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -204,7 +204,7 @@ EOL;
 
         $html = sprintf(
             '<textarea id="%s_content" style="display:none;" name="%s"></textarea>' .
-            '<div contenteditable="true" id="%s">%s</div>',
+            '<div id="%s">%s</div>',
             $identifier,
             $key,
             $identifier,
@@ -463,6 +463,7 @@ EOL;
         <script type="text/javascript">
         $(function() {
             var initEditor = {$jsFunc};
+            $('#{$identifier}').attr('contenteditable', 'true');
             initEditor('#{$identifier}');
          });
         </script>

--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -215,7 +215,6 @@ EOL;
             $identifier,
             [
                 'startupFocus' => true,
-                'disableAutoInline' => true,
             ]
         );
 
@@ -243,10 +242,6 @@ EOL;
      */
     public function outputEditorWithOptions($key, array $options = [], $content = null)
     {
-        $options += [
-            'disableAutoInline' => true,
-        ];
-
         $pluginManager = $this->getPluginManager();
         if ($pluginManager->isSelected('sourcearea')) {
             $pluginManager->deselect('sourcedialog');
@@ -275,9 +270,7 @@ EOL;
      */
     public function outputStandardEditorInitJSFunction()
     {
-        $options = [
-            'disableAutoInline' => true,
-        ];
+        $options = [];
 
         $pluginManager = $this->getPluginManager();
         if ($pluginManager->isSelected('sourcearea')) {


### PR DESCRIPTION
#8118 is caused by this issue:

Here's the situation:

1. [we create a `<div contenteditable="true">`](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/src/Editor/CkeditorEditor.php#L207)
2. [we manually create the CKEditor instance](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/src/Editor/CkeditorEditor.php#L466)
3. [when the DOM is loaded, if `CKEDITOR.disableAutoInline` is true, CKEditor automatically starts the CKEditor instances of all the elements with `contenteditable` set to true](https://github.com/ckeditor/ckeditor4/blob/4.12.0/core/creators/inline.js#L143)

Since we don't set the `disableAutoInline` properly, CKEditor tries to initialize twice an editor for the same HTML element, so it throws [this error](https://github.com/ckeditor/ckeditor4/blob/4.12.0/core/editor.js#L1611).

#8267 tries to solve the issue by setting `disableAutoInline` properly, but this is just a workaround which touch a global variable, which may lead to unexpected side effects ([example](https://github.com/concrete5/concrete5/pull/8267#issuecomment-564687789)).

IMHO the easiest and cleanest solution is to simply avoid setting `contenteditable="true"` editor instances we are manually creating.

Fix #8118