### PR TITLE
Resolving express entry permission checks

### DIFF
--- a/concrete/controllers/backend/express/entry.php
+++ b/concrete/controllers/backend/express/entry.php
@@ -62,7 +62,7 @@ class Entry extends AbstractController
         $entries = $this->getRequestEntries();
         foreach ($entries as $entry) {
             $ep = new \Permissions($entry->getEntity());
-            if (!$ep->canViewExpressEntries()) {
+            if (!$ep->canViewExpressEntry()) {
                 throw new \Exception(t('Access Denied.'));
             }
         }

--- a/concrete/controllers/dialog/express/advanced_search.php
+++ b/concrete/controllers/dialog/express/advanced_search.php
@@ -73,7 +73,7 @@ class AdvancedSearch extends AdvancedSearchController
         $this->loadEntity();
         $ep = new Permissions($this->entity);
 
-        return $ep->canViewExpressEntries();
+        return $ep->canViewExpressEntry();
     }
 
     protected function getExpressCategory()

--- a/concrete/controllers/dialog/express/association/reorder.php
+++ b/concrete/controllers/dialog/express/association/reorder.php
@@ -16,7 +16,7 @@ class Reorder extends BackendInterfaceController
         $entry = $this->getEntry();
         if ($entry) {
             $ep = new \Permissions($entry);
-            return $ep->canViewExpressEntries();
+            return $ep->canViewExpressEntry();
         }
         return false;
     }

--- a/concrete/controllers/dialog/express/preset/delete.php
+++ b/concrete/controllers/dialog/express/preset/delete.php
@@ -34,7 +34,7 @@ class Delete extends PresetDelete
         if (is_object($entity)) {
             $ep = new Permissions($entity);
 
-            return $ep->canViewExpressEntries();
+            return $ep->canViewExpressEntry();
         }
 
         return false;

--- a/concrete/controllers/dialog/express/preset/edit.php
+++ b/concrete/controllers/dialog/express/preset/edit.php
@@ -33,7 +33,7 @@ class Edit extends PresetEdit
         if (is_object($entity)) {
             $ep = new Permissions($entity);
 
-            return $ep->canViewExpressEntries();
+            return $ep->canViewExpressEntry();
         }
 
         return false;

--- a/concrete/controllers/dialog/express/search.php
+++ b/concrete/controllers/dialog/express/search.php
@@ -14,7 +14,7 @@ class Search extends BackendInterfaceController
         $entity = $this->getEntity();
         if (is_object($entity)) {
             $ep = new \Permissions($entity);
-            return $ep->canViewExpressEntries();
+            return $ep->canViewExpressEntry();
         }
         return false;
     }

--- a/concrete/controllers/search/express.php
+++ b/concrete/controllers/search/express.php
@@ -46,7 +46,7 @@ class Express extends Standard
         $this->loadEntity();
         $ep = new Permissions($this->entity);
 
-        return $ep->canViewExpressEntries();
+        return $ep->canViewExpressEntry();
     }
 
     public function expressSearchPreset($entityID, $presetID)

--- a/concrete/controllers/single_page/dashboard/express/entries.php
+++ b/concrete/controllers/single_page/dashboard/express/entries.php
@@ -47,7 +47,7 @@ class Entries extends DashboardExpressEntityPageController
             $this->set('entity', $entity);
             $this->renderList($folder);
             $permissions = new \Permissions($this->getEntity());
-            if ($permissions->canAddExpressEntries()) {
+            if ($permissions->canAddExpressEntry()) {
                 $header = new Header($entity, $this->getPageObject());
                 $this->set('headerMenu', $header);
                 $this->set('pageTitle', t('View %s Entries', $this->getEntity()->getName()));

--- a/concrete/single_pages/dashboard/express/entries/folder.php
+++ b/concrete/single_pages/dashboard/express/entries/folder.php
@@ -19,7 +19,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
             foreach ($nodes as $node) {
                 $formatter = $node->getListFormatter();
                 $np = new Permissions($node);
-                if ($np->canViewExpressEntries()) {
+                if ($np->canViewExpressEntry()) {
                 ?>
                 <tr data-details-url="<?=$view->action('view', $node->getTreeNodeID())?>"
                     class="<?=$formatter->getSearchResultsClass()?>">

--- a/concrete/src/Express/Form/Validator/Routine/CheckPermissionsRoutine.php
+++ b/concrete/src/Express/Form/Validator/Routine/CheckPermissionsRoutine.php
@@ -16,9 +16,9 @@ class CheckPermissionsRoutine implements RoutineInterface
         $entity = $form->getEntity();
         $permissions = new \Permissions($entity);
         if ($requestType = ProcessorInterface::REQUEST_TYPE_ADD) {
-            $valid = $permissions->canAddExpressEntries();
+            $valid = $permissions->canAddExpressEntry();
         } else {
-            $valid = $permissions->canEditExpressEntries();
+            $valid = $permissions->canEditExpressEntry();
         }
         if (!$valid) {
             $error->add(t('You do not have access to submit this form.'));

--- a/concrete/src/Form/Service/Widget/ExpressEntrySelector.php
+++ b/concrete/src/Form/Service/Widget/ExpressEntrySelector.php
@@ -14,7 +14,7 @@ class ExpressEntrySelector
     {
         $v = \View::getInstance();
         $p = new \Permissions($entity);
-        if ($p->canViewExpressEntries()) {
+        if ($p->canViewExpressEntry()) {
             $v->requireAsset('core/express');
 
             $args['entityID'] = $entity->getID();

--- a/concrete/src/Page/Controller/DashboardExpressEntityPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntityPageController.php
@@ -34,7 +34,7 @@ abstract class DashboardExpressEntityPageController extends DashboardExpressEntr
     public function view($folder = null)
     {
         $permissions = new \Permissions($this->getEntity());
-        if ($permissions->canAddExpressEntries()) {
+        if ($permissions->canAddExpressEntry()) {
             $header = new Header($this->getEntity(), $this->getPageObject());
             $this->set('headerMenu', $header);
         }
@@ -53,7 +53,7 @@ abstract class DashboardExpressEntityPageController extends DashboardExpressEntr
             $entry = $r->findOneById($owner_entry_id);
         }
         $permissions = new \Permissions($entity);
-        if (!$permissions->canAddExpressEntries()) {
+        if (!$permissions->canAddExpressEntry()) {
             throw new \Exception(t('You do not have access to add entries of this entity type.'));
         }
         $this->set('entity', $entity);

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -63,7 +63,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
         if (isset($parent) && $parent instanceof \Concrete\Core\Tree\Node\Type\ExpressEntryResults) {
             $entity = $this->getEntity($parent);
             $permissions = new \Permissions($entity);
-            if (!$permissions->canViewExpressEntries()) {
+            if (!$permissions->canViewExpressEntry()) {
                 throw new \Exception(t('Access Denied'));
             }
             $search = new \Concrete\Controller\Search\Express\Entries();
@@ -92,7 +92,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
         $parent = $me->getParentNode($treeNodeParentID);
         $entity = $me->getEntity($parent);
         $permissions = new \Permissions($entity);
-        if (!$permissions->canViewExpressEntries()) {
+        if (!$permissions->canViewExpressEntry()) {
             throw new \Exception(t('Access Denied'));
         }
 

--- a/concrete/src/Permission/Response/ExpressEntryResponse.php
+++ b/concrete/src/Permission/Response/ExpressEntryResponse.php
@@ -30,6 +30,14 @@ class ExpressEntryResponse extends Response
         }
     }
 
+    public function canAddExpressEntry()
+    {
+        $p = $this->getExpressEntryNodePermissions();
+        if (is_object($p)) {
+            return $p->validate('add_express_entries');
+        }
+    }
+
     public function canEditExpressEntry()
     {
         $p = $this->getExpressEntryNodePermissions();


### PR DESCRIPTION
I ran into this issue a while ago, in some places the permission check is made by calling method name in plural instead of singular as it is written, so I've made a local change and it worked.