### PR TITLE
Display only the message of UserMessageException

### DIFF
--- a/concrete/src/Error/UserMessageException.php
+++ b/concrete/src/Error/UserMessageException.php
@@ -97,4 +97,14 @@ class UserMessageException extends Exception implements JsonSerializable, HtmlAw
 
         return $result;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Exception::__toString()
+     */
+    public function __toString()
+    {
+        return $this->getMessage();
+    }
 }


### PR DESCRIPTION
Exceptions of type `UserMessageException` are meant to show errors to the users, without any system details.

BTW, the `system_errors` element may display the place where these exception were created and their stack trace, which is out of scope (see [here](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/elements/system_errors.php#L36)).

So, what about displaying only the error message?