### PR TITLE
Add layout assets to output via registerViewAssets

### DIFF
--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -132,6 +132,17 @@ class Controller extends BlockController
             $this->requireAsset('javascript', 'jquery');
             $this->requireAsset('javascript', 'core/frontend/parallax-image');
         }
+
+        $arLayout = $this->getAreaLayoutObject();
+        if (is_object($arLayout)) {            
+            if ($arLayout instanceof CustomLayout) {
+                $asset = new CssAsset();
+                $asset->setAssetURL(URL::to('/ccm/system/css/layout', $arLayout->getAreaLayoutID()));
+                $asset->setAssetSupportsMinification(false);
+                $asset->setAssetSupportsCombination(false);
+                $this->requireAsset($asset);
+            }
+        }
     }
 
     public function duplicate($newBID)
@@ -356,13 +367,6 @@ class Controller extends BlockController
             if ($this->arLayout->isAreaLayoutUsingThemeGridFramework()) {
                 $pt = $c->getCollectionThemeObject();
                 $gf = $pt->getThemeGridFrameworkObject();
-            }
-            if ($this->arLayout instanceof CustomLayout) {
-                $asset = new CssAsset();
-                $asset->setAssetURL(URL::to('/ccm/system/css/layout', $this->arLayout->getAreaLayoutID()));
-                $asset->setAssetSupportsMinification(false);
-                $asset->setAssetSupportsCombination(false);
-                $this->requireAsset($asset);
             }
 
             $formatter = $this->arLayout->getFormatter();


### PR DESCRIPTION
By moving this from the view function the CSS will always be added, even when the view function doesn't run because of existing block cache.

Related to #2825 and #6477