### PR TITLE
Fix user-selector events firing more than once

### DIFF
--- a/concrete/views/dialogs/user/search.php
+++ b/concrete/views/dialogs/user/search.php
@@ -16,18 +16,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
     $(function() {
         $('div[data-search=users]').concreteAjaxSearch({
             result: <?=json_encode($result->getJSONObject())?>,
-            onUpdateResults: function (concreteSearch) {
-                concreteSearch.$element.find('select[data-bulk-action=users] option:eq(0)').after('<option value="select_users"><?=t('Choose Users')?></option>');
-                concreteSearch.$element.on('click', 'a[data-user-id]', function () {
-                    ConcreteEvent.publish('UserSearchDialogSelectUser', {
-                        uID: $(this).attr('data-user-id'),
-                        uEmail: $(this).attr('data-user-email'),
-                        uName: $(this).attr('data-user-name')
-                    });
-                    ConcreteEvent.publish('UserSearchDialogAfterSelectUser');
-                    return false;
-                });
-
+            onLoad: function(concreteSearch) {
                 concreteSearch.subscribe('SearchBulkActionSelect', function (e, data) {
                     if (data.value == 'select_users') {
                         $.each(data.items, function (i, item) {
@@ -40,6 +29,18 @@ defined('C5_EXECUTE') or die("Access Denied.");
                         });
                         ConcreteEvent.publish('UserSearchDialogAfterSelectUser');
                     }
+                });
+            },
+            onUpdateResults: function (concreteSearch) {
+                concreteSearch.$element.find('select[data-bulk-action=users] option:eq(0)').after('<option value="select_users"><?=t('Choose Users')?></option>');
+                concreteSearch.$element.unbind('click').on('click', 'a[data-user-id]', function () {
+                    ConcreteEvent.publish('UserSearchDialogSelectUser', {
+                        uID: $(this).attr('data-user-id'),
+                        uEmail: $(this).attr('data-user-email'),
+                        uName: $(this).attr('data-user-name')
+                    });
+                    ConcreteEvent.publish('UserSearchDialogAfterSelectUser');
+                    return false;
                 });
             }
         });


### PR DESCRIPTION
This PR fixes an issue when searching in a user selector popup will fire the UserSearchDialogSelectUser and UserSearchDialogSelectUser.core events more than once. Causing popups to be closed multiple times.

For example on the Sitemap click on attributes then clear the author of a page and click choose user. When the user search shows up, search in the box in the right for any user (admin) then select a user (admin). Both the search dialog and attributes pop-up is closed.