### PR TITLE
Moves the custom block template selector from the advanced tab to buttons

### DIFF
--- a/concrete/config/install/base/permissions.xml
+++ b/concrete/config/install/base/permissions.xml
@@ -77,7 +77,7 @@
         <!-- blocks //-->
         <permissionkey handle="view_block" name="View Block" package="" category="block" description="Controls whether users can view this block in the page." />
         <permissionkey handle="edit_block" name="Edit Block" package="" category="block" description="Controls whether users can edit this block. This overrides any area or page permissions." />
-        <permissionkey handle="edit_block_custom_template" name="Change Custom Template" description="Controls whether users can change the custom template on this block. This overrides any area or page permissions." package="" category="block"/>
+        <permissionkey handle="edit_block_custom_template" name="Change Block Template" description="Controls whether users can change the block template on this block. This overrides any area or page permissions." package="" category="block"/>
         <permissionkey handle="edit_block_cache_settings" name="Edit Cache Settings" description="Controls whether users can change the block cache settings for this block instance." package="" category="block"/>
         <permissionkey handle="edit_block_name" name="Edit Name" description="Controls whether users can change the block's name (rarely used.)" package="" category="block"/>
         <permissionkey handle="delete_block" name="Delete Block" package="" category="block" description="Controls whether users can delete this block. This overrides any area or page permissions." />

--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -61,7 +61,7 @@ class AssetsLocalization extends Controller
                 'arrangeBlock' => t('Move'),
                 'arrangeBlockMsg' => t('Blocks arranged successfully.'),
                 'copyBlockToScrapbook' => t('Copy to Clipboard'),
-                'changeBlockTemplate' => t('Custom Template'),
+                'changeBlockTemplate' => t('Block Template'),
                 'changeBlockCSS' => t('Design'),
                 'go' => t('Go'),
                 'confirm' => t('Confirm'),

--- a/concrete/elements/custom_style.php
+++ b/concrete/elements/custom_style.php
@@ -153,6 +153,24 @@ $form = Core::make('helper/form');
 
 <form method="post" action="<?=$saveAction?>" id="ccm-inline-design-form">
     <ul class="ccm-inline-toolbar ccm-ui">
+
+        <?php if ($style instanceof \Concrete\Core\Block\CustomStyle && $canEditCustomTemplate) { ?>
+            <li class="">
+                <span class="small"><?=t('Block Template')?>:</span>
+                <select id="bFilename" name="bFilename" >
+                    <option value=""><?=t('Default')?></option>
+                    <?php
+                    foreach ($templates as $tpl) {
+                        ?>
+                        <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) {
+                            ?> selected <?php
+                        } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
+                        <?php
+                    } ?>
+                </select>
+            </li>
+        <?php } ?>
+
         <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Text Size and Color')?>"><i class="fa fa-font"></i></a>
 
             <div class="ccm-inline-design-dropdown-menu dropdown-menu">
@@ -241,13 +259,13 @@ $form = Core::make('helper/form');
         <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Margin and Padding')?>"><i class="fa fa-arrows-h"></i></a>
 
             <div class="ccm-inline-design-dropdown-menu <?php if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    ?>ccm-inline-design-dropdown-menu-doubled<?php 
+    ?>ccm-inline-design-dropdown-menu-doubled<?php
 } ?> dropdown-menu">
                 <div class="row">
                     <div class="<?php if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    ?>col-sm-6<?php 
+    ?>col-sm-6<?php
 } else {
-    ?>col-sm-12<?php 
+    ?>col-sm-12<?php
 } ?>">
                         <h3><?=t('Padding')?></h3>
                         <div>
@@ -313,7 +331,7 @@ $form = Core::make('helper/form');
                             </span>
                         </div>
                     </div>
-                    <?php 
+                    <?php
 } ?>
 
                 </div>
@@ -386,9 +404,9 @@ $form = Core::make('helper/form');
             $hidden = $set->isHiddenOnDevice($class);
         } ?>
                             <button type="button" data-hide-on-device="<?=$class?>" class="btn btn-default <?php if (!$hidden) {
-            ?>active<?php 
+            ?>active<?php
         } ?>"><i class="<?=$gf->getDeviceHideClassIconClass($class)?>"></i></button>
-                        <?php 
+                        <?php
     } ?>
                         </div>
 
@@ -398,13 +416,13 @@ $form = Core::make('helper/form');
             $hidden = $set->isHiddenOnDevice($class);
         } ?>
                             <input data-hide-on-device-input="<?=$class?>" type="hidden" name="hideOnDevice[<?=$class?>]" value="<?php if ($hidden) {
-            ?>1<?php 
+            ?>1<?php
         } else {
-            ?>0<?php 
+            ?>0<?php
         } ?>" />
-                        <?php 
+                        <?php
     } ?>
-                    <?php 
+                    <?php
 } ?>
 
                     </div>
@@ -412,29 +430,11 @@ $form = Core::make('helper/form');
             </div>
 
         </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Custom CSS Classes, Block Name, Custom Templates and Reset Styles')?>"><i class="fa fa-cog"></i></a>
+        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Custom CSS Classes, Block Name, Block Templates and Reset Styles')?>"><i class="fa fa-cog"></i></a>
 
             <div class="ccm-inline-design-dropdown-menu dropdown-menu">
                 <h3><?=t('Advanced')?></h3>
-                <?php if ($style instanceof \Concrete\Core\Block\CustomStyle && $canEditCustomTemplate) {
-    ?>
-                    <div class="ccm-inline-select-container">
-                        <?=t('Custom Template')?>
-                        <select id="bFilename" name="bFilename" class="form-control">
-                            <option value="">(<?=t('None selected')?>)</option>
-                            <?php
-                            foreach ($templates as $tpl) {
-                                ?>
-                            <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) {
-                                    ?> selected <?php 
-                                } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
-                            <?php 
-                            } ?>
-                        </select>
-                     </div>
-                    <hr/>
-                <?php 
-} ?>
+
 
                 <div>
                     <?=t('Custom Class')?>
@@ -460,18 +460,18 @@ $form = Core::make('helper/form');
                         <?=t('Block Container Class')?>
                         <select id="enableBlockContainer" name="enableBlockContainer" class="form-control">
                             <option value="-1" <?php if ($enableBlockContainer == -1) {
-        ?>selected<?php 
+        ?>selected<?php
     } ?>><?=t('Default Setting')?></option>
                             <option value="0"<?php if ($enableBlockContainer == 0) {
-        ?>selected<?php 
+        ?>selected<?php
     } ?>><?=t('Disable Grid Container')?></option>
                             <option value="1" <?php if ($enableBlockContainer == 1) {
-        ?>selected<?php 
+        ?>selected<?php
     } ?>><?=t('Enable Grid Container')?></option>
                         </select>
                     </div>
                     <hr/>
-                <?php 
+                <?php
 } ?>
 
                 <div>

--- a/concrete/src/Block/Menu/Menu.php
+++ b/concrete/src/Block/Menu/Menu.php
@@ -172,10 +172,10 @@ class Menu extends ContextMenu
                 $this->addItem(new DividerItem());
                 if ($canDesign || $canEditCustomTemplate) {
                     if ($canDesign) {
-                        $menuItemText = t('Design &amp; Custom Template');
+                        $menuItemText = t('Design &amp; Block Template');
                     }
                     else {
-                        $menuItemText = t('Custom Template');
+                        $menuItemText = t('Block Template');
                     }
                     $this->addItem(new LinkItem('#', $menuItemText, [
                         'data-menu-action' => 'block_design',


### PR DESCRIPTION
This PR addresses #7789 

- Moves the custom block template selector from the advanced tab to be at the start of the Design & Custom Template buttons
- Renames instances of 'Custom Template' to 'Block Template'
- Relabels 'Design & Custom Template' to 'Design & Block Template' in block context menu
- Renames '(None selected)' to 'Default', which makes more sense in the context of the 'Block Template' label

![Screen Shot 2020-01-13 at 5 40 48 pm](https://user-images.githubusercontent.com/1079600/72279903-0dbbdd80-362f-11ea-9676-4f0405774afc.png)
![Screen Shot 2020-01-13 at 5 41 20 pm](https://user-images.githubusercontent.com/1079600/72279910-12809180-362f-11ea-8d2d-386c8c830e55.png)
![Screen Shot 2020-01-13 at 5 41 26 pm](https://user-images.githubusercontent.com/1079600/72279924-190f0900-362f-11ea-9741-3fd8abac64f6.png)
