### PR TITLE
Show a logout view to logged in users on the login page

### DIFF
--- a/concrete/authentication/community/form.php
+++ b/concrete/authentication/community/form.php
@@ -9,50 +9,25 @@ if (isset($message)) {
     ?>
     <div class="alert alert-success"><?= $message ?></div>
 <?php
-
-}
-
-$user = Core::make(Concrete\Core\User\User::class);
-
-if ($user->isLoggedIn()) {
-    ?>
-    <div class="form-group">
-        <span>
-            <?= t('Attach a community account') ?>
-        </span>
-        <hr>
-    </div>
-    <div class="form-group">
-        <a href="<?= \URL::to('/ccm/system/authentication/oauth2/community/attempt_attach');
-    ?>" class="btn btn-primary btn-community btn-block">
-            <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= t('Attach a concrete5.org account') ?>
-        </a>
-    </div>
-    <?php
-
-} else {
-    ?>
-    <div class="form-group">
-        <span>
-            <?= t('Sign in with a community account') ?>
-        </span>
-        <hr class="ccm-authentication-type-community">
-    </div>
-    <div class="form-group">
-        <a href="<?= \URL::to('/ccm/system/authentication/oauth2/community/attempt_auth');
-    ?>" class="btn btn-primary btn-community btn-block">
-            <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= t('Log in with concrete5.org') ?>
-        </a>
-    </div>
-    <div class="form-group">
-        <p><?= t('Join the concrete5.org community to setup multiple websites, shop for extensions, and get support.') ?></p>
-    </div>
-    <?php
-
 }
 ?>
+
+<div class="form-group">
+    <span>
+        <?= t('Sign in with a community account') ?>
+    </span>
+    <hr class="ccm-authentication-type-community">
+</div>
+<div class="form-group">
+    <a href="<?= \URL::to('/ccm/system/authentication/oauth2/community/attempt_auth');
+?>" class="btn btn-primary btn-community btn-block">
+        <img src="<?= Core::getApplicationURL() ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
+        <?= t('Log in with concrete5.org') ?>
+    </a>
+</div>
+<div class="form-group">
+    <p><?= t('Join the concrete5.org community to setup multiple websites, shop for extensions, and get support.') ?></p>
+</div>
 <style>
     .ccm-ui .btn-community {
         border-width: 0px;

--- a/concrete/authentication/external_concrete5/form.php
+++ b/concrete/authentication/external_concrete5/form.php
@@ -10,43 +10,22 @@ if (isset($message)) {
     ?>
     <div class="alert alert-success"><?= $message ?></div>
 <?php
-
-}
-
-if ($user->getUserID() && $user->checkLogin()) {
-    ?>
-    <div class="form-group">
-        <span>
-            <?= t('Attach your %s account', h($name)) ?>
-        </span>
-        <hr>
-    </div>
-    <div class="form-group">
-        <a href="<?= $attachUrl ?>" class="btn btn-success btn-login btn-attach btn-block">
-            <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= t('Attach your %s account', h($name)) ?>
-        </a>
-    </div>
-    <?php
-
-} else {
-    ?>
-    <div class="form-group">
-        <span>
-            <?= t('Sign in with your %s account', h($name)) ?>
-        </span>
-        <hr class="ccm-authentication-type-external-concrete5">
-    </div>
-    <div class="form-group">
-        <a href="<?= $authUrl ?>" class="btn btn-success btn-login btn-block">
-            <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
-            <?= t('Log in with %s', h($name)) ?>
-        </a>
-    </div>
-    <?php
-
 }
 ?>
+
+<div class="form-group">
+    <span>
+        <?= t('Sign in with your %s account', h($name)) ?>
+    </span>
+    <hr class="ccm-authentication-type-external-concrete5">
+</div>
+<div class="form-group">
+    <a href="<?= $authUrl ?>" class="btn btn-success btn-login btn-block">
+        <img src="<?= $assetBase ?>/concrete/images/logo.svg" class="concrete5-icon"></i>
+        <?= t('Log in with %s', h($name)) ?>
+    </a>
+</div>
+
 <style>
     .ccm-ui .btn-community {
         border-width: 0px;

--- a/concrete/authentication/facebook/form.php
+++ b/concrete/authentication/facebook/form.php
@@ -41,64 +41,20 @@ if (isset($show_email) && $show_email) {
     <?php
 
 } else {
-
-    if ($user->isLoggedIn()) {
-        ?>
-
-        <?php if ($authenticationType->isHooked($user)):
-            ?>
-            <div class="form-group">
-        <span>
-            <?= t('Detach your %s account', t('facebook')) ?>
-        </span>
-                <hr>
-            </div>
-            <div class="form-group">
-                <a href="<?= \URL::to('/ccm/system/authentication/oauth2/facebook/attempt_detach');
-                ?>" class="btn btn-primary btn-facebook btn-block">
-                    <i class="fa fa-facebook"></i>
-                    <?= t('Detach your %s account', t('facebook')) ?>
-                </a>
-            </div>
-
-        <?php else: ?>
-
-            <div class="form-group">
-            <span>
-                <?= t('Attach a %s account', t('facebook')) ?>
-            </span>
-                <hr>
-            </div>
-            <div class="form-group">
-                <a href="<?= \URL::to('/ccm/system/authentication/oauth2/facebook/attempt_attach');
-                ?>" class="btn btn-primary btn-facebook btn-block">
-                    <i class="fa fa-facebook"></i>
-                    <?= t('Attach a %s account', t('facebook')) ?>
-                </a>
-            </div>
-
-        <?php endif; ?>
-
-        <?php
-
-    } else {
-        ?>
-        <div class="form-group">
-        <span>
-            <?= t('Sign in with %s', t('facebook')) ?>
-        </span>
-            <hr>
-        </div>
-        <div class="form-group">
-            <a href="<?= \URL::to('/ccm/system/authentication/oauth2/facebook/attempt_auth');
-            ?>" class="btn btn-primary btn-facebook btn-block">
-                <i class="fa fa-facebook"></i>
-                <?= t('Log in with %s', 'facebook') ?>
-            </a>
-        </div>
-        <?php
-    }
     ?>
+    <div class="form-group">
+    <span>
+        <?= t('Sign in with %s', t('facebook')) ?>
+    </span>
+        <hr>
+    </div>
+    <div class="form-group">
+        <a href="<?= \URL::to('/ccm/system/authentication/oauth2/facebook/attempt_auth');
+        ?>" class="btn btn-primary btn-facebook btn-block">
+            <i class="fa fa-facebook"></i>
+            <?= t('Log in with %s', 'facebook') ?>
+        </a>
+    </div>
     <div class="form-group">
         <a href="<?= \URL::to('/') ?>" class="btn btn-success btn-block">
             <?= t('Return to Home Page')?>

--- a/concrete/authentication/google/form.php
+++ b/concrete/authentication/google/form.php
@@ -37,61 +37,21 @@ if (isset($show_email) && $show_email) {
     <?php
 
 } else {
-
-    if ($user->isLoggedIn()) {
-        ?>
-
-        <?php if ($authenticationType->isHooked($user)):
-            ?>
-            <div class="form-group">
-        <span>
-            <?= t('Detach your %s account', t('google')) ?>
-        </span>
-                <hr>
-            </div>
-            <div class="form-group">
-                <a href="<?= \URL::to('/ccm/system/authentication/oauth2/google/attempt_detach');
-                ?>" class="btn btn-primary btn-google btn-block">
-                    <i class="fa fa-google"></i>
-                    <?= t('Detach your %s account', t('google')) ?>
-                </a>
-            </div>
-
-        <?php else: ?>
-        <div class="form-group">
-        <span>
-            <?= t('Attach a %s account', t('Google')) ?>
-        </span>
-            <hr>
-        </div>
-        <div class="form-group">
-            <a href="<?= \URL::to('/ccm/system/authentication/oauth2/google/attempt_attach');
-            ?>" class="btn btn-primary btn-google btn-block">
-                <i class="fa fa-google"></i>
-                <?= t('Attach a %s account', t('Google')) ?>
-            </a>
-        </div>
-        <?php endif;
-
-    } else {
-        ?>
-        <div class="form-group">
-        <span>
-            <?= t('Sign in with %s', t('Google')) ?>
-        </span>
-            <hr>
-        </div>
-        <div class="form-group">
-            <a href="<?= \URL::to('/ccm/system/authentication/oauth2/google/attempt_auth');
-            ?>" class="btn btn-primary btn-google btn-block">
-                <i class="fa fa-google"></i>
-                <?= t('Log in with %s', 'Google') ?>
-            </a>
-        </div>
-        <?php
-
-    }
     ?>
+    <div class="form-group">
+    <span>
+        <?= t('Sign in with %s', t('Google')) ?>
+    </span>
+        <hr>
+    </div>
+    <div class="form-group">
+        <a href="<?= \URL::to('/ccm/system/authentication/oauth2/google/attempt_auth');
+        ?>" class="btn btn-primary btn-google btn-block">
+            <i class="fa fa-google"></i>
+            <?= t('Log in with %s', 'Google') ?>
+        </a>
+    </div>
+
     <div class="form-group">
         <a href="<?= \URL::to('/') ?>" class="btn btn-success btn-block">
             <?= t('Return to Home Page')?>

--- a/concrete/authentication/twitter/form.php
+++ b/concrete/authentication/twitter/form.php
@@ -29,61 +29,22 @@ if (isset($show_email) && $show_email) {
     <?php
 
 } else {
-    if ($user->isLoggedIn()) {
-        ?>
-
-        <?php if ($authenticationType->isHooked($user)):
-            ?>
-            <div class="form-group">
+    ?>
+    <div class="form-group">
         <span>
-            <?= t('Detach your %s account', t('twitter')) ?>
+            <?= t('Sign in with %s', t('twitter')) ?>
         </span>
-                <hr>
-            </div>
-            <div class="form-group">
-                <a href="<?= \URL::to('/ccm/system/authentication/oauth2/twitter/attempt_detach');
-                ?>" class="btn btn-primary btn-twitter btn-block">
-                    <i class="fa fa-twitter"></i>
-                    <?= t('Detach your %s account', t('twitter')) ?>
-                </a>
-            </div>
-
-        <?php else: ?>
-            <div class="form-group">
-            <span>
-                <?= t('Attach a %s account', t('twitter')) ?>
-            </span>
-                <hr>
-            </div>
-            <div class="form-group">
-                <a href="<?= \URL::to('/ccm/system/authentication/oauth2/twitter/attempt_attach');
-                ?>"
-                   class="btn btn-primary btn-twitter btn-block">
-                    <i class="fa fa-twitter"></i>
-                    <?= t('Attach a %s account', t('twitter')) ?>
-                </a>
-            </div>
-        <?php endif;
-
-    } else {
-        ?>
-        <div class="form-group">
-            <span>
-                <?= t('Sign in with %s', t('twitter')) ?>
-            </span>
-            <hr>
-        </div>
-        <div class="form-group">
-            <a href="<?= \URL::to('/ccm/system/authentication/oauth2/twitter/attempt_auth');
-            ?>"
-               class="btn btn-primary btn-twitter btn-block">
-                <i class="fa fa-twitter"></i>
-                <?= t('Log in with %s', 'twitter') ?>
-            </a>
-        </div>
-        <?php
-
-    }
+        <hr>
+    </div>
+    <div class="form-group">
+        <a href="<?= \URL::to('/ccm/system/authentication/oauth2/twitter/attempt_auth');
+        ?>"
+           class="btn btn-primary btn-twitter btn-block">
+            <i class="fa fa-twitter"></i>
+            <?= t('Log in with %s', 'twitter') ?>
+        </a>
+    </div>
+    <?php
 
 }
 ?>

--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -311,6 +311,10 @@ class Login extends PageController implements LoggerAwareInterface
     {
         $this->requireAsset('javascript', 'backstretch');
         $this->set('authTypeParams', $this->getSets());
+
+        $user = $this->app->make(User::class);
+        $this->set('user', $user);
+
         if (strlen($type)) {
             try {
                 $at = AuthenticationType::getByHandle($type);

--- a/concrete/single_pages/login.php
+++ b/concrete/single_pages/login.php
@@ -28,6 +28,20 @@ $image = date('Ymd') . '.jpg';
 /* @var Key[] $required_attributes */
 
 $attribute_mode = (isset($required_attributes) && count($required_attributes));
+
+// See if we have a user object and if that user is registered
+$loggedIn = !$attribute_mode && isset($user) && $user->isRegistered();
+
+// Determine title
+$title = t('Sign in.');
+
+if ($attribute_mode) {
+    $title = t('Required Attributes');
+}
+
+if ($loggedIn) {
+    $title = 'Log Out.';
+}
 ?>
 
 <div class="login-page">
@@ -40,7 +54,7 @@ $attribute_mode = (isset($required_attributes) && count($required_attributes));
         </div>
     <?php } ?>
     <div class="col-sm-6 col-sm-offset-3">
-        <h1><?= !$attribute_mode ? t('Sign In.') : t('Required Attributes') ?></h1>
+        <h1><?= $title ?></h1>
     </div>
     <div class="col-sm-6 col-sm-offset-3 login-form">
         <div class="row">
@@ -75,7 +89,7 @@ $attribute_mode = (isset($required_attributes) && count($required_attributes));
             </div>
         </div>
         <div class="row login-row">
-            <div <?php if (count($activeAuths) < 2) {
+            <div <?php if ($loggedIn || count($activeAuths) < 2) {
     ?>style="display: none" <?php 
 } ?> class="types col-sm-4 hidden-xs">
                 <ul class="auth-types">
@@ -103,13 +117,20 @@ $attribute_mode = (isset($required_attributes) && count($required_attributes));
                     ?>
                 </ul>
             </div>
-            <div class="controls <?php if (count($activeAuths) < 2) {
+            <div class="controls <?php if (count($activeAuths) < 2 || $loggedIn) {
     ?>col-sm-12<?php 
 } else {
     ?>col-sm-8<?php 
 } ?> col-xs-12">
                 <?php
-                if ($attribute_mode) {
+                if ($loggedIn) {
+                    ?>
+                    <div class="text-center">
+                        <h3><?= t('You are already logged in.') ?></h3>
+                        <?= Core::make('helper/navigation')->getLogInOutLink() ?>
+                    </div>
+                    <?php
+                } elseif ($attribute_mode) {
                     $attribute_helper = new Concrete\Core\Form\Service\Widget\Attribute();
                     ?>
                     <form action="<?= View::action('fill_attributes') ?>" method="POST">


### PR DESCRIPTION
[](url)
<img width="767" alt="Screen Shot 2020-01-13 at 4 37 03 PM" src="https://user-images.githubusercontent.com/1007419/72303710-0262b500-3623-11ea-9838-0295ff0186c3.png">

We used to show the user buttons that allowed them to hook external accounts to their concrete5 account, instead let's just leave that a part of the user profile pages and show a logout view.

One important note is that we use the login page to manage filling required attributes, this PR takes care to ensure that the required attributes form can be shown and completed during the login process.