### PR TITLE
Use Concrete\Core\User\User singleton instead of creating new User instances

### DIFF
--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -13,7 +13,7 @@ use Concrete\Core\Page\Stack\StackList;
 use Doctrine\ORM\EntityManagerInterface;
 use Concrete\Core\Page\Stack\Stack;
 use Page;
-use User;
+use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Request\DeletePageRequest;
 use Concrete\Core\Workflow\Request\ApproveStackRequest;
 use Concrete\Core\Workflow\Request\ApprovePageRequest;
@@ -405,7 +405,7 @@ class Stacks extends DashboardPageController
                 if (!$this->error->has()) {
                     $sps = new Checker($s);
                     if ($sps->canDeletePage()) {
-                        $u = new \User();
+                        $u = $this->app->make(User::class);
                         $pkr = new DeletePageRequest();
                         $pkr->setRequestedPage($s);
                         $pkr->setRequesterUserID($u->getUserID());
@@ -440,7 +440,7 @@ class Stacks extends DashboardPageController
                 $isGlobalArea = $s->getStackType() == Stack::ST_TYPE_GLOBAL_AREA;
                 $sps = new Checker($s);
                 if ($sps->canApprovePageVersions()) {
-                    $u = new User();
+                    $u = $this->app->make(User::class);
                     $v = Version::get($s, 'RECENT');
                     $pkr = new ApproveStackRequest();
                     $pkr->setRequestedPage($s);
@@ -521,7 +521,7 @@ class Stacks extends DashboardPageController
                                 'cName' => $newName,
                                 'cHandle' => str_replace('-', Config::get('concrete.seo.page_path_separator'), $txt->urlify($newName)),
                             ]);
-                            $u = new User();
+                            $u = $this->app->make(User::class);
                             if ($isFolder) {
                                 $pkr = new ApprovePageRequest();
                             } else {
@@ -687,7 +687,7 @@ class Stacks extends DashboardPageController
                 if (!$sps->canDeletePage()) {
                     $this->error->add(t('You do not have access to delete this stack folder.'));
                 } else {
-                    $u = new User();
+                    $u = $this->app->make(User::class);
                     $pkr = new DeletePageRequest();
                     $pkr->setRequestedPage($folder->getPage());
                     $pkr->setRequesterUserID($u->getUserID());

--- a/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
+++ b/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
@@ -125,7 +125,6 @@ class AddBlockToAreaAreaKey extends AreaKey
      */
     protected function getAllowedBlockTypeIDsFor($operation)
     {
-        $u = new User();
         $pae = $this->getPermissionAccessObject();
         if (!is_object($pae)) {
             return [];


### PR DESCRIPTION
Another pass to remove `new User()` calls