### PR TITLE
Allow empty request path

### DIFF
--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -340,9 +340,11 @@ class PageController extends Controller
         // Example: If a request is made to "domain.com/d" but the shortest path is "domain.com/de"
         // a 404 response should be returned.
         $requestPath = $this->request->getPath();
-        $collectionPath = $this->getPageObject()->getCollectionPath();
-        if (strlen($requestPath) < strlen($collectionPath)) {
-            $valid = false;
+        if ($requestPath !== '') {
+            $collectionPath = $this->getPageObject()->getCollectionPath();
+            if (strlen($requestPath) < strlen($collectionPath)) {
+                $valid = false;
+            }
         }
 
         $this->requestValidated = $valid;


### PR DESCRIPTION
Since #8268 got merged, it's no more possible to edit pages.

Why?

We often access pages with `/index.php?cID=...` (that is, with an empty request path - like for example when we edit a page): in these cases `$request->getPath()` returns an empty string (which has a length lower than than the page path).

So, we shouldn't check the request path length if it's empty and we retrieved the page given its ID.