### PR TITLE
Allow passing route actions through routes

### DIFF
--- a/concrete/src/Routing/RouteActionFactory.php
+++ b/concrete/src/Routing/RouteActionFactory.php
@@ -11,11 +11,17 @@ class RouteActionFactory implements RouteActionFactoryInterface
 
     public function createAction(Route $route)
     {
-        if ($route->getAction() instanceof \Closure) {
+        $action = $route->getAction();
+
+        // Allow passing through explicit route actions
+        if ($action instanceof RouteActionInterface) {
+            return $action;
+        }
+
+        if ($action instanceof \Closure) {
             return new ClosureRouteAction($route->getAction());
         }
 
-        $action = $route->getAction();
         $class = null;
         $method = null;
         if (is_string($action)) {

--- a/tests/tests/Routing/RouteActionFactoryTest.php
+++ b/tests/tests/Routing/RouteActionFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Concrete\Tests\Routing;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Routing\ClosureRouteAction;
+use Concrete\Core\Routing\Route;
+use Concrete\Core\Routing\RouteActionFactory;
+use Concrete\Core\Routing\RouteActionInterface;
+use Mockery as M;
+
+class RouteActionFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRouteActionPassesThrough()
+    {
+        $fakeAction = M::mock(RouteActionInterface::class);
+
+        $route = M::mock(Route::class);
+        $route->shouldReceive('getAction')->andReturn($fakeAction);
+
+        $factory = new RouteActionFactory();
+        $this->assertEquals($fakeAction, $factory->createAction($route));
+    }
+
+    public function testClosureRouteAction()
+    {
+        $called = 0;
+        $fakeAction = function() use (&$called) {
+            $called++;
+        };
+
+        $route = M::mock(Route::class);
+        $route->shouldReceive('getAction')->andReturn($fakeAction);
+
+        // Build the new action
+        $factory = new RouteActionFactory();
+        $result = $factory->createAction($route);
+        $this->assertInstanceOf(ClosureRouteAction::class, $result);
+
+        $this->assertEquals(0, $called, 'The route action was called sooner than expected.');
+
+        // run the action and make sure the underlying closure is called.
+        $result->execute(M::mock(Request::class), $route, []);
+        $this->assertEquals(1, $called, 'The route action was not called.');
+    }
+
+}


### PR DESCRIPTION
In the current concrete5 release the only way to use a completely custom route action for a given route is to override the `RouteActionFactory` class completely. Luckily it's not a huge job to override, but it'd be nice if we simply allowed instances of RouteActionInterface to be set as route actions and to pass through cleanly.

This PR makes that happen and adds a couple tests for it.