### PR TITLE
[Feature] #8367 Add asset loading location for node_modules

### DIFF
--- a/concrete/bootstrap/paths.php
+++ b/concrete/bootstrap/paths.php
@@ -9,14 +9,17 @@ defined('C5_EXECUTE') or define('C5_EXECUTE', md5(uniqid()));
  */
 if (APP_UPDATED_PASSTHRU === false) {
     $ap = $app['app_relative_path'] . '/' . DIRNAME_CORE;
+    $apRoot = $app['app_relative_path'];
 } else {
     $ap = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED . '/' . DIRNAME_CORE;
+    $appRoot = $app['app_relative_path'] . '/' . DIRNAME_UPDATES . '/' . DIRNAME_APP_UPDATED;
 }
 
 define('ASSETS_URL', $ap);
 define('ASSETS_URL_CSS', $ap . '/css');
 define('ASSETS_URL_JAVASCRIPT', $ap . '/js');
 define('ASSETS_URL_IMAGES', $ap . '/images');
+define('ASSETS_URL_NODE_MODULES', $appRoot);
 
 /*
  * ----------------------------------------------------------------------------

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -9,7 +9,7 @@ return [
     'version' => '8.6.0a3',
     'version_installed' => '8.6.0a3',
     'version_db' => '20191002000000', // the key of the latest database migration
- 
+
     /*
      * Installation status
      *
@@ -1194,7 +1194,7 @@ return [
             'node_modules' => [
                 'active' => false,
                 'class' => Concrete\Core\Filesystem\FileLocator\NodeModulesLocation::class,
-            ]
-        ]
-    ]
+            ],
+        ],
+    ],
 ];

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1182,4 +1182,19 @@ return [
             // Where 'icon' is the handle of a FontAwesome 4 icon (see https://fontawesome.com/v4.7.0/icons/ )
         ],
     ],
+
+    /*
+     * ------------------------------------------------------------------------
+     * Asset locations
+     * ------------------------------------------------------------------------
+     */
+    'asset' => [
+        // Add here additional asset loading locations
+        'locations' => [
+            'node_modules' => [
+                'active' => false,
+                'class' => Concrete\Core\Filesystem\FileLocator\NodeModulesLocation::class,
+            ]
+        ]
+    ]
 ];

--- a/concrete/src/Filesystem/FileLocator.php
+++ b/concrete/src/Filesystem/FileLocator.php
@@ -5,7 +5,6 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Filesystem\FileLocator\ApplicationLocation;
 use Concrete\Core\Filesystem\FileLocator\CoreLocation;
 use Concrete\Core\Filesystem\FileLocator\LocationInterface;
-use Concrete\Core\Filesystem\FileLocator\NodeModulesLocation;
 use Concrete\Core\Filesystem\FileLocator\PackageLocation;
 use Concrete\Core\Filesystem\FileLocator\Record;
 use Illuminate\Filesystem\Filesystem;
@@ -43,9 +42,28 @@ class FileLocator
     public function addDefaultLocations()
     {
         array_unshift($this->locations, new ApplicationLocation($this->filesystem));
-        $this->locations[] = new NodeModulesLocation($this->filesystem);
+        //$this->locations[] = new NodeModulesLocation($this->filesystem);
+        $this->addAdditionalLocations();
         $this->locations[] = new CoreLocation($this->filesystem);
     }
+
+    /**
+     * Load additional asset locations from config
+     */
+    public function addAdditionalLocations()
+    {
+        $config = $this->app->make('config');
+        $additionalLocations = $config->get('concrete.asset.locations');
+        if (is_array($additionalLocations)) {
+            foreach ($additionalLocations as $locationHandle => $location) {
+                if ($location['active']) {
+                    $class = $location['class'];
+                    $this->addLocation( new $class($this->filesystem));
+                }
+            }
+        }
+    }
+
     public function addLocation(LocationInterface $location)
     {
         $this->locations[] = $location;

--- a/concrete/src/Filesystem/FileLocator.php
+++ b/concrete/src/Filesystem/FileLocator.php
@@ -5,6 +5,7 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Filesystem\FileLocator\ApplicationLocation;
 use Concrete\Core\Filesystem\FileLocator\CoreLocation;
 use Concrete\Core\Filesystem\FileLocator\LocationInterface;
+use Concrete\Core\Filesystem\FileLocator\NodeModulesLocation;
 use Concrete\Core\Filesystem\FileLocator\PackageLocation;
 use Concrete\Core\Filesystem\FileLocator\Record;
 use Illuminate\Filesystem\Filesystem;
@@ -42,6 +43,7 @@ class FileLocator
     public function addDefaultLocations()
     {
         array_unshift($this->locations, new ApplicationLocation($this->filesystem));
+        $this->locations[] = new NodeModulesLocation($this->filesystem);
         $this->locations[] = new CoreLocation($this->filesystem);
     }
     public function addLocation(LocationInterface $location)

--- a/concrete/src/Filesystem/FileLocator/NodeModulesLocation.php
+++ b/concrete/src/Filesystem/FileLocator/NodeModulesLocation.php
@@ -3,11 +3,12 @@
 namespace Concrete\Core\Filesystem\FileLocator;
 
 /**
- * Class NodeModulesLocation
+ * Class NodeModulesLocation.
+ *
+ * Enables the possibility to load assets from {webroot}/node_modules
  */
 class NodeModulesLocation extends AbstractLocation
 {
-
     /**
      * @return string
      */

--- a/concrete/src/Filesystem/FileLocator/NodeModulesLocation.php
+++ b/concrete/src/Filesystem/FileLocator/NodeModulesLocation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Concrete\Core\Filesystem\FileLocator;
+
+/**
+ * Class NodeModulesLocation
+ */
+class NodeModulesLocation extends AbstractLocation
+{
+
+    /**
+     * @return string
+     */
+    public function getCacheKey()
+    {
+        return 'node_modules';
+    }
+
+    public function getPath()
+    {
+        return DIR_BASE;
+    }
+
+    public function getURL()
+    {
+        return ASSETS_URL_NODE_MODULES;
+    }
+}


### PR DESCRIPTION
## Pull requests adds:
- a new asset loading location for {webroot}/node_modules. The new asset location is turned off by default. 
- possibility to add more custom asset loading locations in the configuration.


## How to test

1. Activate the new asset location by adding following snippet to `application/config/concrete.php`
```php
return [
    'asset' => [
        // Add here additional asset loading locations
        'locations' => [
            'node_modules' => [
                'active' => true,
                'class' => Concrete\Core\Filesystem\FileLocator\NodeModulesLocation::class,
            ],
        ],
    ],
];
```

2. Create the following package.json file in the {webroot}

```json
{
  "name": "concrete5_test_load_npm_modules",
  "description": "Test",
  "version": "0.2.0",
  "dependencies": {
    "moment": "^2.24.0"
  }
}
```
3. Run `npm install`

4. Download this test block [momentjs.zip](https://github.com/concrete5/concrete5/files/4082865/momentjs.zip), unzip it and place it under `application/blocks`
5. Activate the block in the backend and insert it somewhere in a page. The two assets should be loaded without error from `node_modules/`

Related to #8381 