### PR TITLE
Set calendar's contentHeight to 'auto'

### DIFF
--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -27,6 +27,7 @@ if ($c->isEditMode()) {
                     listMonth: { buttonText: '<?= t('list month'); ?>' },
                     listYear: { buttonText: '<?= t('list year'); ?>' }
                 },
+                contentHeight: 'auto',
 
                 <?php if ($defaultView) { ?>
                     defaultView: '<?= $defaultView; ?>',


### PR DESCRIPTION
I added " contentHeight: 'auto' " so that when you put the calendar block into narrow width area, scroll bar will not show up. If it's wide width area, there's no scroll bar.
I think it's better not showing scroll bar as initial setting.

![no-scrollbar](https://user-images.githubusercontent.com/50560719/72885693-bfec5700-3d4b-11ea-8720-9e5d1a602aa6.png)
![scrollbar](https://user-images.githubusercontent.com/50560719/72885694-bfec5700-3d4b-11ea-9e34-d61e983de893.png)

