### PR TITLE
Ensure line endings of files in /concrete/bin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,8 @@
 *.txt normalizetext
 *.xml normalizetext
 *.svg text eol=lf
+/concrete/bin/concrete5 text eol=lf
+/concrete/bin/concrete5.bat text eol=crlf
 
 #
 # Binary files


### PR DESCRIPTION
If `/concrete/bin/concrete5` uses the Windows line endings (`\r\n`), we'll have this error if we run it under POSIX (tested under Ubuntu 18.04):
```
/usr/bin/env: 'php\r': No such file or directory
```

So, let's ask git to use the standard POSIX line endings (`\n`) for that file.

The opposite may occur for the Windows batch file `/concrete/bin/concrete5.bat`.