### PR TITLE
Fix checking blocks than can be added to Stacks/Global Areas

### DIFF
--- a/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
+++ b/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
@@ -7,6 +7,7 @@ use Concrete\Core\Block\Block;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Permission\Assignment\AreaAssignment;
 use Concrete\Core\Permission\Duration as PermissionDuration;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
@@ -125,7 +126,7 @@ class AddBlockToAreaAreaKey extends AreaKey
      */
     protected function getAllowedBlockTypeIDsFor($operation)
     {
-        $pae = $this->getPermissionAccessObject();
+        $pae = $this->getAreaPermissionAccessObject();
         if (!is_object($pae)) {
             return [];
         }
@@ -136,7 +137,7 @@ class AddBlockToAreaAreaKey extends AreaKey
         $u = $app->make(User::class);
         $accessEntities = $u->getUserAccessEntityObjects();
         $accessEntities = $pae->validateAndFilterAccessEntities($accessEntities);
-        $list = $this->getAccessListItems(AreaKey::ACCESS_TYPE_ALL, $accessEntities);
+        $list = $this->getAreaAccessListItems(AreaKey::ACCESS_TYPE_ALL, $accessEntities);
         $list = PermissionDuration::filterByActive($list);
         $btIDs = [];
         if (count($list) > 0) {
@@ -170,23 +171,7 @@ class AddBlockToAreaAreaKey extends AreaKey
             } else {
                 $allBTIDs = $item->get();
             }
-            
-            $a = $this->getPermissionObject();
-            $stack = null;
-            if ($a instanceof Area) {
-                $areaPage = $a->getAreaCollectionObject();
-                if ($areaPage instanceof Page && $areaPage->getPageTypeHandle() === STACKS_PAGE_TYPE) {
-                    $stack = $areaPage;
-                } elseif ($a->isGlobalArea()) {
-                    $stack = Stack::getByName($a->getAreaHandle());
-                    if (!$stack || $stack->isError()) {
-                        $stack = null;
-                    }
-                }
-            }
-            if ($stack !== null) {
-                return $allBTIDs;
-            }
+
             foreach ($list as $l) {
                 switch ($l->getBlockTypesAllowedPermission()) {
                     case 'N':

--- a/concrete/src/Permission/Key/AreaKey.php
+++ b/concrete/src/Permission/Key/AreaKey.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Permission\Key;
 
+use Concrete\Core\Permission\Assignment\AreaAssignment;
 use Loader;
 
 class AreaKey extends Key
@@ -18,6 +19,37 @@ class AreaKey extends Key
                 'pkID' => $this->getPermissionKeyID(),
                 ),
                 array('cID', 'arHandle', 'pkID'), true);
+        }
+    }
+
+    protected function getAreaPermissionAccessObject()
+    {
+        $targ = $this->getPermissionAssignmentObject();
+        if ($targ instanceof AreaAssignment) {
+            return $targ->getAreaPermissionAccessObject();
+        }
+
+        return $this->getPermissionAccessObject();
+    }
+
+    protected function getAreaAccessListItems()
+    {
+        $obj = $this->getAreaPermissionAccessObject();
+        if (!$obj) {
+            return [];
+        }
+        $args = func_get_args();
+        switch (count($args)) {
+            case 0:
+                return $obj->getAccessListItems();
+            case 1:
+                return $obj->getAccessListItems($args[0]);
+            case 2:
+                return $obj->getAccessListItems($args[0], $args[1]);
+            case 3:
+                return $obj->getAccessListItems($args[0], $args[1], $args[2]);
+            default:
+                return call_user_func_array([$obj, 'getAccessListItems'], $args);
         }
     }
 }


### PR DESCRIPTION
Issue #8244 is a bit nasty... Here's a description of the issue.

When we open the *Add Block* panel, the list of blocks is built by the [`buildSetsAndBlockTypes()`](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/controllers/panel/add.php#L82) method of the `panel/add.php` controller.

This method iterate all the non internal block types and basically calls this code to determine the list of allowed block types:

```php
$checker = new Concrete\Core\Permission\Checker($currentPage);
if ($checker->canAddBlockType($blockType)) {
    $allowedBlockTypes[] = $blockType;
}
```

What `canAddBlockType()` does? It forwards the request to the [`canAddBlockType()`](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/src/Permission/Response/PageResponse.php#L108) method of the `Concrete\Core\Permission\Response\PageResponse` class.

That method iterates all the areas in the page, and does something like this for each area:

```php
$checker = new Concrete\Core\Permission\Checker($area);
if ($checker->canAddBlockToArea($blockType)) {
    // ...
}
```

That method basically checks if the ID of `$blockType` is contained in the array returned by the [`getAllowedBlockTypeIDsFor()`](https://github.com/concrete5/concrete5/blob/8.5.2/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php#L125) method of the `Concrete\Core\Permission\Key\AddBlockToAreaAreaKey` permission key.

For normal areas, that function works as expected.

But in case of stacks and global areas there's a big problem: because they behave like pages (they have versions for example), concrete5 currently assumes that they are pages, so the permission systems uses the page-related classes instead of the area-related classes.
This works just fine almost always, except when we need to check the block types that can be added to them.
At the moment, `getAllowedBlockTypeIDsFor()` says that users can add all the block types because it works with page access items and not with area access items, thus it don't have instances of `Concrete\Core\Permission\Access\ListItem\AddBlockBlockTypeListItem` but instances of `Concrete\Core\Permission\Access\ListItem\PageListItem` that don't provide the `getBlockTypesAllowedArray()` method.

We have two solutions IMHO.

The first one is to implement a whole new set of access-related stuff for Stacks and Global Areas (that's what @aembler [pointed out here]()).

The other solution, implemented here, is to simply use the area stuff in the `getAllowedBlockTypeIDsFor()` method, which is much simpler and backward compatible.

Of course any feedback is very welcome: the access-related stuff is super powerful, but also super-convoluted.