### PR TITLE
Enable refresh_token grant

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1161,6 +1161,7 @@ return [
             'client_credentials' => true,
             'authorization_code' => true,
             'password_credentials' => false,
+            'refresh_token' => true,
         ],
     ],
 

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.6.0a3',
     'version_installed' => '8.6.0a3',
-    'version_db' => '20191002000000', // the key of the latest database migration
+    'version_db' => '20200203000000', // the key of the latest database migration
  
     /*
      * Installation status

--- a/concrete/controllers/single_page/dashboard/system/api/settings.php
+++ b/concrete/controllers/single_page/dashboard/system/api/settings.php
@@ -29,6 +29,7 @@ class Settings extends DashboardPageController
             'client_credentials' => t('Client Credentials'),
             'authorization_code' => t('Authorization Code'),
             'password_credentials' => t('Password Credentials'),
+            'refresh_token' => t('Refresh Token'),
         ];
     }
 

--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
+use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -160,6 +161,9 @@ class ApiServiceProvider extends ServiceProvider
             }
             if ($config->get('concrete.api.grant_types.authorization_code')) {
                 $server->enableGrantType($this->app->make(AuthCodeGrant::class, ['authCodeTTL' => $oneDayTTL]), $oneDayTTL);
+            }
+            if ($config->get('concrete.api.grant_types.refresh_token')) {
+                $server->enableGrantType($this->app->make(RefreshTokenGrant::class), $oneHourTTL);
             }
             return $server;
         });

--- a/concrete/src/Entity/OAuth/RefreshToken.php
+++ b/concrete/src/Entity/OAuth/RefreshToken.php
@@ -29,7 +29,7 @@ class RefreshToken implements RefreshTokenEntityInterface
     /**
      * @var \League\OAuth2\Server\Entities\AccessTokenEntityInterface
      * @ORM\OneToOne(targetEntity="AccessToken")
-     * @ORM\JoinColumn(name="accessToken", referencedColumnName="identifier")
+     * @ORM\JoinColumn(name="accessToken", referencedColumnName="identifier", onDelete="SET NULL")
      */
     protected $accessToken;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20200203000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200203000000.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20200203000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            Type::class,
+        ]);
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20200203000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200203000000.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Updater\Migrations\Migrations;
 
-use Concrete\Core\Entity\File\Image\Thumbnail\Type\Type;
+use Concrete\Core\Entity\OAuth\RefreshToken;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
@@ -11,7 +11,7 @@ class Version20200203000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         $this->refreshEntities([
-            Type::class,
+            RefreshToken::class,
         ]);
     }
 }


### PR DESCRIPTION
I worked for refresh_token. To enable it, the following three files need to be modified. It was straight forward.

- concrete/config/concrete.php
- concrete/controllers/single_page/dashboard/system/api/settings.php
- concrete/src/Api/ApiServiceProvider.php

However, this code has a Database integrity issue, because of the following code. In the code, an access token is removed at first, and then, its corresponding refresh token is removed.
```
// vendor/league/oauth2-server/src/Grant/RefreshTokenGrant.php
// Expire old tokens
$this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
$this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
```
Concrete5 database has a foreign key constraint, so that the above code is erroneous.
(DB table "OAuth2RefreshToken" has a column "accessToken", which has a foreign key constraint to the table "OAuth2AccessToken".)

I think the order of the revocation should be opposite, but league/oauth2-server team explicitly declined [the similar pull request](https://github.com/thephpleague/oauth2-server/issues/785).
So, I am suggesting ORM change too.