### PR TITLE
jQuery UI dialog resize handle fix

### DIFF
--- a/concrete/css/build/vendor/jquery-ui/jquery-ui.less
+++ b/concrete/css/build/vendor/jquery-ui/jquery-ui.less
@@ -501,14 +501,12 @@ button.ui-button::-moz-focus-inner {
 	height: 7px;
 }
 .ui-dialog .ui-resizable-se {
-	/* concrete5 */
-	/*
-	right: -5px;
-	bottom: -5px;
-	background-position: 16px 16px;
-	 */
-	right: 0;
-	bottom: 0;
+    /* concrete5 */
+    width: 12px;
+    height: 12px;
+    right: 1px;
+    bottom: 1px;
+    /* end concrete5 */
 }
 .ui-dialog .ui-resizable-sw {
 	left: 0;


### PR DESCRIPTION
When jquery-ui.less was last modified, the rules for the dialog resize handle were overwritten. This prevented the resize handle from being displayed.

The develop and 9.0.0 branch are using the same asset.
https://github.com/concrete5/concrete5/blob/release/9.0.0/concrete/css/build/vendor/jquery-ui/jquery-ui.less

**Current:**

![image](https://user-images.githubusercontent.com/10898145/73783341-852dea00-4761-11ea-919c-9b3753ff29f5.png)

**Changes:**

![image](https://user-images.githubusercontent.com/10898145/73783355-8ced8e80-4761-11ea-8890-41de25a8418a.png)
