### PR TITLE
[Fix] Error when the sortBy column isn't exists on the advanced search result

### DIFF
--- a/concrete/src/Search/AbstractSearchProvider.php
+++ b/concrete/src/Search/AbstractSearchProvider.php
@@ -79,14 +79,12 @@ abstract class AbstractSearchProvider implements ProviderInterface, SessionQuery
             $value = $data[$list->getQuerySortColumnParameter()];
             $sortColumn = $columns->getColumnByKey($value);
 
-            if (isset($data[$list->getQuerySortDirectionParameter()])) {
-                $direction = $data[$list->getQuerySortDirectionParameter()];
-            } else{
-                $direction = $sortColumn->getColumnDefaultSortDirection();
-            }
+            if (is_object($sortColumn)) {
+                $direction = $data[$list->getQuerySortDirectionParameter()] ?? $sortColumn->getColumnDefaultSortDirection();
 
-            $sortColumn->setColumnSortDirection($direction);
-            $list->sortBySearchColumn($sortColumn, $direction);
+                $sortColumn->setColumnSortDirection($direction);
+                $list->sortBySearchColumn($sortColumn, $direction);
+            }
         }
 
         if ($list instanceof PagerProviderInterface) {

--- a/concrete/src/Search/AbstractSearchProvider.php
+++ b/concrete/src/Search/AbstractSearchProvider.php
@@ -80,7 +80,11 @@ abstract class AbstractSearchProvider implements ProviderInterface, SessionQuery
             $sortColumn = $columns->getColumnByKey($value);
 
             if (is_object($sortColumn)) {
-                $direction = $data[$list->getQuerySortDirectionParameter()] ?? $sortColumn->getColumnDefaultSortDirection();
+                if (isset($data[$list->getQuerySortDirectionParameter()]) && !empty($data[$list->getQuerySortDirectionParameter()])) {
+                    $direction = $data[$list->getQuerySortDirectionParameter()];
+                } else {
+                    $direction = $sortColumn->getColumnDefaultSortDirection();
+                }
 
                 $sortColumn->setColumnSortDirection($direction);
                 $list->sortBySearchColumn($sortColumn, $direction);


### PR DESCRIPTION
This PR fixes the following error when the sortBy column isn't exists on the advanced search result

```
Call to a member function setColumnSortDirection() on null
```

## How To Reproduce

- Create an express object
- Add some entries
- Do the advanced search
  - Uncheck `Date Added` from `Choose Columns` section
  - Keep the `Sort By Column` as it is `Date Added`
- Click on pagination
- You'll get the error