### PR TITLE
Add the ability to easily inject custom Config drivers (loaders/saves) and implement Redis drivers

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -263,7 +263,7 @@ define('DIR_FILES_BLOCK_TYPES_FORMS_EXTERNAL_PROCESS_CORE', DIR_FILES_BLOCK_TYPE
 define('DIR_FILES_UPLOADED_STANDARD', DIR_APPLICATION . '/files');
 define('DIR_AL_ICONS', DIR_BASE_CORE . '/images/icons/filetypes');
 define('DIR_LANGUAGES_SITE_INTERFACE', DIR_LANGUAGES . '/' . DIRNAME_LANGUAGES_SITE_INTERFACE);
-const DIR_CORE_CONFIG = DIR_BASE_CORE . '/config';
+define('DIR_CORE_CONFIG', DIR_BASE_CORE . '/config');
 
 /*
  * ----------------------------------------------------------------------------

--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -263,6 +263,7 @@ define('DIR_FILES_BLOCK_TYPES_FORMS_EXTERNAL_PROCESS_CORE', DIR_FILES_BLOCK_TYPE
 define('DIR_FILES_UPLOADED_STANDARD', DIR_APPLICATION . '/files');
 define('DIR_AL_ICONS', DIR_BASE_CORE . '/images/icons/filetypes');
 define('DIR_LANGUAGES_SITE_INTERFACE', DIR_LANGUAGES . '/' . DIRNAME_LANGUAGES_SITE_INTERFACE);
+const DIR_CORE_CONFIG = DIR_BASE_CORE . '/config';
 
 /*
  * ----------------------------------------------------------------------------

--- a/concrete/src/Config/CompositeLoader.php
+++ b/concrete/src/Config/CompositeLoader.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Concrete\Core\Config;
+
+use Concrete\Core\Application\Application;
+
+/**
+ * A loader that delegates method calls to multiple other loaders
+ */
+class CompositeLoader implements LoaderInterface
+{
+
+    protected $app;
+
+    protected $loaders = [];
+
+    protected $processed = false;
+
+    /**
+     * @param LoaderInterface[] $loaders The loaders to delegate to, delegated methods are called in order
+     */
+    public function __construct(Application $app, array $loaders)
+    {
+        $this->loaders = $loaders;
+        $this->app = $app;
+    }
+
+    /**
+     * @param $namespace
+     */
+    public function clearNamespace($namespace)
+    {
+        foreach ($this->getLoaders() as $loader) {
+            $loader->clearNamespace($namespace);
+        }
+    }
+
+    /**
+     * Load the given configuration group.
+     *
+     * @param string $environment
+     * @param string $group
+     * @param string $namespace
+     * @return array
+     */
+    public function load($environment, $group, $namespace = null)
+    {
+        $results = [];
+        foreach ($this->getLoaders() as $loader) {
+            $result = $loader->load($environment, $group, $namespace);;
+            if ($result) {
+                $results[] = $result;
+            }
+        }
+
+        if ($results) {
+            return array_replace_recursive(...$results);
+        }
+
+        return [];
+    }
+
+    /**
+     * Determine if the given configuration group exists.
+     *
+     * @param string $group
+     * @param string $namespace
+     * @return bool
+     */
+    public function exists($group, $namespace = null)
+    {
+        foreach ($this->getLoaders() as $loader) {
+            if ($loader->exists($group, $namespace)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param string $namespace
+     * @param string $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        foreach ($this->getLoaders() as $loader) {
+            $loader->addNamespace($namespace, $hint);
+        }
+    }
+
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        $results = [];
+        foreach ($this->getLoaders() as $loader) {
+            $results[] = $loader->getNamespaces();
+        }
+
+        return array_merge(...$results);
+    }
+
+    /**
+     * Apply any cascades to an array of package options.
+     *
+     * @param string $environment
+     * @param string $package
+     * @param string $group
+     * @param array $items
+     *
+     * @return array
+     */
+    public function cascadePackage($environment, $package, $group, $items)
+    {
+        $results = [];
+        foreach ($this->getLoaders() as $loader) {
+            $results[] = $loader->cascadePackage($environment, $package, $group, $items);
+        }
+
+        return array_merge(...$results);
+    }
+
+    /**
+     * Get the loaders associated with this class, populate instances using the application as needed
+     *
+     * @return array|LoaderInterface[]
+     */
+    private function getLoaders()
+    {
+        if (!$this->processed) {
+            foreach ($this->loaders as &$loader) {
+                if (is_string($loader)) {
+                    $loader = $this->app->make($loader);
+                }
+            }
+            $this->processed = true;
+        }
+
+        return $this->loaders;
+    }
+}

--- a/concrete/src/Config/CompositeLoader.php
+++ b/concrete/src/Config/CompositeLoader.php
@@ -54,7 +54,8 @@ class CompositeLoader implements LoaderInterface
         }
 
         if ($results) {
-            return array_replace_recursive(...$results);
+            /** @TODO Replace with argument unpacking when we can support it */
+            return call_user_func_array('array_replace_recursive', $results);
         }
 
         return [];
@@ -102,10 +103,10 @@ class CompositeLoader implements LoaderInterface
     {
         $results = [];
         foreach ($this->getLoaders() as $loader) {
-            $results[] = $loader->getNamespaces();
+            $results = array_merge($results, $loader->getNamespaces());
         }
 
-        return array_merge(...$results);
+        return $results;
     }
 
     /**
@@ -122,10 +123,10 @@ class CompositeLoader implements LoaderInterface
     {
         $results = [];
         foreach ($this->getLoaders() as $loader) {
-            $results[] = $loader->cascadePackage($environment, $package, $group, $items);
+            $results = array_merge($results, $loader->cascadePackage($environment, $package, $group, $items));
         }
 
-        return array_merge(...$results);
+        return $results;
     }
 
     /**

--- a/concrete/src/Config/ConfigServiceProvider.php
+++ b/concrete/src/Config/ConfigServiceProvider.php
@@ -23,9 +23,17 @@ class ConfigServiceProvider extends Provider
      */
     private function registerFileConfig()
     {
+        $this->app->bindIf(LoaderInterface::class, static function($app) {
+            return $app->make(CompositeLoader::class, [$app, [
+                CoreFileLoader::class,
+                FileLoader::class,
+            ]]);
+        });
+        $this->app->bindIf(SaverInterface::class, FileSaver::class);
+
         $this->app->singleton('config', function ($app) {
-            $loader = $app->make('Concrete\Core\Config\FileLoader');
-            $saver = $app->make('Concrete\Core\Config\FileSaver');
+            $loader = $app->make(LoaderInterface::class);
+            $saver = $app->make(SaverInterface::class);
 
             return $app->build('Concrete\Core\Config\Repository\Repository', array($loader, $saver, $app->environment()));
         });

--- a/concrete/src/Config/CoreFileLoader.php
+++ b/concrete/src/Config/CoreFileLoader.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Concrete\Core\Config;
+
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * A file loader specific to default core file loading.
+ * This loader only loads the main config file and environment specific config.
+ */
+class CoreFileLoader extends FileLoader
+{
+
+    /**
+     * Overridden constructor for the custom `$defaultPath = ...`
+     *
+     * @param Filesystem $files
+     * @param string $defaultPath
+     */
+    public function __construct(Filesystem $files, $defaultPath = DIR_CORE_CONFIG)
+    {
+        parent::__construct($files, $defaultPath);
+    }
+
+    /**
+     * Load files from the core
+     *
+     * @param string $environment
+     * @param string $group
+     * @param null $namespace
+     * @return array
+     */
+    public function load($environment, $group, $namespace = null)
+    {
+        return $this->defaultLoad($environment, $group, $namespace);
+    }
+}

--- a/concrete/src/Config/Driver/Redis/RedisConfigServiceProvider.php
+++ b/concrete/src/Config/Driver/Redis/RedisConfigServiceProvider.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Concrete\Core\Config\Driver\Redis;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\CompositeLoader;
+use Concrete\Core\Config\CoreFileLoader;
+use Concrete\Core\Config\FileLoader;
+use Concrete\Core\Config\LoaderInterface;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Config\SaverInterface;
+use Concrete\Core\Foundation\Service\Provider;
+use Redis;
+
+/**
+ * Redis config service provider.
+ * Use `RedisConfigServiceProvider::setup()` before the core config service provider in order to use redis config
+ */
+class RedisConfigServiceProvider extends Provider
+{
+
+    protected function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    /**
+     * Register Redis as a config saver and loader.
+     *
+     * @param Application $app
+     * @param callable $redisFactory
+     */
+    public static function setup(Application $app, callable $redisFactory)
+    {
+        if ($app->bound('config')) {
+            throw new \RuntimeException('RedisConfigServiceProvider must be registered before the core ConfigServiceProvider.');
+        }
+
+        $redis = null;
+        $memoizedRedis = function() use (&$redis, $redisFactory) {
+            if (!$redis) {
+                $redis = $redisFactory();
+            }
+
+            if (!$redis || !$redis instanceof Redis) {
+                throw new \RuntimeException('Cannot use Redis for config. Invalid Redis instance given.');
+            }
+
+            if (!$redis->isConnected()) {
+                throw new \RuntimeException('Cannot use Redis for config. The given Redis instance is not connected.');
+            }
+
+            return $redis;
+        };
+
+        // Provide the memoized redis instance to both loader and saver
+        $app->when(RedisLoader::class)->needs(Redis::class)->give($memoizedRedis);
+        $app->when(RedisSaver::class)->needs(Redis::class)->give($memoizedRedis);
+
+        (new RedisConfigServiceProvider($app))->register();
+    }
+
+    public function register()
+    {
+        $app = $this->app;
+
+        // Bind a composite loader that includes redis
+        $app->bind(LoaderInterface::class, static function($app) {
+            return $app->make(CompositeLoader::class, [$app, [
+                CoreFileLoader::class,
+                RedisLoader::class,
+                FileLoader::class,
+            ]]);
+        });
+
+        // Bind a redis saver
+        $app->bind(SaverInterface::class, RedisSaver::class);
+    }
+
+}

--- a/concrete/src/Config/Driver/Redis/RedisLoader.php
+++ b/concrete/src/Config/Driver/Redis/RedisLoader.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Concrete\Core\Config\Driver\Redis;
+
+use Concrete\Core\Config\LoaderInterface;
+use Redis;
+
+class RedisLoader implements LoaderInterface
+{
+
+    use RedisPaginatedTrait;
+
+    /** @var Redis */
+    protected $connection;
+
+    public function __construct(Redis $redis)
+    {
+        $this->connection = $redis;
+        $this->configureRedis($redis);
+    }
+
+    /**
+     * @param $namespace
+     */
+    public function clearNamespace($namespace)
+    {
+        $keys = $this->paginatedScan($this->connection, "{$namespace}::*");
+        if ($keys) {
+            $this->connection->del($keys);
+        }
+    }
+
+    /**
+     * Load the given configuration group.
+     *
+     * @param string $environment
+     * @param string $group
+     * @param string $namespace
+     * @return array
+     */
+    public function load($environment, $group, $namespace = null)
+    {
+        $values = [];
+        $results = $this->paginatedScanValues($this->connection, "{$namespace}::{$group}.*");
+
+        foreach ($results as $key => $result) {
+            list($namespace, $key) = explode('::', $key);
+            list($group, $item) = explode('.', $key, 2);
+
+            array_set($values, $item, unserialize($result));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Determine if the given configuration group exists.
+     *
+     * @param string $group
+     * @param string $namespace
+     * @return bool
+     */
+    public function exists($group, $namespace = null)
+    {
+        foreach ($this->paginatedScan($this->connection, "{$namespace}::{$group}.*") as $key) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param string $namespace
+     * @param string $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        // We don't actually have to do anything here
+        return;
+    }
+
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        $namespaces = [];
+        $keys = $this->paginatedScan($this->connection, '*');
+        foreach ($keys as $key) {
+            list($namespace, $key) = explode('::', $key);
+            if ($namespace) {
+                $namespaces[$namespace] = 1;
+            }
+        }
+
+        return array_keys($namespaces);
+    }
+
+    /**
+     * Apply any cascades to an array of package options.
+     *
+     * @param string $environment
+     * @param string $package
+     * @param string $group
+     * @param array $items
+     * @return array
+     */
+    public function cascadePackage($environment, $package, $group, $items)
+    {
+        return $items;
+    }
+}

--- a/concrete/src/Config/Driver/Redis/RedisLoader.php
+++ b/concrete/src/Config/Driver/Redis/RedisLoader.php
@@ -16,7 +16,6 @@ class RedisLoader implements LoaderInterface
     public function __construct(Redis $redis)
     {
         $this->connection = $redis;
-        $this->configureRedis($redis);
     }
 
     /**

--- a/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
+++ b/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
@@ -8,17 +8,6 @@ trait RedisPaginatedTrait
 {
 
     /**
-     * Set redis configuration we need
-     *
-     * @param Redis $redis
-     */
-    protected function configureRedis(Redis $redis)
-    {
-        $redis->setOption($redis::OPT_PREFIX, 'cfg=');
-        $redis->setOption($redis::OPT_SCAN, $redis::SCAN_RETRY);
-    }
-
-    /**
      * Scan for a specific key pattern
      *
      * @param Redis $redis

--- a/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
+++ b/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Concrete\Core\Config\Driver\Redis;
+
+use Redis;
+
+trait RedisPaginatedTrait
+{
+
+    /**
+     * Set redis configuration we need
+     *
+     * @param Redis $redis
+     */
+    protected function configureRedis(Redis $redis)
+    {
+        $redis->setOption($redis::OPT_PREFIX, 'cfg=');
+        $redis->setOption($redis::OPT_SCAN, $redis::SCAN_RETRY);
+    }
+
+    /**
+     * Scan for a specific key pattern
+     *
+     * @param Redis $redis
+     * @param string $pattern The pattern to search for ex: `foo`, `*`, `foo.*`
+     * @return \Generator|string[] A list of keys that match the pattern
+     */
+    protected function paginatedScan(Redis $redis, $pattern)
+    {
+        $i = null;
+        do {
+            $keys = $redis->scan($i, 'cfg=' . $pattern, 100);
+
+            if ($keys) {
+                // Remove the prefix
+                $keys = array_map(static function ($key) {
+                    return substr($key, 4);
+                }, $keys);
+
+                foreach ($keys as $key) {
+                    yield $key;
+                }
+            }
+
+        } while ($keys);
+    }
+
+    /**
+     * Get the keys and values matching a pattern
+     *
+     * @param Redis $redis
+     * @param string $pattern The pattern to search for ex: `foo`, `*`, `foo.*`
+     * @return \Generator|mixed[] A list of key => value results
+     */
+    protected function paginatedScanValues(Redis $redis, $pattern)
+    {
+        $batchSize = 50;
+        $batch = [];
+        foreach ($this->paginatedScan($redis, $pattern) as $key) {
+            $batch[] = $key;
+            if (count($batch) >= $batchSize) {
+
+                // Load in values
+                $values = array_combine($batch, $redis->mget($batch));
+
+                // Yield them out
+                foreach ($values as $valueKey => $value) {
+                    yield $valueKey => $value;
+                }
+
+                // Reset batch
+                $batch = [];
+            }
+        }
+
+        if ($batch) {
+            // Load in values
+            $values = array_combine($batch, $redis->mget($batch));
+
+            // Return any leftover batched items
+            foreach ($values as $valueKey => $value) {
+                yield $valueKey => $value;
+            }
+        }
+    }
+}

--- a/concrete/src/Config/Driver/Redis/RedisSaver.php
+++ b/concrete/src/Config/Driver/Redis/RedisSaver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Concrete\Core\Config\Driver\Redis;
+
+use Concrete\Core\Config\SaverInterface;
+use Illuminate\Support\Arr;
+use Redis;
+
+class RedisSaver implements SaverInterface
+{
+
+    use RedisPaginatedTrait;
+
+    /**
+     * @var Redis
+     */
+    protected $connection;
+
+    public function __construct(Redis $redis)
+    {
+        $this->connection = $redis;
+    }
+
+    /**
+     * Save config item.
+     *
+     * @param string $item
+     * @param string $value
+     * @param string $environment
+     * @param string $group
+     * @param string|null $namespace
+     *
+     * @return bool
+     */
+    public function save($item, $value, $environment, $group, $namespace = null)
+    {
+        // First we gotta clear the item
+        $key = "{$namespace}::{$group}" . ($item ? ".{$item}" : '');
+        $deleteKeys = [$key];
+        foreach ($this->paginatedScan($this->connection, $key . '.*') as $key) {
+            $deleteKeys[] = $key;
+        }
+
+        if ($deleteKeys) {
+            $this->connection->del($deleteKeys);
+        }
+
+        // Now we can convert the value into a flat array and save each key
+        $valueList = $this->flattenValue($namespace, $group, $item, $value);
+        return $this->connection->mset($valueList);
+    }
+
+    /**
+     * Flatten a given value into a list of keys => serialized values
+     * ['a' => ['b' => 'c']] would become ['a.b' => 's:1:"c";']
+     *
+     * @param $namespace
+     * @param $group
+     * @param $item
+     * @param mixed $value
+     *
+     * @return mixed[]
+     */
+    protected function flattenValue($namespace, $group, $item, $value)
+    {
+        $results = [];
+        $prefix = "{$namespace}::{$group}" . ($item ? ".{$item}" : '');
+        return array_map('serialize', Arr::dot($value, $prefix . '.'));
+    }
+}

--- a/concrete/src/Config/FileLoader.php
+++ b/concrete/src/Config/FileLoader.php
@@ -40,11 +40,10 @@ class FileLoader implements LoaderInterface
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $defaultPath
      */
-    public function __construct(Filesystem $files)
+    public function __construct(Filesystem $files, $defaultPath = DIR_CONFIG_SITE)
     {
         $this->files = $files;
-        $this->defaultPath = DIR_CONFIG_SITE;
-        $this->addNamespace('core', DIR_BASE_CORE . '/config');
+        $this->defaultPath = $defaultPath;
     }
 
     /**
@@ -82,9 +81,6 @@ class FileLoader implements LoaderInterface
 
         $paths = [];
         if ($namespace === null || $namespace == '') {
-            // No namespace, let's load up the concrete config first.
-            $items = $this->defaultLoad($environment, $group, 'core');
-
             $paths = [
                 "{$path}/generated_overrides/{$group}.php",
                 "{$path}/{$group}.php",

--- a/tests/tests/Config/CompositeLoaderTest.php
+++ b/tests/tests/Config/CompositeLoaderTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Concrete\Tests\Config;
 
 use Concrete\Core\Application\Application;

--- a/tests/tests/Config/CompositeLoaderTest.php
+++ b/tests/tests/Config/CompositeLoaderTest.php
@@ -24,7 +24,6 @@ class CompositeLoaderTest extends \PHPUnit_Framework_TestCase
         $this->loader2 = M::mock(LoaderInterface::class);
         $this->loader3 = M::mock(LoaderInterface::class);
 
-
         $this->app = M::mock(Application::class);
         $this->composite = new CompositeLoader($this->app, [
             $this->loader1,
@@ -45,11 +44,11 @@ class CompositeLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testFlowsThrough($method, $args, $return, callable $expect = null)
     {
-        $this->loader1->shouldReceive($method)->once()->with(...$args)->andReturn($return[0]);
-        $this->loader2->shouldReceive($method)->once()->with(...$args)->andReturn($return[1]);
-        $this->loader3->shouldReceive($method)->once()->with(...$args)->andReturn($return[2]);
+        $this->loader1->shouldReceive($method)->once()->withArgs($args)->andReturn($return[0]);
+        $this->loader2->shouldReceive($method)->once()->withArgs($args)->andReturn($return[1]);
+        $this->loader3->shouldReceive($method)->once()->withArgs($args)->andReturn($return[2]);
 
-        $result = $this->composite->{$method}(...$args);
+        $result = call_user_func_array([$this->composite, $method], $args);
 
         if ($expect) {
             $expect($result);

--- a/tests/tests/Config/CompositeLoaderTest.php
+++ b/tests/tests/Config/CompositeLoaderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+
+namespace Concrete\Tests\Config;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\CompositeLoader;
+use Concrete\Core\Config\LoaderInterface;
+use \Mockery as M;
+
+class CompositeLoaderTest extends \PHPUnit_Framework_TestCase
+{
+
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    protected $app;
+    protected $composite;
+    protected $loader1;
+    protected $loader2;
+    protected $loader3;
+
+    public function setUp()
+    {
+        $this->loader1 = M::mock(LoaderInterface::class);
+        $this->loader2 = M::mock(LoaderInterface::class);
+        $this->loader3 = M::mock(LoaderInterface::class);
+
+
+        $this->app = M::mock(Application::class);
+        $this->composite = new CompositeLoader($this->app, [
+            $this->loader1,
+            $this->loader2,
+            $this->loader3,
+        ]);
+    }
+
+    public function tearDown()
+    {
+        $this->loader1 = null;
+        $this->loader2 = null;
+        $this->loader3 = null;
+    }
+
+    /**
+     * @dataProvider simpleFlowMethods
+     */
+    public function testFlowsThrough($method, $args, $return, callable $expect = null)
+    {
+        $this->loader1->shouldReceive($method)->once()->with(...$args)->andReturn($return[0]);
+        $this->loader2->shouldReceive($method)->once()->with(...$args)->andReturn($return[1]);
+        $this->loader3->shouldReceive($method)->once()->with(...$args)->andReturn($return[2]);
+
+        $result = $this->composite->{$method}(...$args);
+
+        if ($expect) {
+            $expect($result);
+        }
+
+        parent::assertPostConditions();
+    }
+
+    public function simpleFlowMethods()
+    {
+        $matches = function($match) {
+            return function($results) use ($match) {
+                $this->assertEquals($match, $results);
+            };
+        };
+
+        return [
+            ['clearNamespace', ['foo'], [true, true, true]],
+            ['exists', ['foo', 'baz'], [false, false, false]],
+            ['addNamespace', ['foo', 'baz'], [true, true, true]],
+            ['getNamespaces', [], [['foo', 'baz'], [], ['bar']], $matches(['foo', 'baz', 'bar'])],
+            ['cascadePackage', ['foo', 'bar', 'baz', 'boo'], [['foo', 'baz'], [], ['bar']], $matches(['foo', 'baz', 'bar'])],
+            [
+                'load',
+                ['foo', 'baz', 'bar'], [['test' => true, 'overrideWorks' => false, 'subtest' => ['subtest' => 'works']],
+                ['overrideWorks' => true], ['subtest' => ['stillWorks' => true]]],
+                $matches([
+                    'test' => true,
+                    'overrideWorks' => true,
+                    'subtest' => [
+                        'subtest' => 'works',
+                        'stillWorks' => true
+                    ]
+                ])
+            ],
+        ];
+    }
+
+    public function testInflating()
+    {
+        $loader = new CompositeLoader($this->app, [
+            'foo',
+            'baz',
+            'bar',
+        ]);
+
+        $this->loader1->shouldReceive('exists')->with('foo', null)->times(3);
+
+        $this->app->shouldReceive('make')->once()->with('foo')->andReturn($this->loader1);
+        $this->app->shouldReceive('make')->once()->with('baz')->andReturn($this->loader1);
+        $this->app->shouldReceive('make')->once()->with('bar')->andReturn($this->loader1);
+
+        $loader->exists('foo');
+    }
+
+    public function testLoad()
+    {
+
+    }
+
+}

--- a/tests/tests/Config/Driver/Redis/Fixtures/Redis.php
+++ b/tests/tests/Config/Driver/Redis/Fixtures/Redis.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!class_exists(Redis::class)) {
+    class Redis
+    {
+
+        /**
+         * This method is declared so that Mockery can properly detect the `&$iterator` pass by reference when the redis
+         * extension is not loaded.
+         */
+        public function scan(&$iterator, $pattern = null, $count = 0)
+        {
+        }
+
+    }
+}

--- a/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitFixture.php
+++ b/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Concrete\Tests\Config\Driver\Redis\Fixtures;
+
+use Concrete\Core\Config\Driver\Redis\RedisPaginatedTrait;
+
+class RedisPaginatedTraitFixture
+{
+
+    use RedisPaginatedTrait;
+
+}

--- a/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitValuesFixture.php
+++ b/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitValuesFixture.php
@@ -27,7 +27,9 @@ class RedisPaginatedTraitValuesFixture
     protected function paginatedScan(Redis $redis, $pattern)
     {
         $scanMock = $this->scanMock;
-        yield from $scanMock($redis, $pattern);
+        foreach ($scanMock($redis, $pattern) as $key => $value) {
+            yield $key => $value;
+        }
     }
 
 }

--- a/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitValuesFixture.php
+++ b/tests/tests/Config/Driver/Redis/Fixtures/RedisPaginatedTraitValuesFixture.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Concrete\Tests\Config\Driver\Redis\Fixtures;
+
+use Concrete\Core\Config\Driver\Redis\RedisPaginatedTrait;
+use Redis;
+
+class RedisPaginatedTraitValuesFixture
+{
+
+    use RedisPaginatedTrait;
+
+    protected $scanMock;
+
+    public function __construct($scanMock)
+    {
+        $this->scanMock = $scanMock;
+    }
+
+    /**
+     * Scan for a specific key pattern
+     *
+     * @param Redis $redis
+     * @param string $pattern The pattern to search for ex: `foo`, `*`, `foo.*`
+     * @return \Generator|string[] A list of keys that match the pattern
+     */
+    protected function paginatedScan(Redis $redis, $pattern)
+    {
+        $scanMock = $this->scanMock;
+        yield from $scanMock($redis, $pattern);
+    }
+
+}

--- a/tests/tests/Config/Driver/Redis/RedisPaginatedTraitTest.php
+++ b/tests/tests/Config/Driver/Redis/RedisPaginatedTraitTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Concrete\Tests\Config\Driver\Redis;
+
+use Concrete\Core\Config\Driver\Redis\RedisPaginatedTrait;
+use Concrete\Tests\Config\Driver\Redis\Fixtures\RedisPaginatedTraitFixture;
+use Concrete\Tests\Config\Driver\Redis\Fixtures\RedisPaginatedTraitValuesFixture;
+use Illuminate\Support\Arr;
+use Mockery as M;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Redis;
+
+class RedisPaginatedTraitTest extends \PHPUnit_Framework_TestCase
+{
+
+    use MockeryPHPUnitIntegration;
+
+    public function testPaginatedScan()
+    {
+        $redis = M::mock(Redis::class);
+
+        $redis->shouldReceive('scan')->once()->with(null, 'cfg=some-filter', 100)->andReturnUsing($this->scanMethodHandler());
+        $redis->shouldReceive('scan')->once()->with(0, 'cfg=some-filter', 100)->andReturnUsing($this->scanMethodHandler());
+        $redis->shouldReceive('scan')->once()->with(1, 'cfg=some-filter', 100)->andReturnUsing($this->scanMethodHandler());
+
+        // Call the scan method
+        $method = new \ReflectionMethod(RedisPaginatedTraitFixture::class, 'paginatedScan');
+        $method->setAccessible(true);
+        $fixture = new RedisPaginatedTraitFixture();
+        $result = iterator_to_array($method->invoke($fixture, $redis, 'some-filter'));
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+    }
+
+    public function testPaginatedScanValues()
+    {
+        $keys = $this->range('keys', 1, 60);
+        $values = $this->range('values', 1, 60);
+
+        $chunkedKeys = array_chunk($keys, 50);
+        $chunkedValues = array_chunk($values, 50);
+
+        $scanKeys = $chunkedKeys;
+        $scanMock = function() use ($keys) {
+            yield from $keys;
+        };
+
+        $redis = M::mock(Redis::class);
+        foreach ($chunkedKeys as $chunk) {
+            $redis->shouldReceive('mget')->once()->with($chunk)->andReturn(array_shift($chunkedValues));
+        }
+
+        $fixture = new RedisPaginatedTraitValuesFixture($scanMock);
+        $method = new \ReflectionMethod(RedisPaginatedTraitValuesFixture::class, 'paginatedScanValues');
+        $method->setAccessible(true);
+        $result = iterator_to_array($method->invoke($fixture, $redis, 'some-filter'));
+
+        // Make sure we have all 60 items even though they were requested in chunks of 50
+        $this->assertEquals(array_combine($keys, $values), $result);
+    }
+
+    private function range($prefix, $start, $end)
+    {
+        $keys = [];
+        foreach (range($start, $end) as $key) {
+            $keys[] = $prefix . $key;
+        }
+        return $keys;
+    }
+
+    /**
+     * Return a spoof scan method that manages increasing the iterator and returning varied results
+     *
+     * @return \Closure
+     */
+    private function scanMethodHandler()
+    {
+        return static function(&$iterator, $search, $batch) {
+            $results = [
+                ['cfg=foo', 'cfg=bar'],
+                ['cfg=baz'],
+                false
+            ];
+            if ($iterator === null) {
+                $iterator = -1;
+            }
+
+            $iterator++;
+            if (isset($results[$iterator])) {
+                return $results[$iterator];
+            }
+        };
+    }
+
+}

--- a/tests/tests/Config/Driver/Redis/RedisSaverTest.php
+++ b/tests/tests/Config/Driver/Redis/RedisSaverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Concrete\Tests\Config\Driver\Redis;
+
+use Concrete\Core\Config\Driver\Redis\RedisSaver;
+use Mockery as M;
+
+/**
+ * @depends Concrete\Tests\Config\Driver\Redis\RedisPaginatedTraitTest::testPaginatedScan
+ */
+class RedisSaverTest extends \PHPUnit_Framework_TestCase
+{
+
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    /**
+     * @dataProvider namespacesToTest
+     */
+    public function testSave($namespace)
+    {
+        $expectedIterator = null;
+        $expectedSearch = 'cfg=' . $namespace . '::test.foo.*';
+        $expectedBatch = 100;
+
+        // Bind expectations
+        $redis = M::mock(\Redis::class);
+        $redis->shouldReceive('scan')->once()->with($expectedIterator, $expectedSearch, $expectedBatch)->andReturnUsing(function(&$iterator, $search, $batch) use ($namespace) {
+            if (!$iterator) {
+                $iterator = 1;
+                return ['cfg=' . $namespace . '::test.foo.test'];
+            }
+
+            return false;
+        });
+
+        // Make sure we try to paginate properly
+        $redis->shouldReceive('scan')->once()->with(1, $expectedSearch, $expectedBatch)->andReturnNull();
+        // Make sure we try to delete existing keys
+        $redis->shouldReceive('del')->with([$namespace . '::test.foo', $namespace . '::test.foo.test'])->andReturn(2);
+        // Make sure we try to set the values as serialized
+        $redis->shouldReceive('mset')->with([
+            $namespace . '::test.foo.test' => serialize(10),
+            $namespace . '::test.foo.subarray.subtest' => serialize(true),
+            $namespace . '::test.foo.baz' => serialize('boo'),
+        ])->andReturn(true);
+
+        // Run the method we're testing
+        $saver = new RedisSaver($redis);
+        $saver->save('foo', ['test' => 10, 'subarray' => ['subtest' => true], 'baz' => 'boo'], 'testing', 'test', $namespace);
+    }
+
+    public function namespacesToTest()
+    {
+        return [
+            [''],
+            ['core'],
+            ['test'],
+        ];
+    }
+
+}


### PR DESCRIPTION
This PR does two main things:
1. Split `FileLoader` into two loaders, one for application and one for core and add a `CompositeLoader` with both loaders registered so that functionality is the same. We needed to do this because we need drivers to override the core, but not the manual file overrides.
2. Implement a simple `RedisSaver` and `RedisLoader` for storing and reading config overrides to redis.

**Why?**
Config ends up being the major sticking point when running concrete5 in a distributed way. Today moving config to redis would be an extremely manual process and would overriding the application and many aspects of the runtime.
Redis was a good option as a first driver, database was the initial choice but it became obvious that race conditions with connecting to the database and with reading from config were going to be really painful.

**Trying it out:**
This PR adds a service provider to make enabling redis config really simple:

In `/application/bootstrap/start.php`:
```php
<?php
use Concrete\Core\Application\Application;

$app = new Application();

// Enable Redis config loading and saving
RedisConfigServiceProvider::setup($app, function() {
    // This should be a distinct redis instance, this isn't tested with a shared instance.
    $redis = new Redis();

    // The service provider will complain if we're not connected
    $redis->connect(getenv('REDIS_HOSTNAME'));

    return $redis;
});

return $app;
```

Keep in mind that this adds the Redis loader _between_ the core file loader and the application file loader, that means `generated_overrides` needs to be cleared as it will override redis saved config.

**Making sure it works:**
A simple way to see that it's working is to use the redis `MONITOR` command, you can do that easily from cli with `redis-admin monitor`