### PR TITLE
Use local date time format in CSV

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -114,7 +114,7 @@ return [
         'csv' => [
             // Include the BOM (byte-order mark) in generated CSV files?
             // @var bool
-            'include_bom' => false,,
+            'include_bom' => false,
             'datetime_format' => 'ATOM', 
         ],
     ],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -114,7 +114,8 @@ return [
         'csv' => [
             // Include the BOM (byte-order mark) in generated CSV files?
             // @var bool
-            'include_bom' => false,
+            'include_bom' => false,,
+            'datetime_format' => 'ATOM', 
         ],
     ],
 

--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -22,10 +22,16 @@ class CsvWriter
      */
     protected $dateFormatter;
 
-    public function __construct(Writer $writer, Date $dateFormatter)
+    /**
+     * @var string
+     */
+    private $datetime_format;
+
+    public function __construct(Writer $writer, Date $dateFormatter, string $datetime_format = 'ATOM' )
     {
         $this->writer = $writer;
         $this->dateFormatter = $dateFormatter;
+        $this->datetime_format = $datetime_format;
     }
 
     public function insertHeaders(Entity $entity)
@@ -87,7 +93,7 @@ class CsvWriter
     {
         $date = $entry->getDateCreated();
         if ($date) {
-            yield 'ccm_date_created' => $this->dateFormatter->getLocalDateTime($date);
+            yield 'ccm_date_created' => $this->dateFormatter->formatCustom($this->datetime_format, $date);
         } else {
             yield 'ccm_date_created' => null;
         }

--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -87,7 +87,7 @@ class CsvWriter
     {
         $date = $entry->getDateCreated();
         if ($date) {
-            yield 'ccm_date_created' => $this->dateFormatter->formatCustom(\DateTime::ATOM, $date);
+            yield 'ccm_date_created' => $this->dateFormatter->getLocalDateTime($date);
         } else {
             yield 'ccm_date_created' => null;
         }

--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -27,7 +27,7 @@ class CsvWriter
      */
     private $datetime_format;
 
-    public function __construct(Writer $writer, Date $dateFormatter, string $datetime_format = 'ATOM' )
+    public function __construct(Writer $writer, Date $dateFormatter, $datetime_format = 'ATOM' )
     {
         $this->writer = $writer;
         $this->dateFormatter = $dateFormatter;

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -102,8 +102,9 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
         ];
         $config = $this->app->make('config');
         $bom = $config->get('concrete.export.csv.include_bom') ? $config->get('concrete.charset_bom') : '';
+        $datetime_format = $config->get('concrete.export.csv.datetime_format');
 
-        return StreamedResponse::create(function () use ($entity, $me, $bom) {
+        return StreamedResponse::create(function () use ($entity, $me, $bom, $datetime_format) {
             $entryList = new EntryList($entity);
 
             $writer = $this->app->make(CsvWriter::class, [
@@ -112,7 +113,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
             ]);
             echo $bom;
             $writer->insertHeaders($entity);
-            $writer->insertEntryList($entryList);
+            $writer->insertEntryList($entryList,$datetime_format);
         }, 200, $headers);
     }
 


### PR DESCRIPTION
ATOM format is hard to use for normal user in Japan.

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`