### PR TITLE
Avoid error on save page list block options with empty custom topic node

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -10,6 +10,7 @@ use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Page\Feed;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\Topic;
+use Concrete\Core\Utility\Service\Number;
 use Core;
 use Concrete\Core\Url\SeoCanonical;
 use Database;
@@ -463,7 +464,8 @@ class Controller extends BlockController
         if (!$args['filterByRelated']) {
             $args['relatedTopicAttributeKeyHandle'] = '';
         }
-        if (!$args['filterByCustomTopic']) {
+
+        if (!$args['filterByCustomTopic'] || !$this->app->make('helper/number')->isInteger($args['customTopicTreeNodeID'])) {
             $args['customTopicAttributeKeyHandle'] = '';
             $args['customTopicTreeNodeID'] = 0;
         }

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Block\PageList;
 
 use BlockType;
@@ -10,7 +9,6 @@ use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Page\Feed;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\Topic;
-use Concrete\Core\Utility\Service\Number;
 use Core;
 use Concrete\Core\Url\SeoCanonical;
 use Database;


### PR DESCRIPTION
1. Check custom topic
2. Doesn't select any topic nodes
3. Save

![image](https://user-images.githubusercontent.com/514294/74017702-08587580-49d8-11ea-81a5-f72fa05e9659.png)

You'll get SQL error

```
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `concrete5`.`btpagelist`.`customTopicTreeNodeID` at row 1
```