### PR TITLE
block-title-format #8282

### DIFF
--- a/concrete/blocks/date_navigation/controller.php
+++ b/concrete/blocks/date_navigation/controller.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Block\DateNavigation;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Page\PageList;
 use Concrete\Core\Page\Type\Type;
@@ -19,12 +19,12 @@ class Controller extends BlockController
 
     public function getBlockTypeDescription()
     {
-        return t("Displays a list of months to filter a page list by.");
+        return t('Displays a list of months to filter a page list by.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Date Navigation");
+        return t('Date Navigation');
     }
 
     public function add()
@@ -32,6 +32,7 @@ class Controller extends BlockController
         $this->edit();
         $this->set('maxResults', 3);
         $this->set('title', t('Archives'));
+        $this->set('titleFormat', 'h5');
     }
 
     public function edit()
@@ -56,12 +57,12 @@ class Controller extends BlockController
 
     public function getDateLabel($dateArray)
     {
-        return \Punic\Calendar::getMonthName($dateArray['month'], 'wide', '', true).' '.$dateArray['year'];
+        return \Punic\Calendar::getMonthName($dateArray['month'], 'wide', '', true) . ' ' . $dateArray['year'];
     }
 
     public function getPassThruActionAndParameters($parameters)
     {
-        if (Loader::helper("validation/numbers")->integer($parameters[0])) {
+        if (Loader::helper('validation/numbers')->integer($parameters[0])) {
             // then we're going to treat this as a year.
             $method = 'action_filter_by_date';
             $parameters[0] = intval($parameters[0]);

--- a/concrete/blocks/date_navigation/db.xml
+++ b/concrete/blocks/date_navigation/db.xml
@@ -30,6 +30,10 @@
     <field name="ptID" type="smallint">
       <unsigned/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+        <default value="h5" />
+		<notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/date_navigation/form.php
+++ b/concrete/blocks/date_navigation/form.php
@@ -1,14 +1,14 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <fieldset>
-    <legend><?=t('Filtering')?></legend>
+    <legend><?=t('Filtering'); ?></legend>
     <div class='form-group'>
-        <label for='title' class="control-label"><?=t('By Parent Page')?>:</label>
+        <label for='title' class="control-label"><?=t('By Parent Page'); ?>:</label>
         <div class="checkbox">
             <label>
                 <input <?php if (isset($cParentID) && (int) $cParentID > 0) {
-    ?>checked<?php 
+    ?>checked<?php
 } ?> name="filterByParent" type="checkbox" value="1" />
-                <?=t('Filter by Parent Page')?>
+                <?=t('Filter by Parent Page'); ?>
             </label>
         </div>
         <div id="ccm-block-related-pages-parent-page">
@@ -19,22 +19,20 @@
     </div>
 
     <div class="form-group">
-        <label class="control-label"><?= t('By Page Type') ?></label>
+        <label class="control-label"><?= t('By Page Type'); ?></label>
         <?php ?>
             <select class="form-control" name="ptID" id="selectPTID">
-                <option value="0">** <?php echo t('All') ?> **</option>
+                <option value="0">** <?php echo t('All'); ?> **</option>
                 <?php
                 foreach ($pagetypes as $ct) {
                     ?>
                     <option
-                        value="<?= $ct->getPageTypeID() ?>" <?php if ((isset($ptID) ? $ptID : null) == $ct->getPageTypeID()) {
-    ?> selected <?php 
-}
-                    ?>>
-                        <?= $ct->getPageTypeDisplayName() ?>
+                        value="<?= $ct->getPageTypeID(); ?>" <?php if ((isset($ptID) ? $ptID : null) == $ct->getPageTypeID()) {
+                        ?> selected <?php
+                    } ?>>
+                        <?= $ct->getPageTypeDisplayName(); ?>
                     </option>
                 <?php
-
                 }
                 ?>
             </select>
@@ -42,14 +40,14 @@
     </div>
 </fieldset>
 <fieldset>
-    <legend><?=t("Results")?></legend>
+    <legend><?=t('Results'); ?></legend>
     <div class="form-group">
         <div class="checkbox">
             <label>
                 <input <?php if (isset($cTargetID) && (int) $cTargetID > 0) {
-    ?>checked<?php 
-} ?> name="redirectToResults" type="checkbox" value="1" />
-                <?=t('Redirect to Different Page on Click')?>
+                    ?>checked<?php
+                } ?> name="redirectToResults" type="checkbox" value="1" />
+                <?=t('Redirect to Different Page on Click'); ?>
             </label>
         </div>
         <div id="ccm-block-related-pages-search-page">
@@ -60,11 +58,16 @@
     </div>
 </fieldset>
 <fieldset>
-    <legend><?=t('Formatting')?></legend>
+    <legend><?=t('Formatting'); ?></legend>
     <div class="form-group">
-        <label class="control-label" for="title"><?=t('Title')?></label>
-        <input class="form-control" name="title" id="title" value="<?=$title?>" />
-    </div>
+        <?php echo $form->label('title', t('Title')); ?>
+	    <div class="input-group">
+		    <?php echo $form->text('title', $title); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
+	</div>
 </fieldset>
 
 

--- a/concrete/blocks/date_navigation/view.php
+++ b/concrete/blocks/date_navigation/view.php
@@ -1,35 +1,33 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="ccm-block-date-navigation-wrapper">
 
     <div class="ccm-block-date-navigation-header">
-        <h5><?=h($title)?></h5>
+        <<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>>
     </div>
 
     <?php if (count($dates)) {
     ?>
         <ul class="ccm-block-date-navigation-dates">
-            <li><a href="<?=$view->controller->getDateLink()?>"><?=t('All')?></a></li>
+            <li><a href="<?=$view->controller->getDateLink(); ?>"><?=t('All'); ?></a></li>
 
             <?php foreach ($dates as $date) {
-    ?>
-                <li><a href="<?=$view->controller->getDateLink($date)?>"
+        ?>
+                <li><a href="<?=$view->controller->getDateLink($date); ?>"
                         <?php if ($view->controller->isSelectedDate($date)) {
-    ?>
+            ?>
                             class="ccm-block-date-navigation-date-selected"
-                        <?php 
-}
-    ?>><?=$view->controller->getDateLabel($date)?></a></li>
-            <?php 
-}
-    ?>
+                        <?php
+        } ?>><?=$view->controller->getDateLabel($date); ?></a></li>
+            <?php
+    } ?>
         </ul>
-    <?php 
+    <?php
 } else {
-    ?>
-        <?=t('None.')?>
-    <?php 
-} ?>
+        ?>
+        <?=t('None.'); ?>
+    <?php
+    } ?>
 
 
 </div>

--- a/concrete/blocks/event_list/controller.php
+++ b/concrete/blocks/event_list/controller.php
@@ -2,20 +2,20 @@
 namespace Concrete\Block\EventList;
 
 use Concrete\Core\Attribute\Key\CollectionKey;
-use Concrete\Core\Tree\Node\Node;
-use Concrete\Core\Utility\Service\Validation\Numbers;
 use Concrete\Core\Attribute\Key\EventKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Calendar\Calendar;
 use Concrete\Core\Calendar\CalendarServiceProvider;
 use Concrete\Core\Calendar\Event\EventOccurrenceList;
+use Concrete\Core\Tree\Node\Node;
+use Concrete\Core\Utility\Service\Validation\Numbers;
 use Core;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     protected $btInterfaceWidth = 500;
     protected $btInterfaceHeight = 340;
@@ -23,12 +23,12 @@ class Controller extends BlockController
 
     public function getBlockTypeDescription()
     {
-        return t("Displays a list of events from a calendar.");
+        return t('Displays a list of events from a calendar.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Event List");
+        return t('Event List');
     }
 
     public function add()
@@ -39,6 +39,7 @@ class Controller extends BlockController
         $this->set('totalToRetrieve', 9);
         $this->set('totalPerPage', 3);
         $this->set('filterByTopic', 'none');
+        $this->set('titleFormat', 'h2');
     }
 
     protected function getCalendarOrCalendars()
@@ -57,8 +58,8 @@ class Controller extends BlockController
             } else {
                 $caIDs = json_decode($this->caID);
                 if (is_array($caIDs)) {
-                    $calendars = array();
-                    foreach($caIDs as $caID) {
+                    $calendars = [];
+                    foreach ($caIDs as $caID) {
                         $calendars[] = Calendar::getByID($caID);
                     }
                     if (count($calendars) == 1) {
@@ -82,9 +83,9 @@ class Controller extends BlockController
         if (is_object($calendar)) {
             $permissions = new \Permissions($calendar);
             $this->set('canViewCalendar', $permissions->canViewCalendar());
-        } else if (is_array($calendar)) {
+        } elseif (is_array($calendar)) {
             $canViewCalendar = true;
-            foreach($calendar as $c) {
+            foreach ($calendar as $c) {
                 $permissions = new \Permissions($c);
                 if (!$permissions->canViewCalendar()) {
                     $canViewCalendar = false;
@@ -161,12 +162,12 @@ class Controller extends BlockController
 
             return $p->canViewCalendarInEditInterface();
         });
-        $calendarSelect = array('' => t('** Select a Calendar'));
+        $calendarSelect = ['' => t('** Select a Calendar')];
         foreach ($calendars as $calendar) {
             $calendarSelect[$calendar->getID()] = $calendar->getName();
         }
         $keys = CollectionKey::getList();
-        $pageAttributeKeys = array();
+        $pageAttributeKeys = [];
         foreach ($keys as $ak) {
             if ($ak->getAttributeTypeHandle() == 'topics') {
                 $pageAttributeKeys[] = $ak;
@@ -175,11 +176,11 @@ class Controller extends BlockController
         $this->set('pageAttributeKeys', $pageAttributeKeys);
         $this->set('calendars', $calendarSelect);
         $this->set('featuredAttribute', EventKey::getByHandle('is_featured'));
-        $this->set('pageSelector', Core::make("helper/form/page_selector"));
+        $this->set('pageSelector', Core::make('helper/form/page_selector'));
 
         $number = new Numbers();
         if ($number->integer($this->caID)) {
-            $this->set('caID', array($this->caID)); // legacy single calendar field.
+            $this->set('caID', [$this->caID]); // legacy single calendar field.
         } else {
             $this->set('caID', json_decode($this->caID));
         }
@@ -218,7 +219,7 @@ class Controller extends BlockController
 
     protected function loadKeys()
     {
-        $keys = EventKey::getList(array('atHandle' => 'topics'));
+        $keys = EventKey::getList(['atHandle' => 'topics']);
         $this->set('attributeKeys', array_filter($keys, function ($ak) {
             return $ak->getAttributeTypeHandle() == 'topics';
         }));

--- a/concrete/blocks/event_list/db.xml
+++ b/concrete/blocks/event_list/db.xml
@@ -46,6 +46,10 @@
       <default value="0"/>
       <notnull/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+        <default value="h2" />
+		<notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/event_list/form.php
+++ b/concrete/blocks/event_list/form.php
@@ -1,28 +1,28 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 
 <fieldset>
-    <legend><?=t('Data Source')?></legend>
+    <legend><?=t('Data Source'); ?></legend>
 
-    <?php View::element('calendar/block/data_source', ['multiple' => true, 'caID' => $caID, 'calendarAttributeKeyHandle' => $calendarAttributeKeyHandle]) ?>
+    <?php View::element('calendar/block/data_source', ['multiple' => true, 'caID' => $caID, 'calendarAttributeKeyHandle' => $calendarAttributeKeyHandle]); ?>
 
 </fieldset>
 
 <fieldset>
-    <legend><?=t('Filtering')?></legend>
+    <legend><?=t('Filtering'); ?></legend>
 
     <div class="form-group">
-        <label class="control-label"><?= t('Filter By Topic') ?></label>
+        <label class="control-label"><?= t('Filter By Topic'); ?></label>
         <div class="radio">
             <label>
-                <input type="radio" name="filterByTopic" value="none" <?= $filterByTopic == 'none' ? 'checked' : '' ?>>
+                <input type="radio" name="filterByTopic" value="none" <?= $filterByTopic == 'none' ? 'checked' : ''; ?>>
                 <?php echo t('No topic filtering'); ?>
             </label>
         </div>
         <div class="radio">
             <label>
-                <input type="radio" name="filterByTopic" value="specific" <?= $filterByTopic == 'specific' ? 'checked' : '' ?>>
+                <input type="radio" name="filterByTopic" value="specific" <?= $filterByTopic == 'specific' ? 'checked' : ''; ?>>
                 <?php echo t('Specific Topic'); ?>
             </label>
         </div>
@@ -30,98 +30,94 @@ defined('C5_EXECUTE') or die("Access Denied.");
     ?>
             <div class="radio">
                 <label>
-                    <input type="radio" name="filterByTopic" value="page_attribute" <?= $filterByTopic == 'page_attribute' ? 'checked' : '' ?>>
+                    <input type="radio" name="filterByTopic" value="page_attribute" <?= $filterByTopic == 'page_attribute' ? 'checked' : ''; ?>>
                     <?php echo t('Current Page'); ?>
                 </label>
             </div>
             <div data-row="page-attribute">
                 <div class="form-group">
                     <select class="form-control" name="filterByPageTopicAttributeKeyHandle" id="filterByPageTopicAttributeKeyHandle">
-                        <option value=""><?=t('** Select Page Attribute')?></option>
+                        <option value=""><?=t('** Select Page Attribute'); ?></option>
                         <?php foreach ($pageAttributeKeys as $attributeKey) {
-    ?>
-                            <option value="<?=$attributeKey->getAttributeKeyHandle()?>" <?php if ($attributeKey->getAttributeKeyHandle() == $filterByPageTopicAttributeKeyHandle) {
-    ?>selected<?php
-
-}
-    ?>><?=$attributeKey->getAttributeKeyDisplayName()?></option>
+        ?>
+                            <option value="<?=$attributeKey->getAttributeKeyHandle(); ?>" <?php if ($attributeKey->getAttributeKeyHandle() == $filterByPageTopicAttributeKeyHandle) {
+            ?>selected<?php
+        } ?>><?=$attributeKey->getAttributeKeyDisplayName(); ?></option>
                             <?php
-
-}
-    ?>
+    } ?>
                     </select>
                 </div>
             </div>
-        <?php 
+        <?php
 } ?>
         <div data-row="specific-topic">
             <div class="form-group">
                 <select class="form-control" name="filterByTopicAttributeKeyID">
-                    <option value=""><?=t('** Select Topic Attribute')?></option>
+                    <option value=""><?=t('** Select Topic Attribute'); ?></option>
                     <?php foreach ($attributeKeys as $ak) {
-    $attributeController = $ak->getController();
-    ?>
-                        <option value="<?=$ak->getAttributeKeyID()?>" <?php if ($ak->getAttributeKeyID() == $filterByTopicAttributeKeyID) {
-    ?>selected<?php
-
-}
-    ?> data-tree-id="<?=$attributeController->getTopicTreeID()?>"><?=$ak->getAttributeKeyDisplayName()?></option>
+        $attributeController = $ak->getController(); ?>
+                        <option value="<?=$ak->getAttributeKeyID(); ?>" <?php if ($ak->getAttributeKeyID() == $filterByTopicAttributeKeyID) {
+            ?>selected<?php
+        } ?> data-tree-id="<?=$attributeController->getTopicTreeID(); ?>"><?=$ak->getAttributeKeyDisplayName(); ?></option>
                         <?php
-
-} ?>
+    } ?>
                 </select>
-                <input type="hidden" name="filterByTopicID" value="<?=$filterByTopicID?>">
+                <input type="hidden" name="filterByTopicID" value="<?=$filterByTopicID; ?>">
                 <div id="ccm-block-event-list-topic-tree-wrapper"></div>
             </div>
         </div>
     </div>
 
     <div class="form-group">
-        <label class="control-label"><?= t('Featured Events') ?></label>
+        <label class="control-label"><?= t('Featured Events'); ?></label>
         <div class="checkbox">
             <label>
                 <input <?php if (!is_object($featuredAttribute)) {
-    ?> disabled <?php 
-} ?>
+        ?> disabled <?php
+    } ?>
                     type="checkbox" name="filterByFeatured" value="1" <?php if ($filterByFeatured == 1) {
-    ?> checked <?php 
-} ?>
+        ?> checked <?php
+    } ?>
                     style="vertical-align: middle" />
-                    <?= t('Display featured events only.') ?>
+                    <?= t('Display featured events only.'); ?>
             </label>
         </div>
         <?php if (!is_object($featuredAttribute)) {
-    ?>
+        ?>
             <div class="alert alert-info">
-                <?=t('(<strong>Note</strong>: You must create the "is_featured" event attribute first.)');
-    ?>
+                <?=t('(<strong>Note</strong>: You must create the "is_featured" event attribute first.)'); ?>
             </div>
-        <?php 
-} ?>
+        <?php
+    } ?>
     </div>
 
 </fieldset>
 
 <fieldset>
-    <legend><?=t('Results')?></legend>
+    <legend><?=t('Results'); ?></legend>
     <div class="form-group">
-        <label class="control-label" for="eventListTitle"><?= t('Title') ?></label>
-        <?=$form->text('eventListTitle', $eventListTitle)?>
+        <?php echo $form->label('eventListTitle', t('Title')); ?>
+	    <div class="input-group">
+		    <?php echo $form->text('eventListTitle', $eventListTitle); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
+	</div>
+
+    <div class="form-group">
+        <label class="control-label" for="totalToRetrieve"><?= t('Total Number of Events to Retrieve'); ?></label>
+        <input id="totalToRetrieve" type="text" name="totalToRetrieve" value="<?= $totalToRetrieve; ?>" class="form-control">
     </div>
 
     <div class="form-group">
-        <label class="control-label" for="totalToRetrieve"><?= t('Total Number of Events to Retrieve') ?></label>
-        <input id="totalToRetrieve" type="text" name="totalToRetrieve" value="<?= $totalToRetrieve ?>" class="form-control">
+        <label class="control-label" for="totalPerPage"><?= t('Events to Display Per Page'); ?></label>
+        <input id="totalPerPage" type="text" name="totalPerPage" value="<?= $totalPerPage; ?>" class="form-control">
     </div>
 
     <div class="form-group">
-        <label class="control-label" for="totalPerPage"><?= t('Events to Display Per Page') ?></label>
-        <input id="totalPerPage" type="text" name="totalPerPage" value="<?= $totalPerPage ?>" class="form-control">
-    </div>
-
-    <div class="form-group">
-        <label class="control-label" for="linkToPage"><?= t('Link To More Events Calendar/Page') ?></label>
-        <?=Core::make('helper/form/page_selector')->selectPage('linkToPage', $linkToPage)?>
+        <label class="control-label" for="linkToPage"><?= t('Link To More Events Calendar/Page'); ?></label>
+        <?=Core::make('helper/form/page_selector')->selectPage('linkToPage', $linkToPage); ?>
     </div>
 
 
@@ -158,7 +154,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                 'treeID': chosenTree,
                 'chooseNodeInForm': true,
                 <?php if ($filterByTopicID) { ?>
-                'selectNodesByKey': [<?php echo intval($filterByTopicID) ?>],
+                'selectNodesByKey': [<?php echo intval($filterByTopicID); ?>],
                 <?php } ?>
                 'onSelect' : function(nodes) {
                     if (nodes.length) {

--- a/concrete/blocks/event_list/view.php
+++ b/concrete/blocks/event_list/view.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 if ($calendar) {
     $pagination = $list->getPagination();
@@ -11,20 +11,17 @@ if ($calendar) {
         $service = Core::make('helper/date');
         $c = Page::getCurrentPage();
         $cID = $c->getCollectionID();
-        $numEvents = count($events);
-        ?>
-    <div class="ccm-block-calendar-event-list-wrapper widget-featured-events unbound" data-page="<?= $totalPerPage ?: 3 ?>">
+        $numEvents = count($events); ?>
+    <div class="ccm-block-calendar-event-list-wrapper widget-featured-events unbound" data-page="<?= $totalPerPage ?: 3; ?>">
     <?php if ($eventListTitle) {
-    ?>
-        <h2><?=$eventListTitle?></h2>
-    <?php
+            ?>
+        <<?php echo $titleFormat; ?>><?php echo h($eventListTitle); ?></<?php echo $titleFormat; ?>>
 
-}
-        ?>
+    <?php
+        } ?>
         <div class="ccm-block-calendar-event-list" <?php if ($numEvents > $totalPerPage) {
-    echo 'style="display:none"';
-}
-        ?>>
+            echo 'style="display:none"';
+        } ?>>
 
     <?php
     if ($total = count($events)) {
@@ -33,82 +30,68 @@ if ($calendar) {
             $description = $event->getDescription();
             $safe_name = strtolower($event->getName());
             $safe_name = preg_replace('/[^a-z ]/i', '', $safe_name);
-            $safe_name = str_replace(' ', '+', $safe_name);
-            ?>
+            $safe_name = str_replace(' ', '+', $safe_name); ?>
             <div class="ccm-block-calendar-event-list-event">
                 <div class="ccm-block-calendar-event-list-event-date">
-                    <span><?=$service->formatCustom('M', $occurrence->getStart())?></span>
-                    <span><?=$service->formatCustom('d', $occurrence->getStart())?></span>
+                    <span><?=$service->formatCustom('M', $occurrence->getStart()); ?></span>
+                    <span><?=$service->formatCustom('d', $occurrence->getStart()); ?></span>
                 </div>
                 <div class="ccm-block-calendar-event-list-event-title">
                     <?php
                     $url = $linkFormatter->getEventOccurrenceFrontendViewLink($occurrence);
-                    if ($url) {
-    ?>
-                        <a href="<?= $url ?>"><?= h($event->getName()) ?></a>
+            if ($url) {
+                ?>
+                        <a href="<?= $url; ?>"><?= h($event->getName()); ?></a>
                     <?php
-
-} else {
-    ?>
-                        <?= h($event->getName()) ?>
+            } else {
+                ?>
+                        <?= h($event->getName()); ?>
                     <?php
-
-}
-            ?>
+            } ?>
                 </div>
                 <div class="ccm-block-calendar-event-list-event-date-full">
                     <?php
-                        echo $formatter->getOccurrenceDateString($occurrence);
-                    ?>
+                        echo $formatter->getOccurrenceDateString($occurrence); ?>
                 </div>
                 <?php if ($description) {
-    ?>
+                            ?>
                     <div class="ccm-block-calendar-event-list-event-description">
-                        <?=$description?>
+                        <?=$description; ?>
                     </div>
                 <?php
-
-}
-            ?>
+                        } ?>
             </div>
 
         <?php
-
-        }
-        ?>
+        } ?>
 
     <?php
-
     } else {
         ?>
-        <p class="ccm-block-calendar-event-list-no-events"><?=t('There are no upcoming events.')?></p>
+        <p class="ccm-block-calendar-event-list-no-events"><?=t('There are no upcoming events.'); ?></p>
     <?php
-
-    }
-        ?>
+    } ?>
 
         </div>
 
         <div class="btn-group ccm-block-calendar-event-list-controls">
             <?php if ($numEvents > $totalPerPage) {
-    ?>
+        ?>
             <button type="button" class="btn btn-default" data-cycle="previous"><i class="fa fa-angle-left"></i></button>
                 <button type="button" class="btn btn-default" data-cycle="next"><i class="fa fa-angle-right"></i></button>
             <?php
-
-}
-        ?>
+    } ?>
         </div>
 
         <?php if ($linkToPage) { ?>
             <div class="ccm-block-calendar-event-list-link">
-                <a href="<?=$linkToPage->getCollectionLink()?>"><?=t('View Calendar')?></a>
+                <a href="<?=$linkToPage->getCollectionLink(); ?>"><?=t('View Calendar'); ?></a>
             </div>
         <?php } ?>
 
     </div>
     <?php if ($numEvents > $totalPerPage) {
-    ?>
+        ?>
     <script>
         (function() {
             function Button(element) {
@@ -255,10 +238,8 @@ if ($calendar) {
         }());
     </script>
     <?php
-
-}
     }
-    ?>
+    } ?>
 
 <?php
 } ?>

--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -6,13 +6,13 @@ use Concrete\Controller\Element\Search\SearchFieldSelector;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Entity\Express\Association;
 use Concrete\Core\Entity\Express\Entity;
-use Concrete\Core\Entity\Search\Query;
 use Concrete\Core\Entity\Express\ManyToManyAssociation;
 use Concrete\Core\Entity\Express\ManyToOneAssociation;
+use Concrete\Core\Entity\Search\Query;
 use Concrete\Core\Express\Entry\Search\Result\Result;
 use Concrete\Core\Express\EntryList;
-use Concrete\Core\Express\Search\Field\AssociationField;
 use Concrete\Core\Express\Search\ColumnSet\DefaultSet;
+use Concrete\Core\Express\Search\Field\AssociationField;
 use Concrete\Core\Express\Search\SearchProvider;
 use Concrete\Core\Search\Column\AttributeKeyColumn;
 use Concrete\Core\Search\Field\ManagerFactory;
@@ -22,8 +22,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Controller extends BlockController
 {
-    protected $btInterfaceWidth = "640";
-    protected $btInterfaceHeight = "400";
+    protected $btInterfaceWidth = '640';
+    protected $btInterfaceHeight = '400';
     protected $btTable = 'btExpressEntryList';
     protected $entityAttributes = [];
 
@@ -36,17 +36,17 @@ class Controller extends BlockController
 
     public function getBlockTypeDescription()
     {
-        return t("Add a searchable Express entry list to a page.");
+        return t('Add a searchable Express entry list to a page.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Express Entry List");
+        return t('Express Entry List');
     }
 
     public function getBlockTypeInSetName()
     {
-        return t("List");
+        return t('List');
     }
 
     public function add()
@@ -57,12 +57,14 @@ class Controller extends BlockController
         $this->set('searchAssociations', []);
         $this->set('linkedProperties', []);
         $this->set('displayLimit', 20);
+        $this->set('titleFormat', 'h2');
     }
 
     protected function getSearchFieldManager(Entity $entity)
     {
         $fieldManager = ManagerFactory::get('express');
         $fieldManager->setExpressCategory($entity->getAttributeKeyCategory());
+
         return $fieldManager;
     }
 
@@ -80,7 +82,7 @@ class Controller extends BlockController
                 $field = $manager->getFieldByKey($field);
                 if (is_object($field)) {
                     return new JsonResponse($field);
-    }
+                }
             }
         }
     }
@@ -183,12 +185,12 @@ class Controller extends BlockController
             if ($this->displayLimit > 0) {
                 $list->setItemsPerPage(intval($this->displayLimit));
             }
-            
+
             // Filter by any pre-set search criteria
             if ($this->filterFields) {
                 $filterFields = unserialize($this->filterFields);
                 if (is_array($filterFields)) {
-                    foreach($filterFields as $field) {
+                    foreach ($filterFields as $field) {
                         $field->filterList($list);
                     }
                 }
@@ -336,7 +338,6 @@ class Controller extends BlockController
             $data['filterFields'] = serialize($filterFields);
         }
 
-
         parent::save($data);
     }
 
@@ -377,7 +378,7 @@ class Controller extends BlockController
     {
         $r = $this->entityManager->getRepository(Entity::class);
         $entityObjects = $r->findAll();
-        $entities = ['' => t("** Choose Entity")];
+        $entities = ['' => t('** Choose Entity')];
         foreach ($entityObjects as $entity) {
             $entities[$entity->getID()] = $entity->getEntityDisplayName();
         }

--- a/concrete/blocks/express_entry_list/db.xml
+++ b/concrete/blocks/express_entry_list/db.xml
@@ -53,6 +53,10 @@
     <field name="rowBackgroundColorAlternate" type="string" size="32">
       <default value=""/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+        <default value="h2" />
+		<notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/express_entry_list/edit.php
+++ b/concrete/blocks/express_entry_list/edit.php
@@ -1,30 +1,30 @@
 <?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+defined('C5_EXECUTE') or die(_('Access Denied.'));
 ?>
 
 <?php
 $color = Core::make('helper/form/color');
-echo Core::make('helper/concrete/ui')->tabs(array(
-    array('search', t('Source & Search'), true),
-    array('filtering', t('Filtering')),
-    array('results', t('Results')),
-    array('design', t('Design'))
-));
+echo Core::make('helper/concrete/ui')->tabs([
+    ['search', t('Source & Search'), true],
+    ['filtering', t('Filtering')],
+    ['results', t('Results')],
+    ['design', t('Design')],
+]);
 ?>
 
 <div class="ccm-tab-content" id="ccm-tab-content-search">
 
     <div class="form-group">
-        <?=$form->label('exEntityID', t('Entity'))?>
+        <?=$form->label('exEntityID', t('Entity')); ?>
         <?=$form->select('exEntityID', $entities, $exEntityID, [
-            'data-action' => $view->action('load_entity_data')
-        ]);?>
+            'data-action' => $view->action('load_entity_data'),
+        ]); ?>
     </div>
 
     <div class="form-group">
         <div class="checkbox"><label>
-                <?=$form->checkbox('enableSearch', 1, $enableSearch, array('data-options-toggle' => 'search'))?>
-                <?=t('Enable Search')?>
+                <?=$form->checkbox('enableSearch', 1, $enableSearch, ['data-options-toggle' => 'search']); ?>
+                <?=t('Enable Search'); ?>
             </label>
         </div>
     </div>
@@ -32,16 +32,16 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     <fieldset data-options="search">
 
         <div class="form-group">
-            <label class="control-label"><?=t("Keyword Search")?></label>
+            <label class="control-label"><?=t('Keyword Search'); ?></label>
             <div class="checkbox"><label>
-                    <?=$form->checkbox('enableKeywordSearch', 1, $enableKeywordSearch)?>
-                    <?=t('Search by Keywords')?>
+                    <?=$form->checkbox('enableKeywordSearch', 1, $enableKeywordSearch); ?>
+                    <?=t('Search by Keywords'); ?>
                 </label>
             </div>
         </div>
 
         <div class="form-group">
-            <label class="control-label"><?=t("Enable Searching by Attributes")?></label>
+            <label class="control-label"><?=t('Enable Searching by Attributes'); ?></label>
 
             <div data-container="advanced-search">
 
@@ -49,7 +49,7 @@ echo Core::make('helper/concrete/ui')->tabs(array(
         </div>
 
         <div class="form-group">
-            <label class="control-label"><?=t("Enable Searching by Associations")?></label>
+            <label class="control-label"><?=t('Enable Searching by Associations'); ?></label>
 
             <div data-container="search-associations">
 
@@ -63,9 +63,9 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
     <div data-container="search-field-selector">
         <?php if ($searchFieldSelectorElement) { ?>
-            <?php $searchFieldSelectorElement->render() ?>
+            <?php $searchFieldSelectorElement->render(); ?>
         <?php } else {  ?>
-            <?=t('You must choose an entity before you can customize its filtering.') ?>
+            <?=t('You must choose an entity before you can customize its filtering.'); ?>
         <?php } ?>
     </div>
 
@@ -75,13 +75,13 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 <div class="ccm-tab-content" id="ccm-tab-content-results">
 
     <div class="form-group">
-        <?=$form->label('displayLimit', t('Items Per Page'))?>
-        <?=$form->text('displayLimit', $displayLimit)?>
+        <?=$form->label('displayLimit', t('Items Per Page')); ?>
+        <?=$form->text('displayLimit', $displayLimit); ?>
     </div>
 
     <div class="form-group">
-        <label class="control-label" for="detailPage"><?=t("Link to Detail Page")?></label>
-        <?=Core::make('helper/form/page_selector')->selectPage('detailPage', $detailPage)?>
+        <label class="control-label" for="detailPage"><?=t('Link to Detail Page'); ?></label>
+        <?=Core::make('helper/form/page_selector')->selectPage('detailPage', $detailPage); ?>
 
         <div data-container="linked-attributes">
 
@@ -91,9 +91,9 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
     <div data-container="customize-results">
         <?php if ($customizeElement) { ?>
-            <?php $customizeElement->render() ?>
+            <?php $customizeElement->render(); ?>
         <?php } else {  ?>
-            <?=t('You must choose an entity before you can customize its search results.') ?>
+            <?=t('You must choose an entity before you can customize its search results.'); ?>
         <?php } ?>
     </div>
 </div>
@@ -102,55 +102,60 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
     <fieldset>
         <div class="form-group">
-            <?=$form->label('tableName', t('Name'))?>
-            <?=$form->text('tableName', $tableName, array('maxlength' => '128'))?>
-        </div>
+	        <?php echo $form->label('tableName', t('Name')); ?>
+		    <div class="input-group">
+            	<?=$form->text('tableName', $tableName, ['maxlength' => '128']); ?>
+			    <div class="input-group-addon title-format-addon">
+					<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+			    </div>
+			</div>
+		</div>
         <div class="form-group">
-            <?=$form->label('tableDescription', t('Description'))?>
-            <?=$form->text('tableDescription', $tableDescription, array('maxlength' => '128'))?>
+            <?=$form->label('tableDescription', t('Description')); ?>
+            <?=$form->text('tableDescription', $tableDescription, ['maxlength' => '128']); ?>
         </div>
     </fieldset>
 
     <fieldset>
-        <legend><?=t('Design')?></legend>
+        <legend><?=t('Design'); ?></legend>
         <div class="form-group">
-            <?=$form->label('headerBackgroundColor', t('Header Background'))?>
+            <?=$form->label('headerBackgroundColor', t('Header Background')); ?>
             <div>
-                <?=$color->output('headerBackgroundColor', $headerBackgroundColor)?>
+                <?=$color->output('headerBackgroundColor', $headerBackgroundColor); ?>
             </div>
         </div>
         <div class="form-group">
-            <?=$form->label('headerBackgroundColorActiveSort', t('Header Background (Active Sort)'))?>
+            <?=$form->label('headerBackgroundColorActiveSort', t('Header Background (Active Sort)')); ?>
             <div>
-                <?=$color->output('headerBackgroundColorActiveSort', $headerBackgroundColorActiveSort)?>
+                <?=$color->output('headerBackgroundColorActiveSort', $headerBackgroundColorActiveSort); ?>
             </div>
         </div>
         <div class="form-group">
-            <?=$form->label('headerTextColor', t('Header Text Color'))?>
+            <?=$form->label('headerTextColor', t('Header Text Color')); ?>
             <div>
-                <?=$color->output('headerTextColor', $headerTextColor)?>
+                <?=$color->output('headerTextColor', $headerTextColor); ?>
             </div>
         </div>
         <div class="form-group">
-            <?=$form->label('', t('Table Striping'))?>
+            <?=$form->label('', t('Table Striping')); ?>
             <div class="radio">
                 <label>
-                    <?=$form->radio('tableStriped', 0, $tableStriped)?>
-                    <?=t('Off (all rows the same color)')?>
+                    <?=$form->radio('tableStriped', 0, $tableStriped); ?>
+                    <?=t('Off (all rows the same color)'); ?>
                 </label>
             </div>
             <div class="radio">
                 <label>
-                    <?=$form->radio('tableStriped', 1, $tableStriped)?>
-                    <?=t('On (change color of alternate rows)')?>
+                    <?=$form->radio('tableStriped', 1, $tableStriped); ?>
+                    <?=t('On (change color of alternate rows)'); ?>
                 </label>
             </div>
         </div>
 
         <div class="form-group" data-options="table-striped" style="margin-bottom: 150px;">
-            <?=$form->label('rowBackgroundColorAlternate', t('Alternate Row Background Color'))?>
+            <?=$form->label('rowBackgroundColorAlternate', t('Alternate Row Background Color')); ?>
             <div>
-                <?=$color->output('rowBackgroundColorAlternate', $rowBackgroundColorAlternate)?>
+                <?=$color->output('rowBackgroundColorAlternate', $rowBackgroundColorAlternate); ?>
             </div>
         </div>
     </fieldset>
@@ -196,10 +201,10 @@ echo Core::make('helper/concrete/ui')->tabs(array(
 
 <script type="application/javascript">
     Concrete.event.publish('block.express_entry_list.open', {
-        'searchProperties': <?=json_encode($searchProperties)?>,
-        'searchPropertiesSelected': <?=json_encode($searchPropertiesSelected)?>,
-        'searchAssociations': <?=json_encode($searchAssociations)?>,
-        'searchAssociationsSelected': <?=json_encode($searchAssociationsSelected)?>,
-        'linkedPropertiesSelected': <?=json_encode($linkedPropertiesSelected)?>
+        'searchProperties': <?=json_encode($searchProperties); ?>,
+        'searchPropertiesSelected': <?=json_encode($searchPropertiesSelected); ?>,
+        'searchAssociations': <?=json_encode($searchAssociations); ?>,
+        'searchAssociationsSelected': <?=json_encode($searchAssociationsSelected); ?>,
+        'linkedPropertiesSelected': <?=json_encode($linkedPropertiesSelected); ?>
     });
 </script>

--- a/concrete/blocks/express_entry_list/view.php
+++ b/concrete/blocks/express_entry_list/view.php
@@ -4,42 +4,42 @@ $c = Page::getCurrentPage();
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 if ($tableName) { ?>
-    <h2><?=$tableName?></h2>
+    <<?php echo $titleFormat; ?>><?php echo h($tableName); ?></<?php echo $titleFormat; ?>>
     <?php if ($tableDescription) { ?>
-        <p><?=$tableDescription?></p>
+        <p><?=$tableDescription; ?></p>
     <?php } ?>
 <?php }
 
 if ($entity) { ?>
     <?php if ($enableSearch) { ?>
-        <form method="get" action="<?=$c->getCollectionLink()?>">
+        <form method="get" action="<?=$c->getCollectionLink(); ?>">
             <?php if ($enableKeywordSearch) { ?>
                 <div class="form-inline">
                     <div class="form-group">
-                        <?=$form->label('keywords', t('Keyword Search'))?>
-                        <?=$form->text('keywords')?>
+                        <?=$form->label('keywords', t('Keyword Search')); ?>
+                        <?=$form->text('keywords'); ?>
                     </div>
-                    <button type="submit" class="btn btn-primary" name="search"><?=t('Search')?></button>
+                    <button type="submit" class="btn btn-primary" name="search"><?=t('Search'); ?></button>
                     <?php if (count($tableSearchProperties)) { ?>
-                        <a href="#" data-express-entry-list-advanced-search="<?=$bID?>"
-                        class="ccm-block-express-entry-list-advanced-search"><?=t('Advanced Search')?></a>
+                        <a href="#" data-express-entry-list-advanced-search="<?=$bID; ?>"
+                        class="ccm-block-express-entry-list-advanced-search"><?=t('Advanced Search'); ?></a>
                     <?php } ?>
                 </div>
                 <br>
             <?php } ?>
 
             <?php if (count($tableSearchProperties) || count($tableSearchAssociations)) { ?>
-                <div data-express-entry-list-advanced-search-fields="<?=$bID?>" class="ccm-block-express-entry-list-advanced-search-fields">
-                    <h3><?=t('Search Entries')?></h3>
+                <div data-express-entry-list-advanced-search-fields="<?=$bID; ?>" class="ccm-block-express-entry-list-advanced-search-fields">
+                    <h3><?=t('Search Entries'); ?></h3>
                     <input type="hidden" name="advancedSearchDisplayed" value="<?php echo $app->request->request('advancedSearchDisplayed') ? 1 : ''; ?>">
                     <?php foreach ($tableSearchProperties as $ak) { ?>
-                        <h4><?=$ak->getAttributeKeyDisplayName()?></h4>
+                        <h4><?=$ak->getAttributeKeyDisplayName(); ?></h4>
                         <div>
-                            <?=$ak->render(new \Concrete\Core\Attribute\Context\BasicSearchContext(), null, true)?>
+                            <?=$ak->render(new \Concrete\Core\Attribute\Context\BasicSearchContext(), null, true); ?>
                         </div>
                     <?php } ?>
                     <?php foreach ($tableSearchAssociations as $association) { ?>
-                        <h4><?= $association->getTargetEntity()->getEntityDisplayName() ?></h4>
+                        <h4><?= $association->getTargetEntity()->getEntityDisplayName(); ?></h4>
                         <div>
                             <?php
                             $field = new \Concrete\Core\Express\Search\Field\AssociationField($association);
@@ -53,7 +53,7 @@ if ($entity) { ?>
 
             <?php if (!$enableKeywordSearch) { ?>
                 <div class="form-group clearfix">
-                    <button type="submit" class="btn btn-primary pull-right" name="search"><?=t('Search')?></button>
+                    <button type="submit" class="btn btn-primary pull-right" name="search"><?=t('Search'); ?></button>
                 </div>
             <?php } ?>
         </form>
@@ -61,12 +61,12 @@ if ($entity) { ?>
 
     $results = $result->getItemListObject()->getResults();
     if (count($results)) { ?>
-        <table id="ccm-block-express-entry-list-table-<?=$bID?>"
+        <table id="ccm-block-express-entry-list-table-<?=$bID; ?>"
         class="table ccm-block-express-entry-list-table <?php if ($tableStriped) { ?><?php } ?>">
             <thead>
                 <tr>
                 <?php foreach ($result->getColumns() as $column) { ?>
-                    <th class="<?=$column->getColumnStyleClass()?>"><a href="<?=$column->getColumnSortURL()?>"><?=$column->getColumnTitle()?></a></th>
+                    <th class="<?=$column->getColumnStyleClass(); ?>"><a href="<?=$column->getColumnSortURL(); ?>"><?=$column->getColumnTitle(); ?></a></th>
                 <?php } ?>
                 </tr>
             </thead>
@@ -74,17 +74,17 @@ if ($entity) { ?>
             <?php
             $rowClass = 'ccm-block-express-entry-list-row-a';
             foreach ($result->getItems() as $item) { ?>
-                <tr class="<?=$rowClass?>">
+                <tr class="<?=$rowClass; ?>">
                 <?php foreach ($item->getColumns() as $column) {
-                    if ($controller->linkThisColumn($column)) { ?>
-                        <td><a href="<?=URL::to($detailPage, 'view_express_entity', $item->getEntry()->getId())?>"><?=$column->getColumnValue($item);?></a></td>
+                if ($controller->linkThisColumn($column)) { ?>
+                        <td><a href="<?=URL::to($detailPage, 'view_express_entity', $item->getEntry()->getId()); ?>"><?=$column->getColumnValue($item); ?></a></td>
                     <?php
                     } else { ?>
-                        <td><?=$column->getColumnValue($item);?></td>
+                        <td><?=$column->getColumnValue($item); ?></td>
                     <?php
                     } ?>
                 <?php
-                }
+            }
                 $rowClass = ($rowClass == 'ccm-block-express-entry-list-row-a') ? 'ccm-block-express-entry-list-row-b' : 'ccm-block-express-entry-list-row-a';
                 ?>
                 </tr>
@@ -93,48 +93,48 @@ if ($entity) { ?>
         </table>
 
         <?php if ($pagination) { ?>
-            <?=$pagination ?>
+            <?=$pagination; ?>
         <?php } ?>
 
         <style>
             <?php if ($headerBackgroundColor) { ?>
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th {
-                    background-color: <?=$headerBackgroundColor?>;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th {
+                    background-color: <?=$headerBackgroundColor; ?>;
                 }
             <?php } ?>
             <?php if ($headerTextColor) { ?>
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th,
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th a {
-                    color: <?=$headerTextColor?>;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th,
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th a {
+                    color: <?=$headerTextColor; ?>;
                 }
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th.ccm-results-list-active-sort-asc a:after {
-                    border-color: transparent transparent <?=$headerTextColor?> transparent;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th.ccm-results-list-active-sort-asc a:after {
+                    border-color: transparent transparent <?=$headerTextColor; ?> transparent;
                 }
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th.ccm-results-list-active-sort-desc a:after {
-                    border-color: <?=$headerTextColor?> transparent transparent transparent;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th.ccm-results-list-active-sort-desc a:after {
+                    border-color: <?=$headerTextColor; ?> transparent transparent transparent;
                 }
             <?php } ?>
             <?php if ($headerBackgroundColorActiveSort) { ?>
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th.ccm-results-list-active-sort-asc,
-                #ccm-block-express-entry-list-table-<?=$bID?> thead th.ccm-results-list-active-sort-desc {
-                    background-color: <?=$headerBackgroundColorActiveSort?>;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th.ccm-results-list-active-sort-asc,
+                #ccm-block-express-entry-list-table-<?=$bID; ?> thead th.ccm-results-list-active-sort-desc {
+                    background-color: <?=$headerBackgroundColorActiveSort; ?>;
                 }
             <?php } ?>
             <?php if ($rowBackgroundColorAlternate && $tableStriped) { ?>
-                #ccm-block-express-entry-list-table-<?=$bID?> > tbody > tr.ccm-block-express-entry-list-row-b td {
-                    background-color: <?=$rowBackgroundColorAlternate?>;
+                #ccm-block-express-entry-list-table-<?=$bID; ?> > tbody > tr.ccm-block-express-entry-list-row-b td {
+                    background-color: <?=$rowBackgroundColorAlternate; ?>;
                 }
             <?php } ?>
         </style>
     <?php } else { ?>
-        <p><?=t('No "%s" entries can be found', $entity->getEntityDisplayName())?></p>
+        <p><?=t('No "%s" entries can be found', $entity->getEntityDisplayName()); ?></p>
     <?php } ?>
 
     <?php if ($enableKeywordSearch) { ?>
         <script>
             $(function() {
                 $.concreteExpressEntryList({
-                    'bID': '<?=$bID?>',
+                    'bID': '<?=$bID; ?>',
                     'hideFields': <?php echo !$app->request->request('advancedSearchDisplayed') ? 'true' : 'false'; ?>
                 });
             });

--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -1,35 +1,35 @@
 <?php
 namespace Concrete\Block\Feature;
 
-use Concrete\Core\Editor\LinkAbstractor;
-use Page;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Editor\LinkAbstractor;
+use Core;
 use Less_Parser;
 use Less_Tree_Rule;
-use Core;
+use Page;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     protected $btInterfaceWidth = 400;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
-    protected $btExportPageColumns = array('internalLinkCID');
+    protected $btExportPageColumns = ['internalLinkCID'];
     protected $btInterfaceHeight = 520;
     protected $btTable = 'btFeature';
 
     public function getBlockTypeDescription()
     {
-        return t("Displays an icon, a title, and a short paragraph description.");
+        return t('Displays an icon, a title, and a short paragraph description.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Feature");
+        return t('Feature');
     }
 
     public function getLinkURL()
@@ -73,6 +73,7 @@ class Controller extends BlockController
     public function add()
     {
         $this->edit();
+        $this->set('titleFormat', 'h4');
     }
 
     public function view()
@@ -84,7 +85,7 @@ class Controller extends BlockController
     protected function getIconClasses()
     {
         $iconLessFile = DIR_BASE_CORE . '/css/build/vendor/font-awesome/variables.less';
-        $icons = array();
+        $icons = [];
 
         $l = new Less_Parser();
         $parser = $l->parseFile($iconLessFile, false, true);
@@ -109,7 +110,7 @@ class Controller extends BlockController
         $classes = $this->getIconClasses();
 
         // let's clean them up
-        $icons = array('' => t('Choose Icon'));
+        $icons = ['' => t('Choose Icon')];
         $txt = Core::make('helper/text');
         foreach ($classes as $class) {
             $icons[$class] = $txt->unhandle($class);

--- a/concrete/blocks/feature/db.xml
+++ b/concrete/blocks/feature/db.xml
@@ -16,6 +16,10 @@
       <unsigned/>
       <default value="0"/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+       <default value="h4" />
+	   <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/feature/form.php
+++ b/concrete/blocks/feature/form.php
@@ -1,24 +1,29 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <fieldset>
-    <legend><?=t('Display')?></legend>
+    <legend><?=t('Display'); ?></legend>
     <div class="form-group ccm-block-select-icon">
-        <?php echo $form->label('icon', t('Icon'))?>
+        <?php echo $form->label('icon', t('Icon')); ?>
         <div class="input-group">
             <?php echo $form->select('icon', $icons, $icon); ?>
             <div class="input-group-addon">
-                <i data-preview="icon" class="<?php echo !$icon ?: 'fa fa-' . $icon ?>"></i>
+                <i data-preview="icon" class="<?php echo !$icon ?: 'fa fa-' . $icon; ?>"></i>
             </div>
         </div>
     </div>
 
     <div class="form-group">
-        <?=$form->label('title', t('Title'))?>
-        <?php echo $form->text('title', $title); ?>
-    </div>
+        <?php echo $form->label('title', t('Title')); ?>
+	    <div class="input-group">
+		    <?php echo $form->text('title', $title); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
+	</div>
 
     <div class="form-group">
-        <?php echo $form->label('paragraph', t('Paragraph:'));?>
+        <?php echo $form->label('paragraph', t('Paragraph:')); ?>
         <?php
             $editor = Core::make('editor');
             echo $editor->outputBlockEditModeEditor('paragraph', $controller->getParagraphEditMode());
@@ -28,23 +33,23 @@
 </fieldset>
 
 <fieldset>
-    <legend><?=t('Link')?></legend>
+    <legend><?=t('Link'); ?></legend>
 
     <div class="form-group">
         <select name="linkType" data-select="feature-link-type" class="form-control">
-            <option value="0" <?=(empty($externalLink) && empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('None')?></option>
-            <option value="1" <?=(empty($externalLink) && !empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('Another Page')?></option>
-            <option value="2" <?=(!empty($externalLink) ? 'selected="selected"' : '')?>><?=t('External URL')?></option>
+            <option value="0" <?=(empty($externalLink) && empty($internalLinkCID) ? 'selected="selected"' : ''); ?>><?=t('None'); ?></option>
+            <option value="1" <?=(empty($externalLink) && !empty($internalLinkCID) ? 'selected="selected"' : ''); ?>><?=t('Another Page'); ?></option>
+            <option value="2" <?=(!empty($externalLink) ? 'selected="selected"' : ''); ?>><?=t('External URL'); ?></option>
         </select>
     </div>
 
     <div data-select-contents="feature-link-type-internal" style="display: none;" class="form-group">
-        <?=$form->label('internalLinkCID', t('Choose Page:'))?>
+        <?=$form->label('internalLinkCID', t('Choose Page:')); ?>
         <?= Loader::helper('form/page_selector')->selectPage('internalLinkCID', $internalLinkCID); ?>
     </div>
 
     <div data-select-contents="feature-link-type-external" style="display: none;" class="form-group">
-        <?=$form->label('externalLink', t('URL'))?>
+        <?=$form->label('externalLink', t('URL')); ?>
         <?= $form->text('externalLink', $externalLink); ?>
     </div>
 

--- a/concrete/blocks/feature/view.php
+++ b/concrete/blocks/feature/view.php
@@ -1,4 +1,4 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php  defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <?php
 $title = h($title);
 if ($linkURL) {
@@ -8,8 +8,8 @@ if ($linkURL) {
 <div class="ccm-block-feature-item">
     <?php if ($title) {
     ?>
-        <h4><i class="fa fa-<?=$icon?>"></i> <?=$title?></h4>
-    <?php 
+        <<?php echo $titleFormat; ?>><i class="fa fa-<?=$icon; ?>"></i> <?=$title; ?></<?php echo $titleFormat; ?>>
+    <?php
 } ?>
     <?php
     if ($paragraph) {

--- a/concrete/blocks/google_map/controller.php
+++ b/concrete/blocks/google_map/controller.php
@@ -1,10 +1,10 @@
 <?php
 namespace Concrete\Block\GoogleMap;
 
-use Page;
 use Concrete\Core\Block\BlockController;
 use Config;
 use Core;
+use Page;
 
 class Controller extends BlockController
 {
@@ -16,12 +16,12 @@ class Controller extends BlockController
 
     public function getBlockTypeDescription()
     {
-        return t("Enter an address and a Google Map of that location will be placed in your page.");
+        return t('Enter an address and a Google Map of that location will be placed in your page.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Google Map");
+        return t('Google Map');
     }
 
     public function validate($args)
@@ -54,9 +54,14 @@ class Controller extends BlockController
             $this->addFooterItem(
                 '<script defer src="https://maps.googleapis.com/maps/api/js?callback=concreteGoogleMapInit&key='
                 . Config::get('app.api_keys.google.maps')
-                .'"></script>'
+                . '"></script>'
             );
         }
+    }
+
+    public function add()
+    {
+        $this->set('titleFormat', 'h3');
     }
 
     public function save($data)
@@ -71,6 +76,7 @@ class Controller extends BlockController
            'height' => null,
            'scrollwheel' => 0,
            'apiKey' => '',
+           'titleFormat' => '',
         ];
 
         Config::save('app.api_keys.google.maps', trim($data['apiKey']));
@@ -83,6 +89,7 @@ class Controller extends BlockController
         $args['width'] = $data['width'];
         $args['height'] = $data['height'];
         $args['scrollwheel'] = $data['scrollwheel'] ? 1 : 0;
+        $args['titleFormat'] = $data['titleFormat'];
 
         parent::save($args);
     }

--- a/concrete/blocks/google_map/db.xml
+++ b/concrete/blocks/google_map/db.xml
@@ -20,5 +20,9 @@
             <default value="1" />
             <notnull/>
         </field>
+        <field name="titleFormat" type="string" size="20">
+            <default value="h3" />
+			<notnull/>
+	    </field>
     </table>
 </schema>

--- a/concrete/blocks/google_map/form_setup_html.php
+++ b/concrete/blocks/google_map/form_setup_html.php
@@ -42,64 +42,69 @@ $scrollwheel = !empty($scrollwheel);
 <div class="ccm-google-map-block-container row">
     <div class="col-xs-12">
         <div class="form-group">
-            <?= $form->label('apiKey', t('API Key') . ' <i class="fa fa-question-circle launch-tooltip" title="' . t('The API Key must be enabled for Google Maps and Google Places.') . "\n" . t('API keys can be obtained in the Google Developers Console.') . '"></i>') ?>
+            <?= $form->label('apiKey', t('API Key') . ' <i class="fa fa-question-circle launch-tooltip" title="' . t('The API Key must be enabled for Google Maps and Google Places.') . "\n" . t('API keys can be obtained in the Google Developers Console.') . '"></i>'); ?>
             <div class="input-group">
-                <?= $form->text('apiKey', Config::get('app.api_keys.google.maps')) ?>
+                <?= $form->text('apiKey', Config::get('app.api_keys.google.maps')); ?>
                 <span class="input-group-btn">
                     <a id="ccm-google-map-check-key" class="btn btn-default" href="#">
-                        <?= t('Check') ?>
+                        <?= t('Check'); ?>
                         &nbsp;
                         <i id="ccm-google-map-check-key-spinner" class="fa fa-play"></i>
                     </a>
                 </span>
             </div>
-            <div id="block_note" class="alert alert-info" role="alert"><?= t('Checking API Key...') ?></div>
+            <div id="block_note" class="alert alert-info" role="alert"><?= t('Checking API Key...'); ?></div>
         </div>
 
         <div class="form-group">
         </div>
 
         <div class="form-group">
-            <?= $form->label('title', t('Map Title (optional)')) ?>
-            <?= $form->text('title', $title) ?>
-        </div>
+	        <?php echo $form->label('title', t('Map Title (optional)')); ?>
+		    <div class="input-group">
+			    <?php echo $form->text('title', $title); ?>
+			    <div class="input-group-addon title-format-addon">
+					<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+			    </div>
+			</div>
+		</div>
 
         <div id="ccm-google-map-block-location" class="form-group">
-            <?= $form->label('location', t('Location')  . ' <i class="fa fa-question-circle launch-tooltip" title="' . t('Start typing a location (e.g. Apple Store or 235 W 3rd, New York) then click on the correct entry on the list.') . '"></i>') ?>
-            <?= $form->text('location', $location) ?>
-            <?= $form->hidden('latitude', $latitude) ?>
-            <?= $form->hidden('longitude', $longitude) ?>
+            <?= $form->label('location', t('Location') . ' <i class="fa fa-question-circle launch-tooltip" title="' . t('Start typing a location (e.g. Apple Store or 235 W 3rd, New York) then click on the correct entry on the list.') . '"></i>'); ?>
+            <?= $form->text('location', $location); ?>
+            <?= $form->hidden('latitude', $latitude); ?>
+            <?= $form->hidden('longitude', $longitude); ?>
             <div id="map-canvas"></div>
         </div>
     </div>
 
     <div class="col-xs-4">
         <div class="form-group">
-            <?= $form->label('zoom', t('Zoom')) ?>
+            <?= $form->label('zoom', t('Zoom')); ?>
             <?php
             $zoomLevels = range(0, 21);
             $zoomArray = array_combine($zoomLevels, $zoomLevels);
             ?>
-            <?= $form->select('zoom', $zoomArray, $zoom) ?>
+            <?= $form->select('zoom', $zoomArray, $zoom); ?>
         </div>
     </div>
 
     <div class="col-xs-4">
         <div class="form-group">
-            <?= $form->label('width', t('Map Width')) ?>
+            <?= $form->label('width', t('Map Width')); ?>
             <div class="input-group">
                 <span class="input-group-addon"><i class="fa fa-arrows-h"></i></span>
-                <?= $form->text('width', $width) ?>
+                <?= $form->text('width', $width); ?>
             </div>
         </div>
     </div>
 
     <div class="col-xs-4">
         <div class="form-group">
-            <?= $form->label('height', t('Map Height')) ?>
+            <?= $form->label('height', t('Map Height')); ?>
             <div class="input-group">
                 <span class="input-group-addon"><i class="fa fa-arrows-v"></i></span>
-                <?= $form->text('height', $height) ?>
+                <?= $form->text('height', $height); ?>
             </div>
         </div>
     </div>
@@ -108,8 +113,8 @@ $scrollwheel = !empty($scrollwheel);
         <div class="form-group">
             <div class="checkbox">
                 <label>
-                <?= $form->checkbox('scrollwheel', 1, $scrollwheel) ?>
-                <?= t('Enable Scroll Wheel') ?>
+                <?= $form->checkbox('scrollwheel', 1, $scrollwheel); ?>
+                <?= t('Enable Scroll Wheel'); ?>
                 </label>
             </div>
         </div>
@@ -156,7 +161,7 @@ var setupApiKey = (function() {
             var place = autocomplete.autocomplete.getPlace();
             if (!place.geometry) {
                 $location.addClass('notfound');
-                $note.text(<?= json_encode(t('The place you entered could not be found.')) ?>).removeClass('alert-info alert-success').removeClass('alert-danger').css('visibility', '');
+                $note.text(<?= json_encode(t('The place you entered could not be found.')); ?>).removeClass('alert-info alert-success').removeClass('alert-danger').css('visibility', '');
             } else {
                 $('#ccm-google-map-block-location > input[id=latitude]').val(place.geometry.location.lat());
                 $('#ccm-google-map-block-location > input[id=longitude]').val(place.geometry.location.lng());
@@ -177,7 +182,7 @@ var setupApiKey = (function() {
 
     return function(onSuccess, onError, forceRecheck) {
         if (checking) {
-            onError(<?= json_encode(t('Please wait, operation in progress.')) ?>);
+            onError(<?= json_encode(t('Please wait, operation in progress.')); ?>);
             return;
         }
         if (!onSuccess) {
@@ -239,7 +244,7 @@ var setupApiKey = (function() {
             }
             var places = new google.maps.places.PlacesService(document.createElement('div'));
             window.gm_authFailure = function() {
-                placesLoaded(<?= json_encode(t('The API Key is NOT valid.')) ?>);
+                placesLoaded(<?= json_encode(t('The API Key is NOT valid.')); ?>);
             };
             places.getDetails(
                 {
@@ -247,7 +252,7 @@ var setupApiKey = (function() {
                 },
                 function(place, status) {
                     if (status === 'REQUEST_DENIED') {
-                        placesLoaded(<?= json_encode(t('The API Key is NOT valid for Google Places.')) ?>);
+                        placesLoaded(<?= json_encode(t('The API Key is NOT valid for Google Places.')); ?>);
                     } else {
                         placesLoaded(null, places);
                     }
@@ -259,7 +264,7 @@ var setupApiKey = (function() {
             scriptLoaded(null);
         };
         window.gm_authFailure = function() {
-            scriptLoaded(<?= json_encode(t('The API Key is NOT valid.')) ?>);
+            scriptLoaded(<?= json_encode(t('The API Key is NOT valid.')); ?>);
         };
         $checkSpinner.removeClass('fa-play').addClass('fa-refresh fa-spin');
         $(document.body).append($script = $('<' + 'script src="https://maps.googleapis.com/maps/api/js?key=' + encodeURIComponent(key) + '&libraries=places&callback=' + encodeURIComponent(scriptLoadedFunctionName) + '"></' + 'script>'));
@@ -272,10 +277,10 @@ $key.on('change keydown keypress', function() {
 $('#ccm-google-map-check-key')
     .on('click', function(e) {
         e.preventDefault();
-        $note.text(<?= json_encode(t('Checking API Key...')) ?>).removeClass('alert-success alert-danger').addClass('alert-info').css('visibility', '');
+        $note.text(<?= json_encode(t('Checking API Key...')); ?>).removeClass('alert-success alert-danger').addClass('alert-info').css('visibility', '');
         setupApiKey(
             function() {
-                $note.text(<?= json_encode(t('The API Key is valid.')) ?>).removeClass('alert-info alert-danger').addClass('alert-success');
+                $note.text(<?= json_encode(t('The API Key is valid.')); ?>).removeClass('alert-info alert-danger').addClass('alert-success');
             },
             function(err) {
                 $note.text(err).removeClass('alert-success alert-info').addClass('alert-danger');

--- a/concrete/blocks/google_map/view.php
+++ b/concrete/blocks/google_map/view.php
@@ -1,24 +1,25 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
 $c = Page::getCurrentPage();
 if ($c->isEditMode()) {
     $loc = Localization::getInstance();
-    $loc->pushActiveContext(Localization::CONTEXT_UI);
-    ?>
+    $loc->pushActiveContext(Localization::CONTEXT_UI); ?>
 	<div class="ccm-edit-mode-disabled-item" style="width: <?php echo $width; ?>; height: <?php echo $height; ?>">
-		<div style="padding: 80px 0px 0px 0px"><?=t('Google Map disabled in edit mode.')?></div>
+		<div style="padding: 80px 0px 0px 0px"><?=t('Google Map disabled in edit mode.'); ?></div>
 	</div>
     <?php
     $loc->popActiveContext();
 } else { ?>
-	<?php  if( strlen($title)>0) { ?><h3><?=$title?></h3><?php  } ?>
+	<?php  if (strlen($title) > 0) { ?>
+        <<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>>
+	<?php  } ?>
 	<div class="googleMapCanvas"
-         style="width: <?=$width?>; height: <?=$height?>"
-         data-zoom="<?=$zoom?>"
-         data-latitude="<?=$latitude?>"
-         data-longitude="<?=$longitude?>"
-         data-scrollwheel="<?=!!$scrollwheel ? "true" : "false"?>"
-         data-draggable="<?=!!$scrollwheel ? "true" : "false"?>"
+         style="width: <?=$width; ?>; height: <?=$height; ?>"
+         data-zoom="<?=$zoom; ?>"
+         data-latitude="<?=$latitude; ?>"
+         data-longitude="<?=$longitude; ?>"
+         data-scrollwheel="<?=(bool) $scrollwheel ? 'true' : 'false'; ?>"
+         data-draggable="<?=(bool) $scrollwheel ? 'true' : 'false'; ?>"
     >
     </div>
 <?php  } ?>

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Block\PageList;
 
 use BlockType;
@@ -10,8 +9,8 @@ use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Page\Feed;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\Topic;
-use Core;
 use Concrete\Core\Url\SeoCanonical;
+use Core;
 use Database;
 use Page;
 use PageList;
@@ -241,6 +240,7 @@ class Controller extends BlockController
         $this->set('bt', BlockType::getByHandle('page_list'));
         $this->set('featuredAttribute', CollectionAttributeKey::getByHandle('is_featured'));
         $this->set('thumbnailAttribute', CollectionAttributeKey::getByHandle('thumbnail'));
+        $this->set('titleFormat', 'h5');
         $this->loadKeys();
     }
 

--- a/concrete/blocks/page_list/db.xml
+++ b/concrete/blocks/page_list/db.xml
@@ -113,6 +113,10 @@
     <field name="truncateChars" type="integer">
       <default value="128"/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h5"/>
+      <notnull/>
+    </field>
     <index name="ptID">
       <col>ptID</col>
     </index>

--- a/concrete/blocks/page_list/page_list_form.php
+++ b/concrete/blocks/page_list/page_list_form.php
@@ -12,7 +12,7 @@ if ($c) {
         }
     }
 }
-$form = Loader::helper('form/page_selector');
+$formPageSelector = Loader::helper('form/page_selector');
 ?>
 
 <?=Loader::helper('concrete/ui')->tabs([
@@ -23,40 +23,36 @@ $form = Loader::helper('form/page_selector');
 <div class="ccm-tab-content" id="ccm-tab-content-page-list-settings">
     <div class=" pagelist-form">
 
-        <input type="hidden" name="pageListToolsDir" value="<?= Loader::helper('concrete/urls')->getBlockTypeToolsURL($bt) ?>/"/>
+        <input type="hidden" name="pageListToolsDir" value="<?= Loader::helper('concrete/urls')->getBlockTypeToolsURL($bt); ?>/"/>
 
         <fieldset>
             <div class="form-group">
-                <label class='control-label'><?= t('Number of Pages to Display') ?></label>
-                <input type="text" name="num" value="<?= $num ?>" class="form-control">
+                <label class='control-label'><?= t('Number of Pages to Display'); ?></label>
+                <input type="text" name="num" value="<?= $num; ?>" class="form-control">
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Page Type') ?></label>
+                <label class="control-label"><?= t('Page Type'); ?></label>
                 <?php
                 $ctArray = PageType::getList(false, $siteType);
 
                 if (is_array($ctArray)) {
                     ?>
                     <select class="form-control" name="ptID" id="selectPTID">
-                        <option value="0">** <?php echo t('All') ?> **</option>
+                        <option value="0">** <?php echo t('All'); ?> **</option>
                         <?php
                         foreach ($ctArray as $ct) {
                             ?>
                             <option
-                                value="<?= $ct->getPageTypeID() ?>" <?php if ($ptID == $ct->getPageTypeID()) {
+                                value="<?= $ct->getPageTypeID(); ?>" <?php if ($ptID == $ct->getPageTypeID()) {
                                 ?> selected <?php
-                            }
-                            ?>>
-                                <?= $ct->getPageTypeDisplayName() ?>
+                            } ?>>
+                                <?= $ct->getPageTypeDisplayName(); ?>
                             </option>
                             <?php
-
-                        }
-                        ?>
+                        } ?>
                     </select>
                     <?php
-
                 }
                 ?>
             </div>
@@ -64,66 +60,63 @@ $form = Loader::helper('form/page_selector');
 
         <fieldset>
             <div class="form-group">
-                <label class="control-label"><?= t('Topics') ?></label>
+                <label class="control-label"><?= t('Topics'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="topicFilter" id="topicFilter"
                                value="" <?php if (!$filterByRelated && !$filterByCustomTopic) {
-                            ?> checked<?php
-                        } ?> />
-                        <?= t('No topic filtering') ?>
+                    ?> checked<?php
+                } ?> />
+                        <?= t('No topic filtering'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="topicFilter" id="topicFilterCustom"
                                value="custom" <?php if ($filterByCustomTopic) {
-                            ?> checked<?php
-                        } ?>>
-                        <?= t('Custom Topic') ?>
+                    ?> checked<?php
+                } ?>>
+                        <?= t('Custom Topic'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="topicFilter" id="topicFilterRelated"
                                value="related" <?php if ($filterByRelated) {
-                            ?> checked<?php
-                        } ?> >
-                        <?= t('Related Topic') ?>
+                    ?> checked<?php
+                } ?> >
+                        <?= t('Related Topic'); ?>
                     </label>
                 </div>
                 <div data-row="custom-topic">
                     <select class="form-control" name="customTopicAttributeKeyHandle" id="customTopicAttributeKeyHandle">
-                        <option value=""><?=t('Choose topics attribute.')?></option>
+                        <option value=""><?=t('Choose topics attribute.'); ?></option>
                         <?php foreach ($attributeKeys as $attributeKey) {
-                            $attributeController = $attributeKey->getController();
-                            ?>
-                            <option data-topic-tree-id="<?=$attributeController->getTopicTreeID()?>" value="<?=$attributeKey->getAttributeKeyHandle()?>" <?php if ($attributeKey->getAttributeKeyHandle() == $customTopicAttributeKeyHandle) {
-                            ?>selected<?php
-                            }
-                            ?>><?=$attributeKey->getAttributeKeyDisplayName()?></option>
+                    $attributeController = $attributeKey->getController(); ?>
+                            <option data-topic-tree-id="<?=$attributeController->getTopicTreeID(); ?>" value="<?=$attributeKey->getAttributeKeyHandle(); ?>" <?php if ($attributeKey->getAttributeKeyHandle() == $customTopicAttributeKeyHandle) {
+                        ?>selected<?php
+                    } ?>><?=$attributeKey->getAttributeKeyDisplayName(); ?></option>
                             <?php
-                        } ?>
+                } ?>
                     </select>
                     <div class="tree-view-container">
                         <div class="tree-view-template">
                         </div>
                     </div>
-                    <input type="hidden" name="customTopicTreeNodeID" value="<?php echo $customTopicTreeNodeID ?>">
+                    <input type="hidden" name="customTopicTreeNodeID" value="<?php echo $customTopicTreeNodeID; ?>">
 
                 </div>
                 <div data-row="related-topic">
-                    <span class="help-block"><?=t('Allows other blocks like the topic list block to pass search criteria to this page list block.')?></span>
+                    <span class="help-block"><?=t('Allows other blocks like the topic list block to pass search criteria to this page list block.'); ?></span>
                     <select class="form-control" name="relatedTopicAttributeKeyHandle" id="relatedTopicAttributeKeyHandle">
-                        <option value=""><?=t('Choose topics attribute.')?></option>
+                        <option value=""><?=t('Choose topics attribute.'); ?></option>
                         <?php foreach ($attributeKeys as $attributeKey) {
-                            ?>
-                            <option value="<?=$attributeKey->getAttributeKeyHandle()?>" <?php if ($attributeKey->getAttributeKeyHandle() == $relatedTopicAttributeKeyHandle) {
-                            ?>selected<?php
-                            }
-                            ?>><?=$attributeKey->getAttributeKeyDisplayName()?></option>
+                    ?>
+                            <option value="<?=$attributeKey->getAttributeKeyHandle(); ?>" <?php if ($attributeKey->getAttributeKeyHandle() == $relatedTopicAttributeKeyHandle) {
+                        ?>selected<?php
+                    } ?>><?=$attributeKey->getAttributeKeyDisplayName(); ?></option>
                             <?php
-                        } ?>
+                } ?>
                     </select>
                 </div>
             </div>
@@ -132,7 +125,7 @@ $form = Loader::helper('form/page_selector');
 
         <fieldset>
             <div class="form-group">
-                <label class="control-label"><?= t('Filter by Public Date') ?></label>
+                <label class="control-label"><?= t('Filter by Public Date'); ?></label>
                 <?php
                 $filterDateOptions = [
                     'all' => t('Show All'),
@@ -143,12 +136,11 @@ $form = Loader::helper('form/page_selector');
                 ];
 
                 foreach ($filterDateOptions as $filterDateOptionHandle => $filterDateOptionLabel) {
-                    $isChecked = ($filterDateOption == $filterDateOptionHandle) ? 'checked' : '';
-                    ?>
+                    $isChecked = ($filterDateOption == $filterDateOptionHandle) ? 'checked' : ''; ?>
                     <div class="radio">
                         <label>
-                            <input type="radio" class='filterDateOption' name="filterDateOption" value="<?=$filterDateOptionHandle?>" <?=$isChecked?> />
-                            <?= $filterDateOptionLabel ?>
+                            <input type="radio" class='filterDateOption' name="filterDateOption" value="<?=$filterDateOptionHandle; ?>" <?=$isChecked; ?> />
+                            <?= $filterDateOptionLabel; ?>
                         </label>
                     </div>
                     <?php
@@ -156,15 +148,15 @@ $form = Loader::helper('form/page_selector');
 
                 <div class="filterDateOptionDetail" data-filterDateOption="past">
                     <div class="form-group">
-                        <label class="control-label"><?=t('Days in the Past')?> <i class="launch-tooltip fa fa-question-circle" title="<?=t('Leave 0 to show all past dated pages')?>"></i></label>
-                        <input type="text" name="filterDatePast" value="<?= $filterDateDays ? $filterDateDays : 0 ?>" class="form-control">
+                        <label class="control-label"><?=t('Days in the Past'); ?> <i class="launch-tooltip fa fa-question-circle" title="<?=t('Leave 0 to show all past dated pages'); ?>"></i></label>
+                        <input type="text" name="filterDatePast" value="<?= $filterDateDays ? $filterDateDays : 0; ?>" class="form-control">
                     </div>
                 </div>
 
                 <div class="filterDateOptionDetail" data-filterDateOption="future">
                     <div class="form-group">
-                        <label class="control-label"><?=t('Days in the Future')?> <i class="launch-tooltip fa fa-question-circle" title="<?=t('Leave 0 to show all future dated pages')?>"></i></label>
-                        <input type="text" name="filterDateFuture" value="<?= $filterDateDays ? $filterDateDays : 0 ?>" class="form-control">
+                        <label class="control-label"><?=t('Days in the Future'); ?> <i class="launch-tooltip fa fa-question-circle" title="<?=t('Leave 0 to show all future dated pages'); ?>"></i></label>
+                        <input type="text" name="filterDateFuture" value="<?= $filterDateDays ? $filterDateDays : 0; ?>" class="form-control">
                     </div>
                 </div>
 
@@ -183,24 +175,23 @@ $form = Loader::helper('form/page_selector');
 
         <fieldset>
             <div class="form-group">
-                <label class="control-label"><?= t('Other Filters') ?></label>
+                <label class="control-label"><?= t('Other Filters'); ?></label>
                 <div class="checkbox">
                     <label>
                         <input <?php if (!is_object($featuredAttribute)) {
-                            ?> disabled <?php
-                        } ?> type="checkbox" name="displayFeaturedOnly"
+                        ?> disabled <?php
+                    } ?> type="checkbox" name="displayFeaturedOnly"
                              value="1" <?php if ($displayFeaturedOnly == 1) {
-                            ?> checked <?php
-                        } ?>
+                        ?> checked <?php
+                    } ?>
                              style="vertical-align: middle"/>
-                        <?= t('Featured pages only.') ?>
+                        <?= t('Featured pages only.'); ?>
                     </label>
                     <?php if (!is_object($featuredAttribute)) {
                         ?>
                         <span class="help-block"><?=
                             t(
-                                '(<strong>Note</strong>: You must create the "is_featured" page attribute first.)');
-                            ?></span>
+                                '(<strong>Note</strong>: You must create the "is_featured" page attribute first.)'); ?></span>
                         <?php
                     } ?>
                 </div>
@@ -209,9 +200,9 @@ $form = Loader::helper('form/page_selector');
                     <label>
                         <input type="checkbox" name="displayAliases"
                                value="1" <?php if ($displayAliases == 1) {
-                            ?> checked <?php
-                        } ?> />
-                        <?= t('Display page aliases.') ?>
+                        ?> checked <?php
+                    } ?> />
+                        <?= t('Display page aliases.'); ?>
                     </label>
                 </div>
 
@@ -219,14 +210,14 @@ $form = Loader::helper('form/page_selector');
             <label>
                 <input type="checkbox" name="ignorePermissions"
                        value="1" <?php if ($ignorePermissions == 1) { ?> checked <?php } ?> />
-                <?= t('Ignore page permissions.') ?>
+                <?= t('Ignore page permissions.'); ?>
             </label>
         </div>
 
             <div class="checkbox">
             <label>
                 <input type="checkbox" name="enableExternalFiltering" value="1" <?php if ($enableExternalFiltering) { ?>checked<?php } ?> />
-                <?= t('Enable Other Blocks to Filter This Page List.') ?>
+                <?= t('Enable Other Blocks to Filter This Page List.'); ?>
             </label>
         </div>
 
@@ -234,13 +225,13 @@ $form = Loader::helper('form/page_selector');
 
         <fieldset>
             <div class="form-group">
-                <label class="control-label"><?=t('Pagination')?></label>
+                <label class="control-label"><?=t('Pagination'); ?></label>
                 <div class="checkbox">
                     <label>
                         <input type="checkbox" name="paginate" value="1" <?php if ($paginate == 1) {
-                            ?> checked <?php
-                        } ?> />
-                        <?= t('Display pagination interface if more items are available than are displayed.') ?>
+                        ?> checked <?php
+                    } ?> />
+                        <?= t('Display pagination interface if more items are available than are displayed.'); ?>
                     </label>
                 </div>
             </div>
@@ -248,48 +239,48 @@ $form = Loader::helper('form/page_selector');
 
         <fieldset>
             <div class="form-group">
-                <label class="control-label"><?=t('Location')?></label>
+                <label class="control-label"><?=t('Location'); ?></label>
 
                 <div class="radio">
                     <label>
                         <input type="radio" name="cParentID" id="cEverywhereField"
                                value="0" <?php if ($cParentID == 0) {
-                            ?> checked<?php
-                        } ?> />
-                        <?= t('Everywhere') ?>
+                        ?> checked<?php
+                    } ?> />
+                        <?= t('Everywhere'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="cParentID" id="cThisPageField"
-                               value="<?= $c->getCollectionID() ?>" <?php if ($cThis) {
-                            ?> checked<?php
-                        } ?>>
-                        <?= t('Beneath this page') ?>
+                               value="<?= $c->getCollectionID(); ?>" <?php if ($cThis) {
+                        ?> checked<?php
+                    } ?>>
+                        <?= t('Beneath this page'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="cParentID" id="cThisParentField"
-                               value="<?= $c->getCollectionParentID() ?>" <?php if ($cThisParent) { ?> checked<?php } ?>>
-                        <?= t('At the current level') ?>
+                               value="<?= $c->getCollectionParentID(); ?>" <?php if ($cThisParent) { ?> checked<?php } ?>>
+                        <?= t('At the current level'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="cParentID" id="cOtherField"
                                value="OTHER" <?php if ($isOtherPage) {
-                            ?> checked<?php
-                        } ?>>
-                        <?= t('Beneath another page') ?>
+                        ?> checked<?php
+                    } ?>>
+                        <?= t('Beneath another page'); ?>
                     </label>
                 </div>
 
                 <div class="ccm-page-list-page-other" <?php if (!$isOtherPage) {
-                    ?> style="display: none" <?php
-                } ?>>
+                        ?> style="display: none" <?php
+                    } ?>>
 
-                    <?= $form->selectPage('cParentIDValue', $isOtherPage ? $cParentID : false); ?>
+                    <?= $formPageSelector->selectPage('cParentIDValue', $isOtherPage ? $cParentID : false); ?>
                 </div>
 
                 <div class="ccm-page-list-all-descendents"
@@ -297,8 +288,8 @@ $form = Loader::helper('form/page_selector');
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" name="includeAllDescendents" id="includeAllDescendents"
-                                   value="1" <?php echo $includeAllDescendents ? 'checked="checked"' : '' ?> />
-                            <?php echo t('Include all child pages') ?>
+                                   value="1" <?php echo $includeAllDescendents ? 'checked="checked"' : ''; ?> />
+                            <?php echo t('Include all child pages'); ?>
                         </label>
                     </div>
                 </div>
@@ -310,88 +301,88 @@ $form = Loader::helper('form/page_selector');
         <fieldset>
 
             <div class="form-group">
-                <label class="control-label"><?=t('Sort')?></label>
+                <label class="control-label"><?=t('Sort'); ?></label>
                 <select name="orderBy" class="form-control">
                     <option value="display_asc" <?php if ($orderBy == 'display_asc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Sitemap order') ?>
+                        <?= t('Sitemap order'); ?>
                     </option>
                     <option value="display_desc" <?php if ($orderBy == 'display_desc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Reverse sitemap order') ?>
+                        <?= t('Reverse sitemap order'); ?>
                     </option>
                     <option value="chrono_desc" <?php if ($orderBy == 'chrono_desc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Most recent first') ?>
+                        <?= t('Most recent first'); ?>
                     </option>
                     <option value="chrono_asc" <?php if ($orderBy == 'chrono_asc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Earliest first') ?>
+                        <?= t('Earliest first'); ?>
                     </option>
                     <option value="alpha_asc" <?php if ($orderBy == 'alpha_asc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Alphabetical order') ?>
+                        <?= t('Alphabetical order'); ?>
                     </option>
                     <option value="alpha_desc" <?php if ($orderBy == 'alpha_desc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Reverse alphabetical order') ?>
+                        <?= t('Reverse alphabetical order'); ?>
                     </option>
                     <option value="modified_desc" <?php if ($orderBy == 'modified_desc') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Most recently modified first') ?>
+                        <?= t('Most recently modified first'); ?>
                     </option>
                     <option value="random" <?php if ($orderBy == 'random') {
                         ?> selected <?php
                     } ?>>
-                        <?= t('Random') ?>
+                        <?= t('Random'); ?>
                     </option>
                 </select>
             </div>
         </fieldset>
 
         <fieldset>
-            <legend><?= t('Output') ?></legend>
+            <legend><?= t('Output'); ?></legend>
             <div class="form-group">
-                <label class="control-label"><?= t('Provide RSS Feed') ?></label>
+                <label class="control-label"><?= t('Provide RSS Feed'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="rss" class="rssSelector"
-                               value="0" <?= (is_object($rssFeed) ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                               value="0" <?= (is_object($rssFeed) ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input id="ccm-pagelist-rssSelectorOn" type="radio" name="rss" class="rssSelector"
-                               value="1" <?= (is_object($rssFeed) ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                               value="1" <?= (is_object($rssFeed) ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
-                <div id="ccm-pagelist-rssDetails" <?= (is_object($rssFeed) ? '' : 'style="display:none;"') ?>>
+                <div id="ccm-pagelist-rssDetails" <?= (is_object($rssFeed) ? '' : 'style="display:none;"'); ?>>
                     <?php if (is_object($rssFeed)) {
                         ?>
-                        <?=t('RSS Feed can be found here: <a href="%s" target="_blank">%s</a>', $rssFeed->getFeedURL(), $rssFeed->getFeedURL())?>
+                        <?=t('RSS Feed can be found here: <a href="%s" target="_blank">%s</a>', $rssFeed->getFeedURL(), $rssFeed->getFeedURL()); ?>
                         <?php
                     } else {
                         ?>
                         <div class="form-group">
-                            <label class="control-label"><?= t('RSS Feed Title') ?></label>
+                            <label class="control-label"><?= t('RSS Feed Title'); ?></label>
                             <input class="form-control" id="ccm-pagelist-rssTitle" type="text" name="rssTitle"
                                    value=""/>
                         </div>
                         <div class="form-group">
-                            <label class="control-label"><?= t('RSS Feed Description') ?></label>
+                            <label class="control-label"><?= t('RSS Feed Description'); ?></label>
                             <textarea name="rssDescription" class="form-control"></textarea>
                         </div>
                         <div class="form-group">
-                            <label class="control-label"><?= t('RSS Feed Location') ?></label>
+                            <label class="control-label"><?= t('RSS Feed Location'); ?></label>
                             <div class="input-group">
-                                <span class="input-group-addon"><?=URL::to('/rss')?>/</span>
+                                <span class="input-group-addon"><?=URL::to('/rss'); ?>/</span>
                                 <input type="text" name="rssHandle" value="" />
                             </div>
                         </div>
@@ -401,122 +392,127 @@ $form = Loader::helper('form/page_selector');
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Include Page Name') ?></label>
+                <label class="control-label"><?= t('Include Page Name'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeName"
-                               value="0" <?= ($includeName ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                               value="0" <?= ($includeName ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeName"
-                               value="1" <?= ($includeName ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                               value="1" <?= ($includeName ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Include Page Description') ?></label>
+                <label class="control-label"><?= t('Include Page Description'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeDescription"
-                               value="0" <?= ($includeDescription ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                               value="0" <?= ($includeDescription ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeDescription"
-                               value="1" <?= ($includeDescription ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                               value="1" <?= ($includeDescription ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
-                <div class="ccm-page-list-truncate-description" <?= ($includeDescription ? '' : 'style="display:none;"') ?>>
-                    <label class="control-label"><?=t('Display Truncated Description')?></label>
+                <div class="ccm-page-list-truncate-description" <?= ($includeDescription ? '' : 'style="display:none;"'); ?>>
+                    <label class="control-label"><?=t('Display Truncated Description'); ?></label>
                     <div class="input-group">
             <span class="input-group-addon">
                 <input id="ccm-pagelist-truncateSummariesOn" name="truncateSummaries" type="checkbox"
-                       value="1" <?= ($truncateSummaries ? 'checked="checked"' : '') ?> />
+                       value="1" <?= ($truncateSummaries ? 'checked="checked"' : ''); ?> />
             </span>
-                        <input class="form-control" id="ccm-pagelist-truncateChars" <?= ($truncateSummaries ? '' : 'disabled="disabled"') ?>
-                               type="text" name="truncateChars" size="3" value="<?= (int) $truncateChars ?>" />
+                        <input class="form-control" id="ccm-pagelist-truncateChars" <?= ($truncateSummaries ? '' : 'disabled="disabled"'); ?>
+                               type="text" name="truncateChars" size="3" value="<?= (int) $truncateChars; ?>" />
             <span class="input-group-addon">
-                <?= t('characters') ?>
+                <?= t('characters'); ?>
             </span>
                     </div>
                 </div>
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Include Public Page Date') ?></label>
+                <label class="control-label"><?= t('Include Public Page Date'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeDate"
-                               value="0" <?= ($includeDate ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                               value="0" <?= ($includeDate ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="includeDate"
-                               value="1" <?= ($includeDate ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                               value="1" <?= ($includeDate ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
-                <span class="help-block"><?=t('This is usually the date the page is created. It can be changed from the page attributes panel.')?></span>
+                <span class="help-block"><?=t('This is usually the date the page is created. It can be changed from the page attributes panel.'); ?></span>
             </div>
             <div class="form-group">
-                <label class="control-label"><?= t('Display Thumbnail Image') ?></label>
+                <label class="control-label"><?= t('Display Thumbnail Image'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="displayThumbnail"
-                            <?= (!is_object($thumbnailAttribute) ? 'disabled ' : '')?>
-                               value="0" <?= ($displayThumbnail ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                            <?= (!is_object($thumbnailAttribute) ? 'disabled ' : ''); ?>
+                               value="0" <?= ($displayThumbnail ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="displayThumbnail"
-                            <?= (!is_object($thumbnailAttribute) ? 'disabled ' : '')?>
-                               value="1" <?= ($displayThumbnail ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                            <?= (!is_object($thumbnailAttribute) ? 'disabled ' : ''); ?>
+                               value="1" <?= ($displayThumbnail ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
                 <?php if (!is_object($thumbnailAttribute)) {
-                    ?>
+                        ?>
                     <div class="help-block">
-                        <?=t('You must create an attribute with the \'thumbnail\' handle in order to use this option.')?>
+                        <?=t('You must create an attribute with the \'thumbnail\' handle in order to use this option.'); ?>
                     </div>
                     <?php
-                } ?>
+                    } ?>
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Use Different Link than Page Name') ?></label>
+                <label class="control-label"><?= t('Use Different Link than Page Name'); ?></label>
                 <div class="radio">
                     <label>
                         <input type="radio" name="useButtonForLink"
-                               value="0" <?= ($useButtonForLink ? '' : 'checked="checked"') ?>/> <?= t('No') ?>
+                               value="0" <?= ($useButtonForLink ? '' : 'checked="checked"'); ?>/> <?= t('No'); ?>
                     </label>
                 </div>
                 <div class="radio">
                     <label>
                         <input type="radio" name="useButtonForLink"
-                               value="1" <?= ($useButtonForLink ? 'checked="checked"' : '') ?>/> <?= t('Yes') ?>
+                               value="1" <?= ($useButtonForLink ? 'checked="checked"' : ''); ?>/> <?= t('Yes'); ?>
                     </label>
                 </div>
-                <div class="ccm-page-list-button-text" <?= ($useButtonForLink ? '' : 'style="display:none;"') ?>>
+                <div class="ccm-page-list-button-text" <?= ($useButtonForLink ? '' : 'style="display:none;"'); ?>>
                     <div class="form-group">
-                        <label class="control-label"><?= t('Link Text') ?></label>
-                        <input class="form-control" type="text" name="buttonLinkText" value="<?=$buttonLinkText?>" />
+                        <label class="control-label"><?= t('Link Text'); ?></label>
+                        <input class="form-control" type="text" name="buttonLinkText" value="<?=$buttonLinkText; ?>" />
                     </div>
                 </div>
             </div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Title of Page List') ?></label>
-                <input type="text" class="form-control" name="pageListTitle" value="<?=$pageListTitle?>" />
-            </div>
+		        <?php echo $form->label('pageListTitle', t('Title of Page List')); ?>
+			    <div class="input-group">
+				    <?php echo $form->text('pageListTitle', $pageListTitle); ?>
+				    <div class="input-group-addon title-format-addon">
+						<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+				    </div>
+				</div>
+			</div>
 
             <div class="form-group">
-                <label class="control-label"><?= t('Message to Display When No Pages Listed.') ?></label>
-                <textarea class="form-control" name="noResultsMessage"><?=$noResultsMessage?></textarea>
+                <label class="control-label"><?= t('Message to Display When No Pages Listed.'); ?></label>
+                <textarea class="form-control" name="noResultsMessage"><?=$noResultsMessage; ?></textarea>
             </div>
             <fieldset>
 
@@ -587,7 +583,7 @@ $form = Loader::helper('form/page_selector');
             $('.tree-view-template').concreteTree({
                 'treeID': chosenTree,
                 'chooseNodeInForm': true,
-                'selectNodesByKey': [<?=(int) $customTopicTreeNodeID?>],
+                'selectNodesByKey': [<?=(int) $customTopicTreeNodeID; ?>],
                 'onSelect' : function(nodes) {
                     if (nodes.length) {
                         $('input[name=customTopicTreeNodeID]').val(nodes[0]);

--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -10,24 +10,24 @@ $dh = Core::make('helper/date');
 
 if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
     ?>
-    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Page List Block.') ?></div>
+    <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Page List Block.'); ?></div>
     <?php
 } else {
-    ?>
+        ?>
 
     <div class="ccm-block-page-list-wrapper">
 
         <?php if (isset($pageListTitle) && $pageListTitle) {
             ?>
             <div class="ccm-block-page-list-header">
-                <h5><?php echo h($pageListTitle) ?></h5>
+	            <<?php echo $titleFormat; ?>><?php echo h($pageListTitle); ?></<?php echo $titleFormat; ?>>
             </div>
             <?php
         } ?>
 
         <?php if (isset($rssUrl) && $rssUrl) {
             ?>
-            <a href="<?php echo $rssUrl ?>" target="_blank" class="ccm-block-page-list-rss-feed">
+            <a href="<?php echo $rssUrl; ?>" target="_blank" class="ccm-block-page-list-rss-feed">
                 <i class="fa fa-rss"></i>
             </a>
             <?php
@@ -38,135 +38,132 @@ if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
             <?php
 
             $includeEntryText = false;
-            if (
+        if (
                 (isset($includeName) && $includeName)
                 ||
                 (isset($includeDescription) && $includeDescription)
                 ||
                 (isset($useButtonForLink) && $useButtonForLink)
             ) {
-                $includeEntryText = true;
+            $includeEntryText = true;
+        }
+
+        foreach ($pages as $page) {
+            // Prepare data for each page being listed...
+            $buttonClasses = 'ccm-block-page-list-read-more';
+            $entryClasses = 'ccm-block-page-list-page-entry';
+            $title = $page->getCollectionName();
+            if ($page->getCollectionPointerExternalLink() != '') {
+                $url = $page->getCollectionPointerExternalLink();
+                if ($page->openCollectionPointerExternalLinkInNewWindow()) {
+                    $target = '_blank';
+                }
+            } else {
+                $url = $page->getCollectionLink();
+                $target = $page->getAttribute('nav_target');
+            }
+            $target = empty($target) ? '_self' : $target;
+            $description = $page->getCollectionDescription();
+            $description = $controller->truncateSummaries ? $th->wordSafeShortText($description, $controller->truncateChars) : $description;
+            $thumbnail = false;
+            if ($displayThumbnail) {
+                $thumbnail = $page->getAttribute('thumbnail');
+            }
+            if (is_object($thumbnail) && $includeEntryText) {
+                $entryClasses = 'ccm-block-page-list-page-entry-horizontal';
             }
 
-            foreach ($pages as $page) {
+            $date = $dh->formatDateTime($page->getCollectionDatePublic(), true);
 
-                // Prepare data for each page being listed...
-                $buttonClasses = 'ccm-block-page-list-read-more';
-                $entryClasses = 'ccm-block-page-list-page-entry';
-                $title = $page->getCollectionName();
-                if ($page->getCollectionPointerExternalLink() != '') {
-                    $url = $page->getCollectionPointerExternalLink();
-                    if ($page->openCollectionPointerExternalLinkInNewWindow()) {
-                        $target = '_blank';
-                    }
-                } else {
-                    $url = $page->getCollectionLink();
-                    $target = $page->getAttribute('nav_target');
-                }
-                $target = empty($target) ? '_self' : $target;
-                $description = $page->getCollectionDescription();
-                $description = $controller->truncateSummaries ? $th->wordSafeShortText($description, $controller->truncateChars) : $description;
-                $thumbnail = false;
-                if ($displayThumbnail) {
-                    $thumbnail = $page->getAttribute('thumbnail');
-                }
-                if (is_object($thumbnail) && $includeEntryText) {
-                    $entryClasses = 'ccm-block-page-list-page-entry-horizontal';
-                }
+            //Other useful page data...
 
-                $date = $dh->formatDateTime($page->getCollectionDatePublic(), true);
+            //$last_edited_by = $page->getVersionObject()->getVersionAuthorUserName();
 
-                //Other useful page data...
+            /* DISPLAY PAGE OWNER NAME
+             * $page_owner = UserInfo::getByID($page->getCollectionUserID());
+             * if (is_object($page_owner)) {
+             *     echo $page_owner->getUserDisplayName();
+             * }
+             */
 
-                //$last_edited_by = $page->getVersionObject()->getVersionAuthorUserName();
+            /* CUSTOM ATTRIBUTE EXAMPLES:
+             * $example_value = $page->getAttribute('example_attribute_handle', 'display');
+             *
+             * When you need the raw attribute value or object:
+             * $example_value = $page->getAttribute('example_attribute_handle');
+             */
 
-                /* DISPLAY PAGE OWNER NAME
-                 * $page_owner = UserInfo::getByID($page->getCollectionUserID());
-                 * if (is_object($page_owner)) {
-                 *     echo $page_owner->getUserDisplayName();
-                 * }
-                 */
+            /* End data preparation. */
 
-                /* CUSTOM ATTRIBUTE EXAMPLES:
-                 * $example_value = $page->getAttribute('example_attribute_handle', 'display');
-                 *
-                 * When you need the raw attribute value or object:
-                 * $example_value = $page->getAttribute('example_attribute_handle');
-                 */
+            /* The HTML from here through "endforeach" is repeated for every item in the list... */ ?>
 
-                /* End data preparation. */
-
-                /* The HTML from here through "endforeach" is repeated for every item in the list... */ ?>
-
-                <div class="<?php echo $entryClasses ?>">
+                <div class="<?php echo $entryClasses; ?>">
 
                     <?php if (is_object($thumbnail)) {
-                        ?>
+                ?>
                         <div class="ccm-block-page-list-page-entry-thumbnail">
                             <?php
                             $img = Core::make('html/image', [$thumbnail]);
-                            $tag = $img->getTag();
-                            $tag->addClass('img-responsive');
-                            echo $tag; ?>
+                $tag = $img->getTag();
+                $tag->addClass('img-responsive');
+                echo $tag; ?>
                         </div>
                         <?php
-                    } ?>
+            } ?>
 
                     <?php if ($includeEntryText) {
-                        ?>
+                ?>
                         <div class="ccm-block-page-list-page-entry-text">
 
                             <?php if (isset($includeName) && $includeName) {
-                                ?>
+                    ?>
                                 <div class="ccm-block-page-list-title">
                                     <?php if (isset($useButtonForLink) && $useButtonForLink) {
-                                        ?>
+                        ?>
                                         <?php echo h($title); ?>
                                         <?php
-
-                                    } else {
-                                        ?>
-                                        <a href="<?php echo h($url) ?>"
-                                           target="<?php echo h($target) ?>"><?php echo h($title) ?></a>
+                    } else {
+                        ?>
+                                        <a href="<?php echo h($url); ?>"
+                                           target="<?php echo h($target); ?>"><?php echo h($title); ?></a>
                                         <?php
-
-                                    } ?>
+                    } ?>
                                 </div>
                                 <?php
-                            } ?>
+                } ?>
 
                             <?php if (isset($includeDate) && $includeDate) {
-                                ?>
-                                <div class="ccm-block-page-list-date"><?php echo h($date) ?></div>
+                    ?>
+                                <div class="ccm-block-page-list-date"><?php echo h($date); ?></div>
                                 <?php
-                            } ?>
+                } ?>
 
                             <?php if (isset($includeDescription) && $includeDescription) {
-                                ?>
-                                <div class="ccm-block-page-list-description"><?php echo h($description) ?></div>
+                    ?>
+                                <div class="ccm-block-page-list-description"><?php echo h($description); ?></div>
                                 <?php
-                            } ?>
+                } ?>
 
                             <?php if (isset($useButtonForLink) && $useButtonForLink) {
-                                ?>
+                    ?>
                                 <div class="ccm-block-page-list-page-entry-read-more">
-                                    <a href="<?php echo h($url) ?>" target="<?php echo h($target) ?>"
-                                       class="<?php echo h($buttonClasses) ?>"><?php echo h($buttonLinkText) ?></a>
+                                    <a href="<?php echo h($url); ?>" target="<?php echo h($target); ?>"
+                                       class="<?php echo h($buttonClasses); ?>"><?php echo h($buttonLinkText); ?></a>
                                 </div>
                                 <?php
-                            } ?>
+                } ?>
 
                         </div>
                         <?php
-                    } ?>
+            } ?>
                 </div>
 
                 <?php
-            } ?>
+        } ?>
         </div><!-- end .ccm-block-page-list-pages -->
 
         <?php if (count($pages) == 0) { ?>
-            <div class="ccm-block-page-list-no-pages"><?php echo h($noResultsMessage) ?></div>
+            <div class="ccm-block-page-list-no-pages"><?php echo h($noResultsMessage); ?></div>
         <?php } ?>
 
     </div><!-- end .ccm-block-page-list-wrapper -->
@@ -177,5 +174,4 @@ if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
     <?php } ?>
 
     <?php
-
-} ?>
+    } ?>

--- a/concrete/blocks/rss_displayer/controller.php
+++ b/concrete/blocks/rss_displayer/controller.php
@@ -2,15 +2,15 @@
 namespace Concrete\Block\RssDisplayer;
 
 use Concrete\Core\Block\BlockController;
-use Loader;
 use Core;
+use Loader;
 
 class Controller extends BlockController
 {
-    public $itemsToDisplay = "5";
-    public $showSummary = "1";
-    public $launchInNewWindow = "1";
-    public $title = "";
+    public $itemsToDisplay = '5';
+    public $showSummary = '1';
+    public $launchInNewWindow = '1';
+    public $title = '';
     protected $btTable = 'btRssDisplay';
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 550;
@@ -23,7 +23,7 @@ class Controller extends BlockController
     /**
      * Default number of seconds that the output of this block should be cached
      * (Can be overridden by the user within C5 UI).
-     * 
+     *
      * @var int
      */
     protected $btCacheBlockOutputLifetime = 3600;
@@ -31,17 +31,17 @@ class Controller extends BlockController
     /**
      * Number of seconds that the RSS feed itself should be cached before fetching
      * a fresh copy.
-     * 
+     *
      * (Perhaps this could eventually become a user-setting?)
-     * 
+     *
      * Caching is important as fetching a remote URL can significantly delay
      * the rendering of a PHP page.
-     * 
+     *
      * Setting to "null" should cache it indefinitely until cache is manually cleared.
-     * 
+     *
      * Should probably be less than $btCacheBlockOutputLifetime above, otherwise the
      * block will be re-rendered using the same stale RSS data.
-     * 
+     *
      * @var int
      */
     protected $rssFeedCacheLifetime = 1800;
@@ -51,12 +51,12 @@ class Controller extends BlockController
      */
     public function getBlockTypeDescription()
     {
-        return t("Fetch, parse and display the contents of an RSS or Atom feed.");
+        return t('Fetch, parse and display the contents of an RSS or Atom feed.');
     }
 
     public function getBlockTypeName()
     {
-        return t("RSS Displayer");
+        return t('RSS Displayer');
     }
 
     public function getJavaScriptStrings()
@@ -143,7 +143,7 @@ class Controller extends BlockController
 
     public function view()
     {
-        $fp = Loader::helper("feed");
+        $fp = Loader::helper('feed');
         $posts = [];
 
         try {
@@ -164,6 +164,11 @@ class Controller extends BlockController
         $this->set('title', $this->title);
     }
 
+    public function add()
+    {
+        $this->set('titleFormat', 'h5');
+    }
+
     public function save($data)
     {
         $data += [
@@ -174,6 +179,7 @@ class Controller extends BlockController
             'title' => '',
             'standardDateFormat' => '',
             'customDateFormat' => '',
+            'titleFormat' => 'h5',
         ];
         $args = [
             'url' => $data['url'],
@@ -181,6 +187,7 @@ class Controller extends BlockController
             'showSummary' => $data['showSummary'] ? 1 : 0,
             'launchInNewWindow' => $data['launchInNewWindow'] ? 1 : 0,
             'title' => $data['title'],
+            'titleFormat' => $data['titleFormat'],
         ];
         switch ($data['standardDateFormat']) {
             case ':custom:':
@@ -195,7 +202,7 @@ class Controller extends BlockController
 
     public function getSearchableContent()
     {
-        $fp = Loader::helper("feed");
+        $fp = Loader::helper('feed');
         $posts = [];
 
         try {

--- a/concrete/blocks/rss_displayer/db.xml
+++ b/concrete/blocks/rss_displayer/db.xml
@@ -23,6 +23,10 @@
       <default value="1"/>
       <notnull/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h5"/>
+      <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/rss_displayer/form_setup_html.php
+++ b/concrete/blocks/rss_displayer/form_setup_html.php
@@ -1,20 +1,23 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var $form \Concrete\Core\Form\Service\Form */
 
 ?>
 <div class="form-group">
-    <?= $form->label('url', t('Feed URL')) ?>
-    <input name="url" class="form-control" placeholder="<?= h(t('Feed URL')) ?>" value="<?= h($rssObj->url) ?>" type="text" required="required" />
+    <?= $form->label('url', t('Feed URL')); ?>
+    <input name="url" class="form-control" placeholder="<?= h(t('Feed URL')); ?>" value="<?= h($rssObj->url); ?>" type="text" required="required" />
 </div>
 <div class="form-group">
-    <label for="title" class="control-label">
-        <?= t('Feed Title') ?>
-    </label>
-    <input name="title" class="form-control" placeholder="<?= h(t('Feed Title')) ?>" value="<?= h($rssObj->title) ?>"/>
+    <?php echo $form->label('title', t('Feed Title')); ?>
+    <div class="input-group">
+   	<input name="title" class="form-control" placeholder="<?= h(t('Feed Title')); ?>" value="<?= h($rssObj->title); ?>"/>
+	    <div class="input-group-addon title-format-addon">
+			<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+	    </div>
+	</div>
 </div>
 <div class="form-group">
-    <?= $form->label('standardDateFormat', t('Date Format')) ?>
+    <?= $form->label('standardDateFormat', t('Date Format')); ?>
     <?php
     $dateFormats = $rssObj->getDefaultDateTimeFormats();
     $dateFormats[':custom:'] = t('Custom date/time format');
@@ -45,14 +48,14 @@ $(document).ready(function() {
 });
 </script>
 <div class="form-group">
-    <?= $form->label('itemsToDisplay', t('Items to Show')) ?>
-    <input name="itemsToDisplay" class="form-control" placeholder="10" value="<?= h($rssObj->itemsToDisplay) ?>"/>
+    <?= $form->label('itemsToDisplay', t('Items to Show')); ?>
+    <input name="itemsToDisplay" class="form-control" placeholder="10" value="<?= h($rssObj->itemsToDisplay); ?>"/>
 </div>
 <div class="form-group">
     <div class="checkbox">
         <label>
-            <input type="checkbox" value="1" name="showSummary"<?= ((bool) $rssObj->showSummary ? ' checked' : '') ?> />
-            <?= t('Include Summary') ?>
+            <input type="checkbox" value="1" name="showSummary"<?= ((bool) $rssObj->showSummary ? ' checked' : ''); ?> />
+            <?= t('Include Summary'); ?>
         </label>
     </div>
 </div>
@@ -60,8 +63,8 @@ $(document).ready(function() {
     <div class="checkbox">
         <label>
             <input type="checkbox" value="1"
-               name="launchInNewWindow"<?= ((bool) $rssObj->launchInNewWindow ? ' checked' : '') ?> />
-            <?= t('Open links in a new window') ?>
+               name="launchInNewWindow"<?= ((bool) $rssObj->launchInNewWindow ? ' checked' : ''); ?> />
+            <?= t('Open links in a new window'); ?>
         </label>
     </div>
 </div>

--- a/concrete/blocks/rss_displayer/view.php
+++ b/concrete/blocks/rss_displayer/view.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="ccm-block-rss-displayer-wrapper">
     <div class="ccm-block-rss-displayer">
@@ -7,14 +7,14 @@
 <?php if (strlen($title) > 0) {
     ?>
     <div class="ccm-block-rss-displayer-header">
-    	<h5><?=$title?></h5>
+        <<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>>
     </div>
-<?php 
+<?php
 } ?>
 
 <?php
 $rssObj = $controller;
-$textHelper = Loader::helper("text");
+$textHelper = Loader::helper('text');
 
 if (isset($errorMsg) && strlen($errorMsg) > 0) {
     echo $errorMsg;
@@ -22,32 +22,26 @@ if (isset($errorMsg) && strlen($errorMsg) > 0) {
     foreach ($posts as $itemNumber => $item) {
         if (intval($itemNumber) >= intval($rssObj->itemsToDisplay)) {
             break;
-        }
-        ?>
+        } ?>
 		
 		<div class="ccm-block-rss-displayer-item">
 			<div class="ccm-block-rss-displayer-item-title">
-				<a href="<?= $item->getLink();
-        ?>" <?php if ($rssObj->launchInNewWindow) {
-    echo 'target="_blank"';
-}
-        ?> >
-					<?= $item->getTitle();
-        ?>
+				<a href="<?= $item->getLink(); ?>" <?php if ($rssObj->launchInNewWindow) {
+            echo 'target="_blank"';
+        } ?> >
+					<?= $item->getTitle(); ?>
 				</a>
 			</div>
-			<div class="ccm-block-rss-displayer-item-date"><?= h($this->controller->formatDateTime($item->getDateCreated()));
-        ?></div>
+			<div class="ccm-block-rss-displayer-item-date"><?= h($this->controller->formatDateTime($item->getDateCreated())); ?></div>
 			<div class="ccm-block-rss-displayer-item-summary">
 				<?php
                 if ($rssObj->showSummary) {
                     echo $textHelper->shortText(strip_tags($item->getDescription()));
-                }
-        ?>
+                } ?>
 			</div>
 		</div>
 	
-<?php 
+<?php
     }
 }
 ?>

--- a/concrete/blocks/search/controller.php
+++ b/concrete/blocks/search/controller.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Block\Search;
 
 use CollectionAttributeKey;
@@ -271,6 +270,7 @@ class Controller extends BlockController
         $this->set('postTo_cID', $this->postTo_cID);
         $this->set('allowUserOptions', $this->allow_user_options);
         $this->set('searchAll', $this->search_all);
+        $this->set('titleFormat', $this->titleFormat);
 
         if ((string) $this->resultsURL !== '') {
             $resultsPage = null;
@@ -309,6 +309,7 @@ class Controller extends BlockController
     public function add()
     {
         $this->edit();
+        $this->set('titleFormat', 'h3');
     }
 
     /**
@@ -336,6 +337,7 @@ class Controller extends BlockController
             'resultsURL' => '',
             'resultsPageKind' => '',
             'allowUserOptions' => '',
+            'titleFormat' => '',
         ];
         $args = [
             'title' => (string) $data['title'],
@@ -345,6 +347,7 @@ class Controller extends BlockController
             'resultsURL' => '',
             'search_all' => 0,
             'allow_users_options' => 0,
+            'titleFormat' => (string) $data['titleFormat'],
         ];
         switch ($data['baseSearchPath']) {
             case 'THIS':
@@ -397,7 +400,7 @@ class Controller extends BlockController
     /**
      * Perform the search.
      *
-     * @return null|false
+     * @return false|null
      */
     public function do_search()
     {

--- a/concrete/blocks/search/db.xml
+++ b/concrete/blocks/search/db.xml
@@ -17,6 +17,10 @@
       <unsigned/>
     </field>
     <field name="resultsURL" type="string" size="255"/>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h3"/>
+      <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/search/form_setup_html.php
+++ b/concrete/blocks/search/form_setup_html.php
@@ -15,18 +15,23 @@ $sites = Site::getList();
 
 if (!$controller->indexExists()) {
     ?>
-    <div class="ccm-error"><?= t('The search index does not appear to exist. This block will not function until the reindex job has been run at least once in the dashboard.') ?></div>
+    <div class="ccm-error"><?= t('The search index does not appear to exist. This block will not function until the reindex job has been run at least once in the dashboard.'); ?></div>
     <?php
 }
 ?>
 <fieldset>
     <div class="form-group">
-        <?= $form->label('title', t('Title')) ?>
-        <?= $form->text('title', $controller->title, ['maxlength' => 255]) ?>
-    </div>
+        <?php echo $form->label('title', t('Title')); ?>
+	    <div class="input-group">
+        	<?= $form->text('title', $controller->title, ['maxlength' => 255]); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
+	</div>
     <div class="form-group">
-        <?= $form->label('buttonText', t('Button Text')) ?>
-        <?=$form->text('buttonText', $controller->buttonText, ['maxlength' => 255]) ?>
+        <?= $form->label('buttonText', t('Button Text')); ?>
+        <?=$form->text('buttonText', $controller->buttonText, ['maxlength' => 255]); ?>
     </div>
     <div class="form-group">
         <?php
@@ -48,42 +53,42 @@ if (!$controller->indexExists()) {
         ?>
 
         <?php if (count($sites) > 1) { ?>
-        <?= $form->label('', t('User Options')) ?>
+        <?= $form->label('', t('User Options')); ?>
         <div class="form-group">
-            <?= $form->checkbox('allowUserOptions', 'ALLOW', (int) $allowUserOptions === 1) ?>
-            <?= t('Allow users to choose search options') ?>
+            <?= $form->checkbox('allowUserOptions', 'ALLOW', (int) $allowUserOptions === 1); ?>
+            <?= t('Allow users to choose search options'); ?>
         </div>
         <?php } ?>
 
-        <?= $form->label('', t('Search for Pages')) ?>
+        <?= $form->label('', t('Search for Pages')); ?>
         <div class="radio">
             <label>
-                <?= $form->radio('baseSearchPath', 'EVERYWHERE', $baseSearchPath === 'EVERYWHERE') ?>
-                <?= t('In the Current Site') ?>
+                <?= $form->radio('baseSearchPath', 'EVERYWHERE', $baseSearchPath === 'EVERYWHERE'); ?>
+                <?= t('In the Current Site'); ?>
             </label>
         </div>
         <?php if (count($sites) > 1) { ?>
             <div class="radio">
                 <label>
-                    <?= $form->radio('baseSearchPath', 'ALL', (int) $searchAll === 1) ?>
-                    <?= t('In all Sites') ?>
+                    <?= $form->radio('baseSearchPath', 'ALL', (int) $searchAll === 1); ?>
+                    <?= t('In all Sites'); ?>
                 </label>
             </div>
         <?php } ?>
         <div class="radio">
             <label>
-                <?= $form->radio('baseSearchPath', 'THIS', $baseSearchPath === 'THIS') ?>
-                <?= t('Beneath the Current Page') ?>
+                <?= $form->radio('baseSearchPath', 'THIS', $baseSearchPath === 'THIS'); ?>
+                <?= t('Beneath the Current Page'); ?>
             </label>
         </div>
         <div class="radio">
             <label>
-                <?= $form->radio('baseSearchPath', 'OTHER', $baseSearchPath === 'OTHER') ?>
-                <?= t('Beneath Another Page') ?>
+                <?= $form->radio('baseSearchPath', 'OTHER', $baseSearchPath === 'OTHER'); ?>
+                <?= t('Beneath Another Page'); ?>
             </label>
         </div>
-        <div class="ccm-searchBlock-baseSearchPath" data-for="OTHER" style="<?= $baseSearchPath === 'OTHER' ? '' : 'display:none;' ?>">
-            <?= $pageSelector->selectPage('searchUnderCID', $baseSearchPath === 'OTHER' ? $baseSearchPage->getCollectionID() : null) ?>
+        <div class="ccm-searchBlock-baseSearchPath" data-for="OTHER" style="<?= $baseSearchPath === 'OTHER' ? '' : 'display:none;'; ?>">
+            <?= $pageSelector->selectPage('searchUnderCID', $baseSearchPath === 'OTHER' ? $baseSearchPage->getCollectionID() : null); ?>
         </div>
     </div>
     <div class="form-group">
@@ -96,30 +101,30 @@ if (!$controller->indexExists()) {
             $resultsPageKind = 'THIS';
         }
         ?>
-        <?= $form->label('resultsPageKind', t('Results Page')) ?>
+        <?= $form->label('resultsPageKind', t('Results Page')); ?>
         <div class="radio">
             <label>
-                <?= $form->radio('resultsPageKind', 'THIS', $resultsPageKind === 'THIS') ?>
-                <?= t('Post results to this page') ?>
+                <?= $form->radio('resultsPageKind', 'THIS', $resultsPageKind === 'THIS'); ?>
+                <?= t('Post results to this page'); ?>
             </label>
         </div>
         <div class="radio">
             <label>
-                <?= $form->radio('resultsPageKind', 'CID', $resultsPageKind === 'CID') ?>
-                <?= t('Post results to another page') ?>
+                <?= $form->radio('resultsPageKind', 'CID', $resultsPageKind === 'CID'); ?>
+                <?= t('Post results to another page'); ?>
             </label>
         </div>
         <div class="radio">
             <label>
-                <?= $form->radio('resultsPageKind', 'URL', $resultsPageKind === 'URL') ?>
-                <?= t('Post results to another URL') ?>
+                <?= $form->radio('resultsPageKind', 'URL', $resultsPageKind === 'URL'); ?>
+                <?= t('Post results to another URL'); ?>
             </label>
         </div>
-        <div class="ccm-searchBlock-resultsPageKind" data-for="CID" style="margin-top: 10px;<?= $resultsPageKind === 'CID' ? '' : 'display:none;' ?>">
-            <?= $pageSelector->selectPage('postTo_cID', $controller->postTo_cID) ?>
+        <div class="ccm-searchBlock-resultsPageKind" data-for="CID" style="margin-top: 10px;<?= $resultsPageKind === 'CID' ? '' : 'display:none;'; ?>">
+            <?= $pageSelector->selectPage('postTo_cID', $controller->postTo_cID); ?>
         </div>
-        <div class="ccm-searchBlock-resultsPageKind" data-for="URL" style="margin-top: 10px;<?= $resultsPageKind === 'URL' ? '' : 'display:none;' ?>">
-            <?= $form->text('resultsURL', $controller->resultsURL, ['maxlength' => 255]) ?>
+        <div class="ccm-searchBlock-resultsPageKind" data-for="URL" style="margin-top: 10px;<?= $resultsPageKind === 'URL' ? '' : 'display:none;'; ?>">
+            <?= $form->text('resultsURL', $controller->resultsURL, ['maxlength' => 255]); ?>
         </div>
     </div>
 </fieldset>

--- a/concrete/blocks/search/view.php
+++ b/concrete/blocks/search/view.php
@@ -1,8 +1,7 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
 if (isset($error)) {
-    ?><?= $error ?><br/><br/><?php
-
+    ?><?= $error; ?><br/><br/><?php
 }
 
 if (!isset($query) || !is_string($query)) {
@@ -10,76 +9,64 @@ if (!isset($query) || !is_string($query)) {
 }
 
 ?>
-    <form action="<?= $view->url($resultTarget) ?>" method="get" class="ccm-search-block-form"><?php
+    <form action="<?= $view->url($resultTarget); ?>" method="get" class="ccm-search-block-form"><?php
 if (isset($title) && ($title !== '')) {
-    ?><h3><?= h($title) ?></h3><?php
-
+    ?><<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>><?php
 }
 if ($query === '') {
     ?><input name="search_paths[]" type="hidden"
-             value="<?= htmlentities($baseSearchPath, ENT_COMPAT, APP_CHARSET) ?>" /><?php
-
+             value="<?= htmlentities($baseSearchPath, ENT_COMPAT, APP_CHARSET); ?>" /><?php
 } elseif (isset($_REQUEST['search_paths']) && is_array($_REQUEST['search_paths'])) {
-    foreach ($_REQUEST['search_paths'] as $search_path) {
-        if (is_string($search_path)) {
-            ?><input name="search_paths[]" type="hidden"
-                     value="<?= htmlentities($search_path, ENT_COMPAT, APP_CHARSET) ?>" /><?php
-
+        foreach ($_REQUEST['search_paths'] as $search_path) {
+            if (is_string($search_path)) {
+                ?><input name="search_paths[]" type="hidden"
+                     value="<?= htmlentities($search_path, ENT_COMPAT, APP_CHARSET); ?>" /><?php
+            }
         }
     }
-}
-?><input name="query" type="text" value="<?= htmlentities($query, ENT_COMPAT, APP_CHARSET) ?>"
+?><input name="query" type="text" value="<?= htmlentities($query, ENT_COMPAT, APP_CHARSET); ?>"
          class="ccm-search-block-text" /><?php
 if (isset($buttonText) && ($buttonText !== '')) {
-    ?> <input name="submit" type="submit" value="<?= h($buttonText) ?>"
+    ?> <input name="submit" type="submit" value="<?= h($buttonText); ?>"
               class="btn btn-default ccm-search-block-submit" /><?php
-
 } ?>
 
 <?php if ($allowUserOptions) { ?>
     <div>
-        <h5><?= t('Advanced Search Options') ?></h5>
-        <input type="radio" name="options" value="ALL" <?= $searchAll ? 'checked' : null ?>/> <span
-                style="margin-right:10px;"><?= t('Search All Sites') ?></span>
-        <input type="radio" name="options" value="CURRENT" <?= $searchAll ? null : 'checked' ?>/>
-        <span><?= t('Search Current Site') ?></span>
+        <h5><?= t('Advanced Search Options'); ?></h5>
+        <input type="radio" name="options" value="ALL" <?= $searchAll ? 'checked' : null; ?>/> <span
+                style="margin-right:10px;"><?= t('Search All Sites'); ?></span>
+        <input type="radio" name="options" value="CURRENT" <?= $searchAll ? null : 'checked'; ?>/>
+        <span><?= t('Search Current Site'); ?></span>
     </div>
 <?php } ?>
 
 <?php
 if (isset($do_search) && $do_search) {
-    if (count($results) == 0) {
-        ?>
-        <h4 style="margin-top:32px"><?= t('There were no results found. Please try another keyword or phrase.') ?></h4><?php
-
-    } else {
-        $tt = Core::make('helper/text');
-        ?>
+        if (count($results) == 0) {
+            ?>
+        <h4 style="margin-top:32px"><?= t('There were no results found. Please try another keyword or phrase.'); ?></h4><?php
+        } else {
+            $tt = Core::make('helper/text'); ?>
         <div id="searchResults"><?php
         foreach ($results as $r) {
-            $currentPageBody = $this->controller->highlightedExtendedMarkup($r->getPageIndexContent(), $query);
-            ?>
+            $currentPageBody = $this->controller->highlightedExtendedMarkup($r->getPageIndexContent(), $query); ?>
             <div class="searchResult">
-            <h3><a href="<?= $r->getCollectionLink() ?>"><?= $r->getCollectionName() ?></a></h3>
+            <h3><a href="<?= $r->getCollectionLink(); ?>"><?= $r->getCollectionName(); ?></a></h3>
             <p><?php
                 if ($r->getCollectionDescription()) {
-                    echo $this->controller->highlightedMarkup($tt->shortText($r->getCollectionDescription()), $query);
-                    ?><br/><?php
-
+                    echo $this->controller->highlightedMarkup($tt->shortText($r->getCollectionDescription()), $query); ?><br/><?php
                 }
-                echo $currentPageBody;
-                ?> <br/><a href="<?= $r->getCollectionLink() ?>"
-                           class="pageLink"><?= $this->controller->highlightedMarkup($r->getCollectionLink(), $query) ?></a>
+            echo $currentPageBody; ?> <br/><a href="<?= $r->getCollectionLink(); ?>"
+                           class="pageLink"><?= $this->controller->highlightedMarkup($r->getCollectionLink(), $query); ?></a>
             </p>
             </div><?php
-
-        }
-        ?></div><?php
+        } ?></div><?php
         $pages = $pagination->getCurrentPageResults();
-        if ($pagination->haveToPaginate()) {
-            $showPagination = true;
-            echo $pagination->renderDefaultView();
+            if ($pagination->haveToPaginate()) {
+                $showPagination = true;
+                echo $pagination->renderDefaultView();
+            }
         }
     }
-}
 ?></form><?php

--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -1,18 +1,18 @@
 <?php
 namespace Concrete\Block\Tags;
 
-use Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption;
-use Concrete\Core\Block\BlockController;
 use CollectionAttributeKey;
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption;
 use Page;
 
 class Controller extends BlockController
 {
     protected $btTable = 'btTags';
-    protected $btInterfaceWidth = "450";
-    protected $btInterfaceHeight = "439";
+    protected $btInterfaceWidth = '450';
+    protected $btInterfaceHeight = '439';
 
-    protected $btExportPageColumns = array('targetCID');
+    protected $btExportPageColumns = ['targetCID'];
 
     protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = true;
@@ -23,19 +23,19 @@ class Controller extends BlockController
     public $attributeHandle = 'tags';
     public $displayMode = 'page';
     public $cloudCount = 10;
-    public $helpers = array('navigation');
+    public $helpers = ['navigation'];
 
     /**
      * Used for localization. If we want to localize the name/description we have to include this.
      */
     public function getBlockTypeDescription()
     {
-        return t("List pages based on type, area.");
+        return t('List pages based on type, area.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Tags");
+        return t('Tags');
     }
 
     public function add()
@@ -46,6 +46,7 @@ class Controller extends BlockController
             $this->set('inStackDashboardPage', true);
         }
         $this->set('displayMode', 'page');
+        $this->set('titleFormat', 'h5');
     }
 
     protected function loadAttribute()
@@ -67,12 +68,12 @@ class Controller extends BlockController
     public function view()
     {
         $ak = $this->loadAttribute();
-        if ($this->displayMode == "cloud") {
+        if ($this->displayMode == 'cloud') {
             $type = $ak->getAttributeType();
             $controller = $type->getController();
             $controller->setAttributeKey($ak);
             $items = $controller->getOptions();
-            $options = array();
+            $options = [];
             if ($this->cloudCount > 0 && count($items) > 0) {
                 $i = 1;
                 foreach ($items as $item) {

--- a/concrete/blocks/tags/db.xml
+++ b/concrete/blocks/tags/db.xml
@@ -16,6 +16,10 @@
     <field name="cloudCount" type="integer">
       <default value="10"/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h5"/>
+      <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/tags/tag_form.php
+++ b/concrete/blocks/tags/tag_form.php
@@ -5,24 +5,30 @@ $c = Page::getCurrentPage();
 ?>
 
 <?php if (!$ak instanceof Concrete\Core\Entity\Attribute\Key\Key) { ?>
-<div class="ccm-error"><?php echo t('Error: The required page attribute with the handle of: "%s" doesn\'t exist', $controller->attributeHandle)?><br/><br/></div>
+<div class="ccm-error"><?php echo t('Error: The required page attribute with the handle of: "%s" doesn\'t exist', $controller->attributeHandle); ?><br/><br/></div>
 <?php } else { ?>
-<input type="hidden" name="attributeHandle" value="<?php echo $controller->attributeHandle?>" />
+<input type="hidden" name="attributeHandle" value="<?php echo $controller->attributeHandle; ?>" />
+	
 	<div class="form-group">
-        <?php echo $form->label('title', t('Title'))?>
-		<?php echo $form->text('title', $title); ?>
+        <?php echo $form->label('title', t('Title')); ?>
+	    <div class="input-group">
+		    <?php echo $form->text('title', $title); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
 	</div>
 
     <div class="form-group">
-        <label class="control-label"><?php echo t('Display a List of Tags From')?></label>
+        <label class="control-label"><?php echo t('Display a List of Tags From'); ?></label>
         <div class="radio">
             <label>
-                <?php echo $form->radio('displayMode', 'page', $displayMode)?><?php echo t('The Current Page.')?>
+                <?php echo $form->radio('displayMode', 'page', $displayMode); ?><?php echo t('The Current Page.'); ?>
             </label>
         </div>
         <div class="radio">
             <label>
-                <?php echo $form->radio('displayMode', 'cloud', $displayMode)?><?php echo t('The Entire Site.')?>
+                <?php echo $form->radio('displayMode', 'cloud', $displayMode); ?><?php echo t('The Entire Site.'); ?>
             </label>
         </div>
     </div>
@@ -38,12 +44,12 @@ $c = Page::getCurrentPage();
 	<?php } ?>
 
 	<div id="ccm-tags-display-cloud" class="form-group">
-        <?php echo $form->label('cloudCount', t('Number to Display'))?>
-		<?php echo $form->text('cloudCount', $cloudCount, array('size' => 4))?>
+        <?php echo $form->label('cloudCount', t('Number to Display')); ?>
+		<?php echo $form->text('cloudCount', $cloudCount, ['size' => 4]); ?>
 	</div>
 
 	<div class="form-group">
-    	<label class="control-label"><?php echo t('Link Tags to Filtered Page List')?></label>
+    	<label class="control-label"><?php echo t('Link Tags to Filtered Page List'); ?></label>
 		<?php
         $form_selector = $app->make('helper/form/page_selector');
         echo $form_selector->selectPage('targetCID', $targetCID);

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -4,24 +4,24 @@
     <div class="ccm-block-tags-wrapper">
         <?php if ($title) { ?>
             <div class="ccm-block-tags-header">
-                <h5><?=$title?></h5>
+				<<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>>
             </div>
         <?php } ?>
 
         <?php foreach ($options as $option) { ?>
             <?php if (isset($target) && $target) { ?>
-                <a href="<?=$controller->getTagLink($option) ?>">
+                <a href="<?=$controller->getTagLink($option); ?>">
                     <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-                        <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                        <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue(); ?></span>
                     <?php } else { ?>
-                        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue(); ?></span>
                     <?php } ?>
                 </a>
             <?php } else { ?>
                 <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-                    <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue(); ?></span>
                 <?php } else { ?>
-                    <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue(); ?></span>
                 <?php } ?>
             <?php } ?>
         <?php } ?>

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -4,15 +4,15 @@ namespace Concrete\Block\TopicList;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Tree\Tree;
-use Concrete\Core\Tree\Type\Topic as TopicTree;
 use Concrete\Core\Tree\Type\Topic;
+use Concrete\Core\Tree\Type\Topic as TopicTree;
 use Core;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
-    public $helpers = array('form');
+    public $helpers = ['form'];
 
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 400;
@@ -26,13 +26,14 @@ class Controller extends BlockController
 
     public function getBlockTypeName()
     {
-        return t("Topic List");
+        return t('Topic List');
     }
 
     public function add()
     {
         $this->edit();
         $this->set('title', t('Topics'));
+        $this->set('titleFormat', 'h5');
     }
 
     public function edit()
@@ -46,7 +47,7 @@ class Controller extends BlockController
         }
         $trees = $tt->getList();
         $keys = CollectionKey::getList();
-        $attributeKeys = array();
+        $attributeKeys = [];
         foreach ($keys as $ak) {
             if ($ak->getAttributeTypeHandle() == 'topics') {
                 $attributeKeys[] = $ak;
@@ -111,7 +112,7 @@ class Controller extends BlockController
         $tree = Tree::getByID($this->topicTreeID);
         $data = $blockNode->addChild('data');
         $data->addChild('mode', $this->mode);
-        $data->addChild("title", $this->title);
+        $data->addChild('title', $this->title);
         $data->addChild('topicAttributeKeyHandle', $this->topicAttributeKeyHandle);
         if (is_object($tree)) {
             $data->addChild('tree', $tree->getTreeName());
@@ -126,7 +127,7 @@ class Controller extends BlockController
 
     public function getImportData($blockNode, $page)
     {
-        $args = array();
+        $args = [];
         $treeName = (string) $blockNode->data->tree;
         $page = (string) $blockNode->data->cParentID;
         $tree = Topic::getByName($treeName);
@@ -151,9 +152,9 @@ class Controller extends BlockController
 
     public function save($data)
     {
-        $data += array(
+        $data += [
             'externalTarget' => 0,
-        );
+        ];
         $externalTarget = intval($data['externalTarget']);
         if ($externalTarget === 0) {
             $data['cParentID'] = 0;

--- a/concrete/blocks/topic_list/db.xml
+++ b/concrete/blocks/topic_list/db.xml
@@ -30,6 +30,10 @@
       <default value=""/>
       <notnull/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h5"/>
+      <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/topic_list/form.php
+++ b/concrete/blocks/topic_list/form.php
@@ -1,52 +1,50 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <fieldset>
     <div class="form-group">
-        <label class="control-label" for="modeSelect"><?=t('Mode')?></label>
+        <label class="control-label" for="modeSelect"><?=t('Mode'); ?></label>
         <select class="form-control" name="mode" id="modeSelect">
             <option value="S" <?php if ($mode == 'S') {
-    ?>selected<?php 
-} ?>><?=t('Search – Display a list of all topics for use on a search sidebar.')?></option>
+    ?>selected<?php
+} ?>><?=t('Search – Display a list of all topics for use on a search sidebar.'); ?></option>
             <option value="P" <?php if ($mode == 'P') {
-    ?>selected<?php 
-} ?>><?=t('Page – Display a list of topics for the current page.')?></option>
+        ?>selected<?php
+    } ?>><?=t('Page – Display a list of topics for the current page.'); ?></option>
         </select>
     </div>
     <div class="form-group" data-row="mode-search">
-        <label class="control-label" for="topicTreeIDSelect"><?=t('Topic Tree')?></label>
+        <label class="control-label" for="topicTreeIDSelect"><?=t('Topic Tree'); ?></label>
         <select class="form-control" name="topicTreeID" id="topicTreeIDSelect">
             <?php foreach ($trees as $stree) {
-    ?>
-                <option value="<?=$stree->getTreeID()?>" <?php if ($tree->getTreeID() == $stree->getTreeID()) {
-    ?>selected<?php 
-}
-    ?>><?=$stree->getTreeDisplayName()?></option>
-            <?php 
-} ?>
+        ?>
+                <option value="<?=$stree->getTreeID(); ?>" <?php if ($tree->getTreeID() == $stree->getTreeID()) {
+            ?>selected<?php
+        } ?>><?=$stree->getTreeDisplayName(); ?></option>
+            <?php
+    } ?>
         </select>
     </div>
 
     <div class="form-group" data-row="mode-page">
-        <label class="control-label" for="attributeKeySelect"><?=t('Topic Attribute To Display')?></label>
+        <label class="control-label" for="attributeKeySelect"><?=t('Topic Attribute To Display'); ?></label>
         <select class="form-control" name="topicAttributeKeyHandle" id="attributeKeySelect">
             <?php foreach ($attributeKeys as $attributeKey) {
-    ?>
-                <option value="<?=$attributeKey->getAttributeKeyHandle()?>" <?php if ($attributeKey->getAttributeKeyHandle() == $topicAttributeKeyHandle) {
-    ?>selected<?php 
-}
-    ?>><?=$attributeKey->getAttributeKeyDisplayName()?></option>
-            <?php 
-} ?>
+        ?>
+                <option value="<?=$attributeKey->getAttributeKeyHandle(); ?>" <?php if ($attributeKey->getAttributeKeyHandle() == $topicAttributeKeyHandle) {
+            ?>selected<?php
+        } ?>><?=$attributeKey->getAttributeKeyDisplayName(); ?></option>
+            <?php
+    } ?>
         </select>
     </div>
 
     <div class='form-group'>
-        <label for='title' class="control-label"><?=t('Results Page')?>:</label>
+        <label for='title' class="control-label"><?=t('Results Page'); ?>:</label>
         <div class="checkbox">
             <label for="ccm-search-block-external-target">
                 <input id="ccm-search-block-external-target" <?php if (intval($cParentID) > 0) {
-    ?>checked<?php 
-} ?> name="externalTarget" type="checkbox" value="1" />
-                <?=t('Post Results to a Different Page')?>
+        ?>checked<?php
+    } ?> name="externalTarget" type="checkbox" value="1" />
+                <?=t('Post Results to a Different Page'); ?>
             </label>
         </div>
         <div id="ccm-search-block-external-target-page">
@@ -55,11 +53,16 @@
         ?>
         </div>
     </div>
-
+    
     <div class="form-group">
-        <label class="control-label" for="title"><?=t('Title')?></label>
-        <input class="form-control" name="title" id="title" value="<?=$title?>" />
-    </div>
+        <?php echo $form->label('title', t('Title')); ?>
+	    <div class="input-group">
+		    <?php echo $form->text('title', $title); ?>
+		    <div class="input-group-addon title-format-addon">
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat); ?>
+		    </div>
+		</div>
+	</div>
 
 </fieldset>
 

--- a/concrete/blocks/topic_list/view.php
+++ b/concrete/blocks/topic_list/view.php
@@ -1,9 +1,9 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php  defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="ccm-block-topic-list-wrapper">
 
     <div class="ccm-block-topic-list-header">
-        <h5><?php echo h($title); ?></h5>
+        <<?php echo $titleFormat; ?>><?php echo h($title); ?></<?php echo $titleFormat; ?>>
     </div>
 
     <?php
@@ -24,16 +24,14 @@
                         ?><li><a href="<?php echo $view->controller->getTopicLink($topic); ?>" <?php
                         if (isset($selectedTopicID) && $selectedTopicID == $topic->getTreeNodeID()) {
                             ?> class="ccm-block-topic-list-topic-selected"<?php
-                        }
-                        ?>><?php echo $topic->getTreeNodeDisplayName(); ?></a><?php
+                        } ?>><?php echo $topic->getTreeNodeDisplayName(); ?></a><?php
                     }
                     if (count($topic->getChildNodes())) {
                         $walk($topic);
                     } ?>
                     </li>
                     <?php
-                }
-                ?></ul><?php
+                } ?></ul><?php
             };
             $walk($node);
         }
@@ -44,8 +42,7 @@
             ?><ul class="ccm-block-topic-list-page-topics"><?php
             foreach ($topics as $topic) {
                 ?><li><a href="<?php echo $view->controller->getTopicLink($topic); ?>"><?php echo $topic->getTreeNodeDisplayName(); ?></a></li><?php
-            }
-            ?></ul><?php
+            } ?></ul><?php
         } else {
             echo t('No topics.');
         }

--- a/concrete/css/build/core/app/app.less
+++ b/concrete/css/build/core/app/app.less
@@ -26,6 +26,7 @@
 @import "flatten.less";
 @import "forms.less";
 @import "help.less";
+@import "input-group-dropdown.less";
 @import "panels/add-block.less";
 @import "panels/check-in.less";
 @import "panels/design.less";

--- a/concrete/css/build/core/app/input-group-dropdown.less
+++ b/concrete/css/build/core/app/input-group-dropdown.less
@@ -1,0 +1,15 @@
+.ccm-ui .input-group {
+	width:100%;
+	
+	.input-group-addon.title-format-addon {
+		min-width: 120px;
+		border: 0;
+		padding: 0;
+		margin: 0;
+		
+		select {
+			background-color:#eeeeee;
+			border-left-color:#eeeeee;
+		}
+	}
+}

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -56,6 +56,8 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $identifier;
     protected $btTable = null;
     protected $btID;
+    
+    public static $btTitleFormats = ['h1' => 'H1', 'h2' => 'H2', 'h3' => 'H3', 'h4' => 'H4', 'h5' => 'H5', 'h6' => 'H6', 'p' => 'Normal'];
 
     /**
      * Set this to true if the data sent to the save/performSave methods can contain NULL values that should be persisted.


### PR DESCRIPTION
Adds a title format option to the following blocks as discussed in #8282:

- Date Navigation
- Event List
- Express Entry List
- Feature
- Google Map
- Page List
- RSS Display
- Tags
- Topic List

Note: app.css file needs to be recompiled for dropdown styling.