### PR TITLE
Faster and safer duplication of FAQ/Image Slider blocks

### DIFF
--- a/concrete/blocks/faq/controller.php
+++ b/concrete/blocks/faq/controller.php
@@ -2,6 +2,7 @@
 namespace Concrete\Block\Faq;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Editor\LinkAbstractor;
 
 class Controller extends BlockController
@@ -69,22 +70,15 @@ class Controller extends BlockController
 
     public function duplicate($newBID)
     {
-        $db = $this->app->make('database')->connection();
-        $v = [$this->bID];
-        $q = 'SELECT * FROM btFaqEntries WHERE bID = ?';
-        $r = $db->executeQuery($q, $v);
-        foreach ($r as $row) {
-            $db->executeQuery(
-                'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) VALUES(?,?,?,?,?)',
-                [
-                    $newBID,
-                    $row['title'],
-                    $row['linkTitle'],
-                    $row['description'],
-                    $row['sortOrder'],
-                ]
-            );
-        }
+        $db = $this->app->make(Connection::class);
+        $copyFields = 'title, linkTitle, description, sortOrder';
+        $db->executeUpdate(
+            "INSERT INTO btFaqEntries (bID, {$copyFields}) SELECT ?, {$copyFields} FROM btFaqEntries WHERE bID = ?",
+            [
+                $newBID,
+                $this->bID,
+            ]
+        );
     }
 
     public function delete()

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -3,6 +3,7 @@
 namespace Concrete\Block\ImageSlider;
 
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
@@ -121,23 +122,15 @@ class Controller extends BlockController implements FileTrackableInterface
     public function duplicate($newBID)
     {
         parent::duplicate($newBID);
-        $db = Database::get();
-        $v = [$this->bID];
-        $q = 'select * from btImageSliderEntries where bID = ?';
-        $r = $db->query($q, $v);
-        while ($row = $r->FetchRow()) {
-            $db->execute('INSERT INTO btImageSliderEntries (bID, fID, linkURL, title, description, sortOrder, internalLinkCID) values(?,?,?,?,?,?,?)',
-                [
-                    $newBID,
-                    $row['fID'],
-                    $row['linkURL'],
-                    $row['title'],
-                    $row['description'],
-                    $row['sortOrder'],
-                    $row['internalLinkCID'],
-                ]
-            );
-        }
+        $db = $this->app->make(Connection::class);
+        $copyFields = 'fID, linkURL, title, description, sortOrder, internalLinkCID';
+        $db->executeUpdate(
+            "INSERT INTO btImageSliderEntries (bID, {$copyFields}) SELECT ?, {$copyFields} FROM btImageSliderEntries WHERE bID = ?",
+            [
+                $newBID,
+                $this->bID
+            ]
+        );
     }
 
     public function delete()


### PR DESCRIPTION
What about using just one query to duplicate the data in the `btImageSliderEntries` (Image Slider) and  `btFaqEntries` (FAQ) database tables?

This approach:

1. is faster (just one query for all the sub-records)
2. is safer (data won't be converted from MySQL to PHP and then back to MySQL)
3. is easier to be maintained (if you add/remove/rename a field, simply update the `$copyFields` variable)