### PR TITLE
Add error supression back to category form element loading

### DIFF
--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -137,7 +137,9 @@ if ($key !== null) {
     <?php
     if ($category && $category instanceof \Concrete\Core\Attribute\Category\StandardCategoryInterface) {
         echo $form->hidden('akCategoryID', $category->getCategoryEntity()->getAttributeKeyCategoryID());
-        View::element(
+
+        /** @TODO Catch the \Throwable error rather than suppressing errors */
+        @View::element(
             'attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
             ['key' => $key],
             $category->getCategoryEntity()->getPackageID() ? $category->getCategoryEntity()->getPackageHandle() : null


### PR DESCRIPTION
Error suppression was removed with this commit: https://github.com/concrete5/concrete5/commit/98412449f86614b78748dbbf2637fc7ffbc760b2
which caused attribute editing to break for categories that didn't have a custom element. Unfortunately since we support PHP 5.5 and since changing these to be thrown exceptions would be a BC break, our best bet is to add back error suppression and revisit in v9 or v10.