### PR TITLE
Add error supression back to category form element loading 8.6 branch version

### DIFF
--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -137,7 +137,9 @@ if ($key !== null) {
     <?php
     if ($category && $category instanceof \Concrete\Core\Attribute\Category\StandardCategoryInterface) {
         echo $form->hidden('akCategoryID', $category->getCategoryEntity()->getAttributeKeyCategoryID());
-        View::element(
+
+        /** @TODO Catch the \Throwable error rather than suppressing errors */
+        @View::element(
             'attribute/categories/' . $category->getCategoryEntity()->getAttributeKeyCategoryHandle(),
             ['key' => $key],
             $category->getCategoryEntity()->getPackageID() ? $category->getCategoryEntity()->getPackageHandle() : null


### PR DESCRIPTION
This is exactly the same as #8419 just cherry-picked into this branch