### PR TITLE
[Feature] Make GroupSelector helper singleton

### DIFF
--- a/concrete/src/Form/FormServiceProvider.php
+++ b/concrete/src/Form/FormServiceProvider.php
@@ -21,6 +21,7 @@ class FormServiceProvider extends ServiceProvider
             'helper/form/page_selector' => '\Concrete\Core\Form\Service\Widget\PageSelector',
             'helper/form/rating' => '\Concrete\Core\Form\Service\Widget\Rating',
             'helper/form/user_selector' => '\Concrete\Core\Form\Service\Widget\UserSelector',
+            'helper/form/group_selector' => '\Concrete\Core\Form\Service\Widget\GroupSelector',
             'form/express/entry_selector' => '\Concrete\Core\Form\Service\Widget\ExpressEntrySelector',
         ];
 


### PR DESCRIPTION
How about adding `helper/form/group_selector` to  FormServiceProvider as singleton.

This PR allows to use the `GroupSelector` as follows-

```
$gsfh = Core::make('helper/form/group_selector');
echo $gsfh->selectGroup('group', $group);
```