### PR TITLE
Add ForeignKeyFixer and c5:database:foreignkey:fix CLI command

### DIFF
--- a/concrete/src/Console/Command/FixDatabaseForeignKeys.php
+++ b/concrete/src/Console/Command/FixDatabaseForeignKeys.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Concrete\Core\Console\Command;
+
+use ArrayObject;
+use Concrete\Core\Console\Command;
+use Concrete\Core\Database\ForeignKeyFixer;
+use Concrete\Core\Error\UserMessageException;
+use Exception;
+use Throwable;
+
+class FixDatabaseForeignKeys extends Command
+{
+    protected $canRunAsRoot = false;
+
+    protected $description = 'Fix the foreign keys.';
+
+    protected $signature = <<<'EOT'
+c5:database:foreignkey:fix
+    {table? : the name of the database table to be fixed - if not specified we'll fix all the tables in the database}
+EOT
+    ;
+
+    public function handle(ForeignKeyFixer $foreignKeyFixer)
+    {
+        $tableName = $this->argument('table');
+        $tableNames = $tableName === null ? null : [$tableName];
+
+        $errors = new ArrayObject();
+        $foreignKeyFixer->setTick(function ($what) {
+            if ($what instanceof UserMessageException) {
+                $this->output->error($what->getMessage());
+            } elseif ($what instanceof Exception || $what instanceof Throwable) {
+                $this->output->error($what->getMessage() . "\n" . $what->getTraceAsString());
+            } else {
+                $this->output->writeln((string) $what);
+            }
+        });
+        $foreignKeyFixer->fixForeignKeys($tableNames, $errors);
+
+        return $errors->count() === 0;
+    }
+}

--- a/concrete/src/Console/ServiceProvider.php
+++ b/concrete/src/Console/ServiceProvider.php
@@ -58,6 +58,7 @@ class ServiceProvider extends Provider
         Command\UpdateCommand::class,
         Command\SetDatabaseCharacterSetCommand::class,
         Command\Express\ExportCommand::class,
+        Command\FixDatabaseForeignKeys::class,
     ];
 
     /**

--- a/concrete/src/Database/ForeignKeyFixer.php
+++ b/concrete/src/Database/ForeignKeyFixer.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Concrete\Core\Database;
+
+use ArrayAccess;
+use ArrayObject;
+use Closure;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Error\UserMessageException;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Exception;
+use Throwable;
+
+class ForeignKeyFixer
+{
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    private $connection;
+
+    /**
+     * @var \Doctrine\DBAL\Schema\AbstractSchemaManager
+     */
+    private $schemaManager;
+
+    /**
+     * @var \Closure|null
+     */
+    private $tick;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+        $this->schemaManager = $connection->getSchemaManager();
+    }
+
+    /**
+     * Set a callback to be called to log/display progress.
+     *
+     * @param \Closure|null $callback
+     * @param null|Closure $value
+     *
+     * @return $this
+     */
+    public function setTick(Closure $value = null)
+    {
+        $this->tick = $value;
+
+        return $this;
+    }
+
+    /**
+     * Fix the foreign key definitions.
+     *
+     * @param string[]|null $tableNames the names of the database tables to be fixed (NULL means all tables)
+     * @param \ArrayAccess|null $errors errors occurred during the execution will be added here
+     */
+    public function fixForeignKeys(array $tableNames = null, ArrayAccess $errors = null)
+    {
+        if ($errors === null) {
+            $errors = new ArrayObject();
+        }
+        try {
+            $this->tick(t('Listing database tables'));
+            $actualTableNames = $this->schemaManager->listTableNames();
+            $actualTableNamesLowerCase = array_map('strtolower', $actualTableNames);
+            if ($tableNames === null) {
+                $tableNames = $actualTableNames;
+            }
+            if ($tableNames === []) {
+                $this->tick('No tables to be fixed.');
+
+                return;
+            }
+            natcasesort($tableNames);
+            foreach ($tableNames as $tableName) {
+                $tableIndex = array_search(strtolower($tableName), $actualTableNamesLowerCase, true);
+                if ($tableIndex === false) {
+                    $error = new UserMessageException(t("The database table '%s' does not exist.", $tableName));
+                    $errors[] = $error;
+                    $this->tick($error);
+                    continue;
+                }
+                $this->fixForeignKeysInTable($actualTableNames[$tableIndex], $actualTableNames, $errors);
+            }
+        } catch (Exception $x) {
+            $errors[] = $x;
+            $this->tick($x);
+        } catch (Throwable $x) {
+            $errors[] = $x;
+            $this->tick($x);
+        }
+    }
+
+    /**
+     * @param string $tableName
+     * @param string[] $actualTableNames
+     * @param \ArrayAccess $errors
+     */
+    private function fixForeignKeysInTable($tableName, array $actualTableNames, ArrayAccess $errors)
+    {
+        try {
+            $table = $this->schemaManager->listTableDetails($tableName);
+            $foreignKeys = $table->getForeignKeys();
+            if (empty($foreignKeys)) {
+                return;
+            }
+            $this->tick(t('Checking database table %s', $tableName));
+            foreach ($table->getForeignKeys() as $foreignKey) {
+                $this->fixForeignKey($foreignKey, $actualTableNames, $errors);
+            }
+        } catch (Exception $x) {
+            $errors[] = $x;
+            $this->tick($x);
+        } catch (Throwable $x) {
+            $errors[] = $x;
+            $this->tick($x);
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     * @param string[] $actualTableNames
+     * @param \ArrayAccess $errors
+     */
+    private function fixForeignKey(ForeignKeyConstraint $foreignKey, array $actualTableNames, ArrayAccess $errors)
+    {
+        $foreignTableName = $foreignKey->getForeignTableName();
+        if (in_array($foreignTableName, $actualTableNames, true)) {
+            $this->tick(t('- the foreign key \'%1$s\' (referencing table \'%2$s\') is well formed', $foreignKey->getName(), $foreignTableName));
+
+            return;
+        }
+        $tableIndex = array_search(strtolower($foreignTableName), array_map('strtolower', $actualTableNames));
+        if ($tableIndex === false) {
+            $this->tick(t('- the foreign key \'%1$s\' references an unknown table (\'$2$s\')', $foreignKey->getName(), $foreignTableName));
+
+            return;
+        }
+        $newForeignTableName = $actualTableNames[$tableIndex];
+        $newForeignKey = new ForeignKeyConstraint(
+            $foreignKey->getLocalColumns(),
+            $newForeignTableName,
+            $foreignKey->getForeignColumns(),
+            $foreignKey->getName(),
+            $foreignKey->getOptions()
+        );
+        $newForeignKey->setLocalTable($foreignKey->getLocalTable());
+        try {
+            $this->schemaManager->dropForeignKey($foreignKey, $foreignKey->getLocalTable());
+            $this->tick(t('- the foreign key \'%1$s\' referencing \'$2$s\' has been dropped', $foreignKey->getName(), $foreignTableName));
+        } catch (Exception $x) {
+            $errors[] = $x;
+            $this->tick($x);
+
+            return;
+        } catch (Throwable $x) {
+            $errors[] = $x;
+            $this->tick($x);
+
+            return;
+        }
+        try {
+            $this->schemaManager->createForeignKey($newForeignKey, $newForeignKey->getLocalTable());
+            $this->tick(t('- the foreign key \'%1$s\' referencing \'$2$s\' has been created', $newForeignKey->getName(), $newForeignTableName));
+        } catch (Exception $x) {
+            $errors[] = $x;
+            $this->tick($x);
+
+            return;
+        } catch (Throwable $x) {
+            $errors[] = $x;
+            $this->tick($x);
+
+            return;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string|\Exception|\Throwable $what
+     */
+    private function tick($what)
+    {
+        $closure = $this->tick;
+        if ($closure === null) {
+            return;
+        }
+        $closure($what);
+    }
+}


### PR DESCRIPTION
If a concrete5 instance is upgraded from a previous version, foreign keys may be malformed (see [here](https://github.com/concrete5/concrete5/pull/8428#issuecomment-588875454) for a detailed description).

What about adding a CLI command that fixes these foreign keys?