### PR TITLE
Public Date/Time Composer Error

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
@@ -28,8 +28,16 @@ class DateTimeCorePageProperty extends CorePageProperty
     public function validate()
     {
         $e = Loader::helper('validation/error');
-        $date = $this->getPageTypeComposerControlDraftValue();
-        if (!strtotime($date)) {
+        
+        $val = $this->getRequestValue();
+        
+        if ($val['date_time_dt'] && $val['date_time_h'] && $val['date_time_m']) {
+            $datetime = $val['date_time_dt'] . ' ' . $val['date_time_h'] . ':' . $val['date_time_m'] . ':00';
+        } else {
+            $datetime = $this->getPageTypeComposerControlDraftValue();
+        }
+        
+        if (!strtotime($datetime)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlDisplayLabel()));
 


### PR DESCRIPTION
When creating a new page where you have set the attribute for Public Date Time to required, it doesn't validate the submitted data and tries to obtain this information from the page itself.

During testing I found that this did not behave in the same way `concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php` where it would actually get the information from the request if it was present.

Adding the above snippet in this PR seems to resolve the issue.