### PR TITLE
select filterByAttribute can return all results

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -593,16 +593,16 @@ EOT
             $option = $em->getRepository('\Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption')
                 ->findOneByValue($value);
         }
-        if (is_object($option)) {
-            $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
-            $qb = $list->getQueryObject();
-            $qb->andWhere(
-                $comparison === '!=' || $comparison === '<>'
-                    ? $qb->expr()->notLike($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
-                    : $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
-            );
-            $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $option->getSelectAttributeOptionValue(false) . "\n%");
-        }
+
+        $optionValue = is_object($option) ? $option->getSelectAttributeOptionValue(false) : $value;
+        $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
+        $qb = $list->getQueryObject();
+        $qb->andWhere(
+            $comparison === '!=' || $comparison === '<>'
+                ? $qb->expr()->notLike($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
+                : $qb->expr()->like($column, ':optionValue_' . $this->attributeKey->getAttributeKeyID())
+        );
+        $qb->setParameter('optionValue_' . $this->attributeKey->getAttributeKeyID(), "%\n" . $optionValue . "\n%");
     }
 
     /**


### PR DESCRIPTION
When creating a Page List query filtering on a select attribute it can potentially return incorrect results.

Example.

I'm filtering on some pages of type X that has been tagged with multiple tags.

Title = Page 1; Tags (select multiple) [Tag 1, Tag 2]
Title = Page 2; Tags (select multiple) No tags applied.

```php
$pl = new PageList();
$pl->filterByAttribute('tags', 'fish');
$results = $pl->getResults();
```

The above actually outputs all pages when it should output none.

The fix in this PR corrects that