### PR TITLE
Support blank namespace for pagination

### DIFF
--- a/concrete/src/Search/ItemList/ItemList.php
+++ b/concrete/src/Search/ItemList/ItemList.php
@@ -242,8 +242,10 @@ abstract class ItemList
      */
     public function setNameSpace($nameSpace)
     {
-        $this->paginationPageParameter .= '_' . $nameSpace;
-        $this->sortColumnParameter .= '_' . $nameSpace;
-        $this->sortDirectionParameter .= '_' . $nameSpace;
+        if(!is_null($nameSpace) && $nameSpace!=""){
+            $this->paginationPageParameter .= '_' . $nameSpace;
+            $this->sortColumnParameter .= '_' . $nameSpace;
+            $this->sortDirectionParameter .= '_' . $nameSpace;
+        }
     }
 }


### PR DESCRIPTION
To make pages more SEO friendly, each time the page list block is edited currently it uses the block ID as the namespace. Even if this is overwritten in the page list block controller, it still ends up with an "_" (underscore) in the URL.