### PR TITLE
fix order of parameters in implode method

### DIFF
--- a/concrete/controllers/element/navigation/menu.php
+++ b/concrete/controllers/element/navigation/menu.php
@@ -76,7 +76,7 @@ class Menu extends ElementController
         if (in_array($page->getCollectionID(), $this->trail)) {
             $classes[] = 'nav-path-selected';
         }
-        return implode($classes, ' ');
+        return implode(' ', $classes);
     }
 
     public function displayDivider(Page $page, Page $next = null)

--- a/concrete/src/Permission/Access/Access.php
+++ b/concrete/src/Permission/Access/Access.php
@@ -509,7 +509,7 @@ class Access extends ConcreteObject
             foreach ($filterEntities as $ent) {
                 $filters[] = $ent->getAccessEntityID();
             }
-            $peIDs .= 'and peID in (' . implode($filters, ',') . ')';
+            $peIDs .= 'and peID in (' . implode(',', $filters) . ')';
         }
         if ($accessType == 0) {
             $accessType = '';


### PR DESCRIPTION
Although the `implode` method accept parameters in either order, this order is deprecated.
https://www.php.net/manual/en/function.implode.php : `Note` section