### PR TITLE
Add a param to getPageWrapperClass() method

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2166,9 +2166,11 @@ EOT
     /**
      * Get the CSS class to be used to wrap the whole page contents.
      *
+     * @param null|mixed $additionalClasses
+     * 
      * @return string
      */
-    public function getPageWrapperClass()
+    public function getPageWrapperClass($additionalClasses = null)
     {
         $pt = $this->getPageTypeObject();
 
@@ -2187,6 +2189,13 @@ EOT
             $classes[] = 'page-template-' . str_replace('_', '-', $ptm->getPageTemplateHandle());
         }
 
+        //append additional classes
+        if (is_string($additionalClasses)) {
+            $classes[] = $additionalClasses;
+        } elseif (is_array($additionalClasses)) {
+            $classes = array_merge($classes, $additionalClasses);
+        } 
+        
         return implode(' ', $classes);
     }
 


### PR DESCRIPTION
What about adding a param to getPageWrapperClass() method, so theme designers can append their own classes directly via the method:
```
<div class="<?php echo $c->getPageWrapperClass('my-theme-wrapper-class')?>">
or: 
<div class="<?php echo $c->getPageWrapperClass(['class1', 'class2'])?>">

```
instead of verbose:
```
$additionalPageClasses = ['class1', 'class2'];
<div class="<?= $c->getPageWrapperClass() . ' ' . implode(' ', $additionalPageClasses) ?>">
```