### PR TITLE
Fix Attribute\View::action()

### DIFF
--- a/concrete/src/Attribute/View.php
+++ b/concrete/src/Attribute/View.php
@@ -8,6 +8,7 @@ use Concrete\Core\Attribute\Context\ComposerContext;
 use Concrete\Core\Filesystem\TemplateLocation;
 use Concrete\Core\Form\Context\ContextInterface;
 use Concrete\Core\Filesystem\TemplateLocator;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Loader;
 use Concrete\Core\Attribute\Value\Value as AttributeValue;
 use Concrete\Core\Attribute\Key\Key as AttributeKey;
@@ -158,19 +159,14 @@ class View extends AbstractView
 
     public function action($action)
     {
-        $arguments = array();
-        if (count(func_get_args()) > 1) {
-            $arguments = array_unshift(func_get_args());
-        }
+        $arguments = func_get_args();
         if (is_object($this->attributeKey)) {
-            return (string)
-            \URL::to('/ccm/system/attribute/action/key', $this->attributeKey->getAttributeKeyID(), $action,
-                $arguments);
+            array_unshift($arguments, '/ccm/system/attribute/action/key', $this->attributeKey->getAttributeKeyID());
         } else {
-            return (string)
-            \URL::to('/ccm/system/attribute/action/type', $this->controller->attributeType->getAttributeTypeID(),
-                $action, $arguments);
+            array_unshift($arguments, '/ccm/system/attribute/action/type', $this->controller->attributeType->getAttributeTypeID());
         }
+        
+        return (string) app(ResolverManagerInterface::class)->resolve($arguments);
     }
 
     public function finishRender($contents)

--- a/tests/tests/View/AttributeViewTest.php
+++ b/tests/tests/View/AttributeViewTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Concrete\Tests\View;
+
+use Concrete\Core\Attribute\AttributeKeyInterface;
+use Concrete\Core\Attribute\View;
+use Concrete\Core\Entity\Attribute\Type as AttributeType;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit_Framework_TestCase;
+
+class AttributeViewTest extends PHPUnit_Framework_TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function actionProvider()
+    {
+        return [
+            [
+                ['foo'],
+                'http://www.dummyco.com/path/to/server/index.php/ccm/system/attribute/action/key/123/foo',
+            ],
+            [
+                ['foo', 'bar'],
+                'http://www.dummyco.com/path/to/server/index.php/ccm/system/attribute/action/key/123/foo/bar',
+            ],
+        ];
+    }
+
+    /**
+     * @param array $arguments
+     * @param string $expectedResult
+     * @dataProvider actionProvider
+     */
+    public function testAction(array $arguments, $expectedResult)
+    {
+        $attributeType = Mockery::mock(AttributeType::class);
+        $attributeType
+            ->shouldReceive('getPackageHandle')
+            ->withNoArgs()
+            ->andReturn('')
+        ;
+        $attributeKey = Mockery::mock(AttributeKeyInterface::class);
+        $attributeKey
+            ->shouldReceive('getAttributeType')
+            ->withNoArgs()
+            ->andReturn($attributeType)
+        ;
+        $attributeKey
+            ->shouldReceive('getAttributeKeyID')
+            ->withNoArgs()
+            ->andReturn(123)
+        ;
+        $view = new View($attributeKey);
+        $actualResult = call_user_func_array([$view, 'action'], $arguments);
+        $this->assertSame($expectedResult, $actualResult);
+    }
+}


### PR DESCRIPTION
Calling the `action` method of a `Concrete\Core\Attribute\View` instance causes one of these two errors (depending on the PHP version):

```
array_unshift() expects at least 2 parameters, 1 given
```

or

```
Only variables should be passed by reference
```


Let's fix this.

Before I add a test that shows the error, then I'll add a fix for it.