### PR TITLE
Fix height of selectize selects when multiple options are selected

### DIFF
--- a/concrete/css/build/core/app/flatten.less
+++ b/concrete/css/build/core/app/flatten.less
@@ -8,6 +8,11 @@
     &:focus {
       box-shadow: none !important; // need import because of other classes like has-warning
     }
+    
+    &.selectize-control.multi {
+        height: auto;
+        min-height: 40px;
+    }
   }
 
   // Select menu appearance update


### PR DESCRIPTION
When a `<select multiple>` element is rendered with Selectize, its height may be greater than 40px (imposed by the CSS).
What about setting the *minimum* height to 40px?

Before:
![image](https://user-images.githubusercontent.com/928116/75803334-91b45b00-5d7e-11ea-9548-c6349cd7c09c.png)

After:
![image](https://user-images.githubusercontent.com/928116/75803373-9973ff80-5d7e-11ea-9c95-c11048348004.png)

