### PR TITLE
[Fix] Config command with env option

### DIFF
--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -175,7 +175,7 @@ EOT
 
         $file_loader = new FileLoader($filesystem);
         if ($this->option('generated-overrides')) {
-            $file_saver = new FileSaver($filesystem, $environment == $default_environment ? null : $environment);
+            $file_saver = new FileSaver($filesystem);
         } else {
             $file_saver = new DirectFileSaver($filesystem, $environment == $default_environment ? null : $environment);
         }

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -19,7 +19,6 @@ class ConfigCommand extends Command
         {action : Either "get" or "set"} 
         {item : The config item EG: "concrete.debug.detail"} 
         {value? : The value to set}
-        {--e|environment : The environment, if none specified the global configuration will be used}
         {--g|generated-overrides : Save to generated overrides}';
 
     /** @var Repository */
@@ -27,7 +26,9 @@ class ConfigCommand extends Command
 
     protected function configure()
     {
-        $this->setHelp(<<<EOT
+        $this
+            ->addEnvOption()
+            ->setHelp(<<<EOT
 When setting values that may be evaluated as boolean (true/false), null or numbers, but you want to store them as strings, you can enclose those values in single or double quotes.
 For instance, with
 concrete5 %command.name% set concrete.test_item 1
@@ -170,7 +171,7 @@ EOT
     {
         $default_environment = $config->getEnvironment();
 
-        $environment = $this->option('environment') ?: $default_environment;
+        $environment = $this->option('env') ?: $default_environment;
 
         $file_loader = new FileLoader($filesystem);
         if ($this->option('generated-overrides')) {

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -177,7 +177,7 @@ EOT
         if ($this->option('generated-overrides')) {
             $file_saver = new FileSaver($filesystem);
         } else {
-            $file_saver = new DirectFileSaver($filesystem, $environment == $default_environment ? null : $environment);
+            $file_saver = new DirectFileSaver($filesystem, $environment);
         }
 
         return new Repository($file_loader, $file_saver, $environment);


### PR DESCRIPTION
The config command with the `environment` option doesn't work now as written on the doc.
It can't read or write the proper values. Please check the comments-
https://documentation.concrete5.org/developers-guide/appendix/cli-commands#c5-config

This PR allows you to set the config values with `--env=ENVIRONMENT` option.

I'll update the documentation once it got merged or after release.