### PR TITLE
Fix issue with sitemap generation in multilingual sites

### DIFF
--- a/concrete/src/Page/Sitemap/SitemapGenerator.php
+++ b/concrete/src/Page/Sitemap/SitemapGenerator.php
@@ -345,7 +345,7 @@ class SitemapGenerator
                     $relatedPageID = $relatedSection->getTranslatedPageID($page);
                     if ($relatedPageID) {
                         $relatedPage = Page::getByID($relatedPageID);
-                        if ($relatedPage || $pageListGenerator->canIncludePageInSitemap($relatedPage)) {
+                        if ($relatedPage && $pageListGenerator->canIncludePageInSitemap($relatedPage)) {
                             $relatedUrl = $this->getPageUrl($relatedPage);
                             $sitemapPage->addAlternativeLanguage(new SitemapPageAlternativeLanguage($relatedSection, $relatedPage, $relatedUrl));
                             $addThisPage = true;


### PR DESCRIPTION
In my opinion the OR check in populateLanguageAlternatives() function must change to an AND check in order to respect "exclude_sitemapxml" attribute of related pages (Or better say the whole canIncludePageInSitemap() function). Otherwise it seems that the system allows every related page to be in the sitemap just because it exists without checking if canIncludePageInSitemap functions retrurns true.