### PR TITLE
Fix console service provider test by adding

### DIFF
--- a/tests/tests/Console/ServiceProviderTest.php
+++ b/tests/tests/Console/ServiceProviderTest.php
@@ -6,8 +6,12 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Console\Application as ConsoleApplication;
 use Concrete\Core\Console\ServiceProvider;
 use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Console\Command as ConcreteCommand;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Tools\Console\Command as DBALCommand;
+use Doctrine\DBAL\Migrations\Tools\Console\Command as DBALMigrationCommand;
+use Doctrine\ORM\Tools\Console\Command as ORMCommand;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -44,7 +48,7 @@ class ServiceProviderTest extends PHPUnit_Framework_TestCase
         });
 
         // Setup the extend method
-        $app->shouldReceive('extend')->zeroOrMoreTimes()->andReturnUsing(function ($class, callable $binding) {
+        $app->shouldReceive('extend')->with(ConsoleApplication::class, Mockery::type('callable'))->zeroOrMoreTimes()->andReturnUsing(function ($class, callable $binding) {
             $this->consoleFactory = $binding;
         });
 
@@ -91,19 +95,18 @@ class ServiceProviderTest extends PHPUnit_Framework_TestCase
         $factory = $this->consoleFactory;
         $factory($this->console);
 
-
         $subset = [
-            \Concrete\Core\Console\Command\InfoCommand::class,
-            \Concrete\Core\Console\Command\InstallCommand::class,
-            \Concrete\Core\Console\Command\InstallLanguageCommand::class,
-            \Concrete\Core\Console\Command\TranslatePackageCommand::class,
-            \Concrete\Core\Console\Command\GenerateIDESymbolsCommand::class,
-            \Concrete\Core\Console\Command\ConfigCommand::class,
-            \Concrete\Core\Console\Command\PackPackageCommand::class,
-            \Concrete\Core\Console\Command\ExecCommand::class,
-            \Concrete\Core\Console\Command\ServiceCommand::class,
-            \Concrete\Core\Console\Command\ResetCommand::class,
-            \Concrete\Core\Console\Command\PhpCodingStyleCommand::class,
+            ConcreteCommand\InfoCommand::class,
+            ConcreteCommand\InstallCommand::class,
+            ConcreteCommand\InstallLanguageCommand::class,
+            ConcreteCommand\TranslatePackageCommand::class,
+            ConcreteCommand\GenerateIDESymbolsCommand::class,
+            ConcreteCommand\ConfigCommand::class,
+            ConcreteCommand\PackPackageCommand::class,
+            ConcreteCommand\ExecCommand::class,
+            ConcreteCommand\ServiceCommand::class,
+            ConcreteCommand\ResetCommand::class,
+            ConcreteCommand\PhpCodingStyleCommand::class,
         ];
 
         sort($subset);
@@ -129,61 +132,65 @@ class ServiceProviderTest extends PHPUnit_Framework_TestCase
 
         // Check that the classes we expect have been added
         $subset = [
-            \Concrete\Core\Console\Command\InfoCommand::class,
-            \Concrete\Core\Console\Command\InstallCommand::class,
-            \Concrete\Core\Console\Command\InstallLanguageCommand::class,
-            \Concrete\Core\Console\Command\TranslatePackageCommand::class,
-            \Concrete\Core\Console\Command\GenerateIDESymbolsCommand::class,
-            \Concrete\Core\Console\Command\ConfigCommand::class,
-            \Concrete\Core\Console\Command\PackPackageCommand::class,
-            \Concrete\Core\Console\Command\ExecCommand::class,
-            \Concrete\Core\Console\Command\ServiceCommand::class,
-            \Concrete\Core\Console\Command\ResetCommand::class,
-            \Concrete\Core\Console\Command\PhpCodingStyleCommand::class,
-            \Concrete\Core\Console\Command\CompareSchemaCommand::class,
-            \Concrete\Core\Console\Command\ClearCacheCommand::class,
-            \Concrete\Core\Console\Command\InstallPackageCommand::class,
-            \Concrete\Core\Console\Command\UninstallPackageCommand::class,
-            \Concrete\Core\Console\Command\UpdatePackageCommand::class,
-            \Concrete\Core\Console\Command\InstallThemeCommand::class,
-            \Concrete\Core\Console\Command\BlacklistClear::class,
-            \Concrete\Core\Console\Command\SetDatabaseCharacterSetCommand::class,
-            \Concrete\Core\Console\Command\JobCommand::class,
-            \Concrete\Core\Console\Command\UpdateCommand::class,
-            \Concrete\Core\Console\Command\RescanFilesCommand::class,
-            \Concrete\Core\Console\Command\FillThumbnailsTableCommand::class,
-            \Concrete\Core\Console\Command\GenerateSitemapCommand::class,
-            \Concrete\Core\Console\Command\RefreshEntitiesCommand::class,
-            \Concrete\Core\Console\Command\Express\ExportCommand::class,
-            \Doctrine\DBAL\Tools\Console\Command\ImportCommand::class,
-            \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\GenerateEntitiesCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\RunDqlCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\InfoCommand::class,
-            \Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand::class,
-            \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand::class,
+            ConcreteCommand\InfoCommand::class,
+            ConcreteCommand\InstallCommand::class,
+            ConcreteCommand\InstallLanguageCommand::class,
+            ConcreteCommand\TranslatePackageCommand::class,
+            ConcreteCommand\GenerateIDESymbolsCommand::class,
+            ConcreteCommand\ConfigCommand::class,
+            ConcreteCommand\PackPackageCommand::class,
+            ConcreteCommand\ExecCommand::class,
+            ConcreteCommand\ServiceCommand::class,
+            ConcreteCommand\ResetCommand::class,
+            ConcreteCommand\PhpCodingStyleCommand::class,
+            ConcreteCommand\CompareSchemaCommand::class,
+            ConcreteCommand\ClearCacheCommand::class,
+            ConcreteCommand\InstallPackageCommand::class,
+            ConcreteCommand\UninstallPackageCommand::class,
+            ConcreteCommand\UpdatePackageCommand::class,
+            ConcreteCommand\InstallThemeCommand::class,
+            ConcreteCommand\BlacklistClear::class,
+            ConcreteCommand\SetDatabaseCharacterSetCommand::class,
+            ConcreteCommand\JobCommand::class,
+            ConcreteCommand\UpdateCommand::class,
+            ConcreteCommand\RescanFilesCommand::class,
+            ConcreteCommand\FillThumbnailsTableCommand::class,
+            ConcreteCommand\GenerateSitemapCommand::class,
+            ConcreteCommand\RefreshEntitiesCommand::class,
+            ConcreteCommand\Express\ExportCommand::class,
+            ConcreteCommand\FixDatabaseForeignKeys::class,
+            DBALCommand\ImportCommand::class,
+            DBALCommand\RunSqlCommand::class,
+            ORMCommand\ClearCache\MetadataCommand::class,
+            ORMCommand\ClearCache\QueryCommand::class,
+            ORMCommand\ClearCache\ResultCommand::class,
+            ORMCommand\SchemaTool\CreateCommand::class,
+            ORMCommand\SchemaTool\UpdateCommand::class,
+            ORMCommand\SchemaTool\DropCommand::class,
+            ORMCommand\EnsureProductionSettingsCommand::class,
+            ORMCommand\ConvertDoctrine1SchemaCommand::class,
+            ORMCommand\GenerateRepositoriesCommand::class,
+            ORMCommand\GenerateEntitiesCommand::class,
+            ORMCommand\GenerateProxiesCommand::class,
+            ORMCommand\ConvertMappingCommand::class,
+            ORMCommand\RunDqlCommand::class,
+            ORMCommand\ValidateSchemaCommand::class,
+            ORMCommand\InfoCommand::class,
+            ORMCommand\MappingDescribeCommand::class,
+            DBALMigrationCommand\DiffCommand::class,
+            DBALMigrationCommand\ExecuteCommand::class,
+            DBALMigrationCommand\GenerateCommand::class,
+            DBALMigrationCommand\MigrateCommand::class,
+            DBALMigrationCommand\StatusCommand::class,
+            DBALMigrationCommand\VersionCommand::class,
         ];
 
         sort($subset);
         sort($this->addedClasses);
 
-        $this->assertArraySubset($subset, $this->addedClasses);
+        $added = $this->addedClasses;
+        $discrepency = implode(', ', array_diff($this->addedClasses, array_replace_recursive($added, $subset)));
+
+        $this->assertEquals('', $discrepency, 'Command subset doesn\'t match.');
     }
 }


### PR DESCRIPTION
This PR does a few extra things:
1. Fixes service provider test by adding the missing `FixDatabaseForeignKeys` command
2. Makes the `app->extend` mock a little more robust so that it might catch more failures
3. Aliases different types of command namespaces to make it easier to see what's what at a glance
4. Modifies the assert so that the discrepancies are reported rather than just the whole subset being outputted