### PR TITLE
supporting single action controllers

### DIFF
--- a/concrete/src/Routing/RouteActionFactory.php
+++ b/concrete/src/Routing/RouteActionFactory.php
@@ -26,6 +26,7 @@ class RouteActionFactory implements RouteActionFactoryInterface
         $method = null;
         if (is_string($action)) {
             list($class, $method) = explode('::', $action);
+            $method = $method ?: '__invoke';
         } else {
             $class = $action[0];
             $method = $action[1];


### PR DESCRIPTION
What about supporting single action controllers?
```
Route::register('/testpath', 'Application\Fruit');
// OR:
use Application\Fruit;
Route::register('/testpath', Fruit::class);
```

https://laravel.com/docs/5.7/controllers#single-action-controllers