### PR TITLE
[v8] Implement Clear-Site-Data header after a successful login

### DIFF
--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -226,6 +226,17 @@ class Login extends PageController implements LoggerAwareInterface
             $pll = $this->app->make(PostLoginLocation::class);
             $response = $pll->getPostLoginRedirectResponse(true);
 
+            // Expire the site cache in the logged in user's browser to avoid
+            // their full page cache serving local cached versions of the pages
+            // as they are now logged in and should probably see extra elements
+            // on the pages.
+            //
+            // Unfortunately this does not work in all browsers for insecure
+            // origins by default and you may see an error in the browser
+            // console. To get it to work, see the following e.g. in Chrome:
+            // chrome://flags/#unsafely-treat-insecure-origin-as-secure
+            $response->headers->set('Clear-Site-Data', '"cache"');
+
             return $response;
         } else {
             $session = $this->app->make('session');

--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Controller\SinglePage;
 
 use Concrete\Core\Authentication\AuthenticationType;
@@ -19,7 +18,6 @@ use UserInfo;
 
 class Login extends PageController implements LoggerAwareInterface
 {
-
     use LoggerAwareTrait;
 
     public function getLoggerChannel()
@@ -149,8 +147,7 @@ class Login extends PageController implements LoggerAwareInterface
     public function finishAuthentication(
         AuthenticationType $type,
         User $u
-    )
-    {
+    ) {
         $this->app->instance(User::class, $u);
         if (!$type || !($type instanceof AuthenticationType)) {
             return $this->view();
@@ -290,7 +287,6 @@ class Login extends PageController implements LoggerAwareInterface
 
     /**
      * @deprecated Use the getPostLoginUrl method of \Concrete\Core\User\PostLoginLocation
-     *
      * @see \Concrete\Core\User\PostLoginLocation::getPostLoginUrl()
      *
      * @return string
@@ -305,7 +301,6 @@ class Login extends PageController implements LoggerAwareInterface
 
     /**
      * @deprecated Use the getSessionPostLoginUrl method of \Concrete\Core\User\PostLoginLocation
-     *
      * @see \Concrete\Core\User\PostLoginLocation::getSessionPostLoginUrl()
      *
      * @return string|false

--- a/tests/tests/Controller/SinglePage/LoginTest.php
+++ b/tests/tests/Controller/SinglePage/LoginTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Concrete\Tests\Controller\SinglePage;
+
+use Concrete\Core\Authentication\AuthenticationType;
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Encryption\PasswordHasher;
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ServerInterface;
+use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Permission\Access\Access;
+use Concrete\Core\Permission\Access\Entity\Type as AccessEntityType;
+use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
+use Concrete\Core\Permission\Category as PermissionCategory;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Validation\CSRF\Token as CSRFToken;
+use Concrete\Core\User\UserInfo;
+use Concrete\TestHelpers\Page\PageTestCase;
+use Core;
+use Doctrine\ORM\EntityManagerInterface;
+use Group;
+
+class LoginTest extends PageTestCase
+{
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        // General
+        $this->tables[] = 'Config';
+        // Pages
+        $this->tables[] = 'PageThemeCustomStyles';
+        // Files
+        $this->tables[] = 'FileImageThumbnailPaths';
+        // Users & permissions
+        $this->tables[] = 'UserGroups';
+        $this->tables[] = 'Groups';
+        $this->tables[] = 'TreeTypes';
+        $this->tables[] = 'TreeNodes';
+        $this->tables[] = 'TreeNodePermissionAssignments';
+        $this->tables[] = 'AreaPermissionAssignments';
+        $this->tables[] = 'PermissionAccess';
+        $this->tables[] = 'PermissionAccessEntities';
+        $this->tables[] = 'PermissionAccessEntityGroups';
+        $this->tables[] = 'PermissionAccessList';
+        $this->tables[] = 'PermissionKeyCategories';
+        $this->tables[] = 'PermissionKeys';
+        $this->tables[] = 'TreeNodeTypes';
+        $this->tables[] = 'Trees';
+        $this->tables[] = 'TreeGroupNodes';
+        // Logging in/out the users
+        $this->tables[] = 'AuthenticationTypes';
+        // Blocks
+        $this->tables[] = 'BlockTypes';
+        $this->tables[] = 'Blocks';
+        // Stacks
+        $this->tables[] = 'Stacks';
+
+        // Users
+        $this->metadatas[] = 'Concrete\Core\Entity\User\User';
+        $this->metadatas[] = 'Concrete\Core\Entity\User\UserSignup';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Category';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Key';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\UserValue';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\UserKey';
+        // Permissions
+        $this->metadatas[] = 'Concrete\Core\Entity\Permission\IpAccessControlCategory';
+        $this->metadatas[] = 'Concrete\Core\Entity\Permission\IpAccessControlRange';
+        // Blocks
+        $this->metadatas[] = 'Concrete\Core\Entity\Block\BlockType\BlockType';
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        Category::add('user');
+        Category::add('collection');
+        AccessEntityType::add('page_owner', 'Page Owner');
+        AccessEntityType::add('group', 'Group');
+        PermissionCategory::add('page');
+        PermissionKey::add('page', 'view_page', 'View Page', '', 0, 0);
+        PermissionKey::add('page', 'view_page_versions', 'View Page Versions', '', 0, 0);
+        PermissionKey::add('page', 'edit_page_contents', 'Edit Page Contents', '', 0, 0);
+        PermissionKey::add('page', 'edit_page_properties', 'Edit Page Properties', '', 0, 0);
+
+        AuthenticationType::add('concrete', 'Concrete');
+        $login = SinglePage::add('/login');
+
+        $guest = Group::add('Guest', '');
+
+        $login->setPermissionsToManualOverride();
+
+        $pk = PermissionKey::getByHandle('view_page');
+        $pk->setPermissionObject($login);
+        $pt = $pk->getPermissionAssignmentObject();
+        $pt->clearPermissionAssignment();
+        $pa = Access::create($pk);
+        $pa->addListItem(GroupPermissionAccessEntity::getOrCreate($guest));
+        $pt->assignPermissionAccess($pa);
+
+        $em = Core::make(EntityManagerInterface::class);
+        $category = new IpAccessControlCategory();
+        $category
+            ->setHandle('failed_login')
+            ->setName('Failed Login Attempts')
+            ->setEnabled(true)
+            ->setMaxEvents(5)
+            ->setTimeWindow(300)
+            ->setBanDuration(600)
+            ->setSiteSpecific(false)
+            ->setPackage(null)
+        ;
+        $em->persist($category);
+    }
+
+    public function testConcreteLogin()
+    {
+        $password = 'Sup3r$S3cur3#P4ss';
+        $hasher = Core::make(PasswordHasher::class);
+        $admin = UserInfo::addSuperUser(
+            $hasher->hashPassword($password),
+            'admin@example.org'
+        );
+
+        $token = Core::make('helper/validation/token')->generate('login_concrete');
+        $request = Request::create(
+            'http://www.dummyco.com/login/authenticate/concrete',
+            'POST',
+            [
+                'uName' => 'admin',
+                'uPassword' => $password,
+                CSRFToken::DEFAULT_TOKEN_NAME => $token,
+            ]
+        );
+        // Make the request variables available through the PHP defaults that
+        // concrete5 controllers are using
+        $request->overrideGlobals();
+
+        // This is (yet again) just for the sake of c5's "awesome" testing
+        // framework...
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $server = Core::make(ServerInterface::class);
+        $response = $server->handleRequest($request);
+
+        $this->assertEquals($response->getStatusCode(), 302);
+        $this->assertEquals(
+            $response->headers->get('Location'),
+            'http://www.dummyco.com/path/to/server/index.php/login/login_complete'
+        );
+
+        // Create the after redirect request
+        $request = Request::create(
+            'http://www.dummyco.com/login/login_complete',
+            'GET',
+            [],
+            $response->headers->getCookies()
+        );
+        // Make the request variables available through the PHP defaults that
+        // concrete5 controllers are using
+        $request->overrideGlobals();
+
+        // This is (yet again) just for the sake of c5's "awesome" testing
+        // framework...
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $response = $server->handleRequest($request);
+
+        $this->assertEquals($response->getStatusCode(), 302);
+        $this->assertEquals(
+            $response->headers->get('Location'),
+            'http://www.dummyco.com/path/to/server/index.php'
+        );
+
+        // Ensure that the "Clear-Site-Data" header is sent
+        $this->assertEquals(
+            $response->headers->get('Clear-Site-Data'),
+            '"cache"'
+        );
+    }
+}

--- a/tests/tests/Controller/SinglePage/LoginTest.php
+++ b/tests/tests/Controller/SinglePage/LoginTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Concrete\Tests\Controller\SinglePage;
 
 use Concrete\Core\Authentication\AuthenticationType;


### PR DESCRIPTION
As described in #8434, this implements the `Clear-Site-Data` header after the login.

Please note that at least with Chrome, this only works for secured connections, so make sure your site is running under `https` to test this. It will only work then.

Alternatively, you could try marking your development domain as secure (may or may not work):
chrome://flags/#unsafely-treat-insecure-origin-as-secure

## Steps to test

1. Configure your website to be served through HTTPS
2. Install concrete5 in that domain
3. Enable full page caching in all cases
4. Browse through all the main pages of your website (and take note of the pages you've visited)
5. Login as admin
6. You should now see the editing controls on top of the page without force refreshing the page. Visit all the pages you visited as logged out user in step 4. in order to confirm this.