### PR TITLE
[v8] Fix #8308 non-chunked file uploads directly dropped to dropzones

### DIFF
--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -644,7 +644,7 @@ EOT
         $content .= 'Dropzone.prototype.defaultOptions.defaultParams = Dropzone.prototype.defaultOptions.params;' . "\n";
         $content .= <<<EOT
 Dropzone.prototype.defaultOptions.params = function(files, xhr, chunk) {
-    var params = this.options.defaultParams.call(this, files, xhr, chunk);
+    var params = this.options.defaultParams.call(this, files, xhr, chunk) || {};
     var extraParams = {$extraParamsString};
 
     var keys = Object.keys(extraParams);


### PR DESCRIPTION
Related to #8309 
Original issue #8308 

This fixes a bug caused by #8309 with non-chunked file uploads that are directly dropped to the dropzones.

The issue is further explained in this comment in the original pull request:
https://github.com/concrete5/concrete5/pull/8309#issuecomment-594708442