### PR TITLE
Add the authentication directory to the multilingual extractor

### DIFF
--- a/concrete/src/Multilingual/Service/Extractor.php
+++ b/concrete/src/Multilingual/Service/Extractor.php
@@ -39,6 +39,7 @@ class Extractor
         $configFilesParser->parseDirectory(DIR_BASE, '', $translations);
 
         $processApplication = [
+            DIRNAME_AUTHENTICATION => [$phpParser],
             DIRNAME_BLOCKS => [$phpParser, $blockTemplatesParser],
             DIRNAME_ELEMENTS => [$phpParser],
             DIRNAME_CONTROLLERS => [$phpParser],


### PR DESCRIPTION
Now, concrete5 doesn't translate the files in the `application/authentication` directory. 
How about adding this directory to `multilingual/extractor`?