### PR TITLE
Potential YouTube block expection

### DIFF
--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -38,14 +38,13 @@ class Controller extends BlockController
     {
         $url = parse_url($this->videoURL);
         $pathParts = explode('/', rtrim($url['path'], '/'));
-        parse_str($url['query'], $params);
         $videoID = end($pathParts);
         $playListID = '';
 
-        if (isset($url['query'])) {
+        if (isset($url['query']) === true) {
             parse_str($url['query'], $query);
-
-            if (isset($query['list'])) {
+            
+            if (isset($query['list']) === true) {
                 $playListID = $query['list'];
                 $videoID = '';
             } else {
@@ -66,8 +65,8 @@ class Controller extends BlockController
 
         if ($this->startTimeEnabled == 1 && ($this->startTime === '0' || $this->startTime)) {
             $this->set('startSeconds', $this->convertStringToSeconds($this->startTime));
-        } elseif (!empty($params['t'])) {
-            $this->set('startSeconds', $this->convertStringToSeconds($params['t']));
+        } elseif (isset($query['t']) === true && empty($query['t']) === false) {
+            $this->set('startSeconds', $this->convertStringToSeconds($query['t']));
         }
 
         $this->set('videoID', $videoID);


### PR DESCRIPTION
If a url is passed with no params then ```parse_str($url['query'], $query)``` will throw an exception message as isset is not called before hand. This PR fixes that but also cleans up the code to remove duplication and stricter standards.