### PR TITLE
make `c5:package:uninstall --trash` not throw exception if there wasn't a problem

### DIFF
--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -78,7 +78,7 @@ EOT
         if ($input->getOption('trash')) {
             $output->write('Moving package to trash... ');
             $r = $pkg->backup();
-            if (get_class($r) === ErrorList::class) {
+            if ($r instanceof ErrorList) {
                 throw new Exception(implode("\n", $r->getList()));
             }
             $output->writeln('<info>done.</info>');

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Console\ConsoleAwareInterface;
+use Concrete\Core\Error\ErrorList\ErrorList;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -77,7 +78,7 @@ EOT
         if ($input->getOption('trash')) {
             $output->write('Moving package to trash... ');
             $r = $pkg->backup();
-            if (is_object($r)) {
+            if (get_class($r) === ErrorList::class) {
                 throw new Exception(implode("\n", $r->getList()));
             }
             $output->writeln('<info>done.</info>');


### PR DESCRIPTION
`Concrete\Core\Package\Package::backup()` always returns an object - see https://github.com/concrete5/concrete5/blob/develop/concrete/src/Package/Package.php#L852. Thus, issuing the CLI command to uninstall a package with the `--trash` flag set results in an exception being output to the screen even when everything worked just great. This small change fixes that.