### PR TITLE
[v9] Ask webpack to not resolve symlinks

### DIFF
--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -3,6 +3,9 @@
  */
 let mix = require('laravel-mix');
 mix.webpackConfig({
+    resolve: {
+        symlinks: false
+    },
     externals: {
         jquery: 'jQuery'
     }


### PR DESCRIPTION
This allows developing npm modules (like @concretecms/bedrock) wyth a simple `npm link`

Here's my setup:
1. clone the concrete5 repository (I cloned in to `C:\Dev\Projects\concrete5\concrete5`)
2. install the NPM dependencies:
    ```
    cd build
    npm install
    ```
3. clone the bedrock repository (I cloned in to `C:\Dev\Projects\concrete5\bedrock`)
4. From inside the `build` directory of concrete5, run this command:
    ```
    npm link ..\..\bedrock
    ```

With the change in this pull request, running `npm run prod` seems to correctly generate the assets, without resolution-related issues.