### PR TITLE
Fix importing NProgress

### DIFF
--- a/build/assets/themes/concrete/js/main.js
+++ b/build/assets/themes/concrete/js/main.js
@@ -2,7 +2,7 @@ import * as FrontendBase from '@concretecms/bedrock/assets/bedrock/js/frontend';
 import LoginTabs from './login-tabs';
 //import BackgroundImage from './background-image';
 
-import NProgress from 'NProgress';
+import NProgress from 'nprogress';
 window.NProgress = NProgress;
 
 $('.launch-tooltip').tooltip({


### PR DESCRIPTION
On case-sensitive operating systems, we have this error:
```
ERROR in ./assets/themes/concrete/js/main.js
Module not found: Error: Can't resolve 'NProgress'
```

Let's fix this
