### PR TITLE
Speedup Login

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -42,7 +42,7 @@ class Controller extends AuthenticationTypeController
         }
         $hasher = $this->app->make(PasswordHasher::class);
         $db = $this->app->make(Connection::class);
-        foreach ($db->fetchAll('select token from authTypeConcreteCookieMap WHERE uID = ?', [$authCookie->getUserID()]) as $row) {
+        foreach ($db->fetchAll('select token from authTypeConcreteCookieMap WHERE uID = ? ORDER BY validThrough DESC', [$authCookie->getUserID()]) as $row) {
             if ($hasher->checkPassword($authCookie->getToken(), $row['token'])) {
                 $db->delete('authTypeConcreteCookieMap', ['uID' => $authCookie->getUserID(), 'token' => $row['token']]);
             }
@@ -60,7 +60,7 @@ class Controller extends AuthenticationTypeController
         $db = $this->app->make(Connection::class);
         $hasher = $this->app->make(PasswordHasher::class);
         $validRow = null;
-        foreach ($db->fetchAll('select validThrough, token from authTypeConcreteCookieMap WHERE uID = ?', [$uID]) as $row) {
+        foreach ($db->fetchAll('select validThrough, token from authTypeConcreteCookieMap WHERE uID = ? ORDER BY validThrough DESC', [$uID]) as $row) {
             if ($hasher->checkPassword($hash, $row['token'])) {
                 $validRow = $row;
                 break;


### PR DESCRIPTION
I faced a problem that login & logout are very slow (taking 6-7 seconds for each). The root cause was the use of deprecated logout() function instead of do_logout(), and too many hashed authcookie data remained in the database. Each hashed data needs 200ms for examination, in my environment.

The straight-forward solution is to clean up authTypeConcreteCookieMap table and to use  do_logout(), but many free theme in concrete5.org still don't use do_logout. I believe this trouble should be handled in other ways.

I suggest to check the stored hash in the descending order, so that the newer hash is examined earlier. In my case, the login time became from 7sec to 200ms, because there were needless 34 data.

![Very slow login](https://user-images.githubusercontent.com/19790582/77842539-73e7e380-71ce-11ea-97d5-bf622374e3b5.png)

