### PR TITLE
Form service / select doesn't escape by default: fixed

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -461,7 +461,7 @@ class Form
                 if ((string) $k === (string) $selectedValue) {
                     $str .= ' selected="selected"';
                 }
-                $str .= '>' . $text . '</option>';
+                $str .= '>' . h($text) . '</option>';
             }
         }
         $str .= '</select>';


### PR DESCRIPTION
This pull request fixes #7391 
I simply used t() function to escape values passed on to $form->select() function.