### PR TITLE
Rebuild assets v9 part2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 
     - name: Rebuild JS assets
       language: node_js
-      node_js: '10'
+      node_js: '12'
       before_script:
         - ./.travis/setup-build.sh
       script:

--- a/.travis/rebuild-assets.sh
+++ b/.travis/rebuild-assets.sh
@@ -50,16 +50,20 @@ To create it:
     exit 0
 fi
 
-printf '%s: checking out %s\n' "$AUTO_COMMIT_NAME_BASE" "$TRAVIS_BRANCH"
-cd "$TRAVIS_BUILD_DIR"
-git checkout -qf "$TRAVIS_BRANCH"
-
 printf '%s: building assets\n' "$AUTO_COMMIT_NAME_BASE"
 cd "$TRAVIS_BUILD_DIR/build"
 npm run prod
 
 printf '%s: checking changes\n' "$AUTO_COMMIT_NAME_BASE"
 CHANGES_DETECTED=0
+cd "$TRAVIS_BUILD_DIR/build"
+if test -n "$(git status --porcelain ./package-lock.json)"; then
+    printf -- '- changes detected in package-lock.json file\n'
+    git add --all .
+    CHANGES_DETECTED=1
+else
+    printf -- '- no changes in package-lock.json file\n'
+fi
 cd "$TRAVIS_BUILD_DIR/concrete/css"
 if test -n "$(git status --porcelain .)"; then
     printf -- '- changes detected in CSS assets\n'

--- a/.travis/setup-build.sh
+++ b/.travis/setup-build.sh
@@ -4,9 +4,30 @@ set -o errexit
 
 source "$( dirname "${BASH_SOURCE[0]}" )/travis_retry.sh"
 
+cd "$TRAVIS_BUILD_DIR/build"
+
+case "$TRAVIS_EVENT_TYPE" in
+    push)
+        echo "Checking out branch '$TRAVIS_BRANCH'"
+        git checkout -qf "$TRAVIS_BRANCH"
+        echo 'Installing Node packages as per package-lock.json file'
+        travis_retry npm ci
+        echo 'Updating bedrock to the latest commit in the default branch'
+        npm install https://github.com/concrete5/bedrock.git
+        ;;
+    pull_request)
+        echo 'Installing Node packages as per package-lock.json file'
+        travis_retry npm ci
+        PULL_REQUEST_AUTHOR="${TRAVIS_PULL_REQUEST_SLUG%%/*}"
+        printf "Check if there's a '%s' branch for a bedrock repository owned by user '%s'... " "$TRAVIS_PULL_REQUEST_BRANCH" "$PULL_REQUEST_AUTHOR"
+        if test -n "$(git ls-remote --heads "https://github.com/$PULL_REQUEST_AUTHOR/bedrock.git" "$$TRAVIS_PULL_REQUEST_BRANCH")"; then
+            printf 'found! Using it.\n'
+            npm install "https://github.com/$PULL_REQUEST_AUTHOR/bedrock.git#$TRAVIS_PULL_REQUEST_BRANCH"
+        else
+            printf 'not found.\n'
+        fi
+        ;;
+esac
+
 echo 'Installing Grunt'
 travis_retry npm -g install grunt
-
-echo 'Installing Node packages'
-cd "$TRAVIS_BUILD_DIR/build"
-travis_retry npm ci


### PR DESCRIPTION
In version 9, concrete5 assets are handled in the [`bedrock`](https://github.com/concrete5/bedrock) repository.

So, when we update the assets in the `concrete5` repository, we need to do some extra work:

1. **when there's a pull request**  
  we may need to fetch a `bedrock` branch owned by the user, with the same name as the branch that originated the pull request) (see the [docs](https://documentation.concrete5.org/tutorials/submitting-user-interface-pull-requests-for-concrete5-version-9)).
1. **we push to the concrete5 repository** (for example, when a pull request gets merged)
   in this case we need to use the latest version of the bedrock `master` branch.
