### PR TITLE
Check the right permission when change calendar perms

### DIFF
--- a/concrete/controllers/event/permissions.php
+++ b/concrete/controllers/event/permissions.php
@@ -52,7 +52,7 @@ class Permissions extends \Concrete\Core\Controller\Controller
 
     public function processCalendar()
     {
-        $calendar = Calendar::getByID($this->request->request->get('caID'));
+        $calendar = Calendar::getByID($this->request->get('caID'));
         $cp = new \Permissions($calendar);
         if ($cp->canEditCalendarPermissions()) {
             if ($_REQUEST['task'] == 'add_access_entity' && \Loader::helper("validation/token")->validate('add_access_entity')) {

--- a/concrete/elements/permission/details/calendar.php
+++ b/concrete/elements/permission/details/calendar.php
@@ -11,5 +11,5 @@ $pk->setPermissionObject($calendar);
 <?php Loader::element("permission/detail", array('permissionKey' => $pk)); ?>
 
 <script type="text/javascript">
-    var ccm_permissionDialogURL = '<?=URL::to("/ccm/calendar/dialogs/permissions", "calendar")?>';
+    var ccm_permissionDialogURL = '<?=URL::to("/ccm/calendar/dialogs/permissions", "calendar")?>?caID=<?= $calendar->getID() ?>';
 </script>

--- a/concrete/elements/permission/details/calendar_admin.php
+++ b/concrete/elements/permission/details/calendar_admin.php
@@ -7,5 +7,5 @@ defined('C5_EXECUTE') or die("Access Denied.");
 <?php Loader::element("permission/detail", array('permissionKey' => $pk)); ?>
 
 <script type="text/javascript">
-var ccm_permissionDialogURL = '<?=URL::to("/ccm/calendar/dialogs/permissions", "calendar")?>';
+var ccm_permissionDialogURL = '<?=URL::to("/ccm/calendar/dialogs/permissions", "calendar")?>?caID=<?= $calendar->getID() ?>';
 </script>

--- a/concrete/views/dialogs/permissions/calendar.php
+++ b/concrete/views/dialogs/permissions/calendar.php
@@ -1,7 +1,10 @@
 <?php
 
 defined('C5_EXECUTE') or die("Access Denied.");
-$p = new Permissions();
-if ($p->canAccessTaskPermissions()) {
+
+$checker = new \Concrete\Core\Permission\Checker($calendar);
+if ($checker->canEditCalendarPermissions()) {
     Loader::element('permission/details/calendar', array('calendar' => $calendar));
+} else {
+    echo t('You do not have permission to edit this calendar');
 }


### PR DESCRIPTION
We were checking the 'access task permissions' permission, instead let's check whether you can edit permissions for the specific calendar.

Fixes #8412 