### PR TITLE
Fix: new folder modal

### DIFF
--- a/concrete/elements/files/search_header.php
+++ b/concrete/elements/files/search_header.php
@@ -54,7 +54,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                     <i class="fa fa-share"></i> <?=t('Jump to Folder')?>
                 </a>
             </li>
-            <li><a href="#" data-launch-dialog="add-file-manager-folder"><i class="fa fa-folder-o"></i> <?=t('New Folder')?></a></li>
+            <li><a href="#" data-dialog="add-file-manager-folder"><i class="fa fa-folder-o"></i> <?=t('New Folder')?></a></li>
             <li><a href="#" id="ccm-file-manager-upload" data-dialog="add-files"><i class="fa fa-upload"></i> <?=t('Upload Files')?></a></li>
         </ul>
     </form>


### PR DESCRIPTION
DOM and JS was changed in #7658 but this attribute name was not changed with the rest (from `data-launch-dialog` to `data-dialog`). Consequentially, the new folder modal doesn't work.

This change corrects the attribute name to match the selector in the JS
