### PR TITLE
Fix file-manager drag and drop not working anymore

### DIFF
--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -108,7 +108,7 @@
             });
 
             my.$element.find('tr[data-file-manager-tree-node-type=file_folder], ol[data-search-navigation=breadcrumb] a[data-file-manager-tree-node]').droppable({
-                accept: '.ccm-search-results-folder, .ccm-search-results-file',
+                accept: 'tr[data-file-manager-file], tr[data-file-manager-folder]',
                 tolerance: 'pointer',
                 hoverClass: 'ccm-search-select-active-droppable',
                 drop: function(event, ui) {


### PR DESCRIPTION
the file-manager class names for results are no longer working on the helper function. Im going to assume it was something else was changed or browser behaviour between #8275 being created/merged and now. Because it worked when it was created

This changes the class finder so we don't rely on the helper classes and instead allow the actual element to be passed