### PR TITLE
Fix disabling Job Set scheduling

### DIFF
--- a/concrete/src/Job/Set.php
+++ b/concrete/src/Job/Set.php
@@ -245,7 +245,7 @@ class Set extends ConcreteObject
         if ($this->getJobSetID()) {
             $db = Loader::db();
             $db->query("UPDATE JobSets SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jsID = ?",
-            array($this->isScheduled, $this->scheduledInterval, $this->scheduledValue, $this->getJobSetID()));
+            array($this->isScheduled ? 1 : 0, $this->scheduledInterval, $this->scheduledValue, $this->getJobSetID()));
 
             return true;
         } else {


### PR DESCRIPTION
If we schedule a Job Set to be executed after web visits, and we disable it, we have this exception: 

```
An exception occurred while executing
'UPDATE JobSets SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jsID = ?'
with params
[false, "weeks", "1", "7"]
SQLSTATE[22007]
Invalid datetime format: 1366 Incorrect integer value: '' for column `JobSets`.`isScheduled` at row 1
```

I think it's because I have `NO_ENGINE_SUBSTITUTION` in the `sql_mode` of my MySQL installation (which is the default for recent MySQL/MariaDB versons).
This change fixes this issie.