### PR TITLE
Allow textarea and input elements without id or name

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -249,7 +249,13 @@ class Form
             $value = $requestValue;
         }
 
-        return '<textarea id="' . $key . '" name="' . $key . '"' . $this->parseMiscFields('form-control', $miscFields) . '>' . $value . '</textarea>';
+        $result = '<textarea';
+        if ((string) $key !== '') {
+            $result .= ' id="' . $key . '" name="' . $key . '"';
+        }
+        $result .= $this->parseMiscFields('form-control', $miscFields) . '>' . $value . '</textarea>';
+
+        return $result;
     }
 
     /**
@@ -723,7 +729,13 @@ EOT;
         }
         $value = h($value);
 
-        return "<input type=\"$type\" id=\"$key\" name=\"$key\" value=\"$value\"" . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
+        $result = "<input type=\"$type\"";
+        if ((string) $key !== '') {
+            $result .= " id=\"$key\" name=\"$key\"";
+        }
+        $result .= " value=\"$value\"" . $this->parseMiscFields("form-control ccm-input-$type", $miscFields) . ' />';
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
We may need to output a form element (`<input />` or `<textarea />`), just for displaying a value. Thus, we should be able to skip specifying element names/ids.