### PR TITLE
Changed html markup of all calendar related dashboard pages to bootst…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -222,27 +222,27 @@
         },
         {
             "name": "commerceguys/addressing",
-            "version": "v1.0.6",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/commerceguys/addressing.git",
-                "reference": "8aac9af11d38c1abe04a5e4a252d5a6740b2b69a"
+                "reference": "fa434c03e99a416de0b37d98068c6c0bdfd78cde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/8aac9af11d38c1abe04a5e4a252d5a6740b2b69a",
-                "reference": "8aac9af11d38c1abe04a5e4a252d5a6740b2b69a",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/fa434c03e99a416de0b37d98068c6c0bdfd78cde",
+                "reference": "fa434c03e99a416de0b37d98068c6c0bdfd78cde",
                 "shasum": ""
             },
             "require": {
                 "doctrine/collections": "~1.0",
-                "php": ">=5.5.0"
+                "php": ">=7.0.8"
             },
             "require-dev": {
                 "mikey179/vfsstream": "1.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^6.0",
                 "squizlabs/php_codesniffer": "2.*",
-                "symfony/validator": ">=3.2"
+                "symfony/validator": "^3.4"
             },
             "suggest": {
                 "symfony/validator": "to validate addresses"
@@ -277,7 +277,7 @@
                 "localization",
                 "postal"
             ],
-            "time": "2019-10-21T14:31:17+00:00"
+            "time": "2020-01-24T16:21:06+00:00"
         },
         {
             "name": "concrete5/dependency-patches",
@@ -339,9 +339,9 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "role": "author",
                     "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io"
+                    "homepage": "https://mlocati.github.io",
+                    "role": "author"
                 }
             ],
             "description": "Patches required for concrete5 dependencies",
@@ -636,20 +636,21 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.8.0",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc"
+                "reference": "b9d758e831c70751155c698c2f7df4665314a1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/904dca4eb10715b92569fbcd79e201d5c349b6bc",
-                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b9d758e831c70751155c698c2f7df4665314a1cb",
+                "reference": "b9d758e831c70751155c698c2f7df4665314a1cb",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
                 "php": "^7.1"
             },
             "require-dev": {
@@ -659,7 +660,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.9.x-dev"
                 }
             },
             "autoload": {
@@ -700,7 +701,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2019-10-01T18:55:10+00:00"
+            "time": "2020-04-20T09:18:32+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -939,16 +940,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8"
+                "reference": "aab745e7b6b2de3b47019da81e7225e14dcfdac8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
-                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/aab745e7b6b2de3b47019da81e7225e14dcfdac8",
+                "reference": "aab745e7b6b2de3b47019da81e7225e14dcfdac8",
                 "shasum": ""
             },
             "require": {
@@ -960,9 +961,11 @@
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
                 "jetbrains/phpstorm-stubs": "^2019.1",
-                "phpstan/phpstan": "^0.11.3",
+                "nikic/php-parser": "^4.4",
+                "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^8.4.1",
-                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+                "vimeo/psalm": "^3.11"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1027,7 +1030,7 @@
                 "sqlserver",
                 "sqlsrv"
             ],
-            "time": "2020-01-04T12:56:21+00:00"
+            "time": "2020-04-20T17:19:26+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -1365,16 +1368,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.7.0",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62"
+                "reference": "dafe298ce5d0b995ebe1746670704c0a35868a6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/4d763ca4c925f647b248b9fa01b5f47aa3685d62",
-                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/dafe298ce5d0b995ebe1746670704c0a35868a6a",
+                "reference": "dafe298ce5d0b995ebe1746670704c0a35868a6a",
                 "shasum": ""
             },
             "require": {
@@ -1387,6 +1390,7 @@
                 "doctrine/instantiator": "^1.3",
                 "doctrine/persistence": "^1.2",
                 "ext-pdo": "*",
+                "ocramius/package-versions": "^1.2",
                 "php": "^7.1",
                 "symfony/console": "^3.0|^4.0|^5.0"
             },
@@ -1444,20 +1448,20 @@
                 "database",
                 "orm"
             ],
-            "time": "2019-11-19T08:38:05+00:00"
+            "time": "2020-03-19T06:41:02+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "1.3.5",
+            "version": "1.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "be70c016fdcd44a428405ee062ebcdd01a6867cd"
+                "reference": "0af483f91bada1c9ded6c2cfd26ab7d5ab2094e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/be70c016fdcd44a428405ee062ebcdd01a6867cd",
-                "reference": "be70c016fdcd44a428405ee062ebcdd01a6867cd",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/0af483f91bada1c9ded6c2cfd26ab7d5ab2094e0",
+                "reference": "0af483f91bada1c9ded6c2cfd26ab7d5ab2094e0",
                 "shasum": ""
             },
             "require": {
@@ -1465,7 +1469,7 @@
                 "doctrine/cache": "^1.0",
                 "doctrine/collections": "^1.0",
                 "doctrine/event-manager": "^1.0",
-                "doctrine/reflection": "^1.0",
+                "doctrine/reflection": "^1.2",
                 "php": "^7.1"
             },
             "conflict": {
@@ -1527,20 +1531,20 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2020-01-14T18:44:12+00:00"
+            "time": "2020-03-21T15:13:52+00:00"
         },
         {
             "name": "doctrine/reflection",
-            "version": "v1.1.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/reflection.git",
-                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c"
+                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/reflection/zipball/bc420ead87fdfe08c03ecc3549db603a45b06d4c",
-                "reference": "bc420ead87fdfe08c03ecc3549db603a45b06d4c",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/55e71912dfcd824b2fdd16f2d9afe15684cfce79",
+                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79",
                 "shasum": ""
             },
             "require": {
@@ -1561,7 +1565,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1605,20 +1609,20 @@
                 "reflection",
                 "static"
             ],
-            "time": "2020-01-08T19:53:19+00:00"
+            "time": "2020-03-27T11:06:43+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "1.2.16",
+            "version": "1.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "92fd7ea285f1edd1503d78f75b8d8992b0fb3941"
+                "reference": "19674b35a0a3456be1b96e137098d31ed386fb61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/92fd7ea285f1edd1503d78f75b8d8992b0fb3941",
-                "reference": "92fd7ea285f1edd1503d78f75b8d8992b0fb3941",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/19674b35a0a3456be1b96e137098d31ed386fb61",
+                "reference": "19674b35a0a3456be1b96e137098d31ed386fb61",
                 "shasum": ""
             },
             "require": {
@@ -1653,7 +1657,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-12-30T08:17:06+00:00"
+            "time": "2020-04-11T12:59:45+00:00"
         },
         {
             "name": "filp/whoops",
@@ -1837,23 +1841,24 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.2",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82"
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/43ece0e75098b7ecd8d13918293029e555a50f82",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5"
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.11"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -1861,7 +1866,6 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
@@ -1900,7 +1904,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-12-23T11:57:10+00:00"
+            "time": "2020-04-18T10:38:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2461,16 +2465,16 @@
         },
         {
             "name": "kylekatarnls/update-helper",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kylekatarnls/update-helper.git",
-                "reference": "5786fa188e0361b9adf9e8199d7280d1b2db165e"
+                "reference": "429be50660ed8a196e0798e5939760f168ec8ce9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kylekatarnls/update-helper/zipball/5786fa188e0361b9adf9e8199d7280d1b2db165e",
-                "reference": "5786fa188e0361b9adf9e8199d7280d1b2db165e",
+                "url": "https://api.github.com/repos/kylekatarnls/update-helper/zipball/429be50660ed8a196e0798e5939760f168ec8ce9",
+                "reference": "429be50660ed8a196e0798e5939760f168ec8ce9",
                 "shasum": ""
             },
             "require": {
@@ -2502,7 +2506,7 @@
                 }
             ],
             "description": "Update helper",
-            "time": "2019-07-29T11:03:54+00:00"
+            "time": "2020-04-07T20:44:10+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -2668,16 +2672,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.63",
+            "version": "1.0.67",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6"
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8132daec326565036bc8e8d1876f77ec183a7bd6",
-                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
                 "shasum": ""
             },
             "require": {
@@ -2689,7 +2693,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7.10"
+                "phpunit/phpunit": "^5.7.26"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -2748,7 +2752,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2020-01-04T16:30:31+00:00"
+            "time": "2020-04-16T13:21:26+00:00"
         },
         {
             "name": "league/flysystem-cached-adapter",
@@ -3667,6 +3671,56 @@
             "time": "2019-10-14T05:51:36+00:00"
         },
         {
+            "name": "ocramius/package-versions",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "doctrine/coding-standard": "^5.0.1",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.5.17"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2019-11-15T16:17:10+00:00"
+        },
+        {
             "name": "ocramius/proxy-manager",
             "version": "1.0.2",
             "source": {
@@ -3911,16 +3965,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.23",
+            "version": "2.0.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "c78eb5058d5bb1a183133c36d4ba5b6675dfa099"
+                "reference": "34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/c78eb5058d5bb1a183133c36d4ba5b6675dfa099",
-                "reference": "c78eb5058d5bb1a183133c36d4ba5b6675dfa099",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc",
+                "reference": "34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc",
                 "shasum": ""
             },
             "require": {
@@ -3999,7 +4053,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-09-17T03:41:22+00:00"
+            "time": "2020-04-04T23:17:33+00:00"
         },
         {
             "name": "primal/color",
@@ -4197,16 +4251,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -4240,7 +4294,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -4423,18 +4477,6 @@
                 "php": ">=5.3.2"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "hash": "43699395013691839330f8406ee49fa752c163fb",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
-                            "description": "Fix minus in regular expressions"
-                        }
-                    ]
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Sunra\\PhpSimple\\HtmlDomParser": "Src/"
@@ -4466,16 +4508,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "e212b06996819a2bce026a63da03b7182d05a690"
+                "reference": "e4636a4f23f157278a19e5db160c63de0da297d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/e212b06996819a2bce026a63da03b7182d05a690",
-                "reference": "e212b06996819a2bce026a63da03b7182d05a690",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/e4636a4f23f157278a19e5db160c63de0da297d8",
+                "reference": "e4636a4f23f157278a19e5db160c63de0da297d8",
                 "shasum": ""
             },
             "require": {
@@ -4518,7 +4560,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-20T13:31:17+00:00"
+            "time": "2020-03-15T09:38:08+00:00"
         },
         {
             "name": "symfony/config",
@@ -4731,16 +4773,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.2",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5"
+                "reference": "346636d2cae417992ecfd761979b2ab98b339a45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
-                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/346636d2cae417992ecfd761979b2ab98b339a45",
+                "reference": "346636d2cae417992ecfd761979b2ab98b339a45",
                 "shasum": ""
             },
             "require": {
@@ -4783,20 +4825,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-16T14:46:54+00:00"
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f9031c22ec127d4a2450760f81a8677fe8a10177"
+                "reference": "9d4e22943b73acc1ba50595b7de1a01fe9dbad48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f9031c22ec127d4a2450760f81a8677fe8a10177",
-                "reference": "f9031c22ec127d4a2450760f81a8677fe8a10177",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9d4e22943b73acc1ba50595b7de1a01fe9dbad48",
+                "reference": "9d4e22943b73acc1ba50595b7de1a01fe9dbad48",
                 "shasum": ""
             },
             "require": {
@@ -4846,20 +4888,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-24T15:33:53+00:00"
+            "time": "2020-03-15T09:38:08+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "00cdad0936d06fab136944bc2342b762b1c3a4a2"
+                "reference": "78a93e5606a19d0fb490afc3c4a9b7ecd86e1515"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/00cdad0936d06fab136944bc2342b762b1c3a4a2",
-                "reference": "00cdad0936d06fab136944bc2342b762b1c3a4a2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/78a93e5606a19d0fb490afc3c4a9b7ecd86e1515",
+                "reference": "78a93e5606a19d0fb490afc3c4a9b7ecd86e1515",
                 "shasum": ""
             },
             "require": {
@@ -4896,7 +4938,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-25T16:36:22+00:00"
+            "time": "2020-04-12T16:54:01+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4949,16 +4991,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593"
+                "reference": "eded33daef1147be7ff1249706be9a49fe2c7a44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d2d0cfe8e319d9df44c4cca570710fcf221d4593",
-                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/eded33daef1147be7ff1249706be9a49fe2c7a44",
+                "reference": "eded33daef1147be7ff1249706be9a49fe2c7a44",
                 "shasum": ""
             },
             "require": {
@@ -4999,20 +5041,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-28T12:52:59+00:00"
+            "time": "2020-04-18T20:23:17+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c42c8339acb28cfff0fb1786948db4d23d609ff7"
+                "reference": "139d477cc926de9ca03c3d59b51ab6e22450c6df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c42c8339acb28cfff0fb1786948db4d23d609ff7",
-                "reference": "c42c8339acb28cfff0fb1786948db4d23d609ff7",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/139d477cc926de9ca03c3d59b51ab6e22450c6df",
+                "reference": "139d477cc926de9ca03c3d59b51ab6e22450c6df",
                 "shasum": ""
             },
             "require": {
@@ -5089,20 +5131,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-01T13:50:37+00:00"
+            "time": "2020-04-28T17:41:38+00:00"
         },
         {
             "name": "symfony/inflector",
-            "version": "v4.4.2",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
-                "reference": "98581481d9ddabe4db3a66e10202fe1fa08d791b"
+                "reference": "53cfa47fe9142f39b5605df67bada3893dd4f46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/inflector/zipball/98581481d9ddabe4db3a66e10202fe1fa08d791b",
-                "reference": "98581481d9ddabe4db3a66e10202fe1fa08d791b",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/53cfa47fe9142f39b5605df67bada3893dd4f46c",
+                "reference": "53cfa47fe9142f39b5605df67bada3893dd4f46c",
                 "shasum": ""
             },
             "require": {
@@ -5147,20 +5189,20 @@
                 "symfony",
                 "words"
             ],
-            "time": "2019-11-06T12:02:32+00:00"
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.4.2",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "2be23e63f33de16b49294ea6581f462932a77e2f"
+                "reference": "ade3d89dd3b875b83c8cff2980c9bb0daf6ef297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2be23e63f33de16b49294ea6581f462932a77e2f",
-                "reference": "2be23e63f33de16b49294ea6581f462932a77e2f",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ade3d89dd3b875b83c8cff2980c9bb0daf6ef297",
+                "reference": "ade3d89dd3b875b83c8cff2980c9bb0daf6ef297",
                 "shasum": ""
             },
             "require": {
@@ -5201,20 +5243,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-10-28T21:57:16+00:00"
+            "time": "2020-04-06T10:16:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
@@ -5226,7 +5268,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -5259,20 +5301,82 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.13.1",
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf",
+                "reference": "47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
                 "shasum": ""
             },
             "require": {
@@ -5284,7 +5388,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -5318,20 +5422,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T14:18:11+00:00"
+            "time": "2020-03-09T19:04:49+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.13.1",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4"
+                "reference": "d51ec491c8ddceae7dca8dd6c7e30428f543f37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
-                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/d51ec491c8ddceae7dca8dd6c7e30428f543f37d",
+                "reference": "d51ec491c8ddceae7dca8dd6c7e30428f543f37d",
                 "shasum": ""
             },
             "require": {
@@ -5341,7 +5445,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -5374,20 +5478,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-03-09T19:04:49+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.13.1",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "af23c7bb26a73b850840823662dda371484926c4"
+                "reference": "2a18e37a489803559284416df58c71ccebe50bf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/af23c7bb26a73b850840823662dda371484926c4",
-                "reference": "af23c7bb26a73b850840823662dda371484926c4",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/2a18e37a489803559284416df58c71ccebe50bf0",
+                "reference": "2a18e37a489803559284416df58c71ccebe50bf0",
                 "shasum": ""
             },
             "require": {
@@ -5397,7 +5501,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -5433,20 +5537,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
-            "name": "symfony/polyfill-util",
-            "version": "v1.13.1",
+            "name": "symfony/polyfill-php72",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f"
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "37b0976c78b94856543260ce09b460a7bc852747"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/964a67f293b66b95883a5ed918a65354fcd2258f",
-                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/37b0976c78b94856543260ce09b460a7bc852747",
+                "reference": "37b0976c78b94856543260ce09b460a7bc852747",
                 "shasum": ""
             },
             "require": {
@@ -5455,7 +5559,62 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "d8e76c104127675d0ea3df3be0f2ae24a8619027"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/d8e76c104127675d0ea3df3be0f2ae24a8619027",
+                "reference": "d8e76c104127675d0ea3df3be0f2ae24a8619027",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -5485,20 +5644,20 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-03-02T11:55:35+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "9ec5e220898a97b92b8784422396f4e244c04d29"
+                "reference": "276c184d174b1bbc03f87132b63234a403d0c782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/9ec5e220898a97b92b8784422396f4e244c04d29",
-                "reference": "9ec5e220898a97b92b8784422396f4e244c04d29",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/276c184d174b1bbc03f87132b63234a403d0c782",
+                "reference": "276c184d174b1bbc03f87132b63234a403d0c782",
                 "shasum": ""
             },
             "require": {
@@ -5553,7 +5712,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2019-12-01T10:45:41+00:00"
+            "time": "2020-04-06T10:01:14+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -5622,16 +5781,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "b689ccd48e234ea404806d94b07eeb45f9f6f06a"
+                "reference": "53b432fde8eea7dab820e75abda5b97fdaa829b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/b689ccd48e234ea404806d94b07eeb45f9f6f06a",
-                "reference": "b689ccd48e234ea404806d94b07eeb45f9f6f06a",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/53b432fde8eea7dab820e75abda5b97fdaa829b4",
+                "reference": "53b432fde8eea7dab820e75abda5b97fdaa829b4",
                 "shasum": ""
             },
             "require": {
@@ -5694,20 +5853,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-12-01T08:33:36+00:00"
+            "time": "2020-04-12T09:58:27+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42"
+                "reference": "2e1bdec403d8e7a350884cbbe4807ab7c2a843d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42",
-                "reference": "05a1125ff3fdd10a68a2857a5d1d4a1ceb93ba42",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/2e1bdec403d8e7a350884cbbe4807ab7c2a843d4",
+                "reference": "2e1bdec403d8e7a350884cbbe4807ab7c2a843d4",
                 "shasum": ""
             },
             "require": {
@@ -5773,20 +5932,20 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-25T16:36:22+00:00"
+            "time": "2020-04-12T14:33:46+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "0be25347c4a8695d9423fe897f4c774f46e97b51"
+                "reference": "4e844362f573713e6d45949795c95a4cb6cf760d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/0be25347c4a8695d9423fe897f4c774f46e97b51",
-                "reference": "0be25347c4a8695d9423fe897f4c774f46e97b51",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/4e844362f573713e6d45949795c95a4cb6cf760d",
+                "reference": "4e844362f573713e6d45949795c95a4cb6cf760d",
                 "shasum": ""
             },
             "require": {
@@ -5843,20 +6002,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-23T20:30:33+00:00"
+            "time": "2020-04-12T16:39:58+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.36",
+            "version": "v3.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "dab657db15207879217fc81df4f875947bf68804"
+                "reference": "8fef49ac1357f4e05c997a1f139467ccb186bffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/dab657db15207879217fc81df4f875947bf68804",
-                "reference": "dab657db15207879217fc81df4f875947bf68804",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8fef49ac1357f4e05c997a1f139467ccb186bffa",
+                "reference": "8fef49ac1357f4e05c997a1f139467ccb186bffa",
                 "shasum": ""
             },
             "require": {
@@ -5902,7 +6061,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-24T15:33:53+00:00"
+            "time": "2020-04-24T10:16:04+00:00"
         },
         {
             "name": "tedivm/stash",
@@ -5966,16 +6125,16 @@
         },
         {
             "name": "theorchard/monolog-cascade",
-            "version": "0.5.1",
+            "version": "0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theorchard/monolog-cascade.git",
-                "reference": "5353e00824da0b6073668523b5cdc8e84629f108"
+                "reference": "b515bbc1a1a96efc967ac8836585e0e347fbb9a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theorchard/monolog-cascade/zipball/5353e00824da0b6073668523b5cdc8e84629f108",
-                "reference": "5353e00824da0b6073668523b5cdc8e84629f108",
+                "url": "https://api.github.com/repos/theorchard/monolog-cascade/zipball/b515bbc1a1a96efc967ac8836585e0e347fbb9a0",
+                "reference": "b515bbc1a1a96efc967ac8836585e0e347fbb9a0",
                 "shasum": ""
             },
             "require": {
@@ -6026,7 +6185,7 @@
                 "monolog plugin",
                 "monolog utils"
             ],
-            "time": "2019-01-10T20:41:57+00:00"
+            "time": "2020-02-21T14:47:21+00:00"
         },
         {
             "name": "true/punycode",
@@ -6429,16 +6588,6 @@
                 "branch-alias": {
                     "dev-master": "2.6-dev",
                     "dev-develop": "2.7-dev"
-                },
-                "patches_applied": {
-                    "hash": "43aec57a6422c48c002031806c8a8ca01b6208cf",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-code/switch-continue.patch",
-                            "description": "Fix continue switch in FileGenerator and MethodReflection"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -7063,16 +7212,6 @@
                     "dev-release-2.7": "2.7-dev",
                     "dev-master": "3.0-dev",
                     "dev-develop": "3.1-dev"
-                },
-                "patches_applied": {
-                    "hash": "f247c9d47f2ba4ae8d9dfe6d1a25c8627e377753",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch",
-                            "description": "Fix ArrayObject::unserialize()"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -7279,16 +7418,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
-                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/1ab9842d69e64fb3a01be6b656501032d1b78cb7",
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7",
                 "shasum": ""
             },
             "require": {
@@ -7319,7 +7458,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-11-06T16:40:04+00:00"
+            "time": "2020-03-01T12:26:26+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -7522,16 +7661,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/579bb7356d91f9456ccd505f24ca8b667966a0a7",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -7566,54 +7705,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-12-15T19:12:40+00:00"
-        },
-        {
-            "name": "natxet/CssMin",
-            "version": "v3.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/natxet/CssMin.git",
-                "reference": "d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/natxet/CssMin/zipball/d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd",
-                "reference": "d5d9f4c3e5cedb1ae96a95a21731f8790e38f1dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Joe Scylla",
-                    "email": "joe.scylla@gmail.com",
-                    "homepage": "https://profiles.google.com/joe.scylla"
-                }
-            ],
-            "description": "Minifying CSS",
-            "homepage": "http://code.google.com/p/cssmin/",
-            "keywords": [
-                "css",
-                "minify"
-            ],
-            "time": "2018-01-09T11:15:01+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -7770,23 +7862,20 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
@@ -7818,45 +7907,42 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2020-04-27T09:25:28+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7867,33 +7953,36 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
+            "time": "2020-02-22T12:28:44+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": "^7.2",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
             },
             "type": "library",
             "extra": {
@@ -7917,28 +8006,28 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
+            "time": "2020-02-18T18:59:58+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5 || ^3.2",
@@ -7980,7 +8069,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-22T21:05:45+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/dbunit",
@@ -8938,72 +9027,17 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.13.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/66fea50f6cb37a35eea048d75a7d99a45b586038",
-                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.13-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-11-27T13:56:44+00:00"
-        },
-        {
             "name": "symfony/process",
-            "version": "v4.4.2",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b84501ad50adb72a94fb460a5b5c91f693e99c9b"
+                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b84501ad50adb72a94fb460a5b5c91f693e99c9b",
-                "reference": "b84501ad50adb72a94fb460a5b5c91f693e99c9b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
+                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
                 "shasum": ""
             },
             "require": {
@@ -9039,20 +9073,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-06T10:06:46+00:00"
+            "time": "2020-04-15T15:56:18+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.4.2",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "5745b514fc56ae1907c6b8ed74f94f90f64694e9"
+                "reference": "e0324d3560e4128270e3f08617480d9233d81cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5745b514fc56ae1907c6b8ed74f94f90f64694e9",
-                "reference": "5745b514fc56ae1907c6b8ed74f94f90f64694e9",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e0324d3560e4128270e3f08617480d9233d81cfc",
+                "reference": "e0324d3560e4128270e3f08617480d9233d81cfc",
                 "shasum": ""
             },
             "require": {
@@ -9089,53 +9123,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-05T16:11:08+00:00"
-        },
-        {
-            "name": "tedivm/jshrink",
-            "version": "v1.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tedious/JShrink.git",
-                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tedious/JShrink/zipball/566e0c731ba4e372be2de429ef7d54f4faf4477a",
-                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6|^7.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.8",
-                "php-coveralls/php-coveralls": "^1.1.0",
-                "phpunit/phpunit": "^6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "JShrink": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Robert Hafner",
-                    "email": "tedivm@tedivm.com"
-                }
-            ],
-            "description": "Javascript Minifier built in PHP",
-            "homepage": "http://github.com/tedious/JShrink",
-            "keywords": [
-                "javascript",
-                "minifier"
-            ],
-            "time": "2019-06-28T18:11:46+00:00"
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -9179,16 +9167,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.6.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -9196,7 +9184,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -9223,7 +9211,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24T13:36:37+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         }
     ],
     "aliases": [],
@@ -9240,6 +9228,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/concrete/elements/account/menu.php
+++ b/concrete/elements/account/menu.php
@@ -30,11 +30,11 @@ $url = $app->make('url/manager');
 ?>
 <div style="display: none">
     <div class="btn-group" id="ccm-account-menu">
-        <a class="btn btn-default" href="<?=$desktop->getCollectionLink()?>"><i class="fa fa-user"></i> <?=$ui->getUserDisplayName()?></a>
-        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+        <a class="btn btn-secondary" href="<?=$desktop->getCollectionLink()?>"><i class="fa fa-user"></i> <?=$ui->getUserDisplayName()?></a>
+        <button class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
             <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu pull-right" role="menu">
+        <ul class="dropdown-menu float-right" role="menu">
             <li><a href="<?=$url->resolve([$desktop])?>"><?=t('My Account')?></a></li>
             <li class="divider"></li>
             <?php

--- a/concrete/elements/attribute/key/form.php
+++ b/concrete/elements/attribute/key/form.php
@@ -62,7 +62,11 @@ if ($key !== null) {
             <?= $form->label('akHandle', t('Handle')) ?>
             <div class="input-group">
                 <?= $form->text('akHandle', $akHandle, ['autofocus' => 'autofocus']) ?>
-                <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+                <span class="input-group-append">
+                    <div class="input-group-text">
+                        <i class="fa fa-asterisk"></i>
+                    </div>
+                </span>
             </div>
         </div>
 
@@ -70,7 +74,11 @@ if ($key !== null) {
             <?= $form->label('akName', t('Name')) ?>
             <div class="input-group">
                 <?= $form->text('akName', $key === null ? '' : $key->getAttributeKeyName()) ?>
-                <span class="input-group-addon"><i class="fa fa-asterisk"></i></span>
+                <span class="input-group-append">
+                    <div class="input-group-text">
+                        <i class="fa fa-asterisk"></i>
+                    </div>
+                </span>
             </div>
         </div>
 
@@ -96,39 +104,35 @@ if ($key !== null) {
 
         <div class="form-group">
             <label class="control-label"><?= t('Searchable') ?></label>
-            <div class="checkbox">
-                <label>
-                    <?= $form->checkbox('akIsSearchableIndexed', 1, $key !== null && $key->isAttributeKeyContentIndexed()) ?>
-                    <?= t('Content included in search index.') ?>
-                </label>
+            <div class="form-check">
+                <?= $form->checkbox('akIsSearchableIndexed', 1, $key !== null && $key->isAttributeKeyContentIndexed(), ["class" => "form-check-input"]) ?>
+                <?= $form->label('akIsSearchableIndexed', t('Content included in search index.'), ["class" => "form-check-label"] ) ?>
             </div>
-            <div class="checkbox">
-                <label>
-                    <?= $form->checkbox('akIsSearchable', 1, $key === null || $key->isAttributeKeySearchable()) ?>
-                    <?= t('Field available in advanced search.') ?>
-                    <?php
-                    if ($key && $key->isAttributeKeySearchable()) {
-                        ?>
-                        <div class="alert alert-danger small hide" id="akIsSearchable-warning">
-                            <?= t(
-                                'WARNING: you will need to re-run the %s automated job if you uncheck this value, save the attribute, and then re-check this value',
-                                '<strong>' . t('Index Search Engine - All') . '</strong>'
-                            ) ?>
-                        </div>
-                        <script>
-                        $(document).ready(function() {
-                            $('#akIsSearchable')
-                                .on('change', function() {
-                                    $('#akIsSearchable-warning').toggleClass('hide', $(this).is(':checked'))
-                                })
-                                .trigger('change')
-                            ;
-                        });
-                        </script>
-                        <?php
-                    }
+            <div class="form-check">
+                <?= $form->checkbox('akIsSearchable', 1, $key === null || $key->isAttributeKeySearchable(), ["class" => "form-check-input"]) ?>
+                <?= $form->label('akIsSearchable', t('Field available in advanced search.'), ["class" => "form-check-label"] ) ?>
+                <?php
+                if ($key && $key->isAttributeKeySearchable()) {
                     ?>
-                </label>
+                    <div class="alert alert-danger small hide" id="akIsSearchable-warning">
+                        <?= t(
+                            'WARNING: you will need to re-run the %s automated job if you uncheck this value, save the attribute, and then re-check this value',
+                            '<strong>' . t('Index Search Engine - All') . '</strong>'
+                        ) ?>
+                    </div>
+                    <script>
+                    $(document).ready(function() {
+                        $('#akIsSearchable')
+                            .on('change', function() {
+                                $('#akIsSearchable-warning').toggleClass('hide', $(this).is(':checked'))
+                            })
+                            .trigger('change')
+                        ;
+                    });
+                    </script>
+                    <?php
+                }
+                ?>
             </div>
         </div>
 
@@ -157,8 +161,8 @@ if ($key !== null) {
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <a href="<?= $back ?>" class="btn pull-left btn-default"><?= t('Back') ?></a>
-            <button type="submit" class="btn btn-primary pull-right"><?= $key === null ? t('Add') : t('Save') ?></button>
+            <a href="<?= $back ?>" class="btn float-left btn-secondary"><?= t('Back') ?></a>
+            <button type="submit" class="btn btn-primary float-right"><?= $key === null ? t('Add') : t('Save') ?></button>
         </div>
     </div>
 

--- a/concrete/elements/attribute/key/header.php
+++ b/concrete/elements/attribute/key/header.php
@@ -9,8 +9,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <input type="hidden" name="id" value="<?=$key->getAttributeKeyID()?>">
         <p><?=t('Are you sure you want to delete this attribute? This cannot be undone.')?></p>
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-            <button class="btn btn-danger pull-right" onclick="$('#ccm-dialog-delete-attribute form').submit()"><?=t('Delete Attribute')?></button>
+            <button class="btn btn-secondary float-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+            <button class="btn btn-danger float-right" onclick="$('#ccm-dialog-delete-attribute form').submit()"><?=t('Delete Attribute')?></button>
         </div>
     </form>
 </div>

--- a/concrete/elements/attribute/key/list.php
+++ b/concrete/elements/attribute/key/list.php
@@ -74,21 +74,21 @@ if (isset($types) && is_array($types) && count($types) > 0) {
     ?>
     <h3><?=t('Add Attribute')?></h3>
     <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-button="attribute-type" data-toggle="dropdown">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-button="attribute-type" data-toggle="dropdown">
             <?=t('Choose Type')?> <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu">
+        <div class="dropdown-menu">
             <?php
             foreach ($types as $type) {
                 $controller = $type->getController();
                 $formatter = $controller->getIconFormatter();
                 /* @var \Concrete\Core\Attribute\IconFormatterInterface $formatter */
                 ?>
-                <li><a href="<?=$view->controller->getAddAttributeTypeURL($type)?>"><?=$formatter->getListIconElement()?> <?=$type->getAttributeTypeDisplayName()?></a></li>
+                <a class="dropdown-item" href="<?=$view->controller->getAddAttributeTypeURL($type)?>"><?=$formatter->getListIconElement()?> <?=$type->getAttributeTypeDisplayName()?></a>
                 <?php
             }
             ?>
-        </ul>
+        </div>
     </div>
 
     <script type="text/javascript">

--- a/concrete/elements/attribute/site_standard_list_header.php
+++ b/concrete/elements/attribute/site_standard_list_header.php
@@ -3,10 +3,10 @@ defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
 <div class="btn-group">
-    <a href="<?=URL::to('/dashboard/system/basics/name')?>" class="btn btn-default"><?=t('Back')?></a>
+    <a href="<?=URL::to('/dashboard/system/basics/name')?>" class="btn btn-secondary"><?=t('Back')?></a>
     <?php
         if ($category && $category->getController()->getSetManager()->allowAttributeSets()) {
 ?>
-        <a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-default"><?=t('Manage Sets')?></a>
+        <a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-secondary"><?=t('Manage Sets')?></a>
     <?php } ?>
 </div>

--- a/concrete/elements/attribute/standard_list_header.php
+++ b/concrete/elements/attribute/standard_list_header.php
@@ -4,7 +4,7 @@ if ($category && $category->getController()->getSetManager()->allowAttributeSets
     ?>
 
 
-    <a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-default"><?=t('Manage Sets')?></a>
+    <a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-secondary"><?=t('Manage Sets')?></a>
 
 <?php 
 } ?>

--- a/concrete/elements/attribute/type_form_required.php
+++ b/concrete/elements/attribute/type_form_required.php
@@ -148,14 +148,14 @@ if (is_object($category)) {
 
 <div class="ccm-dashboard-form-actions-wrapper">
 <div class="ccm-dashboard-form-actions">
-	<a href="<?=$back?>" class="btn pull-left btn-default"><?=t('Back')?></a>
+	<a href="<?=$back?>" class="btn float-left btn-secondary"><?=t('Back')?></a>
 <?php if (is_object($key)) {
     ?>
-	<button type="submit" class="btn btn-primary pull-right"><?=t('Save')?></button>
+	<button type="submit" class="btn btn-primary float-right"><?=t('Save')?></button>
 <?php 
 } else {
     ?>
-	<button type="submit" class="btn btn-primary pull-right"><?=t('Add')?></button>
+	<button type="submit" class="btn btn-primary float-right"><?=t('Add')?></button>
 <?php 
 } ?>
 </div>

--- a/concrete/elements/block_footer_edit.php
+++ b/concrete/elements/block_footer_edit.php
@@ -30,8 +30,8 @@ else {
         if (!$b->getProxyBlock() && !$supportsInlineEdit) {
             ?>
             <div class="ccm-buttons dialog-buttons">
-                <a href="javascript:$('#ccm-form-submit-button').get(0).click()" class="btn pull-right btn-primary"><?= t('Save') ?></a>
-                <a style="float:left" href="javascript:void(0)" class="btn btn-default btn-hover-danger" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></a>
+                <a href="javascript:$('#ccm-form-submit-button').get(0).click()" class="btn float-right btn-primary"><?= t('Save') ?></a>
+                <a style="float:left" href="javascript:void(0)" class="btn btn-secondary btn-hover-danger" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></a>
             </div>
             <?php
         }

--- a/concrete/elements/calendar/header.php
+++ b/concrete/elements/calendar/header.php
@@ -16,17 +16,18 @@ if (!isset($month)) {
 <div class="ccm-dashboard-header-buttons">
     <div class="btn-group">
         <div class="btn-group">
-            <button type="button" id="calendar_button" class="btn btn-default" data-toggle="dropdown">
+            <button type="button" id="calendar_button" class="btn btn-secondary dropdown-toggle"
+                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <?= h($calendar->getName()) ?>
                 <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="calendar_button">
+            <div class="dropdown-menu" role="menu" aria-labelledby="calendar_button">
                 <?php foreach ($calendars as $cal) {
     $p = new \Permissions($cal);
     if ($p->canViewCalendarInEditInterface()) {
         ?>
-                        <li><a href="<?= URL::to($preferences->getPreferredViewPath(), 'view',
-                                $cal->getID()) ?>"><?= h($cal->getName()) ?></a></li>
+                        <a href="<?= URL::to($preferences->getPreferredViewPath(), 'view',
+                                $cal->getID()) ?>" class="dropdown-item"><?= h($cal->getName()) ?></a>
                     <?php
     }
     ?>
@@ -35,20 +36,19 @@ if (!isset($month)) {
 } ?>
                 <?php if ($calendarPermissions->canEditCalendar() || $calendarPermissions->canEditCalendarPermissions()) {
     ?>
-                <li class="divider"></li>
-                <li class="dropdown-header"><?= t('Edit') ?></li>
+                <div class="dropdown-divider"></div>
 
             <?php if ($calendarPermissions->canEditCalendar()) {
     ?>
-                <li><a href="<?= URL::to('/dashboard/calendar/add', $calendar->getID()) ?>"><?= t("Details") ?></a>
-                </li>
+                <a href="<?= URL::to('/dashboard/calendar/add', $calendar->getID()) ?>"
+                   class="dropdown-item"><?= t("Details") ?></a>
             <?php
 }
     ?>
             <?php if ($calendarPermissions->canEditCalendarPermissions()) {
     ?>
-                <li><a href="<?= URL::to('/dashboard/calendar/permissions',
-                        $calendar->getID()) ?>"><?= t("Permissions") ?></a>
+                <a href="<?= URL::to('/dashboard/calendar/permissions',
+                    $calendar->getID()) ?>" class="dropdown-item"><?= t("Permissions") ?></a>
 
                     <?php
 }
@@ -58,19 +58,19 @@ if (!isset($month)) {
 
                     <?php if ($calendarPermissions->canDeleteCalendar()) {
     ?>
-                <li class="divider"></li>
-                <li><a href="#" data-dialog="delete-calendar"><span class="text-danger"><?= t(
-                                "Delete Calendar") ?></span></a></li>
+                        <div class="dropdown-divider"></div>
+                <a href="#" data-dialog="delete-calendar" class="dropdown-item"><span class="text-danger"><?= t(
+                                "Delete Calendar") ?></span></a>
             <?php
 } ?>
-            </ul>
+            </div>
         </div>
         <a href="<?= URL::to('/dashboard/calendar/events', 'view',
-            $calendar->getID()) ?>" class="btn btn-default <?php if ($mode != 'list') {
+            $calendar->getID()) ?>" class="btn btn-secondary <?php if ($mode != 'list') {
     ?>active<?php
 } ?>"><i class="fa fa-calendar"></i></a>
         <a href="<?= URL::to('/dashboard/calendar/event_list', 'view',
-            $calendar->getID()) ?>" class="btn btn-default <?php if ($mode == 'list') {
+            $calendar->getID()) ?>" class="btn btn-secondary <?php if ($mode == 'list') {
     ?>active<?php
 } ?>"><i class="fa fa-list"></i></a>
         <?php if ($calendarPermissions->canAddCalendarEvent()) {
@@ -93,8 +93,8 @@ if (!isset($month)) {
             <p><?= t('Are you sure? This action cannot be undone.') ?></p>
         </form>
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></button>
-            <button class="btn btn-danger pull-right" onclick="$('#ccm-dialog-delete-calendar form').submit()"><?= t(
+            <button class="btn btn-secondary float-left" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></button>
+            <button class="btn btn-danger float-right" onclick="$('#ccm-dialog-delete-calendar form').submit()"><?= t(
                     'Delete Calendar') ?></button>
         </div>
     </div>

--- a/concrete/elements/conversation/display.php
+++ b/concrete/elements/conversation/display.php
@@ -47,7 +47,7 @@ $form = $app->make('helper/form');
 	<div class="ccm-conversation-message-permalink" data-dialog-title="<?=t('Link')?>" data-cancel-button-title="<?=t('Close')?>"></div>
 	<div class="ccm-conversation-messages-header">
 		<?php if ($enableOrdering) { ?>
-    		<select class="form-control pull-right ccm-sort-conversations" data-sort="conversation-message-list">
+    		<select class="form-control float-right ccm-sort-conversations" data-sort="conversation-message-list">
     			<option value="date_asc" <?php if ($orderBy == 'date_asc') { ?>selected="selected"<?php } ?>><?=t('Earliest First')?></option>
     			<option value="date_desc" <?php if ($orderBy == 'date_desc') { ?>selected="selected"<?php } ?>><?=t('Most Recent First')?></option>
     			<option value="rating" <?php if ($orderBy == 'rating') { ?>selected="selected"<?php } ?>><?=t('Highest Rated')?></option>

--- a/concrete/elements/conversation/message/add_form.php
+++ b/concrete/elements/conversation/message/add_form.php
@@ -32,10 +32,10 @@ $u = Core::make(Concrete\Core\User\User::class);
 					<?php echo $form->hidden('blockAreaHandle', $blockAreaHandle) ?>
 					<?php echo $form->hidden('cID', $cID) ?>
 					<?php echo $form->hidden('bID', $bID) ?>
-					<button type="button" data-post-parent-id="0" data-submit="conversation-message" class="pull-right btn btn-submit btn-primary"><?=t('Submit')?></button>
+					<button type="button" data-post-parent-id="0" data-submit="conversation-message" class="float-right btn btn-submit btn-primary"><?=t('Submit')?></button>
 					<?php if ($attachmentsEnabled) {
     ?>
-						<button type="button" class="pull-right btn btn-default ccm-conversation-attachment-toggle" href="#" title="<?php echo t('Attach Files');
+						<button type="button" class="float-right btn btn-secondary ccm-conversation-attachment-toggle" href="#" title="<?php echo t('Attach Files');
     ?>"><i class="fa fa-image"></i></button>
 					<?php
 }
@@ -45,11 +45,11 @@ $u = Core::make(Concrete\Core\User\User::class);
 						<a href="<?=URL::to('/ccm/system/dialogs/conversation/subscribe', $conversation->getConversationID())?>" data-conversation-subscribe="unsubscribe" <?php if (!$conversation->isUserSubscribed($u)) {
     ?>style="display: none"<?php
 }
-    ?> class="btn pull-right btn-default"><?=t('Un-Subscribe')?></a>
+    ?> class="btn float-right btn-secondary"><?=t('Un-Subscribe')?></a>
 						<a href="<?=URL::to('/ccm/system/dialogs/conversation/subscribe', $conversation->getConversationID())?>" data-conversation-subscribe="subscribe" <?php if ($conversation->isUserSubscribed($u)) {
     ?>style="display: none"<?php
 }
-    ?> class="btn pull-right btn-default"><?=t('Subscribe to Conversation')?></a>
+    ?> class="btn float-right btn-secondary"><?=t('Subscribe to Conversation')?></a>
 					<?php
 }
     ?>
@@ -84,10 +84,10 @@ $u = Core::make(Concrete\Core\User\User::class);
 					<?php echo $form->hidden('blockAreaHandle', $blockAreaHandle) ?>
 					<?php echo $form->hidden('cID', $cID) ?>
 					<?php echo $form->hidden('bID', $bID) ?>
-					<button type="btn btn-primary" data-submit="conversation-message" class="pull-right btn btn-primary"><?=t('Reply')?> </button>
+					<button type="btn btn-primary" data-submit="conversation-message" class="float-right btn btn-primary"><?=t('Reply')?> </button>
 					<?php if ($attachmentsEnabled) {
     ?>
-						<button type="button" class="pull-right btn btn-default ccm-conversation-attachment-toggle" href="#" title="<?php echo t('Attach Files');
+						<button type="button" class="float-right btn btn-secondary ccm-conversation-attachment-toggle" href="#" title="<?php echo t('Attach Files');
     ?>"><i class="fa fa-image"></i></button>
 					<?php
 }

--- a/concrete/elements/conversation/message/review.php
+++ b/concrete/elements/conversation/message/review.php
@@ -5,7 +5,7 @@
  */
 if (!isset($starsOnly) || !$starsOnly) {
     ?>
-    <label for="review" class="pull-left">
+    <label for="review" class="float-left">
         <?= t('Rating') ?>&nbsp;
     </label>
     <?php

--- a/concrete/elements/custom_style.php
+++ b/concrete/elements/custom_style.php
@@ -403,7 +403,7 @@ $form = Core::make('helper/form');
         if (is_object($set)) {
             $hidden = $set->isHiddenOnDevice($class);
         } ?>
-                            <button type="button" data-hide-on-device="<?=$class?>" class="btn btn-default <?php if (!$hidden) {
+                            <button type="button" data-hide-on-device="<?=$class?>" class="btn btn-secondary <?php if (!$hidden) {
             ?>active<?php
         } ?>"><i class="<?=$gf->getDeviceHideClassIconClass($class)?>"></i></button>
                         <?php

--- a/concrete/elements/dashboard/attributes_table.php
+++ b/concrete/elements/dashboard/attributes_table.php
@@ -13,7 +13,7 @@ if (is_object($category) && $category->allowAttributeSets()) {
 <div class="ccm-dashboard-header-buttons">
 	<?php if (count($sets) > 0) {
     ?>
-		<button type="button" class="btn btn-default" data-toggle="dropdown">
+		<button type="button" class="btn btn-secondary" data-toggle="dropdown">
 		<?=t('View')?> <span class="caret"></span>
 		</button>
 		<ul class="dropdown-menu" role="menu">
@@ -22,7 +22,7 @@ if (is_object($category) && $category->allowAttributeSets()) {
 		</ul>
 	<?php 
 } ?>
-	<a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-default"><?=t('Manage Sets')?></a>
+	<a href="<?=URL::to('/dashboard/system/attributes/sets', 'category', $category->getAttributeKeyCategoryID())?>" class="btn btn-secondary"><?=t('Manage Sets')?></a>
 </div>
 
 <?php
@@ -176,7 +176,7 @@ $(function() {
 	<div class="form-group">
 		<?=$form->select('atID', $types)?>
 	</div>
-	<button type="submit" class="btn btn-default"><?=t('Go')?></button>
+	<button type="submit" class="btn btn-secondary"><?=t('Go')?></button>
 	</div>
 </form>
 <?php 

--- a/concrete/elements/dashboard/express/control.php
+++ b/concrete/elements/dashboard/express/control.php
@@ -36,8 +36,8 @@ $c = Page::getCurrentPage();
 				<input type="hidden" name="field_set_control_id" value="<?=$control->getID()?>">
 				<p><?=t('Are you sure you want to delete this control? This cannot be undone.')?></p>
 				<div class="dialog-buttons">
-					<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-					<button class="btn btn-danger pull-right" onclick="$('#ccm-dialog-delete-set-control-<?=$control->getId()?> form').submit()"><?=t('Delete Set')?></button>
+					<button class="btn btn-secondary float-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+					<button class="btn btn-danger float-right" onclick="$('#ccm-dialog-delete-set-control-<?=$control->getId()?> form').submit()"><?=t('Delete Set')?></button>
 				</div>
 			</form>
 		</div>

--- a/concrete/elements/dashboard/express/detail_navigation.php
+++ b/concrete/elements/dashboard/express/detail_navigation.php
@@ -52,12 +52,12 @@ $c = Page::getCurrentPage();
             class="list-group-item"
             href="<?=URL::to('/dashboard/express/entries', $entity->getId())?>"
         >
-            <i class="fa fa-share pull-right" style="margin-top: 4px"></i>
+            <i class="fa fa-share float-right" style="margin-top: 4px"></i>
             <?=tc(/*i18n: %s is an entity name*/'Express', 'View %s Entries', $entity->getEntityDisplayName())?>
         </a>
 
         <a href="<?=URL::to('/dashboard/system/express/entities', 'clear_entries', $entity->getId())?>" class="list-group-item">
-            <i class="fa fa-trash pull-right text-danger" style="margin-top:4px"></i>
+            <i class="fa fa-trash float-right text-danger" style="margin-top:4px"></i>
             <span class="text-danger"><?= t('Clear Entries') ?></span>
         </a>
     </div>

--- a/concrete/elements/dashboard/express/menu.php
+++ b/concrete/elements/dashboard/express/menu.php
@@ -5,7 +5,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <div class="btn-group">
 
-<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <?=$currentType->getEntityDisplayName()?>
     <span class="caret"></span>
 </button>

--- a/concrete/elements/dashboard/reports/forms/header.php
+++ b/concrete/elements/dashboard/reports/forms/header.php
@@ -39,7 +39,7 @@
  <?php } else { ?>
 
     <?php if (!empty($supportsLegacy)): ?>
-        <a href="<?=URL::to('/dashboard/reports/forms/legacy')?>" class="btn btn-default"><?=t('Legacy Forms')?></a>
+        <a href="<?=URL::to('/dashboard/reports/forms/legacy')?>" class="btn btn-secondary"><?=t('Legacy Forms')?></a>
     <?php endif ?>
 
 <?php } ?>

--- a/concrete/elements/dashboard/system/permissions/blacklist/menu.php
+++ b/concrete/elements/dashboard/system/permissions/blacklist/menu.php
@@ -12,7 +12,7 @@ $categoryID = $category->getIpAccessControlCategoryID();
 ?>
 <div class="ccm-dashboard-header-buttons">
     <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <?= t('View') ?>
             <span class="caret"></span>
         </button>

--- a/concrete/elements/dashboard/users/header.php
+++ b/concrete/elements/dashboard/users/header.php
@@ -10,7 +10,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <?php if (Config::get('concrete.user.registration.validate_email') == true && $canActivateUser) : ?>
             <?php if ($user->isValidated() < 1) : ?>
                 <div class="btn-group">
-                    <button type="button" class="btn dropdown-toggle btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="bstb-undefined">
+                    <button type="button" class="btn dropdown-toggle btn-secondary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="bstb-undefined">
                         <span><?php echo t('Validate') ?></span> <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu">
@@ -29,7 +29,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         if ($user->getAttribute('profile_private_messages_enabled')) {
             $u = Core::make(Concrete\Core\User\User::class);
             if ($u->getUserID() != $user->getUserID()) { ?>
-                <a href="<?php echo View::url('/account/messages', 'write', $user->getUserID())?>" class="btn btn-default"><?php echo t("Send Private Message")?></a>
+                <a href="<?php echo View::url('/account/messages', 'write', $user->getUserID())?>" class="btn btn-secondary"><?php echo t("Send Private Message")?></a>
             <?php } ?>
         <?php } ?>
 
@@ -37,12 +37,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
             <?php if ($user->isActive()) { ?>
                 <?php if (!in_array("deactivate", $workflowRequestActions)) { ?>
                     <button type="submit" name="task" value="deactivate"
-                            class="btn btn-default"><?= t('Deactivate User') ?></button>
+                            class="btn btn-secondary"><?= t('Deactivate User') ?></button>
                 <?php } ?>
             <?php } else { ?>
                 <?php if ((!in_array("activate", $workflowRequestActions) && !in_array("register_activate", $workflowRequestActions))) { ?>
                     <button type="submit" name="task" value="activate"
-                            class="btn btn-default"><?= t('Activate User') ?></button>
+                            class="btn btn-secondary"><?= t('Activate User') ?></button>
                 <?php } ?>
             <?php } ?>
         <?php } ?>
@@ -50,7 +50,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <?php if ($canSignInAsUser) {
             ?>
             <button type="submit" name="task" value="sudo"
-                    class="btn btn-default"><?= t('Sign in As User') ?></button>
+                    class="btn btn-secondary"><?= t('Sign in As User') ?></button>
             <?php
         }
         ?>

--- a/concrete/elements/date_time/duration.php
+++ b/concrete/elements/date_time/duration.php
@@ -137,7 +137,7 @@ $weekDays = \Punic\Calendar::getSortedWeekdays('wide');
                     <% } %>
                 </div>
                 <div class="col-sm-6">
-                    <div class="pull-right text-muted">
+                    <div class="float-right text-muted">
                         <%=repetition.timezone.timezone%>
                     </div>
                 </div>

--- a/concrete/elements/express/form/view/dashboard/association.php
+++ b/concrete/elements/express/form/view/dashboard/association.php
@@ -8,7 +8,7 @@
             ?>
             <a href="<?= URL::to('/ccm/system/dialogs/express/association/reorder')?>?entryID=<?=$entry->getId()?>&amp;controlID=<?=$control->getId()?>"
                dialog-title="<?= t('Reorder Entries') ?>" dialog-width="400" dialog-height="350"
-               class="dialog-launch btn btn-default btn-xs pull-right"><?= t('Reorder Entries') ?></a>
+               class="dialog-launch btn btn-secondary btn-xs float-right"><?= t('Reorder Entries') ?></a>
             <?php } ?>
             <label class="control-label">
                 <?= $label ?></label>

--- a/concrete/elements/files/add_to_sets.php
+++ b/concrete/elements/files/add_to_sets.php
@@ -34,7 +34,7 @@ $sets = FileSet::getMySets();
 } ?>
 </div>
 
-<button type="button" class="btn-sm btn btn-default" data-action="add-file-set"><?=t('Add Set')?> <i class="fa fa-plus-circle"></i></button>
+<button type="button" class="btn-sm btn btn-secondary" data-action="add-file-set"><?=t('Add Set')?> <i class="fa fa-plus-circle"></i></button>
 
 <script type="text/template" class="ccm-template-file-set-checkbox">
 	<div class="input-group">

--- a/concrete/elements/files/properties.php
+++ b/concrete/elements/files/properties.php
@@ -115,7 +115,7 @@ if ($downloadUrl !== $url) {
                     <?= t('Invalid file dimensions, please rescan this file.') ?>
                     <?php if ($mode != 'preview' && $fp->canEditFileContents()) {
     ?>
-                        <a href="#" class="btn pull-right btn-default btn-xs"
+                        <a href="#" class="btn float-right btn-secondary btn-xs"
                            data-action="rescan"><?= t('Rescan') ?></a>
                     <?php
 }
@@ -135,7 +135,7 @@ if ($downloadUrl !== $url) {
                     <?= t('Unknown error retrieving thumbnails, please rescan this file.') ?>
                     <?php if ($mode != 'preview' && $fp->canEditFileContents()) {
     ?>
-                        <a href="#" class="btn pull-right btn-default btn-xs"
+                        <a href="#" class="btn float-right btn-secondary btn-xs"
                            data-action="rescan"><?= t('Rescan') ?></a>
                     <?php
 }

--- a/concrete/elements/files/search_header.php
+++ b/concrete/elements/files/search_header.php
@@ -33,7 +33,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <?php
         if (!empty($itemsPerPageOptions)) { ?>
             <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span id="selected-option"><?= $itemsPerPage; ?></span> <span class="caret"></span></button>
+                <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span id="selected-option"><?= $itemsPerPage; ?></span> <span class="caret"></span></button>
                 <ul class="dropdown-menu" data-action="<?= URL::to('/ccm/system/file/folder/contents'); ?>">
                     <li class="dropdown-header"><?=t('Items per page')?></li>
                     <?php foreach ($itemsPerPageOptions as $itemsPerPageOption) { ?>
@@ -71,8 +71,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
             </div>
         </form>
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
-            <button class="btn btn-primary pull-right" data-dialog-action="submit"><?=t('Add Folder')?></button>
+            <button class="btn btn-secondary float-left" data-dialog-action="cancel"><?=t('Cancel')?></button>
+            <button class="btn btn-primary float-right" data-dialog-action="submit"><?=t('Add Folder')?></button>
         </div>
     </div>
 

--- a/concrete/elements/notification/menu.php
+++ b/concrete/elements/notification/menu.php
@@ -9,7 +9,7 @@ if ($listView->getMenu() instanceof \Concrete\Core\Application\UserInterface\Con
 
 ?>
 
-    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+    <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
         <i class="fa fa-chevron-down"></i>
     </button>
 
@@ -18,7 +18,7 @@ if ($listView->getMenu() instanceof \Concrete\Core\Application\UserInterface\Con
 
 <?php } else { ?>
 
-    <button type="button" data-notification-action="archive" class="btn btn-default btn-waiting-for-me-archive">
+    <button type="button" data-notification-action="archive" class="btn btn-secondary btn-waiting-for-me-archive">
         <i></i>
     </button>
 

--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -419,7 +419,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
         if ($pageInUseBySomeoneElse) {
             $buttons = [];
             if ($canApprovePageVersions) {
-                $buttons[] = '<a onclick="$.get(\'' . REL_DIR_FILES_TOOLS_REQUIRED . '/dashboard/sitemap_check_in?cID=' . $c->getCollectionID() . $token . '\', function() { window.location.reload(); })" href="javascript:void(0)" class="btn btn-xs btn-default">' . t('Force Exit Edit Mode') . '</a>';
+                $buttons[] = '<a onclick="$.get(\'' . REL_DIR_FILES_TOOLS_REQUIRED . '/dashboard/sitemap_check_in?cID=' . $c->getCollectionID() . $token . '\', function() { window.location.reload(); })" href="javascript:void(0)" class="btn btn-xs btn-secondary">' . t('Force Exit Edit Mode') . '</a>';
             }
 
             echo $cih->notify([
@@ -432,7 +432,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
         } else {
             if ($c->getCollectionPointerID() > 0) {
                 $buttons = [];
-                $buttons[] = '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $cID . '" class="btn btn-default btn-xs">' . t('View/Edit Original') . '</a>';
+                $buttons[] = '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $cID . '" class="btn btn-secondary btn-xs">' . t('View/Edit Original') . '</a>';
                 if ($canApprovePageVersions) {
                     $url = URL::to('/ccm/system/dialogs/page/delete_alias?cID=' . $c->getCollectionPointerOriginalID());
                     $buttons[] = '<a href="' . $url . '" dialog-title="' . t('Remove Alias') . '" class="dialog-launch btn btn-xs btn-danger">' . t('Remove Alias') . '</a>';

--- a/concrete/elements/page_types/composer/form/layout_set/control.php
+++ b/concrete/elements/page_types/composer/form/layout_set/control.php
@@ -39,8 +39,8 @@ if (strlen($control->getPageTypeComposerFormLayoutSetControlCustomLabel())) {
 				<?=Core::make('helper/validation/token')->output('delete_set_control')?>
 
 				<div class="dialog-buttons">
-					<button class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-					<button class="btn btn-danger pull-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Delete Control')?></button>
+					<button class="btn btn-secondary float-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+					<button class="btn btn-danger float-right" onclick="Composer.deleteFromLayoutSetControl(<?=$control->getPageTypeComposerFormLayoutSetControlID()?>)"><?=t('Delete Control')?></button>
 				</div>
 
 			</div>

--- a/concrete/elements/permission/access/list.php
+++ b/concrete/elements/permission/access/list.php
@@ -3,7 +3,7 @@
 <?php foreach ($accessTypes as $accessType => $title) {
     $list = $permissionAccess->getAccessListItems($accessType);
     ?>
-	<a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?accessType=<?=$accessType?>&pkCategoryHandle=<?=$pkCategoryHandle?>" dialog-width="510" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-xs btn-default"><?=t('Add')?></a>
+	<a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?accessType=<?=$accessType?>&pkCategoryHandle=<?=$pkCategoryHandle?>" dialog-width="510" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-xs btn-secondary"><?=t('Add')?></a>
 
 	<h4><?=$title?></h4>
 
@@ -21,11 +21,11 @@
     ?>
 <tr>
     <td>
-    <a href="javascript:void(0)" class="icon-link pull-right" style="margin-left: 10px" onclick="ccm_deleteAccessEntityAssignment(<?=$pae->getAccessEntityID()?>)"><i class="fas fa-trash"></i></a>
+    <a href="javascript:void(0)" class="icon-link float-right" style="margin-left: 10px" onclick="ccm_deleteAccessEntityAssignment(<?=$pae->getAccessEntityID()?>)"><i class="fas fa-trash"></i></a>
 	<a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?peID=<?=$pae->getAccessEntityID()?>&pdID=<?=$pdID?>&accessType=<?=$accessType?>" dialog-width="510" dialog-height="500" dialog-title="<?=t('Add Access Entity')?>" class="<?php if (!is_object($pa->getPermissionDurationObject())) {
     ?>icon-link<?php
 }
-    ?> pull-right dialog-launch"><i class="far fa-clock <?php if (is_object($pa->getPermissionDurationObject())) {
+    ?> float-right dialog-launch"><i class="far fa-clock <?php if (is_object($pa->getPermissionDurationObject())) {
     ?>text-info<?php
 }
     ?>"></i></a>

--- a/concrete/elements/permission/clipboard.php
+++ b/concrete/elements/permission/clipboard.php
@@ -4,10 +4,10 @@
 
     $uid = uniqid();
 ?>
-<button class="btn btn-xs btn-default" type="button" id="ccm-permissions-list-copy-permissions-<?= $uid ?>"><?=t('Copy')?></button>
+<button class="btn btn-xs btn-secondary" type="button" id="ccm-permissions-list-copy-permissions-<?= $uid ?>"><?=t('Copy')?></button>
 <?php if (is_object($set) && $set->getPermissionKeyCategory() == $pkCategory->getPermissionKeyCategoryHandle()) {
     ?>
-	<button class="btn btn-xs btn-default" type="button" id="ccm-permissions-list-paste-permissions-<?= $uid ?>"><?=t('Paste')?></button>
+	<button class="btn btn-xs btn-secondary" type="button" id="ccm-permissions-list-paste-permissions-<?= $uid ?>"><?=t('Paste')?></button>
 <?php
 } ?>
 <input type="hidden" name="pkCategoryHandle" value="<?=$pkCategory->getPermissionKeyCategoryHandle()?>" />

--- a/concrete/elements/permission/detail.php
+++ b/concrete/elements/permission/detail.php
@@ -112,8 +112,8 @@ Loader::element('permission/access/list', array('pkCategoryHandle' => $pkCategor
 } ?>
 
 	<div class="dialog-buttons">
-		<button href="javascript:void(0)" class="btn btn-default pull-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
-		<button type="submit" class="btn btn-primary pull-right" onclick="$('#ccm-permissions-detail-form').submit()"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
+		<button href="javascript:void(0)" class="btn btn-secondary float-left" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+		<button type="submit" class="btn btn-primary float-right" onclick="$('#ccm-permissions-detail-form').submit()"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
 	</div>
 </form>
 </div>

--- a/concrete/elements/permission/details/block/timed_guest_access.php
+++ b/concrete/elements/permission/details/block/timed_guest_access.php
@@ -34,8 +34,8 @@ foreach ($list as $pa) {
 <?=Loader::element('permission/duration', array('pd' => $pd)); ?>
 
 <div class="dialog-buttons">
-	<input type="button" onclick="jQuery.fn.dialog.closeTop()" value="<?=t('Cancel')?>" class="btn btn-default pull-left" />
-	<input type="submit" onclick="$('#ccm-permissions-timed-guest-access-form').submit()" value="<?=t('Save')?>" class="btn btn-primary pull-right" />
+	<input type="button" onclick="jQuery.fn.dialog.closeTop()" value="<?=t('Cancel')?>" class="btn btn-secondary float-left" />
+	<input type="submit" onclick="$('#ccm-permissions-timed-guest-access-form').submit()" value="<?=t('Save')?>" class="btn btn-primary float-right" />
 </div>
 
 </form>

--- a/concrete/elements/permission/keys/notify_in_notification_center.php
+++ b/concrete/elements/permission/keys/notify_in_notification_center.php
@@ -7,7 +7,7 @@
 
 
 <h4><?=t('Users/Groups Receiving Notifications')?>
-    <a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?disableDuration=1&accessType=<?=PermissionKey::ACCESS_TYPE_INCLUDE?>&pkCategoryHandle=notification" dialog-width="500" dialog-height="350" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-sm btn-default"><?=t('Add')?></a>
+    <a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?disableDuration=1&accessType=<?=PermissionKey::ACCESS_TYPE_INCLUDE?>&pkCategoryHandle=notification" dialog-width="500" dialog-height="350" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-sm btn-secondary"><?=t('Add')?></a>
 
 </h4>
 
@@ -58,7 +58,7 @@ foreach ($included as $assignment) {
 
 <h4><?=t('Users/Groups Excluded from Notifications')?>
 
-    <a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?disableDuration=1&accessType=<?=PermissionKey::ACCESS_TYPE_EXCLUDE?>&pkCategoryHandle=notification" dialog-width="500" dialog-height="350" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-sm btn-default"><?=t('Add')?></a>
+    <a style="float: right" href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/permissions/access_entity?disableDuration=1&accessType=<?=PermissionKey::ACCESS_TYPE_EXCLUDE?>&pkCategoryHandle=notification" dialog-width="500" dialog-height="350" dialog-title="<?=t('Add Access Entity')?>" class="dialog-launch btn btn-sm btn-secondary"><?=t('Add')?></a>
 
 </h4>
 

--- a/concrete/elements/permission/lists/block.php
+++ b/concrete/elements/permission/lists/block.php
@@ -12,7 +12,7 @@ if (!$b->overrideAreaPermissions()) {
 	<p>
 	<?=t("Permissions for this block are currently dependent on the area containing this block.")?>
 	</p>
-	<a href="javascript:void(0)" class="btn btn-default btn-sm" onclick="ccm_setBlockPermissionsToOverride()"><?=t('Override Permissions')?></a>
+	<a href="javascript:void(0)" class="btn btn-secondary btn-sm" onclick="ccm_setBlockPermissionsToOverride()"><?=t('Override Permissions')?></a>
 	<br/>
 	<br/>
 	</div>
@@ -24,7 +24,7 @@ if (!$b->overrideAreaPermissions()) {
 
 	<div class="block-message alert-message notice">
 	<p><?=t("Permissions for this block currently override those of the area and page.")?></p>
-	<a href="javascript:void(0)" class="btn btn-sm btn-default" onclick="ccm_revertToAreaPermissions()"><?=t('Revert to Area Permissions')?></a>
+	<a href="javascript:void(0)" class="btn btn-sm btn-secondary" onclick="ccm_revertToAreaPermissions()"><?=t('Revert to Area Permissions')?></a>
 	<br/>
 	<br/>
 	</div>
@@ -78,8 +78,8 @@ foreach ($permissions as $pk) {
 <?php if ($enablePermissions) {
     ?>
 <div class="dialog-buttons">
-	<a href="javascript:void(0)" onclick="jQuery.fn.dialog.closeTop()" class="btn btn-default pull-left"><?=t('Cancel')?></a>
-	<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary pull-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
+	<a href="javascript:void(0)" onclick="jQuery.fn.dialog.closeTop()" class="btn btn-secondary float-left"><?=t('Cancel')?></a>
+	<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary float-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
 </div>
 <?php 
 } ?>

--- a/concrete/elements/permission/lists/file.php
+++ b/concrete/elements/permission/lists/file.php
@@ -12,7 +12,7 @@ if (!$f->overrideFileFolderPermissions()) {
 	<?=t("Permissions for this file are currently dependent on its folder and global file permissions.")?>
 	</p>
 	<br/>
-	<a href="javascript:void(0)" class="btn btn-default btn-sm" onclick="ccm_setFilePermissionsToOverride()"><?=t('Override Permissions')?></a>
+	<a href="javascript:void(0)" class="btn btn-secondary btn-sm" onclick="ccm_setFilePermissionsToOverride()"><?=t('Override Permissions')?></a>
 	</div>
 	
 <?php 
@@ -23,7 +23,7 @@ if (!$f->overrideFileFolderPermissions()) {
 	<div class="alert alert-notice">
 	<p><?=t("Permissions for this file currently override its sets and the global file permissions.")?></p>
 	<br/>
-	<a href="javascript:void(0)" class="btn btn-default btn-sm" onclick="ccm_revertToGlobalFilePermissions()"><?=t('Revert to Folder and Global Permissions')?></a>
+	<a href="javascript:void(0)" class="btn btn-secondary btn-sm" onclick="ccm_revertToGlobalFilePermissions()"><?=t('Revert to Folder and Global Permissions')?></a>
 	</div>
 
 <?php 
@@ -75,8 +75,8 @@ foreach ($permissions as $pk) {
 <?php if ($enablePermissions) {
     ?>
 <div id="ccm-file-permissions-advanced-buttons" style="display: none">
-	<button onclick="jQuery.fn.dialog.closeTop()" class="btn btn-default pull-left"><?=t('Cancel')?></button>
-	<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary pull-right"><?=t('Save')?></i></button>
+	<button onclick="jQuery.fn.dialog.closeTop()" class="btn btn-secondary float-left"><?=t('Cancel')?></button>
+	<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary float-right"><?=t('Save')?></i></button>
 </div>
 <?php 
 } ?>

--- a/concrete/elements/permission/lists/tree/node.php
+++ b/concrete/elements/permission/lists/tree/node.php
@@ -95,8 +95,8 @@ foreach ($permissions as $pk) {
 	<?php if (!isset($disableDialog) || !$disableDialog) { ?>
 
 		<div id="topics-tree-node-permissions-buttons" class="dialog-buttons">
-		<button href="javascript:void(0)" onclick="jQuery.fn.dialog.closeTop()" class="btn btn-default pull-left"><?=t('Cancel')?></button>
-		<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary pull-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
+		<button href="javascript:void(0)" onclick="jQuery.fn.dialog.closeTop()" class="btn btn-secondary float-left"><?=t('Cancel')?></button>
+		<button onclick="$('#ccm-permission-list-form').submit()" class="btn btn-primary float-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
 	</div>
 	<?php } ?>
 <?php

--- a/concrete/elements/workflow/type_form_required.php
+++ b/concrete/elements/workflow/type_form_required.php
@@ -48,7 +48,7 @@ if ($type->getPackageID() > 0) {
 
 <div class="ccm-dashboard-form-actions-wrapper">
     <div class="ccm-dashboard-form-actions">
-        <a href="<?=URL::to('/dashboard/system/permissions/workflows')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
+        <a href="<?=URL::to('/dashboard/system/permissions/workflows')?>" class="btn btn-secondary float-left"><?=t('Back to List')?></a>
 
     </div>
 </div>

--- a/concrete/single_pages/dashboard/calendar/add.php
+++ b/concrete/single_pages/dashboard/calendar/add.php
@@ -56,9 +56,9 @@ if ($calendar !== null) {
 
                 <div class="form-group">
                     <?= $form->label('calendarName', t('Calendar Name')) ?>
-                    <?= $form->text('calendarName', $calendarName, ['placeholder' => t('Choose a descriptive name for your calendar.')]) ?>
+                    <?= $form->text('calendarName', $calendarName, ['placeholder' => t('Choose a descriptive name for your calendar.'), ["class" => "form-control"]]) ?>
 
-                    <div class="help-block">
+                    <div class="form-text text-muted">
                         <?= t('Each separate calendar gets a complete separate list of events. Each front-end block can display content from one or multiple calendars.') ?>
                     </div>
                 </div>
@@ -79,7 +79,7 @@ if ($calendar !== null) {
                         '' => t('Do not link to a "More Details" page.'),
                         'create' => t('Create and link to a new "More Details" page.'),
                         'associate' => t('Link to an existing page')
-                    ], $enableMoreDetails)
+                    ], $enableMoreDetails, ["class" => "form-control"])
                     ?>
                 </div>
 
@@ -92,13 +92,13 @@ if ($calendar !== null) {
 
                     <div class="form-group">
                         <?= $form->label('eventPageTypeID', t('Page Type')) ?>
-                        <?= $form->select('eventPageTypeID', $types, $eventPageTypeID) ?>
+                        <?= $form->select('eventPageTypeID', $types, $eventPageTypeID, ["class" => "form-control"]) ?>
                     </div>
 
                     <div class="form-group">
                         <?= $form->label('eventPageAttributeKeyHandle', t('Calendar Event Attribute')) ?>
                         <?= $form->select('eventPageAttributeKeyHandle', $attributeKeys,
-                            $eventPageAttributeKeyHandle) ?>
+                            $eventPageAttributeKeyHandle, ["class" => "form-control"]) ?>
                     </div>
 
                 </div>
@@ -108,9 +108,9 @@ if ($calendar !== null) {
                         <?= $form->label('eventPageAssociatedID', t('Link to Page')) ?>
                         <?= Core::make('helper/form/page_selector')->selectPage('eventPageAssociatedID',
                             isset($eventPageAssociatedID) ? $eventPageAssociatedID : null) ?>
-                    </div>
-                    <div class="help-block">
-                        <?= t('<strong>Important</strong>: The page that you link to should contain a Calendar Event block or custom code that can render a specific calendar occurrence.') ?>
+                        <div class="form-text text-muted">
+                            <?= t('<strong>Important</strong>: The page that you link to should contain a Calendar Event block or custom code that can render a specific calendar occurrence.') ?>
+                        </div>
                     </div>
                 </div>
 

--- a/concrete/single_pages/dashboard/calendar/event_list.php
+++ b/concrete/single_pages/dashboard/calendar/event_list.php
@@ -14,9 +14,9 @@ $topic_id = Request::getInstance()->get('topic_id');
     <div class="form-group">
         <label class="control-label" for="query"><?= t('Search') ?></label>
         <div class="input-group">
-            <?= $form->text('query', array('placeholder' => t('Keywords'))) ?>
+            <?= $form->text('query', array('placeholder' => t('Keywords'), 'class' => 'form-control')) ?>
 
-            <div class="input-group-btn" style="z-index: 501;">
+            <div class="btn-group" role="group" style="z-index: 501;">
 
                 <?php if (isset($topics) && is_array($topics)) { ?>
 
@@ -30,8 +30,9 @@ $topic_id = Request::getInstance()->get('topic_id');
 
                 <?php } ?>
 
-                <button type="submit" class="btn btn-default"><?= t('Search') ?></button>
-
+                <div class="input-group-append">
+                    <button type="submit" class="btn btn-outline-secondary"><?= t('Search') ?></button>
+                </div>
             </div>
 
         </div><!-- /input-group -->
@@ -42,42 +43,39 @@ $topic_id = Request::getInstance()->get('topic_id');
 
 <?php if (count($events)) { ?>
 
-    <div class="table-responsive">
-        <table class="ccm-search-results-table" data-table="event-list">
-            <thead>
+    <table class="ccm-search-results-table" data-table="event-list">
+        <thead>
+        <tr>
+            <th></th>
+            <th><span><?= t('Name') ?></span></th>
+            <th><span><?= t('Date/Time') ?></span></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($events as $occurrence) {
+            $menu = new \Concrete\Core\Calendar\Event\Menu\EventOccurrenceMenu($occurrence);
+            $event = $occurrence->getEvent();
+            $color = $linkFormatter->getEventOccurrenceBackgroundColor($occurrence);
+            $date = $dateFormatter->getOccurrenceDateString($occurrence);
+            ?>
             <tr>
-                <th></th>
-                <th><span><?= t('Name') ?></span></th>
-                <th><span><?= t('Date/Time') ?></span></th>
-                <th></th>
+                <td><span class="event-swatch" style="background-color: <?= $color ?>"></span></td>
+                <td class="ccm-search-results-name">
+                    <?php
+                    print $menu->getMenuElement();
+                    print h($event->getName());
+
+                    if (!$occurrence->getVersion()->isApproved()) {
+                        print ' <i class="fa fa-exclamation-circle"></i>';
+                    }
+                    ?>
+
+                </td>
+                <td class="ccm-search-results-date"><?= $date ?></td>
             </tr>
-            </thead>
-            <tbody>
-            <?php foreach ($events as $occurrence) {
-                $menu = new \Concrete\Core\Calendar\Event\Menu\EventOccurrenceMenu($occurrence);
-                $event = $occurrence->getEvent();
-                $color = $linkFormatter->getEventOccurrenceBackgroundColor($occurrence);
-                $date = $dateFormatter->getOccurrenceDateString($occurrence);
-                ?>
-                <tr>
-                    <td><span class="event-swatch" style="background-color: <?= $color ?>"></span></td>
-                    <td class="ccm-search-results-name">
-                        <?php
-                        print $menu->getMenuElement();
-                        print h($event->getName());
-
-                        if (!$occurrence->getVersion()->isApproved()) {
-                            print ' <i class="fa fa-exclamation-circle"></i>';
-                        }
-                        ?>
-
-                    </td>
-                    <td class="ccm-search-results-date"><?= $date ?></td>
-                </tr>
-            <?php } ?>
-            </tbody>
-        </table>
-    </div>
+        <?php } ?>
+        </tbody>
+    </table>
 
     <?php if (is_object($pagination) && $pagination->haveToPaginate()) { ?>
         <div class="ccm-search-results-pagination"><?= $pagination->renderDefaultView() ?></div>

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -20,36 +20,31 @@ Loader::element('calendar/header', array(
     <h3 id="calendar-month-name"><?= $monthText ?> <?= $year ?></h3>
 
     <div class="btn-group">
-        <a href="<?= $previousLink ?>" class="btn btn-sm btn-default"><i class="fa fa-angle-double-left"></i></a>
-        <a data-nav="month" href="javascript:void(0)" class="btn btn-sm btn-default"><i class="fa fa-calendar-o"></i></a>
-        <a href="<?= $nextLink ?>" class="btn btn-sm btn-default"><i class="fa fa-angle-double-right"></i></a>
+        <a href="<?= $previousLink ?>" class="btn btn-sm btn-secondary"><i class="fa fa-angle-double-left"></i></a>
+        <a data-nav="month" href="javascript:void(0)" class="btn btn-sm btn-secondary"><i class="fa fa-calendar-o"></i></a>
+        <a href="<?= $nextLink ?>" class="btn btn-sm btn-secondary"><i class="fa fa-angle-double-right"></i></a>
     </div>
 
     <?php if (isset($topics) && is_array($topics)) {
         ?>
         <div class="btn-group" id="calendar-topics">
-            <button type="button" id="topics_button" class="btn btn-default btn-sm" data-toggle="dropdown">
+            <button type="button" id="topics_button" class="btn btn-secondary btn-sm" data-toggle="dropdown">
                 <?= $topic ? h($topic->getTreeNodeDisplayName('html')) : t('All Categories') ?>
                 <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="topics_button">
-                <li>
-                    <a href="?topic_id=0"><?= t('All Categories') ?></a>
-                </li>
+            <div class="dropdown-menu" role="menu" aria-labelledby="topics_button">
+                <a href="?topic_id=0" class="dropdown-item"><?= t('All Categories') ?></a>
                 <?php
                 /** @var \Concrete\Core\Tree\Node\Node $topic_node */
                 foreach ((array)$topics as $topic_node) {
                     ?>
-                    <li>
-                        <a href="?topic_id=<?= $topic_node->getTreeNodeID() ?>">
+                        <a class="dropdown-item" href="?topic_id=<?= $topic_node->getTreeNodeID() ?>">
                             <?= h($topic_node->getTreeNodeDisplayName('html')) ?>
                         </a>
-                    </li>
                     <?php
-
                 }
                 ?>
-            </ul>
+            </div>
         </div>
 
         <?php

--- a/concrete/single_pages/dashboard/calendar/permissions.php
+++ b/concrete/single_pages/dashboard/calendar/permissions.php
@@ -9,11 +9,11 @@ $preferences = Core::make('Concrete\Core\Calendar\Utility\Preferences');
 <?=Core::make('token')->output('update_permissions_inheritance')?>
             <?php if (!$calendar->arePermissionsSetToOverride()) {
     ?>
-                <button name="update_inheritance" value="override" class="btn btn-default pull-right"><?=t('Override Default Permissions')?></button>
+                <button name="update_inheritance" value="override" class="btn btn-secondary float-right"><?=t('Override Default Permissions')?></button>
             <?php 
 } else {
     ?>
-                <button name="update_inheritance" value="revert" class="btn btn-default pull-right"><?=t('Remove Custom Permissions')?></button>
+                <button name="update_inheritance" value="revert" class="btn btn-secondary float-right"><?=t('Remove Custom Permissions')?></button>
             <?php 
 } ?>
 </form>
@@ -36,12 +36,12 @@ $preferences = Core::make('Concrete\Core\Calendar\Utility\Preferences');
 
     <?php if ($calendar->arePermissionsSetToOverride()) {
     ?>
-        <a href="<?=URL::to($preferences->getPreferredViewPath(), 'view', $calendar->getID())?>" class="btn btn-default"><?=t('Back')?></a>
-        <button type="submit" name="submit" class="btn pull-right btn-primary"><?=t('Save')?></button>
+        <a href="<?=URL::to($preferences->getPreferredViewPath(), 'view', $calendar->getID())?>" class="btn btn-secondary"><?=t('Back')?></a>
+        <button type="submit" name="submit" class="btn float-right btn-primary"><?=t('Save')?></button>
     <?php 
 } else {
     ?>
-        <a href="<?=URL::to($preferences->getPreferredViewPath(), 'view', $calendar->getID())?>" class="btn btn-default"><?=t('Back')?></a>
+        <a href="<?=URL::to($preferences->getPreferredViewPath(), 'view', $calendar->getID())?>" class="btn btn-secondary"><?=t('Back')?></a>
     <?php 
 } ?>
 

--- a/concrete/single_pages/dashboard/system/calendar/colors.php
+++ b/concrete/single_pages/dashboard/system/calendar/colors.php
@@ -71,7 +71,7 @@
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button class="pull-right btn btn-success" type="submit" ><?=t('Save')?></button>
+            <button class="float-right btn btn-success" type="submit" ><?=t('Save')?></button>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/system/calendar/import.php
+++ b/concrete/single_pages/dashboard/system/calendar/import.php
@@ -11,7 +11,7 @@
 
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
-                <button class="pull-right btn btn-success" type="submit" ><?=t('Import')?></button>
+                <button class="float-right btn btn-success" type="submit" ><?=t('Import')?></button>
             </div>
         </div>
     </form>

--- a/concrete/single_pages/dashboard/system/calendar/permissions.php
+++ b/concrete/single_pages/dashboard/system/calendar/permissions.php
@@ -23,7 +23,7 @@
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button class="pull-right btn btn-primary" type="submit" ><?=t('Save')?></button>
+            <button class="float-right btn btn-primary" type="submit" ><?=t('Save')?></button>
         </div>
     </div>
 </form>

--- a/concrete/single_pages/dashboard/system/calendar/settings.php
+++ b/concrete/single_pages/dashboard/system/calendar/settings.php
@@ -10,7 +10,7 @@
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button class="pull-right btn btn-success" type="submit" ><?=t('Save')?></button>
+            <button class="float-right btn btn-success" type="submit" ><?=t('Save')?></button>
         </div>
     </div>
 

--- a/concrete/views/dialogs/event/delete.php
+++ b/concrete/views/dialogs/event/delete.php
@@ -32,9 +32,9 @@
         <input type="hidden" name="eventID" value="<?=$event->getID()?>">
 
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+            <button class="btn btn-secondary float-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
             <button type="button" data-dialog-action="submit"
-                    class="btn btn-danger pull-right"><?= t('Delete') ?></button>
+                    class="btn btn-danger float-right"><?= t('Delete') ?></button>
         </div>
 
 

--- a/concrete/views/dialogs/event/delete_occurrence.php
+++ b/concrete/views/dialogs/event/delete_occurrence.php
@@ -14,9 +14,9 @@
         <input type="hidden" name="versionOccurrenceID" value="<?=$occurrence->getID()?>">
 
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+            <button class="btn btn-secondary float-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
             <button type="button" data-dialog-action="submit"
-                    class="btn btn-danger pull-right"><?= t('Delete') ?></button>
+                    class="btn btn-danger float-right"><?= t('Delete') ?></button>
         </div>
 
 

--- a/concrete/views/dialogs/event/duplicate.php
+++ b/concrete/views/dialogs/event/duplicate.php
@@ -23,9 +23,9 @@
         <?php } ?>
 
         <div class="dialog-buttons">
-            <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+            <button class="btn btn-secondary float-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
             <button type="button" data-dialog-action="submit"
-                    class="btn btn-primary pull-right"><?= t('Duplicate Event') ?></button>
+                    class="btn btn-primary float-right"><?= t('Duplicate Event') ?></button>
         </div>
 
 

--- a/concrete/views/dialogs/event/form.php
+++ b/concrete/views/dialogs/event/form.php
@@ -27,7 +27,7 @@ if (!isset($occurrence) || !$occurrence) {
     </form>
 </div>
 <div class="dialog-buttons">
-    <button class="btn btn-default pull-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
+    <button class="btn btn-secondary float-left" data-dialog-action="cancel"><?= t('Cancel') ?></button>
 
     <?php if ($occurrence !== null || $cp->canApproveCalendarEvent()) {
         $showButtonGroup = true;
@@ -36,14 +36,14 @@ if (!isset($occurrence) || !$occurrence) {
     } ?>
 
             <?php if ($cp->canApproveCalendarEvent()) { ?>
-            <button type="submit" class="btn btn-success pull-right"
+            <button type="submit" class="btn btn-success float-right"
                     data-event-dialog-action="publish"><?= t('Publish Event') ?></button>
                 <button type="submit" data-event-dialog-action="save"
-                        class="btn btn-primary pull-left"><?= t('Save &amp; Close') ?></button>
+                        class="btn btn-primary float-left"><?= t('Save &amp; Close') ?></button>
 
         <?php } else { ?>
             <button type="submit" style="margin-right: 0px" data-event-dialog-action="save"
-                    class="pull-right btn btn-primary"><?= t('Save &amp; Close') ?></button>
+                    class="float-right btn btn-primary"><?= t('Save &amp; Close') ?></button>
         <?php } ?>
 
     <script type="text/javascript">

--- a/concrete/views/dialogs/event/versions.php
+++ b/concrete/views/dialogs/event/versions.php
@@ -4,7 +4,7 @@
 <div class="ccm-ui">
 
     <div id="ccm-calendar-event-version-reload" class="alert alert-info" style="display: none">
-        <button class="pull-right btn btn-xs btn-default" onclick="window.location.reload()" type="button"><?=t('Reload')?></button>
+        <button class="float-right btn btn-xs btn-secondary" onclick="window.location.reload()" type="button"><?=t('Reload')?></button>
         <?=t('Reload the page to refresh the events.')?>
     </div>
 
@@ -34,8 +34,10 @@
             <tr <?php if ($version->isApproved()) { ?> class="success" <?php } ?>
                 data-calendar-event-version-id="<?= $version->getID() ?>">
                 <td style="text-align: center">
-                    <input type="radio" name="eventVersionID" data-token="<?= Core::make('token')->generate('calendar/event/version/approve/' . $version->getID()) ?>" value="<?= $version->getID() ?>"
+                    <div class="form-check">
+                        <input type="radio" name="eventVersionID" class="form-check-input" data-token="<?= Core::make('token')->generate('calendar/event/version/approve/' . $version->getID()) ?>" value="<?= $version->getID() ?>"
                            <?php if ($version->isApproved()) { ?>checked<?php } ?> />
+                    </div>
                 </td>
                 <td>
                     <div>
@@ -72,8 +74,10 @@
 
         <tr>
             <td style="text-align: center">
-                <input type="radio" name="eventVersionID" data-event-id="<?=$event->getID()?>" data-token="<?= Core::make('token')->generate('unapprove_event') ?>" value="-1"
+                <div class="form-check">
+                <input type="radio" name="eventVersionID" class="form-check-input" data-event-id="<?=$event->getID()?>" data-token="<?= Core::make('token')->generate('unapprove_event') ?>" value="-1"
                        <?php if ($unapprovedChecked) { ?>checked<?php } ?>
+                </div>
             </td>
             <td colspan="6" class="text-muted"><?=t('No approved version.')?></td>
         </tr>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,2 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 require 'concrete/dispatcher.php';

--- a/index.php
+++ b/index.php
@@ -1,3 +1,5 @@
 <?php
-
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
 require 'concrete/dispatcher.php';


### PR DESCRIPTION
I have edited all related calendar pages like Dashboard > Events, all according files in the elements folder and all dialogs.

Here are my annotations about my commit:

* If there are more then 10 events the paginiation is used in the events list view. For the rendering of the pagination the class ConcreteBootstrap3View is used which has depreceated css classes from bootstrap 3. For supporting Bootstrap 4 there needs to be generated new view classes.
* For the fields "start time" and "end time" in edit/add event dialog is currently the library selectize.js in use. (see https://selectize.github.io/selectize.js/) The problem is that this library is currently not supported for bootstrap 4 (see https://github.com/selectize/selectize.js/issues/905)
* At some points the datepicker component of jquery ui is used which is looking terrible in combination with Bootstrap 4. A better alternate is the Boostrap datepicker: https://bootstrap-datepicker.readthedocs.io/en/latest/index.html
* In the "add attribute" section in the page Calendar & Events > Attributes, the attributes "Text", "Date/Time" and "Image/File" has no icons. This is because the fontawesome classes "fa-file-text" and "fa-clock-o" are no longer available in font awesome 5. The related attributes needs to be updated. Furthermore a empty icon should be implemented if a 3rd party attribute has no valid icon handle.
