### PR TITLE
Fix assets required by core/cms asset group

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -519,8 +519,8 @@ return [
 
         'core/cms' => [
             [
-                ['jquery'],
-                ['font-awesome'],
+                ['javascript', 'jquery'],
+                ['css', 'font-awesome'],
                 ['javascript', 'core/cms'],
                 ['javascript-localized', 'core/cms'],
                 ['css', 'core/cms'],


### PR DESCRIPTION
Assets required by asset groups require both the asset type and the asset handle.

PS: detected by turning on the *Consider warnings as errors* option in the System & Settings > Environment > Debug Settings dashboard page