### PR TITLE
Avoid deprecated order if implode() arguments

### DIFF
--- a/concrete/controllers/element/navigation/application_menu.php
+++ b/concrete/controllers/element/navigation/application_menu.php
@@ -84,7 +84,7 @@ class ApplicationMenu extends ElementController
         if (in_array($page->getCollectionID(), $this->trail)) {
             $classes[] = 'nav-path-selected';
         }
-        return implode($classes, ' ');
+        return implode(' ', $classes);
     }
 
     public function displayDivider(Page $page, Page $next = null)


### PR DESCRIPTION
This fixes the following warning:
```
implode(): Passing glue string after array is deprecated. Swap the parameters
```

PS: detected by turning on the *Consider warnings as errors* option in the System & Settings > Environment > Debug Settings dashboard page