### PR TITLE
Fix automatic flashbag sets

### DIFF
--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -23,6 +23,9 @@ class PageController extends Controller
     protected $replacement = null;
     protected $requestValidated;
 
+    /** @var bool A flag to track whether we've loaded sets from the session flash bags */
+    private $hasCheckedSessionMessages = false;
+
     /**
      * array of method names that can't be called through the url
      * @var array
@@ -110,23 +113,37 @@ class PageController extends Controller
         return $this->replacement;
     }
 
+    /**
+     * Get the things "set" against this controller with `$this->set(...)`
+     * This output array may also contain items set with `$this->flash(...)` like `message` `error` `success` or other
+     * custom keys
+     *
+     * @return array Associative array of things set against this controller
+     */
     public function getSets()
     {
-        $app = $this->app;
-        $sets = parent::getSets();
-        $validator = $app->make(SessionValidator::class);
-        $session = Application::getFacadeApplication()->make('session');
-        if ($validator->hasActiveSession()) {
-            if ($session->getFlashBag()->has('page_message')) {
+        // Check if we've already looked at the session flashbag, if so just move on
+        if ($this->hasCheckedSessionMessages === false) {
+            $this->hasCheckedSessionMessages = true;
+            $app = $this->app;
+            $validator = $app->make(SessionValidator::class);
+            $session = Application::getFacadeApplication()->make('session');
+
+            // Check if we have an active session and our expected flash message
+            if ($validator->hasActiveSession() && $session->getFlashBag()->has('page_message')) {
                 $value = $session->getFlashBag()->get('page_message');
+
+                // Add each page_message item to the sets for the page
                 foreach ($value as $message) {
-                    $sets[$message[0]] = $message[1];
-                    $sets[$message[0].'IsHTML'] = isset($message[2]) && $message[2];
+                    $this->set($message[0], $message[1]);
+
+                    // Also set a `{$key}IsHTML` helper boolean to tell whether the set value is supposed to be HTML
+                    $this->set($message[0] . 'IsHTML', isset($message[2]) && $message[2]);
                 }
             }
         }
 
-        return $sets;
+        return parent::getSets();
     }
 
     /**


### PR DESCRIPTION
Before this change the `->getSets()` function would check for a session flashbag value for `page_message` each time it was called, and if there were messages would add those messages to the output by effectively merging them into the result of `parent::getSets()`

The problem with this is the flashbag contents get deleted when they get read, so setting them only in the output means that only the first call to `->getSets()` will include the stuff from the flashbag. To combat that, I've done a few things:

1. Memoize the fact that we've checked the flashbag, this prevents us from checking session every time we need to get the set values and also stops us from resetting the messages over and over
2. Changed from merging the values into the result to setting the values with `$this->set()` so that they are persistent
3. Moved the flashbag check to the top so that it happens before we call `parent::getSets()`