### PR TITLE
[v9] Fix Docker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     - name: Test with PHP nightly
     - name: Test with PHP 7.4
     - name: Check PHP coding style
-    - name: Test in Docker
   include:
 
     - name: Test with PHP 7.2 (with code coverage)

--- a/tests/assets/Docker/run-install.sh
+++ b/tests/assets/Docker/run-install.sh
@@ -2,14 +2,28 @@
 
 set -o errexit
 
+# Set the currently active PHP version
+if test -n "${CCM_TEST_PHPVERSION:-}"; then
+    switch-php "$CCM_TEST_PHPVERSION"
+fi
+
 # Start MariaDB
 ccm-service start db
 
 # Reset previously installed concrete5
-sudo -u www-data -- /app/concrete/bin/concrete5 c5:reset -f
+c5 c5:reset -f
+
+# Output error information to site users
+c5 c5:config -g -- set concrete.debug.display_errors true
+
+# Show the debug error output
+c5 c5:config -g -- set concrete.debug.detail debug
+
+# Consider warnings as errors
+c5 c5:config -g -- set concrete.debug.error_reporting -1
 
 # Re-install concrete5
-sudo -u www-data -- /app/concrete/bin/concrete5 c5:install -vvv \
+c5 c5:install -vvv \
     --db-server=localhost \
     --db-username=c5 \
     --db-password=12345 \

--- a/tests/assets/Docker/run-update.sh
+++ b/tests/assets/Docker/run-update.sh
@@ -2,8 +2,22 @@
 
 set -o errexit
 
+# Set the currently active PHP version
+if test -n "${CCM_TEST_PHPVERSION:-}"; then
+    switch-php "$CCM_TEST_PHPVERSION"
+fi
+
 # Start MariaDB
 ccm-service start db
 
+# Output error information to site users
+c5 c5:config -g -- set concrete.debug.display_errors true
+
+# Show the debug error output
+c5 c5:config -g -- set concrete.debug.detail debug
+
+# Consider warnings as errors
+c5 c5:config -g -- set concrete.debug.error_reporting -1
+
 # Update concrete5 to current version
-sudo -u www-data -- /app/concrete/bin/concrete5 c5:update -vvv
+c5 c5:update -vvv

--- a/tests/helpers/DockerTrait.php
+++ b/tests/helpers/DockerTrait.php
@@ -9,7 +9,7 @@ trait DockerTrait
      *
      * @param string $imageName
      *
-     * @throws \PHPUnit_Framework_SkippedTestError
+     * @throws \PHPUnit\Framework\SkippedTestError
      */
     protected static function ensureDockerImage($imageName)
     {
@@ -26,7 +26,7 @@ trait DockerTrait
         if (trim(implode("\n", $output)) !== '') {
             return;
         }
-        exec('docker pull ' . escapeshellarg($imageName) . ' 2>&1', $output, $rc);
+        exec('docker pull --quiet ' . escapeshellarg($imageName) . ' 2>&1', $output, $rc);
         if ($rc !== 0) {
             self::markTestSkipped("Failed to fetch Docker image \"{$imageName}\": " . trim(implode("\n", $output)));
         }
@@ -37,11 +37,12 @@ trait DockerTrait
      *
      * @param string $imageName
      * @param string $script
+     * @param string $phpVersion
      *
-     * @throws \PHPUnit_Framework_SkippedTestError
-     * @throws \PHPUnit_Framework_AssertionFailedError
+     * @throws \PHPUnit\Framework\SkippedTestError
+     * @throws \PHPUnit\Framework\AssertionFailedError
      */
-    protected function runScriptInDocker($imageName, $script)
+    protected function runScriptInDocker($imageName, $script, $phpVersion = '7.2')
     {
         self::ensureDockerImage($imageName);
         $cmd = implode(' ', [
@@ -53,6 +54,8 @@ trait DockerTrait
             '-v ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE . '/concrete') . ':/app/concrete'),
             // Mount the test directory
             '-v ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE . '/tests/assets/Docker') . ':/app-test'),
+            // Set the CCM_TEST_PHPVERSION environment variable
+            '-e ' . escapeshellarg("CCM_TEST_PHPVERSION={$phpVersion}"),
             // Override the defaul entry point
             '--entrypoint ""',
             // The base container image


### PR DESCRIPTION
Before https://github.com/concrete5-community/docker5/pull/12, the `docker5` docker images contained only one PHP version (which was 5.5 for concrete5 5.7 images and 7.2 for concrete5 8+ images).
This was a problem: since concrete5 9 requires PHP 7.2, we couldn't test upgrading a concrete5 5.7 installation because its docker image uses PHP 5.5.

Now, the `docker5` docker images contain multiple PHP versions: 5.6, 7.2 and 7.4 (you can switch the currently active one by using the new `switch-php` command). There's no PHP 5.5 (which could be useful to test concrete5 5.7) because the used PPA ([`ppa:ondrej/php`](https://launchpad.net/~ondrej/+archive/ubuntu/php)) doesn't offer it.

This change lets us test upgrading a concrete5 5.7 docker image to concrete5 9.