### PR TITLE
Add type hinting to Site Type stuff

### DIFF
--- a/concrete/src/Site/Type/Controller/ControllerInterface.php
+++ b/concrete/src/Site/Type/Controller/ControllerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Site\Type\Controller;
 
 use Concrete\Core\Entity\Site\Site;
@@ -8,20 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface ControllerInterface
 {
-    /**
-     * @param Site $site
-     * @param Request $request
-     * @return Site
-     */
+    public function add(Site $site, Request $request): Site;
 
-    public function add(Site $site, Request $request);
-    public function update(Site $site, Request $request);
-    public function delete(Site $site);
-    public function addType(Type $type);
+    public function update(Site $site, Request $request): Site;
 
-    /**
-     * @return FormatterInterface
-     */
-    public function getFormatter(Type $type);
+    public function delete(Site $site): bool;
 
+    public function addType(Type $type): Type;
+
+    public function getFormatter(Type $type): FormatterInterface;
 }

--- a/concrete/src/Site/Type/Controller/Manager.php
+++ b/concrete/src/Site/Type/Controller/Manager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Site\Type\Controller;
 
 use Concrete\Core\Application\Application;
@@ -6,23 +7,35 @@ use Concrete\Core\Support\Manager as CoreManager;
 
 class Manager extends CoreManager
 {
-
+    /**
+     * @var string
+     */
     protected $standardController = StandardController::class;
 
+    public function __construct(Application $application)
+    {
+        parent::__construct($application);
+    }
+
     /**
-     * @param mixed $standardController
+     * @return $this
      */
-    public function setStandardController($standardController)
+    public function setStandardController(string $vaiue): self
     {
-        $this->standardController = $standardController;
+        $this->standardController = $vaiue;
+
+        return $this;
     }
 
-
-    protected function getStandardController()
-    {
-        return $this->app->make($this->standardController);
-    }
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Illuminate\Support\Manager::driver()
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return \Concrete\Core\Site\Type\Controller\ControllerInterface
+     */
     public function driver($driver = null)
     {
         if (!isset($this->customCreators[$driver]) && !isset($this->drivers[$driver])) {
@@ -32,9 +45,8 @@ class Manager extends CoreManager
         return parent::driver($driver);
     }
 
-    public function __construct(Application $application)
+    protected function getStandardController(): ControllerInterface
     {
-        parent::__construct($application);
+        return $this->app->make($this->standardController);
     }
-
 }

--- a/concrete/src/Site/Type/Formatter/AbstractFormatter.php
+++ b/concrete/src/Site/Type/Formatter/AbstractFormatter.php
@@ -1,22 +1,18 @@
 <?php
+
 namespace Concrete\Core\Site\Type\Formatter;
 
 use Concrete\Core\Entity\Site\Type;
 
 abstract class AbstractFormatter implements FormatterInterface
 {
-
+    /**
+     * @var \Concrete\Core\Entity\Site\Type
+     */
     protected $type;
 
-    /**
-     * AbstractFormatter constructor.
-     * @param $type
-     */
     public function __construct(Type $type)
     {
         $this->type = $type;
     }
-
-
-
 }

--- a/concrete/src/Site/Type/Formatter/DefaultFormatter.php
+++ b/concrete/src/Site/Type/Formatter/DefaultFormatter.php
@@ -1,21 +1,30 @@
 <?php
+
 namespace Concrete\Core\Site\Type\Formatter;
 
 use HtmlObject\Element;
 
 class DefaultFormatter extends AbstractFormatter
 {
-
-    public function getSiteTypeDescription()
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Site\Type\Formatter\FormatterInterface::getSiteTypeDescription()
+     */
+    public function getSiteTypeDescription(): string
     {
         return '';
     }
 
-    public function getSiteTypeIconElement()
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Site\Type\Formatter\FormatterInterface::getSiteTypeIconElement()
+     */
+    public function getSiteTypeIconElement(): Element
     {
         return (new Element('i'))
-            ->addClass('fa fa-file');
+            ->addClass('fas fa-file')
+        ;
     }
-
-
 }

--- a/concrete/src/Site/Type/Formatter/FormatterInterface.php
+++ b/concrete/src/Site/Type/Formatter/FormatterInterface.php
@@ -1,9 +1,12 @@
 <?php
+
 namespace Concrete\Core\Site\Type\Formatter;
+
+use HtmlObject\Element;
 
 interface FormatterInterface
 {
-    function getSiteTypeDescription();
-    function getSiteTypeIconElement();
+    public function getSiteTypeDescription(): string;
 
+    public function getSiteTypeIconElement(): Element;
 }


### PR DESCRIPTION
PHP type hinting is a real life saver: programmers are sure about the returned values from functions, and functions are sure about what they receive.

We can't of course change stuff that has already been released (otherwise overriding classes and methods would break the LSP).

What about adding it for new classes, like the ones included in this PR?