### PR TITLE
Allow specifying custom ID or NAME attributes for form elements

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -154,7 +154,12 @@ class Form
      */
     public function label($forFieldID, $innerHTML, $miscFields = [])
     {
-        return '<label for="' . $forFieldID . '"' . $this->serializeMiscFields('', $miscFields, []) . '>' . $innerHTML . '</label>';
+        $result = '<label';
+        if ((string) $forFieldID !== '') {
+            $result .= ' for="' . $forFieldID . '"';
+        }
+
+        return $result . $this->serializeMiscFields('', $miscFields, []) . '>' . $innerHTML . '</label>';
     }
 
     /**

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -534,7 +534,7 @@ class Form
         } else {
             $selectedOption = $selectedCountryCode;
         }
-        if (!array_key_exist('id', $miscFields) && ubstr($key, -2) === '[]') {
+        if (!array_key_exists('id', $miscFields) && substr($key, -2) === '[]') {
             $miscFields['id'] = substr($key, 0, -2) . $this->selectIndex;
             ++$this->selectIndex;
         }

--- a/tests/tests/Form/Service/FormTest.php
+++ b/tests/tests/Form/Service/FormTest.php
@@ -49,6 +49,26 @@ class FormTest extends TestCase
                 ['Key', 'Value', [], 'MY-CLASS'],
                 '<input type="submit" class="btn ccm-input-submit MY-CLASS" id="Key" name="Key" value="Value" />',
             ],
+            [
+                'submit',
+                ['Key', 'Value', ['id' => ''], 'MY-CLASS'],
+                '<input type="submit" class="btn ccm-input-submit MY-CLASS" name="Key" value="Value" />',
+            ],
+            [
+                'submit',
+                ['Key', 'Value', ['name' => ''], 'MY-CLASS'],
+                '<input type="submit" class="btn ccm-input-submit MY-CLASS" id="Key" value="Value" />',
+            ],
+            [
+                'submit',
+                ['Key', 'Value', ['id' => 'override'], 'MY-CLASS'],
+                '<input type="submit" class="btn ccm-input-submit MY-CLASS" id="override" name="Key" value="Value" />',
+            ],
+            [
+                'submit',
+                ['Key', 'Value', ['id' => 'override1', 'name' => 'override2'], 'MY-CLASS'],
+                '<input type="submit" class="btn ccm-input-submit MY-CLASS" id="override1" name="override2" value="Value" />',
+            ],
             // button
             [
                 'button',
@@ -69,6 +89,16 @@ class FormTest extends TestCase
                 'button',
                 ['Key', 'Value', [], 'MY-CLASS'],
                 '<input type="button" class="btn ccm-input-button MY-CLASS" id="Key" name="Key" value="Value" />',
+            ],
+            [
+                'button',
+                ['Key', 'Value', ['id' => ''], 'MY-CLASS'],
+                '<input type="button" class="btn ccm-input-button MY-CLASS" name="Key" value="Value" />',
+            ],
+            [
+                'button',
+                ['Key', 'Value', ['id' => 'override1', 'name' => 'override2'], 'MY-CLASS'],
+                '<input type="button" class="btn ccm-input-button MY-CLASS" id="override1" name="override2" value="Value" />',
             ],
             // label
             [
@@ -91,6 +121,11 @@ class FormTest extends TestCase
                 ['ForKey', 'text', ['class' => 'MY-CLASS']],
                 '<label for="ForKey" class="MY-CLASS">text</label>',
             ],
+            [
+                'label',
+                ['ForKey', 'text', ['class' => 'MY-CLASS', 'id' => 'my-id']],
+                '<label for="ForKey" class="MY-CLASS" id="my-id">text</label>',
+            ],
             // file
             [
                 'file',
@@ -111,6 +146,16 @@ class FormTest extends TestCase
                 'file',
                 ['Key', ['class' => 'MY-CLASS']],
                 '<input type="file" id="Key" name="Key" value="" class="MY-CLASS form-control" />',
+            ],
+            [
+                'file',
+                ['Key[]', ['id' => '']],
+                '<input type="file" name="Key[]" value="" class="form-control" />',
+            ],
+            [
+                'file',
+                ['Key[]', ['id' => 'override']],
+                '<input type="file" id="override" name="Key[]" value="" class="form-control" />',
             ],
             // hidden
             [
@@ -203,6 +248,24 @@ class FormTest extends TestCase
                 ['Key[subkey1][subkey2]', 'Original value'],
                 '<input type="hidden" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" />',
                 ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'Received value']]]],
+            ],
+            [
+                'hidden',
+                ['Key[subkey1][subkey2]', 'Original value', ['id' => '']],
+                '<input type="hidden" name="Key[subkey1][subkey2]" value="Received value" />',
+                ['Key' => ['subkey1' => ['subkey2' => 'Received value']]],
+            ],
+            [
+                'hidden',
+                ['Key[subkey1][subkey2]', 'Original value', ['name' => 'override']],
+                '<input type="hidden" id="Key[subkey1][subkey2]" name="override" value="Original value" />',
+                ['Key' => ['subkey1' => ['subkey2' => 'Received value']]],
+            ],
+            [
+                'hidden',
+                ['ID', 'Original value', ['name' => 'Key[subkey1][subkey2]']],
+                '<input type="hidden" id="ID" name="Key[subkey1][subkey2]" value="Received value" />',
+                ['Key' => ['subkey1' => ['subkey2' => 'Received value']]],
             ],
             // checkbox
             [
@@ -328,6 +391,24 @@ class FormTest extends TestCase
                 '<input type="checkbox" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-check-input" value="Value" />',
                 ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'Other value']]]],
             ],
+            [
+                'checkbox',
+                ['Key[]', 'Value', false, ['id' => 'custom-id']],
+                '<input type="checkbox" id="custom-id" name="Key[]" class="form-check-input" value="Value" checked="checked" />',
+                ['Key' => ['Look', 'for', 'Value', 'in', 'this', 'array']],
+            ],
+            [
+                'checkbox',
+                ['Key[]', 'Value', false, ['name' => 'custom-name[]']],
+                '<input type="checkbox" id="Key_Value" name="custom-name[]" class="form-check-input" value="Value" />',
+                ['Key' => ['Look', 'for', 'Value', 'in', 'this', 'array']],
+            ],
+            [
+                'checkbox',
+                ['Key[]', 'Value', false, ['name' => 'custom-name[]']],
+                '<input type="checkbox" id="Key_Value" name="custom-name[]" class="form-check-input" value="Value" checked="checked" />',
+                ['custom-name' => ['Look', 'for', 'Value', 'in', 'this', 'array']],
+            ],
             // textarea
             [
                 'textarea',
@@ -390,6 +471,24 @@ class FormTest extends TestCase
                 '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" class="form-control">Original value</textarea>',
                 ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'Received value']]]],
             ],
+            [
+                'textarea',
+                ['Key[subkey1][subkey2]', 'Original value', ['id' => '']],
+                '<textarea name="Key[subkey1][subkey2]" class="form-control">Received value</textarea>',
+                ['Key' => ['subkey1' => ['subkey2' => 'Received value']]],
+            ],
+            [
+                'textarea',
+                ['Key[subkey1][subkey2]', 'Original value', ['name' => 'foo']],
+                '<textarea id="Key[subkey1][subkey2]" name="foo" class="form-control">Original value</textarea>',
+                ['Key' => ['subkey1' => ['subkey2' => 'Received value']]],
+            ],
+            [
+                'textarea',
+                ['Key[subkey1][subkey2]', 'Original value', ['name' => 'Key[subkey1][subkey2override]']],
+                '<textarea id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2override]" class="form-control">Received value</textarea>',
+                ['Key' => ['subkey1' => ['subkey2override' => 'Received value']]],
+            ],
             // radio
             [
                 'radio',
@@ -445,6 +544,24 @@ class FormTest extends TestCase
                 ['Key[subkey1][subkey2]', 'Value'],
                 '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2]" value="Value" class="form-check-input" checked="checked" />',
                 ['Key' => ['subkey1' => ['subkey2' => 'Value']]],
+            ],
+            [
+                'radio',
+                ['Key[subkey1][subkey2]', 'Value', ['id' => '']],
+                '<input type="radio" name="Key[subkey1][subkey2]" value="Value" class="form-check-input" checked="checked" />',
+                ['Key' => ['subkey1' => ['subkey2' => 'Value']]],
+            ],
+            [
+                'radio',
+                ['Key[subkey1][subkey2]', 'Value', ['name' => 'Key[subkey1][subkey2override]']],
+                '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2override]" value="Value" class="form-check-input" />',
+                ['Key' => ['subkey1' => ['subkey2' => 'Value']]],
+            ],
+            [
+                'radio',
+                ['Key[subkey1][subkey2]', 'Value', ['name' => 'Key[subkey1][subkey2override]']],
+                '<input type="radio" id="Key[subkey1][subkey2]**UNIQUENUMBER**" name="Key[subkey1][subkey2override]" value="Value" class="form-check-input" checked="checked" />',
+                ['Key' => ['subkey1' => ['subkey2override' => 'Value']]],
             ],
             // inputType (text, number, email, telephone, url, search, password)
             [
@@ -554,6 +671,16 @@ class FormTest extends TestCase
                 '<input type="text" id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" value="Original value" class="form-control ccm-input-text" />',
                 ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'Received value']]]],
             ],
+            [
+                'text',
+                ['Key', 'Value', ['id' => '']],
+                '<input type="text" name="Key" value="Value" class="form-control ccm-input-text" />',
+            ],
+            [
+                'text',
+                ['Key', 'Value', ['name' => '']],
+                '<input type="text" id="Key" value="Value" class="form-control ccm-input-text" />',
+            ],
             // select
             [
                 'select',
@@ -647,6 +774,24 @@ class FormTest extends TestCase
                 ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two'],
                 '<select id="Key[subkey1][subkey2]" name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
                 ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'One']]]],
+            ],
+            [
+                'select',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['id' => '']],
+                '<select name="Key[subkey1][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                ['Key' => ['subkey1' => ['subkey2' => 'One']]],
+            ],
+            [
+                'select',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['name' => 'Key[subkey1override][subkey2]']],
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1override][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                ['Key' => ['subkey1' => ['subkey2' => 'One']]],
+            ],
+            [
+                'select',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['name' => 'Key[subkey1override][subkey2]']],
+                '<select id="Key[subkey1][subkey2]" name="Key[subkey1override][subkey2]" ccm-passed-value="Two" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                ['Key' => ['subkey1override' => ['subkey2' => 'One']]],
             ],
             // selectMultiple
             [
@@ -775,6 +920,24 @@ class FormTest extends TestCase
                 ['Key', ['One' => 'First', 'Two' => 'Second'], '<Two\'">'],
                 '<select id="Key" name="Key" ccm-passed-value="&lt;Two&#039;&quot;&gt;" class="form-control"><option value="One">First</option><option value="Two">Second</option></select>',
                 ['OtherField' => 'OtherValue'],
+            ],
+            [
+                'selectMultiple',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['id' => '']],
+                '<select name="Key[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'One']]]],
+            ],
+            [
+                'selectMultiple',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['name' => 'KeyOverride[subkey1][subkey2][]']],
+                '<select id="Key[subkey1][subkey2]" name="KeyOverride[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One">First</option><option value="Two" selected="selected">Second</option></select>',
+                ['Key' => ['subkey1' => ['subkey2' => ['subkey3' => 'One']]]],
+            ],
+            [
+                'selectMultiple',
+                ['Key[subkey1][subkey2]', ['One' => 'First', 'Two' => 'Second'], 'Two', ['name' => 'KeyOverride[subkey1][subkey2][]']],
+                '<select id="Key[subkey1][subkey2]" name="KeyOverride[subkey1][subkey2][]" multiple="multiple" class="form-control"><option value="One" selected="selected">First</option><option value="Two">Second</option></select>',
+                ['KeyOverride' => ['subkey1' => ['subkey2' => ['subkey3' => 'One']]]],
             ],
         ];
     }


### PR DESCRIPTION
The current Form service creates HTML elements with the same value for the `name` and the `id` attribute.
This can be problematic when we have multiple forms in the same page, with fields with the name name: we'd have multiple elements with the same ID (which is wrong).
So, what about letting users specify a custom value for the `id` and/or the `name` element of HTML attributes?
We can also remove one of those attributes (simply specify an empty value for it).