### PR TITLE
Fix bindingservice, handle either a statement or an int being returned from ->execute()

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/BindingService.php
+++ b/concrete/src/Authentication/Type/OAuth/BindingService.php
@@ -10,6 +10,7 @@ use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
 use Concrete\Core\User\User;
 use Concrete\Core\User\UserInfo;
+use Doctrine\DBAL\Driver\Statement;
 use Throwable;
 
 class BindingService implements LoggerAwareInterface
@@ -93,8 +94,10 @@ class BindingService implements LoggerAwareInterface
                     'binding' => $binding,
                 ]);
 
-                $result = $qb->execute();
-                $total = $result->fetchColumn();
+                $total = $qb->execute();
+                if ($total instanceof Statement) {
+                    $total = $total->fetchColumn();
+                }
             });
         } catch (\Exception $e) {
             throw new \RuntimeException('Unable to delete binding.');

--- a/tests/tests/Authentication/OAuth/BindingServiceTest.php
+++ b/tests/tests/Authentication/OAuth/BindingServiceTest.php
@@ -129,7 +129,7 @@ class BindingServiceTest extends PHPUnit_Framework_TestCase
                 'binding' => 'foo',
                 'id' => 1
             ], [])
-            ->andReturn($fakeResult);
+            ->andReturn(1);
         $this->assertEquals(1, $service->clearBinding(1, 'foo', 'test', true));
     }
 


### PR DESCRIPTION
Looks like ->execute will return an int and not a statement in this situation, let's handle that properly.