### PR TITLE
Remove core/tree requirement from express_form edit

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -690,7 +690,6 @@ class Controller extends BlockController implements NotificationProviderInterfac
         $this->set('formSubmissionConfig', $this->getFormSubmissionConfigValue());
         $this->set('storeFormSubmission', $this->areFormSubmissionsStored());
         $this->loadResultsFolderInformation();
-        $this->requireAsset('core/tree');
         $this->clearSessionControls();
         $list = Type::getList();
 


### PR DESCRIPTION
This asset group doesn't exist anymore so requiring it here throws errors. Getting rid of those errors unfortunately exposes a broken block edit interface but let's let that be a separate issue.