### PR TITLE
Add DownloadStatistics service

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -37,6 +37,7 @@ use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use ZipArchive;
+use Concrete\Core\File\DownloadStatistics;
 
 class File extends Controller
 {
@@ -338,6 +339,7 @@ class File extends Controller
     public function download()
     {
         $files = $this->getRequestFiles('canViewFileInFileManager');
+        $downloadStatistics = $this->app->make(DownloadStatistics::class);
         if (count($files) > 1) {
             $fh = $this->app->make('helper/file');
             $vh = $this->app->make('helper/validation/identifier');
@@ -358,7 +360,7 @@ class File extends Controller
                         $filename = str_replace('.' . $extension, '', $filename) . '_' . $key . '.' . $extension;
                     }
                     $zip->addFromString($filename, $f->getFileContents());
-                    $f->trackDownload();
+                    $downloadStatistics->trackDownload($f->getApprovedVersion());
                 }
                 $zip->close();
                 $fh->forceDownload($zipFile);
@@ -373,7 +375,7 @@ class File extends Controller
             } else {
                 $fv = $f->getApprovedVersion();
             }
-            $f->trackDownload();
+            $downloadStatistics->trackDownload($f->getApprovedVersion());
             $f->forceDownload();
         }
     }

--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -7,6 +7,7 @@ use Page;
 use Permissions;
 use Concrete\Core\Entity\File\File as FileEntity;
 use Concrete\Core\File\File;
+use Concrete\Core\File\DownloadStatistics;
 
 class DownloadFile extends PageController
 {
@@ -121,7 +122,7 @@ class DownloadFile extends PageController
     protected function download(\Concrete\Core\Entity\File\File $file, $rcID = null)
     {
         $filename = $file->getFilename();
-        $file->trackDownload($rcID);
+        $this->app->make(DownloadStatistics::class)->trackDownload($file->getApprovedVersion(), $rcID ? (int) $rcID : null);
         $fsl = $file->getFileStorageLocationObject();
         $configuration = $fsl->getConfigurationObject();
         $fv = $file->getVersion();
@@ -141,8 +142,8 @@ class DownloadFile extends PageController
      */
     protected function force_download($file, $rcID = null)
     {
-        $file->trackDownload($rcID);
-
+        $this->app->make(DownloadStatistics::class)->trackDownload($file->getApprovedVersion(), $rcID ? (int) $rcID : null);
+        
         // Magic call to approved FileVersion
         return $file->forceDownload();
     }

--- a/concrete/src/File/DownloadStatistics.php
+++ b/concrete/src/File/DownloadStatistics.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Concrete\Core\File;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\File\Version as FileVersion;
+use Concrete\Core\File\DownloadStatistics\Download;
+use Concrete\Core\File\DownloadStatistics\DownloadList;
+use Concrete\Core\File\Event\FileAccess as FileAccessEvent;
+use Concrete\Core\User\User;
+use DateTimeImmutable;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PDO;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class DownloadStatistics
+{
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var \Concrete\Core\User\User
+     */
+    protected $currentUser;
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
+     * @var bool|null
+     */
+    private $trackingEnabled;
+
+    public function __construct(Connection $connection, User $currentUser, EventDispatcherInterface $eventDispatcher, Repository $config)
+    {
+        $this->connection = $connection;
+        $this->currentUser = $currentUser;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->config = $config;
+    }
+
+    /**
+     * Should the downloads be tracked?
+     */
+    public function isTrackingEnabled(): bool
+    {
+        if ($this->trackingEnabled === null) {
+            $this->trackingEnabled = (bool) $this->config->get('concrete.statistics.track_downloads');
+        }
+
+        return $this->trackingEnabled;
+    }
+
+    /**
+     * Should the downloads be tracked?
+     *
+     * @return $this
+     */
+    public function setIsTrackingEnabled(bool $value): self
+    {
+        $this->trackingEnabled = $value;
+
+        return $this;
+    }
+
+    /**
+     * Method to be called whenever a file is downloaded.
+     *
+     * @param \Concrete\Core\Entity\File\Version $fileVersion the file version being downloaded
+     * @param int|null $pageID the ID of the page where the download originated, it available
+     *
+     * @return int|null return the ID of the newly created record (or NULL if downloads are not tracked)
+     */
+    public function trackDownload(FileVersion $fileVersion, ?int $pageID = null): ?int
+    {
+        $fve = new FileAccessEvent($fileVersion);
+        $this->eventDispatcher->dispatch('on_file_download', $fve);
+        if (!$this->isTrackingEnabled()) {
+            return null;
+        }
+        $this->connection->insert(
+            'DownloadStatistics',
+            [
+                'fID' => $fileVersion->getFile()->getFileID(),
+                'fvID' => $fileVersion->getFileVersionID(),
+                'uID' => (int) $this->currentUser->getUserID(),
+                'rcID' => (int) $pageID,
+            ]
+        );
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * Get a download given its ID.
+     */
+    public function getDownloadByID(int $dsID): ?Download
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->from('DownloadStatistics', 'ds')
+            ->select('ds.*')
+            ->andWhere($x->eq('ds.dsID', $qb->createNamedParameter($dsID)))
+            ->setMaxResults(1)
+        ;
+        $row = $qb->execute()->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->buildResult($row);
+    }
+
+    /**
+     * Unlink the download statistics associated to a specific user, setting the associated user ID to an empty value.
+     */
+    public function resetDownloadsForUser(int $userID): void
+    {
+        if ($userID !== 0) {
+            $this->connection->update(
+                'DownloadStatistics',
+                [
+                    'uID' => 0,
+                ],
+                [
+                    'uID' => $userID,
+                ]
+            );
+        }
+    }
+
+    /**
+     * Delete the statistics associated to a specific file.
+     */
+    public function deleteDownloadsForFile(int $fileID): void
+    {
+        $this->connection->delete(
+            'DownloadStatistics',
+            [
+                'fID' => $fileID,
+            ]
+        );
+    }
+
+    /**
+     * Get the total number of downloads of a specific file (and version).
+     *
+     * @param int $fileID the file ID
+     * @param int|null $fileVersionID the version ID (if null, you'll get the downloads of every version)
+     */
+    public function getDownloadCount(int $fileID, ?int $fileVersionID = null): int
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $x = $qb->expr;
+        $qb->from('DownloadStatistics', 'ds')
+            ->select('count(ds.*)')
+            ->andWhere($x->eq('ds.fID', $qb->createNamedParameter($fileID)))
+        ;
+        if ($fileVersionID !== null) {
+            $qb->andWhere($x->eq('ds.fvID', $qb->createNamedParameter($fileVersionID)));
+        }
+
+        return (int) $qb->execute()->fetchColumn();
+    }
+
+    /**
+     * Get the list of downloads ().
+     *
+     * @param int|null $fileID the ID of the file for which you want the downloads (use NULL for every file)
+     * @param int|null $fileVersionID the version ID of the file for which you want the downloads (used only if $fileID is not NULL, use NULL for every version)
+     * @param int|null $limit the maximum number of results (set to NULL for ALL the downloads)
+     * @param int|null $afterID for paginated results, the ID of the download after which you want the results
+     * @param bool $descending set to TRUE (default) for the most recent downloads to first, FALSE to have the older downloads first
+     *
+     * @return \Concrete\Core\File\DownloadStatistics\DownloadList
+     */
+    public function getDownloads(?int $fileID, ?int $fileVersionID, ?int $limit, ?int $afterID = null, bool $descending = true): DownloadList
+    {
+        $qb = $this->createDownloadsQuery($fileID, $fileVersionID, $limit, $afterID, $descending);
+        $rs = $qb->execute();
+        $result = new DownloadList();
+        $count = 0;
+        while (($row = $rs->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $count++;
+            if ($limit !== null && $count > $limit) {
+                $result->setHasMoreDownloads(true);
+                break;
+            }
+            $result->add($this->buildResult($row));
+        }
+
+        return $result;
+    }
+
+    protected function createDownloadsQuery(?int $fileID, ?int $fileVersionID, ?int $limit, ?int $afterID = null, bool $descending = true): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->from('DownloadStatistics', 'ds')
+            ->select('*')
+            ->addOrderBy('ds.timestamp', $descending ? 'DESC' : 'ASC')
+            ->addOrderBy('ds.dsID', $descending ? 'DESC' : 'ASC')
+        ;
+        if ($fileID !== null) {
+            $qb->andWhere($x->eq('ds.fID', $qb->createNamedParameter($fileID)));
+            if ($fileVersionID !== null) {
+                $qb->andWhere($x->eq('ds.fvID', $qb->createNamedParameter($fileVersionID)));
+            }
+        }
+        if ($limit !== null) {
+            $qb->setMaxResults($limit + 1);
+        }
+        if ($afterID !== null) {
+            $aferTimestamp = $this->getTimestamp($afterID, $fileID, $fileVersionID);
+            if ($aferTimestamp === '') {
+                $qb->andWhere($x->eq(1, 0));
+            } else {
+                $idParameter = $qb->createNamedParameter($afterID);
+                $timestampParameter = $qb->createNamedParameter($aferTimestamp);
+                if ($descending) {
+                    $qb->andWhere($x->orX(
+                        $x->lt('ds.timestamp', $timestampParameter),
+                        $x->andX(
+                            $x->eq('ds.timestamp', $timestampParameter),
+                            $x->lt('ds.dsID', $idParameter)
+                        )
+                    ));
+                } else {
+                    $qb->andWhere($x->orX(
+                        $x->gt('ds.timestamp', $timestampParameter),
+                        $x->andX(
+                            $x->eq('ds.timestamp', $timestampParameter),
+                            $x->gt('ds.dsID', $idParameter)
+                        )
+                    ));
+                }
+            }
+        }
+
+        return $qb;
+    }
+
+    protected function getTimestamp(int $id, ?int $fileID, ?int $fileVersionID): string
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $x = $qb->expr();
+        $qb
+            ->from('DownloadStatistics', 'ds')
+            ->select('ds.timestamp')
+            ->andWhere($x->eq('ds.dsID', $qb->createNamedParameter($id)))
+        ;
+        if ($fileID !== null) {
+            $qb->andWhere($x->eq('ds.fID', $qb->createNamedParameter($fileID)));
+            if ($fileVersionID !== null) {
+                $qb->andWhere($x->eq('ds.fvID', $qb->createNamedParameter($fileVersionID)));
+            }
+        }
+
+        return (string) $qb->execute()->fetchColumn();
+    }
+
+    protected function buildResult(array $data): Download
+    {
+        return Download::create(
+            (int) $data['dsID'],
+            (int) $data['fID'],
+            (int) $data['fvID'],
+            empty($data['uID']) ? null : (int) $data['uID'],
+            empty($data['rcID']) ? null : (int) $data['rcID'],
+            DateTimeImmutable::createFromFormat($this->connection->getDatabasePlatform()->getDateTimeFormatString(), $data['timestamp'])
+        );
+    }
+}

--- a/concrete/src/File/DownloadStatistics/Download.php
+++ b/concrete/src/File/DownloadStatistics/Download.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Concrete\Core\File\DownloadStatistics;
+
+use DateTimeImmutable;
+
+class Download
+{
+    /**
+     * @var int
+     */
+    private $downloadID;
+
+    /**
+     * @var int
+     */
+    private $fileID;
+
+    /**
+     * @var int
+     */
+    private $fileVersionID;
+
+    /**
+     * @var int|null
+     */
+    private $userID;
+
+    /**
+     * @var int|null
+     */
+    private $pageID;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $timestamp;
+
+    public static function create(int $downloadID, int $fileID, int $fileVersionID, ?int $userID, ?int $pageID, DateTimeImmutable $timestamp)
+    {
+        $result = new static();
+        $result->downloadID = $downloadID;
+        $result->fileID = $fileID;
+        $result->fileVersionID = $fileVersionID;
+        $result->userID = $userID;
+        $result->pageID = $pageID;
+        $result->timestamp = $timestamp;
+
+        return $result;
+    }
+
+    public function getDownloadID(): int
+    {
+        return $this->downloadID;
+    }
+
+    public function getFileID(): int
+    {
+        return $this->fileID;
+    }
+
+    public function getFileVersionID(): int
+    {
+        return $this->fileVersionID;
+    }
+
+    public function getUserID(): ?int
+    {
+        return $this->userID;
+    }
+
+    public function getPageID(): ?int
+    {
+        return $this->pageID;
+    }
+
+    public function getTimestamp(): DateTimeImmutable
+    {
+        return $this->timestamp;
+    }
+}

--- a/concrete/src/File/DownloadStatistics/DownloadList.php
+++ b/concrete/src/File/DownloadStatistics/DownloadList.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Concrete\Core\File\DownloadStatistics;
+
+class DownloadList
+{
+    private $hasMoreDownloads = false;
+
+    private $list = [];
+
+    public function hasMoreDownloads(): bool
+    {
+        return $this->hasMoreDownloads;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHasMoreDownloads(bool $value): self
+    {
+        $this->hasMoreDownloads = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function add(Download $item): self
+    {
+        $this->list[] = $item;
+
+        return $this;
+    }
+
+    /**
+     * @return \Concrete\Core\File\DownloadStatistics\Download[]
+     */
+    public function getList(): array
+    {
+        return $this->list;
+    }
+}

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -48,6 +48,7 @@ use League\Flysystem\AdapterInterface;
 use League\URL\URLInterface;
 use stdClass;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Concrete\Core\File\DownloadStatistics;
 
 class UserInfo extends ConcreteObject implements AttributeObjectInterface, PermissionObjectInterface, ExportableInterface
 {
@@ -260,7 +261,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
 
         $this->connection->executeQuery('UPDATE Blocks set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);
         $this->connection->executeQuery('UPDATE Pages set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);
-        $this->connection->executeQuery('UPDATE DownloadStatistics set uID = 0 WHERE uID = ?', [(int) $this->getUserID()]);
+        $this->application->make(DownloadStatistics::class)->resetDownloadsForUser((int) $this->getUserID());
 
         // We need to clear out the doctrine proxies for userSignups or we will get a Doctrine Error
         /** @var UserSignup[] $userSignups */

--- a/tests/tests/File/DownloadStatisticsTest.php
+++ b/tests/tests/File/DownloadStatisticsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Concrete\Tests\File;
+
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Entity\File\Version;
+use Concrete\Core\File\DownloadStatistics;
+use Concrete\Core\File\DownloadStatistics\Download;
+use Concrete\TestHelpers\File\FileStorageTestCase;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+
+class DownloadStatisticsTest extends FileStorageTestCase
+{
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->tables = array_merge($this->tables, [
+            'DownloadStatistics',
+        ]);
+    }
+
+    public function testDownloadStatistics()
+    {
+        $downloadStatistics = app(DownloadStatistics::class);
+        $em = app(EntityManagerInterface::class);
+
+        $list = $downloadStatistics->getDownloads(null, null, null);
+        $this->assertSame([], $list->getList());
+        $this->assertSame(false, $list->hasMoreDownloads());
+
+        $fv1 = $this->addFile($em);
+        $fv2 = $this->addFile($em);
+
+        $id = $downloadStatistics->trackDownload($fv2);
+        $this->assertGreaterThan(0, $id);
+        $this->assertInstanceOf(Download::class, $downloadStatistics->getDownloadByID($id));
+
+        $list = $downloadStatistics->getDownloads(null, null, 2);
+        $this->assertSame(1, count($list->getList()));
+        $this->assertSame(false, $list->hasMoreDownloads());
+
+        $downloadStatistics->trackDownload($fv2);
+
+        $list = $downloadStatistics->getDownloads(null, null, 2);
+        $this->assertSame(2, count($list->getList()));
+        $this->assertSame(false, $list->hasMoreDownloads());
+
+        $downloadStatistics->trackDownload($fv1);
+
+        $list = $downloadStatistics->getDownloads(null, null, 2);
+        $this->assertSame(2, count($list->getList()));
+        $this->assertSame(true, $list->hasMoreDownloads());
+
+        $list = $downloadStatistics->getDownloads($fv2->getFile()->getFileID(), null, 2);
+        $this->assertSame(2, count($list->getList()));
+        $this->assertSame(false, $list->hasMoreDownloads());
+
+        $list = $downloadStatistics->getDownloads($fv2->getFile()->getFileID(), $fv2->getFileVersionID(), 2);
+        $this->assertSame(2, count($list->getList()));
+        $this->assertSame(false, $list->hasMoreDownloads());
+
+        $list = $downloadStatistics->getDownloads($fv2->getFile()->getFileID(), $fv2->getFileVersionID() + 100, 2);
+        $this->assertSame(0, count($list->getList()));
+        $this->assertSame(false, $list->hasMoreDownloads());
+    }
+
+    private function addFile(EntityManagerInterface $em): Version
+    {
+        $f = new File();
+        $f->setDateAdded(new DateTime());
+        $fv = new Version();
+        $fv->setFilename('test.txt');
+        $fv->setFile($f);
+        $f->getFileVersions()->add($fv);
+        $em->persist($f);
+        $em->persist($fv);
+        $em->flush();
+
+        return $fv;
+    }
+}


### PR DESCRIPTION
At the moment, managing the download statistics has a few issues:

1. we don't have a service for it: to override this functionality users need to override many stuff, which is not very easy (thing for example if someone wants to store the stats in another database)
2. the current API only allows to retrieve the first X downloads, or all of them: there's no way to have paginated results
3. there's no way to load, let's say, the most recent X downloads of any file: there's a`if (is_object($this) && $this instanceof self)` check in the `File::getDownloadStatistics()` method, which used to work in old PHP versions, but now doesn't work (calling a non-static method statically is no more possible)

So, what about adding a service to handle the file download statistics?
It can for example be useful to implement what should happen when clicking the `More` button in the "Most Recent Downloads" of https://github.com/concrete5/concrete5/issues/8483 (both if that button should update the data listed above it and if a new dialog/page should be displayed to list more downloads).

PS: I didn't implement it with Doctrine Entities, because entities are very memory hungry, and we need to be as fast as possible since we may work with thousands of records