### PR TITLE
Improve translatable string in Express entries

### DIFF
--- a/concrete/controllers/single_page/dashboard/express/entries.php
+++ b/concrete/controllers/single_page/dashboard/express/entries.php
@@ -153,7 +153,7 @@ class Entries extends DashboardSitePageController
                 new SiteField(),
             ]);
             $result = $this->createSearchResult($entity, $query);
-            $this->set('pageTitle', t('%s Entries', $entity->getName()));
+            $this->set('pageTitle', tc(/*i18n: %s is an entity name*/'EntriesOfEntityName', '%s Entries', $entity->getName()));
             $this->renderSearchResult($result);
         } else {
             $this->set('pageTitle', t('View Express Entities'));


### PR DESCRIPTION
(Most) translators don't read the PHP code around strings when they translate: the only see translatable strings out of context.
So, when they see `%s Entries`, they don't know if `%s` is a number (for example: `3 Entries`), or something else (like the entity name associated to the entities, for example `Boat Entries`, that is `Entries of the Boat entity`).
So, since `%s Entries` can have two different meanings, its translations can be different for every meaning.
Solution:
- add a comment (`/*i18n: %s is an entity name*/`) to tell translators that `%s` is the name of an entity
- add a context (`tc('EntriesOfEntityName', '...')`), so that the translations table can have two translatable strings (for example, we can have `tc('NumberOfEntries', '%s Entries')` and `tc('EntriesOfEntityName', '%s Entries')`).