### PR TITLE
Improve distinction between log severity icons

### DIFF
--- a/concrete/src/Logging/LogEntry.php
+++ b/concrete/src/Logging/LogEntry.php
@@ -89,13 +89,15 @@ class LogEntry
             case Monolog::EMERGENCY:
                 return '<i class="text-danger fa fa-fire launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::CRITICAL:
+                return '<i class="text-danger fa fa-ambulance launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::ALERT:
                 return '<i class="text-danger fa fa-exclamation-circle launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::ERROR:
+                return '<i class="text-danger fa fa-flag launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::WARNING:
                 return '<i class="text-warning fa fa-warning launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::NOTICE:
-                return '<i class="fa fa-exclamation launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
+                return '<i class="text-success fa fa-leaf launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::INFO:
                 return '<i class="text-info fa fa-info-circle launch-tooltip" title="' . $this->getLevelDisplayName() . '"></i>';
             case Monolog::DEBUG:


### PR DESCRIPTION
Improve distinction between log severity icons as per #8689 on the dev branch. Copied for 9.0.

Reading the log can be difficult if looking for specific severities. This pull adjusts the icons so that each severity has a distinct icon. The colours are also adjusted slightly. Errors now have the 'danger' red and notices are 'success' green.