### PR TITLE
Require doctrine/persistence version 1

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -37,6 +37,7 @@
     "symfony/http-kernel": "3.4.*",
     "doctrine/orm": "~2.5",
     "doctrine/migrations": "1.* <1.8",
+    "doctrine/persistence": "^1",
     "league/flysystem": "1.*",
     "symfony/event-dispatcher": "3.*",
     "symfony/serializer": "3.*",


### PR DESCRIPTION
In version 2, they removed the `MappingDriverChain` class, which is required by concrete5