### PR TITLE
Require doctrine/common version 2

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -35,6 +35,7 @@
     "symfony/http-foundation": "^3.4.17",
     "symfony/routing": "3.*",
     "symfony/http-kernel": "3.4.*",
+    "doctrine/common": "^2",
     "doctrine/orm": "~2.5",
     "doctrine/migrations": "1.* <1.8",
     "league/flysystem": "1.*",


### PR DESCRIPTION
concrete5 requires the `Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain`
 class.

Until `doctrine/common` version 2.8.x, that class was included in the `doctrine/common` library itself.
From version 2.9.x and before version 3.0 of `doctrine/common`, that class has been moved to the `doctrine/persistence` package version 1.
Starting from `doctrine/common` version 3, that class has been removed from `doctrine/persistence`.

So, as long as we use that class, we have to use `doctrine/common` version 2.