### PR TITLE
Add more extensions to the blacklist

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -96,7 +96,8 @@ return [
          *
          * @var string semi-colon separated.
          */
-        'extensions_blacklist' => '*.php;*.php2;*.php3;*.php4;*.php5;*.php7;*.phtml',
+        'extensions_blacklist' => '*.php;*.php2;*.php3;*.php4;*.php5;*.php7;*.php8;*.phtml;*.phar;*.htaccess;*.pl;*.phpsh;*.pht;*.shtml;*.cgi',
+
         'chunking' => [
             // Enable uploading files in chunks?
             'enabled' => true,


### PR DESCRIPTION
Some webservers could be configured to process these files types. Let's disallow them by default.
Resolves H1 #880621