### PR TITLE
Add information about what file passwords are used for

### DIFF
--- a/concrete/tools/files/permissions.php
+++ b/concrete/tools/files/permissions.php
@@ -94,6 +94,9 @@ if ($_POST['task'] == 'set_location') {
 
         <div class="help-block">
             <p><?=t('Users who access files through the file manager will not be prompted for a password.')?></p>
+            <p>
+                <?= t('File passwords are stored in the database in plain text, they are not to be used for serious security concerns. Instead used a private storage location and user permissions.') ?>
+            </p>
         </div>
     </div>
 

--- a/concrete/tools/files/permissions.php
+++ b/concrete/tools/files/permissions.php
@@ -95,7 +95,7 @@ if ($_POST['task'] == 'set_location') {
         <div class="help-block">
             <p><?=t('Users who access files through the file manager will not be prompted for a password.')?></p>
             <p>
-                <?= t('File passwords are stored in the database in plain text, they are not to be used for serious security concerns. Instead used a private storage location and user permissions.') ?>
+                <?= t('File passwords are stored in the database in plain text, they are not to be used for serious security concerns. Instead use a private storage location and user permissions.') ?>
             </p>
         </div>
     </div>


### PR DESCRIPTION
File passwords aren't the most secure way to protect files. It's really meant to be a simple way of sharing insecure files without having them indexed by search engines. Let's add some info around that and what to use instead for serious security

Resolves h1#459380	