### PR TITLE
[v9] Test against 7.4 and use Xenial instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # Global/default configuration
-dist: trusty
+dist: xenial
 language: php
 sudo: false
+services:
+  - mysql
 cache:
   npm: true
   directories:
@@ -15,7 +17,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - name: Test with PHP nightly
-    - name: Test with PHP 7.4
     - name: Check PHP coding style
   include:
 
@@ -59,7 +60,7 @@ matrix:
         - composer test
 
     - name: Test with PHP 7.4
-      php: 7.4snapshot
+      php: '7.4'
       before_script:
         - ./.travis/composer-deps.sh
       script:
@@ -69,6 +70,7 @@ matrix:
       php: '7.2'
       services:
         - docker
+        - mysql
       before_script:
         - ./.travis/composer-deps.sh
       script:


### PR DESCRIPTION
Since version 9 is targeting 7.2 as minimum and we were already passing against 7.4snapshot, we should be testing against the latest stable 7.4.

So this  changes our build to test  against the latest  stable v7.4 release and brings it out of allowed failures.

This PR also updates us to use  xenial (16.0.4) rather than  Trusty (14.0.4) as trusty is already out of general support and will be EOL april 2022. It may also make some tests run slightly faster...like a few seconds

Also to note '7.4' on trusty is  7.4.0 and doesnt include the correct extensions and 7.4-snapshot is from december