### PR TITLE
Remove $entry validation on express attribute form

### DIFF
--- a/concrete/attributes/express/form.php
+++ b/concrete/attributes/express/form.php
@@ -2,8 +2,7 @@
 defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Entity\Express\Entity;
-use Concrete\Core\Entity\Express\Entry;
 
-if (isset($entity, $entry) && $entity instanceof Entity && $entry instanceof Entry) {
+if (isset($entity) && $entity instanceof Entity) {
     echo $entrySelector->selectEntry($entity, $this->field('value'), $entry);
 }


### PR DESCRIPTION
Fix the issue mentioned on https://github.com/concrete5/concrete5/pull/8406#commitcomment-39783052

We can ignore the $entry validation as the `selectEntry()` method accepts null value for the $entry

[Sorry, it's my bad.]