### PR TITLE
Introduce the DownloadStatistics entity

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.0.0a2',
     'version_installed' => '9.0.0a2',
-    'version_db' => '20200609145307', // the key of the latest database migration
+    'version_db' => '20200610162600', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -1943,52 +1943,6 @@
     </index>
   </table>
 
-  <table name="DownloadStatistics">
-    <field name="dsID" type="integer" size="10">
-      <unsigned/>
-      <autoincrement/>
-      <key/>
-    </field>
-    <field name="fID" type="integer" size="10">
-      <unsigned/>
-      <notnull/>
-    </field>
-    <field name="fvID" type="integer" size="10">
-      <unsigned/>
-      <notnull/>
-    </field>
-    <field name="uID" type="integer" size="10">
-      <unsigned/>
-      <notnull/>
-    </field>
-    <field name="rcID" type="integer" size="10">
-      <unsigned/>
-      <notnull/>
-    </field>
-    <field name="timestamp" type="timestamp">
-      <deftimestamp/>
-      <notnull/>
-    </field>
-    <index name="fID">
-      <col>fID</col>
-      <col>timestamp</col>
-    </index>
-    <index name="fvID">
-      <col>fID</col>
-      <col>fvID</col>
-    </index>
-    <index name="uID">
-      <col>uID</col>
-    </index>
-    <index name="rcID">
-      <col>rcID</col>
-    </index>
-    <index name="timestamp">
-      <col>timestamp</col>
-    </index>
-  </table>
-
-
   <table name="FilePermissionFileTypes">
     <field name="fsID" type="integer" size="10">
       <unsigned/>

--- a/concrete/src/Entity/File/DownloadStatistics.php
+++ b/concrete/src/Entity/File/DownloadStatistics.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Concrete\Core\Entity\File;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(
+ *     name="DownloadStatistics",
+ *     indexes={
+ *         @ORM\Index(name="fID", columns={"fID", "timestamp"}),
+ *         @ORM\Index(name="fvID", columns={"fID", "fvID"}),
+ *         @ORM\Index(name="uID", columns={"uID"}),
+ *         @ORM\Index(name="rcID", columns={"rcID"}),
+ *         @ORM\Index(name="timestamp", columns={"timestamp"})
+ *     },
+ *     options={
+ *         "comment": "List of downloaded files"
+ *     }
+ * )
+ */
+class DownloadStatistics
+{
+    /**
+     * The downloadStatistics record ID.
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="dsID", nullable=false, options={"unsigned": true, "comment": "DownloadStatistics record ID"})
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet saved
+     */
+    protected $id;
+
+    /**
+     * The downloaded file.
+     *
+     * @ORM\ManyToOne(targetEntity="File")
+     * @ORM\JoinColumn(name="fID", referencedColumnName="fID", nullable=false, onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\File\File
+     */
+    protected $file;
+
+    /**
+     * The version of the downloaded file.
+     *
+     * @ORM\Column(type="integer", name="fvID", nullable=false, options={"unsigned": false, "comment": "Version of the downloaded file"})
+     *
+     * @var int
+     */
+    protected $fileVersion;
+
+    /**
+     * The ID of the user that downloaded the file.
+     *
+     * @ORM\Column(type="integer", name="uID", nullable=true, options={"unsigned": true, "comment": "ID of the user that downloaded the file"})
+     *
+     * @var int|null
+     */
+    protected $downloaderID;
+
+    /**
+     * The ID of the page where the download originated.
+     *
+     * @ORM\Column(type="integer", name="rcID", nullable=true, options={"unsigned": true, "comment": "ID of the page where the download originated"})
+     *
+     * @var int|null
+     */
+    protected $relatedPageID;
+
+    /**
+     * The date/time when the file has been downloaded.
+     *
+     * @ORM\Column(type="datetime_immutable", name="timestamp", nullable=false, columnDefinition="TIMESTAMP DEFAULT current_timestamp", options={"comment": "Date/time when the file has been downloaded"})
+     *
+     * @var \DateTimeImmutable
+     */
+    protected $downloadDateTime;
+
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @return static
+     */
+    public static function create(File $file, int $fileVersion, ?int $downloaderID, ?int $relatedPageID, ?DateTimeImmutable $downloadDateTime = null): self
+    {
+        $result = new static();
+        $result->file = $file;
+        $result->fileVersion = $fileVersion;
+        $result->downloaderID = $downloaderID ?: null;
+        $result->relatedPageID = $relatedPageID ?: null;
+        $result->downloadDateTime = $downloadDateTime ?: new DateTimeImmutable('now');
+
+        return $result;
+    }
+
+    /**
+     * Get tthe downloadStatistics record ID.
+     *
+     * @return int|null NULL if not yet saved
+     */
+    public function getID(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the downloaded file.
+     */
+    public function getFile(): File
+    {
+        return $this->file;
+    }
+
+    /**
+     * Get the version of the downloaded file.
+     */
+    public function getFileVersion(): int
+    {
+        return $this->fileVersion;
+    }
+
+    /**
+     * Get the ID of the user that downloaded the file.
+     */
+    public function getDownloaderID(): ?int
+    {
+        return $this->downloaderID;
+    }
+
+    /**
+     * Get the ID of the user that downloaded the file.
+     */
+    public function getRelatedPageID(): ?int
+    {
+        return $this->relatedPageID;
+    }
+
+    /**
+     * Get the ID of the user that downloaded the file.
+     */
+    public function getDownloadDateTime(): DateTimeImmutable
+    {
+        return $this->downloadDateTime;
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20200610162600.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200610162600.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\File\DownloadStatistics;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+final class Version20200610162600 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        // Delete DownloadStatistics records not associated to file entities
+        $this->connection->executeUpdate(
+            <<<'EOT'
+DELETE DownloadStatistics
+FROM DownloadStatistics
+LEFT JOIN Files ON DownloadStatistics.fID = Files.fID
+WHERE Files.fID IS NULL
+EOT
+        );
+        // Refresh the table definition
+        $this->refreshEntities([
+            File::class,
+            DownloadStatistics::class,
+        ]);
+        // Set to NULL the uID column with a value of 0
+        $this->connection->update('DownloadStatistics', ['uID' => null], ['uID' => 0]);
+        // Set to NULL the rcID column with a value of 0
+        $this->connection->update('DownloadStatistics', ['rcID' => null], ['rcID' => 0]);
+    }
+}

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -11,6 +11,7 @@ use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Encryption\PasswordHasher;
 use Concrete\Core\Entity\Attribute\Value\UserValue;
 use Concrete\Core\Entity\Express\Entry;
+use Concrete\Core\Entity\File\DownloadStatistics;
 use Concrete\Core\Entity\User\User as UserEntity;
 use Concrete\Core\Entity\User\UserSignup;
 use Concrete\Core\Error\ErrorList\ErrorList;
@@ -260,7 +261,13 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
 
         $this->connection->executeQuery('UPDATE Blocks set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);
         $this->connection->executeQuery('UPDATE Pages set uID = ? WHERE uID = ?', [(int) USER_SUPER_ID, (int) $this->getUserID()]);
-        $this->connection->executeQuery('UPDATE DownloadStatistics set uID = 0 WHERE uID = ?', [(int) $this->getUserID()]);
+        $this->entityManager->createQueryBuilder()
+            ->update(DownloadStatistics::class, 'ds')
+            ->set('ds.downloaderID', ':null')
+            ->where($this->entityManager->getExpressionBuilder()->eq('ds.downloaderID', ':uID'))
+            ->getQuery()
+            ->execute(['null' => null, 'uID' => $this->getUserID()])
+        ;
 
         // We need to clear out the doctrine proxies for userSignups or we will get a Doctrine Error
         /** @var UserSignup[] $userSignups */


### PR DESCRIPTION
I kept the table definition as is (except for the `fvID` table field which changes from unsigned to signed, because the `FileVersions`.`fvID` table field is signed).

Just one question: should we keep the `TIMESTAMP` type of the `timestamp` field, or should we switch to `DATETIME`?

- `TIMESTAMP` fields can't save values smaller than `1970-01-01` or greater than `2038-01-19`
- `DATETIME` fields require one more byte (6∼8 bytes instead of 5∼7 - that's a 15%∼20% more disk space)
