### PR TITLE
Add setItems() to NavigationInterface

### DIFF
--- a/concrete/src/Application/UserInterface/Dashboard/Navigation/Navigation.php
+++ b/concrete/src/Application/UserInterface/Dashboard/Navigation/Navigation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Application\UserInterface\Dashboard\Navigation;
 
 use Concrete\Core\Navigation\Item\PageItem;
@@ -8,36 +9,52 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class Navigation extends BaseNavigation implements DenormalizableInterface
 {
-
-    public function has(PageItem $pageItem)
+    /**
+     * Check if this instance contains a PageItem instance with the same page ID.
+     *
+     * @param \Concrete\Core\Navigation\Item\PageItem $pageItem
+     *
+     * @return bool
+     */
+    public function has(PageItem $pageItem): bool
     {
-        foreach($this->getItems() as $item) {
-            /**
-             * @var $item PageItem
-             */
+        foreach ($this->getItems() as $item) {
             if ($pageItem->getPageID() == $item->getPageID()) {
                 return true;
             }
         }
+
         return false;
     }
 
-    public function remove(PageItem $pageItem) {
+    /**
+     * Remove (if present) the PageItems with the same page ID as the PageItem specified.
+     *
+     * @param \Concrete\Core\Navigation\Item\PageItem $pageItem
+     *
+     * @return self
+     */
+    public function remove(PageItem $pageItem): self
+    {
         $items = [];
-        foreach($this->getItems() as $item) {
-            /**
-             * @var $item PageItem
-             */
+        foreach ($this->getItems() as $item) {
             if ($pageItem->getPageID() != $item->getPageID()) {
                 $items[] = $item;
             }
         }
         $this->setItems($items);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Serializer\Normalizer\DenormalizableInterface::denormalize()
+     */
     public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = [])
     {
-        foreach($data as $page) {
+        foreach ($data as $page) {
             $item = new PageItem();
             $item->setPageID($page['pageID']);
             $item->setUrl($page['url']);
@@ -46,5 +63,4 @@ class Navigation extends BaseNavigation implements DenormalizableInterface
             $this->add($item);
         }
     }
-
 }

--- a/concrete/src/Navigation/Breadcrumb/BreadcrumbInterface.php
+++ b/concrete/src/Navigation/Breadcrumb/BreadcrumbInterface.php
@@ -1,11 +1,9 @@
 <?php
+
 namespace Concrete\Core\Navigation\Breadcrumb;
 
-use Concrete\Core\Navigation\Item\ItemInterface;
 use Concrete\Core\Navigation\NavigationInterface;
 
 interface BreadcrumbInterface extends NavigationInterface
 {
-
-
 }

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Navigation\Breadcrumb\Dashboard;
 
 use Concrete\Core\Navigation\Breadcrumb\BreadcrumbInterface;
@@ -6,23 +7,30 @@ use Concrete\Core\Navigation\Item\ItemInterface;
 
 class DashboardBreadcrumb implements BreadcrumbInterface
 {
-
     /**
-     * @var ItemInterface[]
+     * @var \Concrete\Core\Navigation\Item\ItemInterface[]
      */
     protected $items = [];
 
-    public function add(ItemInterface $item)
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Navigation\NavigationInterface::add()
+     */
+    public function add(ItemInterface $item): self
     {
         $this->items[] = $item;
+
+        return $this;
     }
 
     /**
-     * @return ItemInterface[]
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Navigation\NavigationInterface::getItems()
      */
     public function getItems(): array
     {
         return $this->items;
     }
-
 }

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Navigation\Breadcrumb\Dashboard;
 
 use Concrete\Core\Navigation\Breadcrumb\BreadcrumbInterface;
 use Concrete\Core\Navigation\Item\ItemInterface;
-use Concrete\Core\Navigation\self;
 
 class DashboardBreadcrumb implements BreadcrumbInterface
 {

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Navigation\Breadcrumb\Dashboard;
 
 use Concrete\Core\Navigation\Breadcrumb\BreadcrumbInterface;
 use Concrete\Core\Navigation\Item\ItemInterface;
+use Concrete\Core\Navigation\self;
 
 class DashboardBreadcrumb implements BreadcrumbInterface
 {
@@ -32,5 +33,20 @@ class DashboardBreadcrumb implements BreadcrumbInterface
     public function getItems(): array
     {
         return $this->items;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Navigation\NavigationInterface::setItems()
+     */
+    public function setItems(array $items): self
+    {
+        $this->items = [];
+        foreach ($items as $item) {
+            $this->add($item);
+        }
+
+        return $this;
     }
 }

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Navigation\Breadcrumb\Dashboard;
 
 use Concrete\Core\Navigation\Breadcrumb\BreadcrumbInterface;
 use Concrete\Core\Navigation\Item\ItemInterface;
+use Concrete\Core\Navigation\NavigationInterface;
 
 class DashboardBreadcrumb implements BreadcrumbInterface
 {
@@ -17,7 +18,7 @@ class DashboardBreadcrumb implements BreadcrumbInterface
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::add()
      */
-    public function add(ItemInterface $item): self
+    public function add(ItemInterface $item): NavigationInterface
     {
         $this->items[] = $item;
 
@@ -39,7 +40,7 @@ class DashboardBreadcrumb implements BreadcrumbInterface
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::setItems()
      */
-    public function setItems(array $items): self
+    public function setItems(array $items): NavigationInterface
     {
         $this->items = [];
         foreach ($items as $item) {

--- a/concrete/src/Navigation/Navigation.php
+++ b/concrete/src/Navigation/Navigation.php
@@ -1,31 +1,42 @@
 <?php
+
 namespace Concrete\Core\Navigation;
 
 use Concrete\Core\Navigation\Item\ItemInterface;
+use JsonSerializable;
 
-class Navigation implements  NavigationInterface, \JsonSerializable
+class Navigation implements NavigationInterface, JsonSerializable
 {
-
     /**
-     * @var ItemInterface[]
+     * @var \Concrete\Core\Navigation\Item\ItemInterface[]
      */
     protected $items = [];
 
-    /**
-     * Adds an item to the navigation.
-     *
-     * @param ItemInterface $item
-     * @return mixed
-     */
-    public function add(ItemInterface $item)
+    public function __clone()
     {
-        $this->items[] = $item;
+        $items = $this->getItems();
+        $this->setItems([]);
+        foreach ($items as $item) {
+            $this->add(clone $item);
+        }
     }
 
     /**
-     * Returns all the items in the navigation
+     * {@inheritdoc}
      *
-     * @return ItemInterface[]
+     * @see \Concrete\Core\Navigation\NavigationInterface::add()
+     */
+    public function add(ItemInterface $item): self
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    /**
+     * Returns all the items in the navigation.
+     *
+     * @return \Concrete\Core\Navigation\Item\ItemInterface[]
      */
     public function getItems(): array
     {
@@ -33,31 +44,31 @@ class Navigation implements  NavigationInterface, \JsonSerializable
     }
 
     /**
-     * @param ItemInterface[] $items
+     * @param \Concrete\Core\Navigation\Item\ItemInterface[] $items
+     *
+     * @return $this
      */
-    public function setItems(array $items): void
+    public function setItems(array $items): self
     {
         $this->items = $items;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     *
+     * @return array
+     */
     public function jsonSerialize()
     {
         $data = [];
-        foreach($this->getItems() as $item) {
+        foreach ($this->getItems() as $item) {
             $data[] = $item->jsonSerialize();
         }
+
         return $data;
     }
-
-    public function __clone()
-    {
-        $items = $this->getItems();
-        $this->setItems([]);
-        foreach($items as $item) {
-            $this->add(clone $item);
-        }
-    }
-
-
-
 }

--- a/concrete/src/Navigation/Navigation.php
+++ b/concrete/src/Navigation/Navigation.php
@@ -26,7 +26,7 @@ class Navigation implements NavigationInterface, JsonSerializable
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::add()
      */
-    public function add(ItemInterface $item): self
+    public function add(ItemInterface $item): NavigationInterface
     {
         $this->items[] = $item;
 
@@ -48,7 +48,7 @@ class Navigation implements NavigationInterface, JsonSerializable
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::setItems()
      */
-    public function setItems(array $items): self
+    public function setItems(array $items): NavigationInterface
     {
         $this->items = $items;
 

--- a/concrete/src/Navigation/Navigation.php
+++ b/concrete/src/Navigation/Navigation.php
@@ -44,9 +44,9 @@ class Navigation implements NavigationInterface, JsonSerializable
     }
 
     /**
-     * @param \Concrete\Core\Navigation\Item\ItemInterface[] $items
+     * {@inheritdoc}
      *
-     * @return $this
+     * @see \Concrete\Core\Navigation\NavigationInterface::setItems()
      */
     public function setItems(array $items): self
     {

--- a/concrete/src/Navigation/NavigationInterface.php
+++ b/concrete/src/Navigation/NavigationInterface.php
@@ -1,24 +1,24 @@
 <?php
+
 namespace Concrete\Core\Navigation;
 
 use Concrete\Core\Navigation\Item\ItemInterface;
 
 interface NavigationInterface
 {
-
     /**
      * Adds an item to the navigation.
      *
-     * @param ItemInterface $item
-     * @return mixed
+     * @param \Concrete\Core\Navigation\Item\ItemInterface $item
+     *
+     * @return $this
      */
-    public function add(ItemInterface $item);
+    public function add(ItemInterface $item): self;
 
     /**
-     * Returns all the items in the navigation
+     * Returns all the items in the navigation.
      *
-     * @return ItemInterface[]
+     * @return \Concrete\Core\Navigation\Item\ItemInterface[]
      */
     public function getItems(): array;
-
 }

--- a/concrete/src/Navigation/NavigationInterface.php
+++ b/concrete/src/Navigation/NavigationInterface.php
@@ -21,4 +21,13 @@ interface NavigationInterface
      * @return \Concrete\Core\Navigation\Item\ItemInterface[]
      */
     public function getItems(): array;
+
+    /**
+     * Replace all the existing items with new ones.
+     *
+     * @param \Concrete\Core\Navigation\Item\ItemInterface[] $items
+     *
+     * @return $this
+     */
+    public function setItems(array $items): self;
 }


### PR DESCRIPTION
We may need to alter the items previously added to a `NavigationInterface` instance: what about adding a new `setItems()` method to it?

I also added some PHPDoc, as well as return types so that we can use method chaining (eg `$breadcrumb->add($a)->add($b);`)