### PR TITLE
Add CCM_UID to global javascript variables

### DIFF
--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -1,6 +1,7 @@
 <?php
 use Concrete\Core\Cookie\ResponseCookieJar;
 use Concrete\Core\Url\SeoCanonical;
+use Concrete\Core\User\User;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Support\Facade\Application;
@@ -190,6 +191,7 @@ if (!empty($alternateHreflangTags)) {
     var CCM_APPLICATION_URL = <?= json_encode(rtrim((string) $app->make('url/canonical'), '/'), JSON_UNESCAPED_SLASHES) ?>;
     var CCM_REL = <?= json_encode((string) $app->make('app_relative_path'), JSON_UNESCAPED_SLASHES) ?>;
     var CCM_ACTIVE_LOCALE = <?= json_encode(Localization::activeLocale(), JSON_UNESCAPED_SLASHES) ?>;
+    var CCM_UID = <?= $app->make(User::class)->getUserID() ?: 'null' ?>;
 </script>
 
 <?php

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -182,14 +182,14 @@ if (!empty($alternateHreflangTags)) {
 }
 ?>
 <script type="text/javascript">
-    var CCM_DISPATCHER_FILENAME = "<?php echo DIR_REL . '/' . DISPATCHER_FILENAME; ?>";
-    var CCM_CID = <?php echo $cID ? $cID : 0; ?>;
-    var CCM_EDIT_MODE = <?php echo $isEditMode ? 'true' : 'false'; ?>;
-    var CCM_ARRANGE_MODE = <?php echo $isArrangeMode ? 'true' : 'false'; ?>;
-    var CCM_IMAGE_PATH = "<?php echo ASSETS_URL_IMAGES; ?>";
-    var CCM_APPLICATION_URL = "<?php echo rtrim((string) $app->make('url/canonical'), '/'); ?>";
-    var CCM_REL = "<?php echo $app->make('app_relative_path'); ?>";
-    var CCM_ACTIVE_LOCALE = <?= json_encode(Localization::activeLocale()) ?>;
+    var CCM_DISPATCHER_FILENAME = <?= json_encode(DIR_REL . '/' . DISPATCHER_FILENAME, JSON_UNESCAPED_SLASHES) ?>;
+    var CCM_CID = <?= (int) $cID ?>;
+    var CCM_EDIT_MODE = <?= $isEditMode ? 'true' : 'false' ?>;
+    var CCM_ARRANGE_MODE = <?= $isArrangeMode ? 'true' : 'false' ?>;
+    var CCM_IMAGE_PATH = <?= json_encode(ASSETS_URL_IMAGES, JSON_UNESCAPED_SLASHES) ?>;
+    var CCM_APPLICATION_URL = <?= json_encode(rtrim((string) $app->make('url/canonical'), '/'), JSON_UNESCAPED_SLASHES) ?>;
+    var CCM_REL = <?= json_encode((string) $app->make('app_relative_path'), JSON_UNESCAPED_SLASHES) ?>;
+    var CCM_ACTIVE_LOCALE = <?= json_encode(Localization::activeLocale(), JSON_UNESCAPED_SLASHES) ?>;
 </script>
 
 <?php

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -191,7 +191,7 @@ if (!empty($alternateHreflangTags)) {
     var CCM_APPLICATION_URL = <?= json_encode(rtrim((string) $app->make('url/canonical'), '/'), JSON_UNESCAPED_SLASHES) ?>;
     var CCM_REL = <?= json_encode((string) $app->make('app_relative_path'), JSON_UNESCAPED_SLASHES) ?>;
     var CCM_ACTIVE_LOCALE = <?= json_encode(Localization::activeLocale(), JSON_UNESCAPED_SLASHES) ?>;
-    var CCM_UID = <?= $app->make(User::class)->getUserID() ?: 'null' ?>;
+    var CCM_USER_REGISTERED = <?= $app->make(User::class)->isRegistered() ? 'true ': 'false' ?>;
 </script>
 
 <?php


### PR DESCRIPTION
I sometimes need to know the ID of the currently logged-in user via JavaScript (I don't think there are security problems doing that).
What about adding it to the global JavaScript variables that we already set in the `header_required.php` element?

PS: I also updated the code, so that PHP strings are sent to JavaScript via `json_encode` instead of a plain `echo`.