### PR TITLE
Check that new migrations don't have an ID less than version_db

### DIFF
--- a/tests/helpers/CI/Exception.php
+++ b/tests/helpers/CI/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+use RuntimeException;
+
+class Exception extends RuntimeException
+{
+}

--- a/tests/helpers/CI/PullRequestState.php
+++ b/tests/helpers/CI/PullRequestState.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+class PullRequestState extends State
+{
+    /**
+     * The SHA-1 of the base commit (that is, the last commit of the base branch).
+     *
+     * @var string
+     */
+    private $baseSha1;
+
+    /**
+     * The SHA-1 of the head commit (that is, the last commit of the pull request branch).
+     *
+     * @var string
+     */
+    private $headSha1;
+
+    /**
+     * The SHA-1 of the merge commit.
+     *
+     * @var string
+     */
+    private $mergeSha1;
+
+    /**
+     * The SHA-1 of the most recent commit in common between the base commit and the head commit.
+     *
+     * @var string
+     */
+    private $commonCommitSha1;
+
+    /**
+     * @param string $engine the current engine (it's the value of one of the State::ENGINE__... constants)
+     * @param string $event the event type (it's the value of one of the State::EVENT__... constants)
+     * @param string $baseSha1 the SHA-1 of the base commit (that is, the last commit of the base branch)
+     * @param string $headSha1 the SHA-1 of the head commit (that is, the last commit of the pull request branch)
+     * @param string $mergeSha1 the SHA-1 of the merge commit
+     * @param string $commonCommitSha1 the SHA-1 of the most recent commit in common between the base commit and the head commit
+     */
+    public function __construct(string $engine, string $event, string $baseSha1, string $headSha1, string $mergeSha1, string $commonCommitSha1)
+    {
+        parent::__construct($engine, $event);
+        $this->baseSha1 = $baseSha1;
+        $this->headSha1 = $headSha1;
+        $this->mergeSha1 = $mergeSha1;
+    }
+
+    /**
+     * Get the SHA-1 of the base commit (that is, the last commit of the base branch).
+     */
+    public function getBaseSha1(): string
+    {
+        return $this->baseSha1;
+    }
+
+    /**
+     * Get the SHA-1 of the head commit (that is, the last commit of the pull request branch).
+     */
+    public function getHeadSha1(): string
+    {
+        return $this->headSha1;
+    }
+
+    /**
+     * Get the SHA-1 of the merge commit.
+     */
+    public function getMergeSha1(): string
+    {
+        return $this->mergeSha1;
+    }
+
+    /**
+     * Get the SHA-1 of the most recent commit in common between the base commit and the head commit.
+     */
+    public function getCommonCommitSha1(): string
+    {
+        return $this->commonCommitSha1;
+    }
+}

--- a/tests/helpers/CI/SingleState.php
+++ b/tests/helpers/CI/SingleState.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+class SingleState extends State
+{
+    /**
+     * The commit SHA-1.
+     *
+     * @var string
+     */
+    private $sha1;
+
+    /**
+     * @param string $engine the current engine (it's the value of one of the State::ENGINE__... constants)
+     * @param string $event the event type (it's the value of one of the State::EVENT__... constants)
+     * @param string $sha1 the commit SHA-1
+     */
+    public function __construct(string $engine, string $event, string $sha1)
+    {
+        parent::__construct($engine, $event);
+        $this->sha1 = $sha1;
+    }
+
+    /**
+     * Get the commit SHA-1.
+     */
+    public function getSha1(): string
+    {
+        return $this->sha1;
+    }
+}

--- a/tests/helpers/CI/State.php
+++ b/tests/helpers/CI/State.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+abstract class State
+{
+    public const ENGINE_TRAVISCI = 'travis-ci';
+
+    public const ENGINE_APPVEYOR = 'appveyor';
+
+    public const ENGINE_GITHUBACTIONS = 'github-actions';
+
+    public const EVENT_PUSH = 'push';
+
+    public const EVENT_PULLREQUEST = 'pull-request';
+
+    public const EVENT_TAG = 'tag';
+
+    public const EVENT_SCHEDULED = 'scheduled';
+
+    public const EVENT_MANUAL = 'manual';
+
+    /**
+     * The current engine (it's the value of one of the State::ENGINE__... constants).
+     *
+     * @var string
+     */
+    private $engine;
+
+    /**
+     * The event type (it's the value of one of the State::EVENT__... constants).
+     *
+     * @var string
+     */
+    private $event;
+
+    /**
+     * @param string $engine the current engine (it's the value of one of the State::ENGINE__... constants)
+     * @param string $event the event type (it's the value of one of the State::EVENT__... constants)
+     */
+    protected function __construct(string $engine, string $event)
+    {
+        $this->engine = $engine;
+        $this->event = $event;
+    }
+
+    /**
+     * Get the current engine (it's the value of one of the State::ENGINE__... constants).
+     *
+     * @return string
+     */
+    public function getEngine(): string
+    {
+        return $this->engine;
+    }
+
+    /**
+     * Get the event type (it's the value of one of the State::EVENT__... constants).
+     *
+     * @return string
+     */
+    public function getEvent(): string
+    {
+        return $this->event;
+    }
+}

--- a/tests/helpers/CI/StateFactory.php
+++ b/tests/helpers/CI/StateFactory.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+class StateFactory
+{
+    /**
+     * The value of the $_ENV global variable.
+     *
+     * @var array
+     */
+    private $env;
+
+    /**
+     * @param array $env the value of the $_ENV global variable
+     */
+    public function __construct(array $env)
+    {
+        $this->env = $env;
+    }
+
+    /**
+     * @throws \Concrete\TestHelpers\CI\Exception
+     */
+    public function getState(): State
+    {
+        switch ($this->getEngine()) {
+            case State::ENGINE_APPVEYOR:
+                return $this->getAppVeyorState();
+            case State::ENGINE_GITHUBACTIONS:
+                return $this->getGitHubActionsState();
+            case State::ENGINE_TRAVISCI:
+                return $this->getTravisCIState();
+        }
+        throw new Exception('Unable to detect the CI engine');
+    }
+
+    protected function getEngine(): string
+    {
+        if (strcasecmp($this->getEnv('APPVEYOR'), 'true') === 0) {
+            return State::ENGINE_APPVEYOR;
+        }
+        if (strcasecmp($this->getEnv('GITHUB_ACTIONS'), 'true') === 0) {
+            return State::ENGINE_GITHUBACTIONS;
+        }
+        if (strcasecmp($this->getEnv('TRAVIS'), 'true') === 0) {
+            return State::ENGINE_TRAVISCI;
+        }
+
+        return '';
+    }
+
+    protected function getAppVeyorState(): State
+    {
+        if ($this->getEnv('APPVEYOR_PULL_REQUEST_HEAD_COMMIT') !== '') {
+            return $this->createPullRequestState(State::ENGINE_APPVEYOR);
+        }
+        $sha1 = $this->getEnv('APPVEYOR_REPO_COMMIT');
+        if ($sha1 === '') {
+            throw new Exception('AppVeyor without commit SHA-1');
+        }
+        if (strcasecmp($this->getEnv('APPVEYOR_REPO_TAG'), 'true') === 0) {
+            $tag = $this->getEnv('APPVEYOR_REPO_TAG_NAME');
+            if ($tag === '') {
+                throw new Exception('AppVeyor tag event without tag name');
+            }
+
+            return new TagState(State::ENGINE_APPVEYOR, State::EVENT_TAG, $sha1, $tag);
+        }
+        if (strcasecmp($this->getEnv('APPVEYOR_SCHEDULED_BUILD'), 'true') === 0) {
+            $event = State::EVENT_SCHEDULED;
+        } elseif ($this->getEnv('APPVEYOR_FORCED_BUILD', 'true') === 0) {
+            $event = State::EVENT_MANUAL;
+        } else {
+            $event = State::EVENT_PUSH;
+        }
+
+        return new SingleState(State::ENGINE_APPVEYOR, $event, $sha1);
+    }
+
+    protected function getGitHubActionsState(): State
+    {
+        $eventName = $this->getEnv('GITHUB_EVENT_NAME');
+        if ($eventName === '') {
+            throw new Exception('GitHub Actions without event name');
+        }
+        if ($eventName === 'pull_request') {
+            return $this->createPullRequestState(State::ENGINE_GITHUBACTIONS);
+        }
+        $sha1 = $this->getEnv('GITHUB_SHA');
+        if ($sha1 === '') {
+            throw new Exception('GitHub Actions without commit SHA-1');
+        }
+        $matches = null;
+        if ($eventName === 'create' && preg_match('%^refs/tags/(.+)%', $this->getEnv('GITHUB_REF'), $matches)) {
+            return new TagState(State::ENGINE_GITHUBACTIONS, State::EVENT_TAG, $sha1, $matches[1]);
+        }
+        $eventMap = [
+            'push' => State::EVENT_PUSH,
+            'schedule' => State::EVENT_SCHEDULED,
+            'repository_dispatch' => State::EVENT_MANUAL,
+        ];
+        $event = $eventMap[$eventName] ?? '';
+        if ($event === '') {
+            throw new Exception("Unrecognized GitHub Actions event name: '{$eventName}'");
+        }
+
+        return new SingleState(State::ENGINE_GITHUBACTIONS, $event, $sha1);
+    }
+
+    /**
+     * @throws \Concrete\TestHelpers\CI\Exception
+     */
+    protected function getTravisCIState(): State
+    {
+        $eventType = $this->getEnv('TRAVIS_EVENT_TYPE');
+        if ($eventType === '') {
+            throw new Exception('TravisCI without event type');
+        }
+        if ($eventType === 'pull_request') {
+            return $this->createPullRequestState(State::ENGINE_TRAVISCI);
+        }
+        $sha1 = $this->getEnv('TRAVIS_COMMIT');
+        if ($sha1 === '') {
+            throw new Exception('TravisCI without commit SHA-1');
+        }
+        $tag = $this->getEnv('TRAVIS_TAG');
+        if ($tag !== '') {
+            return new TagState(State::ENGINE_TRAVISCI, State::EVENT_TAG, $sha1, tag);
+        }
+        $eventMap = [
+            'push' => State::EVENT_PUSH,
+            'cron' => State::EVENT_SCHEDULED,
+            'api' => State::EVENT_MANUAL,
+        ];
+        $event = $eventMap[$eventType] ?? '';
+        if ($event === '') {
+            throw new Exception("Unrecognized TravisCI event type: '{$eventType}'");
+        }
+
+        return new SingleState(State::ENGINE_TRAVISCI, $event, $sha1);
+    }
+
+    protected function getEnv(string $key, ?string $onUnset = ''): ?string
+    {
+        return $this->env[$key] ?? $onUnset;
+    }
+
+    /**
+     * @throws \Concrete\TestHelpers\CI\Exception
+     *
+     * @return string[]
+     */
+    protected function runGit(string $args): array
+    {
+        $rc = -1;
+        $output = [];
+        exec('git -C ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE)) . ' ' . $args, $output, $rc);
+        if ($rc !== 0) {
+            throw new Exception("git command failed:\n" . trim(implode("\n", $output)));
+        }
+
+        return $output;
+    }
+
+    protected function createPullRequestState(string $engine): PullRequestState
+    {
+        list($mergeCommit, $baseSha1, $headSha1) = $this->runGit('rev-list --parents -n1 HEAD');
+        list($commonCommit) = $this->runGit("merge-base {$headSha1} {$headSha1}");
+
+        return [$mergeCommit, $baseSha1, $headSha1, $commonCommit];
+
+        return new PullRequestState($engine, State::EVENT_PULLREQUEST, $baseSha1, $headSha1, $mergeCommit, $commonCommit);
+    }
+}

--- a/tests/helpers/CI/TagState.php
+++ b/tests/helpers/CI/TagState.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Concrete\TestHelpers\CI;
+
+class TagState extends SingleState
+{
+    /**
+     * The tag.
+     *
+     * @var string
+     */
+    private $tag;
+
+    /**
+     * @param string $engine the current engine (it's the value of one of the State::ENGINE__... constants)
+     * @param string $event the event type (it's the value of one of the State::EVENT__... constants)
+     * @param string $sha1 the commit SHA-1
+     * @param string $tag the tag
+     */
+    public function __construct(string $engine, string $event, string $sha1, string $tag)
+    {
+        parent::__construct($engine, $event, $sha1);
+        $this->tag = $tag;
+    }
+
+    /**
+     * Get the tag.
+     */
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+}

--- a/tests/tests/Update/NewMigrationsTest.php
+++ b/tests/tests/Update/NewMigrationsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Concrete\Tests\Update;
+
+use Concrete\TestHelpers\CI\Exception;
+use Concrete\TestHelpers\CI\PullRequestState;
+use Concrete\TestHelpers\CI\StateFactory;
+use PHPUnit\Framework\TestCase;
+
+class NewMigrationsTest extends TestCase
+{
+    public function testNewMigrations()
+    {
+        $state = $this->getPullRequestState();
+        $pullRequestMigrationIDs = $this->listPullRequestMigrationIDs($state->getCommonCommitSha1(), $state->getHeadSha1());
+        if ($pullRequestMigrationIDs === []) {
+            $invalidMigrationIDs = [];
+        } else {
+            $baseMigrationID = $this->getBaseMigrationID($state->getBaseSha1());
+            $invalidMigrationIDs = array_filter($pullRequestMigrationIDs, function (string $pullRequestMigrationID) use ($baseMigrationID): bool {
+                return $pullRequestMigrationID >= $baseMigrationID;
+            });
+        }
+        $this->assertSame([], $invalidMigrationIDs, "There shouldn't be any migration with an ID lower than {$baseMigrationID}");
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\SkippedTestError
+     */
+    protected function getPullRequestState(): PullRequestState
+    {
+        try {
+            $state = app(StateFactory::class, ['env' => getenv()])->getState();
+        } catch (Exception $x) {
+            $this->markTestSkipped('Failed to get the CI state: ' . $x->getMessage());
+        }
+        if (!($state instanceof PullRequestState)) {
+            $this->markTestSkipped('Test valid only for pull request (current event: ' . $state->getEvent() . ')');
+        }
+
+        return $state;
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\SkippedTestError
+     */
+    protected function getBaseMigrationID(string $baseSha1): string
+    {
+        $rc = -1;
+        $output = [];
+        exec('git -C ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE)) . " show {$baseSha1}:concrete/config/concrete.php", $output, $rc);
+        if ($rc !== 0) {
+            $this->markTestSkipped("Failed to retrieve the base migration ID:\n" . trim(implode("\n", $output)));
+        }
+        $matches = null;
+        foreach ($output as $line) {
+            if (preg_match('/^\s*(["\'])version_db\1\s*=>\s*(["\'])(\d+)\2/', $line, $matches)) {
+                return $matches[3];
+            }
+        }
+        $this->markTestSkipped('Failed to extract the base migration ID');
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\SkippedTestError
+     *
+     * @return string[]
+     */
+    protected function listPullRequestMigrationIDs(string $fromSha1, string $toSha1): array
+    {
+        $rc = -1;
+        $output = [];
+        exec('git -C ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, DIR_BASE)) . " diff --name-status {$fromSha1}..{$toSha1}", $output, $rc);
+        if ($rc !== 0) {
+            $this->markTestSkipped("Failed to list the git changes:\n" . trim(implode("\n", $output)));
+        }
+        $result = [];
+        $matches = null;
+        foreach ($output as $line) {
+            if (preg_match('%^[AR].*\sconcrete/src/Updater/Migrations/Migrations/Version(\d+)\.php\s*$/', $line, $matches)) {
+                $result[] = $matches[1];
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
The problem that caused #8771 is that we merged into the 8.5 branch some pull requests that have migrations whose IDs are lower than the value of the `version_db` configuration key.

To avoid such problems in future, what about adding a new test that checks that this doesn't occur?

This test, executed only in case of pull requests, does the following:

- takes the value of the `version_db` configuration key of the base branch (eg `develop`)
- list all the migrations added by the pull request
- checks that those new migrations have an ID lower than `version_db`
