### PR TITLE
Fixing save channel logging

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/logging.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/logging.php
@@ -18,9 +18,9 @@ class Logging extends DashboardPageController
     {
         $config = $this->app->make('config');
         $strStatus = (string) $strStatus;
-        $intLogErrors = $config->get('concrete.log.errors') == 1 ? 1 : 0;
-        $intLogEmails = $config->get('concrete.log.emails') == 1 ? 1 : 0;
-        $intLogApi = $config->get('concrete.log.api') == 1 ? 1 : 0;
+        $intLogErrors = (int) $config->get('concrete.log.errors');
+        $intLogEmails = (int) $config->get('concrete.log.emails');
+        $intLogApi = (int) $config->get('concrete.log.api');
 
         $this->set('fh', Loader::helper('form'));
         $this->set('intLogErrors', $intLogErrors);
@@ -73,9 +73,9 @@ class Logging extends DashboardPageController
         $logFile = $handler === 'file' ? (string) $request->request->get('logFile') : null;
         $enableDashboardReport = $request->request->get('enable_dashboard_report') ? true : false;
         $loggingLevel = strtoupper((string) $request->request->get('logging_level'));
-        $intLogErrorsPost = $request->request->get('ENABLE_LOG_ERRORS') === 1 ? 1 : 0;
-        $intLogEmailsPost = $request->request->get('ENABLE_LOG_EMAILS') === 1 ? 1 : 0;
-        $intLogApiPost = $request->request->get('ENABLE_LOG_API') === 1 ? 1 : 0;
+        $intLogErrorsPost = (int) $request->request->has('ENABLE_LOG_ERRORS');
+        $intLogEmailsPost = (int) $request->request->has('ENABLE_LOG_EMAILS');
+        $intLogApiPost = (int) $request->request->has('ENABLE_LOG_API');
 
 
         // Handle 'file' based logging


### PR DESCRIPTION
The log channels were compared strictly to 1, but looking at the request data,
it was sent as a string ("1"), this made the comparision fail and always put 0.
which made it impossible to save the logging channels.

Since it is a checkbox and not present in the request if it remains unchecked,
we can just check if the checkbox name is present in the request, the value does not matter.

Page: /dashboard/system/environment/logging
