### PR TITLE
Fix ExpressEntityEntries.publicIdentifier migration

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20190509205043.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190509205043.php
@@ -27,7 +27,7 @@ class Version20190509205043 extends AbstractMigration implements RepeatableMigra
         // Now we have to populate this. Let's bust out of the entity manager for performance purposes.
         $connection = $this->connection;
         $this->connection->transactional(function() use ($connection, $generator) {
-            $r = $connection->executeQuery('select exEntryID from ExpressEntityEntries');
+            $r = $connection->executeQuery('select exEntryID from ExpressEntityEntries where publicIdentifier is null');
             while ($row = $r->fetch()) {
                 $identifier = $generator->generate();
                 $connection->update(


### PR DESCRIPTION
This is a repeatable migration, so we should be sure we don't wipe out previous data.

See https://github.com/concrete5/concrete5/pull/7822#discussion_r441125632