### PR TITLE
Require success of "Check PHP coding style" TravisCI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - name: Test with PHP nightly
-    - name: Check PHP coding style
   include:
 
     - name: Test with PHP 7.2 (with code coverage)


### PR DESCRIPTION
Now that we're done moving tons of commits between 8.x and 9.x branches, what about removing the "Check PHP coding style" TravisCI job from the list of jobs that can fail?