### PR TITLE
Dont call on_job_execute event twice in executeJob

### DIFF
--- a/concrete/src/Job/Job.php
+++ b/concrete/src/Job/Job.php
@@ -350,9 +350,6 @@ abstract class Job extends ConcreteObject
             $error = static::JOB_ERROR_EXCEPTION_GENERAL;
         }
 
-        $je = new Event($this);
-        Events::dispatch('on_job_execute', $je);
-
         $obj = $this->markCompleted($error, $resultMsg);
 
         return $obj;


### PR DESCRIPTION
Currently if you run a single job (non queue-able job) when it is finished it will fire the on_job_execute event twice.
It is called in markCompleted and executeJob.
The call in executeJob is redundant as the job status hasn't been updated yet and if we try to get the status of a job it will return the previous run, not the current one.