### PR TITLE
[v8] don't fire event execute_job twice

### DIFF
--- a/concrete/src/Job/Job.php
+++ b/concrete/src/Job/Job.php
@@ -350,9 +350,6 @@ abstract class Job extends ConcreteObject
             $error = static::JOB_ERROR_EXCEPTION_GENERAL;
         }
 
-        $je = new Event($this);
-        Events::dispatch('on_job_execute', $je);
-
         $obj = $this->markCompleted($error, $resultMsg);
 
         return $obj;


### PR DESCRIPTION
same as #8798 but for version 8.5 as well