### PR TITLE
[V9] make page_selector attribute searchable

### DIFF
--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -8,6 +8,8 @@ use Concrete\Core\Page\Page;
 
 class Controller extends AttributeTypeController
 {
+    protected $searchIndexFieldDefinition = ['type' => 'integer', 'options' => ['default' => 0, 'notnull' => false]];
+    
     public function getIconFormatter()
     {
         return new FontAwesomeIconFormatter('link');


### PR DESCRIPTION
It seems that the page selector attribute is not included in CollectionSearchIndexAttributes table because it is missing the $searchIndexFieldDefinition
