### PR TITLE
New Add Container Experience

### DIFF
--- a/concrete/src/Entity/Page/Container.php
+++ b/concrete/src/Entity/Page/Container.php
@@ -106,6 +106,26 @@ class Container
         }
     }
 
+    /**
+     * Determines if the container has templates available.
+     *
+     * @return bool
+     */
+    public function hasAddTemplate()
+    {
+        return false;
+    }
+
+    /**
+     * if a the current container supports inline add or not.
+     *
+     * @return bool
+     */
+    public function supportsInlineAdd()
+    {
+        return false;
+    }
+
     public function export(\SimpleXMLElement $node): void
     {
         $container = $node->addChild('container');

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -260,7 +260,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
                             <?= $setName ?><i class="fa fa-chevron-up float-right"></i>
                         </header>
                         <div id="ccm-block-set-<?= $i ?>" class="ccm-block-set collapse show">
-                        <ul class="d-flex flex-wrap">
+                        <?php
+                            // This class is added to help align the last row when it contains less than 3 elements
+                            $justifyLastRowClass= (count($blockTypes) % 3) > 0 ? 'ccm-flex-align-last-row' : '';
+                        ?>
+                        <ul class="d-flex flex-row flex-wrap justify-content-between <?= $justifyLastRowClass; ?>">
                             <?php
                             foreach ($blockTypes as $bt) {
                                 $btIcon = $ci->getBlockTypeIconURL($bt);
@@ -318,6 +322,13 @@ defined('C5_EXECUTE') or die('Access Denied.');
         // switching the up/down arrows for collapsing block sets
         $('#ccm-panel-add-block').find('div[id^="ccm-block-set-"]').on('hidden.bs.collapse shown.bs.collapse', function () {
             $(this).prev('header[data-toggle="collapse"]').find('i.fa').toggleClass('fa-chevron-up fa-chevron-down');
+        });
+
+        // This makes the elements under the dropdown not react to hover.
+        // Originally the block below the dropdown would grab the focus
+        // and it would be impossible to click a link in the dropdown
+        $('#dropdown-menu').on('hide.bs.dropdown shown.bs.dropdown', function () {
+            $('#ccm-panel-add-blocktypes-list').toggleClass('ccm-no-pointer-events');
         });
         // switching between grid and stacked view for blocks
         var gridViewSwitcher = $('.ccm-panel-header-list-grid-view-switcher');

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -60,13 +60,13 @@ defined('C5_EXECUTE') or die('Access Denied.');
                     <li>
                         <a
                             href="#"
-                            class="ccm-panel-add-block-draggable-block-type"
+                            class="ccm-panel-add-container-item"
                             data-panel-add-block-drag-item="container"
                             data-cID="<?= (int) $c->getCollectionID() ?>"
                             data-container-id="<?=$container->getContainerID() ?>"
                             data-block-type-handle="core_container"
-                            data-has-add-template="no"
-                            data-supports-inline-add="no"
+                            data-has-add-template="<?= $container->hasAddTemplate() ?>"
+                            data-supports-inline-add="<?= $container->supportsInlineAdd() ?>"
                             data-btID="0"
                             data-dragging-avatar="<?= h('<div class="ccm-block-icon-wrapper d-flex align-items-center justify-content-center">' . $container->getContainerIconImage() . '</div><p><span>' . $container->getContainerName() . '</span></p>') ?>"
                         >

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -12,7 +12,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <section>
     <header class="pl-0 pr-0">
-        <div class="dropdown" data-panel-menu="dropdown">
+        <div id="dropdown-menu" class="dropdown" data-panel-menu="dropdown">
             <div class="ccm-panel-header-list-grid-view-switcher"><i class="fa fa-list fa-xs fa-fw"></i></div>
             <h4 data-toggle="dropdown" data-panel-header="dropdown-menu" class="dropdown-toggle">
                 <?php
@@ -46,33 +46,39 @@ defined('C5_EXECUTE') or die('Access Denied.');
     case 'containers':
         /* @var Concrete\Core\Entity\Page\Container[] $containers */
         ?>
-        <ul id="ccm-panel-add-container-list">
-            <?php
-            foreach ($containers as $container) {
-                ?>
-                <li>
-                    <a
-                        href="#"
-                        class="ccm-panel-add-container-item"
-                        data-panel-add-block-drag-item="container"
-                        data-cID="<?= (int) $c->getCollectionID() ?>"
-                        data-container-id="<?=$container->getContainerID() ?>"
-                        data-block-type-handle="core_container"
-                        data-has-add-template="no"
-                        data-supports-inline-add="no"
-                        data-btID="0"
-                        data-dragging-avatar="<?= h('<p>' . $container->getContainerIconImage() . '<span>' . $container->getContainerName() . '</span></p>') ?>"
-                    >
-                       <span class="handle">
-                           <img src="<?=$container->getContainerIconImage(false)?>" />
-                            <span><?= h($container->getContainerName()) ?></span>
-                       </span>
-                    </a>
-                </li>
+        <div class="ccm-panel-header-search">
+            <svg><use xlink:href="#icon-search" /></svg>
+            <input type="text" data-input="search-blocks" placeholder="<?= t('Search') ?>" autocomplete="false"/>
+        </div>
+        <div class="ccm-panel-content-inner ccm-stacked-list" id="ccm-panel-add-blocktypes-list" data-hide-grid-view-switcher>
+            <ul class="ccm-stacked-list">
                 <?php
-            }
-            ?>
-        </ul>
+                foreach ($containers as $container) {
+                    ?>
+                    <li>
+                        <a
+                            href="#"
+                            class="ccm-panel-add-block-draggable-block-type"
+                            data-panel-add-block-drag-item="container"
+                            data-cID="<?= (int) $c->getCollectionID() ?>"
+                            data-container-id="<?=$container->getContainerID() ?>"
+                            data-block-type-handle="core_container"
+                            data-has-add-template="no"
+                            data-supports-inline-add="no"
+                            data-btID="0"
+                            data-dragging-avatar="<?= h('<div class="ccm-block-icon-wrapper d-flex align-items-center justify-content-center">' . $container->getContainerIconImage() . '</div><p><span>' . $container->getContainerName() . '</span></p>') ?>"
+                        >
+                        <!-- <span class="handle"> -->
+                            <div class="ccm-block-icon-wrapper d-flex align-items-center justify-content-center"><img src="<?=$container->getContainerIconImage(false)?>" /></div>
+                                <p><span><?= h($container->getContainerName()) ?></span></p>
+                        <!-- </span> -->
+                        </a>
+                    </li>
+                    <?php
+                }
+                ?>
+            </ul>
+        </div>
         <script>
 
         </script>
@@ -316,9 +322,20 @@ defined('C5_EXECUTE') or die('Access Denied.');
             $(this).prev('header[data-toggle="collapse"]').find('i.fa').toggleClass('fa-chevron-up fa-chevron-down');
         });
         // switching between grid and stacked view for blocks
-        $('.ccm-panel-header-list-grid-view-switcher').on('click', function () {
+        var gridViewSwitcher = $('.ccm-panel-header-list-grid-view-switcher');
+
+        gridViewSwitcher.on('click', function () {
             $('#ccm-panel-add-blocktypes-list').toggleClass('ccm-stacked-list');
             $(this).find('i.fa').toggleClass('fa-list fa-th');
+        });
+
+        // hiding the grid view switcher when not needed.
+        Concrete.event.bind('PanelLoad', function(evt, data) {
+            gridViewSwitcher.removeClass('d-none');
+            var element = $(data.element);
+            if (element.find('[data-hide-grid-view-switcher]').length) {
+                gridViewSwitcher.addClass('d-none');
+            }
         });
     });
 </script>

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -12,6 +12,12 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <section>
     <header class="pl-0 pr-0">
+        <?php if ($tab == 'containers' || $tab == 'blocks') { ?>
+            <div class="ccm-panel-header-search">
+                <svg><use xlink:href="#icon-search" /></svg>
+                <input type="text" data-input="search-blocks" placeholder="<?= t('Search') ?>" autocomplete="false"/>
+            </div>
+        <?php } ?>
         <div id="dropdown-menu" class="dropdown" data-panel-menu="dropdown">
             <div class="ccm-panel-header-list-grid-view-switcher"><i class="fa fa-list fa-xs fa-fw"></i></div>
             <h4 data-toggle="dropdown" data-panel-header="dropdown-menu" class="dropdown-toggle">
@@ -46,10 +52,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
     case 'containers':
         /* @var Concrete\Core\Entity\Page\Container[] $containers */
         ?>
-        <div class="ccm-panel-header-search">
-            <svg><use xlink:href="#icon-search" /></svg>
-            <input type="text" data-input="search-blocks" placeholder="<?= t('Search') ?>" autocomplete="false"/>
-        </div>
         <div class="ccm-panel-content-inner ccm-stacked-list" id="ccm-panel-add-blocktypes-list" data-hide-grid-view-switcher>
             <ul class="ccm-stacked-list">
                 <?php
@@ -242,10 +244,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
         case 'blocks':
             /* @var Concrete\Core\Entity\Block\BlockType\BlockType[] $blockTypesForSets */
             ?>
-            <div class="ccm-panel-header-search">
-                <svg><use xlink:href="#icon-search" /></svg>
-                <input type="text" data-input="search-blocks" placeholder="<?= t('Search') ?>" autocomplete="false"/>
-            </div>
             <div class="ccm-panel-content-inner" id="ccm-panel-add-blocktypes-list">
                 <?php
                 $i = 0;

--- a/concrete/views/panels/add.php
+++ b/concrete/views/panels/add.php
@@ -330,6 +330,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
         });
 
         // hiding the grid view switcher when not needed.
+        // This uses a data attribute to mark panels
+        // that don't require the grid switcher
         Concrete.event.bind('PanelLoad', function(evt, data) {
             gridViewSwitcher.removeClass('d-none');
             var element = $(data.element);


### PR DESCRIPTION
This addresses #8478 
It (kind of) requires a bedrock companion draft pull request https://github.com/concrete5/bedrock/pull/87

The search works and I didn't have to modify liveupdate.js

The reason it's only a draft is that the screenshot on the issue page presents a design that is totally different from what was done for the Add block panel.

I added styling in bedrock to look like the screenshot but for now, it is commented out.

For now, I styled the containers list like the add block panel but without the grid view.

![screenshot](https://user-images.githubusercontent.com/1488833/85961814-e7071e80-b9a4-11ea-9d5f-6b063e945722.png)

If the design should be as it is on the screenshot then I will uncomment the styling I added in bedrock and make a few other modifications.

It will make things difficult for the liveupdate.js part and the styling of the element when clicked before dragging but it's doable.

Also, I noticed a problem in the add block panel. When I build it and it was merged the icons were aligning properly but not anymore as if the containing element's width was changed since.

It's a tiny change to make it look good again. Just decrease a bit the width of the blocks items. Can I add this change here?

A second more important problem exists when in the add block panel with the stacked view and trying to switch to containers. The draggable block element, although under the dropdown, seems to be grabbing the focus away from the dropdown, and clicking on the dropdown becomes extremely difficult. Should I try to fix this as part of this pull request?