### PR TITLE
[V8] Mailimporter update

### DIFF
--- a/concrete/src/Mail/Importer/MailImportedAttachment.php
+++ b/concrete/src/Mail/Importer/MailImportedAttachment.php
@@ -1,0 +1,56 @@
+<?php
+namespace Concrete\Core\Mail\Importer;
+
+class MailImportedAttachment
+{
+    protected $mail;
+    protected $type;
+    protected $content;
+    protected $name;
+
+    public function __construct(MailImportedMessage $mail)
+    {
+        $this->mail = $mail;
+    }
+
+    public function getMail()
+    {
+        return $this->mail;
+    }
+
+    public function setMail($mail)
+    {
+        $this->mail = $mail;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+}

--- a/concrete/src/Mail/Importer/MailImportedMessage.php
+++ b/concrete/src/Mail/Importer/MailImportedMessage.php
@@ -110,7 +110,8 @@ class MailImportedMessage
         return $this->body;
     }
 
-    protected function findAttachedFilesInPart($part) {
+    protected function findAttachedFilesInPart($part) 
+    {
         $files = [];
 
         // Another multipart? Recursively search!

--- a/concrete/src/Mail/Importer/MailImportedMessage.php
+++ b/concrete/src/Mail/Importer/MailImportedMessage.php
@@ -1,0 +1,171 @@
+<?php
+namespace Concrete\Core\Mail\Importer;
+
+use Concrete\Core\Foundation\ConcreteObject;
+use Core;
+use Database;
+use RecursiveIteratorIterator;
+use Concrete\Core\Package\PackageList;
+use Zend\Mail\Storage\Pop3    as MailStoragePop3;
+use Zend\Mail\Storage\Imap    as MailStorageImap;
+use Zend\Mail\Storage\Message as MailMessage;
+use Zend\Mail\Exception       as MailException;
+
+class MailImportedMessage
+{
+    protected $body;
+    protected $subject;
+    protected $sender;
+    protected $validationHash;
+    protected $oMail;
+    protected $oMailMessage;
+    protected $oMailCnt;
+
+    public function __construct($mail, MailMessage $msg, $count)
+    {
+        try {
+            $this->subject = $msg->subject;
+        } catch (Exception $e) {
+        }
+
+        $this->oMail = $mail;
+        $this->oMailMessage = $msg;
+        $this->oMailCnt = $count;
+
+        if (strpos($msg->from, ' ') === false) {
+            $this->sender = str_replace(array('>', '<'), '', $msg->from);
+        } else {
+            $this->sender = substr($msg->from, strpos($msg->from, '<') + 1, strpos($msg->from, '>') - strpos($msg->from, '<') - 1);
+        }
+
+        try {
+            if (strpos($msg->contentType, 'text/plain') !== false) {
+                $this->body = quoted_printable_decode($msg->getContent());
+            } else {
+                $foundPart = null;
+
+                foreach (new RecursiveIteratorIterator($msg) as $part) {
+                    try {
+                        if (strtok($part->contentType, ';') == 'text/plain') {
+                            $foundPart = $part;
+                            break;
+                        }
+                    } catch (MailException $e) {
+                        // ignore
+                    }
+                }
+
+                if ($foundPart) {
+                    $this->body = quoted_printable_decode($foundPart);
+                }
+            }
+        } catch (Exception $e) {
+        }
+
+        // find the hash
+        $r = preg_match(MailImporter::getMessageBodyHashRegularExpression(), $this->body, $matches);
+        if ($r) {
+            $this->validationHash = $matches[1];
+            if ($this->validationHash != '') {
+                $db = Database::connection();
+                $r = $db->GetOne('select data from MailValidationHashes where mHash = ?', array($this->validationHash));
+                if ($r) {
+                    $this->dataObject = unserialize($r);
+                }
+            }
+        }
+    }
+
+    public function getOriginalSender()
+    {
+        return $this->sender;
+    }
+    public function getOriginalMailObject()
+    {
+        return $this->oMail;
+    }
+    public function getOriginalMessageObject()
+    {
+        return $this->oMailMessage;
+    }
+    public function getOriginalMessageCount()
+    {
+        return $this->oMailCnt;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * Returns the relevant content of the email message, minus any quotations, and the line that includes the validation hash.
+     */
+    public function getProcessedBody()
+    {
+        $r = preg_split(MailImporter::getMessageBodyHashRegularExpression(), $this->body);
+        $message = $r[0];
+        $r = preg_replace(array(
+            '/^On (.*) at (.*), (.*) wrote:/sm',
+            '/[\n\r\s\>]*\Z/i',
+        ), '', $message);
+
+        return $r;
+    }
+
+    public function getValidationHash()
+    {
+        return $this->validationHash;
+    }
+
+    /**
+     * Validates the email message - checks the validation hash found in the body with one in the database. Checks the from address as well.
+     */
+    public function validate()
+    {
+        if (!$this->validationHash) {
+            return false;
+        }
+        $db = Database::connection();
+        $row = $db->GetRow("select * from MailValidationHashes where mHash = ? order by mDateGenerated desc limit 1", $this->validationHash);
+        if ($row['mvhID'] > 0) {
+            // Can't do this even though it's a good idea
+            //if ($row['email'] != $this->sender) {
+            //	return false;
+            //} else {
+                return $row['mDateRedeemed'] == 0;
+            //}
+        }
+    }
+
+    public function getDataObject()
+    {
+        return $this->dataObject;
+    }
+
+    /**
+     * checks to see if the message is a bounce or delivery failure.
+     *
+     * @return bool
+     */
+    public function isSendError()
+    {
+        $message = $this->getOriginalMessageObject();
+        $headers = $message->getHeaders();
+        $isSendError = false;
+        if (is_array($headers) && count($headers)) {
+            foreach (array_keys($headers) as $key) {
+                if (strstr($key, 'x-fail') !== false) {
+                    $isSendError = true;
+                    break;
+                }
+            }
+        }
+
+        return $isSendError;
+    }
+}

--- a/concrete/src/Mail/Importer/MailImportedMessage.php
+++ b/concrete/src/Mail/Importer/MailImportedMessage.php
@@ -6,10 +6,11 @@ use Core;
 use Database;
 use RecursiveIteratorIterator;
 use Concrete\Core\Package\PackageList;
-use Zend\Mail\Storage\Pop3    as MailStoragePop3;
-use Zend\Mail\Storage\Imap    as MailStorageImap;
-use Zend\Mail\Storage\Message as MailMessage;
-use Zend\Mail\Exception       as MailException;
+use Zend\Mail\Storage\Pop3                             as MailStoragePop3;
+use Zend\Mail\Storage\Imap                             as MailStorageImap;
+use Zend\Mail\Storage\Message                          as MailMessage;
+use Zend\Mail\Exception                                as MailException;
+use Concrete\Core\Mail\Importer\MailImportedAttachment as Attachment;
 
 class MailImportedMessage
 {
@@ -110,7 +111,7 @@ class MailImportedMessage
         return $this->body;
     }
 
-    protected function findAttachedFilesInPart($part) 
+    protected function findAttachedFilesInPart($part)
     {
         $files = [];
 
@@ -162,11 +163,13 @@ class MailImportedMessage
             }
 
             if ($fileName !== null) {
-                $files[] = [
-                    'name'    => $fileName,
-                    'type'    => $fileType,
-                    'content' => $fileContent
-                ];
+                $attachment = new Attachment($this);
+
+                $attachment->setName($fileName);
+                $attachment->setType($fileType);
+                $attachment->setContent($fileContent);
+
+                $files[] = $attachment;
             }
 
         }

--- a/concrete/src/Mail/Importer/MailImporter.php
+++ b/concrete/src/Mail/Importer/MailImporter.php
@@ -57,11 +57,19 @@ class MailImporter extends ConcreteObject
 
     public static function getByID($miID)
     {
-        $db = Database::connection();
+        $db  = Database::connection();
         $row = $db->GetRow("select miID, miHandle, miServer, miUsername, miPassword, miEncryption, miIsEnabled, miEmail, miPort, miConnectionMethod, Packages.pkgID, pkgHandle from MailImporters left join Packages on MailImporters.pkgID = Packages.pkgID where miID = ?", array($miID));
+
         if (isset($row['miID'])) {
             $txt = Core::make('helper/text');
-            $mi = Core::make('\\Concrete\\Core\\Mail\\Importer\\Type\\' . $txt->camelcase($row['miHandle']));
+
+            if (isset($row['pkgID'])) {
+              $pkgHandle = PackageList::getHandle($row['pkgID']);
+              $mi        = Core::make('\\Concrete\\Package\\' . $txt->camelcase($pkgHandle) . '\\Src\\Mail\\Importer\\Type\\' . $txt->camelcase($row['miHandle']));
+            } else {
+              $mi = Core::make('\\Concrete\\Core\\Mail\\Importer\\Type\\' . $txt->camelcase($row['miHandle']));
+            }
+
             $mi->setPropertiesFromArray($row);
 
             return $mi;

--- a/concrete/src/Mail/Importer/MailImporter.php
+++ b/concrete/src/Mail/Importer/MailImporter.php
@@ -292,7 +292,7 @@ class MailImporter extends ConcreteObject
         }
         $i = 1;
         foreach ($mail as $m) {
-            $mim = new MailImportedMessage($mail, $m, $i++);
+            $mim = new MailImportedMessage($mail, $m, $i);
             $messages[] = $mim;
             ++$i;
         }

--- a/concrete/src/Mail/Importer/MailImporter.php
+++ b/concrete/src/Mail/Importer/MailImporter.php
@@ -5,6 +5,10 @@ use Concrete\Core\Foundation\ConcreteObject;
 use Core;
 use Database;
 use Concrete\Core\Package\PackageList;
+use Zend\Mail\Storage\Pop3    as MailStoragePop3;
+use Zend\Mail\Storage\Imap    as MailStorageImap;
+use Zend\Mail\Storage\Message as MailMessage;
+use Zend\Mail\Exception       as MailException;
 
 class MailImporter extends ConcreteObject
 {
@@ -282,13 +286,13 @@ class MailImporter extends ConcreteObject
         }
 
         if ($this->miConnectionMethod == 'IMAP') {
-            $mail = new Zend_Mail_Storage_Imap($args);
+            $mail = new MailStorageImap($args);
         } else {
-            $mail = new Zend_Mail_Storage_Pop3($args);
+            $mail = new MailStoragePop3($args);
         }
         $i = 1;
         foreach ($mail as $m) {
-            $mim = new MailImportedMessage($mail, $m, $i);
+            $mim = new MailImportedMessage($mail, $m, $i++);
             $messages[] = $mim;
             ++$i;
         }
@@ -304,164 +308,5 @@ class MailImporter extends ConcreteObject
         $m = $me->getOriginalMailObject();
         $msg = $me->getOriginalMessageObject();
         $m->removeMessage($me->getOriginalMessageCount());
-    }
-}
-
-class MailImportedMessage
-{
-    protected $body;
-    protected $subject;
-    protected $sender;
-    protected $validationHash;
-    protected $oMail;
-    protected $oMailMessage;
-    protected $oMailCnt;
-
-    public function __construct($mail, Zend_Mail_Message $msg, $count)
-    {
-        try {
-            $this->subject = $msg->subject;
-        } catch (Exception $e) {
-        }
-
-        $this->oMail = $mail;
-        $this->oMailMessage = $msg;
-        $this->oMailCnt = $count;
-
-        if (strpos($msg->from, ' ') === false) {
-            $this->sender = str_replace(array('>', '<'), '', $msg->from);
-        } else {
-            $this->sender = substr($msg->from, strpos($msg->from, '<') + 1, strpos($msg->from, '>') - strpos($msg->from, '<') - 1);
-        }
-
-        try {
-            if (strpos($msg->contentType, 'text/plain') !== false) {
-                $this->body = quoted_printable_decode($msg->getContent());
-            } else {
-                $foundPart = null;
-
-                foreach (new RecursiveIteratorIterator($msg) as $part) {
-                    try {
-                        if (strtok($part->contentType, ';') == 'text/plain') {
-                            $foundPart = $part;
-                            break;
-                        }
-                    } catch (Zend_Mail_Exception $e) {
-                        // ignore
-                    }
-                }
-
-                if ($foundPart) {
-                    $this->body = quoted_printable_decode($foundPart);
-                }
-            }
-        } catch (Exception $e) {
-        }
-
-        // find the hash
-        $r = preg_match(MailImporter::getMessageBodyHashRegularExpression(), $this->body, $matches);
-        if ($r) {
-            $this->validationHash = $matches[1];
-            if ($this->validationHash != '') {
-                $db = Database::connection();
-                $r = $db->GetOne('select data from MailValidationHashes where mHash = ?', array($this->validationHash));
-                if ($r) {
-                    $this->dataObject = unserialize($r);
-                }
-            }
-        }
-    }
-
-    public function getOriginalSender()
-    {
-        return $this->sender;
-    }
-    public function getOriginalMailObject()
-    {
-        return $this->oMail;
-    }
-    public function getOriginalMessageObject()
-    {
-        return $this->oMailMessage;
-    }
-    public function getOriginalMessageCount()
-    {
-        return $this->oMailCnt;
-    }
-
-    public function getSubject()
-    {
-        return $this->subject;
-    }
-    public function getBody()
-    {
-        return $this->body;
-    }
-
-    /**
-     * Returns the relevant content of the email message, minus any quotations, and the line that includes the validation hash.
-     */
-    public function getProcessedBody()
-    {
-        $r = preg_split(MailImporter::getMessageBodyHashRegularExpression(), $this->body);
-        $message = $r[0];
-        $r = preg_replace(array(
-            '/^On (.*) at (.*), (.*) wrote:/sm',
-            '/[\n\r\s\>]*\Z/i',
-        ), '', $message);
-
-        return $r;
-    }
-
-    public function getValidationHash()
-    {
-        return $this->validationHash;
-    }
-
-    /**
-     * Validates the email message - checks the validation hash found in the body with one in the database. Checks the from address as well.
-     */
-    public function validate()
-    {
-        if (!$this->validationHash) {
-            return false;
-        }
-        $db = Database::connection();
-        $row = $db->GetRow("select * from MailValidationHashes where mHash = ? order by mDateGenerated desc limit 1", $this->validationHash);
-        if ($row['mvhID'] > 0) {
-            // Can't do this even though it's a good idea
-            //if ($row['email'] != $this->sender) {
-            //	return false;
-            //} else {
-                return $row['mDateRedeemed'] == 0;
-            //}
-        }
-    }
-
-    public function getDataObject()
-    {
-        return $this->dataObject;
-    }
-
-    /**
-     * checks to see if the message is a bounce or delivery failure.
-     *
-     * @return bool
-     */
-    public function isSendError()
-    {
-        $message = $this->getOriginalMessageObject();
-        $headers = $message->getHeaders();
-        $isSendError = false;
-        if (is_array($headers) && count($headers)) {
-            foreach (array_keys($headers) as $key) {
-                if (strstr($key, 'x-fail') !== false) {
-                    $isSendError = true;
-                    break;
-                }
-            }
-        }
-
-        return $isSendError;
     }
 }


### PR DESCRIPTION
The intention of these changes is to update the mail importer classes/files.
They seemed pretty outdated. I needed this functionality from within a package and it's working now (v8.5.2).

 I am not 100% sure if e.g. Zend_Mail_Storage_Pop3 can savely be changed to Zend\Mail\Storage\Pop3 on every system.

Nonetheless - it threw exceptions on my system with PHP Version 7.3 and the sources of the importer classes 
were not touched since three years.

Please review. 
We are using this within a custom package checking mails from within a job, reading and saving data from a csv file sent every day at 5AM.

Fixes: #1622 

**Test environment**
```
# concrete5 Version
Core Version - 8.5.2
Version Installed - 8.5.2
Database Version - 20190925072210

# Database Information
Version: 10.3.21-MariaDB
SQL Mode: STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION

# concrete5 Packages
*private* (0.0.1)

# concrete5 Overrides
single_pages/login.php

# concrete5 Cache Settings
Block Cache - Off
Overrides Cache - Off
Full Page Caching - Off
Full Page Cache Lifetime - Every 6 hours (default setting).

# Server Software
nginx/1.16.1

# Server API
fpm-fcgi

# PHP Version
7.3.16

# PHP Extensions
apcu, bcmath, bz2, calendar, cgi-fcgi, Core, ctype, curl, date, dba, dom, exif, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, imap, intl, json, ldap, libxml, mailparse, mbstring, mysqli, mysqlnd, openssl, pcntl, pcre, PDO, pdo_dblib, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, readline, Reflection, session, shmop, SimpleXML, soap, sockets, sodium, SPL, sqlite3, ssh2, standard, sysvmsg, sysvsem, sysvshm, tokenizer, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib

# PHP Settings
max_execution_time - 3600
log_errors_max_len - 1024
max_file_uploads - 20
max_input_nesting_level - 640
max_input_time - 36000
max_input_vars - 10000
memory_limit - 1024M
post_max_size - 64M
upload_max_filesize - 32M
ldap.max_links - Unlimited
mbstring.regex_stack_limit - 100000
mysqli.max_links - Unlimited
mysqli.max_persistent - Unlimited
pcre.backtrack_limit - 1000000
pcre.recursion_limit - 100000
pgsql.max_links - Unlimited
pgsql.max_persistent - Unlimited
session.cache_limiter - <i>no value</i>
session.gc_maxlifetime - 7200
soap.wsdl_cache_limit - 5
opcache.max_accelerated_files - 500000
opcache.max_file_size - 0
opcache.max_wasted_percentage - 5
```

**Test case**

- Create a package
- Add src/Mail/Importer/Type/TestMailImporter.php (copy and rename controler etc. from PrivateMessage)
- Register in package with your settings:

```php
\Concrete\Core\Mail\Importer\MailImporter::add([
      'miHandle'           => 'test_mail_importer',
      'miPort'             => 0,
      'miIsEnabled'        => true,
      'miEncryption'       => 'SSL',
      'miConnectionMethod' => 'IMAP',
      'miServer'           => '',
      'miUsername'         => '',
      'miPassword'         => '',
      'miEmail'            => ''
    ], $this);
```

- Generally if you see it in `{page}/dashboard/system/mail/importers/` it's working

**Info:** 
This is my/our first pull request on an open source project ever. 
Since we extensively using C5 now I/we would like to contribute any changes/bug fixes/additions
done to the core to the project available for others. Expect to see more coming this year.

Just to ask... which branch is preferred for pull requests? Why is it showing commits of other contributers when I point to concrete5:develop eventhough I have just created the new branch? Sorry for stupid questions.

Greetings from KoalaSoft, Düsseldorf Germany!