### PR TITLE
[V8] Correctly parse non decimal ip addresses

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -167,9 +167,9 @@
             "authors": [
                 {
                     "name": "Michele Locati",
+                    "role": "author",
                     "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io",
-                    "role": "author"
+                    "homepage": "https://mlocati.github.io"
                 }
             ],
             "description": "Patches required for concrete5 dependencies",
@@ -2820,16 +2820,16 @@
         },
         {
             "name": "mlocati/ip-lib",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/ip-lib.git",
-                "reference": "b844659e3b87a461d1a8fe8e3e374aa6c4a5d902"
+                "reference": "65a3396d064267f2fef1fd0b8ded712dbe0946b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/b844659e3b87a461d1a8fe8e3e374aa6c4a5d902",
-                "reference": "b844659e3b87a461d1a8fe8e3e374aa6c4a5d902",
+                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/65a3396d064267f2fef1fd0b8ded712dbe0946b2",
+                "reference": "65a3396d064267f2fef1fd0b8ded712dbe0946b2",
                 "shasum": ""
             },
             "require": {
@@ -2872,7 +2872,17 @@
                 "range",
                 "subnet"
             ],
-            "time": "2019-09-20T08:26:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/mlocati",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/mlocati",
+                    "type": "other"
+                }
+            ],
+            "time": "2020-07-09T15:15:38+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3005,7 +3015,7 @@
             "time": "2019-09-06T13:49:17+00:00"
         },
         {
-            "name": "natxet/cssmin",
+            "name": "natxet/CssMin",
             "version": "v3.0.6",
             "source": {
                 "type": "git",
@@ -3180,12 +3190,12 @@
             "version": "v1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/whiteoctober/Pagerfanta.git",
+                "url": "https://github.com/BabDev/Pagerfanta.git",
                 "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/29aade64addfdfb12c05aabf160f09d1aea6b143",
+                "url": "https://api.github.com/repos/BabDev/Pagerfanta/zipball/29aade64addfdfb12c05aabf160f09d1aea6b143",
                 "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143",
                 "shasum": ""
             },

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -74,7 +74,7 @@
     "lusitanian/oauth": "0.8.*",
     "concrete5/oauth-user-data": "~1.0",
     "mlocati/concrete5-translation-library": "^1.5.13",
-    "mlocati/ip-lib": "^1.3.0",
+    "mlocati/ip-lib": "^1.10.0",
     "league/url": "~3.3.5",
     "concrete5/doctrine-xml": "^1.2.0",
     "symfony/yaml":"3.*",

--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -681,12 +681,12 @@ class File extends Controller
             if (in_array(strtolower($host), ['', '0', 'localhost'], true)) {
                 throw new UserMessageException(t('The URL "%s" is not valid.', $u));
             }
-            $ip = IPFactory::addressFromString($host);
+            $ip = IPFactory::addressFromString($host, true, true, true);
             if ($ip === null) {
                 $dnsList = @dns_get_record($host, DNS_A | DNS_AAAA);
                 while ($ip === null && $dnsList !== false && count($dnsList) > 0) {
                     $dns = array_shift($dnsList);
-                    $ip = IPFactory::addressFromString($dns['ip']);
+                    $ip = IPFactory::addressFromString($dns['ip'], true, true, true);
                 }
             }
             if ($ip !== null && !in_array($ip->getRangeType(), [IPRangeType::T_PUBLIC, IPRangeType::T_PRIVATENETWORK], true)) {

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
@@ -11,6 +11,7 @@ use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Permission\IpAccessControlService;
 use Concrete\Core\Permission\IPRangesCsvWriter;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use IPLib\Address\AddressInterface;
 use IPLib\Factory as IPFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -42,7 +43,7 @@ class Range extends Blacklist
         }
         $this->set('type', $type);
         $this->set('service', $service);
-        $this->set('myIPAddress', IPFactory::addressFromString($this->app->make(Request::class)->getClientIp()));
+        $this->set('myIPAddress', $this->app->make(AddressInterface::class));
     }
 
     public function formatRangeRow(IpAccessControlRange $range)
@@ -78,7 +79,7 @@ class Range extends Blacklist
             throw new UserMessageException(t('Unable to find the requested category'));
         }
         if (!$this->request->request->get('force') && ($type & IpAccessControlService::IPRANGEFLAG_BLACKLIST) === IpAccessControlService::IPRANGEFLAG_BLACKLIST) {
-            $myIP = IPFactory::addressFromString($this->app->make(Request::class)->getClientIp());
+            $myIP = $this->app->make(AddressInterface::class);
             if ($range->contains($myIP)) {
                 if (!$service->isWhitelisted($myIP)) {
                     if ($range instanceof \IPLib\Range\Single) {
@@ -114,7 +115,7 @@ class Range extends Blacklist
             }
             $myIpWasWhitelisted = false;
             if (($type & IpAccessControlService::IPRANGEFLAG_WHITELIST) === IpAccessControlService::IPRANGEFLAG_WHITELIST) {
-                $myIP = IPFactory::addressFromString($this->app->make(Request::class)->getClientIp());
+                $myIP = $this->app->make(AddressInterface::class);
                 $range = $record->getIpRange();
                 if ($range->contains($myIP)) {
                     $myIpWasWhitelisted = true;

--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions;
 
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use IPLib\Address\AddressInterface;
 use IPLib\Factory;
 use IPLib\Range\Pattern;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -49,7 +50,7 @@ class TrustedProxies extends DashboardPageController
         $this->set('request', $this->request);
         $currentProxyIP = null;
         if ($this->request->isFromTrustedProxy()) {
-            $clientIP = Factory::addressFromString($this->request->getClientIp());
+            $clientIP = $this->app->make(AddressInterface::class);
             $rawClientIP = Factory::addressFromString($this->request->server->get('REMOTE_ADDR'));
             if ((string) $clientIP !== (string) $rawClientIP) {
                 $currentProxyIP = $rawClientIP;

--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -51,7 +51,7 @@ class TrustedProxies extends DashboardPageController
         $currentProxyIP = null;
         if ($this->request->isFromTrustedProxy()) {
             $clientIP = $this->app->make(AddressInterface::class);
-            $rawClientIP = Factory::addressFromString($this->request->server->get('REMOTE_ADDR'));
+            $rawClientIP = Factory::addressFromString($this->request->server->get('REMOTE_ADDR'), true, true, true);
             if ((string) $clientIP !== (string) $rawClientIP) {
                 $currentProxyIP = $rawClientIP;
             }

--- a/concrete/src/Permission/IPService.php
+++ b/concrete/src/Permission/IPService.php
@@ -115,7 +115,7 @@ class IPService implements LoggerAwareInterface
      */
     public function getRequestIPAddress()
     {
-        return IPFactory::addressFromString($this->request->getClientIp());
+        return app(AddressInterface::class);
     }
 
     /**

--- a/concrete/src/Permission/IPService.php
+++ b/concrete/src/Permission/IPService.php
@@ -2,13 +2,14 @@
 
 namespace Concrete\Core\Permission;
 
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Utility\IPAddress;
 use DateTime;
 use IPLib\Address\AddressInterface;
@@ -18,8 +19,9 @@ use IPLib\Range\RangeInterface;
 /**
  * @deprecated check single methods to see the non-deprecated alternatives
  */
-class IPService implements LoggerAwareInterface
+class IPService implements ApplicationAwareInterface, LoggerAwareInterface
 {
+    use ApplicationAwareTrait;
     use LoggerAwareTrait;
 
     /**
@@ -115,7 +117,7 @@ class IPService implements LoggerAwareInterface
      */
     public function getRequestIPAddress()
     {
-        return app(AddressInterface::class);
+        return $this->app->make(AddressInterface::class);
     }
 
     /**
@@ -278,10 +280,9 @@ class IPService implements LoggerAwareInterface
      */
     public function getRequestIP()
     {
-        $app = Application::getFacadeApplication();
-        $ip = $app->make(\IPLib\Address\AddressInterface::class);
+        $ip = $this->app->make(\IPLib\Address\AddressInterface::class);
 
-        return new IPAddress($ip === null ? null : (string) $ip);
+        return new IPAddress((string) $ip);
     }
 
     /**
@@ -363,8 +364,6 @@ class IPService implements LoggerAwareInterface
      */
     private function getFailedLoginService()
     {
-        $app = Application::getFacadeApplication();
-
-        return $app->make('failed_login');
+        return $this->app->make('failed_login');
     }
 }

--- a/concrete/src/Permission/PermissionServiceProvider.php
+++ b/concrete/src/Permission/PermissionServiceProvider.php
@@ -34,7 +34,7 @@ class PermissionServiceProvider extends ServiceProvider
                 $ip = $request->getClientIp();
             }
 
-            return IPFactory::addressFromString($ip);
+            return IPFactory::addressFromString($ip, true, true, true);
         });
 
         $this->app->bind('failed_login', function (Application $app) {

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -6,6 +6,8 @@ use Concrete\Core\Http\Request;
 use Concrete\Core\Permission\IPService;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Support\Facade\Application;
+use IPLib\Address\AddressInterface;
+use IPLib\Factory;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -31,6 +33,9 @@ class SessionValidatorTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->app = clone Application::getFacadeApplication();
+        $this->app->singleton(AddressInterface::class, function () {
+            return Factory::addressFromString($this->request->getClientIp(), true, true, true);
+        });
         $this->app['config'] = clone $this->app['config'];
 
         $this->request = Request::create('http://url.com/');


### PR DESCRIPTION
IPv4 addresses are usually expresses in decimal notation, for example `127.0.0.1`.
By the way, for historical reasons, widely used libraries (and browsers) accept IPv4 addresses with numbers in octal and/or hexadecimal format.
For example, by opening the URL [`http://0177.0.0.0x1`](http://0177.0.0.0x1), your browser will actually open `http://127.0.0.1`.
We have to take care of this.

PS: this is a fix for v8: I'll submit soon a separate fix for v9
PPS: fix H1 863221