### PR TITLE
Fix malformed URL on form redirect

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -283,7 +283,8 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $c = Page::getByID($this->redirectCID);
                         if (is_object($c) && !$c->isError()) {
                             $r = Redirect::page($c);
-                            $r->setTargetUrl($r->getTargetUrl() . '?form_success=1&entry=' . $entry->getID());
+                            $target = strpos($r->getTargetUrl(),"?") === false ? $r->getTargetUrl()."?" : $r->getTargetUrl()."&";
+                            $r->setTargetUrl($target . 'form_success=1&entry=' . $entry->getID());
                         }
                     }
 


### PR DESCRIPTION
If a form redirects to an external page that includes a query parameter, the result is a malformed URL. This fixes that issue.
