### PR TITLE
BUGFIX: setting of idGenerator in method import() doesn't overwrite cached setting

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressAssociationsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressAssociationsRoutine.php
@@ -18,6 +18,7 @@ class ImportExpressAssociationsRoutine extends AbstractRoutine
         $em = \Database::connection()->getEntityManager();
 
         $em->getClassMetadata('Concrete\Core\Entity\Express\Association')->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
+        $em->flush();
 
         if (isset($sx->expressentities)) {
             foreach ($sx->expressentities->entity as $entityNode) {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressEntitiesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressEntitiesRoutine.php
@@ -22,6 +22,7 @@ class ImportExpressEntitiesRoutine extends AbstractRoutine
         $em = \Database::connection()->getEntityManager();
 
         $em->getClassMetadata('Concrete\Core\Entity\Express\Entity')->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
+        $em->flush();
 
         if (isset($sx->expressentities)) {
             foreach ($sx->expressentities->entity as $entityNode) {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressFormsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressFormsRoutine.php
@@ -20,6 +20,7 @@ class ImportExpressFormsRoutine extends AbstractRoutine
         $em = \Database::connection()->getEntityManager();
 
         $em->getClassMetadata('Concrete\Core\Entity\Express\Form')->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
+        $em->flush();
 
         if (isset($sx->expressentities)) {
             foreach ($sx->expressentities->entity as $entityNode) {


### PR DESCRIPTION
Insertion of $em->flush() in line 21 overwrites cache setting of idGenerator