### PR TITLE
User Registration: Adding "concrete.email.register_notification.name"

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -501,6 +501,10 @@ return [
             'address' => null,
             'name' => null,
         ],
+        'register_notification' => [
+            'address' => null,
+            'name' => null,
+        ],
         'validate_registration' => [
             'address' => null,
             'name' => null,

--- a/concrete/controllers/single_page/dashboard/system/mail/addresses.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/addresses.php
@@ -14,6 +14,7 @@ class Addresses extends DashboardPageController
         $this->set('forgotPasswordAddress', $config->get('concrete.email.forgot_password.address'));
         $this->set('formBlockAddress', $config->get('concrete.email.form_block.address'));
         $this->set('spamNotificationAddress', $config->get('concrete.spam.notify_email'));
+        $this->set('registerNotificationName', $config->get('concrete.email.register_notification.name'));
         $this->set('registerNotificationAddress', $config->get('concrete.email.register_notification.address'));
         $this->set('validateRegistrationName', $config->get('concrete.email.validate_registration.name'));
         $this->set('validateRegistrationAddress', $config->get('concrete.email.validate_registration.address'));
@@ -34,6 +35,7 @@ class Addresses extends DashboardPageController
             $config->save('concrete.email.forgot_password.address', $this->request->post('forgotPasswordAddress'));
             $config->save('concrete.email.form_block.address', $this->request->post('formBlockAddress'));
             $config->save('concrete.spam.notify_email', $this->request->post('spamNotificationAddress'));
+            $config->save('concrete.email.register_notification.name', $this->request->post('registerNotificationName'));
             $config->save('concrete.email.register_notification.address', $this->request->post('registerNotificationAddress'));
             $config->save('concrete.email.validate_registration.name', $this->request->post('validateRegistrationName'));
             $config->save('concrete.email.validate_registration.address', $this->request->post('validateRegistrationAddress'));

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -220,7 +220,12 @@ class Search extends DashboardPageController
                         $mh->to($this->user->getUserEmail());
                         $config = $this->app->make('config');
                         if ($config->get('concrete.email.register_notification.address')) {
-                            $mh->from($config->get('concrete.email.register_notification.address'), t('Website Registration Notification'));
+                            if (Config::get('concrete.email.register_notification.name')) {
+                                $fromName = Config::get('concrete.email.register_notification.name');
+                            } else {
+                                $fromName = t('Website Registration Notification');
+                            }
+                            $mh->from(Config::get('concrete.email.register_notification.address'), $fromName);
                         } else {
                             $adminUser = UserInfo::getByID(USER_SUPER_ID);
                             $mh->from($adminUser->getUserEmail(), t('Website Registration Notification'));

--- a/concrete/controllers/single_page/register.php
+++ b/concrete/controllers/single_page/register.php
@@ -172,7 +172,12 @@ class Register extends PageController
                     $mh->addParameter('siteName', tc('SiteName', \Core::make('site')->getSite()->getSiteName()));
 
                     if ($config->get('concrete.email.register_notification.address')) {
-                        $mh->from($config->get('concrete.email.register_notification.address'), t('Website Registration Notification'));
+                        if (Config::get('concrete.email.register_notification.name')) {
+                            $fromName = Config::get('concrete.email.register_notification.name');
+                        } else {
+                            $fromName = t('Website Registration Notification');
+                        }
+                        $mh->from(Config::get('concrete.email.register_notification.address'), $fromName);
                     } else {
                         $adminUser = UserInfo::getByID(USER_SUPER_ID);
                         if (is_object($adminUser)) {

--- a/concrete/single_pages/dashboard/system/mail/addresses.php
+++ b/concrete/single_pages/dashboard/system/mail/addresses.php
@@ -48,6 +48,10 @@
     <fieldset>
         <legend><?php echo t('Website Registration Notification'); ?></legend>
         <div class="form-group">
+            <?php echo $form->label('registerNotificationName', t('Email From Name')); ?>
+            <?php echo $form->email('registerNotificationName', $registerNotificationName); ?>
+        </div>
+        <div class="form-group">
             <?php echo $form->label('registerNotificationAddress', t('Email Address')); ?>
             <?php echo $form->email('registerNotificationAddress', $registerNotificationAddress); ?>
         </div>

--- a/concrete/src/Workflow/Request/ActivateUserRequest.php
+++ b/concrete/src/Workflow/Request/ActivateUserRequest.php
@@ -136,7 +136,12 @@ class ActivateUserRequest extends UserRequest
         $mh = Loader::helper('mail');
         $mh->to($ui->getUserEmail());
         if (Config::get('concrete.email.register_notification.address')) {
-            $mh->from(Config::get('concrete.email.register_notification.address'), t('Website Registration Notification'));
+            if (Config::get('concrete.email.register_notification.name')) {
+                $fromName = Config::get('concrete.email.register_notification.name');
+            } else {
+                $fromName = t('Website Registration Notification');
+            }
+            $mh->from(Config::get('concrete.email.register_notification.address'), $fromName);
         } else {
             $adminUser = UserInfo::getByID(USER_SUPER_ID);
             $mh->from($adminUser->getUserEmail(), t('Website Registration Notification'));


### PR DESCRIPTION
We're working on a project with user registration.
It's kinda troublesome that we cannot configure from name of register notification email.

This adds the config value or register notification FROM NAME.
I've also added the text input field system email setting page.