### PR TITLE
Block and area design toolbar ui fixes.

### DIFF
--- a/concrete/elements/custom_style.php
+++ b/concrete/elements/custom_style.php
@@ -1,7 +1,19 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php /** @noinspection DuplicatedCode */
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Application\Service\FileManager;
+use Concrete\Core\Block\CustomStyle;
+use Concrete\Core\Entity\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Form\Service\Widget\Color;
+use Concrete\Core\Page\Theme\GridFramework\GridFramework;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Identifier;
+use Concrete\Core\View\View;
 
 if (isset($displayBlockContainerSettings)) {
-    $displayBlockContainerSettings = (bool) $displayBlockContainerSettings;
+    $displayBlockContainerSettings = (bool)$displayBlockContainerSettings;
 }
 
 $backgroundColor = '';
@@ -34,10 +46,14 @@ $boxShadowColor = '';
 $customClass = '';
 $customID = '';
 $customElementAttribute = '';
-$sliderMin = \Config::get('concrete.limits.style_customizer.size_min', -50);
-$sliderMax = \Config::get('concrete.limits.style_customizer.size_max', 200);
-
+/** @var string $resetAction */
+/** @var string $bFilename */
+/** @var string $canEditCustomTemplate */
+/** @var string $saveAction */
+/** @var CustomStyle $style */
+/** @var StyleSet $set */
 $set = $style->getStyleSet();
+
 if (is_object($set)) {
     $backgroundColor = $set->getBackgroundColor();
     $textColor = $set->getTextColor();
@@ -71,445 +87,565 @@ if (is_object($set)) {
     $customElementAttribute = $set->getCustomElementAttribute();
 }
 
-$repeatOptions = [
-    'no-repeat' => t('No Repeat'),
-    'repeat-x' => t('Horizontally'),
-    'repeat-y' => t('Vertically'),
-    'repeat' => t('Horizontally & Vertically'),
-];
-$sizeOptions = [
-    'auto' => t('Auto'),
-    'contain' => t('Contain'),
-    'cover' => t('Cover'),
-    '10%' => t('10%'),
-    '25%' => t('25%'),
-    '50%' => t('50%'),
-    '75%' => t('75%'),
-    '100%' => t('100%'),
-];
-$positionOptions = [
-    'left top' => t('Left Top'),
-    'left center' => t('Left Center'),
-    'left bottom' => t('Left Bottom'),
-    'center top' => t('Center Top'),
-    'center center' => t('Center Center'),
-    'center bottom' => t('Center Bottom'),
-    'right top' => t('Right Top'),
-    'right center' => t('Right Center'),
-    'right bottom' => t('Right Bottom'),
-];
-$borderOptions = [
-    '' => t('None'),
-    'solid' => t('Solid'),
-    'dotted' => t('Dotted'),
-    'dashed' => t('Dashed'),
-    'double' => t('Double'),
-    'groove' => t('Groove'),
-    'ridge' => t('Ridge'),
-    'inset' => t('Inset'),
-    'outset' => t('Outset'),
-];
-$alignmentOptions = [
-    '' => t('None'),
-    'left' => t('Left'),
-    'center' => t('Center'),
-    'right' => t('Right'),
+$enableBlockContainerOptions = [
+    -1 => t('Default Setting'),
+    0 => t('Disable Grid Container'),
+    1 => t('Enable Grid Container')
 ];
 
-$customClassesSelect = [];
-$customClassesSelected = [];
+if ($style instanceof CustomStyle && $canEditCustomTemplate) {
+    $customTemplateOptions = [
+        "" => t('Default')
+    ];
 
-if (is_string($customClass) && $customClass != '') {
-    $customClassesSelected = explode(' ', $customClass);
-}
-
-if (is_array($customClasses)) {
-    foreach ($customClasses as $class) {
-        $customClassesSelect[$class] = $class;
+    foreach ($templates as $tpl) {
+        $customTemplateOptions[$tpl->getTemplateFileFilename()] = $tpl->getTemplateFileDisplayName();
     }
-
-    if ($customClassesSelected) {
-        foreach ($customClassesSelected as $class) {
-            $customClassesSelect[$class] = $class;
-        }
-    }
-}
-
-if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    $method = 'concreteBlockInlineStyleCustomizer';
-} else {
-    $method = 'concreteAreaInlineStyleCustomizer';
 }
 
 $deviceHideClasses = [];
-/* @var $gf \Concrete\Core\Page\Theme\GridFramework\GridFramework */
+/* @var $gf GridFramework */
 if (is_object($gf)) {
     $deviceHideClasses = $gf->getPageThemeGridFrameworkDeviceHideClasses();
 }
 
-$al = new Concrete\Core\Application\Service\FileManager();
-$form = Core::make('helper/form');
+$al = new FileManager();
+$app = Application::getFacadeApplication();
+/** @var Form $form */
+$form = $app->make(Form::class);
+/** @var Color $color */
+$color = $app->make(Color::class);
+/** @var Identifier $identifier */
+$identifier = $app->make(Identifier::class);
+
 ?>
 
-<form method="post" action="<?=$saveAction?>" id="ccm-inline-design-form">
-    <ul class="ccm-inline-toolbar ccm-ui">
+<form method="post" action="<?php echo h($saveAction) ?>" id="ccm-inline-design-form"
+      data-target-element="<?php echo ($style instanceof CustomStyle) ? "block" : "area"; ?>">
 
-        <?php if ($style instanceof \Concrete\Core\Block\CustomStyle && $canEditCustomTemplate) { ?>
-            <li class="">
-                <span class="small"><?=t('Block Template')?>:</span>
-                <select id="bFilename" name="bFilename" >
-                    <option value=""><?=t('Default')?></option>
-                    <?php
-                    foreach ($templates as $tpl) {
-                        ?>
-                        <option value="<?=$tpl->getTemplateFileFilename()?>" <?php if ($bFilename == $tpl->getTemplateFileFilename()) {
-                            ?> selected <?php
-                        } ?>><?=$tpl->getTemplateFileDisplayName()?></option>
-                        <?php
-                    } ?>
-                </select>
+    <ul class="ccm-style-customizer-toolbar ccm-ui">
+        <?php if ($style instanceof CustomStyle && $canEditCustomTemplate) { ?>
+            <li class="ccm-inline-toolbar-select">
+                <div class="form-group">
+                    <?php echo $form->label("bFilename", t('Block Template')); ?>
+                    <?php echo $form->select("bFilename", $customTemplateOptions, $bFilename, ["class" => "selectpicker"]); ?>
+                </div>
             </li>
         <?php } ?>
 
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Text Size and Color')?>"><i class="fa fa-font"></i></a>
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo h(t('Text Size and Color')); ?>">
+                <i class="fa fa-font"></i>
+            </a>
 
-            <div class="ccm-inline-design-dropdown-menu dropdown-menu">
-                <div>
-                    <?=t('Text Color')?>
-                    <?=Loader::helper('form/color')->output('textColor', $textColor); ?>
-                </div>
-                <hr />
-                <div>
-                    <?=t('Link Color')?>
-                    <?=Loader::helper('form/color')->output('linkColor', $linkColor); ?>
-                </div>
-                <hr />
-                <div>
-                    <span class="ccm-inline-style-slider-heading"><?=t('Base Font Size')?></span>
-                    <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                    <span class="ccm-inline-style-slider-display-value">
-                        <input type="text" name="baseFontSize" id="baseFontSize" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $baseFontSize ? $baseFontSize : '0px' ?>" <?php echo $baseFontSize ? '' : 'disabled' ?> autocomplete="off" />
-                    </span>
-                </div>
-                <div class="ccm-inline-select-container">
-                    <?=t('Alignment')?>
-                    <?=$form->select('alignment', $alignmentOptions, $alignment); ?>
-                </div>
-            </div>
-
-        </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Background Color and Image')?>"><i class="fa fa-image"></i></a>
-
-            <div class="ccm-inline-design-dropdown-menu dropdown-menu">
-                <h3><?=t('Background')?></h3>
-                <div>
-                    <?=t('Color')?>
-                    <?=Loader::helper('form/color')->output('backgroundColor', $backgroundColor); ?>
-                </div>
-                <hr />
-                <div>
-                    <?=t('Image')?>
-                    <?=$al->image('backgroundImageFileID', 'backgroundImageFileID', t('Choose Image'), $image); ?>
-                </div>
-                <div class="ccm-inline-select-container">
-                    <?=t('Repeats')?>
-                    <?=$form->select('backgroundRepeat', $repeatOptions, $backgroundRepeat); ?>
-                </div>
-                <div class="ccm-inline-select-container">
-                    <?php echo t('Size')?>
-                    <?php echo $form->select('backgroundSize', $sizeOptions, $backgroundSize); ?>
-                </div>
-                <div class="ccm-inline-select-container">
-                    <?php echo t('Position')?>
-                    <?php echo $form->select('backgroundPosition', $positionOptions, $backgroundPosition); ?>
-                </div>
-            </div>
-
-        </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Borders')?>"><i class="fa fa-square-o"></i></a>
-
-            <div class="ccm-inline-design-dropdown-menu dropdown-menu">
-                <h3><?=t('Border')?></h3>
-                <div>
-                    <?=t('Color')?>
-                    <?=Loader::helper('form/color')->output('borderColor', $borderColor); ?>
-                </div>
-                <hr />
-                <div class="ccm-inline-select-container">
-                    <?=t('Style')?>
-                    <?=$form->select('borderStyle', $borderOptions, $borderStyle); ?>
-                </div>
-                <div>
-                    <span class="ccm-inline-style-slider-heading"><?=t('Width')?></span>
-                    <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                   <span class="ccm-inline-style-slider-display-value">
-                    <input type="text" name="borderWidth" id="borderWidth" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $borderWidth ? $borderWidth : '0px' ?>" <?php echo $borderWidth ? '' : 'disabled' ?> autocomplete="off" />
-                </span>
-                </div>
-                <div>
-                    <span class="ccm-inline-style-slider-heading"><?=t('Radius')?></span>
-                    <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                    <span class="ccm-inline-style-slider-display-value">
-                        <input type="text" name="borderRadius" id="borderRadius" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $borderRadius ? $borderRadius : '0px' ?>" <?php echo $borderRadius ? '' : 'disabled' ?> autocomplete="off" />
-                    </span>
-                </div>
-            </div>
-
-        </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Margin and Padding')?>"><i class="fa fa-arrows-h"></i></a>
-
-            <div class="ccm-inline-design-dropdown-menu <?php if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    ?>ccm-inline-design-dropdown-menu-doubled<?php
-} ?> dropdown-menu">
-                <div class="row">
-                    <div class="<?php if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    ?>col-sm-6<?php
-} else {
-    ?>col-sm-12<?php
-} ?>">
-                        <h3><?=t('Padding')?></h3>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Top')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="paddingTop" id="paddingTop" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $paddingTop ? $paddingTop : '0px' ?>" <?php echo $paddingTop ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Right')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="paddingRight" id="paddingRight" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $paddingRight ? $paddingRight : '0px' ?>" <?php echo $paddingRight ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Bottom')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="paddingBottom" id="paddingBottom" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $paddingBottom ? $paddingBottom : '0px' ?>" <?php echo $paddingBottom ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Left')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="paddingLeft" id="paddingLeft" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $paddingLeft ? $paddingLeft : '0px' ?>" <?php echo $paddingLeft ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                    </div>
-
-                    <?php if ($style instanceof \Concrete\Core\Block\CustomStyle) {
-    ?>
-                    <div class="col-sm-6">
-                        <h3><?=t('Margin')?></h3>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Top')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="marginTop" id="marginTop" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $marginTop ? $marginTop : '0px' ?>" <?php echo $marginTop ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Right')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="marginRight" id="marginRight" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $marginRight ? $marginRight : '0px' ?>" <?php echo $marginRight ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Bottom')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="marginBottom" id="marginBottom" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $marginBottom ? $marginBottom : '0px' ?>" <?php echo $marginBottom ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Left')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                            <span class="ccm-inline-style-slider-display-value">
-                                <input type="text" name="marginLeft" id="marginLeft" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $marginLeft ? $marginLeft : '0px' ?>" <?php echo $marginLeft ? '' : 'disabled' ?> autocomplete="off" />
-                            </span>
-                        </div>
-                    </div>
-                    <?php
-} ?>
-
-                </div>
-            </div>
-
-        </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Shadow and Rotation (CSS3)')?>"><i class="fa fa-magic"></i></a>
-
-            <div class="ccm-inline-design-dropdown-menu  ccm-inline-design-dropdown-menu-doubled dropdown-menu">
-                <h3><?=t('Shadow')?></h3>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <span class="ccm-inline-style-slider-heading"><?=t('Horizontal Position')?></span>
-                        <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                        <span class="ccm-inline-style-slider-display-value">
-                            <input type="text" name="boxShadowHorizontal" id="boxShadowHorizontal" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $boxShadowHorizontal ? $boxShadowHorizontal : '0px' ?>" <?php echo $boxShadowHorizontal ? '' : 'disabled' ?> autocomplete="off" />
-                        </span>
-                    </div>
-                    <div class="col-sm-6">
-                        <span class="ccm-inline-style-slider-heading"><?=t('Vertical Position')?></span>
-                        <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                        <span class="ccm-inline-style-slider-display-value">
-                            <input type="text" name="boxShadowVertical" id="boxShadowVertical" data-value-format="px" class="ccm-inline-style-slider-value" value="<?php echo $boxShadowVertical ? $boxShadowVertical : '0px' ?>" <?php echo $boxShadowVertical ? '' : 'disabled' ?> autocomplete="off" />
-                        </span>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <span class="ccm-inline-style-slider-heading"><?=t('Blur')?></span>
-                        <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                        <span class="ccm-inline-style-slider-display-value">
-                            <input type="text" name="boxShadowBlur" id="boxShadowBlur" class="ccm-inline-style-slider-value" data-value-format="px" value="<?php echo $boxShadowBlur ? $boxShadowBlur : '0px' ?>" <?php echo $boxShadowBlur ? '' : 'disabled' ?> autocomplete="off" />
-                        </span>
-                    </div>
-                    <div class="col-sm-6">
-                        <span class="ccm-inline-style-slider-heading"><?=t('Spread')?></span>
-                        <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                        <span class="ccm-inline-style-slider-display-value">
-                            <input type="text" name="boxShadowSpread" id="boxShadowSpread" class="ccm-inline-style-slider-value" data-value-format="px" value="<?php echo $boxShadowSpread ? $boxShadowSpread : '0px' ?>" <?php echo $boxShadowSpread ? '' : 'disabled' ?> autocomplete="off" />
-                        </span>
-                    </div>
-                </div>
+            <div class="ccm-dropdown-menu">
                 <div class="row">
                     <div class="col-sm-12">
-                        <?=t('Color')?>
-                        <?=Loader::helper('form/color')->output('boxShadowColor', $boxShadowColor, ['showAlpha' => true]); ?>
+                        <fieldset>
+                            <div class="form-group">
+                                <?php echo $form->label("textColor", t('Text Color')) ?>
+                                <?php $color->output('textColor', $textColor); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("linkColor", t('Link Color')) ?>
+                                <?php $color->output('linkColor', $linkColor); ?>
+                            </div>
+
+                            <hr/>
+
+                            <?php
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "baseFontSize",
+                                "label" => t("Base Font Size"),
+                                "value" => $baseFontSize,
+                                "valueFormat" => "px"
+                            ]);
+                            ?>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("alignment", t('Alignment')) ?>
+                                <?php echo $form->select('alignment', [
+                                    '' => t('None'),
+                                    'left' => t('Left'),
+                                    'center' => t('Center'),
+                                    'right' => t('Right'),
+                                ], $alignment, ["class" => "selectpicker"]); ?>
+                            </div>
+                        </fieldset>
                     </div>
                 </div>
+            </div>
+        </li>
+
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo h(t('Background Color and Image')); ?>">
+
+                <i class="fa fa-image"></i>
+            </a>
+
+            <div class="ccm-dropdown-menu">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Background') ?>
+                            </legend>
+
+                            <div class="form-group">
+                                <?php echo $form->label("backgroundColor", t('Color')) ?>
+                                <?php $color->output('backgroundColor', $backgroundColor); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("backgroundImageFileID", t('Image')) ?>
+                                <?php echo $al->image('backgroundImageFileID', 'backgroundImageFileID', t('Choose Image'), $image); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("backgroundRepeat", t('Repeats')) ?>
+                                <?php echo $form->select('backgroundRepeat', [
+                                    'no-repeat' => t('No Repeat'),
+                                    'repeat-x' => t('Horizontally'),
+                                    'repeat-y' => t('Vertically'),
+                                    'repeat' => t('Horizontally & Vertically'),
+                                ], $backgroundRepeat, ["class" => "selectpicker"]); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("backgroundSize", t('Size')) ?>
+                                <?php echo $form->select('backgroundSize', [
+                                    'auto' => t('Auto'),
+                                    'contain' => t('Contain'),
+                                    'cover' => t('Cover'),
+                                    '10%' => t('10%'),
+                                    '25%' => t('25%'),
+                                    '50%' => t('50%'),
+                                    '75%' => t('75%'),
+                                    '100%' => t('100%'),
+                                ], $backgroundSize, ["class" => "selectpicker"]); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("backgroundPosition", t('Position')) ?>
+                                <?php echo $form->select('backgroundPosition', [
+                                    'left top' => t('Left Top'),
+                                    'left center' => t('Left Center'),
+                                    'left bottom' => t('Left Bottom'),
+                                    'center top' => t('Center Top'),
+                                    'center center' => t('Center Center'),
+                                    'center bottom' => t('Center Bottom'),
+                                    'right top' => t('Right Top'),
+                                    'right center' => t('Right Center'),
+                                    'right bottom' => t('Right Bottom'),
+                                ], $backgroundPosition, ["class" => "selectpicker"]); ?>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </li>
+
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo h(t('Borders')); ?>">
+                <i class="fas fa-border-style"></i>
+            </a>
+
+            <div class="ccm-dropdown-menu">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Border') ?>
+                            </legend>
+
+                            <div class="form-group">
+                                <?php echo $form->label("borderColor", t('Color')) ?>
+                                <?php $color->output('borderColor', $borderColor); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("borderStyle", t('Style')) ?>
+                                <?php echo $form->select('borderStyle', [
+                                    '' => t('None'),
+                                    'solid' => t('Solid'),
+                                    'dotted' => t('Dotted'),
+                                    'dashed' => t('Dashed'),
+                                    'double' => t('Double'),
+                                    'groove' => t('Groove'),
+                                    'ridge' => t('Ridge'),
+                                    'inset' => t('Inset'),
+                                    'outset' => t('Outset'),
+                                ], $borderStyle, ["class" => "selectpicker"]); ?>
+                            </div>
+
+                            <hr/>
+
+                            <?php
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "borderWidth",
+                                "label" => t("Width"),
+                                "value" => $borderWidth,
+                                "valueFormat" => "px"
+                            ]);
+                            ?>
+
+                            <?php
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "borderWidth",
+                                "label" => t("Radius"),
+                                "value" => $borderRadius,
+                                "valueFormat" => "px"
+                            ]);
+                            ?>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </li>
+
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo h(t('Margin and Padding')); ?>">
+                <i class="fa fa-arrows-alt-h"></i>
+            </a>
+
+            <div class="ccm-dropdown-menu <?php echo $style instanceof CustomStyle ? "ccm-inline-design-dropdown-menu-doubled" : ""; ?>">
+                <div class="row">
+                    <div class="<?php echo $style instanceof CustomStyle ? "col-sm-6" : "col-sm-12"; ?>">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Padding') ?>
+                            </legend>
+
+                            <?php
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "paddingTop",
+                                "label" => t("Top"),
+                                "value" => $paddingTop,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "paddingRight",
+                                "label" => t("Right"),
+                                "value" => $paddingRight,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "paddingBottom",
+                                "label" => t("Bottom"),
+                                "value" => $paddingBottom,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "paddingLeft",
+                                "label" => t("Left"),
+                                "value" => $paddingLeft,
+                                "valueFormat" => "px"
+                            ]);
+                            ?>
+                        </fieldset>
+                    </div>
+
+                    <?php if ($style instanceof CustomStyle) { ?>
+                    <div class="col-sm-6">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Margin') ?>
+                            </legend>
+
+                            <?php
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "marginTop",
+                                "label" => t("Top"),
+                                "value" => $marginTop,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "marginRight",
+                                "label" => t("Right"),
+                                "value" => $marginRight,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "marginBottom",
+                                "label" => t("Bottom"),
+                                "value" => $marginBottom,
+                                "valueFormat" => "px"
+                            ]);
+
+                            /** @noinspection PhpUnhandledExceptionInspection */
+                            echo View::element("slider", [
+                                "name" => "marginLeft",
+                                "label" => t("Left"),
+                                "value" => $marginLeft,
+                                "valueFormat" => "px"
+                            ]);
+                            ?>
+                        </fieldset>
+                        <?php } ?>
+                    </div>
+                </div>
+            </div>
+        </li>
+
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo h(t('Shadow and Rotation (CSS3)')); ?>">
+                <i class="fa fa-magic"></i>
+            </a>
+
+            <div class="ccm-dropdown-menu ccm-inline-design-dropdown-menu-doubled">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Shadow') ?>
+                            </legend>
+
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <?php
+                                    /** @noinspection PhpUnhandledExceptionInspection */
+                                    echo View::element("slider", [
+                                        "name" => "boxShadowHorizontal",
+                                        "label" => t("Horizontal Position"),
+                                        "value" => $boxShadowHorizontal,
+                                        "valueFormat" => "px"
+                                    ]);
+                                    ?>
+                                </div>
+
+                                <div class="col-sm-6">
+                                    <?php
+                                    /** @noinspection PhpUnhandledExceptionInspection */
+                                    echo View::element("slider", [
+                                        "name" => "boxShadowVertical",
+                                        "label" => t("Vertical Position"),
+                                        "value" => $boxShadowVertical,
+                                        "valueFormat" => "px"
+                                    ]);
+                                    ?>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <?php
+                                    /** @noinspection PhpUnhandledExceptionInspection */
+                                    echo View::element("slider", [
+                                        "name" => "boxShadowBlur",
+                                        "label" => t("Blur"),
+                                        "value" => $boxShadowBlur,
+                                        "valueFormat" => "px"
+                                    ]);
+                                    ?>
+                                </div>
+
+                                <div class="col-sm-6">
+                                    <?php
+                                    /** @noinspection PhpUnhandledExceptionInspection */
+                                    echo View::element("slider", [
+                                        "name" => "boxShadowSpread",
+                                        "label" => t("Spread"),
+                                        "value" => $boxShadowSpread,
+                                        "valueFormat" => "px"
+                                    ]);
+                                    ?>
+                                </div>
+                            </div>
+
+                            <hr/>
+
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="form-group">
+                                        <?php echo $form->label("boxShadowColor", t('Color')) ?>
+                                        <?php $color->output('boxShadowColor', $boxShadowColor, ['showAlpha' => true]); ?>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+
                 <hr/>
+
                 <div class="row">
                     <div class="col-sm-6">
-                        <h3><?=t('Rotate')?></h3>
-                        <div>
-                            <span class="ccm-inline-style-slider-heading"><?=t('Rotation (in degrees)')?></span>
-                            <div class="ccm-inline-style-sliders" data-style-slider-min="<?= $sliderMin ?>" data-style-slider-max="<?= $sliderMax ?>" data-style-slider-default-setting="0"></div>
-                           <span class="ccm-inline-style-slider-display-value">
-                            <input type="text" name="rotate" id="rotate" class="ccm-inline-style-slider-value ccm-slider-value-unit-appended" data-value-format="" value="<?php echo $rotate ? $rotate : '0' ?>" autocomplete="off" /> &deg;
-                        </span>
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Rotate') ?>
+                            </legend>
+
+                            <div>
+                                <?php
+                                /** @noinspection PhpUnhandledExceptionInspection */
+                                echo View::element("slider", [
+                                    "name" => "rotate",
+                                    "label" => t("Rotation (in degrees)"),
+                                    "value" => $rotate,
+                                    "valueFormat" => ""
+                                ]);
+                                ?>
+                            </div>
+                        </fieldset>
+                    </div>
+
+                    <?php if (count($deviceHideClasses)) { ?>
+                        <div class="col-sm-6">
+                            <fieldset>
+                                <legend>
+                                    <?php echo t('Device Visibility') ?>
+
+                                    <i class="fa fa-question-circle launch-tooltip"
+                                       title="<?php echo h(t('Hide the current content on a particular type of device. Un-check a device below to hide the content.')) ?>"></i>
+                                </legend>
+
+                                <div class="btn-group">
+                                    <?php foreach ($deviceHideClasses as $class) {
+                                        $hidden = false;
+
+                                        if (is_object($set)) {
+                                            $hidden = $set->isHiddenOnDevice($class);
+                                        }
+
+                                        echo $form->hidden("hideOnDevice" . $identifier->getString(), (int)$hidden, ["name" => "hideOnDevice[" . h($class) . "]", "data-hide-on-device-input" => $class]);
+
+                                        ?>
+
+                                        <button type="button"
+                                                data-hide-on-device="<?php echo h($class) ?>"
+                                                class="btn btn-secondary <?php echo (!$hidden) ? "active" : ""; ?>">
+                                            <i class="<?php echo $gf->getDeviceHideClassIconClass($class) ?>"></i>
+                                        </button>
+                                    <?php } ?>
+                                </div>
+                            </fieldset>
                         </div>
-                    </div>
-                    <div class="col-sm-6">
-
-                    <?php if (count($deviceHideClasses)) {
-    ?>
-                        <h3><?=t('Device Visibility')?> <i class="fa fa-question-circle launch-tooltip" title="<?=t('Hide the current content on a particular type of device. Un-check a device below to hide the content.')?>"></i></h3>
-                        <div class="btn-group">
-                        <?php foreach ($deviceHideClasses as $class) {
-        $hidden = false;
-        if (is_object($set)) {
-            $hidden = $set->isHiddenOnDevice($class);
-        } ?>
-                            <button type="button" data-hide-on-device="<?=$class?>" class="btn btn-secondary <?php if (!$hidden) {
-            ?>active<?php
-        } ?>"><i class="<?=$gf->getDeviceHideClassIconClass($class)?>"></i></button>
-                        <?php
-    } ?>
-                        </div>
-
-                        <?php foreach ($deviceHideClasses as $class) {
-        $hidden = false;
-        if (is_object($set)) {
-            $hidden = $set->isHiddenOnDevice($class);
-        } ?>
-                            <input data-hide-on-device-input="<?=$class?>" type="hidden" name="hideOnDevice[<?=$class?>]" value="<?php if ($hidden) {
-            ?>1<?php
-        } else {
-            ?>0<?php
-        } ?>" />
-                        <?php
-    } ?>
-                    <?php
-} ?>
-
-                    </div>
-                </div>
-            </div>
-
-        </li>
-        <li class="ccm-inline-toolbar-icon-cell"><a href="#" data-toggle="dropdown" title="<?=t('Custom CSS Classes, Block Name, Block Templates and Reset Styles')?>"><i class="fa fa-cog"></i></a>
-
-            <div class="ccm-inline-design-dropdown-menu dropdown-menu">
-                <h3><?=t('Advanced')?></h3>
-
-
-                <div>
-                    <?=t('Custom Class')?>
-                    <?= $form->selectMultiple('customClass', $customClassesSelect, $customClassesSelected); ?>
-                </div>
-                <hr/>
-
-                <div>
-                    <?= t('Custom ID'); ?>
-                    <?= $form->text('customID', $customID, ['style' => 'height: 38px; font-size: 16px; margin-bottom: 0;']); ?>
-                </div>
-                <hr/>
-
-                <div>
-                    <?= t('Custom Element Attribute'); ?>
-                    <?= $form->textarea('customElementAttribute', $customElementAttribute, ['style' => 'height: 38px; font-size: 16px; margin: 5px 0 0 0;']); ?>
-                </div>
-                <hr>
-
-                <?php if ($displayBlockContainerSettings) {
-    ?>
-                    <div class="ccm-inline-select-container">
-                        <?=t('Block Container Class')?>
-                        <select id="enableBlockContainer" name="enableBlockContainer" class="form-control">
-                            <option value="-1" <?php if ($enableBlockContainer == -1) {
-        ?>selected<?php
-    } ?>><?=t('Default Setting')?></option>
-                            <option value="0"<?php if ($enableBlockContainer == 0) {
-        ?>selected<?php
-    } ?>><?=t('Disable Grid Container')?></option>
-                            <option value="1" <?php if ($enableBlockContainer == 1) {
-        ?>selected<?php
-    } ?>><?=t('Enable Grid Container')?></option>
-                        </select>
-                    </div>
-                    <hr/>
-                <?php
-} ?>
-
-                <div>
-                    <button data-reset-action="<?=$resetAction?>" data-action="reset-design" type="button" class="btn-block btn btn-danger"><?=t("Clear Styles")?></button>
+                    <?php } ?>
                 </div>
             </div>
         </li>
+
+        <li class="ccm-inline-toolbar-icon-cell">
+            <a href="javascript:void(0);"
+               title="<?php echo t('Custom CSS Classes, Block Name, Block Templates and Reset Styles') ?>">
+                <i class="fa fa-cog"></i>
+            </a>
+
+            <div class="ccm-dropdown-menu">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <fieldset>
+                            <legend>
+                                <?php echo t('Advanced') ?>
+                            </legend>
+
+                            <div class="form-group">
+                                <?php echo $form->label("customClass", t('Custom Class')) ?>
+                                <?php
+                                $customClassesSelect = [];
+                                $customClassesSelected = [];
+
+                                if (is_string($customClass) && $customClass != '') {
+                                    $customClassesSelected = explode(' ', $customClass);
+                                }
+
+                                if (is_array($customClasses)) {
+                                    foreach ($customClasses as $class) {
+                                        $customClassesSelect[$class] = $class;
+                                    }
+
+                                    if ($customClassesSelected) {
+                                        foreach ($customClassesSelected as $class) {
+                                            $customClassesSelect[$class] = $class;
+                                        }
+                                    }
+                                }
+
+                                echo $form->selectMultiple('customClass', $customClassesSelect, $customClassesSelected);
+                                ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("customID", t('Custom ID')); ?>
+                                <?php echo $form->text('customID', $customID); ?>
+                            </div>
+
+                            <hr/>
+
+                            <div class="form-group">
+                                <?php echo $form->label("customElementAttribute", t('Custom Element Attribute')); ?>
+                                <?php echo $form->textarea('customElementAttribute', $customElementAttribute); ?>
+                            </div>
+
+                            <hr>
+
+                            <?php if ($displayBlockContainerSettings) { ?>
+                                <div class="form-group">
+                                    <?php echo $form->label("enableBlockContainer", t('Block Container Class')) ?>
+                                    <?php echo $form->select("enableBlockContainer", $enableBlockContainerOptions, $enableBlockContainer, ["class" => "selectpicker"]); ?>
+                                </div>
+
+                                <hr/>
+                            <?php } ?>
+
+                            <div>
+                                <?php echo $form->button("clearStyles", t('Clear Styles'), ["data-reset-action" => h($resetAction), "data-action" => "reset-design"], "btn-block btn-danger"); ?>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </li>
+
         <li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-cancel">
-            <button data-action="cancel-design" type="button" class="btn btn-mini"><?=t("Cancel")?></button>
+            <?php echo $form->button("cancelDesign", t('Cancel'), ["data-action" => "cancel-design"], "btn-secondary"); ?>
         </li>
+
         <li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-save">
-            <button data-action="save-design" class="btn btn-primary" type="button"><?=t('Save')?></button>
+            <?php echo $form->button("cancelDesign", t('Save'), ["data-action" => "save-design"], "btn-primary"); ?>
         </li>
     </ul>
 </form>
 
 <script>
-    $('#ccm-inline-design-form').<?=$method?>();
-
-    $("#customClass").selectize({
-        plugins: ['remove_button'],
-        create: function(input) {
-            return {
-                value: input,
-                text: input
-            }
-        }
-    });
-
-    $('button[data-hide-on-device]').on('click', function(e) {
-        e.stopPropagation();
-        var input = $(this).attr('data-hide-on-device');
-        if ($(this).hasClass('active')) {
-            $(this).removeClass('active');
-            $($('input[data-hide-on-device-input=' + input + ']').val(1));
-        } else {
-            $(this).addClass('active');
-            $($('input[data-hide-on-device-input=' + input + ']').val(0));
-        }
-    });
+    (function ($) {
+        $('#ccm-inline-design-form').concreteInlineStyleCustomizer();
+    })(jQuery);
 </script>

--- a/concrete/elements/slider.php
+++ b/concrete/elements/slider.php
@@ -1,0 +1,53 @@
+<?php
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Support\Facade\Application;
+
+/** @var string $name */
+/** @var string $label */
+/** @var string $value */
+/** @var string $valueFormat */
+/** @var string $default */
+
+$app = Application::getFacadeApplication();
+/** @var Form $form */
+$form = $app->make(Form::class);
+/** @var Repository $config */
+$config = $app->make(Repository::class);
+$min = $config->get('concrete.limits.style_customizer.size_min', -50);
+$max = $config->get('concrete.limits.style_customizer.size_max', 200);
+?>
+<div>
+    <span class="ccm-inline-style-slider-heading">
+        <?php echo $label; ?>
+    </span>
+
+    <div class="ccm-inline-style-slider-wrapper">
+        <div class="ccm-inline-style-sliders"
+             data-style-slider-min="<?php echo h($min) ?>"
+             data-style-slider-max="<?php echo h($max) ?>"
+             data-style-slider-default-setting="<?php echo (int)$default; ?>">
+        </div>
+
+        <span class="ccm-inline-style-slider-display-value">
+        <?php
+        $miscFields = [
+            "class" => "ccm-inline-style-slider-value",
+            "data-value-format" => $valueFormat,
+            "autocomplete" => "off"
+        ];
+
+        if (!$value) {
+            $miscFields["disabled"] = "disabled";
+        }
+
+        echo $form->text($name, $value ? h($value) : '0' . $valueFormat, $miscFields);
+        ?>
+    </span>
+    </div>
+</div>
+
+<div class="clearfix"></div>

--- a/concrete/src/Page/Theme/GridFramework/GridFramework.php
+++ b/concrete/src/Page/Theme/GridFramework/GridFramework.php
@@ -145,7 +145,7 @@ abstract class GridFramework
     {
         switch ($class) {
             case self::DEVICE_CLASSES_HIDE_ON_EXTRA_SMALL:
-                return 'fa fa-mobile-phone';
+                return 'fas fa-mobile';
             case self::DEVICE_CLASSES_HIDE_ON_SMALL:
                 return 'fa fa-tablet';
             case self::DEVICE_CLASSES_HIDE_ON_MEDIUM:


### PR DESCRIPTION
Requires an update of the bedrock repository (https://github.com/concrete5/bedrock/pull/93).

I have completely refactored the toolbar code within this task.

If you prefer that all input fields should have a dark gray background color i can change this. But i really like this style with the mixed background colors.

Issues:
1. Bootstrap is loaded 2 times currently in the frontend. Therefore you need to click two times on the bootstrap select components to get them open. I have sent andrew more details about that issue on slack.
