### PR TITLE
FIx Auto-Nav block add/edit form for BS4 #8834

### DIFF
--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Block\BlockController;
@@ -14,6 +15,8 @@ use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Entity\Block\BlockType\BlockType;
 use Doctrine\ORM\EntityManagerInterface;
 
+defined('C5_EXECUTE') or die('Access Denied.');
+
 /**
  * The controller for the Auto-Nav block.
  *
@@ -25,15 +28,23 @@ use Doctrine\ORM\EntityManagerInterface;
  * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
+
 class Controller extends BlockController implements UsesFeatureInterface
 {
     public $collection;
-    public $navArray = array();
-    public $cParentIDArray = array();
-    public $sorted_array = array();
-    public $navSort = array();
-    public $navObjectNames = array();
-    public $displayPages, $displayPagesCID, $displayPagesIncludeSelf, $displaySubPages, $displaySubPageLevels, $displaySubPageLevelsNum, $orderBy, $displayUnavailablePages;
+    public $navArray = [];
+    public $cParentIDArray = [];
+    public $sorted_array = [];
+    public $navSort = [];
+    public $navObjectNames = [];
+    public $displayPages;
+    Public $displayPagesCID;
+    Public $displayPagesIncludeSelf;
+    Public $displaySubPages;
+    Public $displaySubPageLevels;
+    Public $displaySubPageLevelsNum;
+    Public $orderBy;
+    Public $displayUnavailablePages;
     public $haveRetrievedSelf = false;
     public $haveRetrievedSelfPlus1 = false;
     public $displayUnapproved = false;
@@ -49,15 +60,8 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputLifetime = 300;
     protected $btWrapperClass = 'ccm-ui';
-    protected $btExportPageColumns = array('displayPagesCID');
+    protected $btExportPageColumns = ['displayPagesCID'];
     protected $includeParentItem;
-
-    public function getRequiredFeatures(): array
-    {
-        return [
-            Features::NAVIGATION,
-        ];
-    }
 
     public function __construct($obj = null)
     {
@@ -87,8 +91,14 @@ class Controller extends BlockController implements UsesFeatureInterface
         } else {
             $this->homePageID = Page::getHomePageID();
         }
-
         parent::__construct($obj);
+    }
+
+    public function getRequiredFeatures(): array
+    {
+        return [
+            Features::NAVIGATION,
+        ];
     }
 
     // private variable $displayUnapproved, used by the dashboard
@@ -122,7 +132,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     public function getContent()
     {
         /* our templates expect a variable not an object */
-        $con = array();
+        $con = [];
         foreach ($this as $key => $value) {
             $con[$key] = $value;
         }
@@ -137,8 +147,8 @@ class Controller extends BlockController implements UsesFeatureInterface
         $db = Database::connection();
         $r = $db->query(
                 "select cID from Pages where cParentID = ? order by cDisplayOrder asc",
-                array($c->getCollectionID()));
-        $pages = array();
+                [$c->getCollectionID()]);
+        $pages = [];
         while ($row = $r->fetchRow()) {
             $pages[] = Page::getByID($row['cID'], 'ACTIVE');
         }
@@ -165,7 +175,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         if (!is_object($this->collection)) {
             $c = Page::getCurrentPage();
             if (!is_object($c)) {
-                return array();
+                return [];
             }
         } else {
             $c = $this->collection;
@@ -177,7 +187,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
         //Create an array of parent cIDs so we can determine the "nav path" of the current page
         $inspectC = $c;
-        $selectedPathCIDs = array($inspectC->getCollectionID());
+        $selectedPathCIDs = [$inspectC->getCollectionID()];
         $parentCIDnotZero = true;
 
         while ($parentCIDnotZero) {
@@ -198,7 +208,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $allNavItems = $this->generateNav();
 
         //Remove excluded pages from the list (do this first because some of the data prep code needs to "look ahead" in the list)
-        $includedNavItems = array();
+        $includedNavItems = [];
         $excluded_parent_level = 9999; //Arbitrarily high number denotes that we're NOT currently excluding a parent (because all actual page levels will be lower than this)
         $exclude_children_below_level = 9999; //Same deal as above. Note that in this case "below" means a HIGHER number (because a lower number indicates higher placement in the sitemp -- e.g. 0 is top-level)
         foreach ($allNavItems as $ni) {
@@ -225,7 +235,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         //Prep all data and put it into a clean structure so markup output is as simple as possible
-        $navItems = array();
+        $navItems = [];
         $navItemCount = count($includedNavItems);
         for ($i = 0; $i < $navItemCount; ++$i) {
             $ni = $includedNavItems[$i];
@@ -326,7 +336,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     public function generateNav()
     {
         // Initialize Nav Array
-        $this->navArray = array();
+        $this->navArray = [];
 
         if (isset($this->displayPagesCID) && !Core::make('helper/validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
@@ -445,7 +455,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                 } else {
                     $tc1 = Page::getByID($cParentID, "ACTIVE");
                 }
-                $niRow = array();
+                $niRow = [];
                 $niRow['cvName'] = $tc1->getCollectionName();
                 $niRow['cID'] = $cParentID;
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
@@ -459,7 +469,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             /*
             if ($displayHeadPage) {
-                $niRow = array();
+                $niRow = [];
                 $niRow['cvName'] = $tc1->getCollectionName();
                 $niRow['cID'] = $row['cID'];
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
@@ -497,7 +507,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->populateParentIDArray($this->cID);
 
         $idArray = array_reverse($this->cParentIDArray);
-        $this->cParentIDArray = array();
+        $this->cParentIDArray = [];
         if ($level - count($idArray) == 0) {
             // This means that the parent ID array is one less than the item
             // we're trying to grab - so we return our CURRENT page as the item to get
@@ -585,7 +595,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $displayPage = $this->displayPage($tc);
 
                     if ($displayPage) {
-                        $niRow = array();
+                        $niRow = [];
                         $niRow['cvName'] = $tc->getCollectionName();
                         $niRow['cID'] = $row['cID'];
                         $niRow['cvDescription'] = $tc->getCollectionDescription();

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -458,7 +458,6 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
 
             /*
-
             if ($displayHeadPage) {
                 $niRow = array();
                 $niRow['cvName'] = $tc1->getCollectionName();
@@ -542,7 +541,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         // increment all items in the nav array with a greater $currentLevel
-
         foreach ($this->navArray as $ni) {
             if ($ni->getLevel() + 1 < $currentLevel) {
                 $ni->hasChildren = true;

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -38,7 +38,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     public $haveRetrievedSelfPlus1 = false;
     public $displayUnapproved = false;
     public $ignoreExcludeNav = false;
-    protected $helpers = ['form', 'validation/token'];
+    protected $helpers = ['form', 'validation/token', 'form/page_selector', 'concrete/ui'];
     protected $homePageID;
     protected $btTable = 'btNavigation';
     protected $btInterfaceWidth = 700;
@@ -90,7 +90,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         parent::__construct($obj);
     }
-    
+
     // private variable $displayUnapproved, used by the dashboard
 
     public function getBlockTypeDescription()
@@ -796,7 +796,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $btc->displaySubPageLevelsNum = $post->get('displaySubPageLevelsNum');
         $btc->displayUnavailablePages = $post->get('displayUnavailablePages');
         if ($btc->displayPages === 'custom') {
-            $btc->displayPagesCID = $post->get('displayPagesCID');
+            $btc->displayPagesCID = $post->get('displayPagesCID') ? $post->get('displayPagesCID') : Page::getHomePageID();
             $btc->displayPagesIncludeSelf = $post->get('displayPagesIncludeSelf');
         }
         $bv = new BlockView($bt);

--- a/concrete/blocks/autonav/form_setup_html.php
+++ b/concrete/blocks/autonav/form_setup_html.php
@@ -8,10 +8,13 @@ defined('C5_EXECUTE') or die("Access Denied.");
 /* @var Concrete\Core\Form\Service\Form $form */
 /* @var Concrete\Core\Validation\CSRF\Token $validation_token */
 /* @var array $info */
+
 $c = Page::getCurrentPage();
+
 if (!isset($info)) {
     $info = [];
 }
+
 $info += [
     'orderBy' => null,
     'displayUnavailablePages' => null,
@@ -26,7 +29,7 @@ $info += [
 <?=$concrete_ui->tabs(array(
     array('autonav-settings', t('Settings'), true),
     array('autonav-preview', t('Preview'))
-));?>
+)); ?>
 
 <div class="tab-content">
     <div class="tab-pane show active" id="autonav-settings">
@@ -118,24 +121,20 @@ $info += [
 
                     <select class='form-control' name="displaySubPages" onchange="toggleSubPageLevels(this.value);">
                         <option value="none"<?php if ($info['displaySubPages'] == 'none') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('None') ?>
                         </option>
                         <option value="relevant"<?php if ($info['displaySubPages'] == 'relevant') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Relevant sub pages.') ?>
                         </option>
                         <option
                             value="relevant_breadcrumb"<?php if ($info['displaySubPages'] == 'relevant_breadcrumb') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display breadcrumb trail.') ?>
                         </option>
                         <option value="all"<?php if ($info['displaySubPages'] == 'all') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display all.') ?>
                         </option>
                     </select>

--- a/concrete/blocks/autonav/form_setup_html.php
+++ b/concrete/blocks/autonav/form_setup_html.php
@@ -28,12 +28,9 @@ $info += [
     array('autonav-preview', t('Preview'))
 ));?>
 
-
-
 <div class="tab-content">
     <div class="tab-pane show active" id="autonav-settings">
         <div class="autonav-form">
-
             <input type="hidden" name="autonavCurrentCID" value="<?= $c->getCollectionID() ?>"/>
             <input type="hidden" name="autonavPreviewPane" value="<?= h($controller->getActionURL('preview_pane')) ?>"/>
             <input type="hidden" name="autonavPreviewPaneTokenName" value="<?= h($validation_token::DEFAULT_TOKEN_NAME) ?>" />
@@ -79,38 +76,31 @@ $info += [
                     <label for="displayPages"><?= t('Begin Auto Nav') ?></label>
                     <select name="displayPages" onchange="toggleCustomPage(this.value);" class="form-control">
                         <option value="top"<?php if ($info['displayPages'] == 'top') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('at the top level'); ?>
                         </option>
                         <option value="second_level"<?php if ($info['displayPages'] == 'second_level') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('at the second level') ?>
                         </option>
                         <option value="third_level"<?php if ($info['displayPages'] == 'third_level') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('at the third level') ?>
                         </option>
                         <option value="above"<?php if ($info['displayPages'] == 'above') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('at the level above') ?>
                         </option>
                         <option value="current"<?php if ($info['displayPages'] == 'current') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('at the current level') ?>
                         </option>
                         <option value="below"<?php if ($info['displayPages'] == 'below') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('At the level below') ?>
                         </option>
                         <option value="custom"<?php if ($info['displayPages'] == 'custom') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Beneath a particular page') ?>
                         </option>
                     </select>
@@ -120,7 +110,7 @@ $info += [
                     id="ccm-autonav-page-selector"<?php if ($info['displayPages'] != 'custom') {
                     ?> style="display: none"<?php
                 } ?>>
-                    <?= $form_page_selector->selectPage('displayPagesCID', $info['displayPagesCID']); ?>
+                    <?=$form_page_selector->selectPage('displayPagesCID', $info['displayPagesCID']); ?>
                 </div>
 
                 <div class="form-group">
@@ -157,25 +147,20 @@ $info += [
 
                     <select class="form-control" id="displaySubPageLevels"
                             name="displaySubPageLevels" <?php if ($info['displaySubPages'] == 'none') {
-                        ?> disabled <?php
-                    } ?>
+                        ?> disabled <?php } ?>
                             onchange="toggleSubPageLevelsNum(this.value);">
                         <option value="enough"<?php if ($info['displaySubPageLevels'] == 'enough') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display sub pages to current.') ?></option>
                         <option
                             value="enough_plus1"<?php if ($info['displaySubPageLevels'] == 'enough_plus1') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display sub pages to current +1.') ?></option>
                         <option value="all"<?php if ($info['displaySubPageLevels'] == 'all') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display all.') ?></option>
                         <option value="custom"<?php if ($info['displaySubPageLevels'] == 'custom') {
-                            ?> selected<?php
-                        } ?>>
+                            ?> selected<?php } ?>>
                             <?= t('Display a custom amount.') ?></option>
                     </select>
 
@@ -227,6 +212,7 @@ $info += [
         display: block;
     }
 </style>
+
 <script type="application/javascript">
     Concrete.event.publish('autonav.edit.open');
 </script>

--- a/concrete/blocks/autonav/form_setup_html.php
+++ b/concrete/blocks/autonav/form_setup_html.php
@@ -9,7 +9,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 /* @var Concrete\Core\Validation\CSRF\Token $validation_token */
 /* @var array $info */
 $c = Page::getCurrentPage();
-$page_selector = Loader::helper('form/page_selector');
 if (!isset($info)) {
     $info = [];
 }
@@ -24,7 +23,7 @@ $info += [
 ];
 ?>
 
-<?=Loader::helper('concrete/ui')->tabs(array(
+<?=$concrete_ui->tabs(array(
     array('autonav-settings', t('Settings'), true),
     array('autonav-preview', t('Preview'))
 ));?>
@@ -32,197 +31,199 @@ $info += [
 
 
 <div class="tab-content">
-    <div class="tab-pane active" id="autonav-settings">
+    <div class="tab-pane show active" id="autonav-settings">
         <div class="autonav-form">
 
-        <input type="hidden" name="autonavCurrentCID" value="<?= $c->getCollectionID() ?>"/>
-        <input type="hidden" name="autonavPreviewPane" value="<?= h($controller->getActionURL('preview_pane')) ?>"/>
-        <input type="hidden" name="autonavPreviewPaneTokenName" value="<?= h($validation_token::DEFAULT_TOKEN_NAME) ?>" />
-        <input type="hidden" name="autonavPreviewPaneTokenValue" value="<?= h($validation_token->generate('ccm-autonav-preview')) ?>" />
+            <input type="hidden" name="autonavCurrentCID" value="<?= $c->getCollectionID() ?>"/>
+            <input type="hidden" name="autonavPreviewPane" value="<?= h($controller->getActionURL('preview_pane')) ?>"/>
+            <input type="hidden" name="autonavPreviewPaneTokenName" value="<?= h($validation_token::DEFAULT_TOKEN_NAME) ?>" />
+            <input type="hidden" name="autonavPreviewPaneTokenValue" value="<?= h($validation_token->generate('ccm-autonav-preview')) ?>" />
 
-        <fieldset>
-            <div class="form-group">
-                <label for="orderBy" class="control-label"><?= t('Page Order') ?></label>
-                <select class="form-control" name="orderBy">
-                    <?php
-                    $order = $info['orderBy'];
-                    ?>
-                    <option value="display_asc" <?= $order === 'display_asc' ? 'selected' : '' ?>>
-                        <?= t('in their sitemap order.') ?>
-                    </option>
-                    <option value="chrono_desc" <?= $order === 'chrono_desc' ? 'selected' : '' ?>>
-                        <?= t('with the most recent first.') ?>
-                    </option>
-                    <option value="chrono_asc" <?= $order === 'chrono_asc' ? 'selected' : '' ?>>
-                        <?= t('with the earliest first.') ?>
-                    </option>
-                    <option value="alpha_asc" <?= $order === 'alpha_asc' ? 'selected' : '' ?>>
-                        <?= t('in alphabetical order.') ?>
-                    </option>
-                    <option value="alpha_desc" <?= $order === 'alpha_desc' ? 'selected' : '' ?>>
-                        <?= t('in reverse alphabetical order.') ?>
-                    </option>
-                    <option value="display_desc" <?= $order === 'display_desc' ? 'selected' : '' ?>>
-                        <?= t('in reverse sitemap order.') ?>
-                    </option>
-                </select>
-            </div>
+            <fieldset>
+                <div class="form-group">
+                    <label for="orderBy"><?= t('Page Order') ?></label>
+                    <select class="form-control" name="orderBy">
+                        <?php
+                        $order = $info['orderBy'];
+                        ?>
+                        <option value="display_asc" <?= $order === 'display_asc' ? 'selected' : '' ?>>
+                            <?= t('in their sitemap order.') ?>
+                        </option>
+                        <option value="chrono_desc" <?= $order === 'chrono_desc' ? 'selected' : '' ?>>
+                            <?= t('with the most recent first.') ?>
+                        </option>
+                        <option value="chrono_asc" <?= $order === 'chrono_asc' ? 'selected' : '' ?>>
+                            <?= t('with the earliest first.') ?>
+                        </option>
+                        <option value="alpha_asc" <?= $order === 'alpha_asc' ? 'selected' : '' ?>>
+                            <?= t('in alphabetical order.') ?>
+                        </option>
+                        <option value="alpha_desc" <?= $order === 'alpha_desc' ? 'selected' : '' ?>>
+                            <?= t('in reverse alphabetical order.') ?>
+                        </option>
+                        <option value="display_desc" <?= $order === 'display_desc' ? 'selected' : '' ?>>
+                            <?= t('in reverse sitemap order.') ?>
+                        </option>
+                    </select>
+                </div>
 
-            <div class="form-group">
-                <label for="displayUnavailablePages" class="control-label"><?= t('Check Page Permissions') ?></label>
-                <div class="checkbox">
-                    <label>
+                <div class="form-group">
+                    <label><?= t('Check Page Permissions') ?></label>
+                    <div class="form-check">
                         <?= $form->checkbox('displayUnavailablePages', 1, $info['displayUnavailablePages']); ?>
-                        <?= t('Display links that may require login.'); ?>
-                    </label>
+                        <label for="displayUnavailablePages" class="form-check-label"><?= t('Display links that may require login.'); ?></label>
+                    </div>
                 </div>
-            </div>
 
-            <div class="form-group">
-                <label for="displayPages" class="control-label"><?= t('Begin Auto Nav') ?></label>
-                <select name="displayPages" onchange="toggleCustomPage(this.value);" class="form-control">
-                    <option value="top"<?php if ($info['displayPages'] == 'top') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('at the top level'); ?>
-                    </option>
-                    <option value="second_level"<?php if ($info['displayPages'] == 'second_level') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('at the second level') ?>
-                    </option>
-                    <option value="third_level"<?php if ($info['displayPages'] == 'third_level') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('at the third level') ?>
-                    </option>
-                    <option value="above"<?php if ($info['displayPages'] == 'above') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('at the level above') ?>
-                    </option>
-                    <option value="current"<?php if ($info['displayPages'] == 'current') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('at the current level') ?>
-                    </option>
-                    <option value="below"<?php if ($info['displayPages'] == 'below') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('At the level below') ?>
-                    </option>
-                    <option value="custom"<?php if ($info['displayPages'] == 'custom') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Beneath a particular page') ?>
-                    </option>
-                </select>
-            </div>
-
-            <div class="form-group"
-                 id="ccm-autonav-page-selector"<?php if ($info['displayPages'] != 'custom') {
-                ?> style="display: none"<?php
-            } ?>>
-                <?= $page_selector->selectPage('displayPagesCID', $info['displayPagesCID']); ?>
-            </div>
-
-            <div class="form-group">
-                <label for="displaySubPages" class="control-label"><?= t('Child Pages') ?></label>
-
-                <select class='form-control' name="displaySubPages" onchange="toggleSubPageLevels(this.value);">
-                    <option value="none"<?php if ($info['displaySubPages'] == 'none') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('None') ?>
-                    </option>
-                    <option value="relevant"<?php if ($info['displaySubPages'] == 'relevant') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Relevant sub pages.') ?>
-                    </option>
-                    <option
-                        value="relevant_breadcrumb"<?php if ($info['displaySubPages'] == 'relevant_breadcrumb') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display breadcrumb trail.') ?>
-                    </option>
-                    <option value="all"<?php if ($info['displaySubPages'] == 'all') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display all.') ?>
-                    </option>
-                </select>
-
-            </div>
-
-            <div class="form-group">
-                <label for="displaySubPageLevels" class="control-label"><?= t('Page Levels') ?></label>
-
-                <select class="form-control" id="displaySubPageLevels"
-                        name="displaySubPageLevels" <?php if ($info['displaySubPages'] == 'none') {
-                    ?> disabled <?php
-                } ?>
-                        onchange="toggleSubPageLevelsNum(this.value);">
-                    <option value="enough"<?php if ($info['displaySubPageLevels'] == 'enough') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display sub pages to current.') ?></option>
-                    <option
-                        value="enough_plus1"<?php if ($info['displaySubPageLevels'] == 'enough_plus1') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display sub pages to current +1.') ?></option>
-                    <option value="all"<?php if ($info['displaySubPageLevels'] == 'all') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display all.') ?></option>
-                    <option value="custom"<?php if ($info['displaySubPageLevels'] == 'custom') {
-                        ?> selected<?php
-                    } ?>>
-                        <?= t('Display a custom amount.') ?></option>
-                </select>
-
-            </div>
-
-            <div class="form-group"
-                 id="divSubPageLevelsNum"<?php if ($info['displaySubPageLevels'] != 'custom') {
-                ?> style="display: none"<?php
-            } ?>>
-                <div class="input-group">
-                    <input type="text" name="displaySubPageLevelsNum" value="<?= $info['displaySubPageLevelsNum'] ?>"
-                           class="form-control">
-                    <span class="input-group-addon"> <?= t('levels') ?></span>
+                <div class="form-group">
+                    <label for="displayPages"><?= t('Begin Auto Nav') ?></label>
+                    <select name="displayPages" onchange="toggleCustomPage(this.value);" class="form-control">
+                        <option value="top"<?php if ($info['displayPages'] == 'top') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('at the top level'); ?>
+                        </option>
+                        <option value="second_level"<?php if ($info['displayPages'] == 'second_level') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('at the second level') ?>
+                        </option>
+                        <option value="third_level"<?php if ($info['displayPages'] == 'third_level') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('at the third level') ?>
+                        </option>
+                        <option value="above"<?php if ($info['displayPages'] == 'above') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('at the level above') ?>
+                        </option>
+                        <option value="current"<?php if ($info['displayPages'] == 'current') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('at the current level') ?>
+                        </option>
+                        <option value="below"<?php if ($info['displayPages'] == 'below') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('At the level below') ?>
+                        </option>
+                        <option value="custom"<?php if ($info['displayPages'] == 'custom') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Beneath a particular page') ?>
+                        </option>
+                    </select>
                 </div>
-            </div>
-        </fieldset>
 
-    </div>
-    </div>
-    <div class="tab-preview" id="autonav-preview">
+                <div class="form-group"
+                    id="ccm-autonav-page-selector"<?php if ($info['displayPages'] != 'custom') {
+                    ?> style="display: none"<?php
+                } ?>>
+                    <?= $form_page_selector->selectPage('displayPagesCID', $info['displayPagesCID']); ?>
+                </div>
 
+                <div class="form-group">
+                    <label for="displaySubPages"><?= t('Child Pages') ?></label>
+
+                    <select class='form-control' name="displaySubPages" onchange="toggleSubPageLevels(this.value);">
+                        <option value="none"<?php if ($info['displaySubPages'] == 'none') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('None') ?>
+                        </option>
+                        <option value="relevant"<?php if ($info['displaySubPages'] == 'relevant') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Relevant sub pages.') ?>
+                        </option>
+                        <option
+                            value="relevant_breadcrumb"<?php if ($info['displaySubPages'] == 'relevant_breadcrumb') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display breadcrumb trail.') ?>
+                        </option>
+                        <option value="all"<?php if ($info['displaySubPages'] == 'all') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display all.') ?>
+                        </option>
+                    </select>
+
+                </div>
+
+                <div class="form-group">
+                    <label for="displaySubPageLevels"><?= t('Page Levels') ?></label>
+
+                    <select class="form-control" id="displaySubPageLevels"
+                            name="displaySubPageLevels" <?php if ($info['displaySubPages'] == 'none') {
+                        ?> disabled <?php
+                    } ?>
+                            onchange="toggleSubPageLevelsNum(this.value);">
+                        <option value="enough"<?php if ($info['displaySubPageLevels'] == 'enough') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display sub pages to current.') ?></option>
+                        <option
+                            value="enough_plus1"<?php if ($info['displaySubPageLevels'] == 'enough_plus1') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display sub pages to current +1.') ?></option>
+                        <option value="all"<?php if ($info['displaySubPageLevels'] == 'all') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display all.') ?></option>
+                        <option value="custom"<?php if ($info['displaySubPageLevels'] == 'custom') {
+                            ?> selected<?php
+                        } ?>>
+                            <?= t('Display a custom amount.') ?></option>
+                    </select>
+
+                </div>
+
+                <div class="form-group"
+                    id="divSubPageLevelsNum"<?php if ($info['displaySubPageLevels'] != 'custom') {
+                    ?> style="display: none"<?php
+                } ?>>
+                    <div class="input-group">
+                        <input type="text" name="displaySubPageLevelsNum" value="<?= $info['displaySubPageLevelsNum'] ?>"
+                            class="form-control">
+                        <div class="input-group-append"><span class="input-group-text"><?= t('levels') ?></span></div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+    </div>
+    <div class="tab-pane tab-preview" id="autonav-preview">
         <div class="autonav-preview">
             <div class="render"></div>
             <div class="cover"></div>
         </div>
     </div>
-
 </div>
 
-
 <style type="text/css">
-    div.autonav-form div.cover {
+    div.autonav-preview {
+        position: relative;
+    }
+    div.autonav-preview div.cover {
         width: 100%;
         height: 100%;
         position: absolute;
         top: 0;
         left: 0;
     }
-    div.autonav-form div.render > ul ul {
-        margin-left:25px;
+    div.autonav-preview div.render > ul ul {
+        margin-left: 25px;
+        padding-left: 0;
         list-style-type: none;
     }
-    div.autonav-form div.render li a {
+    div.autonav-preview div.render li a {
         padding: 0;
+        display: block;
+    }
+    div.autonav-preview div.render li {
+        width: 100%;
         display: block;
     }
 </style>


### PR DESCRIPTION
This takes care of #8834 and does **not** have a companion bedrock pull request

### List of fixes
- Fixed the checkbox to use BS4 class names
- Fixed input group to use BS4 class names
- Fixed the tabs with proper BS4 class names
- Removed all obsolete control-label class names
- Styled the preview in the preview tab
- Positioned the "cover" element properly on top of the preview
- Fixed the inline CSS that was using the wrong class name
- Fixed an issue with the preview when "Begin auto nav" was set to "beneath a particular page" and none was selected. The preview was displaying the whole sitemap including system pages.

Concerning the last point, the way I fixed it was to set the selected page to the home page for the preview if none was selected.

Here are a couple of screenshots and below the screenshots, I'll present 2 issues that need fixing but will require more time.

![auto-nav1](https://user-images.githubusercontent.com/1488833/88159398-28d26000-cc05-11ea-8c2f-71169a26de30.png)

![auto-nav2](https://user-images.githubusercontent.com/1488833/88159433-32f45e80-cc05-11ea-94dc-0ee08aca2276.png)

### Problems that need fixing
**Validation**
The same way the preview would get mixed up when not selecting a page, that setting is not validated on save and we end up with an empty nav.
I think we need to add the validate function and do proper validation for that and other things (number of levels) that require it (no validation at the moment)

**Preview Refresh problem**
In the block's auto.js the preview is refreshed a few times when choices are made.
The refresh is also supposed to be triggered on the ConcreteEvent "SitemapSelectPage". The event is triggered but the code doesn't run so the preview is not refreshed when selecting a specific page with the selector. I absolutely have no idea why it's not running.
What I would suggest though is to get rid of all those calls to refresh the preview and simply do it once when the preview tab is activated. Maybe with the addition of a little spinner while it loads.

**Unused setting**
There is a setting "displayPagesIncludeSelf" present in the block's DB table. it's also present in the save function and other places but it's not accessible from the settings screen and the code to use it is commented out. Should it just be removed?

I think fixing these 3 issues would require a couple of hours more.