### PR TITLE
Dialog Versions - FontAwesome icon typo

### DIFF
--- a/concrete/views/dialogs/event/versions.php
+++ b/concrete/views/dialogs/event/versions.php
@@ -65,7 +65,7 @@
                     <td><a <?php if ($version->isApproved()) { ?>style="display: none"<?php } ?> data-action="delete-version"
                            data-calendar-event-version-id="<?= $version->getID() ?>"
                            data-token="<?= Core::make('token')->generate('calendar/event/version/delete/' . $version->getID()) ?>"
-                           href="javascript:void(0)"><i class="fa fa-trash-o"></i></a></td>
+                           href="javascript:void(0)"><i class="fa fa-trash"></i></a></td>
             </tr>
             <?php
             $count--;


### PR DESCRIPTION
At the moment in the Dialog Versions, the trash or delete icon is not being shown because is using `fa fa-trash-o` instead of simply `fa fa-trash` this update fixes this issue. 

Before:
<img width="857" alt="Screen Shot 2020-07-27 at 3 08 18 PM" src="https://user-images.githubusercontent.com/37560903/88596976-15ffc700-d01b-11ea-89d3-4670c30de34b.png">

With the correct icon:
<img width="827" alt="Screen Shot 2020-07-27 at 3 07 42 PM" src="https://user-images.githubusercontent.com/37560903/88596996-22841f80-d01b-11ea-9067-708c317f153c.png">

