### PR TITLE
Add the ability to edit calendar events using a fixed link

### DIFF
--- a/concrete/controllers/single_page/dashboard/calendar/events.php
+++ b/concrete/controllers/single_page/dashboard/calendar/events.php
@@ -82,6 +82,12 @@ class Events extends DashboardCalendarPageController
         $this->set('dateFormatter', $serviceProvider->getDateFormatter());
         $this->set('linkFormatter', $serviceProvider->getLinkFormatter());
 
+        // Process the given edit ID if there is one
+        $initialEdit = (int) $this->request->get('edit');
+        if ($initialEdit > 0) {
+            $this->set('initialEdit', $initialEdit);
+        }
+
         $editor = $this->app->make('editor');
         $editor->requireEditorAssets();
     }

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -190,4 +190,19 @@ Loader::element('calendar/header', array(
     $(function() {
         var admin = new ConcreteCalendarAdmin($('body'));
     });
+    <?php
+    if (isset($initialEdit) && $initialEdit) {
+        ?>
+        setTimeout(function() {
+            let anchor = $(document.createElement('a'))
+                .attr('dialog-title', 'Edit')
+                .attr('dialog-width', 1100)
+                .attr('dialog-height', 600)
+                .attr('href', "/ccm/calendar/dialogs/event/edit?versionOccurrenceID=<?= (int) $initialEdit ?>")
+
+            anchor.dialog().click()
+        });
+        <?php
+    }
+    ?>
 </script>


### PR DESCRIPTION
This change makes it possible to link to the edit dialog of a calendar event using the `edit` GET parameter:
For example: `/dashboard/calendar/events?edit=111222`

This PR makes no attempt to check permissions or anything, the dialog's validation and permission checking should be plenty.