### PR TITLE
Avoid race condition with the dialog functionality by polling

### DIFF
--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -191,9 +191,14 @@ Loader::element('calendar/header', array(
         var admin = new ConcreteCalendarAdmin($('body'));
     });
     <?php
+    // Show an event edit dialog if there was a provided event version occurrence ID
     if (isset($initialEdit) && $initialEdit) {
         ?>
-        setTimeout(function() {
+        let initDialog = function() {
+            if (typeof $.fn.dialog !== 'function') {
+                return setTimeout(initDialog, 50);
+            }
+
             let anchor = $(document.createElement('a'))
                 .attr('dialog-title', 'Edit')
                 .attr('dialog-width', 1100)
@@ -201,7 +206,8 @@ Loader::element('calendar/header', array(
                 .attr('href', "/ccm/calendar/dialogs/event/edit?versionOccurrenceID=<?= (int) $initialEdit ?>")
 
             anchor.dialog().click()
-        });
+        }
+        initDialog()
         <?php
     }
     ?>


### PR DESCRIPTION
I missed this in testing, sometimes the dialog code is not loaded in synchronously. I'm not sure what exactly causes this but it ends up being later in the async queue than this code so our defer is not enough. Instead let's just repeatedly poll every 50ms until the dialog functionality is loaded.