### PR TITLE
Fix can't install page type properly from cif format

### DIFF
--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -396,8 +396,10 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         if ($ptAllowedPageTemplates) {
             $data['allowedTemplates'] = $ptAllowedPageTemplates;
         }
-        if ($node['internal']) {
-            $data['internal'] = true;
+
+        $data['internal'] = 0;
+        if ($node['internal'] == '1') {
+            $data['internal'] = 1;
         }
 
         $data['ptLaunchInComposer'] = 0;


### PR DESCRIPTION
If `<pagetype>` has `internal` attribute, it will be installed as internal page type even if the value is "0".