### PR TITLE
Prevent error from container not being set

### DIFF
--- a/concrete/blocks/core_container/view.php
+++ b/concrete/blocks/core_container/view.php
@@ -6,19 +6,20 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var $c Concrete\Core\Page\Page
  * @var $fileToRender string The file containing the container template.
  */
+if ($container) {
+    $container->startRender();
 
-$container->startRender();
+    $c = Page::getCurrentPage();
+    if ($fileToRender) {
+        include($fileToRender);
+    } else {
+        if ($c->isEditMode()) { ?>
+            <div class="ccm-edit-mode-disabled-item">
+               <?php echo t('Container: %s – no container template file found.', 
+                   $container->getInstance()->getContainer()->getContainerName()); ?>
+            </div>
+        <?php }
+    }
 
-$c = Page::getCurrentPage();
-if ($fileToRender) {
-    include($fileToRender);
-} else {
-    if ($c->isEditMode()) { ?>
-        <div class="ccm-edit-mode-disabled-item">
-           <?php echo t('Container: %s – no container template file found.', 
-               $container->getInstance()->getContainer()->getContainerName()); ?>
-        </div>
-    <?php }
+    $container->endRender();
 }
-
-$container->endRender();

--- a/concrete/blocks/core_container/view.php
+++ b/concrete/blocks/core_container/view.php
@@ -22,4 +22,8 @@ if ($container) {
     }
 
     $container->endRender();
+} elseif (is_object($c) && $c->isEditMode()) {
+    ?>
+    <div class="ccm-edit-mode-disabled-item"><?=t('Empty Container Block.')?></div>
+    <?php
 }


### PR DESCRIPTION
Viewing with [whitespace changes disabled](https://github.com/concrete5/concrete5/pull/8940/files?w=1) is the best way to go