### PR TITLE
Avoid "Call to a member function on null" on page drag request

### DIFF
--- a/concrete/views/dialogs/page/drag_request.php
+++ b/concrete/views/dialogs/page/drag_request.php
@@ -29,6 +29,8 @@ if (!$dragRequestData->canDoAnyOf([$dragRequestData::OPERATION_MOVE, $dragReques
     return;
 }
 $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
+$singleOriginalPageName = (is_object($singleOriginalPage)) ? $singleOriginalPage->getCollectionName() : t('Original Page');
+
 ?>
 
 <div class="alert alert-info">
@@ -37,9 +39,9 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
         echo t('What do you wish to do?');
     } else {
         if ($dragRequestData->getDragMode() === 'none') {
-            echo t('You selected to move/copy "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+            echo t('You selected to move/copy "%s" onto "%s". What do you wish to do?', h($singleOriginalPageName), h($dragRequestData->getDestinationPage()->getCollectionName()));
         } else {
-            echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+            echo t('You dragged "%s" onto "%s". What do you wish to do?', h($singleOriginalPageName), h($dragRequestData->getDestinationPage()->getCollectionName()));
         }
 
     }
@@ -68,7 +70,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                     <input type="radio" name="ctask" value="<?= $dragRequestData::OPERATION_MOVE ?>" />
                     <?php
                     if ($singleOriginalPage !== null) {
-                        echo t('<strong>Move</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+                        echo t('<strong>Move</strong> "%1$s" beneath "%2$s"', h($singleOriginalPageName), h($dragRequestData->getDestinationPage()->getCollectionName()));
                      } else {
                          echo t('<strong>Move</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionName()));
                      }
@@ -99,7 +101,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                     <input type="radio" name="ctask" value="<?= $dragRequestData::OPERATION_ALIAS ?>" />
                     <?php
                     if ($singleOriginalPage !== null) {
-                        echo t('<strong>Alias</strong> "%1$s" beneath "%2$s"', h($singleOriginalPage->getCollectionName()), h($dragRequestData->getDestinationPage()->getCollectionName()));
+                        echo t('<strong>Alias</strong> "%1$s" beneath "%2$s"', h($singleOriginalPageName), h($dragRequestData->getDestinationPage()->getCollectionName()));
                     } else {
                         echo t('<strong>Alias</strong> pages beneath "%s"', h($dragRequestData->getDestinationPage()->getCollectionName()));
                     }
@@ -130,7 +132,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPY ?>" />
                                 <?php
                                 if ($singleOriginalPage !== null) {
-                                    echo h(t('Copy "%1$s" beneath "%2$s"', $singleOriginalPage->getCollectionName(), $dragRequestData->getDestinationPage()->getCollectionName()));
+                                    echo h(t('Copy "%1$s" beneath "%2$s"', $singleOriginalPageName, $dragRequestData->getDestinationPage()->getCollectionName()));
                                 } else {
                                     echo h(t('Copy pages beneath "%s"', $dragRequestData->getDestinationPage()->getCollectionName()));
                                 }
@@ -144,7 +146,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                         <div class="checkbox">
                             <label>
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPYALL ?>" />
-                                <?= h(t('Copy "%1$s" and all its children beneath "%2$s"', $singleOriginalPage->getCollectionName(), $dragRequestData->getDestinationPage()->getCollectionName())) ?>
+                                <?= h(t('Copy "%1$s" and all its children beneath "%2$s"', $singleOriginalPageName, $dragRequestData->getDestinationPage()->getCollectionName())) ?>
                             </label>
                         </div>
                         <?php
@@ -154,7 +156,7 @@ $singleOriginalPage = $dragRequestData->getSingleOriginalPage();
                         <div class="checkbox">
                             <label>
                                 <input type="radio" name="dtask" value="<?= $dragRequestData::OPERATION_COPYVERSION ?>" />
-                                <?= h(t('Replace "%1$s" with a copy of "%2$s"', $dragRequestData->getDestinationPage()->getCollectionName(), $singleOriginalPage->getCollectionName())) ?>
+                                <?= h(t('Replace "%1$s" with a copy of "%2$s"', $dragRequestData->getDestinationPage()->getCollectionName(), $singleOriginalPageName)) ?>
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
#8291 is not enough to check `$singleOriginalPage` is null or not.