### PR TITLE
Redirect to the /occurrence/ date and time when editing an occurrence

### DIFF
--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -179,8 +179,16 @@ class Edit extends BackendInterfaceController
 
             $r->setEventVersion($eventVersion);
 
-            $year = date('Y', strtotime($repetitions[0]->getStartDate()));
-            $month = date('m', strtotime($repetitions[0]->getStartDate()));
+            // Load the local repetition if available. This is what tells us which repetition was being edited
+            $localRepetition = $this->eventRepetitionService->translateFromRequest('local', $event->getCalendar(), $this->request);
+            if (is_array($localRepetition) && count($localRepetition) > 0) {
+                $repetition = $localRepetition[0];
+            } else {
+                $repetition = $repetitions[0];
+            }
+
+            $year = date('Y', strtotime($repetition->getStartDate()));
+            $month = date('m', strtotime($repetition->getStartDate()));
 
             $this->setResponseRedirectURL($calendar, $month, $year, $r);
         }


### PR DESCRIPTION
Currently saving after editing an occurrence redirects you to the calendar date on the event rather than the date on the edited occurrence. By trying to resolve the "local" occurrence from the request we can redirect to the proper date.