### PR TITLE
Implement task #8945

### DIFF
--- a/concrete/blocks/calendar_event/controller.php
+++ b/concrete/blocks/calendar_event/controller.php
@@ -74,6 +74,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $data['calendarID'] = isset($data['calendarID']) ? intval($data['calendarID']) : 0;
         $data['eventID'] = isset($data['eventID']) ? intval($data['eventID']) : 0;
 
+        $data['allowExport'] = isset($data['allowExport']) && $data['allowExport'] ? 1 : 0;
         $data['displayEventName'] = isset($data['displayEventName']) && $data['displayEventName'] ? 1 : 0;
         $data['displayEventDate'] = isset($data['displayEventDate']) && $data['displayEventDate'] ? 1 : 0;
         $data['displayEventDescription'] = isset($data['displayEventDescription']) && $data['displayEventDescription'] ? 1 : 0;

--- a/concrete/blocks/calendar_event/db.xml
+++ b/concrete/blocks/calendar_event/db.xml
@@ -29,6 +29,9 @@
         </field>
         <field name="displayEventAttributes" type="text">
         </field>
+        <field name="allowExport" type="boolean">
+            <default value="0"/>
+        </field>
         <field name="enableLinkToPage" type="boolean">
             <default value="0"/>
         </field>

--- a/concrete/blocks/calendar_event/form.php
+++ b/concrete/blocks/calendar_event/form.php
@@ -19,6 +19,7 @@ use Concrete\Core\Support\Facade\Application;
 /** @var EventKey[] $eventKeys */
 /** @var array $calendars */
 /** @var array $displayEventAttributes */
+/** @var bool $allowExport */
 
 $app = Application::getFacadeApplication();
 /** @var Form $form */
@@ -81,6 +82,11 @@ $form = $app->make(Form::class);
         <div class="form-check">
             <?php echo $form->checkbox('displayEventDescription', 1, $displayEventDescription) ?>
             <?php echo $form->label("displayEventDescription", t('Description'), ["class" => "form-check-label"]) ?>
+        </div>
+
+        <div class="form-check">
+            <?php echo $form->checkbox('allowExport', 1, $allowExport) ?>
+            <?php echo $form->label("allowExport", t('Allow event export'), ["class" => "form-check-label"]) ?>
         </div>
     </div>
 

--- a/concrete/blocks/calendar_event/view.php
+++ b/concrete/blocks/calendar_event/view.php
@@ -1,61 +1,83 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Core\Attribute\Key\EventKey;
+use Concrete\Core\Calendar\Event\Formatter\DateFormatter;
+use Concrete\Core\Entity\Calendar\CalendarEventVersion;
+use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
+use Concrete\Core\Support\Facade\Url;
+
+/** @var DateFormatter $formatter */
+/** @var CalendarEventVersion $event */
+/** @var CalendarEventVersionOccurrence $occurrence */
+/** @var string $mode */
+/** @var string $eventOccurrenceLink */
+/** @var string $calendarEventAttributeKeyHandle */
+/** @var int $calendarID */
+/** @var int $eventID */
+/** @var string $displayEventAttributes */
+/** @var bool $enableLinkToPage */
+/** @var bool $displayEventName */
+/** @var bool $displayEventDate */
+/** @var bool $displayEventDescription */
+/** @var array $calendarEventPageKeys */
+/** @var array $calendars */
+/** @var array $displayEventAttributes */
+/** @var bool $allowExport */
+
+?>
 
 <?php if ($event) { ?>
     <div class="ccm-block-calendar-event-wrapper">
-
-        <?php if ($displayEventName) {
-    ?>
+        <?php if ($displayEventName) { ?>
             <div class="ccm-block-calendar-event-header">
-                <h3><?php if ($enableLinkToPage && $eventOccurrenceLink) {
-    ?>
-                        <a href="<?=$eventOccurrenceLink?>"><?= h($event->getName()) ?></a>
-                    <?php
-} else {
-    ?>
-                        <?= h($event->getName()) ?>
-                    <?php
-}
-    ?>
+                <h3>
+                    <?php if ($enableLinkToPage && $eventOccurrenceLink) { ?>
+                        <a href="<?php echo $eventOccurrenceLink ?>">
+                            <?php echo h($event->getName()) ?>
+                        </a>
+                    <?php } else { ?>
+                        <?php echo h($event->getName()) ?>
+                    <?php } ?>
                 </h3>
             </div>
-        <?php
-}
-    ?>
+        <?php } ?>
 
-        <?php if ($displayEventDate) {
-    ?>
+        <?php if ($displayEventDate) { ?>
             <div class="ccm-block-calendar-event-date-time">
-                <?= $formatter->getOccurrenceDateString($occurrence) ?>
+                <?php echo $formatter->getOccurrenceDateString($occurrence) ?>
             </div>
-        <?php
-}
-    ?>
+        <?php } ?>
 
-        <?php if ($displayEventDescription && $event->getDescription()) {
-    ?>
+        <?php if ($displayEventDescription && $event->getDescription()) { ?>
             <div class="ccm-block-calendar-event-description">
-                <p><?= $event->getDescription() ?></p>
+                <p>
+                    <?php echo $event->getDescription() ?>
+                </p>
             </div>
-        <?php
-}
-    ?>
+        <?php } ?>
 
-        <?php if (count($displayEventAttributes)) {
-    ?>
+        <?php if (count($displayEventAttributes)) { ?>
             <div class="ccm-block-calendar-event-attributes">
                 <?php foreach ($displayEventAttributes as $akID) {
-    $ak = \Concrete\Core\Attribute\Key\EventKey::getByID($akID);
-    if (is_object($ak)) {
-        echo $event->getAttribute($ak->getAttributeKeyHandle(), 'displaySanitized');
-    }
-}
-    ?>
+                    $ak = EventKey::getByID($akID);
+
+                    if (is_object($ak)) {
+                        echo $event->getAttribute($ak->getAttributeKeyHandle(), 'displaySanitized');
+                    }
+                }
+                ?>
             </div>
-        <?php
-}
-    ?>
+        <?php } ?>
 
-
+        <?php if ($allowExport) { ?>
+            <div class="ccm-block-calendar-event-export">
+                <a href="<?php echo Url::to("/ccm/calendar/dialogs/event/export")->setQuery(["eventID" => $event->getID()]); ?>"
+                   title="<?php echo h(t("Export Event")); ?>" class="btn btn-secondary">
+                    <?php echo t("Export Event"); ?>
+                </a>
+            </div>
+        <?php } ?>
     </div>
-<?php
-} ?>
+<?php } ?>

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.0.0a2',
     'version_installed' => '9.0.0a2',
-    'version_db' => '20201596544868', // the key of the latest database migration
+    'version_db' => '20200810000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/controllers/dialog/event/export.php
+++ b/concrete/controllers/dialog/event/export.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Concrete\Controller\Dialog\Event;
+
+use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
+use Concrete\Core\Calendar\Event\EventService;
+use Concrete\Core\Entity\Calendar\Calendar;
+use Concrete\Core\Entity\Calendar\CalendarEvent;
+use Concrete\Core\Entity\Calendar\CalendarEventVersion;
+use Concrete\Core\Entity\User\User;
+use Concrete\Core\Http\Response;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Support\Facade\Url;
+use Sabre\VObject\Component\VCalendar;
+use DateTime;
+use DateTimeZone;
+
+class Export extends BackendInterfaceController
+{
+    /** @var EventService */
+    protected $eventService;
+    /** @var ResponseFactory */
+    protected $responseFactory;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->eventService = $this->app->make(EventService::class);
+        $this->responseFactory = $this->app->make(ResponseFactory::class);
+    }
+
+    public function export()
+    {
+        $eventId = $this->request->query->get("eventID");
+
+        $event = $this->eventService->getByID($eventId, EventService::EVENT_VERSION_RECENT);
+
+        if ($event instanceof CalendarEvent) {
+            $approvedEventVersion = $event->getApprovedVersion();
+
+            if ($approvedEventVersion instanceof CalendarEventVersion) {
+                // create the iCalendar-Object
+                $vCalendar = new VCalendar();
+
+                $i = 0;
+
+                foreach ($approvedEventVersion->getRepetitions() as $repetition) {
+                    // attributes and categories are ignored because they are not supported in the iCalendar format
+                    // @see https://tools.ietf.org/html/rfc2446
+
+                    /** @noinspection PhpUnhandledExceptionInspection */
+                    /** @noinspection HtmlRequiredLangAttribute */
+                    $arrEvent = [
+                        'SUMMARY' => $approvedEventVersion->getName(),
+                        'DESCRIPTION' => strip_tags($approvedEventVersion->getDescription()),
+                        // Add HTML description if supported (https://stackoverflow.com/questions/854036/html-in-ical-attachment)
+                        'X-ALT-DESC' => 'FMTTYPE=text/html:<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN"><HTML>' . $approvedEventVersion->getDescription() . '</HTML>',
+                        'CREATED' => $approvedEventVersion->getDateAdded(),
+                        'URL' => Url::to($approvedEventVersion->getPageObject()),
+                        'DTSTART' => new DateTime($repetition->getStartDate(), new DateTimeZone($event->getCalendar()->getTimezone())),
+                        'DTEND' => new DateTime($repetition->getEndDate(), new DateTimeZone($event->getCalendar()->getTimezone())),
+                        'SEQUENCE' => $i++
+                    ];
+
+                    $author = $approvedEventVersion->getAuthor();
+
+                    if ($author instanceof User) {
+                        $arrEvent['ORGANIZER'] = "CN=" . $approvedEventVersion->getAuthor()->getUserName() . ":MAILTO:" . $approvedEventVersion->getAuthor()->getUserEmail();
+                    }
+
+                    $vCalendar->add('VEVENT', $arrEvent);
+                }
+
+                return $this->responseFactory->create($vCalendar->serialize(), Response::HTTP_OK, [
+                    "Content-Type" => "text/calendar; charset=utf-8",
+                    "Content-Disposition" => "inline; filename=\"" . $approvedEventVersion->getName() . ".ics\""
+                ]);
+            }
+        }
+
+        return $this->responseFactory->forbidden("");
+    }
+
+    protected function canAccess()
+    {
+        $eventId = $this->request->query->get("eventID");
+
+        $event = $this->eventService->getByID($eventId, EventService::EVENT_VERSION_RECENT);
+
+        if ($event instanceof CalendarEvent) {
+            $calendar = $event->getCalendar();
+
+            if ($calendar instanceof Calendar) {
+                $permissionChecker = new Checker($calendar);
+
+                $responseObject = $permissionChecker->getResponseObject();
+
+                /** @noinspection PhpUnhandledExceptionInspection */
+                return $responseObject->validate("view_calendar");
+            }
+        }
+
+        return false;
+    }
+
+
+}

--- a/concrete/routes/calendar.php
+++ b/concrete/routes/calendar.php
@@ -8,6 +8,7 @@ $router->all('/ccm/calendar/dialogs/event/edit', '\Concrete\Controller\Dialog\Ev
 $router->all('/ccm/calendar/dialogs/event/add', '\Concrete\Controller\Dialog\Event\Edit::add');
 $router->all('/ccm/calendar/dialogs/event/add/save', '\Concrete\Controller\Dialog\Event\Edit::addEvent');
 $router->all('/ccm/calendar/dialogs/event/edit/save', '\Concrete\Controller\Dialog\Event\Edit::updateEvent');
+$router->all('/ccm/calendar/dialogs/event/export', '\Concrete\Controller\Dialog\Event\Export::export');
 $router->all('/ccm/calendar/dialogs/event/duplicate', '\Concrete\Controller\Dialog\Event\Duplicate::view');
 $router->all('/ccm/calendar/dialogs/event/duplicate/submit', '\Concrete\Controller\Dialog\Event\Duplicate::submit');
 $router->all('/ccm/calendar/dialogs/event/delete', '\Concrete\Controller\Dialog\Event\Delete::view');

--- a/concrete/src/Calendar/Event/Menu/EventOccurrenceMenu.php
+++ b/concrete/src/Calendar/Event/Menu/EventOccurrenceMenu.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Calendar\Event\Menu;
 
 use Concrete\Core\Application\UserInterface\ContextMenu\Item\DialogLinkItem;
@@ -7,6 +8,7 @@ use Concrete\Core\Application\UserInterface\ContextMenu\Item\LinkItem;
 use Concrete\Core\Application\UserInterface\ContextMenu\PopoverMenu;
 use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Calendar\Event\Formatter\LinkFormatterInterface;
+use Concrete\Core\Support\Facade\Url;
 
 class EventOccurrenceMenu extends PopoverMenu
 {
@@ -26,17 +28,18 @@ class EventOccurrenceMenu extends PopoverMenu
         }
         $this->addItem(new DialogLinkItem(
             \URL::to('ccm/calendar/dialogs/event/occurrence') . '?occurrenceID=' . $occurrence->getID(), t('Details'),
-        t('View Event'), 500, 500));
+            t('View Event'), 500, 500));
+        $this->addItem(new LinkItem(Url::to('/ccm/calendar/dialogs/event/export')->setQuery(['eventID' => $occurrence->getEvent()->getID()]), t('Export Event')));
         $permissions = new \Permissions($calendar);
 
         if ($permissions->canEditCalendarEvents()) {
             $this->addItem(new DividerItem());
             $this->addItem(new DialogLinkItem(
-                \URL::to('/ccm/calendar/dialogs/event/edit') . '?versionOccurrenceID=' . $occurrence->getID(),  t('Edit'),
+                \URL::to('/ccm/calendar/dialogs/event/edit') . '?versionOccurrenceID=' . $occurrence->getID(), t('Edit'),
                 t('Edit'), 1100, 600
             ));
             $this->addItem(new DialogLinkItem(
-                \URL::to('/ccm/calendar/dialogs/event/summary_templates') . '?versionOccurrenceID=' . $occurrence->getID(),  t('Summary Templates'),
+                \URL::to('/ccm/calendar/dialogs/event/summary_templates') . '?versionOccurrenceID=' . $occurrence->getID(), t('Summary Templates'),
                 t('Summary Templates'), '90%', '70%'
             ));
             if ($permissions->canCopyCalendarEvents()) {
@@ -44,7 +47,7 @@ class EventOccurrenceMenu extends PopoverMenu
                 $month = date('m', $occurrence->getStart());
                 $this->addItem(new DialogLinkItem(
                     \URL::to('/ccm/calendar/dialogs/event/duplicate') . '?year=' . $year . '&amp;month=' . $month .
-                    '&amp;eventID=' . $occurrence->getEvent()->getID(),  t('Duplicate'),
+                    '&amp;eventID=' . $occurrence->getEvent()->getID(), t('Duplicate'),
                     t('Duplicate'), 400, 300
                 ));
             }

--- a/concrete/src/Updater/Migrations/Migrations/Version20201596544868.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20201596544868.php
@@ -7,7 +7,7 @@ use Concrete\Core\Entity\Search\SavedLogSearch;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20201596544868 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20200810000000 extends AbstractMigration implements RepeatableMigrationInterface
 {
 
     public function upgradeDatabase()
@@ -18,6 +18,8 @@ class Version20201596544868 extends AbstractMigration implements RepeatableMigra
         $this->output(t('Installing log permissions upgrade XML...'));
         $importer = new ContentImporter();
         $importer->importContentFile(DIR_BASE_CORE . '/config/install/upgrade/log_permissions.xml');
+        /* Refresh image block */
+        $this->refreshBlockType('calendar_event');
     }
 
 }


### PR DESCRIPTION
This pull request contains the export feature.

Furthermore i have changed the version number from the last migration class (thanks to @hissy for bringing this up in https://github.com/concrete5/concrete5/pull/8932#issuecomment-671151142)

After renaming i have extended the same migration class with an block update statement for this feature. 

@aembler If you have already executed the migration with the old-named migration class you need to manually run the refresh of the block type within the dashboard page Block types. Even better you should run the following SQL query: `DELETE FROM SystemDatabaseMigrations  WHERE version = '20201596544868';` to rollback the corrupted timestamp.