### PR TITLE
Adding new Channel Board to Logging and logs when users pin or schedule boards

### DIFF
--- a/concrete/controllers/backend/board/instance.php
+++ b/concrete/controllers/backend/board/instance.php
@@ -7,6 +7,8 @@ use Concrete\Core\Board\Command\UnpinSlotFromBoardCommand;
 use Concrete\Core\Board\Instance\Slot\RenderedSlotCollectionFactory;
 use Concrete\Core\Controller\AbstractController;
 use Concrete\Core\Entity\Board\InstanceSlotRule;
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Package\Offline\Exception;
 use Concrete\Core\Permission\Checker;
 use Doctrine\ORM\EntityManager;
@@ -98,6 +100,11 @@ class Instance extends AbstractController
 
             $renderedSlotCollectionFactory = $this->app->make(RenderedSlotCollectionFactory::class);
             $renderedSlotCollection = $renderedSlotCollectionFactory->createCollection($instance);
+
+            $logger = $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_BOARD);
+            $logger->info(t('Slot {slot} pinned from editing interface'), [
+                'slot' => $this->request->request->get('slot')
+            ]);
 
             return new JsonResponse($renderedSlotCollection->getRenderedSlot($this->request->request->get('slot')));
         }

--- a/concrete/controllers/single_page/dashboard/boards/scheduler.php
+++ b/concrete/controllers/single_page/dashboard/boards/scheduler.php
@@ -23,6 +23,8 @@ use Concrete\Core\Entity\Board\InstanceSlotRule;
 use Concrete\Core\Entity\Board\SlotTemplate;
 use Concrete\Core\Foundation\Serializer\JsonSerializer;
 use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Checker;
@@ -132,6 +134,11 @@ class Scheduler extends DashboardSitePageController
             $command->setStartDate($this->request->request->get('start'));
             $command->setEndDate($this->request->request->get('end'));
             $this->app->executeCommand($command);
+
+            $logger = $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_BOARD);
+            $logger->info(t('Slot {slot} scheduled successfully.'), [
+                'slot' => $this->request->request->get('slot')
+            ]);
 
             $this->flash('success', t('Board element scheduled successfully.'));
             return new JsonResponse([]);

--- a/concrete/src/Logging/Channels.php
+++ b/concrete/src/Logging/Channels.php
@@ -114,6 +114,13 @@ class Channels
     const CHANNEL_API = 'api';
 
     /**
+     * Channel identifier: board.
+     *
+     * @var string
+     */
+    const CHANNEL_BOARD = 'board';
+
+    /**
      * Channel identifier: all – Do NOT use this to log to. This is a separate system channel that tells configuration
      * that you want to apply all configuration options to all channels, and listen to all of them.
      *
@@ -192,6 +199,8 @@ class Channels
                 return tc('Log channel', 'Users');
             case self::CHANNEL_API:
                 return tc('Log channel', 'API');
+            case self::CHANNEL_BOARD:
+                return tc('Log channel', 'BOARD');
             default:
                 return tc('Log channel', $text->unhandle($channel));
         }


### PR DESCRIPTION
Everytime a user pins a board or schedule one we need to log that activity. 

This PR adds the new Channel Board "Board" to the Logging in order to log when users pin a board like this:

<img width="383" alt="Screen Shot 2020-08-11 at 1 00 56 PM" src="https://user-images.githubusercontent.com/37560903/89943201-b1279d80-dbd2-11ea-9cde-c4e70038445b.png">

Or Schedule one from the Dashboard/Boards/Schedule:

<img width="695" alt="Screen Shot 2020-08-11 at 1 02 55 PM" src="https://user-images.githubusercontent.com/37560903/89943419-0499eb80-dbd3-11ea-8538-a000176e2b95.png">

The following is a screenshot of both events logged:

<img width="1288" alt="Screen Shot 2020-08-11 at 12 43 57 PM" src="https://user-images.githubusercontent.com/37560903/89943516-2dba7c00-dbd3-11ea-8e44-f8553eb92f41.png">
<img width="1324" alt="Screen Shot 2020-08-11 at 12 54 32 PM" src="https://user-images.githubusercontent.com/37560903/89943528-327f3000-dbd3-11ea-8369-79fd61b154b9.png">
