### PR TITLE
Fix panels in edge 18

### DIFF
--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -9,11 +9,29 @@ mix.webpackConfig({
     externals: {
         jquery: 'jQuery',
         vue: 'Vue'
+    },
+    // Override the default js compile settings to replace exclude with something that doesn't exclude node_modules.
+    // @see node_modules/laravel-mix/src/components/JavaScript.js for the original
+    module: {
+        rules: [
+            {
+                test: /\.jsx?$/,
+                exclude: /(bower_components)/,
+                use: [
+                    {
+                        loader: 'babel-loader',
+                        options: Config.babel()
+                    }
+                ]
+            }
+        ]
     }
 });
+
 mix.options({
     processCssUrls: false
 });
+
 mix.setPublicPath('../concrete');
 
 /**


### PR DESCRIPTION
Edge 18 (before the chromium switch version <44) had issues with some syntax in dependencies we use. In order to fix this I've overridden the default js rule that comes from laravel mix and replaced it with the same thing except without the node_modules exclusion.
This seems to work well for me but absolutely has the potential to cause trouble with some dependencies. If we run into an issue like that we can either:

A. Update the exclude on a case by case basis and exclude only problematic stuff
B. Create a dist folder and make dist releases for bedrock with the compatibility compiled in