### PR TITLE
Fixing FontAwesome missing calendar icon

### DIFF
--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -21,7 +21,7 @@ Loader::element('calendar/header', array(
 
     <div class="btn-group">
         <a href="<?= $previousLink ?>" class="btn btn-sm btn-secondary"><i class="fa fa-angle-double-left"></i></a>
-        <a data-nav="month" href="javascript:void(0)" class="btn btn-sm btn-secondary"><i class="fa fa-calendar-o"></i></a>
+        <a data-nav="month" href="javascript:void(0)" class="btn btn-sm btn-secondary"><i class="far fa-calendar"></i></a>
         <a href="<?= $nextLink ?>" class="btn btn-sm btn-secondary"><i class="fa fa-angle-double-right"></i></a>
     </div>
 


### PR DESCRIPTION
This PR updates the calendar icon to the correct version. 
In version 4 the calendar uses `fa fa-calendar-o` in version 5 the icon should be change to `far fa-calendar`

This is the expected result:

<img width="492" alt="Screen Shot 2020-08-12 at 11 50 44 AM" src="https://user-images.githubusercontent.com/37560903/90055343-0e365880-dc92-11ea-8751-7a1bc6e6c102.png">
