### PR TITLE
Exclude v-calendar from our babel transforms

### DIFF
--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -16,7 +16,7 @@ mix.webpackConfig({
         rules: [
             {
                 test: /\.jsx?$/,
-                exclude: /(bower_components)/,
+                exclude: /(bower_components|node_modules\/v-calendar)/,
                 use: [
                     {
                         loader: 'babel-loader',


### PR DESCRIPTION
v-calendar was having trouble with the babel polyfills / transforms we have, let's exclude it