### PR TITLE
Fixing migrations, adding new migration for separate functionality

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4592,6 +4592,219 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "sabre/uri",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "059d11012603be2e32ddb7543602965563ddbb09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/059d11012603be2e32ddb7543602965563ddbb09",
+                "reference": "059d11012603be2e32ddb7543602965563ddbb09",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.16.1",
+                "phpunit/phpunit": "^7 || ^8"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2020-01-31T18:53:43+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "a7feca8311462e5da16952454e420b92c20d3586"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/a7feca8311462e5da16952454e420b92c20d3586",
+                "reference": "a7feca8311462e5da16952454e420b92c20d3586",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1",
+                "sabre/xml": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.16.1",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "time": "2020-07-13T11:23:30+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "41c6ba148966b10cafd31d1a4e5feb1e2138d95c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/41c6ba148966b10cafd31d1a4e5feb1e2138d95c",
+                "reference": "41c6ba148966b10cafd31d1a4e5feb1e2138d95c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^7.1",
+                "sabre/uri": ">=1.0,<3.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.16.1",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                },
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "time": "2020-05-11T09:44:55+00:00"
+        },
+        {
             "name": "sunra/php-simple-html-dom-parser",
             "version": "v1.5.2",
             "source": {
@@ -8979,6 +9192,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -94,7 +94,8 @@
     "league/pipeline": "^1.0",
     "symfony/property-access": "3.*",
     "theorchard/monolog-cascade": "0.5.*",
-    "commerceguys/addressing": "^1.0"
+    "commerceguys/addressing": "^1.0",
+    "sabre/vobject": "^4.3"
   },
   "extra": {
     "branch-alias": {

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -6,9 +6,9 @@ return [
      *
      * @var string
      */
-    'version' => '9.0.0a2',
-    'version_installed' => '9.0.0a2',
-    'version_db' => '20200810000000', // the key of the latest database migration
+    'version' => '9.0.0a3',
+    'version_installed' => '9.0.0a3',
+    'version_db' => '20200814143401', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/routes/actions/pages.php
+++ b/concrete/routes/actions/pages.php
@@ -17,7 +17,6 @@ $router->all('/multilingual/assign', 'Page\Multilingual::assign');
 $router->all('/multilingual/create_new', 'Page\Multilingual::create_new');
 $router->all('/multilingual/ignore', 'Page\Multilingual::ignore');
 $router->all('/multilingual/unmap', 'Page\Multilingual::unmap');
-$router->all('/select_sitemap', 'Page\SitemapSelector::view');
 $router->all('/sitemap_data', 'Page\SitemapData::view');
 $router->all('/sitemap_delete_forever', 'Page\SitemapDeleteForever::fillQueue');
 

--- a/concrete/src/Calendar/Event/EventRepetitionService.php
+++ b/concrete/src/Calendar/Event/EventRepetitionService.php
@@ -38,7 +38,7 @@ class EventRepetitionService
 
         $repetitions = array();
 
-        foreach($sets as $repetitionSetID) {
+        foreach((array) $sets as $repetitionSetID) {
 
             $dateStart = $r->get($namespace . '_pdStartDate_' . $repetitionSetID);
             $dateEnd = $r->get($namespace . '_pdEndDate_' . $repetitionSetID);

--- a/concrete/src/Updater/Migrations/Migrations/Version20200810000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200810000000.php
@@ -18,8 +18,6 @@ class Version20200810000000 extends AbstractMigration implements RepeatableMigra
         $this->output(t('Installing log permissions upgrade XML...'));
         $importer = new ContentImporter();
         $importer->importContentFile(DIR_BASE_CORE . '/config/install/upgrade/log_permissions.xml');
-        /* Refresh image block */
-        $this->refreshBlockType('calendar_event');
     }
 
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20200814143401.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200814143401.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20200814143401 extends AbstractMigration implements RepeatableMigrationInterface
+{
+
+    public function upgradeDatabase()
+    {
+        $this->refreshBlockType('calendar_event');
+    }
+}


### PR DESCRIPTION
#8963 broke some tests because the class was misnamed compared to the filename. Additionally, the migration really should be split out to a separate migration because it added functionality (rather than forcing people to have to run migrations again with --rerun.) I've added a separate migration for it.