### PR TITLE
Improve express CSV export

### DIFF
--- a/concrete/src/Site/Service.php
+++ b/concrete/src/Site/Service.php
@@ -17,6 +17,7 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Theme\Theme;
 use Concrete\Core\Site\Resolver\ResolverFactory;
 use Concrete\Core\Site\Type\Controller\Manager;
+use Concrete\Core\Tree\Node\Type\ExpressEntrySiteResults;
 use Concrete\Core\User\Group\Group;
 use Doctrine\ORM\EntityManagerInterface;
 use Punic\Comparer;
@@ -472,6 +473,43 @@ class Service
             $factory = new Factory($this->config);
             return $factory->createEntity($domain->getSite());
         }
+    }
+
+    /**
+     * Resolve the site instance associated with a given results node ID
+     *
+     * This is usually useful when resolving a site object from an express entry.
+     * You'd do `$service->getByExpressNodeID($entry->getResultsNodeID());`
+     *
+     * @param int $resultsNodeID
+     *
+     * @return Site|null
+     */
+    public function getSiteByExpressResultsNodeID(int $resultsNodeID): ?Site
+    {
+        /** @TODO Use an overridable way to resolve results nodes */
+        $siteResultsNode = Node::getByID($resultsNodeID);
+        if ($siteResultsNode instanceof ExpressEntrySiteResults) {
+            return $this->getSiteByExpressResultsNode($siteResultsNode);
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a site instance using an express results node
+     *
+     * This is typically useful when resolving the site from an express entry.
+     *
+     * @see Service::getSiteByExpressResultsNodeID()
+     *
+     * @param ExpressEntrySiteResults $siteResultsNode
+     *
+     * @return Site|null
+     */
+    public function getSiteByExpressResultsNode(ExpressEntrySiteResults $siteResultsNode): ?Site
+    {
+        return $this->getByID($siteResultsNode->getSiteID());
     }
 
 }

--- a/concrete/src/Tree/Node/Type/ExpressEntrySiteResults.php
+++ b/concrete/src/Tree/Node/Type/ExpressEntrySiteResults.php
@@ -28,9 +28,24 @@ class ExpressEntrySiteResults extends ExpressEntryResults
         }
     }
 
+    /**
+     * @deprecated Use the siteservice to resolve the site object using ->getByResultsNode(...)
+     *
+     * @return Site|null
+     */
     public function getSite()
     {
-        return app(Service::class)->getByID($this->siteID);
+        return app(Service::class)->getByID($this->getSiteID());
+    }
+
+    /**
+     * Get the ID of the site this node belongs to
+     *
+     * @return int|null
+     */
+    public function getSiteID(): ?int
+    {
+        return $this->siteID;
     }
 
     public static function add($treeNodeCategoryName = '', $parent = false, Site $site = null)

--- a/tests/tests/Express/Export/EntryList/CsvWriterTest.php
+++ b/tests/tests/Express/Export/EntryList/CsvWriterTest.php
@@ -3,14 +3,18 @@
 namespace Concrete\Tests\Express\Export\EntryList;
 
 use Carbon\Carbon;
+use Concrete\Core\Attribute\Controller as AttributeTypeController;
+use Concrete\Core\Attribute\MulticolumnTextExportableAttributeInterface;
 use Concrete\Core\Entity\Attribute\Key\ExpressKey;
 use Concrete\Core\Entity\Attribute\Value\ExpressValue;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Entity\Express\Entry;
+use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Entity\User\User;
 use Concrete\Core\Express\EntryList;
 use Concrete\Core\Express\Export\EntryList\CsvWriter;
 use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Site\Service;
 use Concrete\Core\User\UserInfo;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
@@ -29,51 +33,21 @@ class CsvWriterTest extends TestCase
             'baz' => $this->attributeKey('baz', 'Baz'),
         ];
 
-        $entryKeys = [
+        $values = [
             $this->attributeValue($entityKeys['bar'], 'BAR value'),
             $this->attributeValue($entityKeys['baz'], 'Baz value'),
             $this->attributeValue($entityKeys['foo'], 'Foo value'),
         ];
 
-        $entity = M::mock(Entity::class);
-        $entity->shouldReceive('getAttributes')->andReturn($entityKeys);
-        $entity->shouldReceive('getAssociations')->andReturn([]);
+        list($entity, $list, $writer, $csvWriter) = $this->getCsvWriterMock($entityKeys, $values);
 
-        $entry = M::mock(Entry::class);
-
-        $created = Carbon::now()->subDays(mt_rand(1, 10000));
-        $userInfo = M::mock(UserInfo::class);
-        $userInfo->shouldReceive('getUserDisplayName')->andReturn('author name');
-        $author = M::mock(User::class);
-        $author->shouldReceive('getUserInfoObject')->andReturn($userInfo);
-        $entry->shouldReceive('getDateCreated')->andReturn($created);
-        $entry->shouldReceive('getAuthor')->andReturn($author);
-        $entry->shouldReceive('getAttributes')->andReturn($entryKeys);
-        $entry->shouldReceive('getPublicIdentifier')->andReturn('abc');
-        $entry->shouldReceive('getAssociations')->andReturn([]);
-
-        $list = M::mock(TestEntryList::class);
-        $list->shouldReceive('deliverQueryObject')->andReturnSelf();
-        $list->shouldReceive('execute')->andReturn([$entry]);
-        $list->shouldReceive('getEntity')->andReturn($entity);
-        $list->shouldReceive('getResult')->andReturnUsing(function($arg) {
-            return $arg;
-        });
-
-        $writer = M::mock(TestWriter::class);
-        $writer->shouldReceive('insertOne')->passthru();
-        $writer->shouldReceive('insertAll')->passthru();
-
-        $dateFormatter = M::mock(Date::class);
-        $dateFormatter->shouldReceive('formatCustom')->andReturn('not now');
-
-        $csvWriter = new CsvWriter($writer, $dateFormatter);
         $csvWriter->insertHeaders($entity);
         $csvWriter->insertEntryList($list);
 
         $this->assertSame([
             'publicIdentifier' => 'publicIdentifier',
             'ccm_date_created' => 'dateCreated',
+            'site' => 'site',
             'author_name' => 'authorName',
             'foo' => 'Foo',
             'bar' => 'Bar',
@@ -84,6 +58,7 @@ class CsvWriterTest extends TestCase
             [
                 'publicIdentifier' => 'abc',
                 'ccm_date_created' => 'not now',
+                'site' => 'foo',
                 'author_name' => 'author name',
                 'foo' => 'Foo value',
                 'bar' => 'BAR value',
@@ -92,22 +67,121 @@ class CsvWriterTest extends TestCase
         ], $writer->entries);
     }
 
-    private function attributeKey($handle, $name)
+    /**
+     * Test an entry being exported that has attributes with mutlicolumn text export enabled
+     */
+    public function testMultiTextAttributeHeaders()
+    {
+        $controller = M::mock(AttributeTypeController::class, MulticolumnTextExportableAttributeInterface::class);
+        $controller->shouldReceive('getAttributeTextRepresentationHeaders')->andReturn(['foo', 'bar', 'baz']);
+        $controller->shouldReceive('getAttributeValueTextRepresentation')->andReturn(['Fooz', 'Barz', 'Bazz']);
+
+        $keys = [
+            'foo' => $this->attributeKey('foo', 'Foo', $controller),
+        ];
+
+        $values = [
+            $this->attributeValue($keys['foo'], 'Foo value', $controller),
+        ];
+
+        list($entity, $list, $writer, $csvWriter) = $this->getCsvWriterMock($keys, $values);
+        $csvWriter->insertHeaders($entity);
+        $csvWriter->insertEntryList($list);
+
+        $this->assertSame([
+            'publicIdentifier' => 'publicIdentifier',
+            'ccm_date_created' => 'dateCreated',
+            'site' => 'site',
+            'author_name' => 'authorName',
+            'foo' => 'Foo',
+            'foo.foo' => 'Foo - foo',
+            'foo.bar' => 'Foo - bar',
+            'foo.baz' => 'Foo - baz',
+        ], $writer->headers);
+
+        $this->assertSame([
+            [
+                'publicIdentifier' => 'abc',
+                'ccm_date_created' => 'not now',
+                'site' => 'foo',
+                'author_name' => 'author name',
+                'foo' => 'Foo value',
+                'foo.foo' => 'Fooz',
+                'foo.bar' => 'Barz',
+                'foo.baz' => 'Bazz',
+            ]
+        ], $writer->entries);
+    }
+
+    private function attributeKey($handle, $name, $controller = null)
     {
         $mock = M::mock(ExpressKey::class);
-        $mock
-            ->shouldReceive('getAttributeKeyHandle')->andReturn($handle)
-            ->shouldReceive('getAttributeKeyDisplayName')->andReturn($name);
+        $mock->shouldReceive('getAttributeKeyHandle')->andReturn($handle);
+        $mock->shouldReceive('getAttributeKeyDisplayName')->andReturn($name);
+        $mock->shouldReceive('getController')->andReturn($controller);
 
         return $mock;
     }
 
-    private function attributeValue($key, $plainValue)
+    private function attributeValue($key, $plainValue, $controller = null)
     {
         $value = M::mock(ExpressValue::class);
         $value->shouldReceive('getAttributeKey')->andReturn($key);
         $value->shouldReceive('getPlainTextValue')->andReturn($plainValue);
+        $value->shouldReceive('getController')->andReturn($controller);
 
         return $value;
+    }
+
+    /**
+     * @param array $entityKeys
+     * @param array $entryKeys
+     * @return array
+     */
+    private function getCsvWriterMock(array $keys, array $values): array
+    {
+        $entity = M::mock(Entity::class);
+        $entity->shouldReceive('getAttributes')->andReturn($keys);
+        $entity->shouldReceive('getAssociations')->andReturn([]);
+
+        $entry = M::mock(Entry::class);
+
+        $entry->shouldReceive('getResultsNodeID')->andReturn(1122);
+
+        $created = Carbon::now()->subDays(mt_rand(1, 10000));
+        $userInfo = M::mock(UserInfo::class);
+        $userInfo->shouldReceive('getUserDisplayName')->andReturn('author name');
+        $author = M::mock(User::class);
+        $author->shouldReceive('getUserInfoObject')->andReturn($userInfo);
+        $entry->shouldReceive('getDateCreated')->andReturn($created);
+        $entry->shouldReceive('getAuthor')->andReturn($author);
+        $entry->shouldReceive('getAttributes')->andReturn($values);
+        $entry->shouldReceive('getPublicIdentifier')->andReturn('abc');
+        $entry->shouldReceive('getAssociations')->andReturn([]);
+
+        $list = M::mock(TestEntryList::class);
+        $list->shouldReceive('deliverQueryObject')->andReturnSelf();
+        $list->shouldReceive('execute')->andReturn([$entry]);
+        $list->shouldReceive('getEntity')->andReturn($entity);
+        $list->shouldReceive('getResult')->andReturnUsing(function ($arg) {
+            return $arg;
+        });
+
+        $writer = M::mock(TestWriter::class);
+        $writer->shouldReceive('insertOne')->passthru();
+        $writer->shouldReceive('insertAll')->passthru();
+
+        $dateFormatter = M::mock(Date::class);
+        $dateFormatter->shouldReceive('formatCustom')->andReturn('not now');
+
+        $siteService = M::mock(Service::class);
+        $site = M::mock(Site::class);
+        $siteService->shouldReceive('getSiteByExpressResultsNodeID')->withArgs([1122])->andReturn($site);
+        $site->shouldReceive('getSiteHandle')->andReturn('foo');
+
+        $csvWriter = new CsvWriter($writer, $dateFormatter);
+        // Mock the site service
+        $csvWriter->setSiteService($siteService);
+        return array($entity, $list, $writer, $csvWriter);
     }
 }


### PR DESCRIPTION
* **Support MultiColumnText interface**. We have some attributes that are able to output multiple text columns instead of just a single key => value pair. This change supports those text columns by prepending them with the attribute name and a hyphen. So for example if an attribute with the display name 'Bar' has 'foo' as a multi column text header we'd output `Bar - foo` as the header.
* **Fix `DATE_ATOM` output**. We were attempting to output ATOM format for date_created but the way things flow through the calendar date tool we were converting the *string* `ATOM` to a date format rather than actually using the `DATE_ATOM` format.
* **Add 'site' handle to export**. This PR adds a header 'site' and outputs the site handle value for each entry.