### PR TITLE
Handle primitive values in the Redis ConfigSaver

### DIFF
--- a/concrete/src/Config/Driver/Redis/RedisSaver.php
+++ b/concrete/src/Config/Driver/Redis/RedisSaver.php
@@ -63,8 +63,12 @@ class RedisSaver implements SaverInterface
      */
     protected function flattenValue($namespace, $group, $item, $value)
     {
-        $results = [];
         $prefix = "{$namespace}::{$group}" . ($item ? ".{$item}" : '');
+
+        if (!is_array($value)) {
+            return [$prefix => serialize($value)];
+        }
+
         return array_map('serialize', Arr::dot($value, $prefix . '.'));
     }
 }


### PR DESCRIPTION
I was setting this up today and realized that there was a bug in the saver that would cause a fatal error if trying to save a primitive value. That's not great so I added a conditional to handle those cases specifically