### PR TITLE
Cleanup bootstrap\helpers.php

### DIFF
--- a/concrete/bootstrap/helpers.php
+++ b/concrete/bootstrap/helpers.php
@@ -1,103 +1,73 @@
 <?php
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
-use Concrete\Core\Utility\Service\Text;
+use Concrete\Core\Filesystem\FileLocator;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Logging\LoggerFactory;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Text;
 
 /**
  * Translate text (simple form).
  *
- * @param string $text The text to be translated.
- * @param        mixed ... Unlimited optional number of arguments: if specified they'll be used for printf.
+ * @param string $text
+ * @param mixed ...$args Unlimited optional number of arguments: if specified they'll be used for printf.
  *
- * @return string Returns the translated text.
+ * @return string returns the translated text
  *
  * @example t('Hello %s') will return translation for 'Hello %s' (example for Italian 'Ciao %s').
  * @example t('Hello %s', 'John') will return translation for 'Hello %s' (example: 'Ciao %s'), using 'John' for printf (so the final result will be 'Ciao John' for Italian).
  */
-function t($text)
+function t($text, ...$args)
 {
     $loc = Localization::getInstance();
     $adapter = $loc->getActiveTranslatorAdapter();
-    $args = func_get_args();
-    switch (count($args)) {
-        case 1:
-            return $adapter->translate($text);
-        case 2:
-            return $adapter->translate($text, $args[1]);
-        case 3:
-            return $adapter->translate($text, $args[1], $args[2]);
-        case 4:
-            return $adapter->translate($text, $args[1], $args[2], $args[3]);
-        default:
-            return call_user_func_array(array($adapter, 'translate'), $args);
-    }
+
+    return $adapter->translate($text, ...$args);
 }
 
 /**
  * Translate text (plural form).
  *
- * @param string $singular The singular form.
- * @param string $plural   The plural form.
- * @param int    $number   The number.
- * @param        mixed     ... Unlimited optional number of arguments: if specified they'll be used for printf
+ * @param string $singular the singular form
+ * @param string $plural the plural form
+ * @param int $number the number
+ * @param mixed ...$args Unlimited optional number of arguments: if specified they'll be used for printf
  *
- * @return string Returns the translated text.
+ * @return string returns the translated text
  *
  * @example t2('%d child', '%d children', $n) will return translated '%d child' if $n is 1, translated '%d children' otherwise.
  * @example t2('%d child', '%d children', $n, $n) will return translated '1 child' if $n is 1, translated '2 children' if $n is 2.
  */
-function t2($singular, $plural, $number)
+function t2($singular, $plural, $number, ...$args)
 {
     $loc = Localization::getInstance();
     $adapter = $loc->getActiveTranslatorAdapter();
-    $args = func_get_args();
-    switch (count($args)) {
-        case 3:
-            return $adapter->translatePlural($singular, $plural, $number);
-        case 4:
-            return $adapter->translatePlural($singular, $plural, $number, $args[3]);
-        case 5:
-            return $adapter->translatePlural($singular, $plural, $number, $args[3], $args[4]);
-        case 6:
-            return $adapter->translatePlural($singular, $plural, $number, $args[3], $args[4], $args[5]);
-        default:
-            return call_user_func_array(array($adapter, 'translatePlural'), $args);
-    }
+
+    return $adapter->translatePlural($singular, $plural, $number, ...$args);
 }
 
 /**
  * Translate text (simple form) with a context.
  *
- * @param string $context A context, useful for translators to better understand the meaning of the text to be translated.
- * @param string $text    The text to be translated.
- * @param        mixed    ... Unlimited optional number of arguments: if specified they'll be used for printf.
+ * @param string $context a context, useful for translators to better understand the meaning of the text to be translated
+ * @param string $text the text to be translated
+ * @param mixed ...$args Unlimited optional number of arguments: if specified they'll be used for printf.
  *
- * @return string Returns the translated text.
+ * @return string returns the translated text
  *
  * @example tc('Recipient', 'To %s') will return translation for 'To %s' (example for Italian 'A %s').
  * @example tc('End date', 'To %s') will return translation for 'To %s' (example for Italian 'Fino al %s').
  * @example tc('Recipient', 'To %s', 'John') will return translation for 'To %s' (example: 'A %s'), using 'John' for printf (so the final result will be 'A John' for Italian).
  * @example tc('End date', 'To %s', '01/01/2000') will return translation for 'To %s' (example: 'Fino al %s'), using '01/01/2000' for printf (so the final result will be 'Fino al 01/01/2000' for Italian).
  */
-function tc($context, $text)
+function tc($context, $text, ...$args)
 {
     $loc = Localization::getInstance();
     $adapter = $loc->getActiveTranslatorAdapter();
-    $args = func_get_args();
-    switch (count($args)) {
-        case 2:
-            return $adapter->translateContext($context, $text);
-        case 3:
-            return $adapter->translateContext($context, $text, $args[2]);
-        case 4:
-            return $adapter->translateContext($context, $text, $args[2], $args[3]);
-        case 5:
-            return $adapter->translateContext($context, $text, $args[2], $args[3], $args[4]);
-        default:
-            return call_user_func_array(array($adapter, 'translateContext'), $args);
-    }
+
+    return $adapter->translateContext($context, $text, ...$args);
 }
 
 /**
@@ -109,7 +79,7 @@ function tc($context, $text)
  */
 function h($input)
 {
-    return id(new Text())->specialchars($input);
+    return (new Text())->specialchars($input);
 }
 
 /**
@@ -117,7 +87,7 @@ function h($input)
  *
  *     id(new Block)->render();
  *
- * @param  mixed $mixed
+ * @param mixed $mixed
  *
  * @return mixed mixed
  */
@@ -130,77 +100,71 @@ function id($mixed)
  *  Returns a concrete5 namespaced class. $prefix is either true (for application), or a package handle or null.
  *
  * @param string $class
- * @param bool   $prefix
+ * @param bool $prefix
  *
  * @return string
  */
 function core_class($class, $prefix = false)
 {
-    $app = \Core::make('app');
     $class = trim($class, '\\');
+    $classPrefix = 'Concrete';
     if ($prefix) {
-        if (substr($class, 0, 5) == "Core\\") {
+        $app = Application::getFacadeApplication();
+        if (strpos($class, 'Core\\') === 0) {
             if ($prefix !== true) {
-                $x = $app->make('Concrete\Core\Package\PackageService')->getClass($prefix);
+                $classPrefix = $prefix;
+                $x = $app->make('Concrete\Core\Package\PackageService')->getClass($classPrefix);
                 if (!$x->shouldEnableLegacyNamespace()) {
                     $class = substr($class, 5);
                 } else {
-                    $class = "Src\\" . substr($class, 5);
+                    $class = 'Src\\' . substr($class, 5);
                 }
+            } elseif (!$app['config']->get('app.enable_legacy_src_namespace')) {
+                $class = 'Concrete\\' . substr($class, 5);
             } else {
-                if (!Config::get('app.enable_legacy_src_namespace')) {
-                    $class = "Concrete\\" . substr($class, 5);
-                } else {
-                    $class = "Src\\" . substr($class, 5);
-                }
+                $class = 'Src\\' . substr($class, 5);
             }
         }
 
         if ($prefix === true) {
-            $prefix = Config::get('app.namespace');
+            $classPrefix = $app['config']->get('app.namespace');
         } else {
-            $prefix = 'Concrete\\Package\\' . camelcase($prefix);
+            $classPrefix = 'Concrete\\Package\\' . camelcase($prefix);
         }
     }
 
-    if (!$prefix) {
-        $prefix = 'Concrete';
-    }
-
-    $class = '\\' . $prefix . '\\' . $class;
-
-    return $class;
+    return '\\' . $classPrefix . '\\' . $class;
 }
 
 function overrideable_core_class($class, $path, $pkgHandle = null)
 {
-    $env = \Environment::get();
+    $app = Application::getFacadeApplication();
+    $locator = $app->make(FileLocator::class);
 
     // First, check to see if the class we're trying to override is in the Core namespace
-    if (substr($class, 0, 5) == "Core\\") {
+    if (strpos($class, 'Core\\') === 0) {
         // If so, we first check to see if application/src/Concrete/This/Stuff exists
         // So let's strip DIRNAME_CLASSES off the front, place /Concrete/ between DIRNAME_CLASSES
         // and the rest of the path.
         $newPath = substr($path, strlen(DIRNAME_CLASSES));
         $newPath = DIRNAME_CLASSES . '/Concrete' . $newPath;
-        $r = $env->getRecord($newPath);
+        $r = $locator->getRecord($newPath);
         if ($r->override) {
             return core_class($class, true);
         }
     }
 
-    $r = $env->getRecord($path);
+    $r = $locator->getRecord($path);
     $prefix = $r->override ? true : $pkgHandle;
 
     return core_class($class, $prefix);
-
 }
 
 /**
  * Returns $string in CamelCase.
  *
  * @param string $string
- * @param bool   $leaveSlashes
+ * @param bool $leaveSlashes
  *
  * @return string
  */
@@ -211,7 +175,7 @@ function camelcase($string, $leaveSlashes = false)
     if (strpos($string, '/')) {
         $segments = explode('/', $string);
         foreach ($segments as $segment) {
-            $subsegments = preg_split("/[_-]/", $segment);
+            $subsegments = preg_split('/[_-]/', $segment);
             foreach ($subsegments as $subsegment) {
                 $return .= ucfirst($subsegment);
             }
@@ -221,7 +185,7 @@ function camelcase($string, $leaveSlashes = false)
         }
         $return = trim($return, '/');
     } else {
-        $segments = preg_split("/[_-]/", $string);
+        $segments = preg_split('/[_-]/', $string);
         foreach ($segments as $segment) {
             $return .= ucfirst($segment);
         }
@@ -233,21 +197,21 @@ function camelcase($string, $leaveSlashes = false)
 /**
  * Returns CamelCase string as camel_case.
  *
- * @param  string $string
+ * @param string $string
  *
  * @return string mixed
  */
 function uncamelcase($string)
 {
     $v = preg_split('/([A-Z])/', $string, false, PREG_SPLIT_DELIM_CAPTURE);
-    $a = array();
+    $a = [];
     array_shift($v);
-    for ($i = 0; $i < count($v); ++$i) {
+    foreach ($v as $i => $char) {
         if ($i % 2) {
             if (function_exists('mb_strtolower')) {
-                $a[] = mb_strtolower($v[$i - 1] . $v[$i], APP_CHARSET);
+                $a[] = mb_strtolower($v[$i - 1] . $char, APP_CHARSET);
             } else {
-                $a[] = strtolower($v[$i - 1] . $v[$i]);
+                $a[] = strtolower($v[$i - 1] . $char);
             }
         }
     }
@@ -257,8 +221,7 @@ function uncamelcase($string)
 
 /**
  * Fills an object properties from an array.
- */
-/**
+ *
  * @param $o
  * @param $array
  *
@@ -267,7 +230,7 @@ function uncamelcase($string)
 function array_to_object($o, $array)
 {
     foreach ($array as $property => $value) {
-        $o->$property = $value;
+        $o->{$property} = $value;
     }
 
     return $o;
@@ -278,6 +241,7 @@ function array_to_object($o, $array)
  *
  * @param $o
  * @param bool $maxDepth
+ * @param mixed $echo
  */
 function var_dump_safe($o, $echo = true, $maxDepth = true)
 {
@@ -310,14 +274,17 @@ function output_vars(array $get_defined_vars, $valueOfThis = null, $return = fal
 
 /**
  * Easily logs something.
+ *
  * @param mixed $channel
  * @param $message
  * @param array $context
+ * @param mixed $level
  */
-function core_log($message,
-  $level = \Monolog\Logger::DEBUG,
-  $channel = \Concrete\Core\Logging\Channels::CHANNEL_APPLICATION)
-{
+function core_log(
+    $message,
+    $level = \Monolog\Logger::DEBUG,
+    $channel = \Concrete\Core\Logging\Channels::CHANNEL_APPLICATION
+) {
     $logger = Core::make(LoggerFactory::class)->createLogger($channel);
     $context = [];
     if (is_array($message)) {
@@ -330,15 +297,16 @@ function core_log($message,
 /**
  * Resolve the given type from the container.
  *
- * @param  string  $abstract
- * @param  array   $parameters
+ * @param string $abstract
+ * @param array $parameters
+ *
  * @return mixed
  */
 function app($abstract = null, array $parameters = [])
 {
-    $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
+    $app = Application::getFacadeApplication();
 
-    if (is_null($abstract)) {
+    if ($abstract === null) {
         return $app;
     }
 


### PR DESCRIPTION
Replaced call_user_func_array with argument unpacking in bootstrap\helpers.php and cleaned it up 

We have prepared another branch that includes  `concrete/src/Localization/Translator/TranslatorAdapterInterface.php` and its implementations if you are okay with these changes, i can update this PR or create another one.
You can check what it's done [here](https://github.com/Xanweb/concrete5/commit/bafad092991a0b7082b74a82189e5c1660a6b07a)