### PR TITLE
Disable the phpdoc_var_without_name PHP CS Fixer rule

### DIFF
--- a/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
@@ -496,7 +496,7 @@ class PhpFixerRuleResolver
             'nullable_type_declaration_for_default_null_value' => ($minimumPhpVersion !== '' && version_compare($minimumPhpVersion, '7.1') < 0) || $hasFlag(PhpFixer::FLAG_OLDPHP) ? false : true,
 
             // `@var` and `@type` annotations should not contain the variable name.
-            'phpdoc_var_without_name' => $hasFlag(PhpFixer::FLAG_PHPONLY) ? true : false,
+            'phpdoc_var_without_name' => false,
 
             // Converts `pow` to the `**` operator.
             'pow_to_exponentiation' => ($minimumPhpVersion !== '' && version_compare($minimumPhpVersion, '5.6') < 0) || $hasFlag(PhpFixer::FLAG_OLDPHP) ? false : true,


### PR DESCRIPTION
Let's disable the [`phpdoc_var_without_name`](https://mlocati.github.io/php-cs-fixer-configurator/#version:2.16|fixer:phpdoc_var_without_name) fixer, since it may mangle some well written code.

For example, given this file:

```php
<?php

defined('C5_EXECUTE') or die('Access Denied.');

/**
 * @var string $foo
 */
// Comment

echo $foo;
```

That fixer transforms it to:

```php
<?php

defined('C5_EXECUTE') or die('Access Denied.');

/**
 * @var string
 */
// Comment

echo $foo;
```

which is a wrong behaviour.