### PR TITLE
Make core_board_slot more resistant to misconfiguration

### DIFF
--- a/concrete/blocks/core_board_slot/controller.php
+++ b/concrete/blocks/core_board_slot/controller.php
@@ -48,7 +48,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $entityManager = $this->app->make(EntityManager::class);
         $renderer = $this->app->make(ContentRenderer::class);
         $collection = $renderer->denormalizeIntoCollection(json_decode($this->contentObjectCollection, true));
-        $template = $entityManager->find(SlotTemplate::class, $this->slotTemplateID);
+        $template = $entityManager->find(SlotTemplate::class, (int) $this->slotTemplateID);
         $this->set('dataCollection', $collection);
         $this->set('renderer', $renderer);
         $this->set('template', $template);

--- a/concrete/blocks/core_board_slot/view.php
+++ b/concrete/blocks/core_board_slot/view.php
@@ -3,10 +3,11 @@
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
- * @var $renderer \Concrete\Core\Board\Instance\Slot\Content\ContentRenderer
- * @var $template \Concrete\Core\Entity\Board\SlotTemplate
+ * @var \Concrete\Core\Board\Instance\Slot\Content\ContentRenderer $renderer
+ * @var \Concrete\Core\Entity\Board\SlotTemplate|null $template
+ * @var \Concrete\Core\Board\Instance\Slot\Content\ObjectCollection $dataCollection
  */
 
-echo $renderer->render($dataCollection, $template);
-?>
-
+if ($template) {
+    echo $renderer->render($dataCollection, $template);
+}


### PR DESCRIPTION
Somehow core_board_slot blocks can be added with a null "slotTemplateID", this change makes it to that the site isn't borked if that happens.