### PR TITLE
Add date modified to csv export

### DIFF
--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -101,11 +101,11 @@ class CsvWriter
     private function projectEntry(Entry $entry)
     {
         $date = $entry->getDateCreated();
-        if ($date) {
-            yield 'ccm_date_created' => $this->dateFormatter->formatCustom($this->datetime_format, $date);
-        } else {
-            yield 'ccm_date_created' => null;
-        }
+        yield 'ccm_date_created' => $date ? $this->dateFormatter->formatCustom($this->datetime_format, $date) : null;
+
+        $date = $entry->getDateModified();
+        yield 'ccm_date_modified' => $date ? $this->dateFormatter->formatCustom($this->datetime_format, $date) : null;
+
         yield 'publicIdentifier' => $entry->getPublicIdentifier();
 
         // Resolve the site
@@ -159,6 +159,7 @@ class CsvWriter
     {
         yield 'publicIdentifier' => 'publicIdentifier';
         yield 'ccm_date_created' => 'dateCreated';
+        yield 'ccm_date_modified' => 'dateModified';
         yield 'site' => 'site';
         yield 'author_name' => 'authorName';
 

--- a/tests/tests/Express/Export/EntryList/CsvWriterTest.php
+++ b/tests/tests/Express/Export/EntryList/CsvWriterTest.php
@@ -47,6 +47,7 @@ class CsvWriterTest extends TestCase
         $this->assertSame([
             'publicIdentifier' => 'publicIdentifier',
             'ccm_date_created' => 'dateCreated',
+            'ccm_date_modified' => 'dateModified',
             'site' => 'site',
             'author_name' => 'authorName',
             'foo' => 'Foo',
@@ -58,6 +59,7 @@ class CsvWriterTest extends TestCase
             [
                 'publicIdentifier' => 'abc',
                 'ccm_date_created' => 'not now',
+                'ccm_date_modified' => 'not now',
                 'site' => 'foo',
                 'author_name' => 'author name',
                 'foo' => 'Foo value',
@@ -91,6 +93,7 @@ class CsvWriterTest extends TestCase
         $this->assertSame([
             'publicIdentifier' => 'publicIdentifier',
             'ccm_date_created' => 'dateCreated',
+            'ccm_date_modified' => 'dateModified',
             'site' => 'site',
             'author_name' => 'authorName',
             'foo' => 'Foo',
@@ -103,6 +106,7 @@ class CsvWriterTest extends TestCase
             [
                 'publicIdentifier' => 'abc',
                 'ccm_date_created' => 'not now',
+                'ccm_date_modified' => 'not now',
                 'site' => 'foo',
                 'author_name' => 'author name',
                 'foo' => 'Foo value',
@@ -154,6 +158,7 @@ class CsvWriterTest extends TestCase
         $author = M::mock(User::class);
         $author->shouldReceive('getUserInfoObject')->andReturn($userInfo);
         $entry->shouldReceive('getDateCreated')->andReturn($created);
+        $entry->shouldReceive('getDateModified')->andReturn($created->copy()->addDays(20));
         $entry->shouldReceive('getAuthor')->andReturn($author);
         $entry->shouldReceive('getAttributes')->andReturn($values);
         $entry->shouldReceive('getPublicIdentifier')->andReturn('abc');


### PR DESCRIPTION
The CSV export included dateCreated but not the last modified date. This PR adds dateModified next to dateCreated and populates it with a date string the same as dateCreated.