### PR TITLE
Fix publish button display when updating stack

### DIFF
--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -232,7 +232,7 @@ if (isset($neutralStack)) {
 
                     <?php if ($showApprovalButton) { ?>
                         <ul class="nav navbar-nav navbar-right">
-                            <li id="ccm-stack-list-approve-button nav-item" class="navbar-form"<?= $vo->isApprovedNow() ? ' style="display: none;"' : '' ?>>
+                            <li id="ccm-stack-list-approve-button" class="nav-item navbar-form"<?= $vo->isApprovedNow() ? ' style="display: none;"' : '' ?>>
                                 <button class="btn btn-success" onclick="window.location.href='<?= $view->action('approve_stack', $stackToEdit->getCollectionID(), $token->generate('approve_stack')) ?>'">
                                     <?= $publishTitle ?>
                                 </button>


### PR DESCRIPTION
Whenever you save a change on a stack the publish button was not showing. JQuery was unable to find the element because had the wrong id name. This PR fixes this issue and moves the nav-item to the class attribute. 

