### PR TITLE
fix issue with duplicate import of files uploaded through an express_…

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -269,7 +269,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                     }
                 }
                 if (isset($e) && !$e->has()) {
-                    $submittedAttributeValues = $manager->getEntryAttributeValuesForm($form, $entry);
+                    $submittedAttributeValues = $entry->getAttributes();
                     $notifier = $controller->getNotifier($this);
                     $notifications = $notifier->getNotificationList();
                     array_walk($notifications->getNotifications(), function ($notification) use ($submittedAttributeValues,$key) {


### PR DESCRIPTION
…form block

This appears to fix #8501 however I do not know the reason behind why `$manager->getEntryAttributeValuesForm($form, $entry);` was used to load the submitted attributes instead of just loading them directly from the entry. There may have been a use-case I am unaware of for this so an extra set of eyes would be appreciated