### PR TITLE
Extend form attributes

### DIFF
--- a/concrete/attributes/email/controller.php
+++ b/concrete/attributes/email/controller.php
@@ -4,6 +4,7 @@ namespace Concrete\Attribute\Email;
 
 use Concrete\Core\Attribute\DefaultController;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
+use Concrete\Core\Entity\Attribute\Key\Settings\TextSettings;
 use Concrete\Core\Error\ErrorList\Error\Error;
 use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
 use Concrete\Core\Error\ErrorList\ErrorList;
@@ -12,15 +13,74 @@ use Concrete\Core\Validator\String\EmailValidator;
 
 class Controller extends DefaultController
 {
+    protected $akTextPlaceholder;
     public $helpers = ['form'];
+
+    public function saveKey($data)
+    {
+        $type = $this->getAttributeKeySettings();
+        $data += array(
+            'akTextPlaceholder' => null,
+        );
+        $akTextPlaceholder = $data['akTextPlaceholder'];
+
+        $type->setPlaceholder($akTextPlaceholder);
+
+        return $type;
+    }
 
     public function form()
     {
+        $this->load();
         $value = null;
         if (is_object($this->attributeValue)) {
             $value = $this->app->make('helper/text')->entities($this->getAttributeValue()->getValue());
         }
         $this->set('value', $value);
+        $akTextPlaceholder = '';
+        if (isset($this->akTextPlaceholder)) {
+            $akTextPlaceholder = $this->akTextPlaceholder;
+        }
+        $this->set('akTextPlaceholder', $akTextPlaceholder);
+    }
+
+    public function type_form()
+    {
+        $this->load();
+    }
+
+    protected function load()
+    {
+        $ak = $this->getAttributeKey();
+        if (!is_object($ak)) {
+            return false;
+        }
+
+        $type = $ak->getAttributeKeySettings();
+        /**
+         * @var $type TextSettings
+         */
+        $this->akTextPlaceholder = $type->getPlaceholder();
+        $this->set('akTextPlaceholder', $type->getPlaceholder());
+    }
+
+    public function exportKey($akey)
+    {
+        $this->load();
+        $akey->addChild('type')->addAttribute('placeholder', $this->akTextPlaceholder);
+
+        return $akey;
+    }
+
+    public function importKey(\SimpleXMLElement $akey)
+    {
+        $type = $this->getAttributeKeySettings();
+        if (isset($akey->type)) {
+            $data['akTextPlaceholder'] = $akey->type['placeholder'];
+            $type->setPlaceholder((string) $akey->type['placeholder']);
+        }
+
+        return $type;
     }
 
     public function getIconFormatter()

--- a/concrete/attributes/email/form.php
+++ b/concrete/attributes/email/form.php
@@ -1,6 +1,9 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-    print $form->email(
-        $this->field('value'),
-        $value
-    );
+defined('C5_EXECUTE') or die("Access Denied.");
+print $form->email(
+    $this->field('value'),
+    $value,
+    [
+        'placeholder' => tc('AttributeKeyPlaceholder', h($akTextPlaceholder))
+    ]
+);

--- a/concrete/attributes/email/type_form.php
+++ b/concrete/attributes/email/type_form.php
@@ -1,0 +1,11 @@
+<fieldset>
+    <legend><?php echo t('Text Options')?></legend>
+
+    <div class="form-group">
+
+        <?php echo $form->label( 'akTextPlaceholder', t('Placeholder Text') )?>
+
+        <?php echo $form->text( 'akTextPlaceholder' , isset($akTextPlaceholder) ? $akTextPlaceholder : '' )?>
+    </div>
+
+</fieldset>

--- a/concrete/attributes/telephone/controller.php
+++ b/concrete/attributes/telephone/controller.php
@@ -3,18 +3,78 @@ namespace Concrete\Attribute\Telephone;
 
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Attribute\DefaultController;
+use Concrete\Core\Entity\Attribute\Key\Settings\TextSettings;
 
 class Controller extends DefaultController
 {
+    protected $akTextPlaceholder;
     public $helpers = ['form'];
+
+    public function saveKey($data)
+    {
+        $type = $this->getAttributeKeySettings();
+        $data += array(
+            'akTextPlaceholder' => null,
+        );
+        $akTextPlaceholder = $data['akTextPlaceholder'];
+
+        $type->setPlaceholder($akTextPlaceholder);
+
+        return $type;
+    }
 
     public function form()
     {
+        $this->load();
         $value = null;
         if (is_object($this->attributeValue)) {
             $value = $this->app->make('helper/text')->entities($this->getAttributeValue()->getValue());
         }
         $this->set('value',$value);
+        $akTextPlaceholder = '';
+        if (isset($this->akTextPlaceholder)) {
+            $akTextPlaceholder = $this->akTextPlaceholder;
+        }
+        $this->set('akTextPlaceholder', $akTextPlaceholder);
+    }
+
+    public function type_form()
+    {
+        $this->load();
+    }
+
+    protected function load()
+    {
+        $ak = $this->getAttributeKey();
+        if (!is_object($ak)) {
+            return false;
+        }
+
+        $type = $ak->getAttributeKeySettings();
+        /**
+         * @var $type TextSettings
+         */
+        $this->akTextPlaceholder = $type->getPlaceholder();
+        $this->set('akTextPlaceholder', $type->getPlaceholder());
+    }
+
+    public function exportKey($akey)
+    {
+        $this->load();
+        $akey->addChild('type')->addAttribute('placeholder', $this->akTextPlaceholder);
+
+        return $akey;
+    }
+
+    public function importKey(\SimpleXMLElement $akey)
+    {
+        $type = $this->getAttributeKeySettings();
+        if (isset($akey->type)) {
+            $data['akTextPlaceholder'] = $akey->type['placeholder'];
+            $type->setPlaceholder((string) $akey->type['placeholder']);
+        }
+
+        return $type;
     }
 
     public function composer()

--- a/concrete/attributes/telephone/form.php
+++ b/concrete/attributes/telephone/form.php
@@ -1,3 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-print $form->telephone($this->field('value'), $value);
+print $form->telephone(
+    $this->field('value'),
+    $value,
+    [
+        'placeholder' => tc('AttributeKeyPlaceholder', h($akTextPlaceholder))
+    ]
+);

--- a/concrete/attributes/telephone/type_form.php
+++ b/concrete/attributes/telephone/type_form.php
@@ -1,0 +1,11 @@
+<fieldset>
+    <legend><?php echo t('Text Options')?></legend>
+    
+    <div class="form-group">
+        
+        <?php echo $form->label( 'akTextPlaceholder', t('Placeholder Text') )?>
+        
+        <?php echo $form->text( 'akTextPlaceholder' , isset($akTextPlaceholder) ? $akTextPlaceholder : '' )?>
+    </div>
+
+</fieldset>

--- a/concrete/attributes/text/form.php
+++ b/concrete/attributes/text/form.php
@@ -1,9 +1,9 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-    print $form->text(
-        $this->field('value'),
-        $value,
-        [
-            'placeholder' => h($akTextPlaceholder)
-        ]
-    );
+defined('C5_EXECUTE') or die("Access Denied.");
+print $form->text(
+    $this->field('value'),
+    $value,
+    [
+        'placeholder' => tc('AttributeKeyPlaceholder', h($akTextPlaceholder))
+    ]
+);

--- a/concrete/attributes/textarea/controller.php
+++ b/concrete/attributes/textarea/controller.php
@@ -172,25 +172,6 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
         return TextareaSettings::class;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @see \Concrete\Core\Attribute\XEditableConfigurableAttributeInterface::getXEditableOptions()
-     */
-    public function getXEditableOptions()
-    {
-        $this->load();
-        if ($this->akTextareaDisplayMode === 'rich_text') {
-            return [
-                'editableMode' => 'inline',
-                'onblur' => 'ignore',
-                'showbuttons' => 'bottom',
-            ];
-        }
-
-        return [];
-    }
-
     protected function load()
     {
         $ak = $this->getAttributeKey();

--- a/concrete/attributes/textarea/controller.php
+++ b/concrete/attributes/textarea/controller.php
@@ -16,6 +16,7 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
 
     protected $akTextareaDisplayMode;
     protected $akTextareaDisplayModeCustomOptions;
+    protected $akTextPlaceholder;
 
     public function getIconFormatter()
     {
@@ -27,6 +28,7 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
         $type = $this->getAttributeKeySettings();
         $data += [
             'akTextareaDisplayMode' => null,
+            'akTextPlaceholder' => null,
         ];
         $akTextareaDisplayMode = $data['akTextareaDisplayMode'];
         if (!$akTextareaDisplayMode) {
@@ -36,8 +38,10 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
         if ($akTextareaDisplayMode == 'rich_text_custom') {
             $options = $data['akTextareaDisplayModeCustomOptions'];
         }
+        $akTextPlaceholder = $data['akTextPlaceholder'];
 
         $type->setMode($akTextareaDisplayMode);
+        $type->setPlaceholder($akTextPlaceholder);
 
         return $type;
     }
@@ -92,6 +96,11 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
         }
         $this->set('akTextareaDisplayMode', $this->akTextareaDisplayMode);
         $this->set('value', $value);
+        $akTextPlaceholder = '';
+        if (isset($this->akTextPlaceholder)) {
+            $akTextPlaceholder = $this->akTextPlaceholder;
+        }
+        $this->set('akTextPlaceholder', $akTextPlaceholder);
     }
 
     public function composer()
@@ -127,6 +136,7 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
     {
         $this->load();
         $akey->addChild('type')->addAttribute('mode', $this->akTextareaDisplayMode);
+        $akey->addChild('type')->addAttribute('placeholder', $this->akTextPlaceholder);
 
         return $akey;
     }
@@ -150,6 +160,8 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
         if (isset($akey->type)) {
             $data['akTextareaDisplayMode'] = $akey->type['mode'];
             $type->setMode((string) $akey->type['mode']);
+            $data['akTextPlaceholder'] = $akey->type['placeholder'];
+            $type->setPlaceholder((string) $akey->type['placeholder']);
         }
 
         return $type;
@@ -178,7 +190,7 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
 
         return [];
     }
-  
+
     protected function load()
     {
         $ak = $this->getAttributeKey();
@@ -192,5 +204,7 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
          */
         $this->akTextareaDisplayMode = $type->getMode();
         $this->set('akTextareaDisplayMode', $type->getMode());
+        $this->akTextPlaceholder = $type->getPlaceholder();
+        $this->set('akTextPlaceholder', $type->getPlaceholder());
     }
 }

--- a/concrete/attributes/textarea/form.php
+++ b/concrete/attributes/textarea/form.php
@@ -7,7 +7,10 @@ if ($akTextareaDisplayMode == 'text' || $akTextareaDisplayMode == '') { ?>
     echo $form->textarea(
         $view->controller->field('value'),
         h($value),
-        array('rows' => 5)
+        [
+            'rows' => 5,
+            'placeholder' => tc('AttributeKeyPlaceholder', h($akTextPlaceholder))
+        ]
     );
     ?>
 

--- a/concrete/attributes/textarea/type_form.php
+++ b/concrete/attributes/textarea/type_form.php
@@ -1,18 +1,25 @@
 <fieldset>
-<legend><?php echo t('Text Area Options')?></legend>
+    <legend><?php echo t('Text Area Options')?></legend>
 
-<div class="form-group">
-	<?php echo $form->label('akTextareaDisplayMode', t('Input Format'))?>
-	<?php
-    $akTextareaDisplayModeOptions = array(
-        'text' => t('Plain Text'),
-        'rich_text' => t('Rich Text - Default Setting'),
-    );
+    <div class="form-group">
+        <?php echo $form->label('akTextareaDisplayMode', t('Input Format'))?>
+        <?php
+        $akTextareaDisplayModeOptions = array(
+            'text' => t('Plain Text'),
+            'rich_text' => t('Rich Text - Default Setting'),
+        );
 
-    ?>
-	<?php echo $form->select('akTextareaDisplayMode', $akTextareaDisplayModeOptions, $akTextareaDisplayMode, array(
-        'class' => 'span8',
-    ))?>
-</div>
+        ?>
+        <?php echo $form->select('akTextareaDisplayMode', $akTextareaDisplayModeOptions, $akTextareaDisplayMode, array(
+            'class' => 'span8',
+        ))?>
+    </div>
+
+    <div class="form-group">
+
+        <?php echo $form->label( 'akTextPlaceholder', t('Placeholder Text') )?>
+
+        <?php echo $form->text( 'akTextPlaceholder' , isset($akTextPlaceholder) ? $akTextPlaceholder : '')?>
+    </div>
 
 </fieldset>

--- a/concrete/attributes/url/controller.php
+++ b/concrete/attributes/url/controller.php
@@ -3,19 +3,78 @@ namespace Concrete\Attribute\Url;
 
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Attribute\DefaultController;
+use Concrete\Core\Entity\Attribute\Key\Settings\TextSettings;
 
 class Controller extends DefaultController
 {
+    protected $akTextPlaceholder;
+    public $helpers = ['form'];
 
-    public $helpers = array('form');
+    public function saveKey($data)
+    {
+        $type = $this->getAttributeKeySettings();
+        $data += array(
+            'akTextPlaceholder' => null,
+        );
+        $akTextPlaceholder = $data['akTextPlaceholder'];
+
+        $type->setPlaceholder($akTextPlaceholder);
+
+        return $type;
+    }
 
     public function form()
     {
+        $this->load();
         $value = null;
         if (is_object($this->attributeValue)) {
             $value = $this->app->make('helper/text')->entities($this->getAttributeValue()->getValue());
         }
         $this->set('value', $value);
+        $akTextPlaceholder = '';
+        if (isset($this->akTextPlaceholder)) {
+            $akTextPlaceholder = $this->akTextPlaceholder;
+        }
+        $this->set('akTextPlaceholder', $akTextPlaceholder);
+    }
+
+    public function type_form()
+    {
+        $this->load();
+    }
+
+    protected function load()
+    {
+        $ak = $this->getAttributeKey();
+        if (!is_object($ak)) {
+            return false;
+        }
+
+        $type = $ak->getAttributeKeySettings();
+        /**
+         * @var $type TextSettings
+         */
+        $this->akTextPlaceholder = $type->getPlaceholder();
+        $this->set('akTextPlaceholder', $type->getPlaceholder());
+    }
+
+    public function exportKey($akey)
+    {
+        $this->load();
+        $akey->addChild('type')->addAttribute('placeholder', $this->akTextPlaceholder);
+
+        return $akey;
+    }
+
+    public function importKey(\SimpleXMLElement $akey)
+    {
+        $type = $this->getAttributeKeySettings();
+        if (isset($akey->type)) {
+            $data['akTextPlaceholder'] = $akey->type['placeholder'];
+            $type->setPlaceholder((string) $akey->type['placeholder']);
+        }
+
+        return $type;
     }
 
     public function getIconFormatter()

--- a/concrete/attributes/url/form.php
+++ b/concrete/attributes/url/form.php
@@ -1,6 +1,9 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-    print $form->url(
-        $this->field('value'),
-        $value
-    );
+defined('C5_EXECUTE') or die("Access Denied.");
+print $form->url(
+    $this->field('value'),
+    $value,
+    [
+        'placeholder' => tc('AttributeKeyPlaceholder', h($akTextPlaceholder))
+    ]
+);

--- a/concrete/attributes/url/type_form.php
+++ b/concrete/attributes/url/type_form.php
@@ -1,0 +1,11 @@
+<fieldset>
+    <legend><?php echo t('Text Options')?></legend>
+
+    <div class="form-group">
+
+        <?php echo $form->label( 'akTextPlaceholder', t('Placeholder Text') )?>
+
+        <?php echo $form->text( 'akTextPlaceholder' , isset($akTextPlaceholder) ? $akTextPlaceholder : '' )?>
+    </div>
+
+</fieldset>

--- a/concrete/src/Entity/Attribute/Key/Settings/TextareaSettings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/TextareaSettings.php
@@ -15,6 +15,11 @@ class TextareaSettings extends Settings
     protected $akTextareaDisplayMode = '';
 
     /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $akTextPlaceholder = '';
+
+    /**
      * @return mixed
      */
     public function getMode()
@@ -28,6 +33,22 @@ class TextareaSettings extends Settings
     public function setMode($mode)
     {
         $this->akTextareaDisplayMode = $mode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPlaceholder()
+    {
+        return $this->akTextPlaceholder;
+    }
+
+    /**
+     * @param string $placeholder
+     */
+    public function setPlaceholder($placeholder)
+    {
+        $this->akTextPlaceholder = $placeholder;
     }
 
 }


### PR DESCRIPTION
C5 express form has placeholder value implemented only for text attribute so these modifications are made for extending other text based attributes with placeholder value: 
- adding placeholder for text derived attributes: currently only text attribute has placeholder but email, telephone and url attributes are derived from text attribute too, so I've extended those with the posibility to have placeholders too
- adding placeholder for textarea attribute: TextSettings entity didn't had placeholder as TextSettings entity so I've extended it to have it, also implemented for textarea attribute placeholder features
- adding translation possibility for placeholders: for all 5 text attributes I've added the possibility to be able to translate placeholders on multilanguage sites