### PR TITLE
[v9] Avoid editing non-editable aliased blocks

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -701,6 +701,13 @@ EOT
      */
     public function isEditable()
     {
+        if ($this->getBlockTypeHandle() === BLOCK_HANDLE_SCRAPBOOK_PROXY) {
+            $controller = $this->getController();
+            $originalBlockID = $controller->getOriginalBlockID();
+            $originalBlock = self::getByID($originalBlockID);
+
+            return $originalBlock && $originalBlock->isEditable();
+        }
         $bv = new BlockView($this);
         $path = $bv->getBlockPath(FILENAME_BLOCK_EDIT);
         if (file_exists($path . '/' . FILENAME_BLOCK_EDIT)) {


### PR DESCRIPTION
Fix #9029