### PR TITLE
Re: Make the User instance as a singleton

### DIFF
--- a/concrete/src/User/UserServiceProvider.php
+++ b/concrete/src/User/UserServiceProvider.php
@@ -34,7 +34,7 @@ class UserServiceProvider extends ServiceProvider
             });
         }
 
-
+        $this->app->singleton(User::class);
     }
 
     /**


### PR DESCRIPTION
@mlocati tried to use `$app->make(User::class)` instead of `new User()` to improve performance on #7433 .

That pull request was already merged, but @aembler deleted registering singleton when merging https://github.com/concrete5/concrete5/commit/fdeb56230f12ca8e28d53d49cd5a20b4e4319a8a

I believe it was an accident, so let's get registering singleton back.

Before

![Screen Shot 2020-09-17 at 3 15 33](https://user-images.githubusercontent.com/514294/93376298-58fc4f00-f894-11ea-8d53-f177d96bd8a6.png)

After

![Screen Shot 2020-09-17 at 3 16 03](https://user-images.githubusercontent.com/514294/93376320-60bbf380-f894-11ea-9aa9-65eed0570963.png)
