### PR TITLE
Reduce "select from Pages" queries by using request cache

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3906,6 +3906,7 @@ EOT
         $key = '/page/row/' . $cInfo;
         $item = $cache->getItem($key);
         $row = false;
+        $originalRow = null;
 
         if ($item->isHit()) {
             $row = $item->get();
@@ -3919,8 +3920,6 @@ EOT
             if ($row !== false && $row['cPointerID'] > 0) {
                 $originalRow = $row;
                 $row = $db->fetchAssoc("SELECT {$fields}, CollectionVersions.cvName FROM {$from} LEFT JOIN CollectionVersions ON CollectionVersions.cID = ? WHERE Pages.cID = ? LIMIT 1", [$row['cID'], $row['cPointerID']]);
-            } else {
-                $originalRow = null;
             }
 
             $item->set($row);

--- a/tests/helpers/Page/PageTestCase.php
+++ b/tests/helpers/Page/PageTestCase.php
@@ -2,12 +2,13 @@
 
 namespace Concrete\TestHelpers\Page;
 
+use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Page\Type\Type as PageType;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use Core;
 use Page;
 use PageTemplate;
-use PageType;
 
 abstract class PageTestCase extends ConcreteDatabaseTestCase
 {
@@ -44,6 +45,7 @@ abstract class PageTestCase extends ConcreteDatabaseTestCase
         'PageTypeComposerFormLayoutSets',
         'BlockFeatureAssignments',
         'BlockPermissionAssignments',
+        'Stacks',
     ]; // so brutal
 
     protected $metadatas = [
@@ -83,6 +85,13 @@ abstract class PageTestCase extends ConcreteDatabaseTestCase
         PageType::add([
             'handle' => 'basic',
             'name' => 'Basic',
+        ]);
+
+        SinglePage::addGlobal(STACKS_PAGE_PATH);
+        PageType::add([
+            'handle' => STACKS_PAGE_TYPE,
+            'name' => 'Stacks',
+            'internal' => 1,
         ]);
     }
 

--- a/tests/tests/Page/PageTest.php
+++ b/tests/tests/Page/PageTest.php
@@ -2,13 +2,16 @@
 
 namespace Concrete\Tests\Page;
 
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Single;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Page\Type\Type;
 use Concrete\TestHelpers\Page\PageTestCase;
 use Config;
 use Core;
 use Database;
 use Exception;
 use Loader;
-use Page;
 use PageTemplate;
 use PageType;
 use SinglePage;
@@ -551,5 +554,26 @@ class PageTest extends PageTestCase
             'contact' => $contact,
             'another' => $another,
         ];
+    }
+
+    public function testInstantiate()
+    {
+        $this->app->make('cache/request')->enable();
+
+        $page = self::createPage('Test Page');
+        $stack = Stack::addStack('Test Stack');
+
+        $pageID = $page->getCollectionID();
+        $stackID = $stack->getCollectionID();
+
+        $newPageInstance = Page::getByID($pageID);
+        $newStackInstance = Stack::getByID($stackID);
+
+        $this->assertTrue($newPageInstance instanceof Page);
+        $this->assertTrue($newStackInstance instanceof Stack);
+        $this->assertEquals($pageID, $newPageInstance->getCollectionID());
+        $this->assertEquals($stackID, $newStackInstance->getCollectionID());
+
+        $this->app->make('cache/request')->disable();
     }
 }


### PR DESCRIPTION
Currently, concrete5 getting the same page information from the Pages table repeatedly.
We're using request cache to avoid wasting database query, but the keys are different by class name.
Specifically, `Page::getByID(123)` `Stack::getByID(123)` and `Section::getByID(123)` will call same select query!
So, let's store the query result in the request cache too!
Also refactored `getByID()` method to remove using deperecated usage of `CacheLocal` class.


Before: 245 statements were executed, 114 of which were duplicates, 131 unique

![Screen Shot 2020-09-17 at 17 43 42](https://user-images.githubusercontent.com/514294/93447562-80433280-f90d-11ea-96a7-bb8d55818347.png)


After: 227 statements were executed, 97 of which were duplicates, 130 unique

![Screen Shot 2020-09-17 at 17 42 34](https://user-images.githubusercontent.com/514294/93447530-79b4bb00-f90d-11ea-81f4-5d3e788fc2cf.png)