### PR TITLE
Avoid to get same Permission Access Entity from database repeatedly

### DIFF
--- a/concrete/src/Permission/Access/Entity/GroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupEntity.php
@@ -87,7 +87,6 @@ class GroupEntity extends Entity
             }
         }
 
-        $pe = null;
         $db = Loader::db();
         $petID = $db->GetOne('select petID from PermissionAccessEntityTypes where petHandle = \'group\'');
         $peID = $db->GetOne('select pae.peID from PermissionAccessEntities pae inner join PermissionAccessEntityGroups paeg on pae.peID = paeg.peID where petID = ? and paeg.gID = ?',


### PR DESCRIPTION
Currently, we're getting the same Permission Access Entity from the database so many times on a single request!
Let's avoid it by using the request cache.

Before: 253 statements were executed, 122 of which were duplicates, 131 unique

![Screen Shot 2020-09-18 at 8 55 28](https://user-images.githubusercontent.com/514294/93539796-c12e5c00-f98c-11ea-8ed1-99b5533eb008.png)

After: 201 statements were executed, 70 of which were duplicates, 131 unique

![Screen Shot 2020-09-18 at 8 54 44](https://user-images.githubusercontent.com/514294/93539810-c8ee0080-f98c-11ea-8aee-0a809c0ca2c5.png)
