### PR TITLE
Avoid getting same Column object from database repeatedly

### DIFF
--- a/concrete/src/Area/Layout/PresetColumn.php
+++ b/concrete/src/Area/Layout/PresetColumn.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Core\Area\Layout;
 
+use Concrete\Core\Cache\Level\RequestCache;
+use Concrete\Core\Support\Facade\Application;
 use HtmlObject\Element;
 
 class PresetColumn extends Column
@@ -12,8 +14,24 @@ class PresetColumn extends Column
      */
     public static function getByID($arLayoutColumnID)
     {
+        $app = Application::getFacadeApplication();
+        /** @var RequestCache $cache */
+        $cache = $app->make('cache/request');
+        $key = '/Area/LayoutColumn/PresetColumn/' . $arLayoutColumnID;
+        if ($cache->isEnabled()) {
+            $item = $cache->getItem($key);
+            if ($item->isHit()) {
+                return $item->get();
+            }
+        }
+
         $al = new static();
         $al->loadBasicInformation($arLayoutColumnID);
+
+        if (isset($item) && $item->isMiss()) {
+            $item->set($al);
+            $cache->save($item);
+        }
 
         return $al;
     }


### PR DESCRIPTION
Almost same as #9040
Let's use request cache to improve performance.

Before: 261 statements were executed, 136 of which were duplicates, 125 unique

![Screen Shot 2020-09-21 at 18 09 56](https://user-images.githubusercontent.com/514294/93749921-b21e0700-fc35-11ea-93ca-59d95d51a881.png)

After: 257 statements were executed, 128 of which were duplicates, 129 unique

![Screen Shot 2020-09-21 at 18 09 41](https://user-images.githubusercontent.com/514294/93749938-b9ddab80-fc35-11ea-9b84-f99cb03e81a4.png)
