### PR TITLE
fix #9053 by not killing the whole page

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -858,7 +858,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             if ($folder = FileFolder::getByID($folderID)) {
                 return $folder;
             } else {
-                throw new \RuntimeException('Invalid Folder ID');
+                return new FileFolder;
             }
         }
 


### PR DESCRIPTION
Fix #9053 

By returning an empty FileFolder object, the page will still render, and the now missing folder will no longer be associated with the block. This conditional block is only called in three methods: `action_upload`, `formatBreadcrumbs` and `setupFolderFileFolderFilter`. The other methods call this method with `$realRoot = true`, thus bypassing this block. 

All three of these methods fail gracefully with this change. If the page is already loaded, then someone deletes the folder before another user uploads a file, the page reloads and the block shows no files found. `formatBreadcrmbs` and `setupFolderFileFolderFildter` similarly fail gracefully. 

It may be better to add a warning that a document library block depends on a folder when deleting it, but this at least doesn't cause the page to fail catastrophically.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
