### PR TITLE
Fix routes with optional arguments

### DIFF
--- a/concrete/src/Routing/Router.php
+++ b/concrete/src/Routing/Router.php
@@ -5,8 +5,6 @@ namespace Concrete\Core\Routing;
 use Concrete\Core\Page\Theme\ThemeRouteCollection;
 use Concrete\Core\Support\Facade\Application;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Exception\MethodNotAllowedException;
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
@@ -232,7 +230,8 @@ class Router implements RouterInterface
         $host = '',
         $schemes = [],
         $methods = [],
-        $condition = null)
+        $condition = null
+    )
     {
         $route = new Route($this->normalizePath($path), [], $requirements, $options, $host, $schemes, $methods, $condition);
         $route->setAction($callback);
@@ -362,5 +361,4 @@ class Router implements RouterInterface
 
         return $result;
     }
-
 }

--- a/concrete/src/Routing/Router.php
+++ b/concrete/src/Routing/Router.php
@@ -314,8 +314,7 @@ class Router implements RouterInterface
 
     private function normalizePath($path)
     {
-        $path = trim($path, '/');
-        return $path === '' ? '/' : "/{$path}/";
+        return '/' . trim($path, '/');
     }
 
     private function createRouteBuilder($path, $action, $methods)
@@ -349,6 +348,9 @@ class Router implements RouterInterface
                 }
             } elseif ($p > 0) {
                 $routeFixedPath = substr($routePath, 0, $p);
+                if ($route->getDefaults() !== []) {
+                    $routeFixedPath = rtrim($routeFixedPath, '/');
+                }
                 if (strpos($path, $routeFixedPath) !== 0) {
                     $skip = true;
                 }

--- a/tests/tests/Core/Routing/RouterTest.php
+++ b/tests/tests/Core/Routing/RouterTest.php
@@ -66,7 +66,7 @@ class RouterTest extends TestCase
         $route = $router->getRoutes()->get('update_api');
         $this->assertInstanceOf(Route::class, $route);
 
-        $this->assertEquals('/api/update/', $route->getPath());
+        $this->assertEquals('/api/update', $route->getPath());
         $methods = $route->getMethods();
         $this->assertCount(1, $methods);
         $this->assertEquals('POST', $methods[0]);
@@ -102,7 +102,7 @@ class RouterTest extends TestCase
         $route = $router->getRoutes()->get('rss');
         $this->assertInstanceOf(Route::class, $route);
 
-        $this->assertEquals('/rss/{identifier}/', $route->getPath());
+        $this->assertEquals('/rss/{identifier}', $route->getPath());
         $methods = $route->getMethods();
         $this->assertCount(1, $methods);
         $this->assertEquals('GET', $methods[0]);
@@ -175,10 +175,10 @@ class RouterTest extends TestCase
         $this->assertCount(4, $routes);
 
         // Test prefix and name.
-        $this->assertEquals('/api/v1/hello-world/', $routes->get('api_v1_hello_world_get')->getPath());
-        $this->assertEquals('/a-fun-test/', $routes->get('a_fun_test_post')->getPath());
-        $this->assertEquals('/api/v1/status/', $routes->get('api_v1_status_get')->getPath());
-        $this->assertEquals('/api/v1/user/{:user}/', $routes->get('user_details')->getPath());
+        $this->assertEquals('/api/v1/hello-world', $routes->get('api_v1_hello_world_get')->getPath());
+        $this->assertEquals('/a-fun-test', $routes->get('a_fun_test_post')->getPath());
+        $this->assertEquals('/api/v1/status', $routes->get('api_v1_status_get')->getPath());
+        $this->assertEquals('/api/v1/user/{:user}', $routes->get('user_details')->getPath());
 
         // Test everything
         $router = new Router(new RouteCollection(), new RouteActionFactory());
@@ -250,7 +250,7 @@ class RouterTest extends TestCase
         $scope = $route->getOption('oauth_scopes');
 
         $this->assertCount(2, $middlewares);
-        $this->assertEquals('/ccm/api/v1/system/status/', $route->getPath());
+        $this->assertEquals('/ccm/api/v1/system/status', $route->getPath());
         $this->assertEquals('api', $scope);
 
         $route = $router->getRoutes()->get('ccm_api_v1_products_add_post');
@@ -259,7 +259,7 @@ class RouterTest extends TestCase
         $methods = $route->getMethods();
 
         $this->assertCount(2, $middlewares);
-        $this->assertEquals('/ccm/api/v1/products/add/', $route->getPath());
+        $this->assertEquals('/ccm/api/v1/products/add', $route->getPath());
         $this->assertCount(1, $methods);
         $this->assertEquals('POST', $methods[0]);
         $this->assertEquals('api,products', $scope);

--- a/tests/tests/Core/Routing/RouterTest.php
+++ b/tests/tests/Core/Routing/RouterTest.php
@@ -1,28 +1,25 @@
 <?php
-namespace Concrete\Tests\Core\Routing;
 
+namespace Concrete\Tests\Core\Routing;
 
 use Concrete\Core\Controller\AbstractController;
 use Concrete\Core\Http\Middleware\FractalNegotiatorMiddleware;
-use Concrete\Core\Http\Middleware\MiddlewareInterface;
 use Concrete\Core\Http\Middleware\OAuthAuthenticationMiddleware;
 use Concrete\Core\Http\Middleware\OAuthErrorMiddleware;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Routing\ClosureRouteAction;
 use Concrete\Core\Routing\ControllerRouteAction;
+use Concrete\Core\Routing\MatchedRoute;
 use Concrete\Core\Routing\Route;
 use Concrete\Core\Routing\RouteActionFactory;
-use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Routing\Router;
-use Concrete\Core\Routing\ClosureRouteAction;
+use Concrete\Core\Support\Facade\Facade;
 use Concrete\Tests\TestCase;
-use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Concrete\Core\Routing\MatchedRoute;
+
 class TestController extends AbstractController
 {
-
     public function hello()
     {
         return 'oh hai';
@@ -31,17 +28,14 @@ class TestController extends AbstractController
 
 class TestMiddleware
 {
-
 }
 
 class AnotherTestMiddleware
 {
-
 }
 
 class RouterTest extends TestCase
 {
-
     public function testCreateRouter()
     {
         $app = Facade::getFacadeApplication();
@@ -53,14 +47,14 @@ class RouterTest extends TestCase
     {
         $app = Facade::getFacadeApplication();
         /**
-         * @var $router Router
+         * @var Router $router
          */
         $router = new Router(new RouteCollection(), new RouteActionFactory());
-        $router->get('/hello-world', function() { return 'hello world.'; });
+        $router->get('/hello-world', function () { return 'hello world.'; });
         $routes = $router->getRoutes();
         $this->assertCount(1, $routes);
 
-        $router->post('/api/update', function() { return 'what';})->setName('update_api');
+        $router->post('/api/update', function () { return 'what'; })->setName('update_api');
         $this->assertCount(2, $routes);
 
         $route = $router->getRoutes()->get('update_api');
@@ -79,14 +73,14 @@ class RouterTest extends TestCase
 
         $route = $router->head('/something/special', 'Something\Controller')
             ->setName('special')
-            ->addMiddleware(TestMiddleware::class);
+            ->addMiddleware(TestMiddleware::class)
+        ;
 
         $route = $router->getRoutes()->get('special');
         $this->assertInstanceOf(Route::class, $route);
         $this->assertCount(1, $route->getMiddlewares());
         $middlewares = $route->getMiddlewares();
         $this->assertEquals('Concrete\Tests\Core\Routing\TestMiddleware', $middlewares[0]->getMiddleware());
-
     }
 
     public function testRestrictions()
@@ -94,7 +88,8 @@ class RouterTest extends TestCase
         $router = new Router(new RouteCollection(), new RouteActionFactory());
         $router->get('/rss/{identifier}', 'test')
             ->setName('rss')
-            ->setRequirements(['identifier' => '[A-Za-z0-9_/.]+']);
+            ->setRequirements(['identifier' => '[A-Za-z0-9_/.]+'])
+        ;
 
         $router->post('/testing', '');
         $router->options('/something/else', '');
@@ -114,14 +109,16 @@ class RouterTest extends TestCase
     public function testCallbacks()
     {
         $router = new Router(new RouteCollection(), new RouteActionFactory());
-        $route = $router->get('/hello-world', function() { return 'hello world.'; })
-            ->getRoute();
+        $route = $router->get('/hello-world', function () { return 'hello world.'; })
+            ->getRoute()
+        ;
         $this->assertInstanceOf(Route::class, $route);
         $callback = $router->resolveAction($route);
         $this->assertInstanceOf(ClosureRouteAction::class, $callback);
 
         $route = $router->get('/hello-world', 'Concrete\Tests\Core\Routing\TestController::hello')
-            ->getRoute();
+            ->getRoute()
+        ;
         $action = $router->resolveAction($route);
         $this->assertInstanceOf(ControllerRouteAction::class, $action);
         $this->assertEquals('Concrete\Tests\Core\Routing\TestController::hello', $action->getControllerCallback());
@@ -163,13 +160,16 @@ class RouterTest extends TestCase
         $router->post('/a-fun-test', 'Concrete\Tests\Core\Routing\TestController::test');
         $router->buildGroup()
             ->setPrefix('/api/v1')
-            ->routes(function($groupRouter) {
+            ->routes(function ($groupRouter) {
                 $groupRouter->get('/hello-world', 'Concrete\Tests\Core\Routing\TestController::hello');
                 $groupRouter->get('/status', 'Concrete\Tests\Core\Routing\TestController::status');
                 $groupRouter->get('/user/{:user}', 'Concrete\Tests\Core\Routing\TestController::getUserDetails')
-                    ->setName('user_details');
+                    ->setName('user_details')
+                ;
+
                 return $groupRouter;
-            });
+            })
+        ;
 
         $routes = $router->getRoutes();
         $this->assertCount(4, $routes);
@@ -188,12 +188,14 @@ class RouterTest extends TestCase
             ->setRequirements(['identifier' => '[A-Za-z0-9_/.]+'])
             ->addMiddleware('Concrete\Tests\Core\Routing\TestMiddleware')
             ->addMiddleware('Concrete\Tests\Core\Routing\AnotherMiddleware')
-            ->routes(function($groupRouter) {
+            ->routes(function ($groupRouter) {
                 $groupRouter->post('/add_group', 'User::addGroup');
                 $groupRouter->post('/remove_group', 'User::removeGroup');
                 $groupRouter->get('/get_json', 'User::getJSON');
+
                 return $groupRouter;
-            });
+            })
+        ;
 
         $route = $router->getRoutes()->get('ccm_system_user_remove_group_post');
         $middlewares = $route->getMiddlewares();
@@ -219,29 +221,36 @@ class RouterTest extends TestCase
             ->setPrefix('/ccm/api/v1')
             ->scope('api')
             ->addMiddleware(OAuthErrorMiddleware::class)
-            ->addMiddleware(OAuthAuthenticationMiddleware::class);
+            ->addMiddleware(OAuthAuthenticationMiddleware::class)
+        ;
 
         $api->buildGroup()
             ->setPrefix('/system')
-            ->routes(function($groupRouter) {
+            ->routes(function ($groupRouter) {
                 $groupRouter->get('/info', 'Concrete\Tests\Core\Routing\TestController::hello');
                 $groupRouter->get('/status', 'Concrete\Tests\Core\Routing\TestController::status');
+
                 return $groupRouter;
-            });
+            })
+        ;
 
         $api->buildGroup()->scope('users')
             ->addMiddleware(FractalNegotiatorMiddleware::class)
-            ->routes(function($groupRouter) {
+            ->routes(function ($groupRouter) {
                 $groupRouter->get('/users', 'Concrete\Tests\Core\Routing\TestController::hello');
                 $groupRouter->post('/user/add', 'Concrete\Tests\Core\Routing\TestController::status');
+
                 return $groupRouter;
-            });
+            })
+        ;
         $api->buildGroup()->scope('products')
-            ->routes(function($groupRouter) {
+            ->routes(function ($groupRouter) {
                 $groupRouter->get('/products', 'Concrete\Tests\Core\Routing\TestController::hello');
                 $groupRouter->post('/products/add', 'Concrete\Tests\Core\Routing\TestController::status');
+
                 return $groupRouter;
-            });
+            })
+        ;
 
         $routes = $router->getRoutes();
         $this->assertEquals(6, count($routes));
@@ -270,7 +279,5 @@ class RouterTest extends TestCase
         $this->assertCount(3, $middlewares);
         $this->assertEquals(FractalNegotiatorMiddleware::class, $middlewares[2]->getMiddleware());
         $this->assertEquals('api,users', $scope);
-
     }
-
 }

--- a/tests/tests/Routing/CheckRoutesTest.php
+++ b/tests/tests/Routing/CheckRoutesTest.php
@@ -10,14 +10,13 @@ class CheckRoutesTest extends TestCase
 {
     public function routeDestinationProvider()
     {
-        
         $app = ApplicationFacade::getFacadeApplication();
-        /** @var $router  \Concrete\Core\Routing\Router */
+        /** @var \Concrete\Core\Routing\Router $router */
         $router = $app->make('router');
         $routes = $router->getRoutes();
         $result = [];
         /**
-         * @var  $route \Concrete\Core\Routing\Route
+         * @var \Concrete\Core\Routing\Route $route
          */
         foreach ($routes as $route) {
             $data = $route->getAction();
@@ -27,35 +26,33 @@ class CheckRoutesTest extends TestCase
             }
         }
 
-
         return $result;
     }
 
-/** @dataProvider routeDestinationProvider
- *
- * @param $app Application
- * @param $path string
- * @param $callable mixed
- */
+    /** @dataProvider routeDestinationProvider
+     *
+     * @param $app Application
+     * @param $path string
+     * @param $callable mixed
+     */
     public function testRouteDestination(Application $app, $path, $callable)
     {
-
         $checked = false;
         if (preg_match('/^([^:]+)::([^:]+)$/', $callable, $m)) {
             $class = $m[1];
             $method = $m[2];
             if ($method === '__construct') {
-                $this->assertTrue(class_exists($m[1], true), "No class! Invalid route for path $path : $callable");
+                $this->assertTrue(class_exists($m[1], true), "No class! Invalid route for path {$path} : {$callable}");
                 $checked = true;
             } elseif (interface_exists($class, true)) {
-                $this->assertTrue(method_exists($class, $method), "No Method! Invalid route for path $path : $callable");
+                $this->assertTrue(method_exists($class, $method), "No Method! Invalid route for path {$path} : {$callable}");
                 $checked = true;
             } elseif ($app->isAlias($class)) {
-                $this->assertTrue(method_exists($class, $method), "Alias but no method! Invalid route for path $path : $callable");
+                $this->assertTrue(method_exists($class, $method), "Alias but no method! Invalid route for path {$path} : {$callable}");
             }
         }
         if ($checked === false) {
-            $this->assertTrue(is_callable($callable), "Not callable! Invalid route for path $path : $callable");
+            $this->assertTrue(is_callable($callable), "Not callable! Invalid route for path {$path} : {$callable}");
         }
     }
 }

--- a/tests/tests/Routing/CheckRoutesTest.php
+++ b/tests/tests/Routing/CheckRoutesTest.php
@@ -3,8 +3,13 @@
 namespace Concrete\Tests\Routing;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Routing\MatchedRoute;
+use Concrete\Core\Routing\Router;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Concrete\Tests\TestCase;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Throwable;
 
 class CheckRoutesTest extends TestCase
 {
@@ -53,6 +58,56 @@ class CheckRoutesTest extends TestCase
         }
         if ($checked === false) {
             $this->assertTrue(is_callable($callable), "Not callable! Invalid route for path {$path} : {$callable}");
+        }
+    }
+
+    public function provideRouteWithDefaultParameters(): array
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+        $result = [];
+        for ($flags = 0b0000; $flags <= 0b1111; $flags++) {
+            $result[] = [
+                $app,
+                ($flags & 0b0001) !== 0,
+                ($flags & 0b0010) !== 0,
+                ($flags & 0b0100) !== 0,
+                ($flags & 0b1000) !== 0,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @dataProvider provideRouteWithDefaultParameters
+     */
+    public function testRouteWithArguments(Application $app, bool $requestArgumentValue, bool $requestWithTrailingSlash, bool $routeWithTrailingShash, bool $routeWithDefaultArgumentValue): void
+    {
+        $router = $app->build(Router::class);
+        $request = Request::create('http://localhost/foo/bar' . ($requestArgumentValue ? '/custom-baz' : '') . ($requestWithTrailingSlash ? '/' : ''));
+        $route = $router->register('/foo/bar/{baz}' . ($routeWithTrailingShash ? '/' : ''), static function ($baz) { return $baz; });
+        if ($routeWithDefaultArgumentValue) {
+            $route->setDefaults(['baz' => 'default-baz']);
+        }
+        $matchedRoute = null;
+        $marchError = null;
+        try {
+            $matchedRoute = $router->matchRoute($request);
+        } catch (Throwable $x) {
+            $marchError = $x;
+        }
+        if ($requestArgumentValue === false && $routeWithDefaultArgumentValue === false) {
+            $this->assertInstanceOf(ResourceNotFoundException::class, $marchError);
+        } else {
+            $this->assertInstanceOf(MatchedRoute::class, $matchedRoute);
+            $this->assertSame($route, $matchedRoute->getRoute());
+            $foundArguments = $matchedRoute->getArguments();
+            $this->assertArrayHasKey('baz', $foundArguments);
+            if ($requestArgumentValue) {
+                $this->assertSame('custom-baz', $foundArguments['baz']);
+            } else {
+                $this->assertSame('default-baz', $foundArguments['baz']);
+            }
         }
     }
 }


### PR DESCRIPTION
Routes can have optional arguments, which are defined by specifying their default values.

For example, if we have:

```php
$route = $router->register('/foo/bar/{baz}'), $callback);
$route->setDefaults(['baz' => 'default-baz']);
```

The route should handle requests like `http://www.example.com/foo/bar/sample` and `http://www.example.com/foo/bar`.
In the first case, `$callback` receives a value of `sample` for the `$baz` argument, in the second case it should receive `default-baz`.

BTW, our current routing system doesn't work well with default arguments.

In this PR I first add a test for this (it should fail), after I'll add a fix.