### PR TITLE
[v8] Don't use Symfony NativeSessionHandler

### DIFF
--- a/concrete/src/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/concrete/src/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Core\Session\Storage\Handler;
 
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
+use SessionHandler;
 
 /**
  * NativeFileSessionHandler.
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandle
  * to. Those directories should be able to be warded off for security reasons using open_basedir restrictions. By
  * testing the existence of that directory such a restriction is useless as it will always generate a fatal error.
  */
-class NativeFileSessionHandler extends NativeSessionHandler
+class NativeFileSessionHandler extends SessionHandler
 {
     /**
      * Constructor.


### PR DESCRIPTION
concrete5 v8 requires [`"symfony/http-foundation": "^3.4.17"`](https://github.com/concrete5/concrete5/blob/8.5.4/concrete/composer.json#L35), and since version 3.4 [we should use](https://github.com/symfony/http-foundation/blob/v3.4.17/Session/Storage/Handler/NativeSessionHandler.php#L22) `\SessionHandler` instead of `ymfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler`.