### PR TITLE
Fix #5578 some of non-existing collection path shows home page on multilingual site

### DIFF
--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -205,9 +205,9 @@ class PageController extends Controller
             $requestPath = $request->getPath();
         }
 
-        if (strpos($requestPath, $this->c->getCollectionPath()) !== false) {
+        if (!empty($this->c->getCollectionPath()) && strpos($requestPath, $this->c->getCollectionPath()) !== false) {
             // If the request path starts with the collection path, remove it
-        $task = substr($requestPath, strlen($this->c->getCollectionPath()) + 1);
+            $task = substr($requestPath, strlen($this->c->getCollectionPath()) + 1);
         } else {
             // Otherwise, just remove leading slash
             $task = ltrim($requestPath, '/');

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -336,17 +336,6 @@ class PageController extends Controller
             }
         }
 
-        // If a request path is shorter than the collection path, the request is not valid
-        // Example: If a request is made to "domain.com/d" but the shortest path is "domain.com/de"
-        // a 404 response should be returned.
-        $requestPath = $this->request->getPath();
-        if ($requestPath !== '') {
-            $collectionPath = $this->getPageObject()->getCollectionPath();
-            if (strlen($requestPath) < strlen($collectionPath)) {
-                $valid = false;
-            }
-        }
-
         $this->requestValidated = $valid;
 
         return $valid;

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -204,7 +204,14 @@ class PageController extends Controller
         if ($requestPath === null) {
             $requestPath = $request->getPath();
         }
+
+        if (strpos($requestPath, $this->c->getCollectionPath()) !== false) {
+            // If the request path starts with the collection path, remove it
         $task = substr($requestPath, strlen($this->c->getCollectionPath()) + 1);
+        } else {
+            // Otherwise, just remove leading slash
+            $task = ltrim($requestPath, '/');
+        }
         $task = str_replace('-/', '', $task);
         $taskparts = explode('/', $task);
         if (isset($taskparts[0]) && $taskparts[0] !== '') {


### PR DESCRIPTION
Original issue #5578 is already closed, but #8268 is not enough to fix the issue.

For example, if there're some multilingual sections like `/en` and `/ja` in your site, still you'll get the home page in some cases.

/f -> Not found ( #8268 fixes this case only, because only this request path is shorter than `/en` )
/fo -> Show default home page
/foo -> Show default home page
/fooo -> Not found

After merging this pull request, you'll get Page Not Found on all paths above.