### PR TITLE
Make it enable to add multibyte banned words

### DIFF
--- a/concrete/src/Validation/BannedWord/BannedWord.php
+++ b/concrete/src/Validation/BannedWord/BannedWord.php
@@ -4,6 +4,9 @@ namespace Concrete\Core\Validation\BannedWord;
 use Concrete\Core\Foundation\ConcreteObject;
 use Loader;
 
+/**
+ * @deprecated This class will be migrated to Entity class from version 9.
+ */
 class BannedWord extends ConcreteObject
 {
     protected $id;

--- a/concrete/src/Validation/BannedWord/BannedWordList.php
+++ b/concrete/src/Validation/BannedWord/BannedWordList.php
@@ -3,6 +3,9 @@ namespace Concrete\Core\Validation\BannedWord;
 
 use Concrete\Core\Legacy\DatabaseItemList;
 
+/**
+ * @deprecated This class will be removed from version 9.
+ */
 class BannedWordList extends DatabaseItemList
 {
     public function __construct()

--- a/concrete/src/Validation/BannedWord/Service.php
+++ b/concrete/src/Validation/BannedWord/Service.php
@@ -1,27 +1,48 @@
 <?php
+
 namespace Concrete\Core\Validation\BannedWord;
 
 class Service
 {
+    /** @deprecated */
     const CASE_FIRST_LOWER = 0;
+    /** @deprecated */
     const CASE_FIRST_UPPER = 1;
+    /** @deprecated */
     const CASE_HAS_LOWER = 2;
+    /** @deprecated */
     const CASE_HAS_UPPER = 4;
+    /** @deprecated */
     const CASE_HAS_NONALPH = 8;
+    /** @deprecated */
     const CASE_MIXED = 6;
-
+    /** @deprecated */
     const TRUNCATE_CHARS = '';
+    /** @deprecated */
     const TRUNCATE_WORDS = '\s+';
+    /** @deprecated */
     const TRUNCATE_SENTS = '[!.?]\s+';
+    /** @deprecated */
     const TRUNCATE_PARS = '\n{2,}';
 
+    /** @var string[] From version 9, this will be private. */
     public $bannedWords;
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $file
+     *
+     * @return false
+     */
     public function getCSV_simple($file)
     {
         return false;
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     */
     public function loadBannedWords()
     {
         if ($this->bannedWords) {
@@ -29,16 +50,23 @@ class Service
         }
         $bw = new BannedWordList();
         $bannedWords = $bw->get();
-        $this->bannedWords = array();
+        $this->bannedWords = [];
         foreach ($bannedWords as $word) {
             $this->bannedWords[] = $word->getWord();
         }
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $word
+     *
+     * @return int
+     */
     public function wordCase($word)
     {
-        $lower = "abcdefghijklmnopqrstuvwxyz";
-        $UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        $lower = 'abcdefghijklmnopqrstuvwxyz';
+        $UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $i = 0;
         $case = 0;
         while ($c = $word[$i]) {
@@ -63,6 +91,12 @@ class Service
         return $case;
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $case
+     * @param $word
+     */
     public function forceCase($case, &$word)
     {
         $word = strtolower($word);
@@ -81,6 +115,13 @@ class Service
         }
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $word
+     *
+     * @return bool
+     */
     public function isBannedWord(&$word)
     {
         $case = self::wordCase($word);
@@ -99,7 +140,7 @@ class Service
     public function setBannedWords($bannedWords)
     {
         $this->bannedWords = $bannedWords;
-                }
+    }
 
     /**
      * @return string[]
@@ -109,11 +150,13 @@ class Service
         if (!is_array($this->bannedWords) || count($this->bannedWords) === 0) {
             $this->loadBannedWords();
         }
+
         return $this->bannedWords;
-            }
+    }
 
     /**
      * @param string $string String to check it has banned words. From version 9, it won't be passed by reference.
+     *
      * @return int Return 1 if string has banned words, otherwise 0. From version 9, it will return boolean.
      */
     public function hasBannedWords(&$string)
@@ -124,12 +167,19 @@ class Service
             if (mb_stripos($string, $bannedWord) !== false) {
                 $out = 1;
                 break;
-        }
+            }
         }
 
         return $out;
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $string
+     *
+     * @return bool
+     */
     public function hasBannedPart($string)
     {
         $this->loadBannedWords();
@@ -143,24 +193,41 @@ class Service
         return false;
     }
 
-    public function truncate($string, $num, $which = self::TRUNCATE_CHARS, $ellipsis = "&#8230;")
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $string
+     * @param $num
+     * @param string $which
+     * @param string $ellipsis
+     *
+     * @return string
+     */
+    public function truncate($string, $num, $which = self::TRUNCATE_CHARS, $ellipsis = '&#8230;')
     {
         $parts = preg_split("/($which)/", $string, -1, PREG_SPLIT_DELIM_CAPTURE);
         $i = 0;
-        $out = "";
+        $out = '';
         while (count($parts) && ++$i < $num) {
-            $out .= array_shift($parts).array_shift($parts);
+            $out .= array_shift($parts) . array_shift($parts);
         }
         if (count($parts)) {
-            $out = trim($out).$ellipsis;
+            $out = trim($out) . $ellipsis;
         }
 
         return $out;
     }
 
+    /**
+     * @deprecated this method will be removed from version 9
+     *
+     * @param $inputArray
+     *
+     * @return array
+     */
     public function getBannedKeys($inputArray)
     {
-        $error_keys = array();
+        $error_keys = [];
         if (is_array($inputArray) && count($inputArray)) {
             foreach (array_keys($inputArray) as $k) {
                 if (is_string($inputArray[$k]) && $this->hasBannedWords($inputArray[$k])) {

--- a/concrete/src/Validation/BannedWord/Service.php
+++ b/concrete/src/Validation/BannedWord/Service.php
@@ -93,48 +93,38 @@ class Service
         return false;
     }
 
+    /**
+     * @param string[] $bannedWords
+     */
+    public function setBannedWords($bannedWords)
+    {
+        $this->bannedWords = $bannedWords;
+                }
+
+    /**
+     * @return string[]
+     */
+    public function getBannedWords()
+    {
+        if (!is_array($this->bannedWords) || count($this->bannedWords) === 0) {
+            $this->loadBannedWords();
+        }
+        return $this->bannedWords;
+            }
+
+    /**
+     * @param string $string String to check it has banned words. From version 9, it won't be passed by reference.
+     * @return int Return 1 if string has banned words, otherwise 0. From version 9, it will return boolean.
+     */
     public function hasBannedWords(&$string)
     {
-        $alpha = "abcdefghijklmnopqrstuvwxyz";
-        $alpha   .= strtoupper($alpha);
-        $start = $end = 0;
-        $ra = 0;
-        $i = 0;
         $out = 0;
-        while ($c = $string[$i]) {
-            if ($ra) {
-                if (strpos($alpha, $c) !== false) {
-                } else {
-                    $ra = 0;
-                    $end = $i;
-                    $word = substr($string, $start, $end - $start);
-                    if ($this->isBannedWord($word)) {
-                        ++$out;
-                        $string = substr($string, 0, $start).
-                      $word.
-                      substr($string, $end);
-                    }
-                }
-            } else {
-                if (strpos($alpha, $c) !== false) {
-                    $ra = 1;
-                    $start = $i;
-                } else {
-                }
-            }
-            ++$i;
+        $bannedWords = $this->getBannedWords();
+        foreach ($bannedWords as $bannedWord) {
+            if (mb_stripos($string, $bannedWord) !== false) {
+                $out = 1;
+                break;
         }
-        if ($ra) {
-            $word = substr($string, $start);
-            if ($this->isBannedWord($word)) {
-                ++$out;
-                $string = substr($string, 0, $start).
-                  $word;
-            }
-        }
-        if (strlen($this->errorMsg) && !$this->errorMsgDisplayed) {
-            //echo "<div class=\"infoBox\">$this->errorMsg</div>";
-            //$this->errorMsgDisplayed=1;
         }
 
         return $out;

--- a/tests/tests/Validation/BannedWordTest.php
+++ b/tests/tests/Validation/BannedWordTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Concrete\Tests\Validation;
+
+use Concrete\Core\Validation\BannedWord\Service;
+use PHPUnit_Framework_TestCase;
+
+class BannedWordTest extends PHPUnit_Framework_TestCase
+{
+    public function testHasBannedWords()
+    {
+        $service = new Service();
+        $service->setBannedWords(['lorem', 'NSECT', 'perché', '建築家']);
+        $haystacks = [
+            'Lorem ipsum dolor sit amet',
+            'consectetur adipiscing elit',
+            'Tuttavia, perché voi intendiate da dove sia nato tutto questo errore',
+            '人間の喜びを築く建築家の実践的な教えを詳しく説明しよう'
+        ];
+        foreach ($haystacks as $haystack) {
+            $this->assertTrue((bool) $service->hasBannedWords($haystack), sprintf('Has Banned Word check failed with %s', $haystack));
+        }
+        $service->setBannedWords(['Duis', 'aute', 'spiegherò', '憤り']);
+        foreach ($haystacks as $haystack) {
+            $this->assertFalse((bool) $service->hasBannedWords($haystack), sprintf('Has not Banned Word check failed with %s', $haystack));
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #8202 but also I added `@deprecated` to unused, old-school functions.
This class was written by Tony, and never updated since 5.4.
https://github.com/concrete5/concrete5-legacy/blob/5.4.2/web/concrete/helpers/validation/banned_words.php
I'd like to rewrite BannedWord class as Doctrine entity for version 9. Can I?