### PR TITLE
Fix User singleton when logging in via code

### DIFF
--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -152,7 +152,6 @@ class Login extends PageController implements LoggerAwareInterface
         User $u
     )
     {
-        $this->app->instance(User::class, $u);
         if (!$type || !($type instanceof AuthenticationType)) {
             return $this->view();
         }

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -1022,6 +1022,7 @@ class User extends ConcreteObject
         if ($cache_interface) {
             $app->make('helper/concrete/ui')->cacheInterfaceItems();
         }
+        $app->instance(User::class, $this);
     }
 
     /**

--- a/tests/tests/Block/BlockRenderTest.php
+++ b/tests/tests/Block/BlockRenderTest.php
@@ -102,9 +102,6 @@ class BlockRenderTest extends PageTestCase
 
     public function testBlockViewChangingScopeVariables()
     {
-
-        $this->markTestIncomplete('Not implemented - User singleton in UserServiceProvider breaks this test.');
-
         AuthenticationType::add('concrete', 'Concrete');
 
         // Add the user and enter it to the admin group


### PR DESCRIPTION
The current way we store the User singleton works when logging in via web.

Let's make it work if we log in via code too.