### PR TITLE
Do not print assets directly on dialog view to avoid cache problem

### DIFF
--- a/concrete/src/View/DialogView.php
+++ b/concrete/src/View/DialogView.php
@@ -27,14 +27,22 @@ class DialogView extends ConcreteView
         return null;
     }
 
+    public function renderViewContents($scopeItems)
+    {
+        $contents = '<!--ccm:assets:'.Asset::ASSET_POSITION_HEADER.'//-->';
+        $contents .= '<!--ccm:assets:'.Asset::ASSET_POSITION_FOOTER.'//-->';
+        $contents .= parent::renderViewContents($scopeItems);
+
+        return $contents;
+    }
 
     public function outputAssetIntoView($item)
     {
         if ($item instanceof Asset) {
             $formatter = new JavascriptFormatter();
-            print $formatter->output($item);
+            return $formatter->output($item);
         } else {
-            print $item . "\n";
+            return $item . "\n";
         }
     }
 


### PR DESCRIPTION
Sometimes composer form cached on browsers due to lack of `cache-control: no-cache, private` header.

![Screen Shot 2020-09-28 at 20 45 37](https://user-images.githubusercontent.com/514294/94477997-973b2c00-020d-11eb-8f78-5ffadd90def1.png)

This pull request fixes #3697 (already closed but not yet fixed), #3696, #6781