### PR TITLE
[V9] Use UserMessageException when invalid path traversal is detected

### DIFF
--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Http;
 
 use Concrete\Core\Application\Application;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\Middleware\DispatcherDelegate;
 use Concrete\Core\Http\Middleware\MiddlewareStack;
 use Concrete\Core\Routing\Redirect;
@@ -48,7 +49,7 @@ class DefaultDispatcher implements DispatcherInterface
 
         if (substr($path, 0, 3) == '../' || substr($path, -3) == '/..' || strpos($path, '/../') ||
             substr($path, 0, 3) == '..\\' || substr($path, -3) == '\\..' || strpos($path, '\\..\\')) {
-            throw new \RuntimeException(t('Invalid path traversal. Please make this request with a valid HTTP client.'));
+            throw new UserMessageException(t('Invalid path traversal. Please make this request with a valid HTTP client.'));
         }
 
         $response = null;


### PR DESCRIPTION
When we detect an invalid path traversal, we currently throw a RuntimeException.

This is not correct IMHO: such exceptions aren't displayed to the users by default, and this may ring all sort of alarm bells for system admins.

What about throwing an UserMessageException instead?