### PR TITLE
[v8] Fix doctrine dbal incompatibility - Take 2

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "ext-PDO": "*",
     "php": ">=5.5.9",
-    "doctrine/dbal": "~2.5",
+    "doctrine/dbal": "~2.5 <2.11",
     "symfony/class-loader": "3.*",
     "symfony/http-foundation": "^3.4.17",
     "symfony/routing": "3.*",

--- a/concrete/src/Database/Driver/PDOStatement.php
+++ b/concrete/src/Database/Driver/PDOStatement.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Database\Driver;
  * The PDO implementation of the Statement interface.
  * Used by all PDO-based drivers.
  *
- * @method @deprecated void free()
+ * @since 2.0
  */
 class PDOStatement extends \Doctrine\DBAL\Driver\PDOStatement
 {
@@ -29,25 +29,19 @@ class PDOStatement extends \Doctrine\DBAL\Driver\PDOStatement
 
     /**
      * @deprecated
+     * alias to old ADODB method
+     */
+    public function free()
+    {
+        return $this->closeCursor();
+    }
+
+    /**
+     * @deprecated
      * alias to old ADODB result method
      */
     public function numRows()
     {
         return $this->rowCount();
-    }
-
-    public function __call($name, $arguments)
-    {
-        switch (strtolower($name)) {
-            case 'free':
-                $this->closeCursor();
-                return;
-            default:
-                $msg = sprintf('Call to undefined method %s::%s()', get_class(), $name);
-                if (class_exists('Error')) {
-                    throw new \Error($msg);
-                }
-                trigger_error($msg, E_USER_ERROR);
-        }
     }
 }


### PR DESCRIPTION
Because the PHP bug https://bugs.php.net/bug.php?id=52098 has not been fixed for all the PHP versions that concrete5 v8 currently supports, we can't fix #9050 with #9052 (for the supported PHP versions see [this example](https://3v4l.org/tTYgg)).

So, the only viable solution for v8 is to require a version of DBAL lower than 2.11.