### PR TITLE
Easily tell git to ignore built assets

### DIFF
--- a/build/.npmrc
+++ b/build/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true

--- a/build/libraries/fs.js
+++ b/build/libraries/fs.js
@@ -1,6 +1,8 @@
 var fs = require('fs');
 var path = require('path');
 
+const WEBROOT = path.dirname(path.dirname(__dirname));
+
 /** Escape a parameter so that it's safe to use it with terminal scripts.
 * @function
 * @param {string} arg The argument to be escaped.
@@ -328,6 +330,7 @@ function copyFile(from, to, callback) {
 	});
 }
 
+exports.WEBROOT = WEBROOT;
 exports.isDirectory = isDirectory;
 exports.isFile = isFile;
 exports.fileExists = fileExists;

--- a/build/libraries/git-skip.js
+++ b/build/libraries/git-skip.js
@@ -81,7 +81,7 @@ function getSkippablePaths()
         'themes/concrete/main.js',
         'themes/dashboard/main.css',
         'themes/dashboard/main.js',
-        'themes/elemental//main.js',
+        'themes/elemental/main.js',
         'themes/elemental/main.css',
     ].concat(
         listCopiedFiles(path.join(fsUtil.WEBROOT, 'build/node_modules/@fortawesome/fontawesome-free/webfonts'), 'css/webfonts')

--- a/build/libraries/git-skip.js
+++ b/build/libraries/git-skip.js
@@ -1,0 +1,169 @@
+const fsUtil = require('./fs')
+const fs = require('fs')
+const path = require('path')
+const child_process = require('child_process')
+
+const DIR_GITROOT = path.join(fsUtil.WEBROOT, 'concrete')
+
+if (process.argv.indexOf('-h') > 1 || process.argv.indexOf('--help') > 1 || process.argv.indexOf('/?') > 1) {
+    exitWithSyntax(0)
+}
+
+setSkipWorktree(getSkippablePaths(), getSkipOption())
+
+function exitWithSyntax(returnCode)
+{
+    console.log(`Syntax: ${fsUtil.escapeShellArg(process.argv[0])} ${fsUtil.escapeShellArg(process.argv[1])} <0|no|off|false|1|yes|on|true>`)
+    process.exit(returnCode)
+}
+
+function getSkipOption()
+{
+    if (process.argv.length !== 3) {
+        exitWithSyntax(1)
+    }
+    switch (process.argv[2].toLowerCase()) {
+        case '0':
+        case 'no':
+        case 'off':
+        case 'false':
+            return false
+        case '1':
+        case 'yes':
+        case 'on':
+        case 'true':
+            return true
+    }
+    exitWithSyntax(1)
+}
+
+function getSkippablePaths()
+{
+    return [
+        'blocks/gallery/auto.js',
+        'css/ckeditor/concrete.css',
+        'css/cms.css',
+        'css/features/basics/frontend.css',
+        'css/features/boards/frontend.css',
+        'css/features/calendar/frontend.css',
+        'css/features/conversations/frontend.css',
+        'css/features/documents/frontend.css',
+        'css/features/express/frontend.css',
+        'css/features/faq/frontend.css',
+        'css/features/imagery/frontend.css',
+        'css/features/maps/frontend.css',
+        'css/features/multilingual/frontend.css',
+        'css/features/navigation/frontend.css',
+        'css/features/polls/frontend.css',
+        'css/features/search/frontend.css',
+        'css/features/social/frontend.css',
+        'css/features/taxonomy/frontend.css',
+        'css/features/testimonials/frontend.css',
+        'css/features/video/frontend.css',
+        'css/fontawesome/all.css',
+        'css/fullcalendar.css',
+        'images/icons/bedrock/sprites.svg',
+        'js/ckeditor/concrete.js',
+        'js/cms.js',
+        'js/features/boards/frontend.js',
+        'js/features/calendar/frontend.js',
+        'js/features/conversations/frontend.js',
+        'js/features/documents/frontend.js',
+        'js/features/express/frontend.js',
+        'js/features/imagery/frontend.js',
+        'js/features/maps/frontend.js',
+        'js/features/multilingual/frontend.js',
+        'js/features/navigation/frontend.js',
+        'js/fullcalendar.js',
+        'js/jquery.js',
+        'js/vue.js',
+        'themes/concrete/main.css',
+        'themes/concrete/main.js',
+        'themes/dashboard/main.css',
+        'themes/dashboard/main.js',
+        'themes/elemental//main.js',
+        'themes/elemental/main.css',
+    ].concat(
+        listCopiedFiles(path.join(fsUtil.WEBROOT, 'build/node_modules/@fortawesome/fontawesome-free/webfonts'), 'css/webfonts')
+    ).concat(
+        listCopiedFiles(path.join(fsUtil.WEBROOT, 'build/node_modules/ace-builds/src-min'), 'js/ace')
+    ).concat(
+        listCopiedFiles(path.join(fsUtil.WEBROOT, 'build/node_modules/ckeditor4'), 'js/ckeditor')
+    )
+}
+
+function listCopiedFiles(sourceDir, relDestDir)
+{
+    const gitResult = child_process.spawnSync(
+        'git',
+        ['ls-files'],
+        {
+            cwd: path.join(DIR_GITROOT, relDestDir),
+            stdio: 'pipe',
+            shell: true,
+            encoding: 'utf-8',
+        }
+    )
+    if (gitResult.status !== 0) {
+        if (gitResult.error) {
+            throw gitResult.error
+        }
+        process.exit(1)
+    }
+    const gitFiles = gitResult.stdout.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n').filter(line => line.length > 0)
+    const fsFiles = listAllFiles(path.join(DIR_GITROOT, relDestDir))
+    const commonFiles = gitFiles.filter(file => fsFiles.indexOf(file) >= 0)
+    return commonFiles.map(file => relDestDir + '/' + file)
+}
+
+function listAllFiles(path, callback)
+{
+    const result = []
+    const walker = function(path, prefix, callback)
+    {
+        fs.readdirSync(
+            path,
+            {
+                withFileTypes: true
+            }
+        ).forEach(entry => {
+            if(entry.isDirectory()) {
+                walker(path + '/' + entry.name, prefix + entry.name + '/', callback)
+            } else {
+                result.push(prefix + entry.name)
+            }
+        })
+    }
+    walker(path, '', callback)
+    return result
+}
+
+function setSkipWorktree(paths, skip)
+{
+    const CHUNK_SIZE = 150
+    for (let index = 0; index < paths.length; index += CHUNK_SIZE) {
+        const args = [
+            'update-index',
+            '-q',
+            skip ? '--skip-worktree' : '--no-skip-worktree',
+        ]
+        paths.slice(index, index + CHUNK_SIZE).forEach(path => {
+            args.push(fsUtil.escapeShellArg(path))
+        })
+        const gitResult = child_process.spawnSync(
+            'git',
+            args,
+            {
+                cwd: DIR_GITROOT,
+                stdio: 'inherit',
+                shell: true,
+            }
+        )
+        if (gitResult.status !== 0) {
+            if (gitResult.error) {
+                throw gitResult.error
+            }
+            process.exit(1)
+        }
+    }
+}

--- a/build/package.json
+++ b/build/package.json
@@ -1,13 +1,15 @@
 {
   "name": "concrete5",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch-poll": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js --watch-poll",
-    "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "prod": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "git-skip" : "node ./libraries/git-skip yes",
+    "git-unskip" : "node ./libraries/git-skip no",
+    "dev": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "development": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch-poll": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js --watch-poll",
+    "hot": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "prod": "npm run-script git-unskip && cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "npm run-script git-unskip && cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
     "@concretecms/bedrock": "github:concrete5/bedrock",

--- a/build/package.json
+++ b/build/package.json
@@ -3,13 +3,13 @@
   "scripts": {
     "git-skip" : "node ./libraries/git-skip yes",
     "git-unskip" : "node ./libraries/git-skip no",
-    "dev": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "development": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch-poll": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js --watch-poll",
-    "hot": "npm run-script git-skip && cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "prod": "npm run-script git-unskip && cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "npm run-script git-unskip && cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch-poll": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js --watch-poll",
+    "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "prod": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
     "@concretecms/bedrock": "github:concrete5/bedrock",

--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -36,6 +36,11 @@ mix.options({
 
 mix.setPublicPath('../concrete');
 
+/********************************************************/
+/* IMPORTANT: when you add/remove a generated asset,    */
+/* remember to update libraries/git-skip.js accordingly */
+/********************************************************/
+
 /**
  * Copy pre-minified assets.
  */


### PR DESCRIPTION
When writing the source javascript/css assets, we often need to build the compiled assets.

When we commit the changes, we may want to commit only the changed source files, not the compiled files.

This is a bit of a mess at the moment.

What about adding an easy way to tell git to ignore the compiled assets?

This pull request:

- add two new `npm` commands:
   - `npm run-script git-skip` tells git to ignore the compiled assets
   - `npm run-script git-unskip` tells git to consider the compiled assets
- for convenience, we also call:
   - `git-skip` when building the assets for development (eg `npm run-script dev`)
   - `git-unskip` when building the assets for production (eg `npm run-script prod`)
