### PR TITLE
[V8] Remove Account Menu stuff from header_required element

### DIFF
--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -190,11 +190,6 @@ if (!empty($alternateHreflangTags)) {
 
 <?php
 $v = View::getRequestInstance();
-$u = $app->make(Concrete\Core\User\User::class);
-if ($u->isRegistered()) {
-    $v->requireAsset('core/account');
-    $v->addFooterItem('<script type="text/javascript">$(function() { if (window.ccm_enableUserProfileMenu) ccm_enableUserProfileMenu(); });</script>');
-}
 if ($cp) {
     View::element('page_controls_header', ['cp' => $cp, 'c' => $c]);
     if ($isEditMode) {


### PR DESCRIPTION
Everything needed is already added by the [`footer_required` element](https://github.com/concrete5/concrete5/blob/8.5.4/concrete/elements/footer_required.php#L37-L58).