### PR TITLE
Avoid an exception on express_entry_detail block when the express form ID is not exists

### DIFF
--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -16,6 +16,7 @@ use Concrete\Core\Search\Result\ItemColumn;
 use Concrete\Core\Support\Facade\Express;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Url\SeoCanonical;
+use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Controller extends BlockController implements UsesFeatureInterface
@@ -102,7 +103,14 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             }
         }
-        $form = $this->entityManager->find('Concrete\Core\Entity\Express\Form', $this->exFormID);
+
+        $form = null;
+        try {
+            $form = $this->entityManager->find('Concrete\Core\Entity\Express\Form', $this->exFormID);
+        } catch (Exception $e) {
+            $logger = $this->app->make('log/exceptions');
+            $logger->addEmergency($e->getMessage());
+        }
 
         if ($form) {
             $express = \Core::make('express');

--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -1,18 +1,15 @@
 <?php
+
 namespace Concrete\Block\ExpressEntryDetail;
 
-use Concrete\Controller\Element\Search\CustomizeResults;
 use Concrete\Core\Attribute\Key\CollectionKey;
-use \Concrete\Core\Block\BlockController;
-use Concrete\Core\Express\Entry\Search\Result\Result;
-use Concrete\Core\Express\EntryList;
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Express\Form\Context\FrontendViewContext;
 use Concrete\Core\Express\Form\Renderer;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Form\Context\ContextFactory;
 use Concrete\Core\Html\Service\Seo;
-use Concrete\Core\Search\Result\ItemColumn;
 use Concrete\Core\Support\Facade\Express;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Url\SeoCanonical;
@@ -21,10 +18,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    protected $btInterfaceWidth = '640';
 
-    protected $btInterfaceWidth = "640";
-    protected $btInterfaceHeight = "400";
+    protected $btInterfaceHeight = '400';
+
     protected $btTable = 'btExpressEntryDetail';
+
     /**
      * @var \Doctrine\ORM\EntityManager
      */
@@ -39,23 +38,23 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function getBlockTypeDescription()
     {
-        return t("Add an Express entry detail display to a page.");
+        return t('Add an Express entry detail display to a page.');
     }
 
     public function getBlockTypeName()
     {
-        return t("Express Entry Detail");
+        return t('Express Entry Detail');
     }
 
     public function getBlockTypeInSetName()
     {
-        return t("Details");
+        return t('Details');
     }
-    
+
     public function getRequiredFeatures(): array
     {
         return [
-            Features::EXPRESS
+            Features::EXPRESS,
         ];
     }
 
@@ -76,7 +75,6 @@ class Controller extends BlockController implements UsesFeatureInterface
                 $this->set('entry', Express::getEntry($this->exSpecificEntryID));
             }
         }
-
     }
 
     public function view()
@@ -104,7 +102,6 @@ class Controller extends BlockController implements UsesFeatureInterface
                 if ($this->entryMode == 'S' && $this->exSpecificEntryID) {
                     $this->set('entry', Express::getEntry($this->exSpecificEntryID));
                 }
-
             }
         }
 
@@ -128,7 +125,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             $this->set('renderer', $renderer);
         }
-
     }
 
     public function action_view_express_entity($exEntryID = null)
@@ -157,14 +153,14 @@ class Controller extends BlockController implements UsesFeatureInterface
         if ($exEntityID) {
             $entity = $this->entityManager->find('Concrete\Core\Entity\Express\Entity', $exEntityID);
             if (is_object($entity)) {
-                $r = new \stdClass;
-                $r->forms = array();
-                foreach($entity->getForms() as $form) {
+                $r = new \stdClass();
+                $r->forms = [];
+                foreach ($entity->getForms() as $form) {
                     $r->forms[] = $form;
                 }
                 ob_start();
                 $form_selector = $this->app->make('form/express/entry_selector');
-                print $form_selector->selectEntry($entity, 'exSpecificEntryID');
+                echo $form_selector->selectEntry($entity, 'exSpecificEntryID');
                 $r->selector = ob_get_contents();
                 ob_end_clean();
 
@@ -175,13 +171,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         \Core::make('app')->shutdown();
     }
 
-
     public function loadData()
     {
         $r = $this->entityManager->getRepository('Concrete\Core\Entity\Express\Entity');
         $entityObjects = $r->findAll();
-        $entities = array('' => t("** Choose Entity"));
-        foreach($entityObjects as $entity) {
+        $entities = ['' => t('** Choose Entity')];
+        foreach ($entityObjects as $entity) {
             $entities[$entity->getID()] = $entity->getEntityDisplayName();
         }
         $this->set('entities', $entities);
@@ -194,5 +189,4 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
         $this->set('expressAttributes', $attributeKeys);
     }
-
 }

--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -25,6 +25,10 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btInterfaceWidth = "640";
     protected $btInterfaceHeight = "400";
     protected $btTable = 'btExpressEntryDetail';
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $entityManager;
 
     public function on_start()
     {


### PR DESCRIPTION
Don't know how, but one of our clients was able to add an `express entry detail` block without the express form ID.
<img width="554" alt="Screen Shot 2020-10-07 at 12 03 46" src="https://user-images.githubusercontent.com/2462951/95282851-3d81d400-0895-11eb-81cf-5c7cab2e9b2f.png">


And then she couldn't fix it as the exception was thrown.
Let's avoid this exception.

