### PR TITLE
Use the ready-to-use "Invalid token" message

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/mail/logging.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/logging.php
@@ -31,7 +31,7 @@ class Logging extends DashboardPageController
                     $this->error->add(t("The log settings are invalid."));
                 }
             } else {
-                $this->error->add(t("The token is invalid."));
+                $this->error->add($this->token->getErrorMessage());
             }
         }
 


### PR DESCRIPTION
Let's save some useless extra work for translators :wink:

cc @bitterdev 