### PR TITLE
[V8] Let's be sure that all the db tables use the configured charset

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20190509000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190509000000.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Database\CharacterSetCollation\Manager;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\LongRunningMigrationInterface;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20190509000000 extends AbstractMigration implements RepeatableMigrationInterface, LongRunningMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $manager = $this->app->make(Manager::class);
+        try {
+            $manager->reapply(
+                $this->connection,
+                function ($message) {
+                    $this->output($message);
+                }
+            );
+        } catch (Exception $x) {
+            $this->output(t('Failed to set character sets: %s', $x->getMessage()));
+        } catch (Throwable $x) {
+            $this->output(t('Failed to set character sets: %s', $x->getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
I just experienced #8981 while trying to upgrade one of our websites from 8.5.2 to 8.5.4.

It turned out that we had mixed collations for the database tables. This prevents the creation of foreign keys (because the linked columns must all use the same collation).

I don't know how this may happen. BTW, to fix this issue, it's enough to reset the collation of all the database tables to the configured values.

For this reason I added a `reapply` method to the `Concrete\Core\Database\CharacterSetCollation\Manager` class, and a migration that calls it.

Closes #8981 