### PR TITLE
Fix Typo in concrete/src/Tree/Node/NodeType.php

### DIFF
--- a/concrete/src/Tree/Node/NodeType.php
+++ b/concrete/src/Tree/Node/NodeType.php
@@ -59,7 +59,7 @@ class NodeType extends ConcreteObject
         $app = Application::getFacadeApplication();
         /** @var RequestCache $cache */
         $cache = $app->make('cache/request');
-        $key = '/Tree/Note/Type/' . $treeNodeTypeID;
+        $key = '/Tree/Node/Type/' . $treeNodeTypeID;
         if ($cache->isEnabled()) {
             $item = $cache->getItem($key);
             if ($item->isHit()) {


### PR DESCRIPTION
We should fix this typo in a subsequent pull request. (Note/Node)

_Originally posted by @aembler in https://github.com/concrete5/concrete5/pull/9042#discussion_r505024288_