### PR TITLE
Fix stack content never updated in some cases

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1112,6 +1112,11 @@ EOT
      */
     public function setBlockCachedOutput($content, $lifetime, $area)
     {
+        // We shouldn't create a cache for stack proxy
+        if ($this->getBlockTypeHandle() === BLOCK_HANDLE_STACK_PROXY) {
+            return false;
+        }
+
         $db = Loader::db();
         $c = $this->getBlockCollectionObject();
 
@@ -1161,6 +1166,11 @@ EOT
      */
     public function getBlockCachedOutput($area)
     {
+        // We shouldn't get a cache for stack proxy
+        if ($this->getBlockTypeHandle() === BLOCK_HANDLE_STACK_PROXY) {
+            return false;
+        }
+
         $db = Loader::db();
 
         $arHandle = $this->getAreaHandle();


### PR DESCRIPTION
Stack proxy block shouldn't prevent full page cache, but it must not create an output cache for entire stack content.

This PR fixes #5717 for 8.5.x only, we should pick this commit for version 9 also.