### PR TITLE
[V9] Avoid to use Connection::executeQuery for insert queries in Collection class

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -11,6 +11,7 @@ use Concrete\Core\Area\GlobalArea;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\CustomStyle as BlockCustomStyle;
 use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Database\Driver\PDOStatement;
 use Concrete\Core\Entity\Attribute\Value\PageValue;
 use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Gathering\Item\Page as PageGatheringItem;
@@ -25,6 +26,7 @@ use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Facade;
 use Config;
+use Doctrine\DBAL\FetchMode;
 use Loader;
 use Page;
 use PageCache;
@@ -98,16 +100,24 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public static function getByID($cID, $version = 'RECENT')
     {
-        $db = Loader::db();
-        $q = 'select Collections.cDateAdded, Collections.cDateModified, Collections.cID from Collections where cID = ?';
-        $row = $db->getRow($q, [$cID]);
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $qb->select('c.cDateAdded', 'c.cDateModified', 'c.cID')
+            ->from('Collections', 'c')
+            ->where('c.cID = :cID')
+            ->setParameter('cID', $cID);
+        $row = $qb->execute()->fetch();
 
         $c = new self();
-        $c->setPropertiesFromArray($row);
+        if ($row !== false) {
+            $c->setPropertiesFromArray($row);
 
-        if ($version != false) {
-            // we don't do this on the front page
-            $c->loadVersionObject($version);
+            if ($version != false) {
+                // we don't do this on the front page
+                $c->loadVersionObject($version);
+            }
         }
 
         return $c;
@@ -123,14 +133,20 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public static function getByHandle($handle)
     {
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $qb->select('c.cID', 'p.cID')
+            ->from('Collections', 'c')
+            ->leftJoin('c', 'Pages', 'p', 'c.cID = p.cID')
+            ->where('c.cHandle = :cHandle')
+            ->setParameter('cHandle', $handle);
 
         // first we ensure that this does NOT appear in the Pages table. This is not a page. It is more basic than that
-        $r = $db->query(
-            'select Collections.cID, Pages.cID as pcID from Collections left join Pages on Collections.cID = Pages.cID where Collections.cHandle = ?',
-            [$handle]
-            );
-        if ($r->numRows() == 0) {
+        /** @var PDOStatement $r */
+        $r = $qb->execute();
+        if ($r->rowCount() === 0) {
             // there is nothing in the collections table for this page, so we create and grab
 
             $data = [
@@ -138,16 +154,14 @@ class Collection extends ConcreteObject implements TrackableInterface
             ];
             $cObj = self::createCollection($data);
         } else {
-            $row = $r->fetchRow();
-            if ($row['cID'] > 0 && $row['pcID'] == null) {
+            $row = $r->fetch();
+            if ($row['cID'] > 0 && $row['pcID'] === null) {
                 // there is a collection, but it is not a page. so we grab it
                 $cObj = self::getByID($row['cID']);
             }
         }
 
-        if (isset($cObj)) {
-            return $cObj;
-        }
+        return $cObj ?? null;
     }
 
     /**
@@ -162,10 +176,16 @@ class Collection extends ConcreteObject implements TrackableInterface
         $indexStack = $app->make(IndexManagerInterface::class);
 
         $num = 0;
-        $db = $app['database']->connection();
-        $r = $db->execute('select cID from PageSearchIndex where cRequiresReindex = 1');
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $r = $qb->select('cID')
+            ->from('PageSearchIndex')
+            ->where('cRequiresReindex = 1')
+            ->execute();
         while ($id = $r->fetchColumn()) {
             $indexStack->index(\Concrete\Core\Page\Page::class, $id);
+            $num++;
         }
         Config::save('concrete.misc.do_page_reindex_check', false);
 
@@ -416,6 +436,11 @@ class Collection extends ConcreteObject implements TrackableInterface
         if ($this->isAlias() && !$this->isExternalLink()) {
             return false;
         }
+
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+
         if ($actuallyDoReindex || Config::get('concrete.page.search.always_reindex') == true) {
             // Retrieve the attribute values for the current page
             $category = \Core::make('Concrete\Core\Attribute\Category\PageCategory');
@@ -431,13 +456,24 @@ class Collection extends ConcreteObject implements TrackableInterface
 
             $index->reindexPage($this);
 
-            $db = \Database::connection();
-            $db->Replace(
-               'PageSearchIndex',
-               ['cID' => $this->getCollectionID(), 'cRequiresReindex' => 0],
-               ['cID'],
-               false
-            );
+            $qb = $db->createQueryBuilder();
+            $r = $qb->select('cID')
+                ->from('PageSearchIndex')
+                ->where('cID = :cID')
+                ->setParameter('cID', $this->getCollectionID())
+                ->execute()->fetch();
+
+            $qb2 = $db->createQueryBuilder();
+            if ($r !== false) {
+                $qb2->update('PageSearchIndex')
+                    ->set('cRequiresReindex', 0)
+                    ->where('cID = :cID');
+            } else {
+                $qb2->insert('PageSearchIndex')
+                    ->setValue('cID', ':cID')
+                    ->setValue('cRequiresReindex', 0);
+            }
+            $qb2->setParameter('cID', $this->getCollectionID())->execute();
 
             $cache = PageCache::getLibrary();
             $cache->purge($this);
@@ -447,14 +483,29 @@ class Collection extends ConcreteObject implements TrackableInterface
             $populator->updateAvailableSummaryTemplates($this);
 
         } else {
-            $db = Loader::db();
             Config::save('concrete.misc.do_page_reindex_check', true);
-            $db->Replace(
-               'PageSearchIndex',
-               ['cID' => $this->getCollectionID(), 'cRequiresReindex' => 1],
-               ['cID'],
-               false
-            );
+
+            $qb = $db->createQueryBuilder();
+            $r = $qb->select('cID')
+                ->from('PageSearchIndex')
+                ->where('cID = :cID')
+                ->setParameter('cID', $this->getCollectionID())
+                ->execute()->fetch();
+
+            $qb2 = $db->createQueryBuilder();
+            if ($r !== false) {
+                $qb2->update('PageSearchIndex')
+                    ->set('cID', $this->getCollectionID())
+                    ->set('cRequiresReindex', 1)
+                    ->where('cID = :cID')
+                    ->setParameter('cID', $this->getCollectionID());
+            } else {
+                $qb2->insert('PageSearchIndex')
+                    ->setValue('cID', ':cID')
+                    ->setValue('cRequiresReindex', 1)
+                    ->setParameter('cID', $this->getCollectionID());
+            }
+            $qb2->execute();
         }
     }
 
@@ -520,21 +571,29 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function clearCollectionAttributes($retainAKIDs = [])
     {
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
         if (count($retainAKIDs) > 0) {
             $cleanAKIDs = [];
             foreach ($retainAKIDs as $akID) {
                 $cleanAKIDs[] = (int) $akID;
             }
-            $akIDStr = implode(',', $cleanAKIDs);
-            $v2 = [$this->getCollectionID(), $this->getVersionID()];
-            $db->query(
-                "delete from CollectionAttributeValues where cID = ? and cvID = ? and akID not in ({$akIDStr})",
-                $v2
-            );
+            $qb->delete('CollectionAttributeValues')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->andWhere($qb->expr()->notIn('akID', $cleanAKIDs))
+                ->setParameter('cID', $this->getCollectionID())
+                ->setParameter('cvID', $this->getVersionID())
+                ->execute();
         } else {
-            $v2 = [$this->getCollectionID(), $this->getVersionID()];
-            $db->query('delete from CollectionAttributeValues where cID = ? and cvID = ?', $v2);
+            $qb->delete('CollectionAttributeValues')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->setParameter('cID', $this->getCollectionID())
+                ->setParameter('cvID', $this->getVersionID())
+                ->execute();
         }
         $this->reindex();
     }
@@ -585,22 +644,32 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function hasAliasedContent()
     {
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
         // aliased content is content on the particular page that is being
         // used elsewhere - but the content on the PAGE is the original version
-        $v = [$this->cID];
-        $q = 'select bID from CollectionVersionBlocks where cID = ? and isOriginal = 1';
-        $r = $db->query($q, $v);
+        $r = $qb->select('bID')
+            ->from('CollectionVersionBlocks')
+            ->where('cID = :cID')
+            ->andWhere('isOriginal = 1')
+            ->setParameter('cID', $this->getCollectionID())
+            ->execute();
         $bIDArray = [];
         if ($r) {
-            while ($row = $r->fetchRow()) {
+            while ($row = $r->fetch()) {
                 $bIDArray[] = $row['bID'];
             }
             if (count($bIDArray) > 0) {
-                $bIDList = implode(',', $bIDArray);
-                $v2 = [$bIDList, $this->cID];
-                $q2 = 'select cID from CollectionVersionBlocks where bID in (?) and cID <> ? limit 1';
-                $aliasedCID = $db->getOne($q2, $v2);
+                $qb2 = $db->createQueryBuilder();
+                $qb2->select('cID')
+                    ->from('CollectionVersionBlocks')
+                    ->where($qb2->expr()->in('bID', $bIDArray))
+                    ->andWhere($qb2->expr()->neq('cID', ':cID'))
+                    ->setParameter('cID', $this->getCollectionID())
+                    ->setMaxResults(1);
+                $aliasedCID = $qb2->execute()->fetchColumn();
                 if ($aliasedCID > 0) {
                     return true;
                 }
@@ -645,18 +714,39 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function setCustomStyleSet($area, $set)
     {
-        $db = Loader::db();
-        $db->Replace(
-            'CollectionVersionAreaStyles',
-            [
-                'cID' => $this->getCollectionID(),
-                'cvID' => $this->getVersionID(),
-                'arHandle' => $area->getAreaHandle(),
-                'issID' => $set->getID(),
-            ],
-            ['cID', 'cvID', 'arHandle'],
-            true
-            );
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $r = $qb->select('cID')
+            ->from('CollectionVersionAreaStyles')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('arHandle = :arHandle')
+            ->setParameter('cID', $this->getCollectionID())
+            ->setParameter('cvID', $this->getVersionID())
+            ->setParameter('arHandle', $area->getAreaHandle())
+            ->execute()->fetch();
+
+        $qb2 = $db->createQueryBuilder();
+        if ($r !== false) {
+            $qb2->update('CollectionVersionAreaStyles')
+                ->set('issID', ':issID')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->andWhere('arHandle = :arHandle');
+        } else {
+            $qb2->insert('CollectionVersionAreaStyles')
+                ->setValue('cID', ':cID')
+                ->setValue('cvID', ':cvID')
+                ->setValue('arHandle', ':arHandle')
+                ->setValue('issID', ':issID');
+        }
+        $qb2->setParameter('cID', $this->getCollectionID())
+            ->setParameter('cvID', $this->getVersionID())
+            ->setParameter('arHandle', $area->getAreaHandle())
+            ->setParameter('issID', $set->getID())
+            ->execute();
     }
 
     /**
@@ -666,15 +756,18 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function resetAreaCustomStyle($area)
     {
-        $db = Loader::db();
-        $db->Execute(
-            'delete from CollectionVersionAreaStyles where cID = ? and cvID = ? and arHandle = ?',
-            [
-                $this->getCollectionID(),
-                $this->getVersionID(),
-                $area->getAreaHandle(),
-            ]
-            );
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $qb->delete('CollectionVersionAreaStyles')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('arHandle = :arHandle')
+            ->setParameter('cID', $this->getCollectionID())
+            ->setParameter('cvID', $this->getVersionID())
+            ->setParameter('arHandle', $area->getAreaHandle())
+            ->execute();
     }
 
     /**
@@ -690,19 +783,31 @@ class Collection extends ConcreteObject implements TrackableInterface
             return '';
         }
 
-        $db = Loader::db();
         $psss = [];
         $txt = Loader::helper('text');
         CacheLocal::set('pssCheck', $this->getCollectionID() . ':' . $this->getVersionID(), true);
 
-        $r1 = $db->GetAll(
-                 'select bID, arHandle, issID from CollectionVersionBlockStyles where cID = ? and cvID = ? and issID > 0',
-                 [$this->getCollectionID(), $this->getVersionID()]
-        );
-        $r2 = $db->GetAll(
-                 'select arHandle, issID from CollectionVersionAreaStyles where cID = ? and cvID = ? and issID > 0',
-                 [$this->getCollectionID(), $this->getVersionID()]
-        );
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb1 = $db->createQueryBuilder();
+        $r1 = $qb1->select('bID', 'arHandle', 'issID')
+            ->from('CollectionVersionBlockStyles')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('issID > 0')
+            ->setParameter(':cID', $this->getCollectionID())
+            ->setParameter(':cvID', $this->getVersionID())
+            ->execute()->fetchAll();
+        $qb2 = $db->createQueryBuilder();
+        $r2 = $qb2->select('arHandle', 'issID')
+            ->from('CollectionVersionAreaStyles')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('issID > 0')
+            ->setParameter(':cID', $this->getCollectionID())
+            ->setParameter(':cvID', $this->getVersionID())
+            ->execute()->fetchAll();
         foreach ($r1 as $r) {
             $issID = $r['issID'];
             $arHandle = $txt->filterNonAlphaNum($r['arHandle']);
@@ -739,10 +844,13 @@ class Collection extends ConcreteObject implements TrackableInterface
         }
 
         // grab all the header block style rules for items in global areas on this page
-        $rs = $db->GetCol(
-                 'select arHandle from Areas where arIsGlobal = 1 and cID = ?',
-                 [$this->getCollectionID()]
-        );
+        $qb3 = $db->createQueryBuilder();
+        $rs = $qb3->select('arHandle')
+            ->from('Areas')
+            ->where('arIsGlobal = 1')
+            ->andWhere('cID = :cID')
+            ->setParameter('cID', $this->getCollectionID())
+            ->execute()->fetchAll(FetchMode::COLUMN);
         if (count($rs) > 0) {
             $pcp = new Permissions($this);
             foreach ($rs as $garHandle) {
@@ -753,10 +861,15 @@ class Collection extends ConcreteObject implements TrackableInterface
                 }
                 if (is_object($s)) {
                     CacheLocal::set('pssCheck', $s->getCollectionID() . ':' . $s->getVersionID(), true);
-                    $rs1 = $db->GetAll(
-                              'select bID, issID, arHandle from CollectionVersionBlockStyles where cID = ? and cvID = ? and issID > 0',
-                              [$s->getCollectionID(), $s->getVersionID()]
-                    );
+                    $qb4 = $db->createQueryBuilder();
+                    $rs1 = $qb4->select('bID', 'issID', 'arHandle')
+                        ->from('CollectionVersionBlockStyles')
+                        ->where('cID', ':cID')
+                        ->andWhere('cvID', ':cvID')
+                        ->andWhere('issID > 0')
+                        ->setParameter('cID', $s->getCollectionID())
+                        ->setParameter('cvID', $s->getVersionID())
+                        ->execute()->fetchAll();
                     foreach ($rs1 as $r) {
                         $issID = $r['issID'];
                         $obj = StyleSet::getByID($issID);
@@ -807,24 +920,31 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function relateVersionEdits($oc)
     {
-        $db = Loader::db();
-        $v = [
-            $this->getCollectionID(),
-            $this->getVersionID(),
-            $oc->getCollectionID(),
-            $oc->getVersionID(),
-        ];
-        $r = $db->GetOne(
-                'select count(*) from CollectionVersionRelatedEdits where cID = ? and cvID = ? and cRelationID = ? and cvRelationID = ?',
-                $v
-        );
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $r = (int) $qb = $qb->select('count(*)')
+            ->from('CollectionVersionRelatedEdits')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('cRelationID = :cRelationID')
+            ->andWhere('cvRelationID = :cvRelationID')
+            ->setParameter('cID', $this->getCollectionID())
+            ->setParameter('cvID', $this->getVersionID())
+            ->setParameter('cRelationID', $oc->getCollectionID())
+            ->setParameter('cvRelationID', $oc->getVersionID())
+            ->execute()->fetchColumn();
         if ($r > 0) {
             return false;
         } else {
-            $db->Execute(
-               'insert into CollectionVersionRelatedEdits (cID, cvID, cRelationID, cvRelationID) values (?, ?, ?, ?)',
-               $v
-            );
+            $qb2 = $db->createQueryBuilder();
+            $qb2->insert('CollectionVersionRelatedEdits')
+                ->setValue('cID', $this->getCollectionID())
+                ->setValue('cvID', $this->getVersionID())
+                ->setValue('cRelationID', $oc->getCollectionID())
+                ->setValue('cvRelationID', $oc->getVersionID())
+                ->execute();
         }
     }
 
@@ -853,9 +973,15 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function getGlobalBlocks()
     {
-        $db = Loader::db();
-        $v = [Stack::ST_TYPE_GLOBAL_AREA];
-        $rs = $db->GetCol('select stName from Stacks where Stacks.stType = ?', $v);
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $rs = $qb->select('stName')
+            ->from('Stacks')
+            ->where('stType = :stType')
+            ->setParameter('stType', Stack::ST_TYPE_GLOBAL_AREA)
+            ->execute()->fetchAll(FetchMode::COLUMN);
         $blocks = [];
         if (count($rs) > 0) {
             $pcp = new Permissions($this);
@@ -914,10 +1040,22 @@ class Collection extends ConcreteObject implements TrackableInterface
         );
 
         if (!is_array($blockIDs)) {
-            $v = [$this->getCollectionID(), $this->getVersionID()];
-            $db = Loader::db();
-            $q = 'select Blocks.bID, CollectionVersionBlocks.arHandle from CollectionVersionBlocks inner join Blocks on (CollectionVersionBlocks.bID = Blocks.bID) inner join BlockTypes on (Blocks.btID = BlockTypes.btID) where CollectionVersionBlocks.cID = ? and (CollectionVersionBlocks.cvID = ? or CollectionVersionBlocks.cbIncludeAll=1) order by CollectionVersionBlocks.cbDisplayOrder asc';
-            $r = $db->GetAll($q, $v);
+            $app = Application::getFacadeApplication();
+            /** @var Connection $db */
+            $db = $app->make(Connection::class);
+            $qb = $db->createQueryBuilder();
+            $r = $qb->select('b.bID', 'cvb.arHandle')
+                ->from('CollectionVersionBlocks', 'cvb')
+                ->innerJoin('cvb', 'Blocks', 'b', 'cvb.bID = b.bID')
+                ->where('cvb.cID = :cID')
+                ->andWhere($qb->expr()->orX(
+                    'cvb.cvID = :cvID',
+                    'cvb.cbIncludeAll = 1'
+                ))
+                ->orderBy('cvb.cbDisplayOrder', 'asc')
+                ->setParameter('cID', $this->getCollectionID())
+                ->setParameter('cvID', $this->getVersionID())
+                ->execute()->fetchAll();
             $blockIDs = [];
             if (is_array($r)) {
                 foreach ($r as $bl) {
@@ -957,7 +1095,9 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function addBlock($bt, $a, $data)
     {
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
 
         // first we add the block to the system
         $nb = $bt->add($data, $this, $a);
@@ -980,26 +1120,33 @@ class Collection extends ConcreteObject implements TrackableInterface
             $newBlockDisplayOrder = $this->getCollectionAreaDisplayOrder($arHandle);
         }
 
-        $cbRelationID = $db->GetOne('select max(cbRelationID) as cbRelationID from CollectionVersionBlocks');
+        $qb = $db->createQueryBuilder();
+        $cbRelationID = (int) $qb->select('max(cbRelationID)')->from('CollectionVersionBlocks')
+            ->execute()->fetchColumn();
         if (!$cbRelationID) {
             $cbRelationID = 1;
         } else {
             ++$cbRelationID;
         }
 
-        $v = [
-            $cID,
-            $vObj->getVersionID(),
-            $nb->getBlockID(),
-            $arHandle,
-            $cbRelationID,
-            $newBlockDisplayOrder,
-            1,
-            (int) ($bt->includeAll()),
-        ];
-        $q = 'insert into CollectionVersionBlocks (cID, cvID, bID, arHandle, cbRelationID, cbDisplayOrder, isOriginal, cbIncludeAll) values (?, ?, ?, ?, ?, ?, ?, ?)';
-
-        $res = $db->Execute($q, $v);
+        $qb2 = $db->createQueryBuilder();
+        $res = $qb2->insert('CollectionVersionBlocks')
+            ->setValue('cID', ':cID')
+            ->setValue('cvID', ':cvID')
+            ->setValue('bID', ':bID')
+            ->setValue('arHandle', ':arHandle')
+            ->setValue('cbRelationID', ':cbRelationID')
+            ->setValue('cbDisplayOrder', ':cbDisplayOrder')
+            ->setValue('isOriginal', 1)
+            ->setValue('cbIncludeAll', ':cbIncludeAll')
+            ->setParameter('cID', $cID)
+            ->setParameter('cvID', $vObj->getVersionID())
+            ->setParameter('bID', $nb->getBlockID())
+            ->setParameter('arHandle', $arHandle)
+            ->setParameter('cbRelationID', $cbRelationID)
+            ->setParameter('cbDisplayOrder', $newBlockDisplayOrder)
+            ->setParameter('cbIncludeAll', (int) ($bt->includeAll()))
+            ->execute();
 
         return Block::getByID($nb->getBlockID(), $this, $a);
     }
@@ -1014,19 +1161,33 @@ class Collection extends ConcreteObject implements TrackableInterface
      */
     public function getCollectionAreaDisplayOrder($arHandle, $ignoreVersions = false)
     {
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
         $cID = $this->cID;
         $cvID = $this->vObj->cvID;
         if ($ignoreVersions) {
-            $q = 'select max(cbDisplayOrder) as cbdis from CollectionVersionBlocks where cID = ? and arHandle = ?';
-            $v = [$cID, $arHandle];
+            $qb->select('max(cbDisplayOrder) as cbdis')
+                ->from('CollectionVersionBlocks')
+                ->where('cID = :cID')
+                ->andWhere('arHandle = :arHandle')
+                ->setParameter('cID', $cID)
+                ->setParameter('arHandle', $arHandle);
         } else {
-            $q = 'select max(cbDisplayOrder) as cbdis from CollectionVersionBlocks where cID = ? and cvID = ? and arHandle = ?';
-            $v = [$cID, $cvID, $arHandle];
+            $qb->select('max(cbDisplayOrder) as cbdis')
+                ->from('CollectionVersionBlocks')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->andWhere('arHandle = :arHandle')
+                ->setParameter('cID', $cID)
+                ->setParameter('cvID', $cvID)
+                ->setParameter('arHandle', $arHandle);
         }
-        $r = $db->query($q, $v);
+        /** @var PDOStatement $r */
+        $r = $qb->execute();
         if ($r) {
-            if ($r->numRows() > 0) {
+            if ($r->rowCount() > 0) {
                 // then we know we got a value; we increment it and return
                 $res = $r->fetchRow();
                 $displayOrder = $res['cbdis'];
@@ -1052,19 +1213,39 @@ class Collection extends ConcreteObject implements TrackableInterface
     {
         // this collection function f
 
-        $db = Loader::db();
         $cID = $this->cID;
         $cvID = $this->vObj->cvID;
-        $args = [$cID, $cvID, $arHandle];
-        $q = 'select bID from CollectionVersionBlocks where cID = ? and cvID = ? and arHandle=? order by cbDisplayOrder asc';
-        $r = $db->query($q, $args);
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $r = $qb->select('bID')
+            ->from('CollectionVersionBlocks')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('arHandle = :arHandle')
+            ->orderBy('cbDisplayOrder', 'asc')
+            ->setParameter('cID', $cID)
+            ->setParameter('cvID', $cvID)
+            ->setParameter('arHandle', $arHandle)
+            ->execute();
 
         if ($r) {
             $displayOrder = 0;
-            while ($row = $r->fetchRow()) {
-                $args = [$displayOrder, $cID, $cvID, $arHandle, $row['bID']];
-                $q = 'update CollectionVersionBlocks set cbDisplayOrder = ? where cID = ? and cvID = ? and arHandle = ? and bID = ?';
-                $db->query($q, $args);
+            while ($row = $r->fetch()) {
+                $qb2 = $db->createQueryBuilder();
+                $qb2->update('CollectionVersionBlocks')
+                    ->set('cbDisplayOrder', ':cbDisplayOrder')
+                    ->where('cID = :cID')
+                    ->andWhere('cvID = :cvID')
+                    ->andWhere('arHandle = :arHandle')
+                    ->andWhere('bID = :bID')
+                    ->setParameter('cbDisplayOrder', $displayOrder)
+                    ->setParameter('cID', $cID)
+                    ->setParameter('cvID', $cvID)
+                    ->setParameter('arHandle', $arHandle)
+                    ->setParameter('bID', $row['bID'])
+                    ->execute();
                 ++$displayOrder;
             }
         }
@@ -1076,14 +1257,19 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function markModified()
     {
         // marks this collection as newly modified
-        $db = Loader::db();
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
         $dh = Loader::helper('date');
         $cDateModified = $dh->getOverridableNow();
 
-        $v = [$cDateModified, $this->cID];
-        $q = 'update Collections set cDateModified = ? where cID = ?';
-        $r = $db->prepare($q);
-        $res = $db->execute($r, $v);
+        $qb = $db->createQueryBuilder();
+        $res = $qb->update('Collections')
+            ->set('cDateModified', ':cDateModified')
+            ->where('cID = :cID')
+            ->setParameter('cDateModified', $cDateModified)
+            ->setParameter('cID', $this->getCollectionID())
+            ->execute();
     }
 
     /**
@@ -1092,7 +1278,9 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function delete()
     {
         if ($this->cID > 0) {
-            $db = Loader::db();
+            $app = Application::getFacadeApplication();
+            /** @var Connection $db */
+            $db = $app->make(Connection::class);
 
             // First we delete all versions
             $vl = new VersionList($this);
@@ -1105,15 +1293,24 @@ class Collection extends ConcreteObject implements TrackableInterface
 
             $cID = $this->getCollectionID();
 
-            $q = "delete from CollectionAttributeValues where cID = {$cID}";
-            $db->query($q);
+            $qb = $db->createQueryBuilder();
+            $qb->delete('CollectionAttributeValues')
+                ->where('cID = :cID')
+                ->setParameter('cID', $cID)
+                ->execute();
 
-            $q = "delete from Collections where cID = '{$cID}'";
-            $r = $db->query($q);
+            $qb = $db->createQueryBuilder();
+            $qb->delete('Collections')
+                ->where('cID = :cID')
+                ->setParameter('cID', $cID)
+                ->execute();
 
             try {
-                $q = "delete from CollectionSearchIndexAttributes where cID = {$cID}";
-                $db->query($q);
+                $qb = $db->createQueryBuilder();
+                $qb->delete('CollectionSearchIndexAttributes')
+                    ->where('cID = :cID')
+                    ->setParameter('cID', $cID)
+                    ->execute();
             } catch (\Exception $e) {
             }
         }

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -495,7 +495,6 @@ class Collection extends ConcreteObject implements TrackableInterface
             $qb2 = $db->createQueryBuilder();
             if ($r !== false) {
                 $qb2->update('PageSearchIndex')
-                    ->set('cID', $this->getCollectionID())
                     ->set('cRequiresReindex', 1)
                     ->where('cID = :cID')
                     ->setParameter('cID', $this->getCollectionID());


### PR DESCRIPTION
I've just created this pull request for moving the discussion of #9126 to forward. It's still a work in progress. At least, I'd like to replace all insert queries in this class at this pull request.