### PR TITLE
page type draft with permission

### DIFF
--- a/concrete/controllers/panel/sitemap.php
+++ b/concrete/controllers/panel/sitemap.php
@@ -48,8 +48,9 @@ class Sitemap extends BackendInterfaceController
         $drafts = ConcretePage::getDrafts($this->site);
         $mydrafts = array();
         foreach ($drafts as $d) {
-            $dp = new Permissions($d);
-            if ($dp->canEditPageContents()) {
+            $pt = $d->getPagetypeObject();
+            $tp = new Permissions($pt);
+            if ($tp->canEditPageTypeDrafts()) {
                 $mydrafts[] = $d;
             }
         }


### PR DESCRIPTION
I made this pull request for issue (#8868 ).
This PR is repaired to show page type according to the permission inside the draft list.