### PR TITLE
Update remove_old_page_versions.php

### DIFF
--- a/concrete/jobs/remove_old_page_versions.php
+++ b/concrete/jobs/remove_old_page_versions.php
@@ -62,8 +62,8 @@ class RemoveOldPageVersions extends AbstractJob
         return t2(
             '%1$d versions deleted from %2$d page (%3$s)',
             '%1$d versions deleted from %2$d pages (%3$s)',
-            $pageCount,
             $versionCount,
+            $pageCount,
             $pageCount,
             implode(',', $pagesAffected)
         );

--- a/concrete/jobs/remove_old_page_versions.php
+++ b/concrete/jobs/remove_old_page_versions.php
@@ -58,7 +58,7 @@ class RemoveOldPageVersions extends AbstractJob
         $pageCount = count($pagesAffected);
         Config::save('concrete.maintenance.version_job_page_num', $pNum);
 
-        //i18n: %1$d is the number of affected pages, %2$d is the number of versions deleted, %1$d is the number of affected pages, %3$d is the number of times that the Remove Old Page Versions job has been executed.
+        //i18n: %1$d is the number of affected pages, %2$d is the number of versions deleted, %3$d is the number of times that the Remove Old Page Versions job has been executed.
         return t2(
             '%2$d version(s) deleted from %1$d page (%3$s)',
             '%2$d version(s) deleted from %1$d pages (%3$s)',

--- a/concrete/jobs/remove_old_page_versions.php
+++ b/concrete/jobs/remove_old_page_versions.php
@@ -60,10 +60,10 @@ class RemoveOldPageVersions extends AbstractJob
 
         //i18n: %1$d is the number of versions deleted, %2$d is the number of affected pages, %3$d is the number of times that the Remove Old Page Versions job has been executed.
         return t2(
-            '%1$d versions deleted from %2$d page (%3$s)',
-            '%1$d versions deleted from %2$d pages (%3$s)',
-            $versionCount,
+            '%2$d version(s) deleted from %1$d page (%3$s)',
+            '%2$d version(s) deleted from %1$d pages (%3$s)',
             $pageCount,
+            $versionCount,
             $pageCount,
             implode(',', $pagesAffected)
         );

--- a/concrete/jobs/remove_old_page_versions.php
+++ b/concrete/jobs/remove_old_page_versions.php
@@ -58,7 +58,7 @@ class RemoveOldPageVersions extends AbstractJob
         $pageCount = count($pagesAffected);
         Config::save('concrete.maintenance.version_job_page_num', $pNum);
 
-        //i18n: %1$d is the number of versions deleted, %2$d is the number of affected pages, %3$d is the number of times that the Remove Old Page Versions job has been executed.
+        //i18n: %1$d is the number of affected pages, %2$d is the number of versions deleted, %1$d is the number of affected pages, %3$d is the number of times that the Remove Old Page Versions job has been executed.
         return t2(
             '%2$d version(s) deleted from %1$d page (%3$s)',
             '%2$d version(s) deleted from %1$d pages (%3$s)',


### PR DESCRIPTION
Variables were swapped.  Upon completion of the job in the dashboard, c5 is reporting back "3 versions deleted from 40 pages (3)" in a case where it should read "40 versions deleted from 3 pages...."

