### PR TITLE
Fix class namespace

### DIFF
--- a/concrete/src/Permission/Registry/Multisite/Object/AuthorObjectRegistry.php
+++ b/concrete/src/Permission/Registry/Multisite/Object/AuthorObjectRegistry.php
@@ -1,5 +1,6 @@
 <?php
-namespace Concrete\Core\Permission\Registry\Object;
+
+namespace Concrete\Core\Permission\Registry\Multisite\Object;
 
 use Concrete\Core\Permission\Registry\AbstractObjectRegistry;
 use Concrete\Core\Permission\Registry\Entry\Object\Object\FileFolder;
@@ -10,7 +11,6 @@ use Concrete\Core\Permission\Registry\Entry\Object\TaskPermissionsEntry;
 
 class AuthorObjectRegistry extends AbstractObjectRegistry
 {
-
     public function __construct()
     {
         $this->addEntry(new PermissionsEntry(new HomePage(), [
@@ -29,7 +29,7 @@ class AuthorObjectRegistry extends AbstractObjectRegistry
         ]));
         $this->addEntry(new PermissionsEntry(new FileFolder('/Shared Files'), [
             'search_file_folder',
-            'add_file'
+            'add_file',
         ]));
 
         $this->addEntry(new PermissionsEntry(new Page('/dashboard/blocks/stacks'), ['view_page'], false));
@@ -44,6 +44,4 @@ class AuthorObjectRegistry extends AbstractObjectRegistry
         $this->addEntry(new TaskPermissionsEntry('add_block'));
         $this->addEntry(new TaskPermissionsEntry('add_stack'));
     }
-
-
 }


### PR DESCRIPTION
`concrete/src/Permission/Registry/Multisite/Object/AuthorObjectRegistry.php` should have `Concrete\Core\Permission\Registry\Multisite\Object` as namespace.
