### PR TITLE
Remove job routes that use tools

### DIFF
--- a/concrete/routes/misc.php
+++ b/concrete/routes/misc.php
@@ -30,11 +30,6 @@ $router->all('/ccm/system/jobs/check_queue', '\Concrete\Controller\Frontend\Jobs
 
 $router->all('/ccm/system/summary_template/render/{categoryHandle}/{memberIdentifier}/{templateID}', '\Concrete\Controller\Backend\SummaryTemplate::render');
 
-// @TODO remove the line below
-$router->all('/tools/required/jobs', '\Concrete\Controller\Frontend\Jobs::view');
-$router->all('/tools/required/jobs/check_queue', '\Concrete\Controller\Frontend\Jobs::check_queue');
-$router->all('/tools/required/jobs/run_single', '\Concrete\Controller\Frontend\Jobs::run_single');
-// end removing lines
 $router->all('/ccm/system/upgrade/', '\Concrete\Controller\Upgrade::view');
 $router->all('/ccm/system/upgrade/submit', '\Concrete\Controller\Upgrade::submit');
 $router->all('/ccm/system/country-stateprovince-link/get_stateprovinces', '\Concrete\Controller\Frontend\CountryDataLink::getStateprovinces');

--- a/concrete/single_pages/dashboard/system/optimization/jobs.php
+++ b/concrete/single_pages/dashboard/system/optimization/jobs.php
@@ -128,7 +128,7 @@ if ($editingJobSet !== null) {
                     <p><?= t('To run all the jobs in this Job Set, schedule this URL using cron or a similar system:') ?></p>
                     <?= $form->textarea(
                         '',
-                        (string) $urlResolver->resolve(["/tools/required/jobs?auth={$auth}&jsID={$editingJobSet->getJobSetID()}"]),
+                        (string) $urlResolver->resolve(["/ccm/system/jobs?auth={$auth}&jsID={$editingJobSet->getJobSetID()}"]),
                         [
                             'class' => 'ccm-default-jobs-url',
                             'rows' => '2',


### PR DESCRIPTION
Let's remove these routes: they were introduced in #1806 just for backward compatibility (their "standard" route alternatives are available since concrete5 5.7.4)