### PR TITLE
Fix bug in  page_types/composer/controls/core_page_property/url_slug element

### DIFF
--- a/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
@@ -73,7 +73,6 @@ $resolverManager = app(ResolverManagerInterface::class);
                     $('.ccm-composer-url-slug-loading').show();
                     $.post(
                         <?= json_encode((string) $resolverManager->resolve(['/ccm/system/page/url_slug'])) ?>,
-                        '<?=REL_DIR_FILES_TOOLS_REQUIRED?>/pages/url_slug',
                         send,
                         function(r) {
                             $('.ccm-composer-url-slug-loading').hide();


### PR DESCRIPTION
This fixes a typo of 58e7b613773ffb0198693edbda0a8b3761168e08 (#9049)