### PR TITLE
Sitemap views:  allow setting includeSystemPages on an instance basis 

### DIFF
--- a/concrete/controllers/dialog/page/sitemap_selector.php
+++ b/concrete/controllers/dialog/page/sitemap_selector.php
@@ -33,19 +33,13 @@ class SitemapSelector extends UserInterfaceController
     {
         /** @var $sanitizer SanitizeService */
         $sanitizer = $this->app->make(SanitizeService::class);
-        $cID = $this->request->query->get('cID');
-        $cID = (int) $sanitizer->sanitizeInt($cID);
-
-        if (!empty($cID)) {
-            $this->set('cID', $cID);
-        }
-
-        $selectMode = $sanitizer->sanitizeString($this->request->query->get('sitemap_select_mode'));
-        if (!empty($selectMode)) {
-            $this->set('selectMode', $selectMode);
-        } else {
-            $this->set('selectMode', '');
-        }
+        $cID = (int) $sanitizer->sanitizeInt($this->request->query->get('cID'));
+        $this->set('cID', $cID ?: null);
+        $selectMode = (string) $sanitizer->sanitizeString($this->request->query->get('sitemap_select_mode'));
+        $this->set('selectMode', $selectMode);
+        $this->set('uniqid', uniqid());
+        $this->set('includeSystemPages', $this->request->query->get('includeSystemPages') ? true : false);
+        $this->set('askIncludeSystemPages', $this->request->query->get('askIncludeSystemPages') ? true : false);
     }
 
     protected function canAccess()

--- a/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
@@ -26,5 +26,6 @@ class SitemapOverlay extends ElementController
         $this->set('overlayID', uniqid());
         $this->set('cParentID', (int) $this->request->query->get('cParentID'));
         $this->set('display', (string) $this->request->query->get('display'));
+        $this->set('includeSystemPages', (bool) $this->request->query->get('includeSystemPages'));
     }
 }

--- a/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
@@ -26,6 +26,6 @@ class SitemapOverlay extends ElementController
         $this->set('overlayID', uniqid());
         $this->set('cParentID', (int) $this->request->query->get('cParentID'));
         $this->set('display', (string) $this->request->query->get('display'));
-        $this->set('includeSystemPages', (bool) $this->request->query->get('includeSystemPages'));
+        $this->set('includeSystemPages', $this->request->query->get('includeSystemPages') ? true : false);
     }
 }

--- a/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/controllers/element/dashboard/sitemap/sitemap_overlay.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\Element\Dashboard\Sitemap;
 
 use Concrete\Core\Controller\ElementController;
@@ -24,9 +25,6 @@ class SitemapOverlay extends ElementController
         }
         $this->set('overlayID', uniqid());
         $this->set('cParentID', (int) $this->request->query->get('cParentID'));
-        $display = $this->request->query->get('display');
-        if (!empty($display)) {
-            $this->set('display', $display);
-        }
+        $this->set('display', (string) $this->request->query->get('display'));
     }
 }

--- a/concrete/controllers/single_page/dashboard/sitemap/explore.php
+++ b/concrete/controllers/single_page/dashboard/sitemap/explore.php
@@ -2,18 +2,18 @@
 
 namespace Concrete\Controller\SinglePage\Dashboard\Sitemap;
 
-use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\Page\Page;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Explore extends DashboardPageController
 {
     public function view($nodeID = 0, $auxMessage = false)
     {
-        $dh = $this->app->make('helper/concrete/dashboard/sitemap');
-        $this->set('dh', $dh);
-        if (!$dh->canRead()) {
+        $canRead = $this->canRead();
+        $this->set('canRead', $canRead);
+        if (!$canRead) {
             return;
         }
         $task = $this->request->request->get('task');
@@ -34,22 +34,19 @@ class Explore extends DashboardPageController
                     $nc->movePageDisplayOrderToBottom();
                     break;
             }
-            $redirectTo = $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/sitemap/explore', $nc->getCollectionParentID(), 'order_updated']);
 
-            return $this->app->make(ResponseFactoryInterface::class)->redirect($redirectTo);
+            return $this->buildRedirect(['/dashboard/sitemap/explore', $nc->getCollectionParentID(), 'order_updated']);
         }
         $nodeID = (int) $nodeID;
         $this->set('nodeID', $nodeID);
-        
-        if ($auxMessage) {
-            switch ($auxMessage) {
-                case 'order_updated':
-                    $this->set('message', t('Sort order saved'));
-                    break;
-            }
+        switch ($auxMessage) {
+            case 'order_updated':
+                $this->set('message', t('Sort order saved'));
+                break;
         }
-        $this->set('includeSystemPages', (bool) $dh->includeSystemPages());
-        $this->addHeaderItem(<<<'EOT'
+        $this->set('includeSystemPages', (bool) $this->app->make('session')->get('ccm-sitemap-includeSystemPages'));
+        $this->addHeaderItem(
+            <<<'EOT'
 <style type="text/css">
     div.ccm-sitemap-explore ul li.ccm-sitemap-explore-paging {
         display: none;
@@ -57,5 +54,24 @@ class Explore extends DashboardPageController
 </style>
 EOT
         );
+    }
+
+    public function include_system_pages($include = 0)
+    {
+        if ($this->canRead()) {
+            $session = $this->app->make('session');
+            if ($include) {
+                $session->set('ccm-sitemap-includeSystemPages', true);
+            } else {
+                $session->remove('ccm-sitemap-includeSystemPages');
+            }
+        }
+
+        return $this->buildRedirect('/dashboard/sitemap/explore');
+    }
+
+    protected function canRead(): bool
+    {
+        return $this->app->make('helper/concrete/dashboard/sitemap')->canRead();
     }
 }

--- a/concrete/controllers/single_page/dashboard/sitemap/full.php
+++ b/concrete/controllers/single_page/dashboard/sitemap/full.php
@@ -1,46 +1,51 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Sitemap;
 
-use Concrete\Core\Multilingual\Service\UserInterface\Flag;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Page\Controller\DashboardSitePageController;
-use Concrete\Core\Routing\Redirect;
-use Concrete\Core\Routing\RedirectResponse;
-use Loader;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Full extends DashboardPageController
 {
     public function view()
     {
-        $dh = Loader::helper('concrete/dashboard/sitemap');
-        $cookie = $this->app->make('cookie');
-        $this->set('includeSystemPages', $dh->includeSystemPages());
-        $this->set('displayDoubleSitemap', $cookie->get('displayDoubleSitemap'));
-        $this->set('flag', $this->app->make(Flag::class));
+        $this->set('canRead', $this->canRead());
+        $session = $this->app->make('session');
+        $this->set('includeSystemPages', (bool) $session->get('ccm-sitemap-includeSystemPages'));
+        $this->set('displayDoubleSitemap', (bool) $session->get('ccm-sitemap-displayDoubleSitemap'));
     }
 
     public function include_system_pages($include = 0)
     {
-        $dh = Loader::helper('concrete/dashboard/sitemap');
-        if ($include == 1) {
-            $dh->setIncludeSystemPages(true);
-        } else {
-            $dh->setIncludeSystemPages(false);
+        if ($this->canRead()) {
+            $session = $this->app->make('session');
+            if ($include) {
+                $session->set('ccm-sitemap-includeSystemPages', true);
+            } else {
+                $session->remove('ccm-sitemap-includeSystemPages');
+            }
         }
-        $response = new RedirectResponse(\URL::to('/dashboard/sitemap/full'));
-        return $response;
+
+        return $this->buildRedirect('/dashboard/sitemap/full');
     }
 
     public function display_double_sitemap($display = 0)
     {
-        $cookie = $this->app->make('cookie');
-        if ($display == 1) {
-            $cookie->set('displayDoubleSitemap', 1);
-        } else {
-            $cookie->set('displayDoubleSitemap', 0);
+        if ($this->canRead()) {
+            $session = $this->app->make('session');
+            if ($display) {
+                $session->set('ccm-sitemap-displayDoubleSitemap', true);
+            } else {
+                $session->remove('ccm-sitemap-displayDoubleSitemap', true);
+            }
         }
-        $response = new RedirectResponse(\URL::to('/dashboard/sitemap/full'));
-        return $response;
+
+        return $this->buildRedirect('/dashboard/sitemap/full');
     }
 
+    protected function canRead(): bool
+    {
+        return $this->app->make('helper/concrete/dashboard/sitemap')->canRead();
+    }
 }

--- a/concrete/elements/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/elements/dashboard/sitemap/sitemap_overlay.php
@@ -11,21 +11,21 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <div class="ccm-sitemap-overlay-<?= $overlayID; ?>"></div>
 
-<script type="text/javascript">
-    $(function () {
-        $('.ccm-sitemap-overlay-<?= $overlayID ?>').concreteSitemap({ 
-            onClickNode: function (node) {
-                ConcreteEvent.publish('SitemapSelectPage', {
-                    cID: node.data.cID,
-                    title: node.title,
-                    instance: this
-                });
-            },
-            cParentID: <?= $cParentID; ?>,
-            displayNodePagination: <?= $display === 'flat' ? 'true' : 'false' ?>,
-            displaySingleLevel: <?= $display === 'flat' ? 'true' : 'false' ?>,
-            includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
-            isSitemapOverlay: true,
-        });
+<script>
+$(function () {
+    $('.ccm-sitemap-overlay-<?= $overlayID ?>').concreteSitemap({ 
+        onClickNode: function (node) {
+            ConcreteEvent.publish('SitemapSelectPage', {
+                cID: node.data.cID,
+                title: node.title,
+                instance: this
+            });
+        },
+        cParentID: <?= $cParentID; ?>,
+        displayNodePagination: <?= $display === 'flat' ? 'true' : 'false' ?>,
+        displaySingleLevel: <?= $display === 'flat' ? 'true' : 'false' ?>,
+        includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
+        isSitemapOverlay: true,
     });
+});
 </script>

--- a/concrete/elements/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/elements/dashboard/sitemap/sitemap_overlay.php
@@ -5,6 +5,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var string $overlayID
  * @var int $cParentID
  * @var string $display
+ * @var bool $includeSystemPages
  */
 ?>
 
@@ -23,6 +24,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
             cParentID: <?= $cParentID; ?>,
             displayNodePagination: <?= $display === 'flat' ? 'true' : 'false' ?>,
             displaySingleLevel: <?= $display === 'flat' ? 'true' : 'false' ?>,
+            includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
             isSitemapOverlay: true,
         });
     });

--- a/concrete/elements/dashboard/sitemap/sitemap_overlay.php
+++ b/concrete/elements/dashboard/sitemap/sitemap_overlay.php
@@ -1,10 +1,18 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var string $overlayID
+ * @var int $cParentID
+ * @var string $display
+ */
+?>
 
 <div class="ccm-sitemap-overlay-<?= $overlayID; ?>"></div>
 
 <script type="text/javascript">
     $(function () {
-        $('.ccm-sitemap-overlay-<?= $overlayID; ?>').concreteSitemap({
+        $('.ccm-sitemap-overlay-<?= $overlayID ?>').concreteSitemap({ 
             onClickNode: function (node) {
                 ConcreteEvent.publish('SitemapSelectPage', {
                     cID: node.data.cID,
@@ -13,8 +21,8 @@
                 });
             },
             cParentID: <?= $cParentID; ?>,
-            displayNodePagination: <?= (isset($display) && $display === 'flat') ? 'true' : 'false'; ?>,
-            displaySingleLevel: <?= (isset($display) && $display === 'flat') ? 'true' : 'false'; ?>,
+            displayNodePagination: <?= $display === 'flat' ? 'true' : 'false' ?>,
+            displaySingleLevel: <?= $display === 'flat' ? 'true' : 'false' ?>,
             isSitemapOverlay: true,
         });
     });

--- a/concrete/single_pages/dashboard/sitemap/explore.php
+++ b/concrete/single_pages/dashboard/sitemap/explore.php
@@ -1,69 +1,74 @@
 <?php
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var Concrete\Controller\SinglePage\Dashboard\Sitemap\Explore $controller */
-/* @var Concrete\Core\Application\Service\Dashboard $dashboard */
-/* @var Concrete\Core\Application\Service\Dashboard\Sitemap $dh */
-/* @var Concrete\Core\Form\Service\Form $form */
-/* @var Concrete\Core\Html\Service\Html $html */
-/* @var Concrete\Core\Application\Service\UserInterface $interface */
-/* @var Concrete\Core\Page\View\PageView $this */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
-/* @var Concrete\Core\Page\View\PageView $view */
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var bool $canRead
+ * @var int $nodeID (if $canView is true)
+ * @var bool $includeSystemPages (if $canView is true)
+ */
 
-/* @var bool $includeSystemPages */
-/* @var int $nodeID */
-
-if ($dh->canRead()) {
+if (!$canRead) {
     ?>
-    <script>
-    (function () {
-        var my_url = <?= json_encode($view->action('')) ?>;
-        $(function () {
-            $('div#ccm-flat-sitemap-container').concreteSitemap({
-                displayNodePagination: true,
-                cParentID: '<?=$nodeID?>',
-                displaySingleLevel: true,
-                includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
-                persist: false,
-                onDisplaySingleLevel: function (node) {
-                    if (window && window.history && window.history.pushState) {
-                        window.history.pushState(
-                            {
-                                key: node.data.cID
-                            },
-                            'title',
-                            my_url + '/-/' + node.data.cID
-                        );
-                    }
-                }
-            });
-        });
-        $(window).on('popstate', function (event) {
-            var redirect;
-            if (event.originalEvent.state && event.originalEvent.state.key) {
-                redirect = my_url + '/-/' + event.originalEvent.state.key;
-            } else {
-                return true;
-            }
-            window.location = redirect;
-            $.fn.dialog.showLoader();
-            return false;
-        });
-    }());
-    </script>
+    <p><?= t('You do not have access to the dashboard sitemap.') ?></p>
     <?php
+    return;
 }
 ?>
+<div class="ccm-dashboard-header-buttons">
+    <button type="button" class="btn btn-secondary dropdown-toggle" data-button="attribute-type" data-toggle="dropdown">
+        <?= t('Options') ?> <span class="caret"></span>
+    </button>
+    <div class="dropdown-menu">
+        <?php
+        if ($includeSystemPages) {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('include_system_pages', 0) ?>"><span class="text-success"><i class="fa fa-check"></i> <?= t('Include System Pages in Sitemap') ?></span></a>
+            <?php
+        } else {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('include_system_pages', 1) ?>"><?= t('Include System Pages in Sitemap') ?></a>
+            <?php
+        }
+        ?>
+    </div>
+</div>
 <div class="ccm-pane-body">
-    <?php
-    if ($dh->canRead()) {
-        ?><div id="ccm-flat-sitemap-container" data-sitemap="container"></div><?php
-    } else {
-        ?><p><?= t('You do not have access to the dashboard sitemap.') ?></p><?php
-    }
-    ?>
+    <div id="ccm-flat-sitemap-container" data-sitemap="container"></div>
 </div>
-<div class="ccm-pane-footer" id="ccm-explore-paging-footer">
-</div>
-
+<div class="ccm-pane-footer" id="ccm-explore-paging-footer"></div>
+<script>
+$(function () {
+    var my_url = <?= json_encode($view->action('')) ?>;
+    $('div#ccm-flat-sitemap-container').concreteSitemap({
+        displayNodePagination: true,
+        cParentID: '<?= $nodeID ?>',
+        displaySingleLevel: true,
+        includeSystemPages: <?= $includeSystemPages ? 'true' : 'false' ?>,
+        persist: false,
+        onDisplaySingleLevel: function (node) {
+            if (window && window.history && window.history.pushState) {
+                window.history.pushState(
+                    {
+                        key: node.data.cID
+                    },
+                    'title',
+                    my_url + '/-/' + node.data.cID
+                );
+            }
+        }
+    });
+    $(window).on('popstate', function (event) {
+        var redirect;
+        if (event.originalEvent.state && event.originalEvent.state.key) {
+            redirect = my_url + '/-/' + event.originalEvent.state.key;
+        } else {
+            return true;
+        }
+        window.location = redirect;
+        $.fn.dialog.showLoader();
+        return false;
+    });
+});
+</script>

--- a/concrete/single_pages/dashboard/sitemap/full.php
+++ b/concrete/single_pages/dashboard/sitemap/full.php
@@ -1,55 +1,66 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-
-$sh = Loader::helper('concrete/dashboard/sitemap');
-?>
-
-<div class="ccm-dashboard-header-buttons">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-button="attribute-type" data-toggle="dropdown">
-        <?=t('Options')?> <span class="caret"></span>
-    </button>
-    <div class="dropdown-menu">
-        <?php if ($includeSystemPages) { ?>
-            <a class="dropdown-item" href="<?=$view->action('include_system_pages', 0)?>"><span class="text-success"><i class="fa fa-check"></i> <?=t('Include System Pages in Sitemap')?></span></a>
-        <?php } else { ?>
-            <a class="dropdown-item" href="<?=$view->action('include_system_pages', 1)?>"><?=t('Include System Pages in Sitemap')?></a>
-        <?php } ?>
-
-
-        <?php if ($displayDoubleSitemap) { ?>
-            <a class="dropdown-item" href="<?=$view->action('display_double_sitemap', 0)?>"><span class="text-success"><i class="fa fa-check"></i> <?=t('View 2-Up Sitemap')?></span></a></li>
-        <?php } else { ?>
-            <a class="dropdown-item" href="<?=$view->action('display_double_sitemap', 1)?>"><?=t('View 2-Up Sitemap')?></a>
-        <?php } ?>
-    </div>
-</div>
-
-
-<?php if ($sh->canRead()) { ?>
-
-    <?php if ($displayDoubleSitemap) { ?>
-
-        <div class="row">
-            <div class="col-md-6">
-                <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap"></div>
-            </div>
-            <div class="col-md-6">
-                <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap" data-sitemap-index="1"></div>
-            </div>
-        </div>
-
-
-    <?php } else {  ?>
-        <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap"></div>
-    <?php } ?>
-
 <?php
-} else {
-?>
-<p><?=t("You do not have access to the sitemap."); ?></p>
-<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var bool $canRead
+ * @var bool $includeSystemPages
+ * @var bool $displayDoubleSitemap
+ */
+
+if (!$canRead) {
+    ?>
+    <p><?= t('You do not have access to the sitemap.') ?></p>
+    <?php
+    return;
 }
 ?>
-
+<div class="ccm-dashboard-header-buttons">
+    <button type="button" class="btn btn-secondary dropdown-toggle" data-button="attribute-type" data-toggle="dropdown">
+        <?= t('Options') ?> <span class="caret"></span>
+    </button>
+    <div class="dropdown-menu">
+        <?php
+        if ($includeSystemPages) {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('include_system_pages', 0) ?>"><span class="text-success"><i class="fa fa-check"></i> <?= t('Include System Pages in Sitemap') ?></span></a>
+            <?php
+        } else {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('include_system_pages', 1) ?>"><?= t('Include System Pages in Sitemap') ?></a>
+            <?php
+        }
+        if ($displayDoubleSitemap) {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('display_double_sitemap', 0) ?>"><span class="text-success"><i class="fa fa-check"></i> <?= t('View 2-Up Sitemap') ?></span></a>
+            <?php
+        } else {
+            ?>
+            <a class="dropdown-item" href="<?= $view->action('display_double_sitemap', 1) ?>"><?= t('View 2-Up Sitemap') ?></a>
+            <?php
+        }
+        ?>
+    </div>
+</div>
+<?php
+if ($displayDoubleSitemap) {
+    ?>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap"></div>
+        </div>
+        <div class="col-md-6">
+            <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap" data-sitemap-index="1"></div>
+        </div>
+    </div>
+    <?php
+} else {
+    ?>
+    <div class="ccm-dashboard-full-sitemap-container" data-container="sitemap"></div>
+    <?php
+}
+?>
 <script>
 $(function() {
     $('div[data-container=sitemap]').each(function() {
@@ -57,15 +68,6 @@ $(function() {
         $my.concreteSitemap({
             includeSystemPages: <?= $includeSystemPages ? 1 : 0 ?>,
             sitemapIndex: parseInt($my.data('sitemap-index'), 10) || 0
-        });
-    });
-
-    $('input[name=includeSystemPages]').on('click', function() {
-        var $tree = $('div#ccm-full-sitemap-container div.ccm-sitemap-tree');
-        $tree.fancytree('destroy');
-
-        $('#ccm-full-sitemap-container').html('').concreteSitemap({
-            includeSystemPages: $('input[name=includeSystemPages]').is(':checked')
         });
     });
 });

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -36,7 +36,7 @@ class Sitemap
     /**
      * @var bool|null
      */
-    protected $includeSystemPages;
+    protected $includeSystemPages = false;
 
     /**
      * Sitemap constructor.
@@ -61,11 +61,6 @@ class Sitemap
      */
     public function includeSystemPages()
     {
-        if ($this->includeSystemPages === null) {
-            $session = $this->app->make('session');
-            $this->includeSystemPages = (bool) $session->get('includeSystemPages');
-        }
-
         return $this->includeSystemPages;
     }
 
@@ -75,12 +70,6 @@ class Sitemap
     public function setIncludeSystemPages($systemPages)
     {
         $this->includeSystemPages = (bool) $systemPages;
-        $session = $this->app->make('session');
-        if ($systemPages) {
-            $session->set('includeSystemPages', true);
-        } else {
-            $session->remove('includeSystemPages');
-        }
     }
 
     /**

--- a/concrete/src/Application/UserInterface/Sitemap/StandardSitemapProvider.php
+++ b/concrete/src/Application/UserInterface/Sitemap/StandardSitemapProvider.php
@@ -257,16 +257,10 @@ class StandardSitemapProvider implements ProviderInterface
     protected function getSitemapDataProvider()
     {
         $dh = $this->app->make('helper/concrete/dashboard/sitemap');
-        if ($this->request->query->has('displayNodePagination') && $this->request->query->get('displayNodePagination')) {
-            $dh->setDisplayNodePagination(true);
-        } else {
-            $dh->setDisplayNodePagination(false);
-        }
-        if ($this->request->query->has('isSitemapOverlay') && $this->request->query->get('isSitemapOverlay')) {
-            $dh->setIsSitemapOverlay(true);
-        } else {
-            $dh->setIsSitemapOverlay(false);
-        }
+        $queryString = $this->request->query;
+        $dh->setDisplayNodePagination($queryString->get('displayNodePagination') ? true : false);
+        $dh->setIsSitemapOverlay($queryString->get('isSitemapOverlay') ? true : false);
+        $dh->setIncludeSystemPages($queryString->get('includeSystemPages') ? true : false);
 
         return $dh;
     }

--- a/concrete/views/dialogs/page/sitemap_selector.php
+++ b/concrete/views/dialogs/page/sitemap_selector.php
@@ -1,12 +1,21 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 
+/**
+ * @var int|null $cID
+ * @var string $selectMode
+ * @var string $uniqid
+ * @var bool $includeSystemPages
+ * @var bool $askIncludeSystemPages
+ */
+?>
 <div class="ccm-ui h-100" id="ccm-sitemap-search-selector">
     <div class="container-fluid h-100">
         <div class="row h-100">
-            <div class="col-3 border-right">
+            <div class="col-3 border-right flex-column">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <a data-toggle="tab" id="sitemap-sitemap-tab" href="#sitemap-sitemap" class="nav-link active"><?=t('Full Sitemap')?></a>
+                        <a data-toggle="tab" id="sitemap-sitemap-tab" href="#sitemap-sitemap" class="nav-link"><?=t('Full Sitemap')?></a>
                     </li> 
                     <li class="nav-item">
                         <a data-toggle="tab" id="sitemap-explore-tab" href="#sitemap-explore" class="nav-link"><?=t('Flat Sitemap')?></a>
@@ -15,13 +24,22 @@
                         <a data-toggle="tab" id="sitemap-search-tab" href="#sitemap-search" class="nav-link"><?=t('Search')?></a>
                     </li>
                 </ul>
+                <?php
+                if ($askIncludeSystemPages) {
+                    ?>
+                    <div class="form-check position-absolute" style="bottom: 0">
+                        <input type="checkbox" class="form-check-input" id="sitemap-include-system-pages"<?= $includeSystemPages ? ' checked="checked"' : ''?> />
+	                   <label class="form-check-label" for="sitemap-include-system-pages"><?= t('Include System Pages in Sitemap') ?></label>
+                    </div>
+                    <?php
+                }
+                ?>
             </div>
-            <div class="col-9">
-                <div class="tab-content">
-                    <div id="sitemap-sitemap" class="tab-pane active"></div>
+            <div class="col-9 mh-100 overflow-auto">
+                <div class="tab-content mh-100">
+                    <div id="sitemap-sitemap" class="tab-pane"></div>
                     <div id="sitemap-explore" class="tab-pane"></div>
                     <div id="sitemap-search" class="tab-pane">
-                        <?php $uniqid = uniqid() ?>
                         <div data-concrete-page-chooser-search="<?= $uniqid ?>">
                             <concrete-page-chooser-search/>
                         </div>
@@ -33,70 +51,80 @@
 
 </div>
 
-<script type="text/javascript">
-
-    loadSitemapOverlay = function(type, url) {
-        if ($('#sitemap-' + type).html() == '') {
-            jQuery.fn.dialog.showLoader();
-            $('#sitemap-' + type).load(url, function() {
-                jQuery.fn.dialog.hideLoader();
+<script>
+$(function() {
+    function loadSitemapOverlay(type, url) {
+        var $el = $('#sitemap-' + type);
+        if ($el.html() == '') {
+            $.fn.dialog.showLoader();
+            $el.load(url, function() {
+                $.fn.dialog.hideLoader();
             });
         }
     }
-
-    <?php if ($selectMode == 'move_copy_delete') {
-       ?>
-    ConcreteEvent.unsubscribe('SitemapSelectPage.search');
-
-    var subscription = function (e, data) {
-        Concrete.event.unsubscribe(e);
-        url = CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/drag_request?dragMode=none&origCID=<?=$cID?>&destCID=' + data.cID;
-        $.fn.dialog.open({
-            width: 520,
-            height: 'auto',
-            href: url,
-            title: ccmi18n_sitemap.moveCopyPage,
-            onDirectClose: function() {
-                ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
-            }
-        });
-    };
-    ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
     <?php
-
-    }?>
-
-
-    $(function() {
-        var cParentID = 0;
-        var sst = jQuery.cookie('ccm-sitemap-selector-tab');
-        if (sst !== 'explore' && sst !== 'search') {
-            sst = 'sitemap';
-        }
-        $("a[href='#sitemap-" + sst + "']").parent().addClass('active');
-        $("a[href='#sitemap-sitemap']").click(function() {
-            loadSitemapOverlay('sitemap', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay');
-        });
-        $("a[href='#sitemap-explore']").click(function() {
-            loadSitemapOverlay('explore', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay?display=flat&cParentID=' + cParentID);
-        });
-
-        $('#ccm-sitemap-search-selector ul li.active a').click();
-
-        $('#ccm-tab-content-sitemap').on('click', '.ccm-sitemap-open-flat-view', function(event) {
-            var node = $.ui.fancytree.getNode(event);
-            if (node && node.data && node.data.cParentID) {
-                cParentID = node.data.cParentID;
-            }
-            $('#ccm-tab-content-explore').html('');
-            $('a[data-tab=explore]').trigger('click');
-        });
-
-        Concrete.Vue.activateContext('cms', function (Vue, config) {
-            new Vue({
-                el: 'div[data-concrete-page-chooser-search="<?= $uniqid ?>"]',
-                components: config.components
+    if ($selectMode == 'move_copy_delete') {
+        ?>
+        ConcreteEvent.unsubscribe('SitemapSelectPage.search');
+        var subscription = function (e, data) {
+            Concrete.event.unsubscribe(e);
+            url = CCM_DISPATCHER_FILENAME + '/ccm/system/dialogs/page/drag_request?dragMode=none&origCID=<?= $cID ?>&destCID=' + data.cID;
+            $.fn.dialog.open({
+                width: 520,
+                height: 'auto',
+                href: url,
+                title: ccmi18n_sitemap.moveCopyPage,
+                onDirectClose: function() {
+                    ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
+                }
             });
+        };
+        ConcreteEvent.subscribe('SitemapSelectPage.search', subscription);
+        <?php
+    }
+    ?>
+    var cParentID = 0,
+        includeSystemPages = <?= $includeSystemPages ? 'true' : 'false' ?>,
+        sst = $.cookie('ccm-sitemap-selector-tab');
+    ;
+    if (sst !== 'explore' && sst !== 'search') {
+        sst = 'sitemap';
+    }
+    $("a[href='#sitemap-" + sst + "']").parent().addClass('active');
+    $("a[href='#sitemap-sitemap']").click(function() {
+        loadSitemapOverlay('sitemap', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay?includeSystemPages=' + (includeSystemPages ? 1 : 0));
+    });
+    $("a[href='#sitemap-explore']").click(function() {
+        loadSitemapOverlay('explore', CCM_DISPATCHER_FILENAME + '/ccm/system/page/sitemap_overlay?&display=flat&cParentID=' + cParentID + '&includeSystemPages=' + (includeSystemPages ? 1 : 0));
+    });
+
+    $('#ccm-sitemap-search-selector ul li.active a').click();
+
+    $('#ccm-tab-content-sitemap').on('click', '.ccm-sitemap-open-flat-view', function(event) {
+        var node = $.ui.fancytree.getNode(event);
+        if (node && node.data && node.data.cParentID) {
+            cParentID = node.data.cParentID;
+        }
+        $('#ccm-tab-content-explore').html('');
+        $('a[data-tab=explore]').trigger('click');
+    });
+    <?php
+    if ($askIncludeSystemPages) {
+        ?>
+        $('#sitemap-include-system-pages').on('change', function() {
+            includeSystemPages = this.checked;
+            $('#sitemap-sitemap,#sitemap-explore').empty();
+            $('#ccm-sitemap-search-selector ul li.nav-item a.active').click();
+        });
+        <?php
+    }
+    ?>
+
+    Concrete.Vue.activateContext('cms', function (Vue, config) {
+        new Vue({
+            el: 'div[data-concrete-page-chooser-search="<?= $uniqid ?>"]',
+            components: config.components
         });
     });
+});
 </script>


### PR DESCRIPTION
We currently store in a cookie if the sitemap browsers should include system pages.
This cookie is set in the `/dashboard/sitemap/full` dashboard page (*Include System Pages in Sitemap* option), but it's used everywhere we display a sitemap (eg in the `/dashboard/sitemap/explore` dashboard page and in the page selector widget).

IMHO it's a very sub-optimal behavior: for example, in order to pick a system page in the `/dashboard/system/registration/postlogin` dashboard page, we need to go to `/dashboard/sitemap/full`, check that flag, and go back to the postlogin page.

What:
- removing the cookie that stores the *Include System Pages in Sitemap* setting
- persist its value only for the `/dashboard/sitemap/full` & `/dashboard/sitemap/explore` dashboard pages (in the session)
- allow the page selector widget to specify if users should see the system pages, as well as if users should be asked to view them.

Here's an example (for the `/dashboard/system/registration/postlogin` page):

![include-system-pages](https://user-images.githubusercontent.com/928116/97328207-1146eb00-1876-11eb-91b4-7b09f7cd50a8.gif)

PS: requires https://github.com/concrete5/bedrock/pull/127