### PR TITLE
[V9] Switch from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![TravisCI Build Status](https://travis-ci.org/concrete5/concrete5.svg?branch=develop)](https://travis-ci.org/concrete5/concrete5)
+[![TravisCI Build Status](https://travis-ci.com/concrete5/concrete5.svg?branch=develop)](https://travis-ci.com/concrete5/concrete5)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/concrete5/concrete5?branch=develop&svg=true)](https://ci.appveyor.com/project/concrete5/concrete5)
 [![Join Slack](https://slack.concrete5.org/badge.svg)](https://slack.concrete5.org/)
 


### PR DESCRIPTION
We migrated from travis-ci.org to travis-ci.com.
Let's make the only change required.