### PR TITLE
Remove useless Page::__destruct

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -177,11 +177,6 @@ class Page extends Collection implements CategoryMemberInterface,
         $this->loadError(COLLECTION_INIT); // init collection until we populate.
     }
 
-    public function __destruct()
-    {
-        parent::__destruct();
-    }
-
     /**
      * Get a page given its path.
      *


### PR DESCRIPTION
Its parent `__destruct` method is already called automatically ([example](https://3v4l.org/VE3Wt).
