### PR TITLE
[V9] Fix wrong class namespaces

### DIFF
--- a/tests/tests/Api/OAuth/ScopeRegistryTest.php
+++ b/tests/tests/Api/OAuth/ScopeRegistryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Api\OAuth\Client;
+namespace Concrete\Tests\Api\OAuth;
 
 use Concrete\Core\Api\OAuth\Scope\ScopeRegistry;
 use Concrete\Core\Api\OAuth\Scope\ScopeRegistryInterface;

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Error;
+namespace Concrete\Tests\Cookie;
 
 use Concrete\Core\Cookie\CookieJar;
 use Concrete\Core\Cookie\ResponseCookieJar;

--- a/tests/tests/Foundation/Queue/BatchTest.php
+++ b/tests/tests/Foundation/Queue/BatchTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Foundation;
+namespace Concrete\Tests\Foundation\Queue;
 
 use Concrete\Core\Entity\Queue\Batch;
 use Concrete\Core\File\Command\RescanFileBatchProcessFactory;

--- a/tests/tests/Foundation/Queue/DatabaseQueueAdapterTest.php
+++ b/tests/tests/Foundation/Queue/DatabaseQueueAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Foundation;
+namespace Concrete\Tests\Foundation\Queue;
 
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use Queue;

--- a/tests/tests/Localization/Translator/Translation/TranslationLoaderRepositoryTest.php
+++ b/tests/tests/Localization/Translator/Translation/TranslationLoaderRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Core\Localization\Translator\Translation;
+namespace Concrete\Tests\Localization\Translator\Translation;
 
 use Concrete\Core\Localization\Translator\Translation\TranslationLoaderRepository;
 use Concrete\TestHelpers\Localization\Translator\Translation\Fixtures\DummyTranslationLoader;

--- a/tests/tests/Localization/Translator/TranslatorAdapterRepositoryTest.php
+++ b/tests/tests/Localization/Translator/TranslatorAdapterRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Core\Localization\Translator;
+namespace Concrete\Tests\Localization\Translator;
 
 use Concrete\Core\Localization\Translator\TranslatorAdapterRepository;
 use Concrete\TestHelpers\Localization\Translator\Fixtures\DummyTranslatorAdapter;

--- a/tests/tests/Summary/Template/FiltererTest.php
+++ b/tests/tests/Summary/Template/FiltererTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Summary\Data\Extractor\Driver;
+namespace Concrete\Tests\Summary\Template;
 
 use Concrete\Core\Entity\Summary\Category;
 use Concrete\Core\Entity\Summary\Field;

--- a/tests/tests/System/MutexTest.php
+++ b/tests/tests/System/MutexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Update;
+namespace Concrete\Tests\System;
 
 use Concrete\Core\Application\Application;
 use Concrete\Core\Error\UserMessageException;

--- a/tests/tests/System/NameAlreadyInUseTest.php
+++ b/tests/tests/System/NameAlreadyInUseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Concrete\Tests\Update;
+namespace Concrete\Tests\System;
 
 use Concrete\Tests\TestCase;
 use RuntimeException;


### PR DESCRIPTION
When have a few class names that are not PSR-4 compliant.
Indeed, by running `composer install --optimize-autoloader` we have these warnings:
```
Deprecation Notice: Class Concrete\Tests\Api\OAuth\Client\ScopeRegistryTest located in tests/tests/Api/OAuth/ScopeRegistryTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Error\CookieTest located in tests/tests/Cookie/CookieTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Foundation\BatchTest located in tests/tests/Foundation/Queue/BatchTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Foundation\DatabaseQueueAdapterTest located in tests/tests/Foundation/Queue/DatabaseQueueAdapterTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Core\Localization\Translator\Translation\TranslationLoaderRepositoryTest located in tests/tests/Localization/Translator/Translation/TranslationLoaderRepositoryTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Core\Localization\Translator\TranslatorAdapterRepositoryTest located in tests/tests/Localization/Translator/TranslatorAdapterRepositoryTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Summary\Data\Extractor\Driver\FiltererTest located in tests/tests/Summary/Template/FiltererTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Update\MutexTest located in tests/tests/System/MutexTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
Deprecation Notice: Class Concrete\Tests\Update\NameAlreadyInUseTest located in tests/tests/System/NameAlreadyInUseTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.

```

Let's fix them.
