### PR TITLE
Fix displayed minimum PHP version

### DIFF
--- a/concrete/dispatcher.php
+++ b/concrete/dispatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70209) {
-    die("concrete5 requires PHP 7.2.0 to run.\nYou are running PHP " . PHP_VERSION . "\n");
+    die("concrete5 requires PHP 7.2.9 to run.\nYou are running PHP " . PHP_VERSION . "\n");
 }
 
 /*

--- a/concrete/src/Install/Preconditions/PhpVersion.php
+++ b/concrete/src/Install/Preconditions/PhpVersion.php
@@ -12,7 +12,7 @@ class PhpVersion implements PreconditionInterface
      *
      * @var string
      */
-    const MINIMUM_PHP_VERSION = '7.2.0';
+    const MINIMUM_PHP_VERSION = '7.2.9';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
As stated [here](https://github.com/concrete5/concrete5/blob/5c3af8a6a21f980ae76676865495ebd742fa96a3/concrete/dispatcher.php#L3), the minimum PHP version for concrete5 9 will be 7.2.9 and not 7.2.0.