### PR TITLE
Fix issue where a rich text field on a form block doesn't re-populate contents after submit

### DIFF
--- a/concrete/attributes/textarea/form.php
+++ b/concrete/attributes/textarea/form.php
@@ -12,6 +12,11 @@ if ($akTextareaDisplayMode == 'text' || $akTextareaDisplayMode == '') { ?>
     ?>
 
 <?php } else {
+    $requestValue = $form->getRequestValue($view->controller->field('value'));
+    if (is_string($requestValue)) {
+        $value = $requestValue;
+    }
+    
     echo Core::make('editor')->outputStandardEditor(
         $view->controller->field('value'),
         h($value)


### PR DESCRIPTION
To replicate issue:
- add a form block to a page with two fields; a simple text field and a textarea field set to 'Rich Text'
- set the first text field to be a required field
- enter content into the rich text field, but leave the required text field blank, then submit the form
- when the page reloads and displays the validation error message, the rich text field will be missing the originally entered content

This change fixes this issue.