### PR TITLE
Improve error message for invalid google maps api key

### DIFF
--- a/concrete/blocks/google_map/form_setup_html.php
+++ b/concrete/blocks/google_map/form_setup_html.php
@@ -226,7 +226,7 @@
                         },
                         function (place, status) {
                             if (status === 'REQUEST_DENIED') {
-                                placesLoaded(<?= json_encode(t('The API Key is NOT valid for Google Places.')) ?>);
+                                placesLoaded(<?= json_encode(t('The API Key is NOT valid for Google Places or not linked to billing account.')) ?>);
                             } else {
                                 placesLoaded(null, places);
                             }


### PR DESCRIPTION
I wasted a few hours why c5 says my google API key is invalid.
I enabled Places API, but not enabled billing information.
This change will help someone who can't understand why their API key is not valid.