### PR TITLE
Fix handling transparent color in style customizer

### DIFF
--- a/concrete/src/StyleCustomizer/Style/ColorStyle.php
+++ b/concrete/src/StyleCustomizer/Style/ColorStyle.php
@@ -95,7 +95,7 @@ EOT
         $cv = null;
         if ($value instanceof Less_Tree_Color) {
             if ($value->isTransparentKeyword) {
-                return false;
+                return self::getTransparentColorValue((string) $variable);
             }
             $cv = new ColorValue($variable);
             $cv->setRed($value->rgb[0]);
@@ -130,7 +130,7 @@ EOT
     {
         $color = $request->get($this->getVariable());
         if (!$color['color']) { // transparent
-            return null;
+            return self::getTransparentColorValue($this->getVariable());
         }
         $cv = new Parser($color['color']);
         $result = $cv->getResult();
@@ -170,5 +170,22 @@ EOT
         }
 
         return $values;
+    }
+
+    /**
+     * @param string $variable
+     *
+     * @return \Concrete\Core\StyleCustomizer\Style\Value\ColorValue
+     */
+    private static function getTransparentColorValue($variable = '')
+    {
+        $cv = new ColorValue($variable);
+
+        return $cv
+            ->setRed(0)
+            ->setGreen(0)
+            ->setBlue(0)
+            ->setAlpha(0)
+        ;
     }
 }


### PR DESCRIPTION
I think that something changed in the less.php parser: if we don't provide it all the variable values it now breaks ([with an error like this](https://github.com/concrete5/concrete5/issues/8787#issuecomment-727049811)).

This PR should fix the issues reported by users at #8787 (PS: [this change](https://github.com/concrete5/concrete5/pull/8991/files/8d5c34196c4989128e7706dc74c45a4ec144202f..67540cf87b4aa23c7c5c00b6b7b3fc68bdfd7204#diff-dfd48b890b7661399710841fa7d1a59949494223f244440567e96941e5196bb9) to the TypeStyle.php file is still required IMHO).