### PR TITLE
Fix visual glitch when disabling font family in typography

### DIFF
--- a/concrete/js/build/core/style-customizer/typography.js
+++ b/concrete/js/build/core/style-customizer/typography.js
@@ -85,7 +85,7 @@
             my.$fontMenu.val(fontFamilyName);
             my.$fontMenu.css('font-family', my.fonts[fontFamilyName].css);
         } else {
-            my.$widget.find('[data-wrapper=fontFamily]').html('');
+            my.$widget.find('[data-wrapper=fontFamily]').remove();
             my.$element.find('[data-wrapper=fontFamily]').remove();
         }
 


### PR DESCRIPTION
When a typography value has disabled the Font Family sub-field, we still have a leftover in the UI.

See for example the palette of a typography with all its values disabled:

![immagine](https://user-images.githubusercontent.com/928116/99882094-544e7100-2c1e-11eb-9547-74f3376132cb.png)

After the fix of this PR:

![immagine](https://user-images.githubusercontent.com/928116/99882152-a7282880-2c1e-11eb-9a4e-36c50dca81f2.png)
