### PR TITLE
Fix AvailableVariablesUpdater::fixThemes()

### DIFF
--- a/concrete/src/Page/Theme/AvailableVariablesUpdater.php
+++ b/concrete/src/Page/Theme/AvailableVariablesUpdater.php
@@ -46,7 +46,7 @@ class AvailableVariablesUpdater
     public function fixThemes($flags)
     {
         $stats = [];
-        foreach (Theme::getAvailableThemes() as $theme) {
+        foreach (Theme::getList() as $theme) {
             $stats[$theme->getThemeHandle()] = $this->fixTheme($theme, $flags);
         }
 


### PR DESCRIPTION
The correct way to get the installed themes is to call `Theme::getList()` and not `Theme::getAvailableThemes()`...