### PR TITLE
[Proposal] Add new tracking code position to support Google Tag Manager

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/seo/codes.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/codes.php
@@ -11,6 +11,7 @@ class Codes extends DashboardSitePageController
     {
         $config = $this->getSite()->getConfigRepository();
         $this->set('tracking_code_header', (string) $config->get('seo.tracking.code.header'));
+        $this->set('tracking_code_body', (string) $config->get('seo.tracking.code.body'));
         $this->set('tracking_code_footer', (string) $config->get('seo.tracking.code.footer'));
     }
 
@@ -25,6 +26,7 @@ class Codes extends DashboardSitePageController
         }
         $config = $this->getSite()->getConfigRepository();
         $config->save('seo.tracking.code.header', (string) $post->get('tracking_code_header'));
+        $config->save('seo.tracking.code.body', (string) $post->get('tracking_code_body'));
         $config->save('seo.tracking.code.footer', (string) $post->get('tracking_code_footer'));
         PageCache::getLibrary()->flush();
         $this->flash('success', t('Tracking code settings updated successfully.') . "\n" . t('Cached files removed.'));

--- a/concrete/elements/body_tracking_code.php
+++ b/concrete/elements/body_tracking_code.php
@@ -1,0 +1,12 @@
+<?php
+use Concrete\Core\Support\Facade\Application;
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+$disableTrackingCode = $disableTrackingCode ?: null;
+$app = Application::getFacadeApplication();
+$site = $app->make('site')->getSite();
+$config = $site->getConfigRepository();
+if (empty($disableTrackingCode)) {
+    echo $config->get('seo.tracking.code.body');
+}

--- a/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/concrete/single_pages/dashboard/system/seo/codes.php
@@ -27,13 +27,13 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <div class="form-group">
         <?= $form->label('tracking_code_body', t('Body Tracking Codes')) ?>
         <?= $form->textarea('tracking_code_body', $tracking_code_body, ['style' => 'height: 250px;', 'class' => 'text-monospace', 'spellcheck' => 'false']) ?>
-        <small class="form-text text-muted"><?= t('This code will be inserted after the &lt;body&gt; tag. Some themes does not support this code.') ?></small>
+        <small class="form-text text-muted"><?= h(t(/*i18n: %s is an HTML tag */'This code will be inserted after the %s tag. Some themes does not support this code.', '<body>')) ?></small>
     </div>
 
     <div class="form-group">
         <?= $form->label('tracking_code_footer', t('Footer Tracking Codes')) ?>
         <?= $form->textarea('tracking_code_footer', $tracking_code_footer, ['style' => 'height: 250px;', 'class' => 'text-monospace', 'spellcheck' => 'false']) ?>
-        <small class="form-text text-muted"><?= t('This code will be inserted before the &lt;/body&gt; tag.') ?></small>
+        <small class="form-text text-muted"><?= h(t(/*i18n: %s is an HTML tag */'This code will be inserted before the %s tag.', '</body>')) ?></small>
     </div>
 
     <div class="ccm-dashboard-form-actions-wrapper">

--- a/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/concrete/single_pages/dashboard/system/seo/codes.php
@@ -6,6 +6,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var Concrete\Core\Form\Service\Form $form
  * @var Concrete\Core\Validation\CSRF\Token $token
  * @var string $tracking_code_footer
+ * @var string $tracking_code_body
  * @var string $tracking_code_header
  */
 ?>
@@ -20,11 +21,19 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <div class="form-group">
         <?= $form->label('tracking_code_header', t('Header Tracking Codes')) ?>
         <?= $form->textarea('tracking_code_header', $tracking_code_header, ['style' => 'height: 250px;', 'class' => 'text-monospace', 'spellcheck' => 'false']) ?>
+        <small class="form-text text-muted"><?= t('This code will be inserted in the head element.') ?></small>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('tracking_code_body', t('Body Tracking Codes')) ?>
+        <?= $form->textarea('tracking_code_body', $tracking_code_body, ['style' => 'height: 250px;', 'class' => 'text-monospace', 'spellcheck' => 'false']) ?>
+        <small class="form-text text-muted"><?= t('This code will be inserted after the &lt;body&gt; tag. Some themes does not support this code.') ?></small>
     </div>
 
     <div class="form-group">
         <?= $form->label('tracking_code_footer', t('Footer Tracking Codes')) ?>
         <?= $form->textarea('tracking_code_footer', $tracking_code_footer, ['style' => 'height: 250px;', 'class' => 'text-monospace', 'spellcheck' => 'false']) ?>
+        <small class="form-text text-muted"><?= t('This code will be inserted before the &lt;/body&gt; tag.') ?></small>
     </div>
 
     <div class="ccm-dashboard-form-actions-wrapper">

--- a/concrete/themes/elemental/elements/header_top.php
+++ b/concrete/themes/elemental/elements/header_top.php
@@ -14,5 +14,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
-
+<?php View::element('body_tracking_code'); ?>
 <div class="<?php echo $c->getPageWrapperClass()?>">


### PR DESCRIPTION
A lot of my clients want to use Google Tag Manager. They asked me how to insert the tracking code in the begging of the `<body>` element, but concrete5 does not support that position.

> * Place the `<script>` code snippet in the `<head>` of your web page's HTML output, preferably as close to the opening <head> tag as possible, but below any dataLayer declarations.
> * Place the `<noscript>` code snippet immediately after the `<body>` tag in your HTML output.

https://support.google.com/tagmanager/answer/6103696

Usually, I update the theme, but how about support this position by default?

I know all of the themes also don't support it, but it may be good timing to change the regulation of themes.