### PR TITLE
block-title-format for Express Entry List block #8282

### DIFF
--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -75,6 +75,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('searchAssociations', []);
         $this->set('linkedProperties', []);
         $this->set('displayLimit', 20);
+        $this->set('titleFormat', 'h2');
     }
 
     protected function getSearchFieldManager(Entity $entity)

--- a/concrete/blocks/express_entry_list/db.xml
+++ b/concrete/blocks/express_entry_list/db.xml
@@ -56,6 +56,10 @@
     <field name="rowBackgroundColorAlternate" type="string" size="32">
       <default value=""/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+      <default value="h2" />
+	  <notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/express_entry_list/edit.php
+++ b/concrete/blocks/express_entry_list/edit.php
@@ -138,8 +138,11 @@ echo $userInterface->tabs([
         <div>
             <div class="form-group">
                 <?php echo $form->label('tableName', t('Name')) ?>
-                <?php echo $form->text('tableName', $tableName, array('maxlength' => '128')) ?>
-            </div>
+			    <div class="input-group">
+                	<?php echo $form->text('tableName', $tableName, array('maxlength' => '128')) ?>
+					<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat, array('style' => 'width:105px;flex-grow:0;', 'class' => 'custom-select input-group-append')); ?>
+				</div>
+			</div>
 
             <div class="form-group">
                 <?php echo $form->label('tableDescription', t('Description')) ?>

--- a/concrete/blocks/express_entry_list/view.php
+++ b/concrete/blocks/express_entry_list/view.php
@@ -4,12 +4,12 @@ $c = Page::getCurrentPage();
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 if ($tableName) { ?>
-    <h2><?=$tableName?></h2>
-    <?php if ($tableDescription) { ?>
-        <p><?=$tableDescription?></p>
-    <?php } ?>
-<?php }
-
+    <<?php echo $titleFormat; ?>><?=$tableName?></<?php echo $titleFormat; ?>>
+<?php } ?>
+<?php if ($tableDescription) { ?>
+    <p><?=$tableDescription?></p>
+<?php } 
+	
 if ($entity) { ?>
     <?php if ($enableSearch) { ?>
         <form method="get" action="<?=$c->getCollectionLink()?>">


### PR DESCRIPTION
Adds a title format option to the Express Entry List block as discussed in #8282 and initial PR #8405

Also changes the nested description in view template so the description can be displayed even when the title is not set.