### PR TITLE
block-title-format for Google Map block #8282

### DIFF
--- a/concrete/blocks/google_map/controller.php
+++ b/concrete/blocks/google_map/controller.php
@@ -47,6 +47,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('width', '100%');
         $this->set('height', '400px');
         $this->set('scrollwheel', 1);
+        $this->set('titleFormat', 'h3');
     }
 
     public function validate($args)
@@ -96,6 +97,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             'height' => null,
             'scrollwheel' => 0,
             'apiKey' => '',
+            'titleFormat' => 'h3',
         ];
 
         Config::save('app.api_keys.google.maps', trim($data['apiKey']));
@@ -108,6 +110,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $args['width'] = $data['width'];
         $args['height'] = $data['height'];
         $args['scrollwheel'] = $data['scrollwheel'] ? 1 : 0;
+        $args['titleFormat'] = $data['titleFormat'];
 
         parent::save($args);
     }

--- a/concrete/blocks/google_map/db.xml
+++ b/concrete/blocks/google_map/db.xml
@@ -20,5 +20,9 @@
             <default value="1" />
             <notnull/>
         </field>
+	    <field name="titleFormat" type="string" size="20">
+	      <default value="h3" />
+		  <notnull/>
+	    </field>
     </table>
 </schema>

--- a/concrete/blocks/google_map/form_setup_html.php
+++ b/concrete/blocks/google_map/form_setup_html.php
@@ -32,8 +32,11 @@
 
         <div class="form-group">
             <?= $form->label('title', t('Map Title (optional)')) ?>
-            <?= $form->text('title', $title) ?>
-        </div>
+		    <div class="input-group">
+            	<?= $form->text('title', $title) ?>
+				<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat, array('style' => 'width:105px;flex-grow:0;', 'class' => 'custom-select input-group-append')); ?>
+			</div>
+		</div>
 
         <div id="ccm-google-map-block-location" class="form-group">
             <?= $form->label('location', t('Location') . ' <i class="fa fa-question-circle launch-tooltip" title="' . t('Start typing a location (e.g. Apple Store or 235 W 3rd, New York) then click on the correct entry on the list.') . '"></i>') ?>

--- a/concrete/blocks/google_map/view.php
+++ b/concrete/blocks/google_map/view.php
@@ -20,7 +20,7 @@ if ($c->isEditMode()) {
     <?php
     $loc->popActiveContext();
 } else { ?>
-    <?php if (strlen($title) > 0) { ?><h3><?= $title; ?></h3><?php } ?>
+    <?php if (strlen($title) > 0) { ?><<?php echo $titleFormat; ?>><?= $title; ?></<?php echo $titleFormat; ?>><?php } ?>
     <div class="googleMapCanvas"
          style="width: <?= $width; ?>; height: <?= $height; ?>"
          data-zoom="<?= $zoom; ?>"


### PR DESCRIPTION
Adds a title format option to the Google Map block as discussed in #8282 and initial PR #8405