### PR TITLE
block-title-format for RSS Displayer block #8282

### DIFF
--- a/concrete/blocks/rss_displayer/controller.php
+++ b/concrete/blocks/rss_displayer/controller.php
@@ -183,6 +183,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             'title' => '',
             'standardDateFormat' => '',
             'customDateFormat' => '',
+            'titleFormat' => '',
         ];
         $args = [
             'url' => $data['url'],
@@ -190,6 +191,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             'showSummary' => $data['showSummary'] ? 1 : 0,
             'launchInNewWindow' => $data['launchInNewWindow'] ? 1 : 0,
             'title' => $data['title'],
+            'titleFormat' => $data['titleFormat'],
         ];
         switch ($data['standardDateFormat']) {
             case ':custom:':

--- a/concrete/blocks/rss_displayer/db.xml
+++ b/concrete/blocks/rss_displayer/db.xml
@@ -23,6 +23,10 @@
       <default value="1"/>
       <notnull/>
     </field>
+    <field name="titleFormat" type="string" size="20">
+        <default value="h5" />
+		<notnull/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/rss_displayer/form_setup_html.php
+++ b/concrete/blocks/rss_displayer/form_setup_html.php
@@ -8,10 +8,11 @@
     <input name="url" class="form-control" placeholder="<?= h(t('Feed URL')) ?>" value="<?= h($rssObj->url) ?>" type="text" required="required" />
 </div>
 <div class="form-group">
-    <label for="title" class="control-label">
-        <?= t('Feed Title') ?>
-    </label>
-    <input name="title" class="form-control" placeholder="<?= h(t('Feed Title')) ?>" value="<?= h($rssObj->title) ?>"/>
+    <?php echo $form->label("title", t('Feed Title')); ?>
+    <div class="input-group">
+    	<input name="title" class="form-control" placeholder="<?= h(t('Feed Title')) ?>" value="<?= h($rssObj->title) ?>"/>
+		<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat, array('style' => 'width:105px;flex-grow:0;', 'class' => 'custom-select input-group-append')); ?>
+	</div>
 </div>
 <div class="form-group">
     <?= $form->label('standardDateFormat', t('Date Format')) ?>

--- a/concrete/blocks/rss_displayer/view.php
+++ b/concrete/blocks/rss_displayer/view.php
@@ -7,7 +7,7 @@
 <?php if (strlen($title) > 0) {
     ?>
     <div class="ccm-block-rss-displayer-header">
-    	<h5><?=$title?></h5>
+        <<?php echo $titleFormat; ?>><?=$title?></<?php echo $titleFormat; ?>>
     </div>
 <?php 
 } ?>


### PR DESCRIPTION
Adds a title format option to the RSS Displayer block as discussed in #8282 and initial PR #8405