### PR TITLE
[V8] Do not remove picture elements on rendering textarea attribute value

### DIFF
--- a/concrete/attributes/textarea/controller.php
+++ b/concrete/attributes/textarea/controller.php
@@ -71,7 +71,13 @@ class Controller extends DefaultController implements XEditableConfigurableAttri
     {
         $value = $this->getValue();
         if ($this->akTextareaDisplayMode == 'rich_text') {
-            return htmLawed($value, ['safe' => 1]);
+            return htmLawed($value, [
+                'balance' => 0, // off
+                'comment' => 3, // allow
+                'safe' => 1,
+                // default allowed elements for safe option + picture
+                'elements' => '* -applet -audio -canvas -embed -iframe -object -script -video +picture'
+            ]);
         }
 
         return nl2br(h($value));


### PR DESCRIPTION
Fixes #8964

Problematic output

```
<p>&lt;!--[if IE 9]&gt;&lt;![endif]--&gt;&lt;!--[if IE 9]&gt;&lt;![endif]--&gt;<img src="/application/files/thumbnails/small/2716/0629/5769/houses.jpg" alt="houses.jpg"></p>
```

Fixed output

```
<p><picture><!--[if IE 9]><video style='display: none;'><![endif] --><!--[if IE 9]></video><![endif] --><img src="/application/files/thumbnails/small/2716/0629/5769/houses.jpg" alt="houses.jpg"></picture></p>
```

We need to fix it for V9 also