### PR TITLE
Show am/pm selector when time format is 12-hour but time resolution is set to hours

### DIFF
--- a/concrete/src/Form/Service/Widget/DateTime.php
+++ b/concrete/src/Form/Service/Widget/DateTime.php
@@ -240,43 +240,43 @@ class DateTime
                 $html .= '>' . sprintf('%02d', $i) . '</option>';
             }
             $html .= '</select>';
-            if ($timeFormat === 12) {
-                $html .= '<select class="form-control" id="' . $id . '_a" name="' . $fieldAMPM . '"' . $disabled . '>';
-                $html .= '<option value="AM"';
-                if ($timeAMPM === 'AM') {
+        }
+        if ($timeFormat === 12) {
+            $html .= '<select class="form-control" id="' . $id . '_a" name="' . $fieldAMPM . '"' . $disabled . '>';
+            $html .= '<option value="AM"';
+            if ($timeAMPM === 'AM') {
+                $html .= ' selected="selected"';
+            }
+            $html .= '>';
+            // This prints out the translation of "AM" in the current language
+            $html .= $dh->date('A', mktime(1), 'system');
+            $html .= '</option>';
+            $html .= '<option value="PM"';
+            if ($timeAMPM === 'PM') {
+                $html .= ' selected="selected"';
+            }
+            $html .= '>';
+            // This prints out the translation of "PM" in the current language
+            $html .= $dh->date('A', mktime(13), 'system');
+            $html .= '</option>';
+            $html .= '</select>';
+        }
+        if ($stepSeconds !== 0) {
+            $html .= '<span class="separator">:</span>';
+            $html .= '<select class="form-control"  id="' . $id . '_s" name="' . $fieldSeconds . '"' . $disabled . '>';
+            $secondsList = [];
+            for ($i = 0; $i < 60; $i += $stepSeconds) {
+                $secondsList[] = $i;
+            }
+            $timeSecond = $this->selectNearestValue($secondsList, $timeSecond);
+            foreach ($secondsList as $i) {
+                $html .= '<option value="' . sprintf('%02d', $i) . '"';
+                if ($i === $timeSecond) {
                     $html .= ' selected="selected"';
                 }
-                $html .= '>';
-                // This prints out the translation of "AM" in the current language
-                $html .= $dh->date('A', mktime(1), 'system');
-                $html .= '</option>';
-                $html .= '<option value="PM"';
-                if ($timeAMPM === 'PM') {
-                    $html .= ' selected="selected"';
-                }
-                $html .= '>';
-                // This prints out the translation of "PM" in the current language
-                $html .= $dh->date('A', mktime(13), 'system');
-                $html .= '</option>';
-                $html .= '</select>';
+                $html .= '>' . sprintf('%02d', $i) . '</option>';
             }
-            if ($stepSeconds !== 0) {
-                $html .= '<span class="separator">:</span>';
-                $html .= '<select class="form-control"  id="' . $id . '_s" name="' . $fieldSeconds . '"' . $disabled . '>';
-                $secondsList = [];
-                for ($i = 0; $i < 60; $i += $stepSeconds) {
-                    $secondsList[] = $i;
-                }
-                $timeSecond = $this->selectNearestValue($secondsList, $timeSecond);
-                foreach ($secondsList as $i) {
-                    $html .= '<option value="' . sprintf('%02d', $i) . '"';
-                    if ($i === $timeSecond) {
-                        $html .= ' selected="selected"';
-                    }
-                    $html .= '>' . sprintf('%02d', $i) . '</option>';
-                }
-                $html .= '</select>';
-            }
+            $html .= '</select>';
         }
         $html .= '</span>';
         $html .= '</div>';


### PR DESCRIPTION
When adding a datetime form element, if the time resolution is set to hours (e.g. 3600) and the time format is set to display 12-hour format with AM/PM indicator, the AM/PM selector is not added to the form.

e.g. 

```
$date =Core::make('helper/form/date_time');
echo $date->datetime('startDate', $entity->getStartDateTime(), false, true, null, 3600);
```

The form shows a date picker, then a drop-down hour selector with numbers 1-12. No AM/PM selector is added to the form.

The code changes look a little weird, but all I've done is move the `if ($timeFormat === 12)` and `if ($stepSeconds !== 0)` out of the `if ($stepMinutes !== 0)` block.