### PR TITLE
[V8] Wider "Apply Style" confirmation dialog

### DIFF
--- a/concrete/css/build/core/app/panels/design.less
+++ b/concrete/css/build/core/app/panels/design.less
@@ -306,7 +306,7 @@ div#ccm-panel-page-design-themes {
     position: absolute;
     top: 110px;
     left: 220px;
-    width: 445px;
+    width: 500px;
   }
 }
 


### PR DESCRIPTION
When we save the custom styles, we have this confirmation dialog:

![immagine](https://user-images.githubusercontent.com/928116/100473232-2bc2ed00-30de-11eb-90e3-ba07dc03b4a2.png)

In Italian the dialog width is not enough:

![immagine](https://user-images.githubusercontent.com/928116/100473254-39787280-30de-11eb-9807-20e962dd9622.png)

What about making it a bit wider?

In English this would still look ok:

![immagine](https://user-images.githubusercontent.com/928116/100473460-b60b5100-30de-11eb-8f32-f19b725fa552.png)

but in Italian it's much better:

![immagine](https://user-images.githubusercontent.com/928116/100473276-42694400-30de-11eb-9d8c-488c0665e033.png)
