### PR TITLE
[V8] Fix "call to a member function overrideCollectionPermissions() on a non-object" in AreaAssignment

### DIFF
--- a/concrete/src/Area/SubArea.php
+++ b/concrete/src/Area/SubArea.php
@@ -51,20 +51,20 @@ class SubArea extends Area
         $db = Loader::db();
         $arParentID = $this->arParentID;
         if ($arParentID == 0) {
-            return false;
-        }
-
-        while ($arParentID > 0) {
-            $row = $db->GetRow('select arID, arHandle, arParentID, arOverrideCollectionPermissions from Areas where arID = ?', array($arParentID));
-            if (empty($row)) {
-                break;
+            $a = false;
+        } else {
+            while ($arParentID > 0) {
+                $row = $db->GetRow('select arID, arHandle, arParentID, arOverrideCollectionPermissions from Areas where arID = ?', array($arParentID));
+                if (empty($row)) {
+                    break;
+                }
+                $arParentID = $row['arParentID'];
+                if ($row['arOverrideCollectionPermissions']) {
+                    break;
+                }
             }
-            $arParentID = $row['arParentID'];
-            if ($row['arOverrideCollectionPermissions']) {
-                break;
-            }
+            $a = empty($row) ? null : Area::get($this->c, $row['arHandle']);
         }
-        $a = empty($row) ? null : Area::get($this->c, $row['arHandle']);
         $cache->save($item->set($a));
 
         return $a;

--- a/concrete/src/Area/SubArea.php
+++ b/concrete/src/Area/SubArea.php
@@ -56,12 +56,15 @@ class SubArea extends Area
 
         while ($arParentID > 0) {
             $row = $db->GetRow('select arID, arHandle, arParentID, arOverrideCollectionPermissions from Areas where arID = ?', array($arParentID));
+            if (empty($row)) {
+                break;
+            }
             $arParentID = $row['arParentID'];
             if ($row['arOverrideCollectionPermissions']) {
                 break;
             }
         }
-        $a = Area::get($this->c, $row['arHandle']);
+        $a = empty($row) ? null : Area::get($this->c, $row['arHandle']);
         $cache->save($item->set($a));
 
         return $a;

--- a/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -84,7 +84,7 @@ class AreaAssignment extends Assignment
         } else {
             $this->stackAssignment = null;
             if ($a instanceof SubArea && !$a->overrideCollectionPermissions()) {
-                $a = $a->getSubAreaParentPermissionsObject();
+                $a = $a->getSubAreaParentPermissionsObject() ?: $a;
             }
         }
 


### PR DESCRIPTION
I don't know why, but visiting a a rather complex page we have this error:
```
Call to a member function overrideCollectionPermissions() on a non-object
in concrete/src/Permission/Assignment/AreaAssignment.php
Line: 94
```
