### PR TITLE
Correct missing return statement in Comparator

### DIFF
--- a/concrete/src/Foundation/Repetition/Comparator.php
+++ b/concrete/src/Foundation/Repetition/Comparator.php
@@ -54,7 +54,10 @@ class Comparator
         }
 
         if ($r1->getRepeatPeriodWeekDays() != $r2->getRepeatPeriodWeekDays()) {
-        }return true;
+            return false;
+        }
+        
+        return true;
     }
 }
 

--- a/concrete/src/Foundation/Repetition/Comparator.php
+++ b/concrete/src/Foundation/Repetition/Comparator.php
@@ -53,11 +53,12 @@ class Comparator
             }
         }
 
-        if ($r1->getRepeatPeriodWeekDays() != $r2->getRepeatPeriodWeekDays()) {
+        $r1Days = $r1->getRepeatPeriodWeekDays();
+        $r2Days = $r2->getRepeatPeriodWeekDays();
+        if (array_diff($r1Days, $r2Days) || array_diff($r2Days, $r1Days)) {
             return false;
         }
-        
+
         return true;
     }
 }
-


### PR DESCRIPTION
Added missing return statement in Repetition Comparator which prevented users from adding event repeat days after event creation. `if` statement was empty so Comparator would improperly return `true` even if the RepeatPeriodWeekDays did not match.

PHP's not equals operator take key/value combination into consideration when comparing so `[1,3] == [3,1]` will be false. The test in `RepetitionComparatorTest.php` suggests that the array keys are not important so I corrected the Comparator to use `array_diff` rather than update the test.

Fixes #9227