### PR TITLE
Fix site default locale detection

### DIFF
--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -83,6 +83,9 @@ class Detector
             $locale = $site->getDefaultLocale();
             $home = Section::getByLocale($locale);
             if ($home) {
+                if (!is_object($locale)) {
+                    $locale = $home->getLocaleObject();
+                }
                 $result = [$locale->getLocale(), $home];
             }
         }

--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -83,7 +83,7 @@ class Detector
             $locale = $site->getDefaultLocale();
             $home = Section::getByLocale($locale);
             if ($home) {
-                $result = [$locale, $home];
+                $result = [$locale->getLocale(), $home];
             }
         }
 


### PR DESCRIPTION
When the site locale detector falls to the site default locale detection, this can cause the whole PHP process to jam (until its timeout is reached).

On this line, look the whole locale object is passed to the result array's first element:
https://github.com/concrete5/concrete5/blob/203eea555989997558bf4431cf19b405b06c80a6/concrete/src/Multilingual/Service/Detector.php#L86

It is fetched here from the site entity object:
https://github.com/concrete5/concrete5/blob/203eea555989997558bf4431cf19b405b06c80a6/concrete/src/Multilingual/Service/Detector.php#L83

And as you can see here it returns an instance of a `Concrete\Core\Entity\Site\Locale` when available:
https://github.com/concrete5/concrete5/blob/203eea555989997558bf4431cf19b405b06c80a6/concrete/src/Entity/Site/Site.php#L280

OK no biggie, but the problem is here:
https://github.com/concrete5/concrete5/blob/203eea555989997558bf4431cf19b405b06c80a6/concrete/src/Multilingual/Service/Detector.php#L91

When you try to assign an object to the session variable, it tries to dump the whole object there. The entity objects are very large and complex. If you try dumping that object on the page (`var_dump(\Core::make('site')->getSite()->getDefaultLocale());`), you will most likely get an HTTP 500 because the object is too large to dump.

This causes the PHP process to jam until its timeout is reached which can cause enormous extra load on the server.

I noticed this bug when upgrading a multisite & multilingual installation from 8.5.1 to 8.5.4. Something has apparently changed between those versions. I assume `$site->getDefaultLocale()` might have previously returned a string (?).