### PR TITLE
Small docblock fix in deprecated method

### DIFF
--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -654,7 +654,7 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * @deprecated
-     * Use $app->make('Concrete\Core\Package\PackageService')->getInstalledHandles()
+     * Use $app->make('Concrete\Core\Package\PackageService')->getByHandle($pkgHandle)
      *
      * @param string $pkgHandle
      *


### PR DESCRIPTION
Update getByHandle() method docblocks to corresponding method instead of copy/paste from other method.