### PR TITLE
Fix redisdriver clearNamespace method

### DIFF
--- a/concrete/src/Config/Driver/Redis/RedisLoader.php
+++ b/concrete/src/Config/Driver/Redis/RedisLoader.php
@@ -24,6 +24,10 @@ class RedisLoader implements LoaderInterface
     public function clearNamespace($namespace)
     {
         $keys = $this->paginatedScan($this->connection, "{$namespace}::*");
+        if ($keys instanceof \Generator) {
+            $keys = iterator_to_array($keys);
+        }
+        
         if ($keys) {
             $this->connection->del($keys);
         }


### PR DESCRIPTION
We were passing a Generator instance into `\Redis::del` which lead to a fatal error on package uninstall.