### PR TITLE
Fix hasBannedWords to keep backward compatibility

### DIFF
--- a/concrete/src/Validation/BannedWord/Service.php
+++ b/concrete/src/Validation/BannedWord/Service.php
@@ -163,10 +163,12 @@ class Service
     {
         $out = 0;
         $bannedWords = $this->getBannedWords();
-        foreach ($bannedWords as $bannedWord) {
-            if (mb_stripos($string, $bannedWord) !== false) {
-                $out = 1;
-                break;
+        foreach (preg_split('/((^\p{P}+)|(\p{P}*\s+\p{P}*)|(\p{P}+$))/u', $string) as $str) {
+            foreach ($bannedWords as $bannedWord) {
+                if (mb_strtolower($str) === mb_strtolower($bannedWord)) {
+                    $out = 1;
+                    break 2;
+                }
             }
         }
 

--- a/tests/tests/Validation/BannedWordTest.php
+++ b/tests/tests/Validation/BannedWordTest.php
@@ -10,17 +10,17 @@ class BannedWordTest extends PHPUnit_Framework_TestCase
     public function testHasBannedWords()
     {
         $service = new Service();
-        $service->setBannedWords(['lorem', 'NSECT', 'perché', '建築家']);
+        $service->setBannedWords(['lorem', 'adipiscing', 'perché', 'コンクリート']);
         $haystacks = [
             'Lorem ipsum dolor sit amet',
             'consectetur adipiscing elit',
-            'Tuttavia, perché voi intendiate da dove sia nato tutto questo errore',
-            '人間の喜びを築く建築家の実践的な教えを詳しく説明しよう'
+            'Tuttavia, "perché" voi intendiate da dove sia nato tutto questo errore',
+            'コンクリート'
         ];
         foreach ($haystacks as $haystack) {
             $this->assertTrue((bool) $service->hasBannedWords($haystack), sprintf('Has Banned Word check failed with %s', $haystack));
         }
-        $service->setBannedWords(['Duis', 'aute', 'spiegherò', '憤り']);
+        $service->setBannedWords(['Duis', 'ore', 'aute', 'ché', 'spiegherò', 'クリ']);
         foreach ($haystacks as $haystack) {
             $this->assertFalse((bool) $service->hasBannedWords($haystack), sprintf('Has not Banned Word check failed with %s', $haystack));
         }


### PR DESCRIPTION
I'd fixed `hasBannedWords` function to support multibyte characters in #9070, but I broke backward compatibility.

As suggested by @jaromirdalecky , it should ban string has whole banned words, instead of a part of the words.

It's not best for agglutinative languages like Japanese, because we don't use white spaces in sentences, but I'll try to support wildcard like `*ban*` in version 9.

On 8.5.5, I think we should just keep backward compatibility.