### PR TITLE
[V8] Fix some issues when using tags on multilingual site

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -200,7 +200,11 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
             } else {
                 $options = $this->getSelectedOptions();
                 foreach ($options as $opt) {
-                    $selectedOptions[] = ['id' => 'SelectAttributeOption:' . $opt->getSelectAttributeOptionID(), 'text' => $opt->getSelectAttributeOptionValue()];
+                    $selectedOptions[] = [
+                        'id' => 'SelectAttributeOption:' . $opt->getSelectAttributeOptionID(),
+                        'label' => $opt->getSelectAttributeOptionDisplayValue(),
+                        'text' => $opt->getSelectAttributeOptionValue()
+                    ];
                     $selectedOptionIDs[] = 'SelectAttributeOption:' . $opt->getSelectAttributeOptionID();
                 }
             }
@@ -530,7 +534,8 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
             foreach ($options as $opt) {
                 $o = new \stdClass();
                 $o->id = 'SelectAttributeOption:' . $opt->getSelectAttributeOptionID();
-                $o->text = $opt->getSelectAttributeOptionValue(false);
+                $o->label = $opt->getSelectAttributeOptionDisplayValue();
+                $o->text = $opt->getSelectAttributeOptionValue();
                 $values[] = $o;
             }
         }
@@ -923,10 +928,12 @@ EOT
                 $option = $r->findOneBy(['list' => $type->getOptionList(), 'avSelectOptionID' => $optionID]);
                 if (is_object($option)) {
                     $o->id = $value;
+                    $o->label = $option->getSelectAttributeOptionDisplayValue();
                     $o->text = $option->getSelectAttributeOptionValue();
                 }
             } else {
                 $o->id = $value;
+                $o->label = $value;
                 $o->text = $value;
             }
 

--- a/concrete/attributes/select/form.php
+++ b/concrete/attributes/select/form.php
@@ -83,7 +83,8 @@ if ($akSelectAllowOtherValues) {
 			$('input[data-select-and-add=<?=$akID?>]').selectize({
                 plugins: ['remove_button'],
 				valueField: 'id',
-				labelField: 'text',
+                labelField: 'label',
+                searchField: 'text',
 				options: <?=json_encode($selectedOptions)?>,
 				items: <?=json_encode($selectedOptionIDs)?>,
 				openOnFocus: false,

--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -144,7 +144,7 @@ class Controller extends BlockController
             $target = \Page::getCurrentPage();
         }
         if ($option) {
-            return \URL::page($target, 'tag', mb_strtolower($option->getSelectAttributeOptionDisplayValue()));
+            return \URL::page($target, 'tag', mb_strtolower(h($option->getSelectAttributeOptionValue())));
         } else {
             return \URL::page($target);
         }

--- a/concrete/blocks/tags/view.php
+++ b/concrete/blocks/tags/view.php
@@ -11,17 +11,17 @@
         <?php foreach ($options as $option) { ?>
             <?php if (isset($target) && $target) { ?>
                 <a href="<?=$controller->getTagLink($option) ?>">
-                    <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-                        <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <?php if (isset($selectedTag) && mb_strtolower(h($option->getSelectAttributeOptionValue())) == mb_strtolower($selectedTag)) { ?>
+                        <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionDisplayValue()?></span>
                     <?php } else { ?>
-                        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                        <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionDisplayValue()?></span>
                     <?php } ?>
                 </a>
             <?php } else { ?>
-                <?php if (isset($selectedTag) && mb_strtolower($option->getSelectAttributeOptionValue()) == mb_strtolower($selectedTag)) { ?>
-                    <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionValue()?></span>
+                <?php if (isset($selectedTag) && mb_strtolower(h($option->getSelectAttributeOptionValue())) == mb_strtolower($selectedTag)) { ?>
+                    <span class="ccm-block-tags-tag ccm-block-tags-tag-selected label"><?=$option->getSelectAttributeOptionDisplayValue()?></span>
                 <?php } else { ?>
-                    <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionValue()?></span>
+                    <span class="ccm-block-tags-tag label"><?=$option->getSelectAttributeOptionDisplayValue()?></span>
                 <?php } ?>
             <?php } ?>
         <?php } ?>


### PR DESCRIPTION
## Issue detail

### Must have

Select option values are translatable on the "Translate Site Interface" page.
However, option values are not displayed as localized labels when you use tags block.
Also, `.ccm-block-tags-tag-selected` class is not applied to the selected tag, because the option value in the filtered URL is translated, but compared in view.php with untranslated option value.

### Should have

Option values are not displayed as a localized string on the composer window.
It's not a serious issue, but it should be translated.