### PR TITLE
[V9] Fix duration of IP bans

### DIFF
--- a/concrete/src/Permission/IpAccessControlService.php
+++ b/concrete/src/Permission/IpAccessControlService.php
@@ -241,7 +241,7 @@ class IpAccessControlService implements LoggerAwareInterface
         if ($this->getCategory()->getBanDuration() === null) {
             $banExpiration = null;
         } else {
-            $banExpiration = new DateTime('+' . $this->getCategory()->getBanDuration() . ' minutes');
+            $banExpiration = new DateTime('+' . $this->getCategory()->getBanDuration() . ' seconds');
         }
 
         $range = $this->createRange(


### PR DESCRIPTION
The ban duration of `IpAccessControlCategory` is in seconds, not minutes (see [here](https://github.com/concrete5/concrete5/blob/ab9be4e74ec460fa6c823f97e0b6705714c8c7c9/concrete/src/Entity/Permission/IpAccessControlCategory.php#L308)).