### PR TITLE
[V8] Fix: make email log readable by decode quoted printable text

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -674,7 +674,12 @@ class Service
                 $l->write('**' . t('EMAILS ARE DISABLED. THIS EMAIL WAS LOGGED BUT NOT SENT') . '**');
             }
             $l->write(t('Template Used') . ': ' . $this->template);
-            $l->write(t('Mail Details: %s', $mail->toString()));
+            $detail = $mail->toString();
+            $encoding = $mail->getHeaders()->get('Content-Transfer-Encoding');
+            if (is_object($encoding) && $encoding->getFieldValue() === 'quoted-printable') {
+                $detail = quoted_printable_decode($detail);
+            }
+            $l->write(t('Mail Details: %s', $detail));
             $l->close();
         }
 


### PR DESCRIPTION
↓ After
![Screen Shot 2020-12-18 at 23 55 19](https://user-images.githubusercontent.com/514294/102628387-f06f8780-418c-11eb-9a47-c5e404472457.png)
↑ Before