### PR TITLE
[V8] Fix bug: Express Form can generate same attribute keys for multiple attribute keys

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -515,6 +515,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         }
 
         $attributeKeyCategory = $entity->getAttributeKeyCategory();
+        $attributeKeyHandleGenerator = new AttributeKeyHandleGenerator($attributeKeyCategory);
 
         // First, we get the existing controls, so we can check them
         // to see if controls should be removed later.
@@ -548,7 +549,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $mergedKey = $entityManager->merge($key);
                         $mergedKey->setAttributeType($mergedType);
                         $mergedKey->setEntity($entity);
-                        $mergedKey->setAttributeKeyHandle((new AttributeKeyHandleGenerator($attributeKeyCategory))->generate($mergedKey));
+                        $mergedKey->setAttributeKeyHandle($attributeKeyHandleGenerator->generate($mergedKey));
                         $entityManager->persist($mergedKey);
                         $entityManager->flush();
 
@@ -578,7 +579,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
                                 // question name
                                 $key->setAttributeKeyName($control->getAttributeKey()->getAttributeKeyName());
-                                $key->setAttributeKeyHandle((new AttributeKeyHandleGenerator($attributeKeyCategory))->generate($key));
+                                $key->setAttributeKeyHandle($attributeKeyHandleGenerator->generate($key));
 
                                 // Key Type
                                 $key = $entityManager->merge($key);

--- a/concrete/src/Express/Attribute/AttributeKeyHandleGenerator.php
+++ b/concrete/src/Express/Attribute/AttributeKeyHandleGenerator.php
@@ -8,7 +8,8 @@ use Concrete\Core\Entity\Attribute\Key\Key;
 
 class AttributeKeyHandleGenerator implements AttributeKeyHandleGeneratorInterface
 {
-
+    /** @var string[] */
+    protected $requestHandles = [];
     protected $category;
 
     public function __construct(ExpressCategory $category)
@@ -18,14 +19,20 @@ class AttributeKeyHandleGenerator implements AttributeKeyHandleGeneratorInterfac
 
     protected function handleIsAvailable($handleToTest, Key $existingKey)
     {
+        if (in_array($handleToTest, $this->requestHandles, true)) {
+            return false;
+        }
+
         $key = $this->category->getByHandle($handleToTest);
         if (is_object($key)) {
             if ($key->getAttributeKeyID() != $existingKey->getAttributeKeyID()) {
                 return false;
             } else {
+                $this->requestHandles[] = $handleToTest;
                 return true;
             }
         } else {
+            $this->requestHandles[] = $handleToTest;
             return true;
         }
     }

--- a/tests/tests/Express/AttributeKeyHandleGeneratorTest.php
+++ b/tests/tests/Express/AttributeKeyHandleGeneratorTest.php
@@ -21,7 +21,6 @@ class AttributeKeyHandleGeneratorTest extends ConcreteDatabaseTestCase
     public static function setupBeforeClass()
     {
         parent::setUpBeforeClass();
-        \Core::make('cache/request')->disable();
     }
 
     public function testExpressHandleGenerator()


### PR DESCRIPTION
When adding Express Form with multibyte only fields, it generates the same attribute handle 'attribute_key' for those attribute keys.

https://user-images.githubusercontent.com/514294/105643220-e2223300-5ed1-11eb-94d6-634fe15cb19f.mov

https://user-images.githubusercontent.com/514294/105643226-e77f7d80-5ed1-11eb-80d8-a9cfa9d4e167.mov

It causes because the information that missing existing attribute keys also stored in the request cache.
Let's store already generated handles in the instance of the generator to avoid the request cache effect.

We need to pick this fix for V9 also.