### PR TITLE
[V9] Fix bug: Express Form can generate same attribute keys for multiple attribute keys

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -533,6 +533,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         }
 
         $attributeKeyCategory = $entity->getAttributeKeyCategory();
+        $attributeKeyHandleGenerator = new AttributeKeyHandleGenerator($attributeKeyCategory);
 
         // First, we get the existing controls, so we can check them
         // to see if controls should be removed later.
@@ -566,7 +567,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $mergedKey = $entityManager->merge($key);
                         $mergedKey->setAttributeType($mergedType);
                         $mergedKey->setEntity($entity);
-                        $mergedKey->setAttributeKeyHandle((new AttributeKeyHandleGenerator($attributeKeyCategory))->generate($mergedKey));
+                        $mergedKey->setAttributeKeyHandle($attributeKeyHandleGenerator->generate($mergedKey));
                         $entityManager->persist($mergedKey);
                         $entityManager->flush();
 
@@ -596,7 +597,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
                                 // question name
                                 $key->setAttributeKeyName($control->getAttributeKey()->getAttributeKeyName());
-                                $key->setAttributeKeyHandle((new AttributeKeyHandleGenerator($attributeKeyCategory))->generate($key));
+                                $key->setAttributeKeyHandle($attributeKeyHandleGenerator->generate($key));
 
                                 // Key Type
                                 $key = $entityManager->merge($key);

--- a/concrete/src/Express/Attribute/AttributeKeyHandleGenerator.php
+++ b/concrete/src/Express/Attribute/AttributeKeyHandleGenerator.php
@@ -8,7 +8,8 @@ use Concrete\Core\Entity\Attribute\Key\Key;
 
 class AttributeKeyHandleGenerator implements AttributeKeyHandleGeneratorInterface
 {
-
+    /** @var string[] */
+    protected $requestHandles = [];
     protected $category;
 
     public function __construct(ExpressCategory $category)
@@ -18,14 +19,20 @@ class AttributeKeyHandleGenerator implements AttributeKeyHandleGeneratorInterfac
 
     protected function handleIsAvailable($handleToTest, Key $existingKey)
     {
+        if (in_array($handleToTest, $this->requestHandles, true)) {
+            return false;
+        }
+
         $key = $this->category->getByHandle($handleToTest);
         if (is_object($key)) {
             if ($key->getAttributeKeyID() != $existingKey->getAttributeKeyID()) {
                 return false;
             } else {
+                $this->requestHandles[] = $handleToTest;
                 return true;
             }
         } else {
+            $this->requestHandles[] = $handleToTest;
             return true;
         }
     }

--- a/tests/tests/Express/AttributeKeyHandleGeneratorTest.php
+++ b/tests/tests/Express/AttributeKeyHandleGeneratorTest.php
@@ -21,7 +21,6 @@ class AttributeKeyHandleGeneratorTest extends ConcreteDatabaseTestCase
     public static function setupBeforeClass()
     {
         parent::setUpBeforeClass();
-        \Core::make('cache/request')->disable();
     }
 
     public function testExpressHandleGenerator()


### PR DESCRIPTION
Refs #9342

How to reproduce

https://user-images.githubusercontent.com/514294/105901513-d44ee800-6060-11eb-9d3e-a44489b1cff7.mov

