### PR TITLE
Fix document library 'in all sets' filter and add a folder hiding option

### DIFF
--- a/concrete/blocks/document_library/db.xml
+++ b/concrete/blocks/document_library/db.xml
@@ -85,6 +85,9 @@
     <field name="rowBackgroundColorAlternate" type="string" size="32">
       <default value=""/>
     </field>
+    <field name="hideFolders" type="integer">
+      <default value="0"/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/document_library/edit.php
+++ b/concrete/blocks/document_library/edit.php
@@ -10,6 +10,7 @@ echo Core::make('helper/concrete/ui')->tabs(array(
     array('results', t('Results'))
 ));
 
+$hideFolders = isset($hideFolders) ? $hideFolders : false;
 ?>
 
 <div class="ccm-tab-content" id="ccm-tab-content-sources">
@@ -31,6 +32,17 @@ echo Core::make('helper/concrete/ui')->tabs(array(
                     <?=$set->getFileSetDisplayName()?>
                 </label></div>
             <?php } ?>
+        </div>
+
+        <div class="form-group">
+            <?= $form->label('showFolders', t('Show Folders')) ?>
+
+            <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('showFolders', '1', !$hideFolders) ?>
+                    <?= t('Show Folders') ?>
+                </label>
+            </div>
         </div>
 
         <div class="form-group">

--- a/concrete/src/Updater/Migrations/Migrations/Version20210128214511.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210128214511.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20210128214511 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshBlockType('document_library');
+    }
+}


### PR DESCRIPTION
This PR:

- Fixes the 'in all sets' filter, it didn't work because it was attempting to check multiple rows in a join which as far as I'm aware is not possible. Instead we use a subselect that selects a count of the selected sets and match against the count we expect.
- Adds a "Show Folders" option that defaults to checked for new and existing blocks that hides folders and their contents. One caveat is if there is no selected folder, we will search all folders and show results from everywhere instead of just at the top level.