### PR TITLE
Fix #8819 (v9)

### DIFF
--- a/concrete/elements/block_area_footer.php
+++ b/concrete/elements/block_area_footer.php
@@ -76,12 +76,16 @@ $class = 'ccm-area-footer';
                                     if ($pk->validate()) {
                                         $btc = $bx->getController();
                                         $arLayout = $btc->getAreaLayoutObject();
-                                        ?>
+
+                                        if ($arLayout instanceof \Concrete\Core\Area\Layout\PresetLayout) { ?>
+                                            <a href="#" class="dropdown-item disabled" disabled"><?=t('Save Layout as Preset')?></a>
+                                        <?php } else { ?>
                                         <a class="dropdown-item dialog-launch"
                                                href="<?= URL::to('/ccm/system/dialogs/area/layout/presets', $arLayout->getAreaLayoutID()) ?>"
                                                dialog-title="<?= t('Save Layout as Preset') ?>" dialog-width="360"
                                                dialog-height="300"
                                                dialog-modal="true"><?= t("Save Layout as Preset") ?></a>
+                                        <?php } ?>
                                         <a class="dropdown-item dialog-launch"
                                                href="<?= URL::to('/ccm/system/dialogs/area/layout/presets/manage') ?>"
                                                dialog-title="<?= t('Manage Presets') ?>" dialog-width="360"

--- a/concrete/src/Area/Layout/Preset/Provider/Manager.php
+++ b/concrete/src/Area/Layout/Preset/Provider/Manager.php
@@ -13,12 +13,19 @@ class Manager
     public function register(ProviderInterface $provider)
     {
         $this->providers[$provider->getName()] = $provider;
+        $this->reset();
+    }
+
+    public function reset()
+    {
+        unset($this->presets);
     }
 
     public function unregister($nameOrObject)
     {
         $plugin = ($nameOrObject instanceof ProviderInterface) ? $nameOrObject : $this->providers[$nameOrObject];
         unset($this->providers[$plugin->getName()]);
+        $this->reset();
     }
 
     public function getByName($name)
@@ -54,6 +61,9 @@ class Manager
         });
         $results = array_values($results);
 
-        return $results[0];
+        if (!empty($results[0])) {
+            return $results[0];
+        }
+        return null;
     }
 }

--- a/concrete/src/Area/Layout/Preset/Provider/Manager.php
+++ b/concrete/src/Area/Layout/Preset/Provider/Manager.php
@@ -8,6 +8,8 @@ class Manager
 {
     protected $providers = array();
 
+    protected $presets;
+
     public function register(ProviderInterface $provider)
     {
         $this->providers[$provider->getName()] = $provider;
@@ -31,17 +33,18 @@ class Manager
 
     public function getPresets()
     {
-        $presets = array();
-        foreach ($this->providers as $provider) {
-            $presets = array_merge($presets, $provider->getPresets());
-        }
-        array_map(function ($preset) {
-            if (!($preset instanceof PresetInterface)) {
-                throw new InvalidPresetException(t('Items returned by getPresets() must implement the PresetInterface'));
+        if (!isset($this->presets)) {
+            $this->presets = array();
+            foreach ($this->providers as $provider) {
+                $this->presets = array_merge($this->presets, $provider->getPresets());
             }
-        }, $presets);
-
-        return $presets;
+            array_map(function ($preset) {
+                if (!($preset instanceof PresetInterface)) {
+                    throw new InvalidPresetException(t('Items returned by getPresets() must implement the PresetInterface'));
+                }
+            }, $this->presets);
+        }
+        return $this->presets;
     }
 
     public function getPresetByIdentifier($identifier)

--- a/tests/tests/Area/AreaLayoutPresetTest.php
+++ b/tests/tests/Area/AreaLayoutPresetTest.php
@@ -52,6 +52,8 @@ class AreaLayoutPresetTest extends PageTestCase
 
     public function tearDown(): void
     {
+        $manager = Core::make('manager/area_layout_preset_provider');
+        $manager->reset();
         parent::tearDown();
         $this->truncateTables();
     }
@@ -137,6 +139,7 @@ class AreaLayoutPresetTest extends PageTestCase
         $req = Request::getInstance();
         $req->setCurrentPage($c);
 
+        $manager->reset();
         $presets = $manager->getPresets();
         $this->assertCount(1, $presets);
         $c = Page::getCurrentPage();


### PR DESCRIPTION
This makes it so that sites are no longer bricked if a theme preset is re-saved as a user layout preset.

The layouts themselves that have been applied may look strange – I tried to make them actually apply the styles of the theme preset but that required a lot of recursive code and it was just too much potential error for too little gain. Instead, just use the theme presets and don't re-save them as user presets. There's no gain to resaving them as user presets. 

Additionally I've made it so you cannot re-save theme presets as user presets in the UI. 