### PR TITLE
Fix: invalid HTML

### DIFF
--- a/concrete/elements/block_area_footer.php
+++ b/concrete/elements/block_area_footer.php
@@ -78,7 +78,7 @@ $class = 'ccm-area-footer';
                                         $arLayout = $btc->getAreaLayoutObject();
 
                                         if ($arLayout instanceof \Concrete\Core\Area\Layout\PresetLayout) { ?>
-                                            <a href="#" class="dropdown-item disabled" disabled"><?=t('Save Layout as Preset')?></a>
+                                            <a href="#" class="dropdown-item disabled"><?=t('Save Layout as Preset')?></a>
                                         <?php } else { ?>
                                         <a class="dropdown-item dialog-launch"
                                                href="<?= URL::to('/ccm/system/dialogs/area/layout/presets', $arLayout->getAreaLayoutID()) ?>"


### PR DESCRIPTION
Looks like the "disabled" class was added twice, but it created invalid HTML due to the extra quotation mark
