### PR TITLE
Checks author isn't null before getting ID

### DIFF
--- a/concrete/elements/express/form/form/author.php
+++ b/concrete/elements/express/form/form/author.php
@@ -1,12 +1,16 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 $form = Core::make("helper/form/user_selector");
-$author = null;
+$authorID = null;
 if ($entry) {
-    $author = $entry->getAuthor()->getUserID();
+    $author = $entry->getAuthor();
+
+    if ($author) {
+        $authorID = $author->getUserID();
+    }
 } else {
     $u = Core::make(Concrete\Core\User\User::class);
-    $author = $u->getUserID();
+    $authorID = $u->getUserID();
 }
 ?>
 
@@ -14,5 +18,5 @@ if ($entry) {
     <?php if ($view->supportsLabel()) { ?>
         <label class="control-label"><?=$label?></label>
     <?php } ?>
-    <?=$form->selectUser('author', $author);?>
+    <?=$form->selectUser('author', $authorID);?>
 </div>


### PR DESCRIPTION
Adds an additional check to ensure `getUserID()` isn't run on `null` when an author isn't set for an Express entry.

Fixes error when editing an Express entry without an author in Dashboard -> Express, in the form view.