### PR TITLE
Unsets author in Entry when it's cleared in Express form

### DIFF
--- a/concrete/src/Express/Form/Control/SaveHandler/AuthorSaveHandler.php
+++ b/concrete/src/Express/Form/Control/SaveHandler/AuthorSaveHandler.php
@@ -18,10 +18,12 @@ class AuthorSaveHandler implements SaveHandlerInterface
      */
     public function saveFromRequest(Control $control, Entry $entry, Request $request)
     {
-        $author = $request->request->get('author');
-        if ($author) {
-            $ui = UserInfo::getById($request->request->get('author'));
+        $authorID = $request->request->get('author');
+        if ($authorID) {
+            $ui = UserInfo::getById($authorID);
             $entry->setAuthor($ui->getEntityObject());
+        } else {
+            $entry->setAuthor(null);
         }
     }
 }


### PR DESCRIPTION
If an author is set on an Express Entry, you cannot unset that user.

Added an `else` to the `if` condition to unset the current user.