### PR TITLE
Fixing empty response

### DIFF
--- a/concrete/routes/api/system.php
+++ b/concrete/routes/api/system.php
@@ -11,5 +11,5 @@ use Concrete\Core\System\InfoTransformer;
 use League\Fractal\Resource\Item;
 
 $router->get('/system/info', function () {
-    return new Item(new Info(), new InfoTransformer());
+    return new JsonResponse(['data' => (new InfoTransformer())->transform(new Info())],200);
 })->setScopes('system:info:read');


### PR DESCRIPTION
Fixing an empty response issue. 
According to this video https://youtu.be/p8ySVFeCgv0
It should return the system info, but in the current version it returns an empty string. 
