### PR TITLE
[V8] Let user specify the SMTP HELO/EHLO domain

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -149,6 +149,8 @@ return [
                 'password' => '',
                 'encryption' => '',
                 'messages_per_connection' => null,
+                // The domain to be used in the HELO/EHLO step (if empty we'll use localhost)
+                'helo_domain' => 'localhost',
             ],
         ],
     ],

--- a/concrete/controllers/single_page/dashboard/system/mail/method.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method.php
@@ -24,6 +24,7 @@ class Method extends DashboardPageController
                 $config->save('concrete.mail.methods.smtp.encryption', $this->post('MAIL_SEND_METHOD_SMTP_ENCRYPTION'));
                 $messages_per_connection = (int) $this->post('MAIL_SEND_METHOD_SMTP_MESSAGES_PER_CONNECTION');
                 $config->save('concrete.mail.methods.smtp.messages_per_connection', $messages_per_connection > 0 ? $messages_per_connection : null);
+                $config->save('concrete.mail.methods.smtp.helo_domain', (string) $this->post('MAIL_SEND_METHOD_SMTP_HELO_DOMAIN'));
             } else {
                 $config->clear('concrete.mail.methods.smtp.server');
                 $config->clear('concrete.mail.methods.smtp.username');

--- a/concrete/controllers/single_page/dashboard/system/mail/method/test.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method/test.php
@@ -54,6 +54,7 @@ class Test extends DashboardPageController
                                     $body .= "\n- " . t('SMTP Server: %s', $config->get('concrete.mail.methods.smtp.server'));
                                     $body .= "\n- " . t('SMTP Port: %s', $config->get('concrete.mail.methods.smtp.port', tc('SMTP Port', 'default')));
                                     $body .= "\n- " . t('SMTP Encryption: %s', $config->get('concrete.mail.methods.smtp.encryption', tc('SMTP Encryption', 'none')));
+                                    $body .= "\n- " . t(/*i18n: %1%s is HELO, %2$s is the domain*/'SMTP %1$s Domain: %2$s', 'HELO', $config->get('concrete.mail.methods.smtp.helo_domain'));
                                     if (!$config->get('concrete.mail.methods.smtp.username')) {
                                         $body .= "\n- " . t('SMTP Authentication: none');
                                     } else {

--- a/concrete/single_pages/dashboard/system/mail/method.php
+++ b/concrete/single_pages/dashboard/system/mail/method.php
@@ -65,6 +65,11 @@ $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('E
         </div>
 
         <div class="form-group">
+            <?= $form->label('MAIL_SEND_METHOD_SMTP_HELO_DOMAIN', t(/*i18n: %1$s is HELO, %2$s is localhost*/'%1$s domain (Leave blank for %2$s)', 'HELO', 'localhost')) ?>
+            <?= $form->text('MAIL_SEND_METHOD_SMTP_HELO_DOMAIN', $config->get('concrete.mail.methods.smtp.helo_domain')) ?>
+        </div>
+
+        <div class="form-group">
             <?= $form->label('MAIL_SEND_METHOD_SMTP_MESSAGES_PER_CONNECTION', t('Messages per connection'), ['class' => 'launch-tooltip', 'title' => t('Sending multiple messages per connection can speed up sending many emails at once, but this feature must be supported by the SMTP server')]) ?>
             <?= $form->number('MAIL_SEND_METHOD_SMTP_MESSAGES_PER_CONNECTION', $config->get('concrete.mail.methods.smtp.messages_per_connection') ?: '', ['min' => 1, 'placeholder' => t('Leave empty for unlimited messages per connection')]) ?>
         </div>

--- a/concrete/src/Mail/Transport/Factory.php
+++ b/concrete/src/Mail/Transport/Factory.php
@@ -77,6 +77,10 @@ class Factory
         if ($encryption) {
             $options['connection_config']['ssl'] = (string) $encryption;
         }
+        $heloDomain = (string) array_get($array, 'helo_domain');
+        if ($heloDomain !== '') {
+            $options['name'] = $heloDomain;
+        }
         $mpc = array_get($array, 'messages_per_connection');
         $messagesPerConnection = $mpc ? (int) $mpc : 0;
 


### PR DESCRIPTION
At the moment, ~~concrete5~~ ConcreteCMS always use `localhost` ([the default value](https://github.com/zendframework/zend-mail/blob/release-2.7.3/src/Transport/SmtpOptions.php#L20)) in the `HELO`/`EHLO` step of the SMTP connection procedure.

Some SMTP delivery services *require* a registered domain to be used instead of `localhost`.

Tested with the [SMTP relay service of Google Workspace](https://support.google.com/a/answer/176600?hl=en), and already in production for us.