### PR TITLE
Strip script tag contents from the page search index

### DIFF
--- a/tests/tests/Page/Search/IndexedSearchTest.php
+++ b/tests/tests/Page/Search/IndexedSearchTest.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Concrete\Tests\Page\Search;
+
+
+use Concrete\Core\Page\Search\IndexedSearch;
+use PHPUnit\Framework\TestCase;
+
+class IndexedSearchTest extends TestCase
+{
+
+    public function testStripBadTagContents()
+    {
+        $testString = <<<STR
+1
+<script>
+// Normal script tag
+foo
+</script>
+2
+<SCRIPT CAPITALIZED="YA">
+foo
+</SCRIPT>
+3
+<script >
+foo
+</script   >
+4
+<script type="text/javascript" >
+foo
+</script>
+5
+STR;
+
+        $indexedSearch = new IndexedSearch();
+
+        $method = new \ReflectionMethod($indexedSearch, 'stripBadTagContents');
+        $method->setAccessible(true);
+
+        $expected = implode("\n\n", range(1,5));
+        $this->assertEquals($expected, $method->invoke($indexedSearch, $testString));
+    }
+
+}


### PR DESCRIPTION
This PR prevents raw javascript added to blocks from being indexed in the page index.

Imagine a situation where a page has an html block with a large inline <script> tag. Today, the search indexer will strip the *tags* but will leave the *contents* of that script tag to be indexed. With this change, an extra step happens before stripping tags that normalizes the HTML and then removes script tags and their contents.

This isn't exactly a full solution, it still has edge cases that slip past. For example if a block has contents like:
```html
<script>
//</script>
alert('foo');
</script>
```
`alert('foo')` will be included in the search content. Most script content in blocks will be well formed though so I'd argue this is an adequate solution for now until we find a reason to use a DOM parser instead.