### PR TITLE
Fix page search index block order in 8.6

### DIFF
--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -127,7 +127,7 @@ class IndexedSearch
         $blarray = [];
         $db = Loader::db();
         $r = $db->Execute(
-            'select bID, arHandle from CollectionVersionBlocks where cID = ? and cvID = ?',
+            'select bID, arHandle from CollectionVersionBlocks where cID = ? and cvID = ? order by arHandle, cbDisplayOrder',
             [$c->getCollectionID(), $c->getVersionID()]
         );
         $th = Loader::helper('text');


### PR DESCRIPTION
This PR does the same thing as #9365, see the discussion there and in the related issue for more info