### PR TITLE
Avoid implode() invalid arguments when editing block

### DIFF
--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -77,14 +77,14 @@ if ($controller->getAction() == 'add') {
     $attachmentsEnabled = intval($config->get('conversations.attachments_enabled'));
     $notificationUsers = Conversation::getDefaultSubscribedUsers();
     $subscriptionEnabled = intval($config->get('conversations.subscription_enabled'));
-    $fileAccessFileTypesBlacklist = $config->get('conversations.files.disallowed_types');
-
-    if ($fileAccessFileTypesBlacklist === null) {
-        $fileAccessFileTypesBlacklist = $config->get('concrete.upload.extensions_blacklist');
-    }
-
-    $fileAccessFileTypesBlacklist = $helperFile->unserializeUploadFileExtensions($fileAccessFileTypesBlacklist);
 }
+$fileAccessFileTypesBlacklist = $config->get('conversations.files.disallowed_types');
+
+if ($fileAccessFileTypesBlacklist === null) {
+    $fileAccessFileTypesBlacklist = $config->get('concrete.upload.extensions_blacklist');    
+}
+
+$fileAccessFileTypesBlacklist = $helperFile->unserializeUploadFileExtensions($fileAccessFileTypesBlacklist);
 
 if (!$dateFormat) {
     $dateFormat = 'default';


### PR DESCRIPTION
This is a more complete fix for https://github.com/concrete5/concrete5/commit/5b8a2a1f66cd3c93913605c7652ca9bb14456a19

As noted in the comment to that commit, the problem is that `$fileAccessFileTypesBlacklist` is only being set for the add task. Lines 35--39 need to be taken out of the conditional beginning on line 7, or otherwise refactored to make the form work when editing the block.
