### PR TITLE
fix check that lead to pages never beeing indexed through CLI

### DIFF
--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -87,7 +87,7 @@ class IndexedSearch
     public function reindexPage($page)
     {
         $db = Loader::db();
-        if (is_object($page) && ($page instanceof Collection) && (1 != $page->getAttribute('exclude_search_index'))) {
+        if (is_object($page) && ($page instanceof Collection || $page instanceof Page) && (1 != $page->getAttribute('exclude_search_index'))) {
             $datetime = Loader::helper('date')->getOverridableNow();
             $db->Replace(
                 'PageSearchIndex',


### PR DESCRIPTION
This solves a issue with running the search Index from CLI, reported here: https://github.com/concrete5/concrete5/issues/9390
