### PR TITLE
Warning/error on file block drag and drop

### DIFF
--- a/concrete/blocks/file/controller.php
+++ b/concrete/blocks/file/controller.php
@@ -63,7 +63,10 @@ class Controller extends BlockController
 
     public function save($args)
     {
-        $args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+        if (is_array($args) && isset($args['forceDownload'])) {
+            $args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+        }
+
         parent::save($args);
     }
 


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.3 And 7.4 when "Consider warnings as errors" is set and file block is dragged and dropped on a page::

Undefined index: forceDownload
/Applications/MAMP/htdocs/c855/concrete/blocks/File/Controller.php(66): Whoops\Exception\ErrorException->null

We've added some checks to fix it.