### PR TITLE
Warning/error on HTML block drag and drop

### DIFF
--- a/concrete/blocks/html/controller.php
+++ b/concrete/blocks/html/controller.php
@@ -34,6 +34,7 @@ class Controller extends BlockController
 
     public function add()
     {
+        $this->set('content', '');
         $this->edit();
     }
 

--- a/concrete/blocks/html/form_setup_html.php
+++ b/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,4 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
-
-$content = isset($content) ? $content : null;
 ?>
 
 <div id="ccm-block-html-value"><?php echo htmlspecialchars($content,ENT_QUOTES,APP_CHARSET) ?></div>

--- a/concrete/blocks/html/form_setup_html.php
+++ b/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>  
 
-<div id="ccm-block-html-value"><?php echo htmlspecialchars($content,ENT_QUOTES,APP_CHARSET) ?></div>
+<div id="ccm-block-html-value"><?php echo htmlspecialchars($this->controller->content,ENT_QUOTES,APP_CHARSET) ?></div>
 <textarea style="display: none" id="ccm-block-html-value-textarea" name="content"></textarea>
 
 <style type="text/css">

--- a/concrete/blocks/html/form_setup_html.php
+++ b/concrete/blocks/html/form_setup_html.php
@@ -1,6 +1,9 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>  
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
-<div id="ccm-block-html-value"><?php echo htmlspecialchars($this->controller->content,ENT_QUOTES,APP_CHARSET) ?></div>
+$content = isset($content) ? $content : null;
+?>
+
+<div id="ccm-block-html-value"><?php echo htmlspecialchars($content,ENT_QUOTES,APP_CHARSET) ?></div>
 <textarea style="display: none" id="ccm-block-html-value-textarea" name="content"></textarea>
 
 <style type="text/css">


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.3 And 7.4 when "Consider warnings as errors" is set and HTML block is dragged and dropped on a page:

Undefined variable: content
/Applications/MAMP/htdocs/c855/concrete/blocks/html/form_setup_html.php(3): Whoops\Exception\ErrorException->null