### PR TITLE
Fixing page edit mode

### DIFF
--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -524,11 +524,8 @@ class Controller extends AbstractController implements AttributeInterface
     {
         $request = array_merge($this->request->request->all(), $this->request->query->all());
         $req = ($this->requestArray == false) ? $request : $this->requestArray;
-        if ($this->attributeKey && is_array($req['akID'])) {
-            return true;
-        }
 
-        return false;
+        return $this->attributeKey && isset($req['akID']) && is_array($req['akID']);
     }
 
     /**

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -68,7 +68,9 @@ class NameCorePageProperty extends CorePageProperty
     public function getRequestValue($args = false)
     {
         $data = parent::getRequestValue($args);
-        $data['name'] = Core::make('helper/security')->sanitizeString($data['name']);
+        if (is_array($data) && isset($data['name'])) {
+            $data['name'] = Core::make('helper/security')->sanitizeString($data['name']);
+        }
 
         return $data;
     }


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.3 And 7.4 when "Consider warnings as errors" is set and the user tries to save/delete/publish a page changes (edit mode -> save/delete/publish):

Exception Occurred: /Applications/MAMP/htdocs/c855/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php:71 Trying to access array offset on value of type null (8) 

We've added some checks to fix it.