### PR TITLE
Fixing Welcome Back Page (Desktop Latest Form Block Type)

### DIFF
--- a/concrete/blocks/desktop_latest_form/controller.php
+++ b/concrete/blocks/desktop_latest_form/controller.php
@@ -24,7 +24,10 @@ use Concrete\Core\Block\BlockController;
             $r = $db->query('select * from btFormAnswerSet order by created desc limit 1');
             $row = $r->fetch();
 
-            $legacyDateCreated = strtotime($row['created']);
+            $legacyDateCreated = 0;
+            if (is_array($row) && isset($row['created'])) {
+                $legacyDateCreated = strtotime($row['created']);
+            }
 
             $entityManager = $db->getEntityManager();
             $forms = $entityManager->getRepository('Concrete\Core\Entity\Express\Entity')


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.4 when "Consider warnings as errors" is set and the user logs back in to c5:

Whoops\Exception\ErrorException thrown with message "Trying to access array offset on value of type bool"

Stacktrace:
#38 Whoops\Exception\ErrorException in /Applications/MAMP/htdocs/c855/concrete/blocks/desktop_latest_form/controller.php:27
#37 Whoops\Run:handleError in /Applications/MAMP/htdocs/c855/concrete/blocks/desktop_latest_form/controller.php:27

We've added some checks and initialized $legacyDateCreated to fix it.