### PR TITLE
Fixing Page Settings -> Delete Page

### DIFF
--- a/concrete/controllers/dialog/page/delete.php
+++ b/concrete/controllers/dialog/page/delete.php
@@ -20,6 +20,7 @@ class Delete extends BackendInterfacePageController
 
     public function view()
     {
+        $this->set('sitemap', false);
         $this->set('numChildren', $this->page->getNumChildren());
     }
 

--- a/concrete/views/dialogs/page/delete.php
+++ b/concrete/views/dialogs/page/delete.php
@@ -1,7 +1,5 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-
-$sitemap = isset($sitemap) ? $sitemap : null;
 ?>
 
 <div class="ccm-ui">

--- a/concrete/views/dialogs/page/delete.php
+++ b/concrete/views/dialogs/page/delete.php
@@ -1,7 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$sitemap = Loader::helper('concrete/dashboard/sitemap');
+$sitemap = isset($sitemap) ? $sitemap : null;
 ?>
 
 <div class="ccm-ui">

--- a/concrete/views/dialogs/page/delete.php
+++ b/concrete/views/dialogs/page/delete.php
@@ -1,5 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
+
+$sitemap = Loader::helper('concrete/dashboard/sitemap');
 ?>
 
 <div class="ccm-ui">


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.3 And 7.4 when "Consider warnings as errors" is set and the user goes to Page Settings and then clicks on Delete Page:

Undefined variable: sitemap
/Applications/MAMP/htdocs/c855/concrete/views/dialogs/page/delete.php(21): Whoops\Exception\ErrorException->null	
/Applications/MAMP/htdocs/c855/concrete/views/dialogs/page/delete.php(21): Whoops\Run->handleError	

We've initialized $sitemap to fix it.