### PR TITLE
Fixing Page Settings -> Location

### DIFF
--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -1,14 +1,12 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-
-$sitemap = Loader::helper('concrete/dashboard/sitemap');
 ?>
 <section class="ccm-ui">
 	<header><?=t('Location')?></header>
 	<form method="post" action="<?=$controller->action('submit')?>" data-dialog-form="location" data-panel-detail-form="location">
         <input type="hidden" name="cParentID" value="<?=$cParentID?>" />
 
-        <?php if ($isHome == false && !isset($sitemap) && $sitemap == false) {
+        <?php if ((!isset($isHome) || $isHome === false) && (!isset($sitemap) || $sitemap === false)) {
     ?>
             <div style="min-height: 140px">
                 <?php if ($c->isPageDraft()) {

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -1,5 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
+
+$sitemap = Loader::helper('concrete/dashboard/sitemap');
 ?>
 <section class="ccm-ui">
 	<header><?=t('Location')?></header>


### PR DESCRIPTION
This PR fixes the following error/warning that occurs with PHP 7.3 And 7.4 when "Consider warnings as errors" is set and the user goes to Page Settings and then clicks on Location:

Exception Occurred: /Applications/MAMP/htdocs/c855/concrete/views/panels/details/page/location.php:9 Undefined variable: sitemap (8)

We've initialized $sitemap to fix it.