### PR TITLE
Bugfix: make "show folders" option work without filesets

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -743,6 +743,11 @@ class Controller extends BlockController
             }
         }
 
+        if ($this->hideFolders) {
+            $query = $list->getQueryObject();
+            $query->orWhere('nt.treeNodeTypeHandle != "file_folder"');
+        }
+
         $list = $this->setupFolderAdvancedSearch($list);
         $list->setItemsPerPage($this->displayLimit);
 


### PR DESCRIPTION
New "show folders" option only worked when a file set was also selected. However, it's not clear from the label that these two settings go together. It would be more self-explanatory if the "show folders" option worked independently of other settings. This change simply conditionally modifies the query in the view method based on `$this->hideFolders`.

