### PR TITLE
Make Migration Tool work again

### DIFF
--- a/concrete/src/Foundation/Processor/Processor.php
+++ b/concrete/src/Foundation/Processor/Processor.php
@@ -1,0 +1,63 @@
+<?php
+namespace Concrete\Core\Foundation\Processor;
+
+class Processor implements ProcessorInterface
+{
+    protected $target;
+    protected $tasks = array();
+
+    public function __construct(TargetInterface $target)
+    {
+        $this->target = $target;
+    }
+
+    public function registerTask(TaskInterface $task, $priority = 0)
+    {
+        $this->tasks[] = array($priority, $task);
+    }
+
+    public function execute(ActionInterface $action)
+    {
+        $action->execute();
+    }
+
+    public function finish()
+    {
+        $tasks = $this->getTasks();
+        foreach ($tasks as $task) {
+            $action = new Action($this, $this->target, $task[1]);
+            $action->finish();
+        }
+    }
+
+    public function getTasks()
+    {
+        $tasks = $this->tasks;
+        usort($tasks, function ($a, $b) {
+            if ($a[0] == $b[0]) {
+                return 0;
+            }
+
+            return ($a[0] < $b[0]) ? -1 : 1;
+        });
+
+        return $tasks;
+    }
+
+    public function getTotalTasks()
+    {
+        return count($this->getTasks());
+    }
+
+    public function process()
+    {
+        $tasks = $this->getTasks();
+        foreach ($this->target->getItems() as $targetItem) {
+            foreach ($tasks as $task) {
+                $action = new Action($this, $this->target, $task[1], $targetItem);
+                $this->execute($action);
+            }
+        }
+        $this->finish();
+    }
+}

--- a/concrete/src/Foundation/Processor/ProcessorInterface.php
+++ b/concrete/src/Foundation/Processor/ProcessorInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Concrete\Core\Foundation\Processor;
+
+interface ProcessorInterface
+{
+    public function getTotalTasks();
+    public function process();
+    public function registerTask(TaskInterface $task, $priority = 0);
+    public function getTasks();
+    public function execute(ActionInterface $action);
+}

--- a/concrete/src/Foundation/Processor/ProcessorQueue.php
+++ b/concrete/src/Foundation/Processor/ProcessorQueue.php
@@ -1,0 +1,93 @@
+<?php
+namespace Concrete\Core\Foundation\Processor;
+
+class ProcessorQueue extends Processor
+{
+    protected $itemsPerBatch = 20;
+    protected $tasks = array();
+    protected $queue;
+
+    /**
+     * @return int
+     */
+    public function getItemsPerBatch()
+    {
+        return $this->itemsPerBatch;
+    }
+
+    /**
+     * @param int $itemsPerBatch
+     */
+    public function setItemsPerBatch($itemsPerBatch)
+    {
+        $this->itemsPerBatch = $itemsPerBatch;
+    }
+
+    public function setQueue(\ZendQueue\Queue $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    public function getQueue()
+    {
+        return $this->queue;
+    }
+
+    public function __sleep()
+    {
+        return array('itemsPerBatch', 'tasks');
+    }
+
+    public function receive()
+    {
+        $queueItems = $this->getQueue()->receive($this->itemsPerBatch);
+        $items = array();
+        foreach ($queueItems as $queueItem) {
+            $action = unserialize($queueItem->body);
+            $action->setQueueItem($queueItem);
+            $items[] = $action;
+        }
+
+        return $items;
+    }
+
+    public function finish()
+    {
+        $this->getQueue()->deleteQueue();
+        $tasks = $this->getTasks();
+        foreach ($tasks as $task) {
+            $action = new QueueAction($this, $this->target, $task[1]);
+            $action->finish();
+        }
+    }
+
+    public function execute(ActionInterface $action)
+    {
+        $action->execute();
+        $this->getQueue()->deleteMessage($action->getQueueItem());
+        if ($this->getQueue()->count() == 0) {
+            $this->finish();
+        }
+    }
+
+    public function getTotalTasks()
+    {
+        return $this->getQueue()->count();
+    }
+
+    /**
+     * Takes the current queue, and fills it based on the currently registered tasks and the
+     * registered processor.
+     */
+    public function process()
+    {
+        $queue = $this->getQueue();
+        $tasks = $this->getTasks();
+        foreach ($this->target->getItems() as $targetItem) {
+            foreach ($tasks as $task) {
+                $action = new QueueAction($this, $this->target, $task[1], $targetItem);
+                $queue->send(serialize($action));
+            }
+        }
+    }
+}

--- a/concrete/src/Foundation/Processor/TargetInterface.php
+++ b/concrete/src/Foundation/Processor/TargetInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Concrete\Core\Foundation\Processor;
+
+interface TargetInterface
+{
+    public function getItems();
+}

--- a/concrete/src/Foundation/Processor/TaskInterface.php
+++ b/concrete/src/Foundation/Processor/TaskInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Concrete\Core\Foundation\Processor;
+
+interface TaskInterface
+{
+    public function execute(ActionInterface $action);
+    public function finish(ActionInterface $action);
+}


### PR DESCRIPTION
The Migration Tool was not working on V9 because this files are removed. Now as i have bring this files back the migration tool works on V9. Of course the migration tool needs some BS4 style updates but from a logical point of view it's working again :)