### PR TITLE
Fix/php7.3 and 7.4 errors

### DIFF
--- a/concrete/blocks/file/controller.php
+++ b/concrete/blocks/file/controller.php
@@ -99,7 +99,10 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function save($args)
     {
-        $args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+        if (is_array($args) && isset($args['forceDownload'])) {
+            $args['forceDownload'] = ($args['forceDownload']) ? '1' : '0';
+        }
+
         parent::save($args);
     }
 

--- a/concrete/blocks/html/controller.php
+++ b/concrete/blocks/html/controller.php
@@ -43,6 +43,7 @@ class Controller extends BlockController
 
     public function add()
     {
+        $this->set('content', '');
         $this->edit();
     }
 

--- a/concrete/controllers/dialog/page/delete.php
+++ b/concrete/controllers/dialog/page/delete.php
@@ -21,6 +21,7 @@ class Delete extends BackendInterfacePageController
 
     public function view()
     {
+        $this->set('sitemap', false);
         $this->set('numChildren', $this->page->getNumChildren());
     }
 

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -546,11 +546,8 @@ class Controller extends AbstractController implements AttributeInterface
     {
         $request = array_merge($this->request->request->all(), $this->request->query->all());
         $req = ($this->requestArray == false) ? $request : $this->requestArray;
-        if ($this->attributeKey && is_array($req['akID'])) {
-            return true;
-        }
 
-        return false;
+        return $this->attributeKey && isset($req['akID']) && is_array($req['akID']);
     }
 
     /**

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/NameCorePageProperty.php
@@ -68,7 +68,9 @@ class NameCorePageProperty extends CorePageProperty
     public function getRequestValue($args = false)
     {
         $data = parent::getRequestValue($args);
-        $data['name'] = Core::make('helper/security')->sanitizeString($data['name']);
+        if (is_array($data) && isset($data['name'])) {
+            $data['name'] = Core::make('helper/security')->sanitizeString($data['name']);
+        }
 
         return $data;
     }


### PR DESCRIPTION
These are fixes for errors/warning occurring with PHP 7.3 and 7.4 when "Consider warnings as errors" is set.
Also, all fixes have already been validated by @aembler in PRs against branch 8.5.x and this PR is being submitted on his suggestion.