### PR TITLE
Fixes #9419

### DIFF
--- a/concrete/js/build/core/app/dialog.js
+++ b/concrete/js/build/core/app/dialog.js
@@ -176,7 +176,8 @@
                 // jshint -W061
                 var $dialog = $(this);
                 var nd = $(".ui-dialog").length;
-                if (nd == 1) {
+                var lastOverflow = $('body').css('overflow');
+                if (nd == 1 && lastOverflow !== 'hidden') {
                     $("body").attr('data-last-overflow', $('body').css('overflow'));
                     $("body").css("overflow", "hidden");
                 }
@@ -216,8 +217,9 @@
             },
             'beforeClose': function() {
                 var nd = $(".ui-dialog:visible").length;
+                var lastOverflow = $('body').attr('data-last-overflow');
                 if (nd == 1) {
-                    $("body").css("overflow", $('body').attr('data-last-overflow'));
+                    $("body").css("overflow", lastOverflow);
                 }
             },
             'close': function(ev, u) {

--- a/concrete/js/build/core/app/dialog.js
+++ b/concrete/js/build/core/app/dialog.js
@@ -218,7 +218,7 @@
             'beforeClose': function() {
                 var nd = $(".ui-dialog:visible").length;
                 var lastOverflow = $('body').attr('data-last-overflow');
-                if (nd == 1) {
+                if (nd == 1 && lastOverflow) {
                     $("body").css("overflow", lastOverflow);
                 }
             },


### PR DESCRIPTION
# Why #9419 happens?

From CKEditor 4.13, it adds `overflow:hidden` to `<body>` element when it opens its dialog by adding `.cke_dialog_open` class. However, it conflicts with concrete5 core dialog.js (jQuery UI dialog) because it does the same thing by adding `style="overflow: hidden"`.

# How can you fix it?

Do not add `style="overflow: hidden"` attribute if overflow of `<body>` element is already hidden.

# When this bug happened?

Since Concrete 8.5.5 (Oct 14, 2020, on GitHub). 8.5.4 still uses CKEditor 4.12.