### PR TITLE
Fix dashboard's block types view. Return 0 when $numActive is less than 0.

### DIFF
--- a/concrete/single_pages/dashboard/blocks/types/view.php
+++ b/concrete/single_pages/dashboard/blocks/types/view.php
@@ -29,7 +29,7 @@ if ($controller->getAction() == 'inspect') {
             if ($numActive > 0) {
                 ?><a href="<?= $view->action('search', $bt->getBlockTypeID()) ?>"><?= $numActive ?></a><?php
             } else {
-                echo $num;
+                echo 0;
             }
             ?>
         </dd>


### PR DESCRIPTION
The variable is not supposed to be $num but $numActive.
Since it's going to be 0 either way, it's better to simply echo 0.
Please refer to this slack.
https://concrete5.slack.com/archives/C2N3FLUBW/p1617266646210300

