### PR TITLE
[V9] Make Copy Locale Tree function work again

### DIFF
--- a/concrete/single_pages/dashboard/system/multilingual/copy.php
+++ b/concrete/single_pages/dashboard/system/multilingual/copy.php
@@ -63,6 +63,7 @@ use Concrete\Core\Multilingual\Page\Section\Section as MultilingualSection;
                                         {'name': 'origCID', 'value': ctf},
                                         {'name': 'destCID', 'value': ctt},
                                         {'name': 'copyChildrenOnly', 'value': true},
+                                        {'name': 'multilingual', 'value': true},
                                         {name: <?= json_encode($token::DEFAULT_TOKEN_NAME) ?>, value: <?= json_encode($token->generate('/dialogs/page/drag_request'))?>}
                                     ],
                                     title: "<?=t('Copy Locale Tree')?>",

--- a/concrete/src/Page/Command/CopyPageCommand.php
+++ b/concrete/src/Page/Command/CopyPageCommand.php
@@ -16,11 +16,11 @@ class CopyPageCommand extends PageCommand implements BatchableCommandInterface
      */
     protected $isMultilingual;
 
-    public function __construct(int $pageID, int $destinationPageID, bool $isMultilingual = false)
+    public function __construct(int $pageID, int $destinationPageID, bool $multilingualCopy = false)
     {
         parent::__construct($pageID);
         $this->setDestinationPageID($destinationPageID);
-        $this->isMultilingual = $isMultilingual;
+        $this->isMultilingual = $multilingualCopy;
     }
 
     /**


### PR DESCRIPTION
I'd like to show version 9  for my client with the multilingual feature, but the copy locale tree button doesn't work.
It seems half migrated to the new batch system by @aembler , so I'm trying to finish it now.
It works almost fine, but it doesn't copy child pages and it creates pages every time I pushed "Copy Tree" button.
Am I something wrong? I need some advice to finish it.