### PR TITLE
fix #9431 show edit block link when block is editable

### DIFF
--- a/concrete/src/Block/Menu/Menu.php
+++ b/concrete/src/Block/Menu/Menu.php
@@ -142,7 +142,7 @@ class Menu extends ContextMenu
                         'data-area-grid-maximum-columns' => $a->getAreaGridMaximumColumns()
                     ]));
                 }
-            } else {
+            } elseif (is_null($_bo) || $_bo && $_bo->isEditable() == true) {
                 $this->addItem(new LinkItem('javascript:void(0)', t('Edit Block'), [
                     'data-menu-action' => 'block_dialog',
                     'data-menu-href' => \URL::to('/ccm/system/dialogs/block/edit'),


### PR DESCRIPTION
fixes issue #9431 I check to see if we have a original block and if we do if its editable and then show the link or if we don't have an original object it will show it too