### PR TITLE
[Fix] Can't attach a facebook account

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -522,7 +522,13 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
      */
     public function getBindingForUser($user)
     {
-        return $this->getBindingService()->getUserBinding($user, $this->getHandle());
+        if (is_object($user)) {
+            $userID = $user->getUserID();
+        } else {
+            $userID = (int) $user;
+        }
+
+        return $this->getBindingService()->getUserBinding($userID, $this->getHandle());
     }
 
     public function getUniqueId()


### PR DESCRIPTION
This PR fixes the exception which is thrown when a user tries to attach his facebook account on concrete5 8.5.5.
The bug was introduced from this commit https://github.com/concrete5/concrete5/commit/4123eab28d33cf19d85f9bc3b148695eb3f0c91e.
Though Scrutinizer / Inspection recognized this, seems it was ignored.

```
An exception occurred while executing 'SELECT binding FROM OauthUserMap WHERE (namespace = ?) AND (user_id = ?)' with params ["facebook", {"uID":"47","uName":"c5j_biplob","uGroups":{"2":"2","3":"3","1":"1"},"superUser":false,"uTimezone":null,"error":""}]: Object of class Concrete\Core\User\User could not be converted to string
```
