### PR TITLE
[V8] Fix display order of express entities in dashboard

### DIFF
--- a/concrete/controllers/element/dashboard/express/menu.php
+++ b/concrete/controllers/element/dashboard/express/menu.php
@@ -28,7 +28,7 @@ class Menu extends ElementController
     public function view()
     {
         $r = \ORM::entityManager()->getRepository('\Concrete\Core\Entity\Express\Entity');
-        $entities = $r->findAll(array(), array('name' => 'asc'));
+        $entities = $r->findBy(array(), array('name' => 'asc'));
         $this->set('types', $entities);
         $this->set('currentType', $this->currentEntity);
         $this->set('entityAction', $this->entityAction);

--- a/concrete/controllers/single_page/dashboard/system/express/entities.php
+++ b/concrete/controllers/single_page/dashboard/system/express/entities.php
@@ -98,7 +98,7 @@ class Entities extends DashboardPageController
     public function view()
     {
         $r = $this->entityManager->getRepository('\Concrete\Core\Entity\Express\Entity');
-        $entities = $r->findAll(array(), array('name' => 'asc'));
+        $entities = $r->findBy(array(), array('name' => 'asc'));
         $this->set('entities', $entities);
     }
 


### PR DESCRIPTION
`\Doctrine\ORM\EntityRepository::findAll()` doesn't accept any parameters.
IMO this is just a typo.

Issue

![Screen Shot 2021-04-23 at 3 32 17](https://user-images.githubusercontent.com/514294/115768123-d7017500-a3e4-11eb-8166-9d65b32a5fba.png)

![Screen Shot 2021-04-23 at 3 32 26](https://user-images.githubusercontent.com/514294/115768128-dc5ebf80-a3e4-11eb-8df0-935b9955a9cd.png)

Fixed

![Screen Shot 2021-04-23 at 3 29 58](https://user-images.githubusercontent.com/514294/115768151-e385cd80-a3e4-11eb-8a36-62f36719e605.png)

![Screen Shot 2021-04-23 at 3 29 50](https://user-images.githubusercontent.com/514294/115768166-e7b1eb00-a3e4-11eb-9f79-1f4d79a73af9.png)
