### PR TITLE
[v8][Fix] Error on switching language using switch_language block

### DIFF
--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -86,7 +86,7 @@ class Controller extends BlockController
             }
         }
 
-        $this->action_switch_language($this->post('rcID'), $this->post('language'));
+        return $this->action_switch_language($this->post('rcID'), $this->post('language'));
     }
 
     public function add()


### PR DESCRIPTION
This PR fixes the following exception on switching language using switch_language block

![Screen Shot 2021-04-26 at 11 41 49 AM](https://user-images.githubusercontent.com/2462951/116022093-7c864400-a684-11eb-92ba-31f5e7ea225c.png)
