### PR TITLE
[v9][Fix] Error on switching language using switch_language block

### DIFF
--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -95,7 +95,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
         }
 
-        $this->action_switch_language($this->post('rcID'), $this->post('language'));
+        return $this->action_switch_language($this->post('rcID'), $this->post('language'));
     }
 
     public function add()


### PR DESCRIPTION
This PR fixes the following exception on switching language using switch_language block

See https://github.com/concrete5/concrete5/pull/9446