### PR TITLE
Localization support for text attr placeholders

### DIFF
--- a/concrete/attributes/text/form.php
+++ b/concrete/attributes/text/form.php
@@ -4,6 +4,6 @@
         $this->field('value'),
         $value,
         [
-            'placeholder' => h($akTextPlaceholder)
+            'placeholder' => h(t($akTextPlaceholder))
         ]
     );

--- a/concrete/src/Attribute/Key/Factory.php
+++ b/concrete/src/Attribute/Key/Factory.php
@@ -71,6 +71,15 @@ class Factory
             ->findAll();
         foreach($keys as $key) {
             $translations->insert('AttributeKeyName', $key->getAttributeKeyName());
+
+            // text attribute placeholder
+            $type = $key->getAttributeKeySettings();
+            if ($type instanceof \Concrete\Core\Entity\Attribute\Key\Settings\TextSettings) {
+                $placeholder = $type->getPlaceholder();
+                if ($placeholder !== '') {
+                    $translations->insert('AttributeKeyPlaceholder', $placeholder);
+                }
+            }
         }
         return $translations;
     }


### PR DESCRIPTION
Enbale translation for text attributes' placeholders. Useful when adding express forms on the frontend.