### PR TITLE
[V8] Private messages max limit fix

### DIFF
--- a/concrete/src/User/PrivateMessage/Limit.php
+++ b/concrete/src/User/PrivateMessage/Limit.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace Concrete\Core\User\PrivateMessage;
 
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\Event\UserInfo;
 use Concrete\Core\User\UserInfoRepository;
 use DateTime;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Limit
 {
-
     /**
      * @var bool Tracks whether limiting is enabled
      */
@@ -36,9 +37,9 @@ class Limit
 
         $db = $app->make(Connection::class);
         $dt = new DateTime();
-        $dt->modify('-'.$app['config']->get('concrete.user.private_messages.throttle_max_timespan').' minutes');
-        $v = array($uID, $dt->format('Y-m-d H:i:s'));
-        $q = "SELECT COUNT(msgID) as sent_count FROM UserPrivateMessages WHERE uAuthorID = ? AND msgDateCreated >= ?";
+        $dt->modify('-' . $app['config']->get('concrete.user.private_messages.throttle_max_timespan') . ' minutes');
+        $v = [$uID, $dt->format('Y-m-d H:i:s')];
+        $q = 'SELECT COUNT(msgID) as sent_count FROM UserPrivateMessages WHERE uAuthorID = ? AND msgDateCreated >= ?';
         $count = $db->fetchColumn($q, $v);
 
         if ($count > $app['config']->get('concrete.user.private_messages.throttle_max')) {
@@ -59,6 +60,16 @@ class Limit
         return $ve;
     }
 
+    /**
+     * Enable or disable Limits.
+     *
+     * @param bool $enabled
+     */
+    public static function setEnabled($enabled = true)
+    {
+        static::$enabled = (bool) $enabled;
+    }
+
     protected static function notifyAdmin($offenderID)
     {
         $app = Application::getFacadeApplication();
@@ -66,13 +77,13 @@ class Limit
         $repository = $app->make(UserInfoRepository::class);
         $offender = $repository->getByID($offenderID);
         if ($offender) {
-            $ue = new \Concrete\Core\User\Event\UserInfo($offender);
+            $ue = new UserInfo($offender);
             $app->make(EventDispatcherInterface::class)->dispatch('on_private_message_over_limit', $ue);
 
             $admin = $repository->getByID(USER_SUPER_ID);
 
             $logger = $app->make('log/factory')->createLogger(Channels::CHANNEL_SPAM);
-            $logger->warning(t("User: %s has tried to send more than %s private messages within %s minutes",
+            $logger->warning(t('User: %s has tried to send more than %s private messages within %s minutes',
                 $offender->getUserName(),
                 $app['config']->get('concrete.user.private_messages.throttle_max'),
                 $app['config']->get('concrete.user.private_messages.throttle_max_timespan')));
@@ -88,15 +99,5 @@ class Limit
             $mh->load('private_message_admin_warning');
             $mh->sendMail();
         }
-    }
-
-    /**
-     * Enable or disable Limits
-     *
-     * @param bool $enabled
-     */
-    public static function setEnabled($enabled = true)
-    {
-        static::$enabled = (bool) $enabled;
     }
 }


### PR DESCRIPTION
# Issue

Can't send a notification email when you hit the maximum limit of private messages.

```
Error thrown with message "Class 'Concrete\Core\User\PrivateMessage\Facade' not found"

Stacktrace:
#26 Error in /path/to/concrete5/concrete/src/User/PrivateMessage/Limit.php:68
#25 Concrete\Core\User\PrivateMessage\Limit:notifyAdmin in /path/to/concrete5/concrete/src/User/PrivateMessage/Limit.php:43
#24 Concrete\Core\User\PrivateMessage\Limit:isOverLimit in /path/to/concrete5/concrete/src/User/UserInfo.php:362
#23 Concrete\Core\User\UserInfo:sendPrivateMessage in /path/to/concrete5/concrete/controllers/single_page/dashboard/users/groups/message.php:112
#22 Concrete\Controller\SinglePage\Dashboard\Users\Groups\Message:sendMessage in /path/to/concrete5/concrete/controllers/single_page/dashboard/users/groups/message.php:91
#21 Concrete\Controller\SinglePage\Dashboard\Users\Groups\Message:process in /path/to/concrete5/concrete/src/Controller/AbstractController.php:315
#20 call_user_func_array in /path/to/concrete5/concrete/src/Controller/AbstractController.php:315
#19 Concrete\Core\Controller\AbstractController:runAction in /path/to/concrete5/concrete/src/Http/ResponseFactory.php:189
#18 Concrete\Core\Http\ResponseFactory:controller in /path/to/concrete5/concrete/src/Http/ResponseFactory.php:367
#17 Concrete\Core\Http\ResponseFactory:collection in /path/to/concrete5/concrete/src/Http/DefaultDispatcher.php:131
#16 Concrete\Core\Http\DefaultDispatcher:handleDispatch in /path/to/concrete5/concrete/src/Http/DefaultDispatcher.php:59
#15 Concrete\Core\Http\DefaultDispatcher:dispatch in /path/to/concrete5/concrete/src/Http/Middleware/DispatcherDelegate.php:39
#14 Concrete\Core\Http\Middleware\DispatcherDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/ThumbnailMiddleware.php:76
#13 Concrete\Core\Http\Middleware\ThumbnailMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:50
#12 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/FrameOptionsMiddleware.php:39
#11 Concrete\Core\Http\Middleware\FrameOptionsMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:50
#10 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/CookieMiddleware.php:35
#9 Concrete\Core\Http\Middleware\CookieMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:50
#8 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/ApplicationMiddleware.php:29
#7 Concrete\Core\Http\Middleware\ApplicationMiddleware:process in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareDelegate.php:50
#6 Concrete\Core\Http\Middleware\MiddlewareDelegate:next in /path/to/concrete5/concrete/src/Http/Middleware/MiddlewareStack.php:86
#5 Concrete\Core\Http\Middleware\MiddlewareStack:process in /path/to/concrete5/concrete/src/Http/DefaultServer.php:85
#4 Concrete\Core\Http\DefaultServer:handleRequest in /path/to/concrete5/concrete/src/Foundation/Runtime/Run/DefaultRunner.php:128
#3 Concrete\Core\Foundation\Runtime\Run\DefaultRunner:run in /path/to/concrete5/concrete/src/Foundation/Runtime/DefaultRuntime.php:102
#2 Concrete\Core\Foundation\Runtime\DefaultRuntime:run in /path/to/concrete5/concrete/dispatcher.php:45
#1 require in /path/to/concrete5/index.php:3
```

# How to reproduce

Set max limit then send private messages

```
<?php

return [
    'user' => [
        'private_messages' => [
            'throttle_max' => 1,
            'throttle_max_timespan' => 10,
        ],
    ],
];
```