### PR TITLE
[V8] Render single pages like 404, 403, login, register in default site locale

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -228,6 +228,9 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             throw new \RuntimeException('Cannot resolve collections without a reference to the application');
         }
 
+        $dl = $this->app->make('multilingual/detector');
+        $dl->setupSiteInterfaceLocalization($collection);
+
         $request = $this->request;
 
         if ($collection->isError() && $collection->getError() == COLLECTION_NOT_FOUND) {
@@ -310,8 +313,6 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             return $response;
         }
 
-        $dl = $cms->make('multilingual/detector');
-
         if (!$request->getPath()
             && $request->isMethod('GET')
             && !$request->query->has('cID')
@@ -337,7 +338,6 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
                 return $this->redirect(\URL::to($collection));
             }
         }
-        $dl->setupSiteInterfaceLocalization($collection);
 
         $request->setCurrentPage($collection);
         $c = $collection; // process.php needs this

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -93,6 +93,8 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
 
         if (is_object($c) && !$c->isError()) {
             // Display not found
+            $dl = $this->app->make('multilingual/detector');
+            $dl->setupSiteInterfaceLocalization($c);
             $this->request->setCurrentPage($c);
 
             return $this->controller($c->getPageController(), $code, $headers);
@@ -122,6 +124,8 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         $item = '/page_forbidden';
         $c = Page::getByPath($item);
         if (is_object($c) && !$c->isError()) {
+            $dl = $this->app->make('multilingual/detector');
+            $dl->setupSiteInterfaceLocalization($c);
             $this->request->setCurrentPage($c);
 
             return $this->controller($c->getPageController(), $code, $headers);
@@ -229,8 +233,6 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         }
 
         $dl = $this->app->make('multilingual/detector');
-        $dl->setupSiteInterfaceLocalization($collection);
-
         $request = $this->request;
 
         if ($collection->isError() && $collection->getError() == COLLECTION_NOT_FOUND) {
@@ -259,6 +261,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             if ($smm == 1 && !Key::getByHandle('view_in_maintenance_mode')->validate() && ($_SERVER['REQUEST_METHOD'] != 'POST' || $this->app->make('token')->validate() == false)) {
                 $v = new View('/frontend/maintenance_mode');
                 $v->addScopeItems(['c' => $collection]);
+                $dl->setupSiteInterfaceLocalization($collection);
                 $request->setCurrentPage($collection);
 
                 return $this->view($v, $code, $headers);
@@ -339,6 +342,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             }
         }
 
+        $dl->setupSiteInterfaceLocalization($collection);
         $request->setCurrentPage($collection);
         $c = $collection; // process.php needs this
         require DIR_BASE_CORE . '/bootstrap/process.php';

--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -180,6 +180,12 @@ class Detector implements ApplicationAwareInterface, SiteAggregateInterface
             }
         }
         if (!$locale) {
+            $localeEntity = $this->getSite()->getDefaultLocale();
+            if ($localeEntity) {
+                $locale = $localeEntity->getLocale();
+            }
+        }
+        if (!$locale) {
             $locale = $this->app->make('config')->get('concrete.locale');
         }
         $loc->setContextLocale(Localization::CONTEXT_SITE, $locale);

--- a/concrete/themes/concrete/elements/header.php
+++ b/concrete/themes/concrete/elements/header.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 <!DOCTYPE html>
-<html>
+<html lang="<?php echo Localization::activeLanguage() ?>">
 <head>
     <link rel="stylesheet" type="text/css" href="<?=$this->getThemePath()?>/main.css" />
     <?php

--- a/concrete/themes/core/error.php
+++ b/concrete/themes/core/error.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="<?php echo Localization::activeLanguage() ?>" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="content-type" content="text/html; charset=<?=APP_CHARSET?>" />
     <link rel="stylesheet" type="text/css" href="<?=DIR_REL?>/concrete/themes/concrete/main.css" />

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -41,7 +41,7 @@ $show_tooltips = (bool) $config->get('concrete.accessibility.toolbar_tooltips');
 $large_font = (bool) $config->get('concrete.accessibility.toolbar_large_font');
 
 ?><!DOCTYPE html>
-<html<?= $hideDashboardPanel ? '' : ' class="ccm-panel-open ccm-panel-right"'; ?>>
+<html<?= $hideDashboardPanel ? '' : ' class="ccm-panel-open ccm-panel-right"'; ?> lang="<?php echo Localization::activeLanguage() ?>">
 <head>
     <link rel="stylesheet" type="text/css" href="<?=$this->getThemePath()?>/main.css" />
     <?php View::element('header_required', ['disableTrackingCode' => true, 'pageTitle' => isset($pageTitle) ? $pageTitle : null]); ?>


### PR DESCRIPTION
This PR fixes #7909, #6500 (already closed), #6228 (already closed), #5775 (already closed), #3345 (already closed).
This PR doesn't cover all pages described on #3350 but it's a related topic.

## Single locale site before merged

### UI: en_US / SITE: en_US

Single pages rendered in English, it's fine.

![Screen Shot 2021-05-02 at 22 52 17](https://user-images.githubusercontent.com/514294/116816003-37d63d80-ab9b-11eb-9039-d03fdadf8f98.png)
![Screen Shot 2021-05-02 at 23 16 03](https://user-images.githubusercontent.com/514294/116816323-715b7880-ab9c-11eb-9eac-7ef5659bae9b.png)
![Screen Shot 2021-05-02 at 23 16 08](https://user-images.githubusercontent.com/514294/116816328-74eeff80-ab9c-11eb-8178-06fe8bc45091.png)
![Screen Shot 2021-05-02 at 23 16 11](https://user-images.githubusercontent.com/514294/116816330-76b8c300-ab9c-11eb-9e3b-51cf186cd968.png)
![Screen Shot 2021-05-02 at 23 16 15](https://user-images.githubusercontent.com/514294/116816333-79b3b380-ab9c-11eb-8b80-365d80d2178d.png)

### UI: ja_JP / SITE: en_US

Users in the site will use English because this is an English site, but administrators use Japanese. In this case, /register page should be rendered in English, but it did in Japanese. The login page is a difficult issue because if the site is not registerable, only admin users use /login page, and they'll want to use it in Japanese.

![Screen Shot 2021-05-02 at 22 51 33](https://user-images.githubusercontent.com/514294/116816084-7f5cc980-ab9b-11eb-9786-4a26b5bec997.png)
![Screen Shot 2021-05-02 at 23 17 35](https://user-images.githubusercontent.com/514294/116816370-9fd95380-ab9c-11eb-8ec8-0a8662f0aab1.png)
![Screen Shot 2021-05-02 at 23 17 37](https://user-images.githubusercontent.com/514294/116816377-a36cda80-ab9c-11eb-8205-eebb27ecc914.png)
![Screen Shot 2021-05-02 at 23 17 39](https://user-images.githubusercontent.com/514294/116816380-a49e0780-ab9c-11eb-8929-5322d669c4cd.png)
![Screen Shot 2021-05-02 at 23 17 42](https://user-images.githubusercontent.com/514294/116816384-a667cb00-ab9c-11eb-8a38-520fd87f11d0.png)

### UI: en_US / SITE: ja_JP

404 and 403 pages should be displayed in Japanese because this is a Japanese site.

![Screen Shot 2021-05-02 at 22 49 48](https://user-images.githubusercontent.com/514294/116816150-c1860b00-ab9b-11eb-8de8-61991875cf07.png)
![Screen Shot 2021-05-02 at 23 19 05](https://user-images.githubusercontent.com/514294/116816423-d44d0f80-ab9c-11eb-92cb-39655eb411f5.png)
![Screen Shot 2021-05-02 at 23 19 07](https://user-images.githubusercontent.com/514294/116816427-d8792d00-ab9c-11eb-9b4f-28318b7f9c6d.png)
![Screen Shot 2021-05-02 at 23 19 10](https://user-images.githubusercontent.com/514294/116816431-dadb8700-ab9c-11eb-8211-90e3059aa537.png)
![Screen Shot 2021-05-02 at 23 19 12](https://user-images.githubusercontent.com/514294/116816435-dd3de100-ab9c-11eb-9725-09e178b64974.png)

### UI: ja_JP / SITE: ja_JP

404 and 403 pages should be displayed in Japanese because this is a Japanese site.

![Screen Shot 2021-05-02 at 22 50 33](https://user-images.githubusercontent.com/514294/116816192-eda18c00-ab9b-11eb-8f1a-15b1b3374a6b.png)
![Screen Shot 2021-05-02 at 23 19 51](https://user-images.githubusercontent.com/514294/116816450-f0e94780-ab9c-11eb-9bf5-fd38b60f24d6.png)
![Screen Shot 2021-05-02 at 23 19 53](https://user-images.githubusercontent.com/514294/116816453-f47cce80-ab9c-11eb-84b7-329c54ac6116.png)
![Screen Shot 2021-05-02 at 23 19 55](https://user-images.githubusercontent.com/514294/116816455-f5adfb80-ab9c-11eb-91a9-368362192aa0.png)
![Screen Shot 2021-05-02 at 23 19 57](https://user-images.githubusercontent.com/514294/116816458-f777bf00-ab9c-11eb-8891-76023b078dee.png)

## Single locale site after merged

### UI: en_US / SITE: en_US

Nothing changed

![Screen Shot 2021-05-02 at 22 52 00](https://user-images.githubusercontent.com/514294/116816008-3c9af180-ab9b-11eb-90b0-a799a4c414e5.png)
![Screen Shot 2021-05-02 at 22 52 03](https://user-images.githubusercontent.com/514294/116816010-3d338800-ab9b-11eb-8845-6fef62aafc55.png)
![Screen Shot 2021-05-02 at 22 52 06](https://user-images.githubusercontent.com/514294/116816012-3efd4b80-ab9b-11eb-8684-a6f6cb5cef30.png)
![Screen Shot 2021-05-02 at 22 52 08](https://user-images.githubusercontent.com/514294/116816015-40c70f00-ab9b-11eb-9e77-712d022c61e9.png)

### UI: ja_JP / SITE: en_US

I believe these pages should be rendered in English because it's an English site, but changed from current behavior.

![Screen Shot 2021-05-02 at 22 51 18](https://user-images.githubusercontent.com/514294/116816091-8552aa80-ab9b-11eb-8897-c4df50ec0bc7.png)
![Screen Shot 2021-05-02 at 22 51 21](https://user-images.githubusercontent.com/514294/116816092-85eb4100-ab9b-11eb-8170-19ca3c4f38d0.png)
![Screen Shot 2021-05-02 at 22 51 23](https://user-images.githubusercontent.com/514294/116816093-871c6e00-ab9b-11eb-93a3-74b0607ea392.png)
![Screen Shot 2021-05-02 at 22 51 25](https://user-images.githubusercontent.com/514294/116816100-8b488b80-ab9b-11eb-8724-f7b8c4a372f2.png)

### UI: en_US / SITE: ja_JP

I believe these pages should be rendered in Japanese because it's a Japanese site, but changed from current behavior.

![Screen Shot 2021-05-02 at 22 47 45](https://user-images.githubusercontent.com/514294/116816154-c5199200-ab9b-11eb-979a-49a0971d65e0.png)
![Screen Shot 2021-05-02 at 22 47 48](https://user-images.githubusercontent.com/514294/116816155-c64abf00-ab9b-11eb-85a7-d975653b32c2.png)
![Screen Shot 2021-05-02 at 22 47 55](https://user-images.githubusercontent.com/514294/116816157-c77bec00-ab9b-11eb-96a8-f3e9b481d6a7.png)
![Screen Shot 2021-05-02 at 22 47 58](https://user-images.githubusercontent.com/514294/116816160-c945af80-ab9b-11eb-9883-27c9d69367ba.png)

### UI: ja_JP / SITE: ja_JP

Many users reported this issue and completely fixed it.

![Screen Shot 2021-05-02 at 22 50 13](https://user-images.githubusercontent.com/514294/116816212-fb571180-ab9b-11eb-9f4d-eefa112d868d.png)
![Screen Shot 2021-05-02 at 22 50 17](https://user-images.githubusercontent.com/514294/116816219-feea9880-ab9b-11eb-9be0-f17f17d2ad1b.png)
![Screen Shot 2021-05-02 at 22 50 23](https://user-images.githubusercontent.com/514294/116816221-00b45c00-ab9c-11eb-87d4-41f8b2afe02c.png)
![Screen Shot 2021-05-02 at 22 50 26](https://user-images.githubusercontent.com/514294/116816223-027e1f80-ab9c-11eb-9870-b2226437a526.png)

## Backward Compatibility check

I picked some comments by @mlocati from some related issues. These are about multilingual site, and this pull request doesn't break these behaviors because `\Concrete\Core\Multilingual\Service\Detector::getPreferredSection` will fire before the fallback I added.

> Currently, pages that are not associated to a language (for example: login, page not found, forbidden, ...) use the last known language.
> For instance, the login page is in French if the last visited page was in French, and in English if the last visited page was in English.
> Maybe for the page not found page we could have an exception, because you may arrive to the non existing page coming from an external link,

https://github.com/concrete5/concrete5/issues/6500#issuecomment-371047786

Unfortunately, 404 page doesn't respect the `multilingual_default_locale` value. This PR also fixes it.

> The login page should be presented in the last language that users visited.
> For instance, if a user is visiting a Finnish page and then goes to the login page, it should be in Finnish.
> If another user is visiting a Swedish page and then goes to the login page, it should be in Swedish.

https://github.com/concrete5/concrete5/issues/6228#issuecomment-351365789

## Additional note

I'm waiting for @mlocati 's opinion [here](https://github.com/concrete5/concrete5/issues/7909#issuecomment-830788187). Please wait for him before merge this pull request.