### PR TITLE
[V8] Localization support for checkbox attr label

### DIFF
--- a/concrete/attributes/boolean/form.php
+++ b/concrete/attributes/boolean/form.php
@@ -7,6 +7,6 @@
             name="<?=$view->field('value')?>"
             <?php if ($checked) { ?> checked <?php } ?>
         >
-        <?=$controller->getCheckboxLabel()?>
+        <?=t($controller->getCheckboxLabel())?>
     </label>
 </div>

--- a/concrete/src/Attribute/Key/Factory.php
+++ b/concrete/src/Attribute/Key/Factory.php
@@ -72,12 +72,21 @@ class Factory
         foreach($keys as $key) {
             $translations->insert('AttributeKeyName', $key->getAttributeKeyName());
 
-            // text attribute placeholder
             $type = $key->getAttributeKeySettings();
+
+            // text attribute: placeholder
             if ($type instanceof \Concrete\Core\Entity\Attribute\Key\Settings\TextSettings) {
                 $placeholder = $type->getPlaceholder();
                 if ($placeholder !== '') {
                     $translations->insert('AttributeKeyPlaceholder', $placeholder);
+                }
+            }
+
+            // checkbox attribute: label
+            if ($type instanceof \Concrete\Core\Entity\Attribute\Key\Settings\BooleanSettings) {
+                $label = $type->getCheckboxLabel();
+                if ($label !== '') {
+                    $translations->insert('AttributeKeyLabel', $label);
                 }
             }
         }


### PR DESCRIPTION
Enbale translation for checkbox attributes' labels. Useful when adding express forms on the frontend.

Equivalent PR for V9: #9477 