### PR TITLE
[V8] Ignore errors when closing the mail transport

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -144,6 +144,15 @@ class Service
         $this->reset();
     }
 
+    public function __destruct()
+    {
+        try {
+            $this->transport = null;
+        } catch (Exception $x) {
+        } catch (Throwable $x) {
+        }
+    }
+
     /**
      * Clean up the instance of this object (reset the class scope variables).
      */


### PR DESCRIPTION
We need this because, in case of connection errors (eg wrong login), the SMTP transport may throw an exception when it gets destructed, hiding the actual connection problem.
(See https://github.com/concrete5/concrete5/pull/9375#issuecomment-835565053 for example).