### PR TITLE
Avoid uneccessary grid row nesting

### DIFF
--- a/concrete/elements/block_footer_view.php
+++ b/concrete/elements/block_footer_view.php
@@ -20,8 +20,11 @@ if (
     && !$b->ignorePageThemeGridFrameworkContainer()
 ) {
     $gf = $pt->getThemeGridFrameworkObject();
-    echo '</div>';
-    echo $gf->getPageThemeGridFrameworkRowEndHTML();
+	/* The 'core_area_layout' block deals with it's own row */
+    if ($b->getBlockTypeHandle() != BLOCK_HANDLE_LAYOUT_PROXY) {
+        echo '</div>';
+        echo $gf->getPageThemeGridFrameworkRowEndHTML();
+    }
     echo $gf->getPageThemeGridFrameworkContainerEndHTML();
 }
 

--- a/concrete/elements/block_header_view.php
+++ b/concrete/elements/block_header_view.php
@@ -46,10 +46,13 @@ if (
 ) {
     $gf = $pt->getThemeGridFrameworkObject();
     echo $gf->getPageThemeGridFrameworkContainerStartHTML();
-    echo $gf->getPageThemeGridFrameworkRowStartHTML();
-    printf('<div class="%s">', $gf->getPageThemeGridFrameworkColumnClassesForSpan(
-        min($a->getAreaGridMaximumColumns(), $gf->getPageThemeGridFrameworkNumColumns())
-    ));
+    /* No need to add a row if the block is of the 'core_area_layout' type as the area block will add its own row */
+    if ($b->getBlockTypeHandle() != BLOCK_HANDLE_LAYOUT_PROXY) {
+        echo $gf->getPageThemeGridFrameworkRowStartHTML();
+        printf('<div class="%s">', $gf->getPageThemeGridFrameworkColumnClassesForSpan(
+            min($a->getAreaGridMaximumColumns(), $gf->getPageThemeGridFrameworkNumColumns())
+        ));
+    }
 }
 
 if ($showMenu) {


### PR DESCRIPTION
This PR fixes issue #8681 when the block header and footer of an area get rendered and the area is using the theme grid framework then there is no need to add an additional row and class as the area template itself will take care of everything.