### PR TITLE
Fix "unknown" state/province formatting in addresses

### DIFF
--- a/concrete/src/Localization/Address/Formatter.php
+++ b/concrete/src/Localization/Address/Formatter.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Concrete\Core\Localization\Address;
 
-use CommerceGuys\Addressing\AddressInterface;
 use CommerceGuys\Addressing\AddressFormat\AddressFormat;
+use CommerceGuys\Addressing\AddressInterface;
 use CommerceGuys\Addressing\Formatter\DefaultFormatter;
 use CommerceGuys\Addressing\Locale;
 use CommerceGuys\Addressing\Subdivision\Subdivision;
@@ -72,15 +73,15 @@ class Formatter extends DefaultFormatter
      * This only gets the subdivision values and possibly converts the normally
      * returned codes to subdivision names.
      *
-     * @param  AddressInterface $address       the address for which to fetch
-     *                                         the subdivisions
-     * @param  AddressFormat    $addressFormat the address format object
-     *                                         defining the used subdivision
-     *                                         fields
+     * @param AddressInterface $address the address for which to fetch
+     *                                  the subdivisions
+     * @param AddressFormat $addressFormat the address format object
+     *                                     defining the used subdivision
+     *                                     fields
      *
-     * @return array                           an array containing the keys of
-     *                                         the subdivision fields and their
-     *                                         corresponding values
+     * @return array an array containing the keys of
+     *               the subdivision fields and their
+     *               corresponding values
      */
     protected function getSubdivisionValuesWithNames(
         AddressInterface $address,
@@ -92,7 +93,7 @@ class Formatter extends DefaultFormatter
         $parents = [$address->getCountryCode()];
         foreach ($subdivisionFields as $index => $field) {
             $getter = 'get' . ucfirst($field);
-            $subdivisionValue = $address->$getter();
+            $subdivisionValue = $address->{$getter}();
             if (empty($subdivisionValue)) {
                 // This level is empty, so there can be no sublevels.
                 break;
@@ -166,15 +167,15 @@ class Formatter extends DefaultFormatter
     /**
      * Gets the subdivision's name value.
      *
-     * @param  AddressInterface $address     the address for which to get the
-     *                                       name
-     * @param  Subdivision      $subdivision the subdivision's code to get
-     *                                       the name for
+     * @param AddressInterface $address the address for which to get the
+     *                                  name
+     * @param Subdivision $subdivision the subdivision's code to get
+     *                                 the name for
      *
-     * @return string|null                   a text representation of the
-     *                                       subdivision's name or null if a
-     *                                       corresponding text representation
-     *                                       does not exist
+     * @return string|null a text representation of the
+     *                     subdivision's name or null if a
+     *                     corresponding text representation
+     *                     does not exist
      */
     protected function getSubdivisionNameValue(
         AddressInterface $address,

--- a/tests/tests/Localization/Address/FormatterTest.php
+++ b/tests/tests/Localization/Address/FormatterTest.php
@@ -71,16 +71,14 @@ class FormatterTest extends TestCase
         // out and defines in which language the administrative area is printed
         $address = $address->withLocale('en');
         $address = $address->withCountryCode('JP');
-        $address = $address->withAddressLine1('1-13');
-        $address = $address->withAddressLine2('Chiyoda');
+        $address = $address->withAddressLine1('1 Chome - 13');
         $address = $address->withAdministrativeArea('13');
-        $address = $address->withLocality('Tokyo');
+        $address = $address->withLocality('Chiyoda');
         $address = $address->withPostalCode('101-0054');
 
         $this->assertEquals(
-            '1-13' . "\n" .
-            'Chiyoda' . "\n" .
-            'Tokyo, Tokyo' . "\n" .
+            '1 Chome - 13' . "\n" .
+            'Chiyoda, Tokyo' . "\n" .
             '101-0054' . "\n" .
             'Japan',
             $this->formatTextAddressFor($address)

--- a/tests/tests/Localization/Address/FormatterTest.php
+++ b/tests/tests/Localization/Address/FormatterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Concrete\Tests\Localization\Address;
+
+use CommerceGuys\Addressing\Address;
+use CommerceGuys\Addressing\AddressFormat\AddressFormatRepository;
+use CommerceGuys\Addressing\Country\CountryRepository;
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepository;
+use Concrete\Core\Localization\Address\Formatter;
+use Concrete\Tests\TestCase;
+
+class FormatterTest extends TestCase
+{
+    /**
+     * @var \CommerceGuys\Addressing\Formatter\FormatterInterface
+     */
+    protected $formatter;
+
+    public function setUp()
+    {
+        $addressFormatRepository = new AddressFormatRepository();
+        $countryRepository = new CountryRepository();
+        $subdivisionRepository = new SubdivisionRepository(
+            $addressFormatRepository
+        );
+
+        $this->formatter = new Formatter(
+            $addressFormatRepository,
+            $countryRepository,
+            $subdivisionRepository
+        );
+    }
+
+    /**
+     * The CMS knows the Japanese subdivisions as plain numbers, e.g. '13', but
+     * commerceguys/addressing knows them as e.g. 'JP-13'. This causes the
+     * subdivision (state/province) values for Japan to be stored as the numbers
+     * known to the CMS. This tests that these are properly mapped to the
+     * commerceguys/addressing values when this kind of addresses are formatted
+     * to the user.
+     */
+    public function testFormatUnknownIsoCompatibleAdministrativeArea()
+    {
+        $address = new Address();
+        // The address locale sets the order of the address fields in the print
+        // out and defines in which language the administrative area is printed
+        $address = $address->withLocale('ja');
+        $address = $address->withCountryCode('JP');
+        $address = $address->withAddressLine1('１丁目１３番地');
+        $address = $address->withAdministrativeArea('13');
+        $address = $address->withLocality('千代田区');
+        $address = $address->withPostalCode('101-0054');
+
+        $this->assertEquals(
+            '日本' . "\n" .
+            '〒101-0054' . "\n" .
+            '東京都千代田区' . "\n" .
+            '１丁目１３番地',
+            $this->formatTextAddressFor($address, 'ja')
+        );
+    }
+
+    /**
+     * Same as above but address is written in English and printed out in
+     * English.
+     */
+    public function testFormatUnknownIsoCompatibleAdministrativeAreaInEnglish()
+    {
+        $address = new Address();
+        // The address locale sets the order of the address fields in the print
+        // out and defines in which language the administrative area is printed
+        $address = $address->withLocale('en');
+        $address = $address->withCountryCode('JP');
+        $address = $address->withAddressLine1('13, Chiyoda 1-Chome');
+        $address = $address->withAdministrativeArea('13');
+        $address = $address->withLocality('Tokyo');
+        $address = $address->withPostalCode('101-0054');
+
+        $this->assertEquals(
+            '13, Chiyoda 1-Chome' . "\n" .
+            'Tokyo, Tokyo' . "\n" .
+            '101-0054' . "\n" .
+            'Japan',
+            $this->formatTextAddressFor($address)
+        );
+    }
+
+    /**
+     * The CMS has subdivisions defined for some countries that do not have any
+     * known subdivisions in commerceguys/addressing. This tests that for this
+     * kind of country subdivision that cannot be found from
+     * commerceguys/addressing is correctly fetched through the CMS's own
+     * country/province list.
+     */
+    public function testFormatUnknownAdministrativeAreaKnownToCms()
+    {
+        $address = new Address();
+        // The address locale sets the order of the address fields in the print
+        // out and defines in which language the administrative area is printed
+        $address = $address->withLocale('en');
+        $address = $address->withCountryCode('IE');
+        $address = $address->withAddressLine1('Baldoyle Ind Est, 13');
+        $address = $address->withAdministrativeArea('CO DUBLIN');
+        $address = $address->withLocality('Dublin');
+        $address = $address->withPostalCode('WN7 4TN');
+
+        $this->assertEquals(
+            'Baldoyle Ind Est, 13' . "\n" .
+            'Dublin' . "\n" .
+            'County Dublin WN7 4TN' . "\n" .
+            'Ireland',
+            $this->formatTextAddressFor($address)
+        );
+    }
+
+    /**
+     * Formats the address for the given address object.
+     *
+     * @param Address $address the address object to be formatted
+     * @param string $locale the locale code in which to format the address,
+     *                       affects the country name
+     *
+     * @return string the formatted address text
+     */
+    private function formatTextAddressFor(
+        Address $address,
+        $locale = 'en'
+    ) {
+        $options = [
+            'locale' => $locale, // the locale in which the country is printed
+            'html' => false,
+        ];
+
+        return $this->formatter->format($address, $options);
+    }
+}

--- a/tests/tests/Localization/Address/FormatterTest.php
+++ b/tests/tests/Localization/Address/FormatterTest.php
@@ -71,13 +71,15 @@ class FormatterTest extends TestCase
         // out and defines in which language the administrative area is printed
         $address = $address->withLocale('en');
         $address = $address->withCountryCode('JP');
-        $address = $address->withAddressLine1('1-13, Chiyoda');
+        $address = $address->withAddressLine1('1-13');
+        $address = $address->withAddressLine2('Chiyoda');
         $address = $address->withAdministrativeArea('13');
         $address = $address->withLocality('Tokyo');
         $address = $address->withPostalCode('101-0054');
 
         $this->assertEquals(
-            '1-13, Chiyoda' . "\n" .
+            '1-13' . "\n" .
+            'Chiyoda' . "\n" .
             'Tokyo, Tokyo' . "\n" .
             '101-0054' . "\n" .
             'Japan',

--- a/tests/tests/Localization/Address/FormatterTest.php
+++ b/tests/tests/Localization/Address/FormatterTest.php
@@ -71,13 +71,13 @@ class FormatterTest extends TestCase
         // out and defines in which language the administrative area is printed
         $address = $address->withLocale('en');
         $address = $address->withCountryCode('JP');
-        $address = $address->withAddressLine1('13, Chiyoda 1-Chome');
+        $address = $address->withAddressLine1('1-13, Chiyoda');
         $address = $address->withAdministrativeArea('13');
         $address = $address->withLocality('Tokyo');
         $address = $address->withPostalCode('101-0054');
 
         $this->assertEquals(
-            '13, Chiyoda 1-Chome' . "\n" .
+            '1-13, Chiyoda' . "\n" .
             'Tokyo, Tokyo' . "\n" .
             '101-0054' . "\n" .
             'Japan',


### PR DESCRIPTION
This should fix issue pointed out in #9316 with previous fix attempt at #8539.

The problem is because concrete5 stores its own lists of states/provinces:
https://github.com/concrete5/concrete5/blob/f3ff41f3b92074b160aad96f0de6438cb9308807/concrete/src/Localization/Service/StatesProvincesList.php#L19

The state/province codes do not match what is expected for `commerceguys/addressing`, e.g. for Tokyo, Japan the correct "code" would be "Tokyo" or "JA-xx" where `xx` is the concrete5 code:
https://github.com/commerceguys/addressing/blob/311040bd78ea2ea82105dd1f17205c449ac8de47/resources/subdivision/JP.json#L65-L69

In addition, c5 provides states/provinces for some countries that `commerceguys/addressing` does not know as far as my observations went. An example of such country is Ireland:
https://github.com/concrete5/concrete5/blob/f3ff41f3b92074b160aad96f0de6438cb9308807/concrete/src/Localization/Service/StatesProvincesList.php#L339

`commerceguys/addressing` doesn't recognize these subdivision codes at all as they are not in their data.

This provides two fixes in these situations:
- When a subdivision is not found with the concrete5 code, try for `NN-xx` ISO-code where `NN` is the country and `xx` is the subdivision as reported by concrete5
- When the previous step fails to find a subdivision, look for the subdivision name from concrete5's own "database"

Fix #9316