### PR TITLE
Fix: Japanese text in test

### DIFF
--- a/tests/tests/Utility/Service/TextTest.php
+++ b/tests/tests/Utility/Service/TextTest.php
@@ -38,12 +38,12 @@ class TextTest extends ConcreteDatabaseTestCase
     {
         return [
             ['Mixed with English and Germaen', 'Mixed with English and Germän', 'de_DE'],
-            ['Mixed with English and ', 'Mixed with English and 日本人', ''],
-            ['Mixed with English and .doc', 'Mixed with English and 日本人.doc', ''],
-            ['Mixed with English and .', 'Mixed with English and 日本人.日本人', ''],
-            ['', '日本人', ''],
-            ['.doc', '日本人.doc', ''],
-            ['.', '日本人.日本人', ''],
+            ['Mixed with English and ', 'Mixed with English and 日本語', ''],
+            ['Mixed with English and .doc', 'Mixed with English and 日本語.doc', ''],
+            ['Mixed with English and .', 'Mixed with English and 日本語.日本語', ''],
+            ['', '日本語', ''],
+            ['.doc', '日本語.doc', ''],
+            ['.', '日本語.日本語', ''],
         ];
     }
 


### PR DESCRIPTION
Japanese text in test means "Japanese person" but the sentence is
clearly referring to "Japanese language". Change the character to mean
"language".