### PR TITLE
[v8] fix select on single file in multi-file selector

### DIFF
--- a/concrete/js/build/core/file-manager/search.js
+++ b/concrete/js/build/core/file-manager/search.js
@@ -398,7 +398,7 @@
             // prepend choose
             holder.prepend('<li><a data-file-manager-action="choose" href="#">'+ccmi18n_filemanager.select+'</a></li>' +
                 '<li class="divider"></li>');
-            holder.on('click.concreteFileManagerChooseFile','a[data-file-manager-action=choose]', function(e) {
+            holder.find('a[data-file-manager-action=choose]').on('click.concreteFileManagerChooseFile', function(e) {
                 var ids = [];
 
                 $.each(my.getSelectedResults(), function(i, result) {


### PR DESCRIPTION

If you try to use the context menu to select a single file it will not work.

This fixes an issue when using the multi-file selector in version 8

Its only applicable to v8 since version 9 file selector is different