### PR TITLE
Use | characters to provide multiple valid redirect urls for an oauth2 client

### DIFF
--- a/concrete/single_pages/dashboard/system/api/integrations/edit.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/edit.php
@@ -26,11 +26,12 @@ $consentType = $client->getConsentType();
         <div class="form-group">
             <label for="redirect"><?php echo t('Redirect'); ?></label>
             <div class="input-group">
-                <?php echo $form->url('redirect', $client->getRedirectUri(), array('autocomplete' => 'off')); ?>
+                <?php echo $form->url('redirect', implode('|', (array) $client->getRedirectUri()), array('autocomplete' => 'off')); ?>
                 <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-asterisk"></i></span>
                 </div>
             </div>
+            <span class="help-block"><?= t('Separate multiple redirect urls using %s (pipe) characters', '<code>|</code>') ?></span>
         </div>
 
         <div class="form-group">

--- a/concrete/single_pages/dashboard/system/api/integrations/view_client.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/view_client.php
@@ -34,7 +34,12 @@ $consentType = $client->getConsentType();
 
     <div class="form-group">
         <label><?=t('Redirect URI')?></label>
-        <div><?=$client->getRedirectUri() ?: t('None provided') ?></div>
+        <?php
+        $redirectUri = $client->getRedirectUri() ?: t('None provided');
+        ?>
+        <ul>
+            <li><?= implode('</li><li>', (array) $redirectUri) ?></li>
+        </ul>
     </div>
 
     <div class="form-group">

--- a/concrete/src/Entity/OAuth/Client.php
+++ b/concrete/src/Entity/OAuth/Client.php
@@ -149,7 +149,13 @@ class Client implements ClientEntityInterface
          * is_string() and this returns an empty string. So let's use the falsy check to turn even empty strings
          * into nulls.
          */
-        return $this->redirectUri ? $this->redirectUri : null;
+        $url = $this->redirectUri ? $this->redirectUri : null;
+
+        if (is_string($url) && strpos($url, '|') !== false) {
+            return explode('|', $url);
+        }
+
+        return $url;
     }
 
     /**
@@ -159,7 +165,7 @@ class Client implements ClientEntityInterface
      */
     public function setRedirectUri($redirectUri)
     {
-        $this->redirectUri = $redirectUri;
+        $this->redirectUri = is_array($redirectUri) ? implode('|', $redirectUri) : $redirectUri;
     }
 
     /**


### PR DESCRIPTION
This PR gives users the ability to specify multiple valid redirect urls for a given oauth2 client. Before this change we could only ever have one client per domain if we wanted to maintain proper oauth2 security.
