### PR TITLE
[v8]Optimize memory usage to handle large number of records on batch processing

### DIFF
--- a/concrete/jobs/index_search_all.php
+++ b/concrete/jobs/index_search_all.php
@@ -14,6 +14,7 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Search\Index\IndexManagerInterface;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\User\User;
+use Doctrine\ORM\EntityManagerInterface;
 use Punic\Misc as PunicMisc;
 use ZendQueue\Message as ZendQueueMessage;
 use ZendQueue\Queue as ZendQueue;
@@ -168,6 +169,19 @@ class IndexSearchAll extends QueueableJob
         } else {
             return t('Indexed pages, users, files, sites and express data.');
         }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @see \Concrete\Core\Job\QueueableJob::executeBatch()
+     */
+    public function executeBatch($batch, ZendQueue $queue)
+    {
+        parent::executeBatch($batch, $queue);
+
+        $em = Facade::getFacadeApplication()->make(EntityManagerInterface::class);
+        $em->clear();
     }
 
     protected function clearExpressEntityIndex($id)

--- a/concrete/src/Job/QueueableJob.php
+++ b/concrete/src/Job/QueueableJob.php
@@ -2,9 +2,7 @@
 
 namespace Concrete\Core\Job;
 
-use Concrete\Core\Support\Facade\Facade;
 use Config;
-use Doctrine\ORM\EntityManagerInterface;
 use Job as AbstractJob;
 use Queue;
 use ZendQueue\Message as ZendQueueMessage;
@@ -170,9 +168,5 @@ abstract class QueueableJob extends AbstractJob
             $this->processQueueItem($item);
             $queue->deleteMessage($item);
         }
-
-        // Clear out the memory
-        $em = Facade::getFacadeApplication()->make(EntityManagerInterface::class);
-        $em->clear();
     }
 }

--- a/concrete/src/Job/QueueableJob.php
+++ b/concrete/src/Job/QueueableJob.php
@@ -2,7 +2,9 @@
 
 namespace Concrete\Core\Job;
 
+use Concrete\Core\Support\Facade\Facade;
 use Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Job as AbstractJob;
 use Queue;
 use ZendQueue\Message as ZendQueueMessage;
@@ -168,5 +170,9 @@ abstract class QueueableJob extends AbstractJob
             $this->processQueueItem($item);
             $queue->deleteMessage($item);
         }
+
+        // Clear out the memory
+        $em = Facade::getFacadeApplication()->make(EntityManagerInterface::class);
+        $em->clear();
     }
 }


### PR DESCRIPTION
Recently, when we ran the `index_search` job on an 8.5.5 site it got failed due to the consumption of a lot of memory.
It took around `250MB` to process about `34000` records.

With this small fix, the peak usage of the memory was only `45MB`.

I haven't opened the pull request for v9 as things have been changed a lot there. But if you want I'll check that too.