### PR TITLE
[V9] Don't make the mail transport a singleton

### DIFF
--- a/concrete/src/Mail/MailServiceProvider.php
+++ b/concrete/src/Mail/MailServiceProvider.php
@@ -20,7 +20,7 @@ class MailServiceProvider extends ServiceProvider
             $app->bind($key, $value);
         }
 
-        $this->app->singleton(TransportInterface::class, function () use ($app) {
+        $this->app->bind(TransportInterface::class, function () use ($app) {
             $factory = $app->make(TransportFactory::class);
 
             return $factory->createTransportFromConfig($app->make('config'));


### PR DESCRIPTION
#9484 (for V9) and #9483 (for V8) aren't enough: since the mail transport is a singleton, its instance is released only when the application life-cycle ends (that is, at the end of the request &rarr; response process).

Having the mail transport being a singleton may be problematic when the SMTP connection is closed prematurely by the SMTP server (for example because of wrong authentication): in this case, with the current implementation of the SMTP client, the state is undetermined, and we shouldn't re-use the client (for example, we see a "connection already closed" error instead of "wrong login/password").

It's much safer to create a new transport client when we need it.