### PR TITLE
"Index Search Engine - Updates" job should not re-index all entries.

### DIFF
--- a/concrete/jobs/index_search.php
+++ b/concrete/jobs/index_search.php
@@ -3,7 +3,11 @@ namespace Concrete\Job;
 
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\File\File;
 use Concrete\Core\Job\JobQueueMessage;
+use Concrete\Core\Page\Page;
+use Concrete\Core\User\User;
 
 class IndexSearch extends IndexSearchAll implements ApplicationAwareInterface
 {


### PR DESCRIPTION
It Fixes #9501 but we need to make another PR for 8.6.

Should I move `pagesToQueue()` method into `IndexObjectProvider` class? If so, I'll update this PR.