### PR TITLE
Improve caching expierence for the avatar service by adding an query …

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.0.0a3',
     'version_installed' => '9.0.0a3',
-    'version_db' => '20210428212600', // the key of the latest database migration
+    'version_db' => '20210528170900', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -79,6 +79,11 @@ class User implements UserEntityInterface, \JsonSerializable
     protected $uLastPasswordChange = null;
 
     /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    protected $uDateLastUpdated = null;
+
+    /**
      * @ORM\Column(type="boolean")
      */
     protected $uHasAvatar = false;
@@ -137,6 +142,7 @@ class User implements UserEntityInterface, \JsonSerializable
     public function __construct()
     {
         $this->uLastPasswordChange = new \DateTime();
+        $this->uDateLastUpdated = new \DateTime();
         $this->uDateAdded = new \DateTime();
     }
 
@@ -214,6 +220,14 @@ class User implements UserEntityInterface, \JsonSerializable
     public function getUserLastPasswordChange()
     {
         return $this->uLastPasswordChange;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUserDateLastUpdated()
+    {
+        return $this->uDateLastUpdated;
     }
 
     /**
@@ -366,6 +380,14 @@ class User implements UserEntityInterface, \JsonSerializable
     public function setUserLastPasswordChange($uLastPasswordChange)
     {
         $this->uLastPasswordChange = $uLastPasswordChange;
+    }
+
+    /**
+     * @param \DateTime $uDateLastUpdated
+     */
+    public function setUserDateLastUpdated($uDateLastUpdated)
+    {
+        $this->uDateLastUpdated = $uDateLastUpdated;
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20210528170900.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210528170900.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\User\User;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20210528170900 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([User::class]);
+    }
+}

--- a/concrete/src/User/Avatar/StandardAvatar.php
+++ b/concrete/src/User/Avatar/StandardAvatar.php
@@ -22,7 +22,10 @@ class StandardAvatar implements AvatarInterface
         $fsl = StorageLocation::getDefault();
         $configuration = $fsl->getConfigurationObject();
         $src = $configuration->getPublicURLToFile(REL_DIR_FILES_AVATARS . '/' . $this->userInfo->getUserID() . '.jpg');
-
+        $lastUpdated = $this->userInfo->getUserDateLastUpdated();
+        if ($lastUpdated instanceof \DateTime) {
+            $src .= sprintf("?%s", http_build_query(["s" => $lastUpdated->getTimestamp()]));
+        }
         return $src;
     }
 

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -338,7 +338,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
             ]
         );
 
-        $this->connection->executeQuery('update Users set uHasAvatar = 1 where uID = ? limit 1', [$this->getUserID()]);
+        $this->connection->executeQuery('update Users set uHasAvatar = 1, uDateLastUpdated = NOW() where uID = ? limit 1', [$this->getUserID()]);
 
         // run any internal event we have for user update
         $ui = $this->application->make(UserInfoRepository::class)->getByID($this->getUserID());
@@ -893,6 +893,14 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     public function getUserID()
     {
         return $this->entity->getUserID();
+    }
+
+    /**
+     * @see \Concrete\Core\Entity\User\User::getUserID()
+     */
+    public function getUserDateLastUpdated()
+    {
+        return $this->entity->getUserDateLastUpdated();
     }
 
     /**


### PR DESCRIPTION
This pull request is useful if you use concrete5 in combination with CloudFlare, CloudFront and similar caching engines. It tracks changes of user avatars and appends the last time stamp to avatar urls. Thanks to @aembler and @katzueno  