### PR TITLE
Improve error messages

### DIFF
--- a/concrete/src/Install/Preconditions/RequestUrls.php
+++ b/concrete/src/Install/Preconditions/RequestUrls.php
@@ -84,6 +84,7 @@ class RequestUrls implements WebPreconditionInterface
     {
         $url = json_encode((string) $this->resolver->resolve(['/install', 'web_precondition', 'request_urls', '20']));
         $errorMessage = json_encode(t('concrete5 cannot parse the PATH_INFO or ORIG_PATH_INFO information provided by your server.'));
+        $ajaxFailErrorMessage = json_encode(t('Request failed: unable to verify support for request URLs'));
         $myIdentifier = json_encode($this->getUniqueIdentifier());
 
         return <<<EOT
@@ -103,7 +104,7 @@ $(document).ready(function() {
         }
     })
     .fail(function(xhr, textStatus, errorThrown) {
-        setWebPreconditionResult({$myIdentifier}, false, {$errorMessage});
+        setWebPreconditionResult({$myIdentifier}, false, {$ajaxFailErrorMessage});
     });
 });
 </script>


### PR DESCRIPTION
Give a specific error message for when ajax request fails which could be reasons different to this check. For example, if the server responds with a status code of 500, it's unlikely related to this check, but many forum posts ([one example here](https://www.concrete5.org/community/forums/installation/installation-c5-ver.8.5.2-fail-during-checking-required-items-su)) show that people get stuck on this thinking the problem has to do with PATH_INFO. This new error message will at least point people in the right direction.

