### PR TITLE
Add the ability to hide specified superglobal or config keys when rendering whoops error pages

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -63,6 +63,49 @@ return [
          * @var int|null
          */
         'error_reporting' => null,
+
+        /**
+         * Hide specified superglobal keys and config items from whoops error output.
+         * If you wanted to hide an environment variable named "DB_PASSWORD", you'd specify it like this:
+         * ```
+         * '_ENV' => ['DB_PASSWORD'],
+         * ```
+         *
+         * The same applies for all superglobals.
+         *
+         * @var array<string, string[]>
+         */
+        'hide_keys' => [
+            /** @var string[] */
+            '_ENV' => [],
+
+            /** @var string[] */
+            '_SERVER' => [],
+
+            /** @var string[] */
+            '_GET' => [],
+
+            /** @var string[] */
+            '_POST' => [],
+
+            /** @var string[] */
+            '_FILES' => [],
+
+            /** @var string[] */
+            '_COOKIE' => [],
+
+            /** @var string[] */
+            '_SESSION' => [],
+
+            /**
+             * Hide specified config keys from whoops error output
+             * `concrete.debug.display_errors` will hide that specific config item while `concrete.debug` will hide
+             * all items in the `concrete.debug` array.
+             *
+             * @var string[]
+             */
+            'config' => [],
+        ]
     ],
 
     /*

--- a/concrete/src/Error/Handler/ErrorHandler.php
+++ b/concrete/src/Error/Handler/ErrorHandler.php
@@ -15,7 +15,7 @@ use Whoops\Handler\PrettyPageHandler;
 class ErrorHandler extends PrettyPageHandler
 {
 
-    private array $hideConfigKeys = [];
+    private $hideConfigKeys = [];
 
     /**
      * {@inheritdoc}

--- a/concrete/src/Error/Handler/ErrorHandler.php
+++ b/concrete/src/Error/Handler/ErrorHandler.php
@@ -130,7 +130,7 @@ class ErrorHandler extends PrettyPageHandler
         return $flat;
     }
 
-    protected function registerHideList()
+    protected function registerHideList(): void
     {
         foreach (Config::get('concrete.debug.hide_keys', []) as $superGlobal => $keys) {
             if ($superGlobal === 'config') {
@@ -146,7 +146,7 @@ class ErrorHandler extends PrettyPageHandler
         }
     }
 
-    private function isKeyHidden(string $key)
+    private function isKeyHidden(string $key): bool
     {
         // We have to check each node to make sure it's not hidden:
         $key = explode('.', $key);

--- a/concrete/src/Error/Handler/ErrorHandler.php
+++ b/concrete/src/Error/Handler/ErrorHandler.php
@@ -3,7 +3,7 @@ namespace Concrete\Core\Error\Handler;
 
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Support\Facade\Database;
-use Config;
+use Concrete\Core\Support\Facade\Config;
 use Core;
 use Whoops\Handler\PrettyPageHandler;
 
@@ -14,6 +14,9 @@ use Whoops\Handler\PrettyPageHandler;
  */
 class ErrorHandler extends PrettyPageHandler
 {
+
+    private array $hideConfigKeys = [];
+
     /**
      * {@inheritdoc}
      */
@@ -37,7 +40,9 @@ class ErrorHandler extends PrettyPageHandler
         }
         if ($enabled) {
             if ($detail === 'debug') {
+                $this->registerHideList();
                 $this->addDetails();
+
                 $result = parent::handle();
             } else {
                 Core::make('helper/concrete/ui')->renderError(
@@ -102,15 +107,58 @@ class ErrorHandler extends PrettyPageHandler
     {
         $flat = [];
         foreach ($config as $key => $value) {
+            $assembled = "{$group}.{$key}";
+            if ($this->isKeyHidden($assembled)) {
+                if (is_array($value)) {
+                    $flat[$assembled] = '[***]';
+                } else {
+                    $flat[$assembled] = str_repeat('*', is_string($value) ? strlen($value) : 3);
+                }
+
+                continue;
+            }
+
             if (is_array($value)) {
                 $flat = array_merge($flat, $this->flatConfig($value, "{$group}.{$key}"));
             } elseif (is_string($value)) {
-                $flat["{$group}.{$key}"] = $value;
+                $flat[$assembled] = $value;
             } else {
-                $flat["{$group}.{$key}"] = json_encode($value);
+                $flat[$assembled] = json_encode($value);
             }
         }
 
         return $flat;
+    }
+
+    protected function registerHideList()
+    {
+        foreach (Config::get('concrete.debug.hide_keys', []) as $superGlobal => $keys) {
+            if ($superGlobal === 'config') {
+                foreach ($keys as $key) {
+                    $this->hideConfigKeys[$key] = true;
+                }
+                continue;
+            }
+
+            foreach ((array) $keys as $key) {
+                $this->hideSuperglobalKey($superGlobal, $key);
+            }
+        }
+    }
+
+    private function isKeyHidden(string $key)
+    {
+        // We have to check each node to make sure it's not hidden:
+        $key = explode('.', $key);
+        $length = count($key);
+
+        do {
+            $tryKey = implode('.', array_slice($key, 0, $length));
+            if (isset($this->hideConfigKeys[$tryKey])) {
+                return true;
+            }
+        } while ($length-- > 1);
+
+        return false;
     }
 }


### PR DESCRIPTION
This is largely inspired by [laravel's implementation](https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php#L61) which leverages whoops' built in hide support. We go a small step further and allow the ability to hide config items as well.

The way this is used is you specify the superglobal key or config item you want to hide in the appropriate superglobal or config array. So for example if you're using composer based concrete5 and you want to hide the password and hostname environment variables for the database you might have:

```php
return [
    'debug' => [
        'hide_keys' => [
            '_ENV' => ['DB_PASSWORD', 'DB_HOSTNAME'],
        ]
    ]
];
```

This same thing works for all superglobals for example if you want to hide a specific query parameter when a user requests something like `/foo/?password=something`:
```php
'_GET' => ['password'],
```