### PR TITLE
[V8] Do not combine dropzone js

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -419,7 +419,7 @@ return [
         ],
         'dropzone' => [
             ['javascript', 'js/dropzone.js'],
-            ['javascript-localized', '/ccm/assets/localization/dropzone/js'],
+            ['javascript-localized', '/ccm/assets/localization/dropzone/js', ['combine' => false]],
             ['css', 'css/dropzone.css', ['minify' => false]],
         ],
         'jquery/form' => [


### PR DESCRIPTION
Fixes #9507

Before, token included in the asset cache file, so concrete5 generates these caches forever

![Screen Shot 2021-06-04 at 3 11 10](https://user-images.githubusercontent.com/514294/120693002-6ec5a900-c4e3-11eb-9220-0c788af22dc8.png)

After, token never included in the asset cache file

![Screen Shot 2021-06-04 at 3 12 55](https://user-images.githubusercontent.com/514294/120693189-ad5b6380-c4e3-11eb-80c1-6cce8ba7bf46.png)
