### PR TITLE
Set default hide keys for environment variables config and cookies

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -77,10 +77,34 @@ return [
          */
         'hide_keys' => [
             /** @var string[] */
-            '_ENV' => [],
+            '_ENV' => [
+                // Likely database environment variables
+                'DB_PASSWORD',
+                'DB_USERNAME',
+                'DB_HOSTNAME',
+                'DB_HOST',
+                'DB_SERVER',
+                'DATABASE_PASSWORD',
+                'DATABASE_USERNAME',
+                'DATABASE_HOSTNAME',
+                'DATABASE_HOST',
+                'DATABASE_SERVER',
+            ],
 
             /** @var string[] */
-            '_SERVER' => [],
+            '_SERVER' => [
+                // Likely database environment variables
+                'DB_PASSWORD',
+                'DB_USERNAME',
+                'DB_HOSTNAME',
+                'DB_HOST',
+                'DB_SERVER',
+                'DATABASE_PASSWORD',
+                'DATABASE_USERNAME',
+                'DATABASE_HOSTNAME',
+                'DATABASE_HOST',
+                'DATABASE_SERVER',
+            ],
 
             /** @var string[] */
             '_GET' => [],
@@ -92,7 +116,9 @@ return [
             '_FILES' => [],
 
             /** @var string[] */
-            '_COOKIE' => [],
+            '_COOKIE' => [
+                'CONCRETE5',
+            ],
 
             /** @var string[] */
             '_SESSION' => [],
@@ -104,7 +130,16 @@ return [
              *
              * @var string[]
              */
-            'config' => [],
+            'config' => [
+                'concrete.proxy.password',
+                'concrete.mail.methods.smtp.password',
+                'concrete.email.default.address',
+                'concrete.email.form_block.address',
+                'concrete.email.forgot_password.address',
+                'concrete.email.validate_registration.address',
+                'concrete.email.workflow_notification.address',
+                'concrete.debug.hide_keys',
+            ],
         ]
     ],
 


### PR DESCRIPTION
This PR follows up #9506 with some default values as recommended in the comments.

One caveat to adding entries here as opposed to adding them to `application/config/concrete.php` is there's no way to reenable some of these things without doing something like setting these config values in code.