### PR TITLE
Bugfix: anchor target attribute can be incorrect

### DIFF
--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -54,6 +54,7 @@ if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
                 $buttonClasses = 'ccm-block-page-list-read-more';
                 $entryClasses = 'ccm-block-page-list-page-entry';
                 $title = $page->getCollectionName();
+                $target = '_self';
                 if ($page->getCollectionPointerExternalLink() != '') {
                     $url = $page->getCollectionPointerExternalLink();
                     if ($page->openCollectionPointerExternalLinkInNewWindow()) {
@@ -63,7 +64,6 @@ if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
                     $url = $page->getCollectionLink();
                     $target = $page->getAttribute('nav_target');
                 }
-                $target = empty($target) ? '_self' : $target;
                 $description = $page->getCollectionDescription();
                 $description = $controller->truncateSummaries ? $th->wordSafeShortText($description, $controller->truncateChars) : $description;
                 $thumbnail = false;


### PR DESCRIPTION
The anchor target attribute will only be set correctly for the first page in the list because in the check to set it to "_self" (the default), `$target` has to be null. But it's only null on the first iteration. I changed this so that it's "_self" be default and then only changes if certain conditions are met.

