### PR TITLE
Fix the IE format in the address formatter test

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -222,27 +222,27 @@
         },
         {
             "name": "commerceguys/addressing",
-            "version": "v1.0.8",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/commerceguys/addressing.git",
-                "reference": "cf202c913c10d85085ab5ed9ec88607e312839ce"
+                "reference": "311040bd78ea2ea82105dd1f17205c449ac8de47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/cf202c913c10d85085ab5ed9ec88607e312839ce",
-                "reference": "cf202c913c10d85085ab5ed9ec88607e312839ce",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/311040bd78ea2ea82105dd1f17205c449ac8de47",
+                "reference": "311040bd78ea2ea82105dd1f17205c449ac8de47",
                 "shasum": ""
             },
             "require": {
                 "doctrine/collections": "~1.0",
-                "php": ">=7.0.8"
+                "php": ">=7.1.3"
             },
             "require-dev": {
                 "mikey179/vfsstream": "1.*",
-                "phpunit/phpunit": "^6.0",
-                "squizlabs/php_codesniffer": "2.*",
-                "symfony/validator": "^3.4"
+                "phpunit/phpunit": "^7.5",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/validator": "^4.4"
             },
             "suggest": {
                 "symfony/validator": "to validate addresses"
@@ -277,7 +277,7 @@
                 "localization",
                 "postal"
             ],
-            "time": "2020-05-26T11:04:04+00:00"
+            "time": "2021-05-17T08:05:21+00:00"
         },
         {
             "name": "concrete5/dependency-patches",
@@ -4108,6 +4108,7 @@
                 "utf-8",
                 "utf8"
             ],
+            "abandoned": "symfony/polyfill-mbstring or symfony/string",
             "time": "2019-12-03T14:44:12+00:00"
         },
         {
@@ -4207,12 +4208,12 @@
             "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nrk/predis.git",
+                "url": "https://github.com/predis/predis.git",
                 "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "url": "https://api.github.com/repos/predis/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
                 "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
                 "shasum": ""
             },
@@ -5710,6 +5711,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "use `EnglishInflector` from the String component instead",
             "time": "2020-05-20T08:37:50+00:00"
         },
         {

--- a/tests/tests/Localization/Address/FormatterTest.php
+++ b/tests/tests/Localization/Address/FormatterTest.php
@@ -107,7 +107,8 @@ class FormatterTest extends TestCase
         $this->assertEquals(
             'Baldoyle Ind Est, 13' . "\n" .
             'Dublin' . "\n" .
-            'County Dublin WN7 4TN' . "\n" .
+            'County Dublin' . "\n" .
+            'WN7 4TN' . "\n" .
             'Ireland',
             $this->formatTextAddressFor($address)
         );


### PR DESCRIPTION
The address format for Ireland (`IE`) has changed at commerceguys/addressing:
https://github.com/commerceguys/addressing/commit/77028d411d90747e7b2a0569807ccc6d01507099

This causes the address formatter test to fail as reported by @aembler at #9491.

This only happens because the packages are updated during the test runs. It does not happen if you install the packages using the `composer.lock` file in development.