### PR TITLE
Fix "count() Parameter must be an array" if the current use doesn't have allowed property

### DIFF
--- a/concrete/src/Permission/Access/ListItem/EditPagePropertiesPageListItem.php
+++ b/concrete/src/Permission/Access/ListItem/EditPagePropertiesPageListItem.php
@@ -21,7 +21,7 @@ class EditPagePropertiesPageListItem extends PageListItem
     }
     public function setAttributesAllowedArray($akIDs)
     {
-        $this->customAttributeKeyArray = $akIDs;
+        $this->customAttributeKeyArray = (array) $akIDs;
     }
     public function getAttributesAllowedArray()
     {

--- a/concrete/src/Permission/Access/ListItem/EditUserPropertiesUserListItem.php
+++ b/concrete/src/Permission/Access/ListItem/EditUserPropertiesUserListItem.php
@@ -24,7 +24,7 @@ class EditUserPropertiesUserListItem extends UserListItem
 
     public function setAttributesAllowedArray($akIDs)
     {
-        $this->customAttributeKeyArray = $akIDs;
+        $this->customAttributeKeyArray = (array) $akIDs;
     }
 
     public function getAttributesAllowedArray()

--- a/concrete/src/Permission/Access/ListItem/ViewUserAttributesUserListItem.php
+++ b/concrete/src/Permission/Access/ListItem/ViewUserAttributesUserListItem.php
@@ -16,7 +16,7 @@ class ViewUserAttributesUserListItem extends UserListItem
     }
     public function setAttributesAllowedArray($akIDs)
     {
-        $this->customAttributeArray = $akIDs;
+        $this->customAttributeArray = (array) $akIDs;
     }
     public function getAttributesAllowedArray()
     {


### PR DESCRIPTION
Error message

```
Whoops\Exception\ErrorException thrown with message "count(): Parameter must be an array or an object that implements Countable"

Stacktrace:
#36 Whoops\Exception\ErrorException in /path/to/concrete/src/Permission/Key/EditPagePropertiesPageKey.php:145
#35 count in /path/to/concrete/src/Permission/Key/EditPagePropertiesPageKey.php:145
#34 Concrete\Core\Permission\Key\EditPagePropertiesPageKey:validate in /path/to/concrete/src/Permission/Response/PageResponse.php:133
#33 Concrete\Core\Permission\Response\PageResponse:canEditPageProperties in /path/to/concrete/src/Permission/Checker.php:52
#32 Concrete\Core\Permission\Checker:__call in /path/to/concrete/elements/page_controls_footer.php:114
#31 include in /path/to/concrete/src/View/View.php:476
#30 Concrete\Core\View\View:element in /path/to/concrete/elements/footer_required.php:25
#29 include in /path/to/concrete/src/View/View.php:476
```