### PR TITLE
[Proposal] Add option to unapprove other versions on page version scheduling

### DIFF
--- a/concrete/controllers/panel/detail/page/composer.php
+++ b/concrete/controllers/panel/detail/page/composer.php
@@ -4,6 +4,8 @@ namespace Concrete\Controller\Panel\Detail\Page;
 
 use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
 use Concrete\Core\Form\Service\Widget\DateTime;
+use Concrete\Core\Page\Collection\Version\Event;
+use Concrete\Core\Page\Collection\Version\Version;
 use Concrete\Core\Page\EditResponse as PageEditResponse;
 use Concrete\Core\Page\Template as PageTemplate;
 use Concrete\Core\Page\Type\Type as PageType;
@@ -91,6 +93,15 @@ class Composer extends BackendInterfacePageController
                     $dateTime = new DateTime();
                     $publishDateTime = $dateTime->translate('cvPublishDate');
                     $publishEndDateTime = $dateTime->translate('cvPublishEndDate');
+
+                    if ($this->request->request->get('unapproveOtherVersions')) {
+                        $v = Version::get($c, 'RECENT');
+                        $v->deny();
+
+                        $ev = new Event($c);
+                        $ev->setCollectionVersionObject($v);
+                        $this->app->make('director')->dispatch('on_page_version_submit_deny', $ev);
+                    }
                 }
 
                 $pagetype->publish($c, $publishDateTime, $publishEndDateTime);

--- a/concrete/controllers/panel/page/check_in.php
+++ b/concrete/controllers/panel/page/check_in.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\Panel\Page;
 
 use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
 use Concrete\Core\Form\Service\Widget\DateTime;
+use Concrete\Core\Page\Collection\Version\Event;
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\User\User;
 use Permissions;
@@ -106,6 +107,14 @@ class CheckIn extends BackendInterfacePageController
                         $publishDateTime = $dateTime->translate('cvPublishDate');
                         $publishEndDateTime = $dateTime->translate('cvPublishEndDate');
                         $pkr->scheduleVersion($publishDateTime, $publishEndDateTime);
+
+                        if ($this->request->request->get('unapproveOtherVersions')) {
+                            $v->deny();
+
+                            $ev = new Event($c);
+                            $ev->setCollectionVersionObject($v);
+                            $this->app->make('director')->dispatch('on_page_version_submit_deny', $ev);
+                        }
                     }
 
                     if ($c->isPageDraft()) {

--- a/concrete/elements/pages/schedule.php
+++ b/concrete/elements/pages/schedule.php
@@ -4,6 +4,7 @@ $datetime = Loader::helper('form/date_time');
 
 $publishDate = '';
 $publishEndDate = '';
+$isDraft = null;
 if (isset($page) && is_object($page)) {
     $v = CollectionVersion::get($page, "RECENT");
     $publishDate = $v->getPublishDate();
@@ -18,6 +19,8 @@ if (isset($page) && is_object($page)) {
         </div>
         <?php
     }
+
+    $isDraft = $page->isPageDraft();
 }
 
 $dateService = Core::make('date');
@@ -39,6 +42,13 @@ $timezone = $dateService->getTimezoneDisplayName($timezone);
 <div style="text-align: right">
     <span class="form-text help-block"><?=t('Time Zone: %s', $timezone)?></span>
 </div>
+
+<?php if (!$isDraft) { ?>
+<div class="form-group form-group-last form-check" style="padding-left: 1.25rem">
+    <input type="checkbox" class="form-check-input" name="unapproveOtherVersions" id="unapproveOtherVersions" value="1">
+    <label class="form-check-label" for="unapproveOtherVersions"><?= t('Unapprove other versions') ?></label>
+</div>
+<?php } ?>
 
 <div class="dialog-buttons">
     <button type="submit" name="action" value="schedule"


### PR DESCRIPTION
I'd added the message for editors to avoid misunderstanding about scheduling a new page version on #8311
However, many of my clients still misunderstand this "Schedule" button is for the page itself instead of the specific version of the page.
They claimed, Absolutely I set "To" date but the page still alive even if the time passed!
If this behavior is hard to understand, how about adding an option to make the "Schedule" button can control the page itself?

![Screen Shot 2021-06-20 at 18 47 30](https://user-images.githubusercontent.com/514294/122669638-4636f200-d1f9-11eb-9e31-13ec488665f8.png)

If you check this "Unapprove other versions" option, all versions will be unapproved, then "From" and "To" dates can control entire page.