### PR TITLE
Multilingual Page Calls Expensive DB calls

### DIFF
--- a/concrete/src/Multilingual/Page/Section/Section.php
+++ b/concrete/src/Multilingual/Page/Section/Section.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Core\Multilingual\Page\Section;
 
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Cache\Level\RequestCache;
 use Concrete\Core\Entity\Site\Locale;
 use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Entity\Site\SiteTree;
@@ -31,12 +33,29 @@ class Section extends Page
 
     protected static function getLocaleFromHomePageID($cID)
     {
-        $em = Database::get()->getEntityManager();
-        $tree = $em->getRepository('Concrete\Core\Entity\Site\SiteTree')
-            ->findOneBySiteHomePageID($cID);
-        if (is_object($tree)) {
-            return $em->getRepository('Concrete\Core\Entity\Site\Locale')
-                ->findOneByTree($tree);
+        if ($cID) {
+            $cache = Application::getFacadeApplication()->make(RequestCache::class);
+            $item = $cache->getItem('section_local_from_homepage_id/' .  $cID);
+            
+            if ($item->isMiss() === true) {
+                $item->lock();
+                
+                $em = Database::get()->getEntityManager();
+                $tree = $em->getRepository('Concrete\Core\Entity\Site\SiteTree')
+                    ->findOneBySiteHomePageID($cID);
+                
+                if (is_object($tree)) {
+                    $locale = $em->getRepository('Concrete\Core\Entity\Site\Locale')
+                        ->findOneByTree($tree);
+
+                    $item->set($locale);
+                    $cache->save($item);
+
+                    return $locale;
+                }
+            } else {
+                return $item->get();
+            }
         }
     }
 

--- a/concrete/src/Multilingual/Page/Section/Section.php
+++ b/concrete/src/Multilingual/Page/Section/Section.php
@@ -35,7 +35,7 @@ class Section extends Page
     {
         if ($cID) {
             $cache = Application::getFacadeApplication()->make(RequestCache::class);
-            $item = $cache->getItem('section_local_from_homepage_id/' .  $cID);
+            $item = $cache->getItem('section_locale_from_homepage_id/' .  $cID);
             
             if ($item->isMiss() === true) {
                 $item->lock();


### PR DESCRIPTION
We currently use the miltilingual feature on our website and we've notice quite a heavy amount of calls to the Section::getLocaleFromHomePageID to the database. Adding the above the request cache like it does for pages already has reduced this dramatically.

Before

<img width="84" alt="Screenshot 2021-06-27 at 14 19 19" src="https://user-images.githubusercontent.com/8473296/123546191-82b3a200-d753-11eb-9e7f-1f9c4865d0d1.png">


After 

<img width="86" alt="Screenshot 2021-06-27 at 14 19 50" src="https://user-images.githubusercontent.com/8473296/123546197-85ae9280-d753-11eb-85da-0c8cfcf83436.png">

