### PR TITLE
Populating Theme Query expensive DB calls

### DIFF
--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -589,6 +589,7 @@ class Theme extends ConcreteObject
             $env = Environment::get();
 
             if (!empty($row)) {
+                $item->lock();
                 $standardClass = '\\Concrete\Core\\Page\\Theme\\Theme';
                 if ($row['pThemeHasCustomClass']) {
                     $pkgHandle = PackageList::getHandle($row['pkgID']);


### PR DESCRIPTION
This function is called multiple times on single page load and like the pages cache we can place this into request caching to boost performance of a page load.


Before DB Calls
<img width="87" alt="Screenshot 2021-06-27 at 16 18 27" src="https://user-images.githubusercontent.com/8473296/123550229-8865b380-d764-11eb-91fa-621a4877b889.png">


After DB Calls
<img width="84" alt="Screenshot 2021-06-27 at 16 18 43" src="https://user-images.githubusercontent.com/8473296/123550240-94517580-d764-11eb-980e-f84e6162eb57.png">
