### PR TITLE
Cache repeatable attribute value calls

### DIFF
--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -243,7 +243,16 @@ class Controller extends AbstractController implements AttributeInterface
         try {
             $class = $this->getAttributeValueClass();
             if ($class && $this->attributeValue && !empty($this->attributeValue->getAttributeValueID())) {
-                $result = $this->entityManager->find($class, $this->attributeValue->getGenericValue());
+                $cache = $this->app->make(RequestCache::class);
+                $item  = $cache->getItem('get_attribute_value_object/' . $class . $this->attributeValue->getAttributeValueID() . $this->attributeKey->getAttributeKeyHandle());
+
+                if ($item->isMiss() === false) {
+                    $result = $this->entityManager->find($class, $this->attributeValue->getGenericValue());
+                    $item->set($result);
+                    $cache->save($item);
+                } else {
+                    $result = $item->get();
+                }
             } else {
                 if ($class && $this->attributeValue) {
                     $result = $this->attributeValue;

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -247,6 +247,7 @@ class Controller extends AbstractController implements AttributeInterface
                 $item  = $cache->getItem('get_attribute_value_object/' . $class . $this->attributeValue->getAttributeValueID() . $this->attributeKey->getAttributeKeyHandle());
 
                 if ($item->isMiss() === false) {
+                    $item->lock();
                     $result = $this->entityManager->find($class, $this->attributeValue->getGenericValue());
                     $item->set($result);
                     $cache->save($item);

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -247,7 +247,7 @@ class Controller extends AbstractController implements AttributeInterface
                 $cache = $this->app->make(RequestCache::class);
                 $item  = $cache->getItem('get_attribute_value_object/' . $class . $this->attributeValue->getAttributeValueID() . $this->attributeKey->getAttributeKeyHandle());
 
-                if ($item->isMiss() === false) {
+                if ($item->isMiss() === true) {
                     $item->lock();
                     $result = $this->entityManager->find($class, $this->attributeValue->getGenericValue());
                     $item->set($result);

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Attribute;
 
+use Concrete\Core\Cache\Level\RequestCache;
 use Concrete\Core\Attribute\Form\Control\View\View as ControlView;
 use Concrete\Core\Attribute\Value\EmptyRequestAttributeValue;
 use Concrete\Core\Attribute\View as AttributeTypeView;


### PR DESCRIPTION
This method is called quite a bit on a page load request caching the value when a page is loaded reduces the page calls down quite a bit.

Before

<img width="98" alt="Screenshot 2021-06-27 at 17 54 14" src="https://user-images.githubusercontent.com/8473296/123557392-8d3c5e80-d788-11eb-9efb-197659311b55.png">

After

<img width="85" alt="Screenshot 2021-06-27 at 20 36 22" src="https://user-images.githubusercontent.com/8473296/123557394-91687c00-d788-11eb-907b-88d94b1fca80.png">
