### PR TITLE
Block ip variants from importing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -167,9 +167,9 @@
             "authors": [
                 {
                     "name": "Michele Locati",
-                    "role": "author",
                     "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io"
+                    "homepage": "https://mlocati.github.io",
+                    "role": "author"
                 }
             ],
             "description": "Patches required for concrete5 dependencies",
@@ -2820,16 +2820,16 @@
         },
         {
             "name": "mlocati/ip-lib",
-            "version": "1.10.0",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/ip-lib.git",
-                "reference": "65a3396d064267f2fef1fd0b8ded712dbe0946b2"
+                "reference": "f3db91bff131b8c6a83d27a9f4dbbe768397ce47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/65a3396d064267f2fef1fd0b8ded712dbe0946b2",
-                "reference": "65a3396d064267f2fef1fd0b8ded712dbe0946b2",
+                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/f3db91bff131b8c6a83d27a9f4dbbe768397ce47",
+                "reference": "f3db91bff131b8c6a83d27a9f4dbbe768397ce47",
                 "shasum": ""
             },
             "require": {
@@ -2837,8 +2837,7 @@
             },
             "require-dev": {
                 "ext-pdo_sqlite": "*",
-                "phpunit/dbunit": "^1.4 || ^2 || ^3 || ^4",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.5"
             },
             "type": "library",
             "autoload": {
@@ -2866,6 +2865,8 @@
                 "addresses",
                 "ipv4",
                 "ipv6",
+                "manage",
+                "managing",
                 "matching",
                 "network",
                 "networking",
@@ -2882,7 +2883,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-07-09T15:15:38+00:00"
+            "time": "2021-05-31T20:43:23+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3252,6 +3253,12 @@
                 "paginator",
                 "paging"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/mbabker",
+                    "type": "github"
+                }
+            ],
             "time": "2017-03-20T13:46:15+00:00"
         },
         {
@@ -3360,6 +3367,7 @@
                 "utf-8",
                 "utf8"
             ],
+            "abandoned": "symfony/polyfill-mbstring or symfony/string",
             "time": "2016-05-18T13:57:10+00:00"
         },
         {

--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -681,6 +681,18 @@ class File extends Controller
             if (in_array(strtolower($host), ['', '0', 'localhost'], true)) {
                 throw new UserMessageException(t('The URL "%s" is not valid.', $u));
             }
+
+            $ipFormatBlocks = [
+                '/^\d+$/', // No fully integer / octal hostnames http://2130706433 http://017700000001
+                '/^0x[0-9a-f]+$/i', // No Hexadecimal hostnames http://0x07f000001
+            ];
+
+            foreach ($ipFormatBlocks as $block) {
+                if (preg_match($block, $host) !== 0) {
+                    throw new UserMessageException(t('The URL "%s" is not valid.', $u));
+                }
+            }
+
             $ip = IPFactory::addressFromString($host, true, true, true);
             if ($ip === null) {
                 $dnsList = @dns_get_record($host, DNS_A | DNS_AAAA);

--- a/tests/tests/Controller/Backend/FileTest.php
+++ b/tests/tests/Controller/Backend/FileTest.php
@@ -67,7 +67,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
         yield ['http://' . $simpleIp]; // This is allowed because it's an external IP
         yield ['http://' . $hex, UserMessageException::class, '/The URL ".+?" is not valid./'];
         yield ['http://' . $octal]; // This form is allowed because it at least converts properly in ip-lib
-        yield ['http://' . $octal2, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['http://' . $octal2]; // Same as the first octal
         yield ['http://' . $octal3, UserMessageException::class, '/The URL ".+?" is not valid./'];
         yield ['http://' . $integer, UserMessageException::class, '/The URL ".+?" is not valid./'];
     }

--- a/tests/tests/Controller/Backend/FileTest.php
+++ b/tests/tests/Controller/Backend/FileTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Concrete\Tests\Controller\Backend;
+
+use Concrete\Controller\Backend\File;
+use Concrete\Core\Error\UserMessageException;
+use Mockery as M;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+class FileTest extends \PHPUnit_Framework_TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @dataProvider remoteUrlsToTry
+     * @see File::checkRemoteURlsToImport()
+     */
+    public function testCheckRemoteURlsToImport($urls, ...$exception)
+    {
+        $controller = new File();
+
+        // Note odd capitalization of "URL" in this method name
+        $accessor = new \ReflectionMethod($controller, 'checkRemoteURlsToImport');
+        $accessor->setAccessible(true);
+        $closure = $accessor->getClosure($controller);
+
+        // Expect an exception if one was provided, otherwise we expect to complete successfully
+        if ($exception) {
+            $this->setExpectedExceptionRegExp(...$exception);
+        }
+
+        $closure((array)$urls);
+
+        if (!$exception) {
+            // Run a successful condition to track the test
+            $this->assertTrue(true);
+        }
+    }
+
+    public function remoteUrlsToTry(): iterable
+    {
+        // Local IP
+        $simpleIp = '127.0.0.1';
+        $hex = '0x7f000001';
+        $octal = '0177.0000.0000.0001';
+        $octal2 = '0177.0.0.1';
+        $octal3 = '017700000001';
+        $integer = '2130706433';
+
+        // Test hexadecimal IPs get caught as local
+        yield ['https://' . $simpleIp, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['https://' . $hex, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['https://' . $octal, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['https://' . $octal2, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['https://' . $octal3, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['https://' . $integer, UserMessageException::class, '/The URL ".+?" is not valid./'];
+
+        // Remote IP
+        $simpleIp = '8.8.8.8';
+        $hex = '0x08080808';
+        $octal = '0010.0010.0010.0010';
+        $octal2 = '0010.8.8.0010';
+        $octal3 = '01002004010';
+        $integer = '134744072';
+
+        // Test hexadecimal IPs get caught as local
+        yield ['http://' . $simpleIp]; // This is allowed because it's an external IP
+        yield ['http://' . $hex, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['http://' . $octal]; // This form is allowed because it at least converts properly in ip-lib
+        yield ['http://' . $octal2, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['http://' . $octal3, UserMessageException::class, '/The URL ".+?" is not valid./'];
+        yield ['http://' . $integer, UserMessageException::class, '/The URL ".+?" is not valid./'];
+    }
+
+}


### PR DESCRIPTION
The tests should make it clear how this behaves differently now, basically we disallow any hostnames that are either integers or hexadecimal values.

We use [ip-lib](https://github.com/mlocati/ip-lib/) to deal with the complex parts of parsing and classifying IP addresses, in this case the actual issue is we're parsing the plain text version of the url while curl (or whatever the http client here is) is actually parsing the hostname from a hexadecimal number or octal or integer into an IP address before sending the request. With that in mind it'd be much better if we just did that same conversion ourselves before sending the IP to ip-lib either on our own or maybe with some tooling ip-lib provides but that's not something that exists yet and I'm not sure I fully understand the problem well enough to write a parser that would be effective. Track https://github.com/mlocati/ip-lib/issues/59 for changes in ip-lib support for these variants.

That said, blocking all ints and `0x[0-9a-f]+` matches should prevent any of these known variants from making it through the parser with the caveat that sometimes people really want to use hexadecimal or integer domains instead of the 4 hex (or octal) ip addresses for some reason and we're making that impossible by outright blocking any that match those patterns.