### PR TITLE
Add http client method to send request without following redirects

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -708,8 +708,10 @@ class File extends Controller
     protected function downloadRemoteURL($url, $temporaryDirectory)
     {
         $client = $this->app->make('http/client');
+
         $request = $client->getRequest()->setUri($url);
-        $response = $client->send();
+        $response = $client->sendWithoutRedirects();
+
         if (!$response->isSuccess()) {
             throw new UserMessageException(t(/*i18n: %1$s is an URL, %2$s is an error message*/'There was an error downloading "%1$s": %2$s', $url, $response->getReasonPhrase() . ' (' . $response->getStatusCode() . ')'));
         }

--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -57,10 +57,11 @@ class Client extends ZendClient implements LoggerAwareInterface
         $maxRedirects = $this->config['maxredirects'];
         $this->config['maxredirects'] = 0;
 
-        $result = $this->send($request);
-
-        $this->config['maxredirects'] = $maxRedirects;
-        return $result;
+        try {
+            return $this->send($request);
+        } finally {
+            $this->config['maxredirects'] = $maxRedirects;
+        }
     }
 
     /**

--- a/concrete/src/Http/Client/Client.php
+++ b/concrete/src/Http/Client/Client.php
@@ -46,6 +46,24 @@ class Client extends ZendClient implements LoggerAwareInterface
     }
 
     /**
+     * Send a request without following any redirects
+     *
+     * @see ZendClient::send()
+     * @param ZendRequest|null $request
+     * @return \Zend\Http\Response
+     */
+    public function sendWithoutRedirects(ZendRequest $request = null)
+    {
+        $maxRedirects = $this->config['maxredirects'];
+        $this->config['maxredirects'] = 0;
+
+        $result = $this->send($request);
+
+        $this->config['maxredirects'] = $maxRedirects;
+        return $result;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see ZendClient::send()


### PR DESCRIPTION
This PR adds a method to the c5 zend based client that allows sending requests without following any redirects. Additionally I've updated the file download call to use this new method.