### PR TITLE
Use a new session ID on login

### DIFF
--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -1045,6 +1045,10 @@ class User extends ConcreteObject
 
         /** @var \Symfony\Component\HttpFoundation\Session\Session $session */
         $session = $app['session'];
+
+        // Get a new session ID
+        $session->migrate();
+
         $session->set('uID', $this->getUserID());
         $session->set('uName', $this->getUserName());
         $session->set('uBlockTypesSet', false);


### PR DESCRIPTION
We are currently just using whatever session is available on login which can make caching at the CDN a little tricky. This change makes it so that a new session ID is generated on login while preserving any session data that was set before login.