### PR TITLE
Use fetchdepth 2 to fix scrutinizer

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: shivammathur/setup-php@2.11.0


### PR DESCRIPTION
Scrutinizer needs at least 2 commits to identify pulls so without 2 it ends up hanging for 10 minutes.