### PR TITLE
Page Attribute Display - Fix thumbnail w/h & dateFormat issues

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -46,11 +46,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         return t("Page Attribute Display");
     }
 
-    public function add()
-    {
-        $this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
-    }
-
     public function getRequiredFeatures(): array
     {
         return [

--- a/concrete/blocks/page_attribute_display/form.php
+++ b/concrete/blocks/page_attribute_display/form.php
@@ -69,7 +69,7 @@ echo $ui->tabs([
 
         <div class="form-group">
             <?php echo $form->label("dateFormat", t('Format of Date Properties')); ?>
-            <?php echo $form->text("dateFormat", $dateFormat); ?>
+            <?php echo $form->text("dateFormat", $controller->dateFormat); ?>
 
             <div class="help-block">
                 <?php echo sprintf(t('See the formatting options for date at %s.'), '<a href="http://www.php.net/date" target="_blank">php.net/date</a>'); ?>
@@ -98,7 +98,7 @@ echo $ui->tabs([
                 <?php echo $form->label("thumbnailWidth", t('Max Width')); ?>
 
                 <div class="input-group">
-                    <?php echo $form->number('thumbnailWidth', $thumbnailWidth, ["min" => 0, "step" => 1]); ?>
+                    <?php echo $form->number('thumbnailWidth', $controller->thumbnailWidth, ["min" => 0, "step" => 1]); ?>
 
                     <div class="input-group-append">
                         <span class="input-group-text">
@@ -112,7 +112,7 @@ echo $ui->tabs([
                 <?php echo $form->label("thumbnailHeight", t('Max Height')); ?>
 
                 <div class="input-group">
-                    <?php echo $form->number('thumbnailHeight', $thumbnailHeight, ["min" => 0, "step" => 1]); ?>
+                    <?php echo $form->number('thumbnailHeight', $controller->thumbnailHeight, ["min" => 0, "step" => 1]); ?>
 
                     <div class="input-group-append">
                         <span class="input-group-text">


### PR DESCRIPTION
Fixing issues referenced here: https://github.com/concrete5/concrete5/issues/9568

The block is currently not adding default values to inputs when adding a new block.  It is also declaring $dateFormat twice, once in the controller and then again in the controller add() method (to a second format, overwriting the first it is set to.)  The lack of default values for the thumbnail inputs is then causing error when saving.

I've removed the add() method completely and changed form.php to get the default values correctly.