### PR TITLE
Page Attribute Display - Fix thumbnail w/h & dateFormat issues #2

### DIFF
--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -21,7 +21,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btTable = 'btPageAttributeDisplay';
     protected $btInterfaceWidth = "500";
     protected $btInterfaceHeight = "365";
-    public $dateFormat = "m/d/y h:ia";
+    public $dateFormat;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
@@ -48,10 +48,27 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function add()
     {
-        //$this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
+        $this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
         $this->set('dateFormat', $this->dateFormat);
         $this->set('thumbnailWidth', $this->thumbnailWidth);
         $this->set('thumbnailHeight', $this->thumbnailHeight);
+    }
+    
+    public function validate($args)
+    {
+        $error = $this->app->make('helper/validation/error');
+
+        if (empty($args['thumbnailHeight'])) {
+            $error->add(t('Thumbnail Height must be a number.'));
+        }
+        
+        if (empty($args['thumbnailWidth'])) {
+            $error->add(t('Thumbnail Width must be a number.'));
+        }
+
+        if ($error->has()) {
+            return $error;
+        }
     }
 
     public function getRequiredFeatures(): array

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -21,7 +21,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btTable = 'btPageAttributeDisplay';
     protected $btInterfaceWidth = "500";
     protected $btInterfaceHeight = "365";
-    public $dateFormat = "m/d/y h:i:a";
+    public $dateFormat = "m/d/y h:ia";
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
@@ -48,7 +48,10 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function add()
     {
-        $this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
+        //$this->dateFormat = $this->app->make('date')->getPHPDateTimePattern();
+        $this->set('dateFormat', $this->dateFormat);
+        $this->set('thumbnailWidth', $this->thumbnailWidth);
+        $this->set('thumbnailHeight', $this->thumbnailHeight);
     }
 
     public function getRequiredFeatures(): array

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -58,11 +58,11 @@ class Controller extends BlockController implements UsesFeatureInterface
     {
         $error = $this->app->make('helper/validation/error');
 
-        if (empty($args['thumbnailHeight'])) {
+        if (!is_numeric($args['thumbnailHeight'])) {
             $error->add(t('Thumbnail Height must be a number.'));
         }
         
-        if (empty($args['thumbnailWidth'])) {
+        if (!is_numeric($args['thumbnailWidth'])) {
             $error->add(t('Thumbnail Width must be a number.'));
         }
 


### PR DESCRIPTION
Fixing issues referenced here: https://github.com/concrete5/concrete5/issues/9568

9.0.0a3

The block is currently not adding default values to inputs when adding a new block. It is also declaring $dateFormat twice, once in the controller and then again in the controller add() method (to a second format, overwriting the first it is set to.) The lack of default values for the thumbnail inputs is then causing error when saving.

I'm setting the variables in the add() method to get default values to the view correctly.  I removed the colon from the dateFormat string for better display and all is working well.

Couple questions for @aembler or @tylerryan ...  as you can see I left one line commented out.  Do we want to keep the $dateFormat string like it's declared in the controller, or do we want it set to the PHPDateTimePattern?  I'm guessing PHPDateTimePattern is more internationally recognized and we may want to go with that as default?  Maybe that's why it was being set in the add() method and the declaration in the controller had been forgotten about (never removed)?

Open to all thoughts in regards and then I'll put the finishing touches on it!