### PR TITLE
External Link can be rendered as internal link

### DIFF
--- a/concrete/controllers/dialog/page/edit_external.php
+++ b/concrete/controllers/dialog/page/edit_external.php
@@ -25,7 +25,7 @@ class EditExternal extends BackendInterfacePageController
             $request = \Request::getInstance();
             $this->page->updateCollectionAliasExternal(
                 $request->request->get('name'),
-                $request->request->get('link'),
+                trim($request->request->get('link')),
                 $request->request->get('openInNewWindow')
             );
             $pr = new EditResponse();


### PR DESCRIPTION
We had a scenario where a user entered a link in the website which started with a space ` https://www.google.co.uk`, because of this it rendered the extneral url as an internal link like so `https://www.mywebsite.com/https%3A/www.google.co.uk`, the above corrects that.