### PR TITLE
[v9] use the config for datetime_format for csv export

### DIFF
--- a/concrete/src/Controller/Traits/DashboardExpressEntryListTrait.php
+++ b/concrete/src/Controller/Traits/DashboardExpressEntryListTrait.php
@@ -262,11 +262,12 @@ trait DashboardExpressEntryListTrait
         return StreamedResponse::create(function () use ($entity, $entryList, $bom, $datetime_format) {
             $writer = $this->app->make(CsvWriter::class, [
                 $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
-                new Date()
+                new Date(),
+                $datetime_format
             ]);
             echo $bom;
             $writer->insertHeaders($entity);
-            $writer->insertEntryList($entryList,$datetime_format);
+            $writer->insertEntryList($entryList);
         }, 200, $headers);
     }
 }


### PR DESCRIPTION
This is the version 9 fix of this #9162

also removed $datetime_format from `$writer->insertEntryList($entryList,$datetime_format)`; as it only accepts 1 parameter