### PR TITLE
[v8]Fix default formatting of datetime exports in express export csv

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -116,7 +116,7 @@ return [
             // Include the BOM (byte-order mark) in generated CSV files?
             // @var bool
             'include_bom' => false,
-            'datetime_format' => 'ATOM',
+            'datetime_format' => DATE_ATOM,
         ],
     ],
 

--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -27,7 +27,7 @@ class CsvWriter
      */
     private $datetime_format;
 
-    public function __construct(Writer $writer, Date $dateFormatter, $datetime_format = 'ATOM' )
+    public function __construct(Writer $writer, Date $dateFormatter, $datetime_format = DATE_ATOM )
     {
         $this->writer = $writer;
         $this->dateFormatter = $dateFormatter;

--- a/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
+++ b/concrete/src/Page/Controller/DashboardExpressEntriesPageController.php
@@ -114,7 +114,7 @@ abstract class DashboardExpressEntriesPageController extends DashboardPageContro
             ]);
             echo $bom;
             $writer->insertHeaders($entity);
-            $writer->insertEntryList($entryList,$datetime_format);
+            $writer->insertEntryList($entryList);
         }, 200, $headers);
     }
 


### PR DESCRIPTION
This fixes the default formatting of exports in the express export csv writer

Currently it uses the text 'ATOM' which produces weird output like `AMEDT-0400Jul`

This changes brings the defaults in line with version 9 and uses the `DATE_ATOM `constant

I also removed $datetime_format from `$writer->insertEntryList($entryList,$datetime_format);` as it only expects one parameter