### PR TITLE
[V8] Fix: error message doesn't display when upload file failed via drag & drop

### DIFF
--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -591,7 +591,7 @@ class File extends Controller
             if ($replacingFile === null) {
                 $fp = new Checker($folder);
                 if (!$fp->canAddFiles()) {
-                    throw new UserMessageException(t('Unable to add files.'), 400);
+                    throw new UserMessageException(t("You don't have the permission to upload to %s", $folder->getTreeNodeDisplayName()), 400);
                 }
             }
             $this->destinationFolder = $folder;

--- a/concrete/js/ckeditor4/core/concrete5uploadimage/plugin.js
+++ b/concrete/js/ckeditor4/core/concrete5uploadimage/plugin.js
@@ -23,7 +23,10 @@
 
                 if (xhr.status == 200) {
                     var respObj = jQuery.parseJSON(xhr.responseText);
-                    if (respObj.files.length > 0) {
+                    if (respObj.error) {
+                        data.message = respObj.errors.join();
+                        evt.cancel();
+                    } else if (respObj.files.length > 0) {
                         data.url = respObj.files[0].urlInline;
                     }
                 } else {


### PR DESCRIPTION
# How to reproduce the issue

Make a user belongs to some group

![Screen Shot 2021-07-19 at 5 47 03](https://user-images.githubusercontent.com/514294/126082092-ea7ece44-e505-4209-8eef-3b3df6e10394.png)

The user can access the File Manager but can not upload files

![Screen Shot 2021-07-19 at 5 51 45](https://user-images.githubusercontent.com/514294/126082107-c480f527-fec3-4f5d-9dcf-31a4c36399ea.png)

You'll get "File successfully uploaded." message, but the file upload failed due to the permission settings.

https://user-images.githubusercontent.com/514294/126082127-bf609f1d-25fe-4f61-9dc1-d6a14dbc44a9.mov

# After merged this PR

You'll get an error message when you don't have permission to upload a file.

https://user-images.githubusercontent.com/514294/126082160-1c094e6f-1557-438d-bd27-e0eb9a65ab96.mov

