### PR TITLE
[V9] Fix: Page type default topic attribute values are not set on the newly created page type

### DIFF
--- a/concrete/src/Entity/Attribute/Value/Value/TopicsValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/TopicsValue.php
@@ -63,4 +63,16 @@ class TopicsValue extends AbstractValue
         }
         return implode(', ', $topics);
     }
+
+    public function __clone()
+    {
+        $clonedSelectedTopics = new ArrayCollection();
+        foreach ($this->getSelectedTopics() as $selectedTopic) {
+            /** @var SelectedTopic $clonedSelectedTopic */
+            $clonedSelectedTopic = clone $selectedTopic;
+            $clonedSelectedTopic->setAttributeValue($this);
+            $clonedSelectedTopics->add($clonedSelectedTopic);
+        }
+        $this->setSelectedTopics($clonedSelectedTopics);
+    }
 }


### PR DESCRIPTION
V9 version of #9560