### PR TITLE
[V9] Add more excluded query parameters for canonical tag

### DIFF
--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -146,6 +146,26 @@ return [
                     'excluded_querystring_parameters' => [
                         'cID',
                         'ccm_token',
+                        // calendar block
+                        'start',
+                        'end',
+                        // express_entry_list block
+                        'keywords',
+                        'itemsPerPage',
+                        'search',
+                        // search block
+                        'query',
+                        'search_paths',
+                        'options',
+                        // Facebook
+                        'fbclid',
+                        // Google Analytics & Ads
+                        'utm_source',
+                        'utm_medium',
+                        'utm_campaign',
+                        'utm_content',
+                        'utm_term',
+                        'gclid',
                     ],
                 ],
                 'tracking' => [


### PR DESCRIPTION
Let's remove query parameters like `query` or `utm_source` from canonical tag to improve SEO.

Issue: #8259