### PR TITLE
[v8] fix #9582 - Fix session set not working correctly on redirect in redis/memcached/slow filesystem

### DIFF
--- a/concrete/controllers/single_page/dashboard/pages/types/output.php
+++ b/concrete/controllers/single_page/dashboard/pages/types/output.php
@@ -1,33 +1,57 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Pages\Types;
 
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use PageTemplate;
-use PageType;
-use Redirect;
-use Session;
+use Concrete\Core\Page\Template;
+use Concrete\Core\Page\Type\Type;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Url\Resolver\Manager\ResolverManager;
 
 class Output extends DashboardPageController
 {
+    /** @var \Concrete\Core\Page\Type\Type */
+    private $pagetype;
+
+    /**
+     * The main view method to display the available page templates
+     * for the passed page type.
+     *
+     * @param mixed $ptID the id of the page type
+     *
+     * @throws \Concrete\Core\Error\UserMessageException
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse | void
+     */
     public function view($ptID = false)
     {
-        $this->pagetype = PageType::getByID($ptID);
+        $this->pagetype = Type::getByID($ptID);
         if (!$this->pagetype) {
-            $this->redirect('/dashboard/pages/types');
+            return $this->buildRedirect('/dashboard/pages/types');
         }
-        $cmp = new \Permissions($this->pagetype);
+        $cmp = new Checker($this->pagetype);
         if (!$cmp->canEditPageType()) {
-            throw new \Exception(t('You do not have access to edit this page type.'));
+            throw new UserMessageException(t('You do not have access to edit this page type.'));
         }
         $this->set('pagetype', $this->pagetype);
     }
 
+    /**
+     * This function mainly redirects to the master collection for the
+     * given page type and page template.
+     *
+     * @param mixed $ptID the id of the page type
+     * @param mixed $pTemplateID the id of the page template
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse | void
+     */
     public function edit_defaults($ptID = false, $pTemplateID = false)
     {
         $this->view($ptID);
-        $template = PageTemplate::getByID($pTemplateID);
+        $template = Template::getByID($pTemplateID);
         if (!is_object($template)) {
-            $this->redirect('/dashboard/pages/types');
+            return $this->buildRedirect('/dashboard/pages/types');
         }
         $valid = false;
         foreach ($this->pagetype->getPageTypePageTemplateObjects() as $pt) {
@@ -42,8 +66,9 @@ class Output extends DashboardPageController
         if (!$this->error->has()) {
             // we load up the master template for this composer/template combination.
             $c = $this->pagetype->getPageTypePageTemplateDefaultPageObject($template);
-            Session::set('mcEditID', $c->getCollectionID());
-            Redirect::url(\URL::to($c))->send();
+            $this->app->make('session')->set('mcEditID', $c->getCollectionID());
+
+            return $this->buildRedirect($this->app->make(ResolverManager::class)->resolve([$c]))->send();
         }
     }
 }


### PR DESCRIPTION
This fixes the bug when a user who can edit page type is given access denied when clicking edit on the page type outputs.

This happens when the session cache system is set to any system with a delay in read/writes such as redis/memcahced or a slow filesystem.

Using the Session::set() and Redirect::url(\URL::to($c))->send(); together means that the variable isn't actually saved before the redirect happens.

Updating the methods always results in the session actually being set

Though we should remove Session::set/Session::get facades from the core as we advise not to use them..

This PR also cleans up some of the methods, removes facades and adds extra documentation