### PR TITLE
[V8] Upgrade IPLib to version 1.17.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -167,9 +167,9 @@
             "authors": [
                 {
                     "name": "Michele Locati",
+                    "role": "author",
                     "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io",
-                    "role": "author"
+                    "homepage": "https://mlocati.github.io"
                 }
             ],
             "description": "Patches required for concrete5 dependencies",
@@ -2820,16 +2820,16 @@
         },
         {
             "name": "mlocati/ip-lib",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/ip-lib.git",
-                "reference": "f3db91bff131b8c6a83d27a9f4dbbe768397ce47"
+                "reference": "db9552c3460d5fa19a4c8183767fe89da7752a4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/f3db91bff131b8c6a83d27a9f4dbbe768397ce47",
-                "reference": "f3db91bff131b8c6a83d27a9f4dbbe768397ce47",
+                "url": "https://api.github.com/repos/mlocati/ip-lib/zipball/db9552c3460d5fa19a4c8183767fe89da7752a4e",
+                "reference": "db9552c3460d5fa19a4c8183767fe89da7752a4e",
                 "shasum": ""
             },
             "require": {
@@ -2883,7 +2883,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-05-31T20:43:23+00:00"
+            "time": "2021-08-03T15:42:09+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -3252,12 +3252,6 @@
                 "pagination",
                 "paginator",
                 "paging"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mbabker",
-                    "type": "github"
-                }
             ],
             "time": "2017-03-20T13:46:15+00:00"
         },
@@ -7252,6 +7246,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
         {
@@ -8037,12 +8032,12 @@
             "version": "1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -74,7 +74,7 @@
     "lusitanian/oauth": "0.8.*",
     "concrete5/oauth-user-data": "~1.0",
     "mlocati/concrete5-translation-library": "^1.5.13",
-    "mlocati/ip-lib": "^1.10.0",
+    "mlocati/ip-lib": "^1.17.0",
     "league/url": "~3.3.5",
     "concrete5/doctrine-xml": "^1.2.0",
     "symfony/yaml":"3.*",

--- a/concrete/controllers/backend/file.php
+++ b/concrete/controllers/backend/file.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use FileSet;
 use IPLib\Factory as IPFactory;
+use IPLib\ParseStringFlag as IPParseStringFlag;
 use IPLib\Range\Type as IPRangeType;
 use Permissions as ConcretePermissions;
 use RuntimeException;
@@ -693,12 +694,13 @@ class File extends Controller
                 }
             }
 
-            $ip = IPFactory::addressFromString($host, true, true, true);
+            $ipFlags = IPParseStringFlag::IPV4_MAYBE_NON_DECIMAL | IPParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | IPParseStringFlag::MAY_INCLUDE_PORT | IPParseStringFlag::MAY_INCLUDE_ZONEID;
+            $ip = IPFactory::parseAddressString($host, $ipFlags);
             if ($ip === null) {
                 $dnsList = @dns_get_record($host, DNS_A | DNS_AAAA);
                 while ($ip === null && $dnsList !== false && count($dnsList) > 0) {
                     $dns = array_shift($dnsList);
-                    $ip = IPFactory::addressFromString($dns['ip'], true, true, true);
+                    $ip = IPFactory::parseAddressString($dns['ip']);
                 }
             }
             if ($ip !== null && !in_array($ip->getRangeType(), [IPRangeType::T_PUBLIC, IPRangeType::T_PRIVATENETWORK], true)) {

--- a/concrete/controllers/single_page/dashboard/system/environment/geolocation.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/geolocation.php
@@ -81,7 +81,7 @@ EOT
             throw new UserMessageException($this->token->getErrorMessage());
         }
         $post = $this->request->request;
-        $ip = IPFactory::addressFromString($post->get('ip'));
+        $ip = IPFactory::parseAddressString($post->get('ip'));
         if ($ip === null) {
             throw new UserMessageException(t('The specified IP address is not valid.'));
         }

--- a/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/blacklist/range.php
@@ -70,7 +70,7 @@ class Range extends Blacklist
         if (!$this->token->validate('add_range/' . $type . '/' . $id)) {
             throw new UserMessageException($this->token->getErrorMessage());
         }
-        $range = IPFactory::rangeFromString($this->request->request->get('range'));
+        $range = IPFactory::parseRangeString($this->request->request->get('range'));
         if ($range === null) {
             throw new UserMessageException(t('The specified IP range is invalid'));
         }

--- a/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/trusted_proxies.php
@@ -6,6 +6,7 @@ use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use IPLib\Range\Pattern;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -51,7 +52,7 @@ class TrustedProxies extends DashboardPageController
         $currentProxyIP = null;
         if ($this->request->isFromTrustedProxy()) {
             $clientIP = $this->app->make(AddressInterface::class);
-            $rawClientIP = Factory::addressFromString($this->request->server->get('REMOTE_ADDR'), true, true, true);
+            $rawClientIP = Factory::parseAddressString($this->request->server->get('REMOTE_ADDR'), ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | ParseStringFlag::MAY_INCLUDE_PORT | ParseStringFlag::MAY_INCLUDE_ZONEID);
             if ((string) $clientIP !== (string) $rawClientIP) {
                 $currentProxyIP = $rawClientIP;
             }
@@ -110,7 +111,7 @@ class TrustedProxies extends DashboardPageController
         if (is_string($input)) {
             foreach (preg_split('/\s+/', $input, -1, PREG_SPLIT_NO_EMPTY) as $rawRange) {
                 if (!in_array($rawRange, $invalidIPs, true)) {
-                    $range = Factory::rangeFromString($rawRange);
+                    $range = Factory::parseRangeString($rawRange);
                     if ($range === null || $range instanceof Pattern) {
                         $invalidIPs[] = $rawRange;
                     } else {

--- a/concrete/src/Entity/Permission/IpAccessControlEvent.php
+++ b/concrete/src/Entity/Permission/IpAccessControlEvent.php
@@ -145,7 +145,7 @@ class IpAccessControlEvent
         if ($this->ipAddress === null) {
             $ip = (string) $this->getIp();
             if ($ip !== '') {
-                $this->ipAddress = Factory::addressFromString($ip);
+                $this->ipAddress = Factory::parseAddressString($ip);
             }
         }
 

--- a/concrete/src/Entity/Permission/IpAccessControlRange.php
+++ b/concrete/src/Entity/Permission/IpAccessControlRange.php
@@ -166,7 +166,7 @@ class IpAccessControlRange
             if ($ipFrom !== '') {
                 $ipTo = (string) $this->getIpTo();
                 if ($ipTo !== '') {
-                    $this->ipRange = Factory::rangeFromBoundaries($ipFrom, $ipTo);
+                    $this->ipRange = Factory::getRangeFromBoundaries($ipFrom, $ipTo);
                 }
             }
         }

--- a/concrete/src/Permission/IPRange.php
+++ b/concrete/src/Permission/IPRange.php
@@ -86,7 +86,7 @@ class IPRange
     {
         $result = new static();
         $result->id = empty($row['lcirID']) ? null : (int) $row['lcirID'];
-        $result->ipRange = IPFactory::rangeFromBoundaries($row['lcirIpFrom'], $row['lcirIpTo']);
+        $result->ipRange = IPFactory::getRangeFromBoundaries($row['lcirIpFrom'], $row['lcirIpTo']);
         $result->type = (int) $row['lcirType'];
         $result->expires = empty($row['lcirExpires']) ? null : DateTime::createFromFormat($dateTimeFormat, $row['lcirExpires']);
 

--- a/concrete/src/Permission/IPService.php
+++ b/concrete/src/Permission/IPService.php
@@ -280,7 +280,7 @@ class IPService implements ApplicationAwareInterface, LoggerAwareInterface
      */
     public function getRequestIP()
     {
-        $ip = $this->app->make(\IPLib\Address\AddressInterface::class);
+        $ip = $this->app->make(AddressInterface::class);
 
         return new IPAddress((string) $ip);
     }
@@ -294,7 +294,7 @@ class IPService implements ApplicationAwareInterface, LoggerAwareInterface
     {
         $ipAddress = null;
         if ($ip instanceof IPAddress) {
-            $ipAddress = IPFactory::addressFromString($ip->getIp(IPAddress::FORMAT_IP_STRING));
+            $ipAddress = IPFactory::parseAddressString($ip->getIp(IPAddress::FORMAT_IP_STRING));
         }
 
         return $this->getFailedLoginService()->isBlacklisted($ipAddress);
@@ -310,7 +310,7 @@ class IPService implements ApplicationAwareInterface, LoggerAwareInterface
     {
         $ipAddress = null;
         if ($ip instanceof IPAddress) {
-            $ipAddress = IPFactory::addressFromString($ip->getIp(IPAddress::FORMAT_IP_STRING));
+            $ipAddress = IPFactory::parseAddressString($ip->getIp(IPAddress::FORMAT_IP_STRING));
         }
         $this->getFailedLoginService()->addToBlacklistForThresholdReached($ipAddress, $ignoreConfig);
     }

--- a/concrete/src/Permission/IpAccessControlService.php
+++ b/concrete/src/Permission/IpAccessControlService.php
@@ -245,7 +245,7 @@ class IpAccessControlService implements LoggerAwareInterface
         }
 
         $range = $this->createRange(
-            IPFactory::rangeFromBoundaries($ipAddress, $ipAddress),
+            IPFactory::getRangeFromBoundaries($ipAddress, $ipAddress),
             static::IPRANGETYPE_BLACKLIST_AUTOMATIC,
             $banExpiration
         );

--- a/concrete/src/Permission/PermissionServiceProvider.php
+++ b/concrete/src/Permission/PermissionServiceProvider.php
@@ -10,6 +10,7 @@ use Concrete\Core\Http\Request;
 use Doctrine\ORM\EntityManagerInterface;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory as IPFactory;
+use IPLib\ParseStringFlag as IPParseStringFlag;
 
 class PermissionServiceProvider extends ServiceProvider
 {
@@ -34,7 +35,7 @@ class PermissionServiceProvider extends ServiceProvider
                 $ip = $request->getClientIp();
             }
 
-            return IPFactory::addressFromString($ip, true, true, true);
+            return IPFactory::parseAddressString($ip, IPParseStringFlag::IPV4_MAYBE_NON_DECIMAL | IPParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | IPParseStringFlag::MAY_INCLUDE_PORT | IPParseStringFlag::MAY_INCLUDE_ZONEID);
         });
 
         $this->app->bind('failed_login', function (Application $app) {

--- a/tests/tests/Permission/IPServiceTest.php
+++ b/tests/tests/Permission/IPServiceTest.php
@@ -87,7 +87,7 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         for ($attempt = 1; $attempt <= $allowedAttempts; ++$attempt) {
             $this->assertFalse($this->ipService->isWhitelisted($ip));
             $this->assertFalse($this->ipService->isBlacklisted($ip));
@@ -104,7 +104,7 @@ class IPServiceTest extends ConcreteDatabaseTestCase
         $this->ipService->addToBlacklistForThresholdReached($ip);
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertTrue($this->ipService->isBlacklisted($ip));
-        $ip2 = IPFactory::addressFromString('::');
+        $ip2 = IPFactory::parseAddressString('::');
         $this->assertFalse($this->ipService->isWhitelisted($ip2));
         $this->assertFalse($this->ipService->isBlacklisted($ip2));
     }
@@ -117,7 +117,7 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         for ($attempt = 1; $attempt <= 10; ++$attempt) {
             $this->ipService->logFailedLogin($ip);
         }
@@ -133,10 +133,10 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL);
+        $this->ipService->createRange(IPFactory::parseRangeString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL);
         $this->assertTrue($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
         for ($attempt = 1; $attempt <= 10; ++$attempt) {
@@ -155,10 +155,10 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_MANUAL);
+        $this->ipService->createRange(IPFactory::parseRangeString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_MANUAL);
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertTrue($this->ipService->isBlacklisted($ip));
     }
@@ -171,13 +171,13 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('-1 seconds'));
+        $this->ipService->createRange(IPFactory::parseRangeString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('-1 seconds'));
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 seconds'));
+        $this->ipService->createRange(IPFactory::parseRangeString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 seconds'));
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertTrue($this->ipService->isBlacklisted($ip));
     }
@@ -190,13 +190,13 @@ class IPServiceTest extends ConcreteDatabaseTestCase
             ->setTimeWindow(300)
             ->setBanDuration(600)
         ;
-        $ip = IPFactory::addressFromString('1.2.3.4');
+        $ip = IPFactory::parseAddressString('1.2.3.4');
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 hours'));
+        $this->ipService->createRange(IPFactory::parseRangeString('1.*.*.*'), IPService::IPRANGETYPE_BLACKLIST_AUTOMATIC, new DateTime('+10 hours'));
         $this->assertFalse($this->ipService->isWhitelisted($ip));
         $this->assertTrue($this->ipService->isBlacklisted($ip));
-        $this->ipService->createRange(IPFactory::rangeFromString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL, new DateTime('+10 hours'));
+        $this->ipService->createRange(IPFactory::parseRangeString('1.2.3.*'), IPService::IPRANGETYPE_WHITELIST_MANUAL, new DateTime('+10 hours'));
         $this->assertTrue($this->ipService->isWhitelisted($ip));
         $this->assertFalse($this->ipService->isBlacklisted($ip));
     }

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -8,6 +8,7 @@ use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Support\Facade\Application;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -34,7 +35,7 @@ class SessionValidatorTest extends PHPUnit_Framework_TestCase
     {
         $this->app = clone Application::getFacadeApplication();
         $this->app->singleton(AddressInterface::class, function () {
-            return Factory::addressFromString($this->request->getClientIp(), true, true, true);
+            return Factory::parseAddressString($this->request->getClientIp(), ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | ParseStringFlag::MAY_INCLUDE_PORT | ParseStringFlag::MAY_INCLUDE_ZONEID);
         });
         $this->app['config'] = clone $this->app['config'];
 

--- a/tests/tests/User/Login/LoginServiceTest.php
+++ b/tests/tests/User/Login/LoginServiceTest.php
@@ -17,7 +17,6 @@ use Concrete\Core\User\Login\LoginAttemptService;
 use Concrete\Core\User\Login\LoginService;
 use Concrete\Tests\User\Login\MockUser;
 use Doctrine\ORM\EntityManagerInterface;
-use IPLib\Address\AddressInterface;
 use IPLib\Address\IPv4;
 use Mockery as M;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;


### PR DESCRIPTION
Since [version 1.17.0](https://github.com/mlocati/ip-lib/releases/tag/1.17.0), IPLib is able to parse addresses in non-quad-dotted format.
For example, `0xff.010` is an acceptable IP address for many `inet_aton` and `inet_addr` implementations, and it's like writing `255.0.0.8`:

![immagine](https://user-images.githubusercontent.com/928116/128052534-6076bb6b-581b-4a47-b539-37c19474338b.png)

For safety reasons, it's better to be able to parse such addresses.

PS: I'll also submit a PR for v9 asap