### PR TITLE
[9.0rc] fix migration misspelling

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
@@ -17,6 +17,6 @@ final class Version20210729191135 extends AbstractMigration implements Repeatabl
             $this->connection->execute(sprintf('alter table %s rename %s', 'btDesktopNewsflowLatest', 'btDesktopConcreteLatest'));
         }
         $this->connection->executeStatement("update PermissionKeyCategories set pkCategoryHandle = 'marketplace' where pkCategoryHandle = 'marketplace_newsflow'");
-        $db->executeStatement('update AuthenticationTypes set authTypeHandle = "external_concrete", authTypeName = "External Concrete" where btHandle = "external_concrete5"');
+        $db->executeStatement('update AuthenticationTypes set authTypeHandle = "external_concrete", authTypeName = "External Concrete" where authTypeHandle = "external_concrete5"');
     }
 }


### PR DESCRIPTION
This fixes a misspelling in the latest migration on the 9.0rc branch which causes c5:update to fail