### PR TITLE
Fix #9704. Permissions never complete a save. jQuery infinite error o…

### DIFF
--- a/concrete/elements/permission/message_list.php
+++ b/concrete/elements/permission/message_list.php
@@ -35,7 +35,7 @@ if ($_REQUEST['message'] == 'custom_options_saved') {
 $(function() {
 	$("#ccm-permissions-message-list").show('highlight', {'color': '#fff'}, function() {
 		setTimeout(function() {
-			$("#ccm-permissions-message-list").fadeOut(300, 'easeInExpo');
+			$("#ccm-permissions-message-list").fadeOut(300, 'swing');
 		}, 1200);
 	});
 });


### PR DESCRIPTION
Fix #9704  [V9RC2] Permissions never complete a save. jQuery infinite error on easing

Easing function 'easeInExpo' is no available. The simplistic fix is to replace it with swing.
