### PR TITLE
Fix CLI command return values

### DIFF
--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -23,18 +23,25 @@ use Throwable;
 abstract class Command extends SymfonyCommand
 {
     /**
-     * The return code we should return when running the command is successful.
+     * @deprecated Use SUCCESS
      *
      * @var int
      */
-    public const RETURN_CODE_ON_SUCCESS = 0;
+    public const RETURN_CODE_ON_SUCCESS = self::SUCCESS;
 
     /**
-     * The return code we should return when an exception is thrown while running the command.
+     * @deprecated Use FAILURE
      *
      * @var int
      */
-    public const RETURN_CODE_ON_FAILURE = 1;
+    public const RETURN_CODE_ON_FAILURE = self::FAILURE;
+
+    /**
+     * Concrete requires symfony/console ^5.2, and the INVALID constant has been introduced in symfony/console 5.3.0
+     *
+     * @var int
+     */
+    public const INVALID = 2;
 
     /**
      * The name of the CLI option that allows running CLI commands as root without confirmation.

--- a/concrete/src/Console/Command/BlacklistClear.php
+++ b/concrete/src/Console/Command/BlacklistClear.php
@@ -33,7 +33,8 @@ class BlacklistClear extends Command
 
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $automaticBansAll = static::DELETE_AUTOMATIC_BANS_ALL;
         $automaticBansExpired = static::DELETE_AUTOMATIC_BANS_EXPIRED;
         $this
@@ -52,7 +53,7 @@ To clear the events data, use the --min-age option.
 To clear the automatic bans, use the --automatic-bans option.
 
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-blacklist-clear
@@ -66,7 +67,7 @@ EOT
         if ($input->getOption('list')) {
             $this->listCategories($output);
 
-            return 0;
+            return static::SUCCESS;
         }
         $app = Application::getFacadeApplication();
         $minAge = $input->getOption('min-age');
@@ -149,7 +150,7 @@ EOT
             }
         }
 
-        return 0;
+        return static::SUCCESS;
     }
 
     protected function listCategories(OutputInterface $output)

--- a/concrete/src/Console/Command/BulkUserAssignCommand.php
+++ b/concrete/src/Console/Command/BulkUserAssignCommand.php
@@ -32,7 +32,7 @@ class BulkUserAssignCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return mixed|void
+     * @return int
      * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -134,6 +134,8 @@ class BulkUserAssignCommand extends Command
             $totalUsersAddedToTargetGroup,
             $totalUsersRemovedFromTargetGroup
         ));
+
+        return static::SUCCESS;
     }
 
 }

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -13,7 +13,8 @@ class ClearCacheCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:clear-cache')
             ->setDescription('Clear the concrete5 cache')
@@ -24,7 +25,7 @@ class ClearCacheCommand extends Command
 If the --thumbnails options is not specified, we'll use the last value set in the dashboard.
 
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-clear-cache
@@ -54,5 +55,7 @@ EOT
         $output->write('Clearing the concrete5 cache... ');
         $cms->clearCaches();
         $output->writeln('<info>done.</info>');
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -16,14 +16,15 @@ class CompareSchemaCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:compare-schema')
             ->setDescription('Compares db.xml in concrete5 XML schema, concrete5 entities, and all installed package schemas and entities with the contents of the database and prints the difference.')
             ->addEnvOption()
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 EOT
             )
@@ -93,6 +94,8 @@ EOT
         } else {
             $output->writeln(t('No differences found between schema and database.'));
         }
+
+        return static::SUCCESS;
     }
 
     /**

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -32,14 +32,12 @@ class ConfigCommand extends Command
         $item = $this->argument('item');
         switch ($this->argument('action')) {
             case 'get':
-                $this->doGetAction($repository, $item);
-                break;
+                return $this->doGetAction($repository, $item);
             case 'set':
-                $this->doSetAction($repository, $item);
-                break;
+                return $this->doSetAction($repository, $item);
             default:
                 $this->output->error('Invalid action specified, please specify either "set" or "get"');
-                break;
+                return static::FAILURE;
         }
     }
 
@@ -137,9 +135,11 @@ EOT
      * @param $repository
      * @param $item
      */
-    private function doGetAction($repository, $item)
+    private function doGetAction($repository, $item): int
     {
         $this->output->writeln($this->serialize($repository->get($item)));
+
+        return static::SUCCESS;
     }
 
     /**
@@ -148,14 +148,18 @@ EOT
      * @param Repository $repository
      * @param string $item
      */
-    private function doSetAction(Repository $repository, $item)
+    private function doSetAction(Repository $repository, $item): int
     {
         if (!$this->hasArgument('value')) {
             $this->output->error('A value must be provided when using the "set" action.');
+
+            return static::FAILURE;
         }
 
         $value = $this->argument('value');
         $repository->save($item, $this->unserialize($value));
+
+        return static::SUCCESS;
     }
 
     /**

--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -11,7 +11,8 @@ class ExecCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:exec')
             ->setDescription('Execute a PHP script within the concrete5 environment')
@@ -27,7 +28,7 @@ In the included script you'll have these variables:
 To specify the command return code, define an int variable named '\$rc'.
 
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-exec
@@ -44,6 +45,6 @@ EOT
         $args = $input->getArgument('arguments');
         require $input->getArgument('script');
 
-        return isset($rc) ? $rc : 0;
+        return isset($rc) ? $rc : static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/Express/ExportCommand.php
+++ b/concrete/src/Console/Command/Express/ExportCommand.php
@@ -57,7 +57,7 @@ class ExportCommand extends Command
         // Make sure we found a proper entity
         if (!$entity) {
             $this->output->error('Invalid entity handle.');
-            return 2;
+            return static::INVALID;
         }
 
         return $this->outputFormatCsv($entity, $app, $config, $factory);
@@ -98,7 +98,7 @@ class ExportCommand extends Command
         $writer->insertEntryList($entryList);
 
         // Success
-        return 0;
+        return static::SUCCESS;
     }
 
 }

--- a/concrete/src/Console/Command/FillThumbnailsTableCommand.php
+++ b/concrete/src/Console/Command/FillThumbnailsTableCommand.php
@@ -17,14 +17,15 @@ class FillThumbnailsTableCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:fill-thumbnails-table')
             ->setDescription('Populate the thumbnail table with all the files.')
             ->addEnvOption()
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 EOT
             )
@@ -54,6 +55,8 @@ EOT
             }
         }
         $output->writeln("{$count} thumbnail paths processed.");
+
+        return static::SUCCESS;
     }
 
     /**

--- a/concrete/src/Console/Command/FixDatabaseForeignKeys.php
+++ b/concrete/src/Console/Command/FixDatabaseForeignKeys.php
@@ -38,6 +38,6 @@ EOT
         });
         $foreignKeyFixer->fixForeignKeys($tableNames, $errors);
 
-        return $errors->count() === 0;
+        return $errors->count() === 0 ? static::SUCCESS : static::FAILURE;
     }
 }

--- a/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
+++ b/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
@@ -52,5 +52,7 @@ EOT
         $entityManager->flush();
 
         $output->writeln(sprintf("Unique identifier has been successfully changed for %s files.", $fileList->getTotalResults()));
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -14,7 +14,8 @@ class GenerateIDESymbolsCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:ide-symbols')
             ->setDescription('Generate IDE symbols')
@@ -23,7 +24,7 @@ class GenerateIDESymbolsCommand extends Command
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', ['all'])
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-ide-symbols
@@ -34,7 +35,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
+        $rc = static::SUCCESS;
         $what = $input->getArgument('generate-what');
         $p = array_search('ide-classes', $what);
         if ($p !== false || in_array('all', $what)) {
@@ -44,7 +45,7 @@ EOT
             $output->write('Generating fake PHP classes to help IDE... ');
             if (!Core::make('app')->isInstalled()) {
                 $output->writeln('<error>failed: concrete5 is not installed.</error>');
-                $rc = static::RETURN_CODE_ON_FAILURE;
+                $rc = static::FAILURE;
             } else {
                 $this->generateIDEClasses();
                 $output->writeln('<info>done.</info>');

--- a/concrete/src/Console/Command/GenerateSitemapCommand.php
+++ b/concrete/src/Console/Command/GenerateSitemapCommand.php
@@ -17,7 +17,8 @@ class GenerateSitemapCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:sitemap:generate')
             ->setDescription('Generate the sitemap in XML format.')
@@ -29,7 +30,7 @@ class GenerateSitemapCommand extends Command
         ;
         $this->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  {$okExitCode} operation completed successfully
   {$errExitCode} errors occurred
 EOT
             );
@@ -84,5 +85,7 @@ EOT
             $output->writeln(sprintf('Sitemap visible at: %s', $sitemapUrl));
         }
         $output->writeln(sprintf('Number of pages included in sitemap: %s', $numPages));
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -11,14 +11,15 @@ class InfoCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:info')
             ->setDescription('Get server and concrete5 detailed informations.')
             ->addEnvOption()
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-info
@@ -75,5 +76,7 @@ EOT
         $output->writeln('');
         $output->writeln('<info># PHP Settings</info>');
         $output->writeln($info->getPhpSettings());
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -56,7 +56,8 @@ class InstallCommand extends Command
 
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:install')
             ->setDescription('Install concrete5')
@@ -85,7 +86,7 @@ class InstallCommand extends Command
             ->addOption('ignore-warnings', null, InputOption::VALUE_NONE, 'Ignore warnings')
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-install
@@ -110,12 +111,12 @@ EOT
             switch ($this->checkOptionPreconditions($app, $installer, $input, $output)) {
                 case self::OPTIONPRECONDITIONS_ERROR:
                     $output->writeln('One or more precondition failed!');
-                    exit(1);
+                    exit(static::FAILURE);
                 case self::OPTIONPRECONDITIONS_WARNINGS:
                     if (!$input->getOption('ignore-warnings')) {
                         if (!$input->isInteractive()) {
                             $output->writeln('One or more precondition failed!');
-                            exit(1);
+                            exit(static::FAILURE);
                         }
                         $confirm = new Question('Configuration warnings detected. Would you like to install anyway? [Y]es / [N]o: ', false);
                         $confirm->setValidator(function ($given) {
@@ -130,7 +131,7 @@ EOT
                         // Cancel if they said no
                         if (stripos('n', $answer) === 0) {
                             $output->writeln('Installation cancelled.');
-                            exit(1);
+                            exit(static::FAILURE);
                         }
                     }
                     break;
@@ -182,6 +183,8 @@ EOT
             $output->writeln('done.');
         }
         $output->writeln('<info>Installation Complete!</info>');
+
+        return static::SUCCESS;
     }
 
     /**
@@ -236,7 +239,7 @@ EOT
                         // Cancel if they said no
                         if (stripos('n', $answer) === 0) {
                             $output->writeln('Installation cancelled.');
-                            exit(1);
+                            exit(static::FAILURE);
                         }
                         continue 2;
                     case self::OPTIONPRECONDITIONS_WARNINGS:
@@ -252,7 +255,7 @@ EOT
                         // Cancel if they said no
                         if (stripos('a', $answer) === 0) {
                             $output->writeln('Installation cancelled.');
-                            exit(1);
+                            exit(static::FAILURE);
                         }
                         if (stripos('y', $answer) === 0) {
                             continue 2;
@@ -293,7 +296,7 @@ EOT
                 // Cancel if they said no
                 if (stripos('n', $answer) === 0) {
                     $output->writeln('Installation cancelled.');
-                    exit(1);
+                    exit(static::FAILURE);
                 }
 
                 // Retry if they ask so

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -43,7 +43,8 @@ class InstallLanguageCommand extends Command
 
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
         ->setName('c5:language-install')
         ->setAliases(['c5:install-language'])
@@ -76,7 +77,7 @@ $ concrete/bin/concrete5 c5:language-install --add it_IT --add de_DE
 $ concrete/bin/concrete5 c5:language-install --add it_IT --add de_DE --core
             
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
             
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-language-install
@@ -110,6 +111,8 @@ EOT
         if ($this->shouldClearLocalizationCache) {
             Localization::clearCache();
         }
+
+        return static::SUCCESS;
     }
 
     /**

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -22,7 +22,8 @@ class InstallPackageCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:package:install')
             ->setAliases([
@@ -38,7 +39,7 @@ class InstallPackageCommand extends Command
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-install
@@ -181,5 +182,7 @@ EOT
             }
             $output->writeln('<info>done.</info>');
         }
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/InstallThemeCommand.php
+++ b/concrete/src/Console/Command/InstallThemeCommand.php
@@ -14,7 +14,6 @@ class InstallThemeCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this->setName('c5:theme:install')
         ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate this theme after install', null)
         ->setDescription('Install a Concrete5 Theme')
@@ -24,6 +23,7 @@ class InstallThemeCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $rc = static::SUCCESS;
         $theme = Theme::getByFileHandle($input->getArgument('theme-handle'));
 
         $app = Application::getFacadeApplication();
@@ -47,8 +47,11 @@ class InstallThemeCommand extends Command
                     break;
                 default:
                     $output->writeln($e->getMessage());
+                    $rc = static::FAILURE;
                     break;
             }
         }
+
+        return $rc;
     }
 }

--- a/concrete/src/Console/Command/IsInstalledCommand.php
+++ b/concrete/src/Console/Command/IsInstalledCommand.php
@@ -6,14 +6,19 @@ use Concrete\Core\Console\Command;
 use Concrete\Core\Support\Facade\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class IsInstalledCommand extends Command
 {
-    const RETURN_CODE_ON_FAILURE = 2;
+    const CONCRETE_IS_INSTALLED = self::SUCCESS;
+    const CONCRETE_IS_NOT_INSTALLED = 1;
+    const FAILURE = 2;
 
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $installedExitCode = static::CONCRETE_IS_INSTALLED;
+        $notInstalledExitCode = static::CONCRETE_IS_NOT_INSTALLED;
+        $errExitCode = static::FAILURE;
 
         $this
             ->setName('c5:is-installed')
@@ -23,8 +28,8 @@ class IsInstalledCommand extends Command
 This command will print out if concrete5 is already installed (unless the --quiet option is specified),
 and set the following return codes
 
-  0 concrete5 is installed
-  1 concrete5 is not installed
+  $installedExitCode concrete5 is installed
+  $notInstalledExitCode concrete5 is not installed
   $errExitCode errors occurred
 EOT
             )
@@ -33,12 +38,17 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $app = Application::getFacadeApplication();
-        $isInstalled = $app->isInstalled();
-        if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
-            $output->writeln($isInstalled ? 'concrete5 is installed' : 'concrete5 is not installed');
-        }
+        try {
+            $app = Application::getFacadeApplication();
+            $isInstalled = $app->isInstalled();
+            if ($output->getVerbosity() >= OutputInterface::OUTPUT_NORMAL) {
+                $output->writeln($isInstalled ? 'concrete5 is installed' : 'concrete5 is not installed');
+            }
 
-        return $isInstalled ? 0 : 1;
+            return $isInstalled ? static::CONCRETE_IS_INSTALLED : static::CONCRETE_IS_NOT_INSTALLED;
+        } catch (Throwable $error) {
+            $this->writeError($output, $error);
+            return static::FAILURE;
+        }
     }
 }

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -16,7 +16,8 @@ class JobCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:job')
             ->setDescription(t('Run a concrete5 job'))
@@ -30,7 +31,7 @@ class JobCommand extends Command
             )
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-job
@@ -41,7 +42,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
+        $rc = static::SUCCESS;
         $options = $input->getOptions();
         $formatter = $this->getHelper('formatter');
 
@@ -81,7 +82,7 @@ EOT
                     if ($set) {
                         $jobs = array_merge($jobs, $set->getJobs());
                     } else {
-                        $rc = 1;
+                        $rc = static::FAILURE;
                         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln(
                                 '<error>' . t('A job set with name "%s" was not found', $setName) . '</error>'
@@ -95,7 +96,7 @@ EOT
                     if ($job) {
                         $jobs[] = $job;
                     } else {
-                        $rc = 1;
+                        $rc = static::FAILURE;
                         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln(
                                 '<error>' . t('A job with handle "%s" was not found', $jobHandle) . '</error>'
@@ -114,7 +115,7 @@ EOT
 
                     $result = $job->executeJob();
                     if ($result->isError()) {
-                        $rc = 1;
+                        $rc = static::FAILURE;
                         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln(
                                 $formatter->formatSection(

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -122,6 +122,8 @@ final class PackPackageCommand extends Command
         $filters = $this->createFilters($app, $packageInfo);
         $writers = $this->createWriters($app, $packageInfo);
         $packer->process($packageInfo, $filters, $writers);
+
+        return static::SUCCESS;
     }
 
     /**
@@ -136,7 +138,8 @@ final class PackPackageCommand extends Command
         $keepSources = self::KEEP_SOURCES;
         $keepComposerJson = self::KEEP_COMPOSER_JSON;
         $keepComposerLock = self::KEEP_COMPOSER_LOCK;
-        $errExitCode = self::RETURN_CODE_ON_FAILURE;
+        $okExitCode = self::SUCCESS;
+        $errExitCode = self::FAILURE;
         $this
             ->setName('c5:package:pack')
             ->setAliases([
@@ -170,7 +173,7 @@ To include in the zip archive the composer.json file but not the composer.lock f
 Please remark that this command can also parse legacy (pre-5.7) packages.
 
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-pack

--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -78,24 +78,27 @@ EOT
         $this->printErrors($errors, $dryRun);
         $this->printCountersTable($counters, $dryRun);
         if ($dryRun) {
-            return empty($changes) && $errors->isEmpty() ? 0 : 1;
+            return empty($changes) && $errors->isEmpty() ? static::SUCCESS : static::FAILURE;
         }
 
-        return $errors->isEmpty() ? 0 : 1;
+        return $errors->isEmpty() ? static::SUCCESS : static::FAILURE;
     }
 
     protected function configure()
     {
+        $okExitCode = self::SUCCESS;
+        $errExitCode = self::FAILURE;
+
         $this->setHelp(<<<EOT
 Check or fix the PHP coding style.
 
 Return values when checking the coding style:
-- 0: the coding style is valid and no error occurred
-- 1: some fixes are needed or some error occurred
+- {$okExitCode}: the coding style is valid and no error occurred
+- {$errExitCode}: some fixes are needed or some error occurred
 
 Return values when applying the coding style:
-- 0: no error occurred
-- 1: some error occurred
+- {$okExitCode}: no error occurred
+- {$errExitCode}: some error occurred
 EOT
         );
     }

--- a/concrete/src/Console/Command/RefreshBoardsCommand.php
+++ b/concrete/src/Console/Command/RefreshBoardsCommand.php
@@ -21,7 +21,8 @@ class RefreshBoardsCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
 
         $this
             ->setName('c5:boards:refresh')
@@ -34,7 +35,7 @@ class RefreshBoardsCommand extends Command
             ->setHelp(<<<EOT
 This command will add content to specified boards or board instances.
 
-  0 operation completed successfully
+  {$okExitCode} operation completed successfully
   {$errExitCode} errors occurred
 EOT
             )
@@ -92,6 +93,6 @@ EOT
                 throw new \Exception(t('You must specify a board ID or use the --all option.'));
             }
         }
-        return 0;
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/RefreshEntitiesCommand.php
+++ b/concrete/src/Console/Command/RefreshEntitiesCommand.php
@@ -15,7 +15,8 @@ class RefreshEntitiesCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::FAILURE;
+        $errExitCode = static::FAILURE;
 
         $this
             ->setName('c5:entities:refresh')
@@ -25,7 +26,7 @@ class RefreshEntitiesCommand extends Command
             ->setHelp(<<<EOT
 This command will refresh the Doctrine database entities and set the following return codes
 
-  0 operation completed successfully
+  {$okExitCode} operation completed successfully
   {$errExitCode} errors occurred
 EOT
             )
@@ -48,6 +49,6 @@ EOT
             $output->writeln('Doctrine cache cleared, proxy classes regenerated, entity database table schema updated.');
         }
 
-        return 0;
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/ReindexCommand.php
+++ b/concrete/src/Console/Command/ReindexCommand.php
@@ -24,7 +24,6 @@ class ReindexCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
         $this
             ->setName('c5:reindex')
             ->setDescription('Reindex pages, files, users and express entities')
@@ -104,7 +103,7 @@ class ReindexCommand extends Command
                 }
             }
 
-            return 0;
+            return static::SUCCESS;
         } else {
             throw new \Exception(t('You must include at least one type to reindex. Valid types are --pages/-p, --express/-e'));
         }

--- a/concrete/src/Console/Command/RescanFilesCommand.php
+++ b/concrete/src/Console/Command/RescanFilesCommand.php
@@ -101,5 +101,7 @@ class RescanFilesCommand extends Command
             $output->writeln(t('Unable to rescan file "%s" (ID: %s): %s', $currentFilename, $currentID, $e->getMessage()));
         }
         $output->writeln("{$count} files rescanned.");
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -14,7 +14,8 @@ class ResetCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:reset')
             ->setDescription('Reset the concrete5 installation, deleting files and emptying the database')
@@ -23,7 +24,7 @@ class ResetCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-reset
@@ -127,5 +128,7 @@ EOT
                 $output->writeln('<info>done.</info>');
             }
         }
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/ServiceCommand.php
+++ b/concrete/src/Console/Command/ServiceCommand.php
@@ -16,7 +16,9 @@ final class ServiceCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
+        $errInvalid = static::INVALID;
         $serviceHandles = [];
         $help = '';
         $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
@@ -42,12 +44,12 @@ final class ServiceCommand extends Command
         $help .= <<<EOT
 
 Return codes for the check operation:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
+  $errInvalid web server configuration is not aligned
   $errExitCode errors occurred
-  2 web server configuration is not aligned
 
 Return codes for the update operation:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-service
@@ -67,7 +69,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
+        $rc = static::SUCCESS;
         $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
         /* @var \Concrete\Core\Service\Manager\ServiceManager $manager */
         $service = $manager->getService($input->getArgument('service'), $input->getOption('service-version'));
@@ -82,7 +84,7 @@ EOT
         switch ($operation) {
             case 'check':
                 if ($this->checkConfiguration($service, $ruleOptions, $output) === false) {
-                    $rc = 2;
+                    $rc = static::INVALID;
                 }
                 break;
             case 'update':

--- a/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
+++ b/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
@@ -40,23 +40,23 @@ EOT
             } catch (UnsupportedCollationException $x) {
                 $this->output->error(sprintf('"%s" is neither a valid character set nor a valid collation.', $this->argument('charset')));
 
-                return 2;
+                return static::INVALID;
             } catch (Exception $x) {
                 $this->output->error($x->getMessage());
 
-                return 1;
+                return static::FAILURE;
             }
         } catch (Exception $x) {
             $this->output->error($x->getMessage());
 
-            return 1;
+            return static::FAILURE;
         }
         $params = $connection->getParams();
         if (isset($params['character_set']) && $params['character_set'] === $characterSet && isset($params['collation']) && $params['collation'] === $collation) {
             if (!$this->option('force')) {
                 $this->output->writeln(sprintf('Skipping since the connection "%s" is already using character set "%s" and collation "%s"', $connectionName, $characterSet, $collation));
 
-                return 0;
+                return static::SUCCESS;
             }
         }
         $manager->apply(
@@ -69,6 +69,6 @@ EOT
             }
         );
 
-        return 0;
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -17,7 +17,8 @@ class TranslatePackageCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:package:translate')
             ->setAliases([
@@ -47,7 +48,7 @@ Examples:
 Please remark that this command can also parse legacy (pre-5.7) packages.
             
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
             
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-translate
@@ -217,6 +218,8 @@ EOT
             $po->toMoFile($moFile);
             $output->writeln('<info>done.</info>');
         }
+
+        return static::SUCCESS;
     }
     
     private function guessPackageDetails($packageDirectory)

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -15,7 +15,8 @@ class UninstallPackageCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:package:uninstall')
             ->setAliases([
@@ -29,7 +30,7 @@ class UninstallPackageCommand extends Command
             ->setDescription('Uninstall a concrete5 package')
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-uninstall
@@ -83,5 +84,7 @@ EOT
             }
             $output->writeln('<info>done.</info>');
         }
+
+        return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -17,7 +17,8 @@ class UpdateCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:update')
             ->setDescription('Runs all database migrations to bring the concrete5 installation up to date.')
@@ -48,7 +49,7 @@ Examples:
     Execute the migrations starting from the 20171218000000 migration (even if they have already been marked as executed)
 
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 EOT
             )

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -14,7 +14,8 @@ class UpdatePackageCommand extends Command
 {
     protected function configure()
     {
-        $errExitCode = static::RETURN_CODE_ON_FAILURE;
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:package:update')
             ->setAliases([
@@ -29,7 +30,7 @@ class UpdatePackageCommand extends Command
             ->setDescription('Update a concrete5 package')
             ->setHelp(<<<EOT
 Returns codes:
-  0 operation completed successfully
+  $okExitCode operation completed successfully
   $errExitCode errors occurred
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-package-update
@@ -40,7 +41,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rc = 0;
+        $rc = static::SUCCESS;
         $updatableHandles = [];
         $force = $input->getOption('force');
         if ($input->getOption('all')) {
@@ -73,7 +74,7 @@ EOT
                 $this->updatePackage($updatableHandle, $output, $input, $force);
             } catch (Exception $x) {
                 $this->writeError($output, $x);
-                $rc = 1;
+                $rc = static::FAILURE;
             }
         }
 


### PR DESCRIPTION
All the CLI commands now have to return an integer, otherwise we have this error:

```
TypeError: Return value of "Concrete\Core\Console\Command\...::execute()" must be of the type int, "null" returned.
```

In addition, the definition of "success" and "error" return codes are defined both in [`Concrete\Core\Console\Command`](https://github.com/concrete5/concrete5/blob/9.0.0RC1/concrete/src/Console/Command.php#L25-L37) and in [`Symfony\Component\Console\Command\Command`](https://github.com/symfony/console/blob/v5.2.0/Command/Command.php#L32-L33).

This PR:
- deprecates the Concrete constants
- fixes all the return codes of the core CLI command
