### PR TITLE
[9.0rc] Fix incorrect permission key handle in migration Version20210813173441

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20210813173441.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210813173441.php
@@ -19,7 +19,7 @@ final class Version20210813173441 extends AbstractMigration implements Repeatabl
         }
         $key = Key::getByHandle('assign_groups');
         if (!$key) {
-            $key = Key::add('group_folder', 'add_group_folder', t("Assign Groups"), t("Can assign the groups within this folder."), false, false);
+            $key = Key::add('group_folder', 'assign_groups', t("Assign Groups"), t("Can assign the groups within this folder."), false, false);
         }
 
     }


### PR DESCRIPTION
The migration was failing with the following error:
```
An exception occurred while executing 'INSERT INTO PermissionKeys (pkHandle, pkName, pkDescription, pkCategoryID, pkCanTriggerWorkflow, pkHasCustomClass, pkgID) VALUES (?, ?, ?, ?, ?, ?, ?)' with params ["add_group_folder", "Assign Groups", "Can assign the groups within this folder.", "30", 0, 0, 0]:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'add_group_folder' for key 'akHandle'
```