### PR TITLE
Allow publish dates to be accessible for page workflow requests

### DIFF
--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -182,4 +182,14 @@ class ApprovePageRequest extends PageRequest
         return $v->getVersionComments();
     }
 
+    public function getPublishDate()
+    {
+        return $this->cvPublishDate;
+    }
+
+    public function getPublishEndDate()
+    {
+        return $this->cvPublishEndDate;
+    } 
+
 }


### PR DESCRIPTION
This update should allow page workflow requests to disclose the scheduled publishing dates of page versions that have been submitted for approval. This could be useful for showing messages to the approver about when a pending page version is scheduled.