### PR TITLE
[9.0rc3]fixes #9760 - Make Logs nicely formatted again

### DIFF
--- a/concrete/src/Logging/Search/ColumnSet/Column/MessageColumn.php
+++ b/concrete/src/Logging/Search/ColumnSet/Column/MessageColumn.php
@@ -26,7 +26,7 @@ class MessageColumn extends Column implements PagerColumnInterface
 
     public function getColumnCallback()
     {
-        return 'getMessage';
+        return ['\Concrete\Core\Logging\Search\ColumnSet\DefaultSet', 'getFormattedMessage'];
     }
 
     /**

--- a/concrete/src/Logging/Search/ColumnSet/DefaultSet.php
+++ b/concrete/src/Logging/Search/ColumnSet/DefaultSet.php
@@ -13,6 +13,7 @@ use Concrete\Core\Logging\Search\ColumnSet\Column\TimeColumn;
 use Concrete\Core\Logging\Search\ColumnSet\Column\UserIdentifierColumn;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\UserInfo;
+use Concrete\Core\Utility\Service\Text as TextService;
 use Punic\Exception;
 use Punic\Exception\BadArgumentType;
 
@@ -58,6 +59,20 @@ class DefaultSet extends ColumnSet
     public function getCollectionLevel($logEntry)
     {
         return Levels::getLevelDisplayName($logEntry->getLevel());
+    }
+
+    /**
+     * @param $logEntry LogEntry
+     * @return string
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function getFormattedMessage($logEntry)
+    {
+        $app = Application::getFacadeApplication();
+        /** @var TextService $textHelper */
+        $textHelper  = $app->make(TextService::class);
+        return $textHelper->makenice($logEntry->getMessage());
+
     }
 
     public function __construct()

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -736,6 +736,10 @@ class Service
                 }
 
                 $mailDetails = $mailWithoutAttachments->toString();
+                $encoding = $mailWithoutAttachments->getHeaders()->get('Content-Transfer-Encoding');
+                if (is_object($encoding) && $encoding->getFieldValue() === 'quoted-printable') {
+                    $mailDetails = quoted_printable_decode($mailDetails);
+                }
 
                 // append the attached file names to the mail log
                 foreach($attachedFiles as $attachedFile) {


### PR DESCRIPTION
fixes #9760 
Re-adds `makenice` to logs
Also re-adds the quoted printable decode if the email has that encoding enabled. (was in v8)