### PR TITLE
[v8] fix #9800

### DIFF
--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -587,10 +587,13 @@
 
 	ConcreteAjaxSearch.prototype.setupPagination = function() {
 		var cs = this;
-		this.$element.on('click', 'div.ccm-search-results-pagination a:not([disabled])', function() {
-			cs.ajaxUpdate($(this).attr('href'));
-			return false;
-		});
+		if (this.$resultsPagination) {
+			this.$resultsPagination.on('click', 'a:not([disabled])', function() {
+				cs.ajaxUpdate($(this).attr('href'));
+				return false;
+			});
+		}
+
 	};
 
 	ConcreteAjaxSearch.prototype.getResultMenu = function(results) {
@@ -619,7 +622,7 @@
 
 	ConcreteAjaxSearch.prototype.setupCheckboxes = function() {
 		var cs = this;
-		cs.$element.on('click', 'input[data-search-checkbox=select-all]', function() {
+		cs.$resultsTableHead.on('click', 'input[data-search-checkbox=select-all]', function() {
 			cs.$element.find('input[data-search-checkbox=individual]').prop('checked', $(this).is(':checked')).trigger('change');
 		});
 		cs.$element.on('change', 'input[data-search-checkbox=individual]', function() {

--- a/concrete/js/build/core/app/search/base.js
+++ b/concrete/js/build/core/app/search/base.js
@@ -417,7 +417,7 @@
 
 	ConcreteAjaxSearch.prototype.setupSort = function() {
 		var cs = this;
-		this.$element.on('click', 'thead th > a', function() {
+		this.$resultsTableHead.on('click', 'th > a', function() {
 			cs.ajaxUpdate($(this).attr('href'));
 			return false;
 		});


### PR DESCRIPTION
fixes #9800 by moving the click handler to the thead element rather than the div so the event propagation finds the sortable columns after they are loaded/changed 