### PR TITLE
Prevent ReCAPTCHA timeout

### DIFF
--- a/concrete/js/captcha/recaptchav3.js
+++ b/concrete/js/captcha/recaptchav3.js
@@ -4,6 +4,17 @@
 ;(function(global, $) {
 'use strict';
 
+function ready(clientId) {
+    grecaptcha.ready(function () {
+        grecaptcha.execute(
+            clientId,
+            {
+                action: 'submit'
+            }
+        );
+    });
+}
+
 function render(element) {
     var $element = $(element),
         clientId = grecaptcha.render(
@@ -15,14 +26,8 @@ function render(element) {
                 size: 'invisible'
             }
         );
-    grecaptcha.ready(function () {
-        grecaptcha.execute(
-            clientId,
-            {
-                action: 'submit'
-            }
-        );
-    });
+    ready(clientId);
+    setInterval(function(){ready(clientId)}, 110000);
 }
 
 global.RecaptchaV3 = function() {


### PR DESCRIPTION
Issue 9780

When a form using reCAPTCHA V3 is loaded a time-out timer starts running. After 2 minutes the code expires and every form submission after this 2 minutes is not accepted and an error is given.

All we have to do is call grecaptcha.ready again a few seconds before it times out.