### PR TITLE
Remove hautelook in favor of using the php stdlib password_hash functionality

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
 #          - "8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -2207,50 +2207,6 @@
             "time": "2021-04-26T09:17:50+00:00"
         },
         {
-            "name": "hautelook/phpass",
-            "version": "0.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hautelook/phpass.git",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/phpass/zipball/b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Hautelook": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Public Domain"
-            ],
-            "authors": [
-                {
-                    "name": "Solar Designer",
-                    "email": "solar@openwall.com",
-                    "homepage": "http://openwall.com/phpass/"
-                }
-            ],
-            "description": "Portable PHP password hashing framework",
-            "homepage": "http://github.com/hautelook/phpass/",
-            "keywords": [
-                "blowfish",
-                "crypt",
-                "password",
-                "security"
-            ],
-            "time": "2012-08-31T00:00:00+00:00"
-        },
-        {
             "name": "htmlawed/htmlawed",
             "version": "1.1.22",
             "source": {

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -64,7 +64,6 @@
     "mobiledetect/mobiledetectlib": "2.*",
     "monolog/monolog": "^1.5.0",
     "sunra/php-simple-html-dom-parser": "^1.5.2",
-    "hautelook/phpass": "0.3.*",
     "voku/urlify": "~1.0.1",
     "dapphp/securimage": "3.*",
     "anahkiasen/html-object": "~1.4",

--- a/concrete/src/Encryption/PasswordHasher.php
+++ b/concrete/src/Encryption/PasswordHasher.php
@@ -3,24 +3,22 @@
 namespace Concrete\Core\Encryption;
 
 use Concrete\Core\Config\Repository\Repository;
-use Hautelook\Phpass\PasswordHash;
 
 class PasswordHasher
 {
-    /**
-     * @var \Hautelook\Phpass\PasswordHash
-     */
-    private $phpassPasswordHash;
+
+    /** @var int|null */
+    private $cost = null;
 
     /**
      * @param \Concrete\Core\Config\Repository\Repository $config
      */
     public function __construct(Repository $config)
     {
-        $this->phpassPasswordHash = new PasswordHash(
-            $config->get('concrete.user.password.hash_cost_log2'),
-            $config->get('concrete.user.password.hash_portable')
-        );
+        $cost = $config->get('concrete.user.password.hash_cost_log2', null);
+        if ($cost !== null) {
+            $this->cost = (int) $cost;
+        }
     }
 
     /**
@@ -32,7 +30,9 @@ class PasswordHasher
      */
     public function hashPassword($password)
     {
-        return $this->phpassPasswordHash->HashPassword($password);
+        return password_hash($password, PASSWORD_BCRYPT, [
+            'cost' => $this->cost ?: PASSWORD_BCRYPT_DEFAULT_COST
+        ]);
     }
 
     /**
@@ -43,6 +43,6 @@ class PasswordHasher
      */
     public function checkPassword($password, $storedHash)
     {
-        return $this->phpassPasswordHash->CheckPassword($password, $storedHash);
+        return password_verify($password, $storedHash);
     }
 }

--- a/concrete/src/Encryption/PasswordHasher.php
+++ b/concrete/src/Encryption/PasswordHasher.php
@@ -10,6 +10,8 @@ class PasswordHasher
     /** @var int|null */
     private $cost = null;
 
+    private const ALGORITHM = PASSWORD_BCRYPT;
+
     /**
      * @param \Concrete\Core\Config\Repository\Repository $config
      */
@@ -30,7 +32,7 @@ class PasswordHasher
      */
     public function hashPassword($password)
     {
-        return password_hash($password, PASSWORD_BCRYPT, [
+        return password_hash($password, self::ALGORITHM, [
             'cost' => $this->cost ?: PASSWORD_BCRYPT_DEFAULT_COST
         ]);
     }
@@ -44,5 +46,10 @@ class PasswordHasher
     public function checkPassword($password, $storedHash)
     {
         return password_verify($password, $storedHash);
+    }
+
+    public function needsRehash($hash): bool
+    {
+        return password_needs_rehash($hash, self::ALGORITHM);
     }
 }

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -20,7 +20,6 @@ use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Page\Page;
 use Concrete\Core\User\Group\GroupList;
 use Concrete\Core\User\Group\GroupRole;
-use Hautelook\Phpass\PasswordHash;
 use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Encryption\PasswordHasher;
 
@@ -1007,25 +1006,6 @@ class User extends ConcreteObject
         $r = $db->query($q);
 
         return $r;
-    }
-
-    /**
-     * @return \Hautelook\Phpass\PasswordHash
-     * @deprecated Use $app->make(\Concrete\Core\Encryption\PasswordHasher::class)
-     *
-     */
-    public function getUserPasswordHasher()
-    {
-        $app = Application::getFacadeApplication();
-        $config = $app['config'];
-        if (isset($this->hasher)) {
-            return $this->hasher;
-        }
-        $this->hasher = new PasswordHash(
-            $config->get('concrete.user.password.hash_cost_log2'),
-            $config->get('concrete.user.password.hash_portable'));
-
-        return $this->hasher;
     }
 
     /**

--- a/concrete/src/Utility/Service/Identifier.php
+++ b/concrete/src/Utility/Service/Identifier.php
@@ -3,7 +3,6 @@ namespace Concrete\Core\Utility\Service;
 
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Support\Facade\Application;
-use Hautelook\Phpass\PasswordHash;
 
 /**
  * \@package Helpers
@@ -94,12 +93,7 @@ class Identifier
         $size = ceil($length / 2);
 
         try {
-            if (function_exists('random_bytes')) {
-                $bytes = random_bytes($size);
-            } else {
-                $hash = new PasswordHash(8, false);
-                $bytes = $hash->get_random_bytes($size);
-            }
+            $bytes = random_bytes($size);
         } catch (\Exception $e) {
             die('Could not generate a random string.');
         }

--- a/tests/config/concrete.php
+++ b/tests/config/concrete.php
@@ -10,7 +10,7 @@ return [
     ],
     'user' => [
         'password' => [
-            'hash_cost_log2' => 1,
+            'hash_cost_log2' => 4,
         ],
         'email' => [
             // Needed because of a bug in 1.1.x versions of Egulias\EmailValidator which throws a "Undefined variable: dns" warning if this isn't set


### PR DESCRIPTION
This resolves #4777
We have a high enough minimum PHP version that we can just drop this dependency without needing another to replace it. Hautelook passwords do verify with php's built in password tools as far as I've been able to test so I think we're solid there, we just need to start rehashing passwords when `password_needs_rehash()` says it needs to be rehashed.