### PR TITLE
[V8] Do not reset passwords actually when resetting user passwords globally

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/registration/global_password_reset.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/global_password_reset.php
@@ -23,7 +23,6 @@ class GlobalPasswordReset extends DashboardPageController
         $users->ignorePermissions();
         foreach ($users->getResults() as $userInfo) {
             if ($userInfo instanceof UserInfo) {
-                $userInfo->resetUserPassword();
                 $userInfo->markAsPasswordReset();
             }
         }


### PR DESCRIPTION
Users must reset their password if they are marked as password reset, so we don’t need to reset it actually.
If we reset their password actually, they don’t see the "Your user account is being upgraded” message.

This PR fixes #7574 for version 8.

Now works as expected

https://user-images.githubusercontent.com/514294/133677447-34149027-4bef-4117-ba2d-f0ed64bb61e8.mov


