### PR TITLE
[V9] Do not reset passwords actually when resetting user passwords globally

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/registration/global_password_reset.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/global_password_reset.php
@@ -82,7 +82,6 @@ class GlobalPasswordReset extends DashboardPageController
         $users->ignorePermissions();
         foreach ($users->getResults() as $userInfo) {
             if ($userInfo instanceof UserInfo) {
-                $userInfo->resetUserPassword();
                 $userInfo->markAsPasswordReset();
             }
         }

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -38,7 +38,7 @@ abstract class AuthenticationTypeController extends Controller implements Logger
 
     public function getAuthenticationType()
     {
-        if (!$this->authenticationType) {
+        if (!$this->authenticationType || !$this->authenticationType->getAuthenticationTypeID()) {
             $this->authenticationType = AuthenticationType::getByHandle($this->getHandle());
         }
 


### PR DESCRIPTION
This PR fixes #7574 for version 9.

I don't know why it happens on version 9 only, but `getAuthenticationType()` returns empty AuthenticationType class, so I fixed it also.

Before

https://user-images.githubusercontent.com/514294/133682515-977e22cb-775d-4ea6-a0de-4216857b297e.mov

After

https://user-images.githubusercontent.com/514294/133682560-7ca47155-da3d-4c37-958b-9873c5274003.mov

