### PR TITLE
[V9] Fix to show page drafts created by the current user

### DIFF
--- a/concrete/controllers/panel/sitemap.php
+++ b/concrete/controllers/panel/sitemap.php
@@ -2,10 +2,9 @@
 namespace Concrete\Controller\Panel;
 
 use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
-use Loader;
-use PageType;
-use Page as ConcretePage;
-use Permissions;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Type\Type;
+use Concrete\Core\Permission\Checker;
 
 class Sitemap extends BackendInterfaceController
 {
@@ -13,24 +12,25 @@ class Sitemap extends BackendInterfaceController
     protected $frequentPageTypes = array();
     protected $otherPageTypes = array();
     protected $site;
+    protected $canViewSitemap;
 
     public function on_start()
     {
-        $sh = Loader::helper('concrete/dashboard/sitemap');
+        $sh = $this->app->make('helper/concrete/dashboard/sitemap');
         $this->canViewSitemap = $sh->canRead();
-        $this->site = \Core::make('site')->getSite();
+        $this->site = $this->app->make('site')->getSite();
         $type = $this->site->getType();
-        $frequentlyUsed = PageType::getFrequentlyUsedList($type);
+        $frequentlyUsed = Type::getFrequentlyUsedList($type);
         foreach ($frequentlyUsed as $pt) {
-            $ptp = new Permissions($pt);
+            $ptp = new Checker($pt);
             if ($ptp->canAddPageType()) {
                 $this->frequentPageTypes[] = $pt;
             }
         }
 
-        $otherPageTypes = PageType::getInfrequentlyUsedList($type);
+        $otherPageTypes = Type::getInfrequentlyUsedList($type);
         foreach ($otherPageTypes as $pt) {
-            $ptp = new Permissions($pt);
+            $ptp = new Checker($pt);
             if ($ptp->canAddPageType()) {
                 $this->otherPageTypes[] = $pt;
             }
@@ -44,12 +44,12 @@ class Sitemap extends BackendInterfaceController
 
     public function view()
     {
-        $drafts = ConcretePage::getDrafts($this->site);
+        $drafts = Page::getDrafts($this->site);
         $mydrafts = array();
         foreach ($drafts as $d) {
-            $dp = new Permissions($d);
+            $dp = new Checker($d);
             $pt = $d->getPagetypeObject();
-            $tp = new Permissions($pt);
+            $tp = new Checker($pt);
             if ($tp->canEditPageTypeDrafts() || $dp->canEditPageContents()) {
                 $mydrafts[] = $d;
             }
@@ -57,7 +57,7 @@ class Sitemap extends BackendInterfaceController
 
         $siteTreeID = 0;
         if ($this->request->query->has('cID')) {
-            $page = ConcretePage::getByID(intval($this->request->query->get('cID')));
+            $page = Page::getByID(intval($this->request->query->get('cID')));
             if ($page && !$page->isError()) {
                 $siteTreeID = $page->getSiteTreeID();
             }

--- a/concrete/controllers/panel/sitemap.php
+++ b/concrete/controllers/panel/sitemap.php
@@ -47,9 +47,10 @@ class Sitemap extends BackendInterfaceController
         $drafts = ConcretePage::getDrafts($this->site);
         $mydrafts = array();
         foreach ($drafts as $d) {
+            $dp = new Permissions($d);
             $pt = $d->getPagetypeObject();
             $tp = new Permissions($pt);
-            if ($tp->canEditPageTypeDrafts()) {
+            if ($tp->canEditPageTypeDrafts() || $dp->canEditPageContents()) {
                 $mydrafts[] = $d;
             }
         }

--- a/concrete/src/Permission/Access/Access.php
+++ b/concrete/src/Permission/Access/Access.php
@@ -489,7 +489,15 @@ class Access extends ConcreteObject
             $filter .= $pae->getAccessEntityID() . ':';
         }
         $filter = trim($filter, ':');
-        $paID = $this->getPermissionAccessID();
+        if ($this->listItems !== null) {
+            $aeIDs = [];
+            foreach ($this->listItems as $listItem) {
+                $aeIDs[] = $listItem->getPermissionAccessID();
+            }
+            $paID = implode(':', $aeIDs);
+        } else {
+            $paID = $this->getPermissionAccessID();
+        }
         $class = strtolower(get_class($this->pk));
 
         return sprintf('permission/access/list_items/%s/%s/%s', $paID, $filter, $class);


### PR DESCRIPTION
Same as #9489 but for version 9
Fixes #9481 and #8868

I want to run PHP CS Fix for old-style files, but couldn't due to #9830

# How to reproduce

## Set up users

| Username | Group |
| ---- | ---- |
| demo | Administrators |
| author1 | Authors |
| author2 | Authors |

![Screen Shot 2021-09-19 at 1 44 49](https://user-images.githubusercontent.com/514294/133897419-2dba300c-c36c-45f8-b89d-05fa1d63c052.png)
![Screen Shot 2021-09-19 at 1 45 00](https://user-images.githubusercontent.com/514294/133897422-2223ed62-03b1-454f-b957-4da2f700f213.png)
![Screen Shot 2021-09-19 at 1 45 08](https://user-images.githubusercontent.com/514294/133897424-d11b8105-23a7-498e-a5b6-61108003b8d5.png)

## Before merge

![Screen Shot 2021-09-19 at 1 46 13](https://user-images.githubusercontent.com/514294/133897469-09079e75-1f48-4db6-802e-6b17299e2b01.png)
<img width="1498" alt="Screen Shot 2021-09-19 at 1 46 54" src="https://user-images.githubusercontent.com/514294/133897471-acb37518-df89-4372-aa23-2df0772c75bf.png">
<img width="1509" alt="Screen Shot 2021-09-19 at 1 47 57" src="https://user-images.githubusercontent.com/514294/133897476-108902d7-5b64-4d59-90ae-f65836cc389b.png">

## After merge

![Screen Shot 2021-09-19 at 2 27 09](https://user-images.githubusercontent.com/514294/133897499-2f9fac89-96c0-472b-8a1a-a5cb98ed0224.png)
<img width="1498" alt="Screen Shot 2021-09-19 at 2 27 24" src="https://user-images.githubusercontent.com/514294/133897500-0077773c-7a4f-4623-bbfe-e453cb97dc0f.png">
<img width="1509" alt="Screen Shot 2021-09-19 at 2 27 31" src="https://user-images.githubusercontent.com/514294/133897502-6cd067f3-fa96-4aea-974e-40eafda3084f.png">
