### PR TITLE
Prevent ReCAPTCHA timeout

### DIFF
--- a/concrete/src/Captcha/RecaptchaV3Controller.php
+++ b/concrete/src/Captcha/RecaptchaV3Controller.php
@@ -141,17 +141,21 @@ if (typeof window.RecaptchaV3 === "undefined") {
                 }
             ));
         });
-
-        grecaptcha.ready(function () {
-            $('.recaptcha-v3').each(function () {
-                grecaptcha.execute(
-                    $(this).data("clientId"),
-                    {
-                        action: 'submit'
-                    }
-                );
-            });
-        });
+		
+		function ready() {
+			grecaptcha.ready(function () {
+				$('.recaptcha-v3').each(function () {
+					grecaptcha.execute(
+						$(this).data("clientId"),
+						{
+							action: 'submit'
+						}
+					);
+				});
+			});
+		}
+		ready();
+		setInterval(ready, 110000);
     };
 }
 </script>


### PR DESCRIPTION
Issue 9780

When a form using reCAPTCHA V3 is loaded a time-out timer starts running. After 2 minutes the code expires and every form submission after this 2 minutes is not accepted and an error is given.

All we have to do is call grecaptcha.ready again a few seconds before it times out.