### PR TITLE
Adding the one-click functionality to clear the log. Button can be fo…

### DIFF
--- a/concrete/controllers/dialog/logs/delete_all.php
+++ b/concrete/controllers/dialog/logs/delete_all.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Concrete\Controller\Dialog\Logs;
+
+use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Page\EditResponse;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker as Permissions;
+
+
+class DeleteAll extends BackendInterfaceController
+{
+    protected $viewPath = '/dialogs/logs/delete_all';
+    protected $controllerActionPath = '/ccm/system/dialogs/logs/delete_all';
+
+    protected function canAccess()
+    {
+        $page = Page::getByPath('/dashboard/reports/logs');
+        $checker = new Permissions($page);
+        return $checker->canViewPage();
+    }
+
+    public function view()
+    {}
+
+    public function submit()
+    {
+        /** @var ResponseFactory $responseFactory */
+        $responseFactory = $this->app->make(ResponseFactory::class);
+        /** @var EditResponse $editResponse */
+        $editResponse = new EditResponse();
+
+        if($this->canAccess()){
+            /** @var Connection $db */
+            $db = $this->app->make(Connection::class);
+
+            /** @noinspection PhpUnhandledExceptionInspection */
+            /** @noinspection SqlDialectInspection */
+            /** @noinspection SqlNoDataSourceInspection */
+            $db->executeQuery("TRUNCATE TABLE Logs");
+
+            $editResponse->setMessage(t('Log cleared successfully.'));
+        }else{
+            $editResponse->setMessage(t('Access denied'));
+        }
+
+        return $responseFactory->json($editResponse->getJSONObject());
+
+    }
+}

--- a/concrete/elements/dashboard/reports/logs/search/menu.php
+++ b/concrete/elements/dashboard/reports/logs/search/menu.php
@@ -50,6 +50,11 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <div class="col-auto">
         <ul class="ccm-dashboard-header-icons">
             <li>
+                <a href="<?php echo (string)UrlFacade::to("/ccm/system/dialogs/logs/delete_all"); ?>" class="ccm-hover-icon dialog-launch" dialog-title="Delete All" title="<?php echo h(t('Clear log')) ?>">
+                    <i class="fa fa-trash" aria-hidden="true"></i>
+                </a>
+            </li>
+            <li>
                 <a href="<?php echo (string)UrlFacade::to("/dashboard/reports/logs/export"); ?>" class="ccm-hover-icon" title="<?php echo h(t('Export CSV')) ?>">
                     <i class="fa fa-download" aria-hidden="true"></i>
                 </a>

--- a/concrete/routes/dialogs/logs.php
+++ b/concrete/routes/dialogs/logs.php
@@ -20,6 +20,8 @@ $router->all('/bulk/delete', 'Bulk\Delete::view');
 $router->all('/bulk/delete/submit', 'Bulk\Delete::submit');
 $router->all('/delete', 'Delete::view');
 $router->all('/delete/submit', 'Delete::submit');
+$router->all('/delete_all', 'DeleteAll::view');
+$router->all('/delete_all/submit', 'DeleteAll::submit');
 
 $router->all('/advanced_search/preset/edit', 'Preset\Edit::view');
 $router->all('/advanced_search/preset/edit/edit_search_preset', 'Preset\Edit::edit_search_preset');

--- a/concrete/views/dialogs/logs/delete_all.php
+++ b/concrete/views/dialogs/logs/delete_all.php
@@ -1,0 +1,33 @@
+<?php
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Controller\Dialog\Logs\DeleteAll;
+use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Support\Facade\Application;
+
+/** @var int $logItem */
+/** @var DeleteAll $controller */
+
+$app = Application::getFacadeApplication();
+/** @var Form $form */
+$form = $app->make(Form::class)
+?>
+
+<div class="ccm-ui">
+    <form method="post" data-dialog-form="delete-all-log-entry" action="<?php echo $controller->action('submit') ?>">
+        <div class="dialog-buttons">
+            <button class="btn btn-secondary float-start" data-dialog-action="cancel">
+                <?php echo t('Cancel') ?>
+            </button>
+
+            <button type="button" data-dialog-action="submit" class="btn btn-danger float-end">
+                <?php echo t('Delete') ?>
+            </button>
+        </div>
+
+        <strong>
+            <?php echo t('Are you sure you wish to clear the log?') ?>
+        </strong>
+    </form>
+</div>


### PR DESCRIPTION
Since log can fill up pretty easily and deleting log items one-by-one is a long and boring task I've added an extra button to clear the log with one click. Button can be found next to the Export and it has confirmation window (similar way as the single delete).

Initial pull request can be found here: 
https://github.com/concrete5/concrete5/pull/9805