### PR TITLE
[V9 RC]Fixed cookie not being cleared properly to open "add block panel".

### DIFF
--- a/concrete/controllers/backend/page.php
+++ b/concrete/controllers/backend/page.php
@@ -78,7 +78,7 @@ class Page extends Controller
                 $redirectUrl = $redirectUrl->setQuery($query);
                 break;
             case 'add-block':
-                $this->app->make(ResponseCookieJar::class)->addCookie('ccmLoadAddBlockWindow', '1');
+                $this->app->make(ResponseCookieJar::class)->addCookie('ccmLoadAddBlockWindow', '1', 0, $this->app->make('app_relative_path') . '/');
                 break;
         }
 


### PR DESCRIPTION
Clicking the "+" icon will set the "ccmLoadAddBlockWindow" cookie, open the "add block panel", and delete the cookie in hreader_require.php.
However, because of the difference in the path to be set (fixed to "/") and the path to be deleted (installation directory)
If you have installed Concrete5 in a subdirectory, the cookie will not be deleted.
The "add block panel" will open even if you go to edit mode with the pencil icon because the cookie is still there.

Modify it to specify app_relative_path at the time of setting the cookie.

* Probably #9660 will be fixed...
* We were unable to verify the results with multi-site.

[/ccm/system/page/checkout/[Page ID]/add-block/... and set a cookie.]
![スクリーンショット 2021-09-23 174445](https://user-images.githubusercontent.com/49182821/134490700-39a7b6eb-c993-4813-b85d-462b13485ed0.png)

[Delete cookies in header_required.php]
![スクリーンショット 2021-09-23 174546](https://user-images.githubusercontent.com/49182821/134490706-3b70d5bb-90fa-4bee-b249-715aacae9ce5.png)

(The text may not be correct as it was translated from Japanese using DeepL..)