### PR TITLE
[V8] Improve messages for admin users to better understand canceling page version schedule

### DIFF
--- a/concrete/bootstrap/process.php
+++ b/concrete/bootstrap/process.php
@@ -79,7 +79,6 @@ if (isset($_REQUEST['ctask']) && $_REQUEST['ctask'] && $valt->validate()) {
                 $pkr = new UnapprovePageRequest();
                 $pkr->setRequestedPage($c);
                 $v = CollectionVersion::get($c, "SCHEDULED");
-                $v->setPublishInterval(null, null);
                 $pkr->setRequestedVersionID($v->getVersionID());
                 $pkr->setRequesterUserID($u->getUserID());
                 $response = $pkr->trigger();

--- a/concrete/controllers/panel/page/versions.php
+++ b/concrete/controllers/panel/page/versions.php
@@ -234,8 +234,8 @@ class Versions extends BackendInterfacePageController
                     // we are deferred
                     $r->setMessage(t('<strong>Request Saved.</strong> You must complete the workflow before this change is active.'));
                 } else {
-                    $r->addCollectionVersion(CollectionVersion::get($c, $cvID));
-                    $r->setMessage(t('Version %s unapproved successfully', $v->getVersionID()));
+                    $r->addCollectionVersion($v);
+                    $r->setRedirectURL($c->getCollectionLink());
                 }
             } else {
                 $e = Loader::helper('validation/error');

--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -493,16 +493,29 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                                 }
                                 $buttons[] = '<a href="' . DIR_REL . '/' . DISPATCHER_FILENAME . '?cID=' . $cID . '&ctask=approve-recent' . $token . '" class="btn btn-primary btn-xs">' . $appLabel . '</a>';
                             }
+                            $isActive = false;
+                            $active = \Concrete\Core\Page\Collection\Version\Version::get($c, 'ACTIVE');
+                            if (is_object($active) && !$active->isError()) {
+                                $isActive = true;
+                            }
+                            if ($isActive) {
+                                $pendingMessage = t('This page is newer than what appears to visitors on your live site.');
+                                $notifyIcon = 'fa fa-cog';
+                            } else {
+                                $pendingMessage = t("This page is not approved and visitors can't see it.");
+                                $notifyIcon = 'fa fa-exclamation-triangle';
+                            }
                             echo $cih->notify([
                                 'title' => t('Page is Pending Approval.'),
-                                'text' => t('This page is newer than what appears to visitors on your live site.'),
+                                'text' => $pendingMessage,
                                 'type' => 'info',
-                                'icon' => 'fa fa-cog',
+                                'icon' => $notifyIcon,
                                 'buttons' => $buttons,
                             ]);
                         }
                     } else {
                         $publishDate = $vo->getPublishDate();
+                        $publishEndDate = $vo->getPublishEndDate();
                         if ($publishDate && $dateHelper->toDateTime() < $dateHelper->toDateTime($publishDate)) {
                             $date = $dateHelper->formatDate($publishDate);
                             $time = $dateHelper->formatTime($publishDate);
@@ -518,6 +531,17 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
                                 'type' => 'info',
                                 'icon' => 'fa fa-cog',
                                 'buttons' => $buttons,
+                            ]);
+                        } elseif ($publishEndDate && $dateHelper->toDateTime() < $dateHelper->toDateTime($publishEndDate)) {
+                            $date = $dateHelper->formatDate($publishEndDate);
+                            $time = $dateHelper->formatTime($publishEndDate);
+                            $message = t(/*i18n: %1$s is a date, %2$s is a time */'This version of the page is scheduled to be closed on %1$s at %2$s.', $date, $time);
+                            echo $cih->notify([
+                                'title' => t('Scheduled to close.'),
+                                'text' => $message,
+                                'type' => 'info',
+                                'icon' => 'fa fa-info-circle',
+                                'buttons' => [],
                             ]);
                         }
                     }

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -881,7 +881,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             ->set('cvIsApproved', 0)
             ->set('cvApproverUID', 0)
             ->where('cID = :cID')
-            ->where('cvID = :cvID')
+            ->andWhere('cvID = :cvID')
             ->setParameter('cID', $cID)
             ->setParameter('cvID', $cvID)
             ->execute();

--- a/concrete/views/panels/page/versions.php
+++ b/concrete/views/panels/page/versions.php
@@ -42,9 +42,15 @@ defined('C5_EXECUTE') or die('Access Denied.');
             <% } %>
             <% } %>
             <% if (cvIsScheduled) { %>
-            <p><?= t('Scheduled by') ?>
-                <%-cvApproverUserName%> <?= tc(/*i18n: In the sentence Scheduled by USERNAME for DATE/TIME*/
-                    'ScheduledByFor', ' for ') ?> <%-cvPublishDate%></p>
+            <p><?= t('Scheduled by') ?> <%-cvApproverUserName%>
+                <% if (cvPublishDate && cvPublishEndDate) { %>
+                    <?= tc(/*i18n: In the sentence Scheduled by USERNAME between DATE/TIME and DATE/TIME*/'ScheduledDate', 'between %s and %s', '<%-cvPublishDate%>', '<%-cvPublishEndDate%>') ?>
+                <% } else if (cvPublishDate) { %>
+                    <?= tc(/*i18n: In the sentence Scheduled by USERNAME for DATE/TIME*/'ScheduledDate', 'for %s', '<%-cvPublishDate%>') ?>
+                <% } else if (cvPublishEndDate) { %>
+                    <?= tc(/*i18n: In the sentence Scheduled by USERNAME to close on DATE/TIME*/'ScheduledDate', 'to close on %s', '<%-cvPublishEndDate%>') ?>
+                <% } %>
+            </p>
             <% } %>
         </div>
         <div class="ccm-popover-inverse popover fade" data-menu="ccm-panel-page-versions-version-menu-<%-cvID%>">
@@ -239,14 +245,18 @@ defined('C5_EXECUTE') or die('Access Denied.');
                             'name': 'cvID',
                             'value': cvID
                         }], function (r) {
-                            ConcreteAlert.notify({
-                                'message': r.message
-                            });
-                            ConcretePageVersionList.handleVersionUpdateResponse(r);
-                            ConcreteEvent.publish('PageVersionChanged.unapproved', {
-                                cID: <?= (int)$c->getCollectionID() ?>,
-                                cvID: cvID
-                            });
+                            if (r.redirectURL) {
+                                window.location.href = r.redirectURL;
+                            } else {
+                                ConcreteAlert.notify({
+                                    'message': r.message
+                                });
+                                ConcretePageVersionList.handleVersionUpdateResponse(r);
+                                ConcreteEvent.publish('PageVersionChanged.unapproved', {
+                                    cID: <?= (int)$c->getCollectionID() ?>,
+                                    cvID: cvID
+                                });
+                            }
                         });
                         break;
                     case 'duplicate':


### PR DESCRIPTION
Original issue: #9794

I added the button to canceling page publish scheduling on #8311

This button will call `\Concrete\Core\Page\Collection\Version\Version::deny()` function.
I expected this function to disapprove the specific version because it exists in the `Version` class, but unexpectedly, it disapproves all versions of the page.

I think it was fine when we didn't have a scheduling function before, but now we shouldn't unapprove all of the versions because some of them will appear in the future or are already published.

For example, you have "Version 1" which is already published. Then you added the "Version 2" scheduled to be published in the future. But you cancel the new scheduled version due to some mistake. If we can deny the recent version only, "Version 1" is still public as you expected. Fine.

So, I tried to fix `Version::deny()` to deny itself and avoid disapproving all.
However, I found I can't do it.

The reason is `avoidApprovalOverlapping()` function introduced by @mlocati on #7238 .
This function changes all older versions when we set schedules for the recent version.
That's why we can't cancel scheduling as we expected.

Back to the example case. The page will be unpublished after you cancel "Version 2", because "Version 1" was already set to close at the time "Version 2" will be published. We lost information about when "Version 1" was originally scheduled (or not scheduled).

IMO, we shouldn't change the history of page versions. I can't trust version history if it changes unexpectedly.
I know we have to discuss what is the best, and we shouldn't change functionality a lot in the `8.5.x` branch.
So I decide to improve the confusing user interface and messages.


## Before merge

You can cancel scheduling, but you may not notice this page has been unpublished completely.

https://user-images.githubusercontent.com/514294/134492857-d4213b4a-91e0-4122-910d-513b5319e32d.mov

You may expect only Version 2 has been unapproved, but all versions have been unapproved actually.

https://user-images.githubusercontent.com/514294/134493008-f23962b5-b3ce-4509-a081-751bd2c71b26.mov


## After merge

https://user-images.githubusercontent.com/514294/134493656-4ac0a5f5-6195-432f-88af-520a7bd8492b.mov

* Versions panel now displays Publish End Date
* Reload page when you unapprove the version
* Notification message now tells you visitors can't see this page if all versions are unapproved.

