### PR TITLE
[V9 RC] Fix #9834

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -55,7 +55,9 @@ class UrlSlugCorePageProperty extends CorePageProperty
     public function getRequestValue($args = false)
     {
         $data = parent::getRequestValue($args);
-        $data['url_slug'] = Core::make('helper/security')->sanitizeString($data['url_slug']);
+        if(isset($data['url_slug'])) {
+            $data['url_slug'] = Core::make('helper/security')->sanitizeString($data['url_slug']);
+        }
 
         return $data;
     }


### PR DESCRIPTION
Since it is sanitized in UrlSlugCorePageProperty::getRequestValue() and the undefined is replaced with blank strings, the
Change it to sanitize only if it is defined.

[Behaviors that are considered to be expected]
Composer's URL Slug will not send fields if they are not updated.
The null is set in UrlSlugCorePageProperty::publishToPage(), and the current handle is used in HandleGenerator::generate() in Page::update().
