### PR TITLE
[v9rc4] Add php 8.1 testing (allow failures)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,6 +23,7 @@ jobs:
           - 3306:3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
+      continue-on-error: ${{ matrix.php-version == '8.1' }}
       matrix:
         php-version:
           - "7.3"
@@ -44,6 +45,9 @@ jobs:
             operating-system: "ubuntu-latest"
             dependencies: "locked"
             composer: "composer:v1, prestissimo"
+          - php-version: 8.1
+            operating-system: "ubuntu-latest"
+            dependencies: "locked"
 
     steps:
       - name: "Checkout"
@@ -79,8 +83,6 @@ jobs:
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
         run: |
-          composer install --no-interaction --no-progress --no-suggest
-          # Run twice for mediawiki merge
           composer update --no-interaction --no-progress --no-suggest
 
       - name: "Install locked dependencies"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       LC_ALL: en_US.UTF-8
       CODE_COVERAGE: n
+    continue-on-error: ${{ matrix.php-version == '8.1' }}
 
     runs-on: ${{ matrix.operating-system }}
     services:
@@ -23,7 +24,6 @@ jobs:
           - 3306:3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
-      continue-on-error: ${{ matrix.php-version == '8.1' }}
       matrix:
         php-version:
           - "7.3"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -89,11 +89,17 @@ jobs:
         if: ${{ matrix.dependencies == 'locked' }}
         run: |
           composer install --no-interaction --no-progress --no-suggest
+        # Since continue on error still marks a job as failed.
+        # We also have to add continue-on-error here so it doesnt X the whole build
+        # See https://github.com/actions/toolkit/issues/399
+        continue-on-error: ${{ matrix.php-version == '8.1' }}
 
 
       - name: "Tests"
         if: env.CODE_COVERAGE == 'n'
         run: php ./concrete/vendor/phpunit/phpunit/phpunit
+        # Same as above
+        continue-on-error: ${{ matrix.php-version == '8.1' }}
 
       - name: "Tests with coverage"
         if: env.CODE_COVERAGE == 'y'


### PR DESCRIPTION
This PR adds testing for 8.1 and allows it fail
It also removes the unnecessary composer install before composer update in highest dependencies

Due to continue-on-error still marking builds as failed I had to add it in a few more steps.
See : https://github.com/actions/toolkit/issues/399

This means that if the 8.1 builds fail it doesn't show up as a red X until GitHub introduce actual allowed failures