### PR TITLE
Re-implemented Remove Unvalidated Users Task

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1104,6 +1104,14 @@ return [
              */
             'validate_email' => false,
 
+            /**
+             * Threshold in seconds to delete unvalidated users
+             *
+             * @see \Concrete\Core\Command\Task\Controller\RemoveUnvalidatedUsersController
+             * @var int Seconds
+             */
+            'validate_email_threshold' => 5184000, // 60 days
+
             /*
              * Admins approve each registration
              *

--- a/concrete/config/install/base/tasks.xml
+++ b/concrete/config/install/base/tasks.xml
@@ -11,6 +11,7 @@
         <task handle="process_email" package=""/>
         <task handle="update_statistics" package=""/>
         <task handle="remove_old_file_attachments" package=""/>
+        <task handle="remove_unvalidated_users" package=""/>
     </tasks>
     <tasksets>
         <taskset handle="maintenance" name="Maintenance" package="">
@@ -28,6 +29,7 @@
             <task handle="check_automated_groups"/>
             <task handle="deactivate_users"/>
             <task handle="process_email"/>
+            <task handle="remove_unvalidated_users"/>
         </taskset>
     </tasksets>
 

--- a/concrete/src/Command/EmptyResultCommand.php
+++ b/concrete/src/Command/EmptyResultCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Command;
+
+use Concrete\Core\Foundation\Command\Command;
+
+class EmptyResultCommand extends Command
+{
+
+}

--- a/concrete/src/Command/EmptyResultCommandHandler.php
+++ b/concrete/src/Command/EmptyResultCommandHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Concrete\Core\Command;
+
+class EmptyResultCommandHandler
+{
+    public function __invoke(EmptyResultCommand $command)
+    {
+    }
+}

--- a/concrete/src/Command/Task/Controller/RemoveUnvalidatedUsersController.php
+++ b/concrete/src/Command/Task/Controller/RemoveUnvalidatedUsersController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Concrete\Core\Command\Task\Controller;
+
+use Concrete\Core\Command\Batch\Batch;
+use Concrete\Core\Command\EmptyResultCommand;
+use Concrete\Core\Command\Task\Input\InputInterface;
+use Concrete\Core\Command\Task\Runner\BatchProcessTaskRunner;
+use Concrete\Core\Command\Task\Runner\CommandTaskRunner;
+use Concrete\Core\Command\Task\Runner\TaskRunnerInterface;
+use Concrete\Core\Command\Task\TaskInterface;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\User\Command\DeleteUserCommand;
+
+defined('C5_EXECUTE') or die("Access Denied.");
+
+class RemoveUnvalidatedUsersController extends AbstractController
+{
+    /**
+     * @var Connection
+     */
+    protected $db;
+
+    public function __construct(Connection $db)
+    {
+        $this->db = $db;
+    }
+
+    public function getName(): string
+    {
+        return t('Remove Unvalidated Users');
+    }
+
+    public function getDescription(): string
+    {
+        return t('Remove users who never validate their email address long time.');
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getTaskRunner(TaskInterface $task, InputInterface $input): TaskRunnerInterface
+    {
+        $config = app('config');
+        if ($config->get('concrete.user.registration.type') === 'validate_email') {
+            $threshold = $config->get('concrete.user.registration.validate_email_threshold');
+            if ($threshold) {
+                $thresholdDateTime = new \DateTime();
+                $thresholdDateTime->sub(new \DateInterval('PT' . $threshold . 'S'));
+                $qb = $this->db->createQueryBuilder();
+                // Get users recently registered but not validated and also not signed in yet.
+                $result = $qb->select('u.uID')
+                    ->from('Users', 'u')
+                    ->andWhere('u.uIsValidated = :uIsValidated')
+                    ->setParameter('uIsValidated', false)
+                    ->andWhere('u.uNumLogins = :uNumLogins')
+                    ->setParameter('uNumLogins', 0)
+                    ->andWhere($qb->expr()->comparison(
+                        'u.uDateAdded',
+                        '<',
+                        $qb->createNamedParameter($thresholdDateTime->format('Y-m-d H:i:s'))
+                    ))
+                    ->execute();
+
+                if ($result->rowCount() > 0) {
+                    $batch = Batch::create();
+                    while ($row = $result->fetch()) {
+                        $batch->add(new DeleteUserCommand($row['uID']));
+                    }
+                    return new BatchProcessTaskRunner($task, $batch, $input, t('Removing invalidated users...'));
+                }
+            }
+        }
+
+        return new CommandTaskRunner($task, new EmptyResultCommand(), t('No invalidated users found.'));
+    }
+
+}

--- a/concrete/src/Command/Task/Manager.php
+++ b/concrete/src/Command/Task/Manager.php
@@ -8,6 +8,7 @@ use Concrete\Core\Command\Task\Controller\DeactivateUsersController;
 use Concrete\Core\Command\Task\Controller\GenerateSitemapController;
 use Concrete\Core\Command\Task\Controller\ProcessEmailController;
 use Concrete\Core\Command\Task\Controller\ReindexContentController;
+use Concrete\Core\Command\Task\Controller\RemoveUnvalidatedUsersController;
 use Concrete\Core\Command\Task\Controller\RemoveOldFileAttachmentsController;
 use Concrete\Core\Command\Task\Controller\RemoveOldPageVersionsController;
 use Concrete\Core\Command\Task\Controller\RescanFilesController;
@@ -67,6 +68,11 @@ class Manager extends CoreManager
     public function createRemoveOldFileAttachmentsDriver()
     {
         return $this->container->make(RemoveOldFileAttachmentsController::class);
+    }
+
+    public function createRemoveUnvalidatedUsersDriver()
+    {
+        return $this->container->make(RemoveUnvalidatedUsersController::class);
     }
 
     public function __construct(Application $app)

--- a/concrete/src/Updater/Migrations/Migrations/Version20210926120638.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210926120638.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Command\Task\TaskSetService;
+use Concrete\Core\Entity\Automation\Task;
+use Concrete\Core\Entity\Automation\TaskSet;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class Version20210926120638 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function upgradeDatabase()
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $this->app->make(EntityManagerInterface::class);
+        $task = $entityManager->getRepository(Task::class)->findOneByHandle('remove_unvalidated_users');
+        if (!$task) {
+            $task = new Task();
+            $task->setHandle('remove_unvalidated_users');
+            $entityManager->persist($task);
+            $entityManager->flush();
+            /** @var TaskSetService $taskSetService */
+            $taskSetService = $this->app->make(TaskSetService::class);
+            /** @var TaskSet $taskSet */
+            $taskSet = $taskSetService->getByHandle('user_groups');
+            if ($taskSet && !$taskSetService->taskSetContainsTask($taskSet, $task)) {
+                $taskSetService->addTaskToSet($task, $taskSet);
+            }
+        }
+    }
+}

--- a/concrete/src/User/Command/DeleteUserCommand.php
+++ b/concrete/src/User/Command/DeleteUserCommand.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Concrete\Core\User\Command;
+
+class DeleteUserCommand extends UserCommand
+{
+
+}

--- a/concrete/src/User/Command/DeleteUserCommandHandler.php
+++ b/concrete/src/User/Command/DeleteUserCommandHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Concrete\Core\User\Command;
+
+use Concrete\Core\Command\Task\Output\OutputAwareInterface;
+use Concrete\Core\Command\Task\Output\OutputAwareTrait;
+use Concrete\Core\User\UserInfoRepository;
+
+class DeleteUserCommandHandler implements OutputAwareInterface
+{
+    use OutputAwareTrait;
+
+    /** @var UserInfoRepository */
+    protected $repository;
+
+    /**
+     * @param UserInfoRepository $repository
+     */
+    public function __construct(UserInfoRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param DeleteUserCommand $command
+     */
+    public function __invoke(DeleteUserCommand $command)
+    {
+        $this->output->write(t('Deleting user ID: %s', $command->getUserID()));
+        $user = $this->repository->getByID($command->getUserID());
+        if ($user) {
+            if ($user->delete() === false) {
+                $this->output->write(t('Deleting user %s has been canceled...', $command->getUserID()));
+            }
+        } else {
+            $this->output->write(t('Userinfo object for ID %s not found. Skipping...', $command->getUserID()));
+        }
+    }
+}


### PR DESCRIPTION
Previous PR: #8962 and #8089
Original Issue: #7555

FYI: Some other tasks that can make an empty batch like "Check Automated Groups" also be able to break the activity page.
We should avoid making an empty batch and return EmptyResultCommand instead.