### PR TITLE
Fix some missing prefixes

### DIFF
--- a/concrete/src/Application/UserInterface/Menu/Item/Controller.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Controller.php
@@ -41,10 +41,10 @@ class Controller extends AbstractController implements ControllerInterface
         if ($icon_str) {
             $icon = new Element('i');
             /*
-             * Allows menu items to set icons with full FA spec such as fas and far
+             * Allows menu items to set icons with full FA spec such as fas,far...fab
              * Defaults to prior behaviour of prefixing if full FA spec is not specified
              */
-            if(preg_match("/\b(fa|fas|far)\b/",$icon_str)){
+            if(preg_match("/\b(fa|fas|far|fal|fad|fab)\b/",$icon_str)){
                 $icon->addClass($icon_str);
             } else {
                 $icon->addClass('fa fa-' . $icon_str);


### PR DESCRIPTION
The first pull missed some prefixes. This allows the whole group, free and pro.

Thoughts triggered by discussion in https://github.com/concrete5/concrete5/pull/9835, so original fix will now be out of date.
