### PR TITLE
[Enhancement] Notify when Advanced Permission is turned off, before enabling Multiple site

### DIFF
--- a/concrete/single_pages/dashboard/system/multisite/settings.php
+++ b/concrete/single_pages/dashboard/system/multisite/settings.php
@@ -23,6 +23,13 @@ if ($service->isMultisiteEnabled()) {
             <div class="alert alert-danger">
                 <?= t('You must enable multiple site hosting before you can access multiple sites or site types.') ?>
             </div>
+        <?php
+        } else if (Config::get('concrete.permissions.model') == 'simple') {
+        ?>
+            <div class="alert alert-info">
+                <?= t('Advanced permissions are turned off.') ?>
+                <?= t('You must enable Advanced permissions before you enable multiple site hosting.') ?>
+            </div>
         <?php } else { ?>
             <p><?= t('Multiple sites are not currently enabled. Enable them below.') ?></p>
         <?php } ?>


### PR DESCRIPTION
Since Multiple site requires Advanced Permission, it is recommended to check Advanced Permission is enabled.

If Advanced Permission is off, a message "**Advanced permissions are turned off.**" and "**You must enable Advanced permissions before you enable multiple site hosting.**" will be displayed.
