### PR TITLE
Don't pass null argument when express entity is null.

### DIFF
--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -115,15 +115,17 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         if ($form) {
             $express = \Core::make('express');
-            $controller = $express->getEntityController($entity);
-            $factory = new ContextFactory($controller);
-            $context = $factory->getContext(new FrontendViewContext());
-            $renderer = new Renderer(
-                $context,
-                $form
-            );
+            if(is_object($entity)){
+                $controller = $express->getEntityController($entity);
+                $factory = new ContextFactory($controller);
+                $context = $factory->getContext(new FrontendViewContext());
+                $renderer = new Renderer(
+                    $context,
+                    $form
+                );
 
-            $this->set('renderer', $renderer);
+                $this->set('renderer', $renderer);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes  `Argument 1 passed to Concrete\Core\Express\ObjectManager::getEntityController() must be an instance of Concrete\Core\Entity\Express\Entity, null given`error when entity is null.