### PR TITLE
Upgrade translation-library from 1.6.0 to 1.7.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5824,16 +5824,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5-community/translation-library.git",
-                "reference": "4caccae6c1e28edbdccc619c527bd42dbedec331"
+                "reference": "1ecd6d3d0addf2406ca3992ee22f2351310ff0ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5-community/translation-library/zipball/4caccae6c1e28edbdccc619c527bd42dbedec331",
-                "reference": "4caccae6c1e28edbdccc619c527bd42dbedec331",
+                "url": "https://api.github.com/repos/concrete5-community/translation-library/zipball/1ecd6d3d0addf2406ca3992ee22f2351310ff0ad",
+                "reference": "1ecd6d3d0addf2406ca3992ee22f2351310ff0ad",
                 "shasum": ""
             },
             "require": {
@@ -5875,7 +5875,7 @@
                 "issues": "https://github.com/concrete5-community/translation-library/issues",
                 "source": "https://github.com/concrete5-community/translation-library"
             },
-            "time": "2020-04-21T10:13:21+00:00"
+            "time": "2021-11-01T20:41:15+00:00"
         },
         {
             "name": "mlocati/ip-lib",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -75,7 +75,7 @@
     "tedivm/stash": "0.16.*",
     "lusitanian/oauth": "0.8.*",
     "concrete5/oauth-user-data": "~1.0",
-    "mlocati/concrete5-translation-library": "^1.6.0",
+    "mlocati/concrete5-translation-library": "^1.7.0",
     "mlocati/ip-lib": "^1.17.0",
     "league/url": "~3.3.5",
     "concrete5/doctrine-xml": "^1.2.0",


### PR DESCRIPTION
Translation library 1.7.0 now fully supports concrete cms v9.