### PR TITLE
Bugfix: wrong count for root dashboard page

### DIFF
--- a/concrete/elements/panels/dashboard.php
+++ b/concrete/elements/panels/dashboard.php
@@ -16,10 +16,10 @@ $favoritesMenu = Element::get('dashboard/navigation/panel/favorites');
 $section = null;
 if ($dashboard->inDashboard($c)) {
     $parents = array_reverse(app(\Concrete\Core\Html\Service\Navigation::class)->getTrailToCollection($c));
-    if (count($parents) === 0) {
+    if (count($parents) == 0) {
         $section = $c;
     } else {
-        $section = $parents[1];
+        $section = $parents[0];
     }
 } else if ($account->inMyAccount($c)) {
     $section = \Concrete\Core\Page\Page::getByPath('/dashboard/welcome');

--- a/concrete/elements/panels/dashboard.php
+++ b/concrete/elements/panels/dashboard.php
@@ -16,7 +16,7 @@ $favoritesMenu = Element::get('dashboard/navigation/panel/favorites');
 $section = null;
 if ($dashboard->inDashboard($c)) {
     $parents = array_reverse(app(\Concrete\Core\Html\Service\Navigation::class)->getTrailToCollection($c));
-    if (count($parents) == 0) {
+    if (count($parents) === 0) {
         $section = $c;
     } else {
         $section = $parents[0];

--- a/concrete/elements/panels/dashboard.php
+++ b/concrete/elements/panels/dashboard.php
@@ -16,7 +16,7 @@ $favoritesMenu = Element::get('dashboard/navigation/panel/favorites');
 $section = null;
 if ($dashboard->inDashboard($c)) {
     $parents = array_reverse(app(\Concrete\Core\Html\Service\Navigation::class)->getTrailToCollection($c));
-    if (count($parents) == 1) {
+    if (count($parents) === 0) {
         $section = $c;
     } else {
         $section = $parents[1];


### PR DESCRIPTION
Currently when you try to login, it will error because there are no parents available and we check if there is 1 parent, which is not correct due to the else statement.