### PR TITLE
[v8] Avoid Call to a member function setEntryDisplayOrder() on null

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/express/entities/order_entries.php
+++ b/concrete/controllers/single_page/dashboard/system/express/entities/order_entries.php
@@ -35,9 +35,11 @@ class OrderEntries extends DashboardPageController
             $displayOrder = 0;
             foreach($this->request->request->get('entry') as $entryID) {
                 $entry = $this->entityManager->find('Concrete\Core\Entity\Express\Entry', $entryID);
-                $entry->setEntryDisplayOrder($displayOrder);
-                $this->entityManager->persist($entry);
-                $displayOrder++;
+                if ($entry) {
+                    $entry->setEntryDisplayOrder($displayOrder);
+                    $this->entityManager->persist($entry);
+                    $displayOrder++;
+                }
             }
             $this->entityManager->flush();
             $this->flash('success', t('Display order updated successfully.'));


### PR DESCRIPTION
One of our clients deleted an express entry just before reordering the entries and got this exception!
