### PR TITLE
Fix #10069

### DIFF
--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -973,7 +973,6 @@ abstract class Package implements LocalizablePackageInterface
             $app = ApplicationFacade::getFacadeApplication();
             $db = $app->make(Connection::class);
             /* @var Connection $db */
-            $db->beginTransaction();
 
             $parser = Schema::getSchemaParser(simplexml_load_file($xmlFile));
             $parser->setIgnoreExistingTables(false);
@@ -984,11 +983,14 @@ abstract class Package implements LocalizablePackageInterface
             $schemaDiff = $comparator->compare($fromSchema, $toSchema);
             $saveQueries = $schemaDiff->toSaveSql($db->getDatabasePlatform());
 
-            foreach ($saveQueries as $query) {
-                $db->query($query);
-            }
-            if ($db->isTransactionActive() && !$db->isAutoCommit()) {
-                $db->commit();
+            if (count($saveQueries)) {
+                $db->beginTransaction();
+                foreach ($saveQueries as $query) {
+                    $db->query($query);
+                }
+                if ($db->isTransactionActive() && !$db->isAutoCommit()) {
+                    $db->commit();
+                }
             }
 
             $result = new stdClass();


### PR DESCRIPTION
Fixes #10069 – something about the new auto commit detection breaks block reinstallation if the block database table already exists in the table and there are no queries to run. The way to fix this I think is to only start a transaction and commit it if there are actual queries to run. 