### PR TITLE
Rehash passwords when needed

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1156,8 +1156,29 @@ return [
             'required_upper_case' => 0,
             'reuse' => 0,
             'custom_regex' => [],
+
+            /**
+             * Using PASSWORD_DEFAULT means that we will automatically switch to better algorithms when they are available.
+             * Keep in mind hash_options are different depending on the algorithm specified
+             * @see https://www.php.net/manual/en/password.constants.php
+             */
+            'hash_algorithm' => PASSWORD_DEFAULT,
+            'hash_options' => [
+                // 'cost' => '12', // Bcrypt cost
+                // 'memory_cost' => '1024', // Argon2 memory cost in bytes
+                // 'time_cost' => '10', // Argon2 time cost in milliseconds
+            ],
+
+            /**
+             * @deprecated This setting is no longer used by the core.
+             */
             'hash_portable' => false,
+
+            /**
+             * @deprecated This setting is no longer used by the core, use hash_options instead.
+             */
             'hash_cost_log2' => 12,
+
             'legacy_salt' => '',
         ],
         'email' => [

--- a/concrete/src/Api/OAuth/Controller.php
+++ b/concrete/src/Api/OAuth/Controller.php
@@ -186,6 +186,21 @@ final class Controller implements LoggerAwareInterface
 
             // User successfully logged in
             if ($user && $user->getUserID() && $hasher->checkPassword($password, $user->getUserPassword())) {
+                if ($hasher->needsRehash($user->getUserPassword())) {
+                    $em = $app->make(EntityManagerInterface::class);
+
+                    try {
+                        $em->transactional(function () use ($user, $hasher, $password) {
+                            $user->setUserPassword($hasher->hashPassword($password));
+                        });
+                    } catch (\Throwable $e) {
+                        $this->logger->emergency('Unable to rehash password for user {user} ({id}): {message}', [
+                            'user' => $user->getUserName(),
+                            'id' => $user->getUserID(),
+                            'message' => $e->getMessage(),
+                        ]);
+                    }
+                }
 
                 $userInfo = $this->entityManager->find(User::class, $user->getUserID());
                 $request->setUser($userInfo);

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -49,6 +49,7 @@ class User implements UserEntityInterface, \JsonSerializable
     protected $uEmail;
 
     /**
+     * 255 is the recommended width according to https://www.php.net/manual/en/password.constants.php
      * @ORM\Column(type="string", length=255)
      */
     protected $uPassword;

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -23,6 +23,8 @@ use Concrete\Core\User\Group\GroupRepository;
 use Concrete\Core\User\Group\GroupRole;
 use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Encryption\PasswordHasher;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 
 class User extends ConcreteObject
 {
@@ -195,7 +197,29 @@ class User extends ConcreteObject
                     $pw_is_valid_legacy = ($config->get(
                             'concrete.user.password.legacy_salt'
                         ) && self::legacyEncryptPassword($password) == $row['uPassword']);
+
                     $pw_is_valid = $pw_is_valid_legacy || $hasher->checkPassword($password, $row['uPassword']);
+                    if ($pw_is_valid && $hasher->needsRehash($row['uPassword'])) {
+                        $em = $app->make(EntityManagerInterface::class);
+
+                        try {
+                            $em->transactional(function (EntityManagerInterface $em) use ($hasher, $password, $row) {
+                                $user = $em->find(\Concrete\Core\Entity\User\User::class, $row['uID']);
+                                if (!$user) {
+                                    throw new \RuntimeException('User not found.');
+                                }
+
+                                $user->setUserPassword($hasher->hashPassword($password));
+                            });
+                        } catch (\Throwable $e) {
+                            $app->make(LoggerInterface::class)->emergency('Unable to rehash password for user {user} ({id}): {message}', [
+                                'user' => $row['uName'],
+                                'id' => $row['uID'],
+                                'message' => $e->getMessage(),
+                            ]);
+                        }
+                    }
+
                     if ($row['uID'] && $row['uIsValidated'] === '0' && $config->get(
                             'concrete.user.registration.validate_email'
                         )) {
@@ -225,12 +249,6 @@ class User extends ConcreteObject
                         $this->loadError(USER_INACTIVE);
                     } else {
                         $this->loadError(USER_INVALID);
-                    }
-                    if ($pw_is_valid_legacy) {
-                        // this password was generated on a previous version of Concrete5.
-                        // We re-hash it to make it more secure.
-                        $v = [$hasher->hashPassword($password), $this->uID];
-                        $db->execute($db->prepare('update Users set uPassword = ? where uID = ?'), $v);
                     }
                 } else {
                     $this->loadError(USER_INVALID);

--- a/tests/tests/Encryption/PasswordHasherTest.php
+++ b/tests/tests/Encryption/PasswordHasherTest.php
@@ -13,7 +13,7 @@ class PasswordHasherTest extends TestCase
 {
 
     private function hasher(
-        string $algorithm = PASSWORD_BCRYPT,
+        $algorithm = PASSWORD_BCRYPT,
         ?int $cost = null,
         array $hashOptions = [],
         bool $portable = false

--- a/tests/tests/Encryption/PasswordHasherTest.php
+++ b/tests/tests/Encryption/PasswordHasherTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Encryption;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Encryption\PasswordHasher;
+use Concrete\Core\Legacy\PasswordHash;
+use Concrete\Tests\TestCase;
+
+class PasswordHasherTest extends TestCase
+{
+
+    private function hasher(
+        string $algorithm = PASSWORD_BCRYPT,
+        ?int $cost = null,
+        array $hashOptions = [],
+        bool $portable = false
+    ) {
+        $config = \Mockery::mock(Repository::class);
+
+        $config->shouldReceive('get')->with('concrete.user.password.hash_algorithm')->andReturn($algorithm);
+        $config->shouldReceive('get')->with('concrete.user.password.hash_options', [])->andReturn($hashOptions);
+        $config->shouldReceive('get')->with(
+            'concrete.user.password.hash_cost_log2',
+            PASSWORD_BCRYPT_DEFAULT_COST
+        )->andReturn($cost);
+        $config->shouldReceive('get')->with('concrete.user.password.hash_portable')->andReturn($portable);
+
+        return new PasswordHasher($config);
+    }
+
+    /**
+     * @dataProvider portableHashes
+     */
+    public function testPortableHashesSucceed(string $password, string $hash)
+    {
+        $this->assertTrue($this->hasher()->checkPassword($password, $hash));
+    }
+
+    /**
+     * @dataProvider bcryptHashes
+     */
+    public function testBcryptHashesSucceed(string $password, string $hash)
+    {
+        $this->assertTrue($this->hasher()->checkPassword($password, $hash));
+    }
+
+    /**
+     * @dataProvider argon2IHashes
+     */
+    public function testArgon2IHashesSucceed(string $password, string $hash)
+    {
+        $this->assertTrue($this->hasher()->checkPassword($password, $hash));
+    }
+
+    /**
+     * @dataProvider argon2IDHashes
+     */
+    public function testArgon2IDHashesSucceed(string $password, string $hash)
+    {
+        $this->assertTrue($this->hasher()->checkPassword($password, $hash));
+    }
+
+    /**
+     * @dataProvider portableHashes
+     */
+    public function testPortableRehash(string $password, string $hash)
+    {
+        $this->assertTrue($this->hasher()->needsRehash($hash));
+    }
+
+    /**
+     * @dataProvider bcryptHashes
+     */
+    public function testBcryptRehash(string $password, string $hash)
+    {
+        [, $cost,] = explode('$', $hash);
+        if (strpos('$2y', $hash) === 0) {
+            // Normal PHP Bcrypt passwords
+            $this->assertFalse($this->hasher(PASSWORD_BCRYPT, 0, ['cost' => (int) $cost])->needsRehash($hash));
+        } else {
+            // phpass Bcrypt passwords
+            $this->assertTrue($this->hasher(PASSWORD_BCRYPT, 0, ['cost' => (int) $cost])->needsRehash($hash));
+        }
+
+        // Make sure we _do_ rehash when a different algorithm is selected
+        $this->assertTrue($this->hasher(PASSWORD_ARGON2I)->needsRehash($hash));
+    }
+
+    /**
+     * @dataProvider argon2IHashes
+     */
+    public function testArgonPasswordRehash(string $password, string $hash)
+    {
+        $this->assertFalse($this->hasher(PASSWORD_ARGON2I)->needsRehash($hash));
+        $this->assertTrue($this->hasher(PASSWORD_BCRYPT)->needsRehash($hash));
+    }
+
+    private function testPasswords(): array
+    {
+        return [
+            'test' => [
+                '$P$8g.Za0pIMib3iN5n67qPPdcsO4SOEP.',
+                '$2y$10$pWumkN0.3qMv2tKrUI.T6uJZTM3yh74pF1dT9bnXBBEco4tXMjGrS',
+                '$argon2i$v=19$m=65536,t=4,p=1$cXl0SWpIQ1FrekdkclJjNg$Co3gyfUDrORD2dHDcmgLtc06HSwEQVXpCDPsbtwCLrA',
+                '$argon2id$v=19$m=65536,t=4,p=1$UDlRQUhlZUFUTzdScWh3aQ$JgLJV6aSjDCZcteay2yIbA8WwoVOHr7lxcnbSl1H+sY',
+            ],
+            'foobar' => [
+                '$P$88oBskqXEWX7rOxrCyNaDok5B/oN3C1',
+                '$2y$10$10q/v3k7mo0Z8h7JIPpEvOlsgs8i7AxGVwWbEHBfc3.Qv/YYJ7jCe',
+                '$argon2i$v=19$m=65536,t=4,p=1$QmphTXpjdzF5a3hvYXdHcA$FlmL/MDZhgH7j36AlSEDaGcEEebU5GzJtoQ5zvFCUVE',
+                '$argon2id$v=19$m=65536,t=4,p=1$aE9iTk1mNFR4NVFzclQ5Rw$re30N5yfOepebPBGo/K7ZyBt+8B232Wblkqg7fmHNR0',
+            ],
+            '12342534634556394802458201394r578013947562358630-4586-2085-2385034786908345679034578602834512' => [
+                '$P$BuHyIFZwn/f/JEOqo3nh2kQKCRqGBg.',
+                '$2y$10$IC.ZoKeDI1zcctL1pSaLYOPH.QV6ohWAuRR5iXE.EYkqTkBldGQmW',
+                '$argon2i$v=19$m=65536,t=4,p=1$Qy4yQTRrRXFCWS9DeTdWcg$Uqp17XIJTdEI155pLeVcre6szpRtNBh2WZVianbfTyc',
+                '$argon2id$v=19$m=65536,t=4,p=1$Q292Q0R0MGMuZTRMSFZNUQ$wD8764iNx8RqIK5ca7WfmUOrAtm7CJU4e5b+wkVpXUI',
+            ],
+            '' => [
+                '$P$8r7Ap2g6hrAkULLh.YcklS9BSqHjVa/',
+                '$2y$10$/qciYxbCfqkhUvlEsViY7ec/ejn7N0lCqJ19z1hht2a.tXGYUU8uy',
+                '$argon2i$v=19$m=65536,t=4,p=1$L0FkNEEzSHFrZGwwQ3ZhRg$pKH2B/D/I+geZz8cuLzUsfPikdjaxRcA8iIKC7RyTC4',
+                '$argon2id$v=19$m=65536,t=4,p=1$U3VkcTgwamQxMzhtUGlaNA$QlqcO+MXAigKBMLbUHCzb9wJ/Vp5JzukRah9veONCnI',
+            ],
+        ];
+    }
+
+
+    public function portableHashes(): iterable
+    {
+        foreach ($this->testPasswords() as $password => $hashes) {
+            yield [$password, $hashes[0]];
+        }
+
+        $hasher = new PasswordHash(5, true);
+        foreach (array_keys($this->testPasswords()) as $password) {
+            yield [$password, $hasher->HashPassword($password)];
+        }
+    }
+
+    public function bcryptHashes(): iterable
+    {
+        foreach ($this->testPasswords() as $password => $hashes) {
+            yield [$password, $hashes[1]];
+        }
+
+        $hasher = new PasswordHash(5, false);
+        foreach (array_keys($this->testPasswords()) as $password) {
+            yield [$password, $hasher->HashPassword($password)];
+        }
+    }
+
+    public function argon2IHashes(): iterable
+    {
+        foreach ($this->testPasswords() as $password => $hashes) {
+            yield [$password, $hashes[2]];
+        }
+    }
+
+    public function argon2IDHashes(): iterable
+    {
+        foreach ($this->testPasswords() as $password => $hashes) {
+            yield [$password, $hashes[3]];
+        }
+    }
+
+}

--- a/tests/tests/Encryption/PasswordHasherTest.php
+++ b/tests/tests/Encryption/PasswordHasherTest.php
@@ -52,6 +52,10 @@ class PasswordHasherTest extends TestCase
      */
     public function testArgon2IHashesSucceed(string $password, string $hash)
     {
+        if (!defined('PASSWORD_ARGON2I')) {
+            $this->markTestSkipped('Argon2i is not available.');
+        }
+
         $this->assertTrue($this->hasher()->checkPassword($password, $hash));
     }
 
@@ -60,6 +64,10 @@ class PasswordHasherTest extends TestCase
      */
     public function testArgon2IDHashesSucceed(string $password, string $hash)
     {
+        if (!defined('PASSWORD_ARGON2ID')) {
+            $this->markTestSkipped('Argon2id is not available.');
+        }
+
         $this->assertTrue($this->hasher()->checkPassword($password, $hash));
     }
 


### PR DESCRIPTION
PHP has functionality to determine if a password hash matches expected hash settings, this gives us the ability to detect when hashes should be "upgraded" during the login procedure which makes it so users are always kept on the latest secure hash.

We did something similar in the past to support upgrading from legacy passwords to bcrypt passwords, this change takes it the full distance by upgrading bcrypt passwords as needed.

Some extra notes
- Cost makes sense still as long as you're sticking with bcrypt. However if you decide to use argon cost is no longer a logarithmic integer, it's a memory value or a time value. For this reason I've replaced the "hash_cost_log2" config item with a "hash_options" array that gets provided during password hashing / rehash checking. I made sure to keep `hash_cost_log2` if bcrypt is enabled and a cost isn't otherwise provided so backwards compatibility is maintained.
- `hash_portable` doesn't do anything any more
- We should eventually wrap password checking AND hash upgrading into its own class that uses the PasswordHasher and can handle the entire flow of validating a password and upgrading it safely. The reason is if someone were to accidentally rehash the password /before/ verifying the hash is correct they would essentially allow any password to be used for any account, so preventing this is important.
