### PR TITLE
Don't add spaces in meta_keywords attribute values

### DIFF
--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -48,8 +48,7 @@
               description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>add file, delete file, copy, move, alias, resize, crop, rename, images, title, attribute
-                    </value>
+                    <value>add file, delete file, copy, move, alias, resize, crop, rename, images, title, attribute</value>
                 </attributekey>
             </attributes>
         </page>
@@ -579,9 +578,7 @@
               description="Share content across your site." package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>stacks, global areas, reusable content, scrapbook, copy, paste, paste block, copy block, site
-                        name, logo
-                    </value>
+                    <value>stacks, global areas, reusable content, scrapbook, copy, paste, paste block, copy block, site name, logo</value>
                 </attributekey>
             </attributes>
 
@@ -616,9 +613,7 @@
               package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>add-on, addon, add on, package, app, ecommerce, discussions, forums, themes, templates,
-                        blocks
-                    </value>
+                    <value>add-on, addon, add on, package, app, ecommerce, discussions, forums, themes, templates, blocks</value>
                 </attributekey>
             </attributes>
         </page>
@@ -659,9 +654,7 @@
               pagetype="" description="Download add-ons from the marketplace." package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>buy addon, buy add on, buy add-on, purchase addon, purchase add on, purchase add-on, find
-                        addon, new addon, marketplace
-                    </value>
+                    <value>buy addon, buy add on, buy add-on, purchase addon, purchase add on, purchase add-on, find addon, new addon, marketplace</value>
                 </attributekey>
             </attributes>
         </page>
@@ -963,9 +956,7 @@
                     <value>1</value>
                 </attributekey>
                 <attributekey handle="meta_keywords">
-                    <value>thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick,
-                        transparency
-                    </value>
+                    <value>thumbnail, format, png, jpg, jpeg, quality, compression, gd, imagick, imagemagick, transparency</value>
                 </attributekey>
             </attributes>
         </page>
@@ -973,9 +964,7 @@
               filename="/dashboard/system/files/image_uploading.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>uploading, upload, images, image, resizing, manager, exif, rotation, rotate, quality,
-                        compression, png, jpg, jpeg
-                    </value>
+                    <value>uploading, upload, images, image, resizing, manager, exif, rotation, rotate, quality, compression, png, jpg, jpeg</value>
                 </attributekey>
             </attributes>
         </page>
@@ -1067,9 +1056,7 @@
               filename="/dashboard/system/optimization/cache.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>cache option, change cache, override, turn on cache, turn off cache, no cache, page cache,
-                        caching
-                    </value>
+                    <value>cache option, change cache, override, turn on cache, turn off cache, no cache, page cache, caching</value>
                 </attributekey>
             </attributes>
         </page>
@@ -1085,9 +1072,7 @@
               filename="/dashboard/system/optimization/jobs.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>index search, reindex search, build sitemap, sitemap.xml, clear old versions, page versions,
-                        remove old
-                    </value>
+                    <value>index search, reindex search, build sitemap, sitemap.xml, clear old versions, page versions, remove old</value>
                 </attributekey>
             </attributes>
         </page>
@@ -1281,9 +1266,7 @@
               filename="/dashboard/system/mail/importers.php" pagetype="" description="" package="">
             <attributes>
                 <attributekey handle="meta_keywords">
-                    <value>email server, mail settings, mail configuration, private message, message system, import,
-                        email, message
-                    </value>
+                    <value>email server, mail settings, mail configuration, private message, message system, import, email, message</value>
                 </attributekey>
             </attributes>
         </page>


### PR DESCRIPTION
They are useless, and translators may see odd translatable strings, like for example this one:

![immagine](https://user-images.githubusercontent.com/928116/143257559-3bc80c81-fc80-469f-86dc-72cb364422b0.png)
