### PR TITLE
Fix title of footer link to concretecms.org

### DIFF
--- a/concrete/themes/atomik/elements/footer.php
+++ b/concrete/themes/atomik/elements/footer.php
@@ -41,7 +41,7 @@ use Concrete\Core\Area\GlobalArea;
             <div class="row">
                 <div class="col-md-6">
                     <?=t('Copyright %s. ', date('Y'))?>
-                    <?php echo t('Built with <strong><a href="https://www.concretecms.org" class="Concrete CMS" rel="nofollow">Concrete CMS</a></strong>.') ?>
+                    <?php echo t('Built with <strong><a href="https://www.concretecms.org" title="Concrete CMS" rel="nofollow">Concrete CMS</a></strong>.') ?>
                 </div>
                 <div class="col-md-6 text-md-end">
                     <?php echo Core::make('helper/navigation')->getLogInOutLink() ?>


### PR DESCRIPTION
I guess we should have `title` instead of `class` here, right?