### PR TITLE
Fix position of caption in Language Details dialog

### DIFF
--- a/concrete/views/dialogs/language/update/details.php
+++ b/concrete/views/dialogs/language/update/details.php
@@ -6,7 +6,7 @@
 
 ?>
 <table class="table">
-    <caption><h4><?= t('Local translations file') ?></h4></caption>
+    <caption class="caption-top"><h4><?= t('Local translations file') ?></h4></caption>
     <tbody>
         <tr>
             <th><?= t('File path') ?></th>
@@ -23,7 +23,7 @@
     </tbody>
 </table>
 <table class="table">
-    <caption><h4><?= t('Remote translations file') ?></h4></caption>
+    <caption class="caption-top"><h4><?= t('Remote translations file') ?></h4></caption>
     <tbody>
         <tr>
             <th><?= t('Version') ?></th>


### PR DESCRIPTION
Before:

![immagine](https://user-images.githubusercontent.com/928116/143275158-b2ecf849-9eb6-4da3-80c0-6c54a4d81fb2.png)

After: 

![immagine](https://user-images.githubusercontent.com/928116/143275247-57673d09-a83d-49f4-beca-282c93c758c3.png)
