### PR TITLE
Don't translate strings in concrete:scheduler:run-dev CLI command

### DIFF
--- a/concrete/src/Console/Command/RunSchedulerInForegroundCommand.php
+++ b/concrete/src/Console/Command/RunSchedulerInForegroundCommand.php
@@ -21,7 +21,7 @@ class RunSchedulerInForegroundCommand extends Command
 
     public function handle()
     {
-        $this->output->writeln(t('Running the worker every minute...'));
+        $this->output->writeln('Running the worker every minute...');
         $command = $this->getApplication()->find('concrete:scheduler:run');
         while (true) {
             if (Carbon::now()->second === 0) {


### PR DESCRIPTION
1. none of the CLI command is translated at the moment
2. CLI commands are almost only for people with a technical knowledge (and techy people can often understand English)