### PR TITLE
Use base64 encoding and decoding on submitted tracking codes

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/seo/codes.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/codes.php
@@ -24,8 +24,8 @@ class Codes extends DashboardSitePageController
             return $this->view();
         }
         $config = $this->getSite()->getConfigRepository();
-        $config->save('seo.tracking.code.header', (string) $post->get('tracking_code_header'));
-        $config->save('seo.tracking.code.footer', (string) $post->get('tracking_code_footer'));
+        $config->save('seo.tracking.code.header', (string) base64_decode($post->get('tracking_code_header')));
+        $config->save('seo.tracking.code.footer', (string) base64_decode($post->get('tracking_code_footer')));
         PageCache::getLibrary()->flush();
         $this->flash('success', t('Tracking code settings updated successfully.') . "\n" . t('Cached files removed.'));
 

--- a/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/concrete/single_pages/dashboard/system/seo/codes.php
@@ -19,17 +19,42 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <div class="form-group">
         <?= $form->label('tracking_code_header', t('Header Tracking Codes')) ?>
-        <?= $form->textarea('tracking_code_header', $tracking_code_header, ['style' => 'height: 250px;', 'class' => 'form-control font-monospace', 'spellcheck' => 'false']) ?>
+        <?= $form->textarea('tracking_code_header_input', $tracking_code_header, ['style' => 'height: 250px;', 'class' => 'form-control font-monospace', 'spellcheck' => 'false']) ?>
+        <?= $form->hidden('tracking_code_header', '') ?>
     </div>
 
     <div class="form-group">
         <?= $form->label('tracking_code_footer', t('Footer Tracking Codes')) ?>
-        <?= $form->textarea('tracking_code_footer', $tracking_code_footer, ['style' => 'height: 250px;', 'class' => 'form-control font-monospace', 'spellcheck' => 'false']) ?>
+        <?= $form->textarea('tracking_code_footer_input', $tracking_code_footer, ['style' => 'height: 250px;', 'class' => 'form-control font-monospace', 'spellcheck' => 'false']) ?>
+        <?= $form->hidden('tracking_code_footer', '') ?>
     </div>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button type="submit" class="btn btn-primary float-end"><?= t('Save') ?></button>
+            <button type="submit" id="tracking-code-form-button" class="btn btn-primary float-end"><?= t('Save') ?></button>
         </div>
     </div>
 </form>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function(event) {
+        var trackingCodeForm = document.getElementById("tracking-code-form-button");
+        var trackingCodeHeaderInput = document.getElementById("tracking_code_header_input");
+        var trackingCodeFooterInput = document.getElementById("tracking_code_footer_input");
+        var trackingCodeHeader = document.getElementById("tracking_code_header");
+        var trackingCodeFooter = document.getElementById("tracking_code_footer");
+
+        trackingCodeForm.addEventListener("click", function(e) {
+            trackingCodeHeader.value = b64EncodeUnicode(trackingCodeHeaderInput.value);
+            trackingCodeHeaderInput.setAttribute("disabled", "disabled");
+            trackingCodeFooter.value = b64EncodeUnicode(trackingCodeFooterInput.value);
+            trackingCodeFooterInput.setAttribute("disabled", "disabled");
+        });
+    });
+
+    function b64EncodeUnicode(str) {
+        return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+            return String.fromCharCode('0x' + p1);
+        }));
+    }
+</script>

--- a/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/concrete/single_pages/dashboard/system/seo/codes.php
@@ -38,13 +38,13 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <script>
     document.addEventListener('DOMContentLoaded', function(event) {
-        var trackingCodeForm = document.getElementById("tracking-code-form-button");
+        var trackingCodeForm = document.getElementById("tracking-code-form");
         var trackingCodeHeaderInput = document.getElementById("tracking_code_header_input");
         var trackingCodeFooterInput = document.getElementById("tracking_code_footer_input");
         var trackingCodeHeader = document.getElementById("tracking_code_header");
         var trackingCodeFooter = document.getElementById("tracking_code_footer");
 
-        trackingCodeForm.addEventListener("click", function(e) {
+        trackingCodeForm.addEventListener("submit", function(e) {
             trackingCodeHeader.value = b64EncodeUnicode(trackingCodeHeaderInput.value);
             trackingCodeHeaderInput.setAttribute("disabled", "disabled");
             trackingCodeFooter.value = b64EncodeUnicode(trackingCodeFooterInput.value);

--- a/concrete/single_pages/dashboard/system/seo/codes.php
+++ b/concrete/single_pages/dashboard/system/seo/codes.php
@@ -31,7 +31,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <button type="submit" id="tracking-code-form-button" class="btn btn-primary float-end"><?= t('Save') ?></button>
+            <button type="submit" class="btn btn-primary float-end"><?= t('Save') ?></button>
         </div>
     </div>
 </form>


### PR DESCRIPTION
**What this does**
This change is for the Tracking Codes dashboard page at /dashboard/system/seo/codes.

On submit, the browser base 64 encodes both the header and footer data and submits those values, instead of the original scripts pasted in. To avoid showing the base 64 encoded values, the values are copied into hidden fields and the original input fields are disabled (so they won't be sent).

Server side, `base64_decode` is called on the submitted values, so that they are saved to the config as originally submitted. 

**Why is it needed**
This is needed to prevent Mod Security, installed on most cPanel systems, from being triggered when tracking codes are POSTed to the server. When Mod Security rules are triggered it will create a 403 forbidden response, and this is what is seen after hitting save.

I'd say that 50% of the time when I'm asked to add tracking codes to a site on cPanel, I can't do so because of Mod Rewrite blocking the request.

Whilst some cPanel installations allow you to disable Mod Security temporarily to allow tracking codes to be saved successfully, many/most don't, and instead you either have to:
- put in a support request to exclude whatever security rule is being triggered (which may change as further scripts are entered)
- directly edit the config file, escaping quotes, etc

Both approaches above are troublesome, but even before these you have to know _what_ has gone wrong with the 403 error to know what to do - such a response when saving codes simply looks like a bug.  

**Where else this is used**
I've used this same approach on a marketplace block, [Code Display](https://marketplace.concretecms.com/marketplace/addons/code-display), when saving the block. The block is used to display code snippets, scripts, etc, so is _very_ likely to trigger Mod Security rules. This base 64 encoding workaround has worked very well for this block, and I've had no reports of it mis-handling submitted code.