### PR TITLE
[V8] Bugfix: conversation blocks are synced if these added from master collection

### DIFF
--- a/concrete/controllers/dialog/block/aliasing.php
+++ b/concrete/controllers/dialog/block/aliasing.php
@@ -45,7 +45,12 @@ class Aliasing extends BackendInterfaceBlockController
 
                             $page = \Page::getByID($record['cID'], $record['cvID']);
                             if ($record['action'] == 'add_alias') {
-                                $this->block->alias($page);
+                                $bt = $b->getBlockTypeObject();
+                                if ($bt->isCopiedWhenPropagated()) {
+                                    $this->block->duplicate($page, true);
+                                } else {
+                                    $this->block->alias($page);
+                                }
                             } else if ($record['action'] == 'update_forked_alias') {
                                 $forked = \Block::getByID($record['bID'], $page, $record['arHandle']);
                                 if (is_object($forked) && !$forked->isError()) {


### PR DESCRIPTION
How to reproduce

https://user-images.githubusercontent.com/514294/144747991-87eeaecd-8bd2-42ac-a725-585c979385c8.mp4

How it fixed

https://user-images.githubusercontent.com/514294/144748000-7ca8d80f-833b-499f-9fb8-efa945b5beb4.mp4

