### PR TITLE
[V9] Bugfix: conversation blocks are synced if these added from master collection

### DIFF
--- a/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
+++ b/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
@@ -17,7 +17,12 @@ class AddAliasDefaultsBlockCommandHandler
             if ($mc && !$mc->isError()) {
                 $b = Block::getByID($command->getOriginalBlockID(), $mc, $command->getOriginalAreaHandle());
                 if ($b) {
-                    $b->alias($page);
+                    $bt = $b->getBlockTypeObject();
+                    if ($bt->isCopiedWhenPropagated()) {
+                        $b->duplicate($page, true);
+                    } else {
+                        $b->alias($page);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Same fix for V8: #10150

How to reproduce

https://user-images.githubusercontent.com/514294/144749482-04dddcc3-617d-4437-b558-6702d0a757bb.mp4

Fixed

https://user-images.githubusercontent.com/514294/144749493-d0bb8bed-d4df-4bc8-a199-cb8dbea2f5ac.mp4

