### PR TITLE
[v8] Throw InvalidAttributeException when attribute is not found

### DIFF
--- a/concrete/src/Attribute/Exception/InvalidAttributeException.php
+++ b/concrete/src/Attribute/Exception/InvalidAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Concrete\Core\Attribute\Exception;
+
+use Exception;
+
+class InvalidAttributeException extends Exception
+{
+
+}

--- a/concrete/src/Attribute/Exception/InvalidAttributeException.php
+++ b/concrete/src/Attribute/Exception/InvalidAttributeException.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Concrete\Core\Attribute\Exception;
 
 use Exception;
 
 class InvalidAttributeException extends Exception
 {
-
 }

--- a/concrete/src/Search/ItemList/Database/AttributedItemList.php
+++ b/concrete/src/Search/ItemList/Database/AttributedItemList.php
@@ -1,32 +1,18 @@
 <?php
+
 namespace Concrete\Core\Search\ItemList\Database;
 
 use Concrete\Core\Attribute\Exception\InvalidAttributeException;
 use Concrete\Core\Search\StickyRequest;
-use Database;
 
-abstract class  AttributedItemList extends ItemList
+abstract class AttributedItemList extends ItemList
 {
-
-    abstract protected function getAttributeKeyClassName();
-
-    /**
-     * Filters by a attribute.
-     * @throws InvalidAttributeException
-     */
-    public function filterByAttribute($handle, $value, $comparison = '=')
-    {
-        $ak = call_user_func_array(array($this->getAttributeKeyClassName(), 'getByHandle'), array($handle));
-        if (!is_object($ak)) {
-            throw new InvalidAttributeException(t('Unable to find attribute %s', $handle));
-        }
-        $ak->getController()->filterByAttribute($this, $value, $comparison);
-    }
-
     /**
      * Magic method for setting up additional filtering by attributes.
+     *
      * @param $nm
      * @param $a
+     *
      * @throws \Exception
      */
     public function __call($nm, $a)
@@ -53,6 +39,24 @@ abstract class  AttributedItemList extends ItemList
     }
 
     /**
+     * Filters by a attribute.
+     *
+     * @param mixed $handle
+     * @param mixed $value
+     * @param mixed $comparison
+     *
+     * @throws InvalidAttributeException
+     */
+    public function filterByAttribute($handle, $value, $comparison = '=')
+    {
+        $ak = call_user_func_array([$this->getAttributeKeyClassName(), 'getByHandle'], [$handle]);
+        if (!is_object($ak)) {
+            throw new InvalidAttributeException(t('Unable to find attribute %s', $handle));
+        }
+        $ak->getController()->filterByAttribute($this, $value, $comparison);
+    }
+
+    /**
      * @param StickyRequest $request
      */
     public function setupAutomaticSorting(StickyRequest $request = null)
@@ -60,9 +64,9 @@ abstract class  AttributedItemList extends ItemList
         if ($this->enableAutomaticSorting) {
             // First, we check to see if there are any sortable attributes we can add to the
             // auto sort columns.
-            if (is_callable(array($this->getAttributeKeyClassName(), 'getList'))) {
-                $l = call_user_func(array($this->getAttributeKeyClassName(), 'getList'));
-                foreach($l as $ak) {
+            if (is_callable([$this->getAttributeKeyClassName(), 'getList'])) {
+                $l = call_user_func([$this->getAttributeKeyClassName(), 'getList']);
+                foreach ($l as $ak) {
                     $this->autoSortColumns[] = 'ak_' . $ak->getAttributeKeyHandle();
                 }
             }
@@ -71,4 +75,5 @@ abstract class  AttributedItemList extends ItemList
         }
     }
 
+    abstract protected function getAttributeKeyClassName();
 }

--- a/concrete/src/Search/ItemList/Database/AttributedItemList.php
+++ b/concrete/src/Search/ItemList/Database/AttributedItemList.php
@@ -1,7 +1,10 @@
 <?php
 namespace Concrete\Core\Search\ItemList\Database;
+
+use Concrete\Core\Attribute\Exception\InvalidAttributeException;
 use Concrete\Core\Search\StickyRequest;
 use Database;
+
 abstract class  AttributedItemList extends ItemList
 {
 
@@ -9,12 +12,13 @@ abstract class  AttributedItemList extends ItemList
 
     /**
      * Filters by a attribute.
+     * @throws InvalidAttributeException
      */
     public function filterByAttribute($handle, $value, $comparison = '=')
     {
         $ak = call_user_func_array(array($this->getAttributeKeyClassName(), 'getByHandle'), array($handle));
         if (!is_object($ak)) {
-            throw new \Exception(t('Unable to find attribute %s', $handle));
+            throw new InvalidAttributeException(t('Unable to find attribute %s', $handle));
         }
         $ak->getController()->filterByAttribute($this, $value, $comparison);
     }


### PR DESCRIPTION
Yesterday we faced an issue we added filtering with a new collection attribute which was supposed to be created on package update.
But we got lots of exceptions in between the code deploy and the package update due to not having the actual attribute which should be filtered by. 

**Let's throw `InvalidAttributeException` instead of a plain`Exception`.** 
So that, we can customize the behavior by catching this type of exception.  
