### PR TITLE
Fix various Type Errors/warnings on php 8 and above and fix c5:phpcs command

### DIFF
--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -13,22 +13,58 @@ use Concrete\Core\Area\Layout\ThemeGridLayout as ThemeGridAreaLayout;
 use Concrete\Core\Area\SubArea;
 use Concrete\Core\Asset\CssAsset;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Block\BlockType\BlockType;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Feature\UsesFeatureInterface;
+use Concrete\Core\Page\Page;
 use Concrete\Core\StyleCustomizer\Inline\StyleSet;
-use Core;
-use Database;
-use Page;
-use URL;
+use Concrete\Core\Support\Facade\Url;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var \Concrete\Core\Area\Layout\CustomLayout|\Concrete\Core\Area\Layout\PresetLayout|\Concrete\Core\Area\Layout\ThemeGridLayout|null
+     */
+    public $arLayout;
+
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineAdd = true;
+
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineEdit = true;
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btCoreAreaLayout';
+
+    /**
+     * @var bool
+     */
     protected $btIsInternal = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheSettingsInitialized = false;
+
+    /**
+     * @var string[]
+     */
     protected $requiredFeatures = [];
 
+    /**
+     * @var Area|null
+     */
+    protected $area;
+
+    /**
+     * @return bool
+     */
     public function cacheBlockOutput()
     {
         $this->setupCacheSettings();
@@ -36,6 +72,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $this->btCacheBlockOutput;
     }
 
+    /**
+     * @return bool
+     */
     public function cacheBlockOutputOnPost()
     {
         $this->setupCacheSettings();
@@ -43,6 +82,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $this->btCacheBlockOutputOnPost;
     }
 
+    /**
+     * @return int
+     */
     public function getBlockTypeCacheOutputLifetime()
     {
         $this->setupCacheSettings();
@@ -50,22 +92,43 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $this->btCacheBlockOutputLifetime;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
         return t('Proxy block for area layouts.');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t('Area Layout');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string[]
+     */
     public function getRequiredFeatures(): array
     {
         $this->setupCacheSettings();
+
         return $this->requiredFeatures;
     }
 
+    /**
+     * @param string $outputContent
+     *
+     * @return void
+     */
     public function registerViewAssets($outputContent = '')
     {
         if (is_object($this->block) && $this->block->getBlockFilename() == 'parallax') {
@@ -77,27 +140,44 @@ class Controller extends BlockController implements UsesFeatureInterface
         if (is_object($arLayout)) {
             if ($arLayout instanceof CustomLayout) {
                 $asset = new CssAsset();
-                $asset->setAssetURL(URL::to('/ccm/system/css/layout', $arLayout->getAreaLayoutID()));
+                $asset->setAssetURL((string) Url::to('/ccm/system/css/layout', $arLayout->getAreaLayoutID()));
                 $this->requireAsset($asset);
             }
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param int $newBID
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException|\Doctrine\DBAL\Exception
+     *
+     * @return \Concrete\Core\Legacy\BlockRecord|null
+     */
     public function duplicate($newBID)
     {
-        $db = Database::connection();
-        parent::duplicate($newBID);
-        $ar = AreaLayout::getByID($this->arLayoutID);
-        $nr = $ar->duplicate();
-        $db->Execute(
-            'update btCoreAreaLayout set arLayoutID = ? where bID = ?',
-            [$nr->getAreaLayoutID(), $newBID]
-        );
+        /** @var Connection $db */
+        $db = $this->app->make(Connection::class);
+        $record = parent::duplicate($newBID);
+        if (isset($this->arLayoutID)) {
+            $ar = AreaLayout::getByID($this->arLayoutID);
+            $nr = $ar->duplicate();
+            $db->executeStatement(
+                'update btCoreAreaLayout set arLayoutID = ? where bID = ?',
+                [$nr->getAreaLayoutID(), $newBID]
+            );
+        }
+
+        return $record;
     }
 
+    /**
+     * @return \Concrete\Core\Area\Layout\CustomLayout|\Concrete\Core\Area\Layout\PresetLayout|\Concrete\Core\Area\Layout\ThemeGridLayout|null
+     */
     public function getAreaLayoutObject()
     {
-        if ($this->arLayoutID) {
+        if (isset($this->arLayoutID)) {
             $arLayout = AreaLayout::getByID($this->arLayoutID);
             $b = $this->getBlockObject();
             if (is_object($arLayout) && is_object($b)) {
@@ -106,8 +186,13 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             return $arLayout;
         }
+
+        return null;
     }
 
+    /**
+     * @return void
+     */
     public function delete()
     {
         $arLayout = $this->getAreaLayoutObject();
@@ -117,12 +202,25 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::delete();
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     *
+     * @return void
+     */
     public function export(\SimpleXMLElement $blockNode)
     {
         $layout = $this->getAreaLayoutObject();
         $layout->export($blockNode);
     }
 
+    /**
+     * @param array<string,mixed> $post
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return void;
+     */
     public function save($post)
     {
         if (isset($post['arLayoutID']) && !isset($post['arLayoutEdit'])) {
@@ -135,8 +233,9 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             return;
         }
-        $db = Database::connection();
-        $arLayoutID = $db->GetOne('select arLayoutID from btCoreAreaLayout where bID = ?', [$this->bID]);
+        /** @var Connection $db */
+        $db = $this->app->make(Connection::class);
+        $arLayoutID = $db->fetchOne('select arLayoutID from btCoreAreaLayout where bID = ?', [$this->bID]);
         if (!$arLayoutID) {
             $arLayout = $this->addFromPost($post);
         } else {
@@ -146,8 +245,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
             // save spacing
             if ($arLayout->isAreaLayoutUsingThemeGridFramework()) {
+                /** @var \Concrete\Core\Area\Layout\ThemeGridColumn[] $columns */
                 $columns = $arLayout->getAreaLayoutColumns();
-                for ($i = 0; $i < count($columns); ++$i) {
+                for ($i = 0; $i < count($columns); $i++) {
                     $col = $columns[$i];
                     $span = ($post['span'][$i]) ? $post['span'][$i] : 0;
                     $offset = ($post['offset'][$i]) ? $post['offset'][$i] : 0;
@@ -160,10 +260,11 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $arLayout->disableAreaLayoutCustomColumnWidths();
                 } else {
                     $arLayout->enableAreaLayoutCustomColumnWidths();
+                    /** @var \Concrete\Core\Area\Layout\CustomColumn[]|\Concrete\Core\Area\Layout\PresetColumn $columns */
                     $columns = $arLayout->getAreaLayoutColumns();
-                    for ($i = 0; $i < count($columns); ++$i) {
+                    for ($i = 0; $i < count($columns); $i++) {
                         $col = $columns[$i];
-                        $width = ($post['width'][$i]) ? $post['width'][$i] : 0;
+                        $width = $post['width'][$i] ?: 0;
                         $col->setAreaLayoutColumnWidth($width);
                     }
                 }
@@ -174,6 +275,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::save($values);
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param mixed $page
+     *
+     * @return array<string,mixed>
+     */
     public function getImportData($blockNode, $page)
     {
         $args = [];
@@ -191,7 +298,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     foreach ($node->columns->column as $column) {
                         $args['span'][$i] = (int) ($column['span']);
                         $args['offset'][$i] = (int) ($column['offset']);
-                        ++$i;
+                        $i++;
                     }
                     break;
                 case 'custom':
@@ -207,7 +314,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $i = 0;
                     foreach ($node->columns->column as $column) {
                         $args['width'][$i] = (int) ($column['width']);
-                        ++$i;
+                        $i++;
                     }
                     break;
             }
@@ -216,16 +323,23 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $args;
     }
 
+    /**
+     * @param array<string,mixed> $post
+     *
+     * @return \Concrete\Core\Area\Layout\CustomLayout|\Concrete\Core\Area\Layout\PresetLayout|\Concrete\Core\Area\Layout\ThemeGridLayout|null
+     */
     public function addFromPost($post)
     {
         // we are adding a new layout
         switch ($post['gridType']) {
             case 'TG':
+                /** @var ThemeGridLayout $arLayout */
                 $arLayout = ThemeGridAreaLayout::add();
                 $arLayout->setAreaLayoutMaxColumns($post['arLayoutMaxColumns']);
-                for ($i = 0; $i < $post['themeGridColumns']; ++$i) {
+                for ($i = 0; $i < $post['themeGridColumns']; $i++) {
                     $span = ($post['span'][$i]) ? $post['span'][$i] : 0;
                     $offset = ($post['offset'][$i]) ? $post['offset'][$i] : 0;
+                    /** @var \Concrete\Core\Area\Layout\ThemeGridColumn $column */
                     $column = $arLayout->addLayoutColumn();
                     $column->setAreaLayoutColumnSpan($span);
                     $column->setAreaLayoutColumnOffset($offset);
@@ -233,13 +347,15 @@ class Controller extends BlockController implements UsesFeatureInterface
                 break;
             case 'FF':
                 if ((!$post['isautomated']) && $post['columns'] > 1) {
-                    $iscustom = 1;
+                    $iscustom = true;
                 } else {
-                    $iscustom = 0;
+                    $iscustom = false;
                 }
+                /** @var CustomAreaLayout $arLayout */
                 $arLayout = CustomAreaLayout::add($post['spacing'], $iscustom);
-                for ($i = 0; $i < $post['columns']; ++$i) {
+                for ($i = 0; $i < $post['columns']; $i++) {
                     $width = ($post['width'][$i]) ? $post['width'][$i] : 0;
+                    /** @var \Concrete\Core\Area\Layout\CustomColumn $column */
                     $column = $arLayout->addLayoutColumn();
                     $column->setAreaLayoutColumnWidth($width);
                 }
@@ -256,6 +372,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $arLayout;
     }
 
+    /**
+     * @return void
+     */
     public function view()
     {
         $b = $this->getBlockObject();
@@ -282,9 +401,15 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
     public function edit()
     {
         $this->view();
+        $gf = null;
         // since we set a render override in view() we have to explicitly declare edit
         if ($this->arLayout->isAreaLayoutUsingThemeGridFramework()) {
             $c = Page::getCurrentPage();
@@ -311,6 +436,11 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('columnsNum', count($this->arLayout->getAreaLayoutColumns()));
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
     public function add()
     {
         $maxColumns = 12; // normally
@@ -318,8 +448,8 @@ class Controller extends BlockController implements UsesFeatureInterface
         $c = Page::getCurrentPage();
         $pt = $c->getCollectionThemeObject();
         if (is_object($pt) && $pt->supportsGridFramework() && is_object(
-                $this->area
-            ) && $this->area->getAreaGridMaximumColumns()
+            $this->area
+        ) && $this->area->getAreaGridMaximumColumns()
         ) {
             $gf = $pt->getThemeGridFrameworkObject();
             $this->set('enableThemeGrid', true);
@@ -333,6 +463,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('maxColumns', $maxColumns);
     }
 
+    /**
+     * @return void
+     */
     protected function setupCacheSettings()
     {
         if ($this->btCacheSettingsInitialized || Page::getCurrentPage()->isEditMode()) {
@@ -364,9 +497,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
         }
 
-
         $arrAssetBlocks = [];
 
+        /** @var \Concrete\Core\Block\Block $b */
         foreach ($blocks as $b) {
             if ($b->overrideAreaPermissions()) {
                 $btCacheBlockOutput = false;
@@ -375,18 +508,19 @@ class Controller extends BlockController implements UsesFeatureInterface
                 break;
             }
 
-            $btCacheBlockOutput = $btCacheBlockOutput && $b->cacheBlockOutput();
             $btCacheBlockOutputOnPost = $btCacheBlockOutputOnPost && $b->cacheBlockOutputOnPost();
 
             //As soon as we find something which cannot be cached, entire block cannot be cached, so stop checking.
-            if (!$btCacheBlockOutput) {
+            if (!$b->cacheBlockOutput()) {
+                $this->btCacheBlockOutput = false;
+                $this->btCacheBlockOutputOnPost = false;
+                $this->btCacheBlockOutputLifetime = 0;
+
                 return;
             }
-
-            if ($expires = $b->getBlockOutputCacheLifetime()) {
-                if ($expires && $btCacheBlockOutputLifetime < $expires) {
-                    $btCacheBlockOutputLifetime = $expires;
-                }
+            $expires = $b->getBlockOutputCacheLifetime();
+            if ($expires && $btCacheBlockOutputLifetime < $expires) {
+                $btCacheBlockOutputLifetime = $expires;
             }
 
             $objController = $b->getController();
@@ -404,7 +538,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             $objController->outputAutoHeaderItems();
             $objController->registerViewAssets();
             if ($objController instanceof UsesFeatureInterface) {
-                foreach($objController->getRequiredFeatures() as $feature) {
+                foreach ($objController->getRequiredFeatures() as $feature) {
                     if (!in_array($feature, $this->requiredFeatures)) {
                         $this->requiredFeatures[] = $feature;
                     }
@@ -413,20 +547,30 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
     }
 
+    /**
+     * @param \Concrete\Core\Block\Block $b
+     * @param \SimpleXMLElement $blockNode
+     *
+     * @throws \Exception
+     *
+     * @return void
+     */
     protected function importAdditionalData($b, $blockNode)
     {
+        /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
         $controller = $b->getController();
         $arLayout = $controller->getAreaLayoutObject();
 
         $columns = $arLayout->getAreaLayoutColumns();
         $layoutArea = $b->getBlockAreaObject();
         $arLayout->setAreaObject($b->getBlockAreaObject());
+        /** @var Page $page */
         $page = $b->getBlockCollectionObject();
 
         $i = 0;
         foreach ($blockNode->arealayout->columns->column as $columnNode) {
             $column = $columns[$i];
-            $as = new SubArea($column->getAreaLayoutColumnDisplayID(), $layoutArea->getAreaHandle(), $layoutArea->getAreaID());
+            $as = new SubArea((string) $column->getAreaLayoutColumnDisplayID(), $layoutArea->getAreaHandle(), $layoutArea->getAreaID());
             $as->load($page);
             $column->setAreaID($as->getAreaID());
             $area = $column->getAreaObject();
@@ -435,14 +579,14 @@ class Controller extends BlockController implements UsesFeatureInterface
                 $page->setCustomStyleSet($area, $set);
             }
             foreach ($columnNode->block as $bx) {
-                $bt = \BlockType::getByHandle((string) $bx['type']);
+                $bt = BlockType::getByHandle((string) $bx['type']);
                 if (!is_object($bt)) {
                     throw new \Exception(t('Invalid block type handle: %s', (string) ($bx['type'])));
                 }
                 $btc = $bt->getController();
                 $btc->import($page, $area->getAreaHandle(), $bx);
             }
-            ++$i;
+            $i++;
         }
     }
 }

--- a/concrete/blocks/core_area_layout/edit.php
+++ b/concrete/blocks/core_area_layout/edit.php
@@ -1,6 +1,17 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
 
+$minColumns = 1;
+$columnsNum = $columnsNum ?? 1;
+$maxColumns = $maxColumns ?? 12;
+$enableThemeGrid = $enableThemeGrid ?? false;
+$columns = $columns ?? [];
+$iscustom = $iscustom ?? false;
+    /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+    /** @var \Concrete\Core\Block\Block $b */
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    /** @var \Concrete\Core\Area\Area $a */
+    /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
     $this->inc('form.php', ['b' => $b, 'a' => $a]);
 
 ?>
@@ -16,7 +27,7 @@
 	<?php $i = $col->getAreaLayoutColumnIndex();
     ?>
 	<div class="<?=$col->getAreaLayoutColumnClass()?>" id="ccm-edit-layout-column-<?=$i?>" <?php if ($iscustom) {
-    ?>data-width="<?=$col->getAreaLayoutColumnWidth()?>" <?php 
+    ?>data-width="<?=$col->getAreaLayoutColumnWidth()?>" <?php
 }
     ?>>
 		<div class="ccm-layout-column-inner ccm-layout-column-highlight">
@@ -26,7 +37,7 @@
     ?>
 		</div>
 	</div>
-<?php 
+<?php
 } ?>
 
 </div>

--- a/concrete/blocks/core_area_layout/edit_grid.php
+++ b/concrete/blocks/core_area_layout/edit_grid.php
@@ -1,5 +1,16 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
+$minColumns = 1;
+$columnsNum = $columnsNum ?? 1;
+$maxColumns = $maxColumns ?? 12;
+$enableThemeGrid = $enableThemeGrid ?? false;
+$columns = $columns ?? [];
+    /** @var \Concrete\Core\Area\Layout\Formatter\FormatterInterface $formatter */
+    /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+    /** @var \Concrete\Core\Block\Block $b */
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    /** @var \Concrete\Core\Area\Area $a */
+    /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
     $this->inc('form.php', ['b' => $b, 'a' => $a]);
 
 ?>
@@ -20,7 +31,7 @@
 	<?php if ($col->getAreaLayoutColumnOffset() > 0) {
     ?>
 		<div class="<?=$col->getAreaLayoutColumnOffsetEditClass()?> ccm-theme-grid-offset-column">&nbsp;</div>
-	<?php 
+	<?php
 }
     ?>
 
@@ -33,7 +44,7 @@
     ?>
 		</div>
 	</div>
-<?php 
+<?php
 } ?>
 
 </div>

--- a/concrete/blocks/core_area_layout/edit_preset.php
+++ b/concrete/blocks/core_area_layout/edit_preset.php
@@ -1,5 +1,16 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
+$minColumns = 1;
+$columnsNum = $columnsNum ?? 1;
+$maxColumns = $maxColumns ?? 12;
+$enableThemeGrid = $enableThemeGrid ?? false;
+$columns = $columns ?? [];
+    /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+    /** @var \Concrete\Core\Block\Block $b */
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    /** @var \Concrete\Core\Area\Area $a */
+    /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
+    /** @var \Concrete\Core\Area\Layout\Formatter\FormatterInterface $formatter */
     $this->inc('form.php', ['b' => $b, 'a' => $a]);
 
 ?>

--- a/concrete/blocks/core_area_layout/form.php
+++ b/concrete/blocks/core_area_layout/form.php
@@ -2,12 +2,19 @@
     defined('C5_EXECUTE') or die('Access Denied.');
 
     $minColumns = 1;
-
+    $columnsNum = $columnsNum ?? 1;
+    $maxColumns = $maxColumns ?? 12;
+    $enableThemeGrid = $enableThemeGrid ?? false;
+    /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+    /** @var \Concrete\Core\Block\Block $b */
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    /** @var \Concrete\Core\Area\Area $a */
+    /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
     if ($controller->getTask() == 'add') {
         $spacing = 0;
         $iscustom = false;
     }
-    $presets = Core::make('manager/area_layout_preset_provider')->getPresets();
+    $presets = app('manager/area_layout_preset_provider')->getPresets();
 ?>
 
 <ul id="ccm-layouts-toolbar" class="ccm-inline-toolbar ccm-ui">
@@ -17,7 +24,7 @@
 			<optgroup label="<?=t('Grids')?>">
 			<?php if ($enableThemeGrid) {
     ?>
-				<option value="TG"><?=$themeGridName?></option>
+				<option value="TG"><?=$themeGridName ?? ''?></option>
 			<?php
 } ?>
 			<option value="FF"><?=t('Free-Form Layout')?></option>
@@ -42,7 +49,7 @@
 	<li data-grid-form-view="themegrid">
 		<label for="themeGridColumns"><?=t('Columns:')?></label>
 		<input type="number" name="themeGridColumns" id="themeGridColumns" style="width: 40px" <?php if ($controller->getTask() == 'add') {
-    ?>  min="<?=$minColumns?>" max="<?= isset($themeGridMaxColumns) ? $themeGridMaxColumns : '' ?>" <?php
+    ?>  min="<?=$minColumns?>" max="<?= $themeGridMaxColumns ?? '' ?>" <?php
 } ?> value="<?=$columnsNum?>" />
 		<?php if ($controller->getTask() == 'edit') {
     // we need this to actually go through the form in edit mode, for layout presets to be saveable in edit mode.?>
@@ -63,7 +70,7 @@
 	</li>
 	<li data-grid-form-view="custom">
 		<label for="columns"><?=t('Spacing:')?></label>
-		<input name="spacing" id="spacing" type="number" style="width: 40px" min="0" max="1000" value="<?=isset($spacing) ? $spacing : ''?>" />
+		<input name="spacing" id="spacing" type="number" style="width: 40px" min="0" max="1000" value="<?=$spacing ?? ''?>" />
 	</li>
 	<li data-grid-form-view="custom" class="ccm-inline-toolbar-icon-cell <?php if (empty($iscustom)) {
     ?>ccm-inline-toolbar-icon-selected<?php
@@ -75,12 +82,13 @@
 } ?>" />
 	</li>
 	<?php if ($controller->getTask() == 'edit') {
-    $bp = new Permissions($b);
+    $bp = new \Concrete\Core\Permission\Checker($b);
     ?>
 
 		<li class="ccm-inline-toolbar-icon-cell"><a href="#" data-layout-command="move-block"><i class="fas fa-arrows-alt"></i></a></li>
 
 		<?php
+        /** @phpstan-ignore-next-line */
         if ($bp->canDeleteBlock()) {
             $deleteMessage = t('Do you want to delete this layout? This will remove all blocks inside it.');
             ?>
@@ -136,7 +144,7 @@ $(function() {
 			ConcreteEvent.unsubscribe('EditModeBlockDeleteAfterComplete');
 		});
 
-		Concrete.event.fire('EditModeBlockDelete', {message: '<?=$deleteMessage?>', block: block, event: e});
+		Concrete.event.fire('EditModeBlockDelete', {message: '<?=$deleteMessage ?? ''?>', block: block, event: e});
 		return false;
 	});
 	<?php
@@ -159,14 +167,14 @@ $(function() {
 		<?php
 } else {
     ?>
-		'maxcolumns': '<?=$themeGridMaxColumns?>',
+		'maxcolumns': '<?=$themeGridMaxColumns ?? ''?>',
 		<?php
 }
     ?>
 		'gridColumnClasses': [
 			<?php $classes = $themeGridFramework->getPageThemeGridFrameworkColumnClasses();
     ?>
-			<?php for ($i = 0; $i < count($classes); ++$i) {
+			<?php for ($i = 0; $i < count($classes); $i++) {
     $class = $classes[$i];
     ?>
 				'<?=$class?>' <?php if (($i + 1) < count($classes)) {

--- a/concrete/blocks/core_area_layout/templates/parallax/view.php
+++ b/concrete/blocks/core_area_layout/templates/parallax/view.php
@@ -1,4 +1,15 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+$minColumns = 1;
+$columnsNum = $columnsNum ?? 1;
+$maxColumns = $maxColumns ?? 12;
+$enableThemeGrid = $enableThemeGrid ?? false;
+$columns = $columns ?? [];
+/** @var \Concrete\Core\Area\Layout\Formatter\FormatterInterface $formatter */
+/** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+/** @var \Concrete\Core\Block\Block $b */
+/** @var \Concrete\Core\Block\View\BlockView $view */
+/** @var \Concrete\Core\Area\Area $a */
+/** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
 $a = $b->getBlockAreaObject();
 $rootContainer = $formatter->getLayoutContainerHtmlObject();
 $container = $rootContainer;

--- a/concrete/blocks/core_area_layout/view.php
+++ b/concrete/blocks/core_area_layout/view.php
@@ -1,5 +1,16 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
+$minColumns = 1;
+$columnsNum = $columnsNum ?? 1;
+$maxColumns = $maxColumns ?? 12;
+$enableThemeGrid = $enableThemeGrid ?? false;
+$columns = $columns ?? [];
+    /** @var \Concrete\Core\Area\Layout\Formatter\FormatterInterface $formatter */
+    /** @var \Concrete\Block\CoreAreaLayout\Controller $controller */
+    /** @var \Concrete\Core\Block\Block $b */
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    /** @var \Concrete\Core\Area\Area $a */
+    /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
     $a = $b->getBlockAreaObject();
 
     $rootContainer = $formatter->getLayoutContainerHtmlObject();

--- a/concrete/blocks/page_attribute_display/form.php
+++ b/concrete/blocks/page_attribute_display/form.php
@@ -8,13 +8,18 @@ use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Support\Facade\Application;
 
 /** @var Controller $controller */
-/** @var string $displayTag */
-/** @var string $dateFormat */
-/** @var string $delimiter */
+/** @var string|null $displayTag */
+/** @var string|null $dateFormat */
+/** @var string|null $delimiter */
 /** @var int $thumbnailWidth */
 /** @var int $thumbnailHeight */
-/** @var string $attributeTitleText */
-/** @var string $attributeHandle */
+/** @var string|null $attributeTitleText */
+/** @var string|null $attributeHandle */
+$attributeTitleText = $attributeTitleText ?? null;
+$attributeHandle = $attributeHandle ?? null;
+$delimiter = $delimiter ?? null;
+$displayTag = $displayTag ?? null;
+
 
 $app = Application::getFacadeApplication();
 

--- a/concrete/blocks/page_attribute_display/templates/date_time.php
+++ b/concrete/blocks/page_attribute_display/templates/date_time.php
@@ -1,7 +1,19 @@
 <?php
 
 defined('C5_EXECUTE') or die('Access Denied.');
-$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
+/** @var \Concrete\Block\PageAttributeDisplay\Controller $controller */
+/** @var string|null $displayTag */
+/** @var string|null $dateFormat */
+/** @var string|null $delimiter */
+/** @var int $thumbnailWidth */
+/** @var int $thumbnailHeight */
+/** @var string|null $attributeTitleText */
+/** @var string|null $attributeHandle */
+$attributeTitleText = $attributeTitleText ?? null;
+$attributeHandle = $attributeHandle ?? null;
+$delimiter = $delimiter ?? null;
+$displayTag = $displayTag ?? null;
+$dh = app('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
 echo $this->controller->getOpenTag();
 echo $this->controller->getTitle();
 try {

--- a/concrete/blocks/page_attribute_display/view.php
+++ b/concrete/blocks/page_attribute_display/view.php
@@ -1,7 +1,7 @@
 <?php
 
 defined('C5_EXECUTE') or die('Access Denied.');
-
+/** @var \Concrete\Block\PageAttributeDisplay\Controller $controller */
 echo $controller->getOpenTag();
 if ($controller->getTitle()) {
     echo '<span class="ccm-block-page-attribute-display-title">' . $controller->getTitle() . '</span>';

--- a/concrete/blocks/page_title/controller.php
+++ b/concrete/blocks/page_title/controller.php
@@ -1,47 +1,88 @@
 <?php
+
 namespace Concrete\Block\PageTitle;
 
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Block\BlockController;
 use Concrete\Core\Tree\Node\Type\Topic;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-
-    /** @var  string | int  */
-    protected $btInterfaceWidth = 470;
-    /** @var  string | int  */
-    protected $btInterfaceHeight = 500;
-    /** @var  bool  */
-    protected $btCacheBlockOutput = true;
-    /** @var  bool  */
-    protected $btCacheBlockOutputOnPost = true;
-    /** @var  bool  */
-    protected $btCacheBlockOutputForRegisteredUsers = false;
-    /** @var  string  */
-    protected $btTable = 'btPageTitle';
-    /** @var  string  */
-    protected $btWrapperClass = 'ccm-ui';
-
-    /**  @var string */
+    /**
+     * @var string
+     */
     public $titleText = '';
-    /**  @var bool */
-    public $useCustomTitle = false;
-    /** @var bool  */
-    public $useFilterTitle = false;
-    /** @var bool  */
-    public $useFilterTopic = false;
-    /** @var bool  */
-    public $useFilterTag = false;
-    /** @var bool  */
-    public $useFilterDate = false;
-    /** @var string */
-    public $formatting = "h1";
 
     /**
-     * @inheritDoc
+     * @var bool
+     */
+    public $useCustomTitle = false;
+
+    /**
+     * @var bool
+     */
+    public $useFilterTitle = false;
+
+    /**
+     * @var bool
+     */
+    public $useFilterTopic = false;
+
+    /**
+     * @var bool
+     */
+    public $useFilterTag = false;
+
+    /**
+     * @var bool
+     */
+    public $useFilterDate = false;
+
+    /**
+     * @var string
+     */
+    public $formatting = 'h1';
+
+    /**
+     * @var string|int
+     */
+    protected $btInterfaceWidth = 470;
+
+    /**
+     * @var string|int
+     */
+    protected $btInterfaceHeight = 500;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutputForRegisteredUsers = false;
+
+    /**
+     * @var string
+     */
+    protected $btTable = 'btPageTitle';
+
+    /**
+     * @var string
+     */
+    protected $btWrapperClass = 'ccm-ui';
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function getBlockTypeDescription()
@@ -50,12 +91,13 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function getBlockTypeName()
     {
-        return t("Page Title");
+        return t('Page Title');
     }
 
     /**
@@ -87,13 +129,14 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
+     *
      * @return string[]
      */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::BASICS
+            Features::BASICS,
         ];
     }
 
@@ -102,9 +145,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function view()
     {
-        if (!(isset($this->formatting) && $this->formatting)) {
-            $this->set('formatting', 'h1');
-        }
         $this->set('title', $this->getTitleText());
     }
 
@@ -120,13 +160,17 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
+     *
      * @param array<string, mixed> $data
+     *
      * @return void
      */
     public function save($data)
     {
-        if (!is_array($data)) $data = [];
+        if (!is_array($data)) {
+            $data = [];
+        }
         $data['useCustomTitle'] = isset($data['useCustomTitle']) && $data['useCustomTitle'] ? 1 : 0;
         $data['useFilterTitle'] = isset($data['useFilterTitle']) && $data['useFilterTitle'] ? 1 : 0;
         $data['useFilterTopic'] = isset($data['useFilterTopic']) && $data['useFilterTopic'] ? 1 : 0;
@@ -139,12 +183,13 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param string|int|false $treeNodeID
      * @param false $topic
+     *
      * @return void
      */
     public function action_topic($treeNodeID = false, $topic = false)
     {
         if ($treeNodeID) {
-            $topicObj = Topic::getByID(intval($treeNodeID));
+            $topicObj = Topic::getByID((int) $treeNodeID);
             if ($topicObj instanceof Topic) {
                 $this->set('currentTopic', $topicObj);
             }
@@ -154,6 +199,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param bool|string|null $tag
+     *
      * @return void
      */
     public function action_tag($tag = false)
@@ -168,6 +214,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param int|false $year
      * @param int|false $month
+     *
      * @return void
      */
     public function action_date($year = false, $month = false)
@@ -183,7 +230,9 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param string[] $parameters
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
      * @return array<int,mixed>
      */
     public function getPassThruActionAndParameters($parameters)
@@ -196,9 +245,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             $parameters = array_slice($parameters, 1);
         } elseif ($this->app->make('helper/validation/numbers')->integer($parameters[0])) {
             $method = 'action_date';
-            $parameters[0] = intval($parameters[0]);
+            $parameters[0] = (int) ($parameters[0]);
             if (isset($parameters[1])) {
-                $parameters[1] = intval($parameters[1]);
+                $parameters[1] = (int) ($parameters[1]);
             }
         } else {
             $parameters = $method = null;
@@ -210,6 +259,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param string $title
      * @param bool $case
+     *
      * @return string
      */
     public function formatPageTitle($title, $case = false)
@@ -235,6 +285,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param string $method
      * @param array<int,mixed> $parameters
+     *
      * @return bool
      */
     public function isValidControllerTask($method, $parameters = [])

--- a/concrete/blocks/page_title/controller.php
+++ b/concrete/blocks/page_title/controller.php
@@ -37,6 +37,8 @@ class Controller extends BlockController implements UsesFeatureInterface
     public $useFilterTag = false;
     /** @var bool  */
     public $useFilterDate = false;
+    /** @var string */
+    public $formatting = "h1";
 
     /**
      * @inheritDoc

--- a/concrete/blocks/page_title/form_add_edit.php
+++ b/concrete/blocks/page_title/form_add_edit.php
@@ -31,7 +31,7 @@ if (!strlen($titleText ?? '')) {
 
     <div class="form-check">
         <label for="useCustomTitle" class="form-check-label">
-            <?php echo $form->checkbox('useCustomTitle', '1', $useCustomTitle); ?>
+            <?php echo $form->checkbox('useCustomTitle', '1', $useCustomTitle ?? false); ?>
             <?php echo t('Override page name with custom title?'); ?>
         </label>
     </div>
@@ -62,7 +62,7 @@ if (!strlen($titleText ?? '')) {
 
     <div class="form-check">
         <label for="useFilterTitle" class="form-check-label">
-            <?php echo $form->checkbox('useFilterTitle', '1', $useFilterTitle); ?>
+            <?php echo $form->checkbox('useFilterTitle', '1', $useFilterTitle ?? false); ?>
             <?php echo t('Enable other blocks to filter this page title'); ?>
         </label>
     </div>
@@ -70,21 +70,21 @@ if (!strlen($titleText ?? '')) {
     <div class="well filterTitleOptions">
         <div class="form-check">
             <label for="useFilterTopic" class="form-check-label">
-                <?php echo $form->checkbox('useFilterTopic', '1', $useFilterTopic); ?>
+                <?php echo $form->checkbox('useFilterTopic', '1', $useFilterTopic ?? false); ?>
                 <?php echo t('Topic'); ?>
             </label>
         </div>
 
         <div class="form-check">
             <label for="useFilterTag" class="form-check-label">
-                <?php echo $form->checkbox('useFilterTag', '1', $useFilterTag); ?>
+                <?php echo $form->checkbox('useFilterTag', '1', $useFilterTag ?? false); ?>
                 <?php echo t('Tag'); ?>
             </label>
         </div>
 
         <div class="form-check">
             <label for="useFilterDate" class="form-check-label">
-                <?php echo $form->checkbox('useFilterDate', '1', $useFilterDate); ?>
+                <?php echo $form->checkbox('useFilterDate', '1', $useFilterDate ?? false); ?>
                 <?php echo t('Date'); ?>
             </label>
         </div>
@@ -99,7 +99,7 @@ if (!strlen($titleText ?? '')) {
                         'upperFirst' => t('Capitalize first word'),
                         'lowercase' => t('Lowercase'),
                         'uppercase' => t('Uppercase')
-                    ], $topicTextFormat); ?>
+                    ], $topicTextFormat ?? 0); ?>
             </div>
         </div>
 
@@ -112,7 +112,7 @@ if (!strlen($titleText ?? '')) {
                         'upperFirst' => t('Capitalize first word'),
                         'lowercase' => t('Lowercase'),
                         'uppercase' => t('Uppercase')
-                    ], $tagTextFormat); ?>
+                    ], $tagTextFormat ?? null); ?>
             </div>
         </div>
 
@@ -126,12 +126,12 @@ if (!strlen($titleText ?? '')) {
                         'upperFirst' => t('Capitalize first word'),
                         'lowercase' => t('Lowercase'),
                         'uppercase' => t('Uppercase')
-                    ], $dateTextFormat); ?>
+                    ], $dateTextFormat ?? 0); ?>
             </div>
 
             <div class="form-group">
                 <?php echo $form->label('filterDateFormat', t('Date Year and Month Format')); ?>
-                <?php echo $form->text('filterDateFormat', $filterDateFormat ? $filterDateFormat : t('F Y')); ?>
+                <?php echo $form->text('filterDateFormat', $filterDateFormat ?? t('F Y')); ?>
             </div>
 
             <div class="help-block">

--- a/concrete/blocks/page_title/form_add_edit.php
+++ b/concrete/blocks/page_title/form_add_edit.php
@@ -5,19 +5,20 @@ use Concrete\Block\PageTitle\Controller;
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /** @var Controller $controller */
-/** @var bool $useCustomTitle */
-/** @var bool $useFilterTitle */
-/** @var bool $useFilterTopic */
-/** @var bool $useFilterTag */
-/** @var bool $useFilterDate */
-/** @var string $topicTextFormat */
-/** @var string $tagTextFormat */
-/** @var string $dateTextFormat */
-/** @var string $filterDateFormat */
-/** @var string $titleText */
-/** @var string $formatting */
+/** @var bool|null $useCustomTitle */
+/** @var bool|null $useFilterTitle */
+/** @var bool|null $useFilterTopic */
+/** @var bool|null $useFilterTag */
+/** @var bool|null $useFilterDate */
+/** @var string|null $topicTextFormat */
+/** @var string|null $tagTextFormat */
+/** @var string|null $dateTextFormat */
+/** @var string|null $filterDateFormat */
+/** @var string|null $titleText */
+/** @var string|null $formatting */
+/** @var \Concrete\Core\Form\Service\Form $form */
 
-if (!strlen($titleText)) {
+if (!strlen($titleText ?? '')) {
     $titleText = $controller->getTitleText();
 }
 
@@ -30,7 +31,7 @@ if (!strlen($titleText)) {
 
     <div class="form-check">
         <label for="useCustomTitle" class="form-check-label">
-            <?php echo $form->checkbox('useCustomTitle', 1, $useCustomTitle); ?>
+            <?php echo $form->checkbox('useCustomTitle', '1', $useCustomTitle); ?>
             <?php echo t('Override page name with custom title?'); ?>
         </label>
     </div>
@@ -38,7 +39,7 @@ if (!strlen($titleText)) {
 
 <div class="form-group">
     <?php echo $form->label('titleText', t('Custom Title Text')); ?>
-    <?php echo $form->text('titleText', $titleText ? $titleText : $controller->getTitleText()); ?>
+    <?php echo $form->text('titleText', $titleText); ?>
 </div>
 
 <div class="form-group">
@@ -61,7 +62,7 @@ if (!strlen($titleText)) {
 
     <div class="form-check">
         <label for="useFilterTitle" class="form-check-label">
-            <?php echo $form->checkbox('useFilterTitle', 1, $useFilterTitle); ?>
+            <?php echo $form->checkbox('useFilterTitle', '1', $useFilterTitle); ?>
             <?php echo t('Enable other blocks to filter this page title'); ?>
         </label>
     </div>
@@ -69,21 +70,21 @@ if (!strlen($titleText)) {
     <div class="well filterTitleOptions">
         <div class="form-check">
             <label for="useFilterTopic" class="form-check-label">
-                <?php echo $form->checkbox('useFilterTopic', 1, $useFilterTopic); ?>
+                <?php echo $form->checkbox('useFilterTopic', '1', $useFilterTopic); ?>
                 <?php echo t('Topic'); ?>
             </label>
         </div>
 
         <div class="form-check">
             <label for="useFilterTag" class="form-check-label">
-                <?php echo $form->checkbox('useFilterTag', 1, $useFilterTag); ?>
+                <?php echo $form->checkbox('useFilterTag', '1', $useFilterTag); ?>
                 <?php echo t('Tag'); ?>
             </label>
         </div>
 
         <div class="form-check">
             <label for="useFilterDate" class="form-check-label">
-                <?php echo $form->checkbox('useFilterDate', 1, $useFilterDate); ?>
+                <?php echo $form->checkbox('useFilterDate', '1', $useFilterDate); ?>
                 <?php echo t('Date'); ?>
             </label>
         </div>

--- a/concrete/blocks/page_title/templates/archive.php
+++ b/concrete/blocks/page_title/templates/archive.php
@@ -1,5 +1,6 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
+/** @var \Concrete\Core\Tree\Node\Type\Topic | null $currentTopic */
 
 if (isset($currentTopic) && is_object($currentTopic)) {
     $title = t('Topic Archives: %s', $currentTopic->getTreeNodeDisplayName());

--- a/concrete/blocks/page_title/templates/byline.php
+++ b/concrete/blocks/page_title/templates/byline.php
@@ -1,8 +1,13 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied.");
-$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
-$page = Page::getCurrentPage();
+<?php use Concrete\Core\User\UserInfoRepository;
+
+defined('C5_EXECUTE') or die("Access Denied.");
+$dh = app('helper/date');
+/* @var $dh \Concrete\Core\Localization\Service\Date */
+$page = \Concrete\Core\Page\Page::getCurrentPage();
 $date = $dh->formatDate($page->getCollectionDatePublic(), true);
-$user = UserInfo::getByID($page->getCollectionUserID());
+/** @var \Concrete\Core\User\UserInfo $user */
+$user = app(UserInfoRepository::class)->getByID($page->getCollectionUserID());
+$title = $title ?? null;
 ?>
 <div class="ccm-block-page-title-byline">
     <h1 class="page-title"><?=h($title)?></h1>

--- a/concrete/blocks/page_title/view.php
+++ b/concrete/blocks/page_title/view.php
@@ -1,18 +1,28 @@
 <?php  defined('C5_EXECUTE') or die('Access Denied.');
 
-if ($useFilterTitle) {
-    if (is_object($currentTopic) && $useFilterTopic) {
-        $title = $controller->formatPageTitle($currentTopic->getTreeNodeDisplayName(), $topicTextFormat);
-    }
-    if ($tag && $useFilterTag) {
-        $title = $controller->formatPageTitle($tag, $tagTextFormat);
-    }
-    if ($year && $month && $useFilterDate) {
-        $srv = Core::make('helper/date');
-        $date = strtotime("$year-$month-01");
-        $title = $srv->date($filterDateFormat ? $filterDateFormat : 'F Y', $date);
+/** @var bool $useFilterTitle  */
+/** @var bool $useFilterTopic */
+/** @var bool $useFilterDate */
+/** @var bool $useFilterTag */
+/** @var bool $formatting */
+/** @var Concrete\Block\PageTitle\Controller $controller */
+/** @var string $title */
+/** @var \Concrete\Core\Tree\Node\Type\Topic | null $currentTopic */
 
-        $title = $controller->formatPageTitle($title, $dateTextFormat);
+if ($useFilterTitle) {
+    $currentTopic = $currentTopic ?? null;
+    if (is_object($currentTopic) && $useFilterTopic) {
+        $title = $controller->formatPageTitle($currentTopic->getTreeNodeDisplayName(), $topicTextFormat ?? false);
+    }
+    if (isset($tag) && $useFilterTag) {
+        $title = $controller->formatPageTitle($tag, $tagTextFormat ?? false);
+    }
+    if (isset($year) && isset($month) && $useFilterDate) {
+        $srv = app('helper/date');
+        $date = strtotime("$year-$month-01");
+        $title = $srv->date($filterDateFormat ?? 'F Y', $date);
+
+        $title = $controller->formatPageTitle($title, $dateTextFormat ?? false);
     }
 }
 

--- a/concrete/blocks/topic_list/add.php
+++ b/concrete/blocks/topic_list/add.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -1,43 +1,69 @@
 <?php
 namespace Concrete\Block\TopicList;
 
-use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
+use Concrete\Core\Support\Facade\Url;
 use Concrete\Core\Tree\Tree;
 use Concrete\Core\Tree\Type\Topic as TopicTree;
-use Concrete\Core\Tree\Type\Topic;
-use Core;
+use Concrete\Core\Page\Page;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = array('form');
+    public $helpers = ['form','form/page_selector'];
 
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 400;
     protected $btTable = 'btTopicList';
+    /** @var string[] */
     protected $btExportPageColumns = ['cParentID'];
+    /** @var int|null */
+    public $topicTreeID;
+    /** @var string|null */
+    public $mode;
+    /** @var string|null */
+    public $topicAttributeKeyHandle;
+    /** @var int|null */
+    public $cParentID;
+    /** @var string|null */
+    public $title;
 
+    /**
+     * {@inheritDoc}
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
         return t("Displays a list of your site's topics, allowing you to click on them to filter a page list.");
     }
 
+    /**
+     * {@inheritDoc}
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t("Topic List");
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @return void
+     */
     public function add()
     {
         $this->edit();
         $this->set('title', t('Topics'));
         $this->set('titleFormat', 'h5');
     }
-    
+
+    /**
+     * {@inheritDoc}
+     * @return string[]
+     */
     public function getRequiredFeatures(): array
     {
         return [
@@ -45,17 +71,24 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @return void
+     */
     public function edit()
     {
-        $tt = new TopicTree();
-        $defaultTree = $tt->getDefault();
-        $tree = $tt->getByID(Core::make('helper/security')->sanitizeInt($this->topicTreeID));
+        $defaultTree = TopicTree::getDefault();
+        $tree = TopicTree::getByID($this->app->make('helper/security')->sanitizeInt($this->topicTreeID));
         if (!$tree) {
             $tree = $defaultTree;
         }
-        $trees = $tt->getList();
-        $keys = CollectionKey::getList();
-        $attributeKeys = array();
+        $trees = TopicTree::getList();
+
+
+        $categoryService = $this->app->make('\Concrete\Core\Attribute\Category\PageCategory');
+        /** @var \Concrete\Core\Entity\Attribute\Key\PageKey[] */
+        $keys = $categoryService->getList();
+        $attributeKeys = [];
         foreach ($keys as $ak) {
             if ($ak->getAttributeTypeHandle() == 'topics') {
                 $attributeKeys[] = $ak;
@@ -66,45 +99,64 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('trees', $trees);
     }
 
+    /**
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     */
     public function view()
     {
         if ($this->mode == 'P') {
-            $page = \Page::getCurrentPage();
+            $page = Page::getCurrentPage();
             $topics = $page->getAttribute($this->topicAttributeKeyHandle);
             if (is_array($topics)) {
                 $this->set('topics', $topics);
             }
         } else {
-            $tt = new TopicTree();
-            $tree = $tt->getByID(Core::make('helper/security')->sanitizeInt($this->topicTreeID));
+            $tree = TopicTree::getByID($this->app->make('helper/security')->sanitizeInt($this->topicTreeID));
             $this->set('tree', $tree);
         }
     }
 
+    /**
+     * @param int|false $treeNodeID
+     * @param string|false $topic
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public function action_topic($treeNodeID = false, $topic = false)
     {
         $this->set('selectedTopicID', intval($treeNodeID));
         $this->view();
     }
 
+    /**
+     * @param \Concrete\Core\Tree\Node\Node|null $topic
+     * @return \League\Url\UrlInterface
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public function getTopicLink(\Concrete\Core\Tree\Node\Node $topic = null)
     {
         if ($this->cParentID) {
-            $c = \Page::getByID($this->cParentID);
+            $c = Page::getByID($this->cParentID);
         } else {
-            $c = \Page::getCurrentPage();
+            $c = Page::getCurrentPage();
         }
         if ($topic) {
             $nodeName = $topic->getTreeNodeName();
             $nodeName = strtolower($nodeName); // convert to lowercase
             $nodeName = preg_replace('/[[:space:]]+/', '-', $nodeName);
-            $nodeName = Core::make('helper/text')->encodePath($nodeName); // urlencode
-            return \URL::page($c, 'topic', $topic->getTreeNodeID(), $nodeName);
+            $nodeName = $this->app->make('helper/text')->encodePath($nodeName); // urlencode
+            return Url::to($c, 'topic', $topic->getTreeNodeID(), $nodeName);
         } else {
-            return \URL::page($c);
+            return Url::to($c);
         }
     }
 
+    /**
+     * @param int $treeID
+     * @return string|null
+     */
     public static function replaceTreeWithPlaceHolder($treeID)
     {
         if ($treeID > 0) {
@@ -113,8 +165,13 @@ class Controller extends BlockController implements UsesFeatureInterface
                 return '{ccm:export:tree:' . $tree->getTreeName() . '}';
             }
         }
+        return null;
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @return void
+     */
     public function export(\SimpleXMLElement $blockNode)
     {
         $tree = Tree::getByID($this->topicTreeID);
@@ -127,18 +184,23 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
         $path = null;
         if ($this->cParentID) {
-            $parent = \Page::getByID($this->cParentID);
+            $parent = Page::getByID($this->cParentID);
             $path = '{ccm:export:page:' . $parent->getCollectionPath() . '}';
         }
         $data->addChild('cParentID', $path);
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode The block node to import
+     * @param Page|mixed $page This is ignored
+     * @return array<string, mixed>
+     */
     public function getImportData($blockNode, $page)
     {
         $args = array();
         $treeName = (string) $blockNode->data->tree;
         $page = (string) $blockNode->data->cParentID;
-        $tree = Topic::getByName($treeName);
+        $tree = TopicTree::getByName($treeName);
         $args['topicTreeID'] = $tree->getTreeID();
         $args['cParentID'] = 0;
         $args['title'] = (string) $blockNode->data->title;
@@ -153,7 +215,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $args['topicAttributeKeyHandle'] = (string) $blockNode->data->topicAttributeKeyHandle;
         if ($page) {
             if (preg_match('/\{ccm:export:page:(.*?)\}/i', $page, $matches)) {
-                $c = \Page::getByPath($matches[1]);
+                $c = Page::getByPath($matches[1]);
                 $args['externalTarget'] = 1;
                 $args['cParentID'] = $c->getCollectionID();
             }
@@ -162,6 +224,10 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $args;
     }
 
+    /**
+     * @param array<string,mixed> $data
+     * @return void
+     */
     public function save($data)
     {
         $data += array(

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -1,38 +1,60 @@
 <?php
+
 namespace Concrete\Block\TopicList;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Url;
 use Concrete\Core\Tree\Tree;
 use Concrete\Core\Tree\Type\Topic as TopicTree;
-use Concrete\Core\Page\Page;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = ['form','form/page_selector'];
-
-    protected $btInterfaceWidth = 400;
-    protected $btInterfaceHeight = 400;
-    protected $btTable = 'btTopicList';
-    /** @var string[] */
-    protected $btExportPageColumns = ['cParentID'];
-    /** @var int|null */
-    public $topicTreeID;
-    /** @var string|null */
-    public $mode;
-    /** @var string|null */
-    public $topicAttributeKeyHandle;
-    /** @var int|null */
-    public $cParentID;
-    /** @var string|null */
-    public $title;
+    public $helpers = ['form', 'form/page_selector'];
 
     /**
-     * {@inheritDoc}
+     * @var int|null
+     */
+    public $topicTreeID;
+
+    /**
+     * @var string|null
+     */
+    public $mode;
+
+    /**
+     * @var string|null
+     */
+    public $topicAttributeKeyHandle;
+
+    /**
+     * @var int|null
+     */
+    public $cParentID;
+
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    protected $btInterfaceWidth = 400;
+
+    protected $btInterfaceHeight = 400;
+
+    protected $btTable = 'btTopicList';
+
+    /**
+     * @var string[]
+     */
+    protected $btExportPageColumns = ['cParentID'];
+
+    /**
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function getBlockTypeDescription()
@@ -41,16 +63,18 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function getBlockTypeName()
     {
-        return t("Topic List");
+        return t('Topic List');
     }
 
     /**
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
      * @return void
      */
     public function add()
@@ -61,18 +85,20 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @return string[]
      */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::TAXONOMY
+            Features::TAXONOMY,
         ];
     }
 
     /**
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
      * @return void
      */
     public function edit()
@@ -83,7 +109,6 @@ class Controller extends BlockController implements UsesFeatureInterface
             $tree = $defaultTree;
         }
         $trees = TopicTree::getList();
-
 
         $categoryService = $this->app->make('\Concrete\Core\Attribute\Category\PageCategory');
         /** @var \Concrete\Core\Entity\Attribute\Key\PageKey[] */
@@ -100,9 +125,9 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @return void
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      *
+     * @return void
      */
     public function view()
     {
@@ -121,21 +146,25 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param int|false $treeNodeID
      * @param string|false $topic
-     * @return void
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
      */
     public function action_topic($treeNodeID = false, $topic = false)
     {
-        $this->set('selectedTopicID', intval($treeNodeID));
+        $this->set('selectedTopicID', (int) $treeNodeID);
         $this->view();
     }
 
     /**
      * @param \Concrete\Core\Tree\Node\Node|null $topic
-     * @return \League\Url\UrlInterface
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \League\Url\UrlInterface
      */
-    public function getTopicLink(\Concrete\Core\Tree\Node\Node $topic = null)
+    public function getTopicLink(?\Concrete\Core\Tree\Node\Node $topic = null)
     {
         if ($this->cParentID) {
             $c = Page::getByID($this->cParentID);
@@ -147,14 +176,16 @@ class Controller extends BlockController implements UsesFeatureInterface
             $nodeName = strtolower($nodeName); // convert to lowercase
             $nodeName = preg_replace('/[[:space:]]+/', '-', $nodeName);
             $nodeName = $this->app->make('helper/text')->encodePath($nodeName); // urlencode
+
             return Url::to($c, 'topic', $topic->getTreeNodeID(), $nodeName);
-        } else {
-            return Url::to($c);
         }
+
+            return Url::to($c);
     }
 
     /**
      * @param int $treeID
+     *
      * @return string|null
      */
     public static function replaceTreeWithPlaceHolder($treeID)
@@ -165,11 +196,13 @@ class Controller extends BlockController implements UsesFeatureInterface
                 return '{ccm:export:tree:' . $tree->getTreeName() . '}';
             }
         }
+
         return null;
     }
 
     /**
      * @param \SimpleXMLElement $blockNode
+     *
      * @return void
      */
     public function export(\SimpleXMLElement $blockNode)
@@ -177,7 +210,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $tree = Tree::getByID($this->topicTreeID);
         $data = $blockNode->addChild('data');
         $data->addChild('mode', $this->mode);
-        $data->addChild("title", $this->title);
+        $data->addChild('title', $this->title);
         $data->addChild('topicAttributeKeyHandle', $this->topicAttributeKeyHandle);
         if (is_object($tree)) {
             $data->addChild('tree', $tree->getTreeName());
@@ -193,11 +226,12 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @param \SimpleXMLElement $blockNode The block node to import
      * @param Page|mixed $page This is ignored
+     *
      * @return array<string, mixed>
      */
     public function getImportData($blockNode, $page)
     {
-        $args = array();
+        $args = [];
         $treeName = (string) $blockNode->data->tree;
         $page = (string) $blockNode->data->cParentID;
         $tree = TopicTree::getByName($treeName);
@@ -226,18 +260,19 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param array<string,mixed> $data
+     *
      * @return void
      */
     public function save($data)
     {
-        $data += array(
+        $data += [
             'externalTarget' => 0,
-        );
-        $externalTarget = intval($data['externalTarget']);
+        ];
+        $externalTarget = (int) ($data['externalTarget']);
         if ($externalTarget === 0) {
             $data['cParentID'] = 0;
         } else {
-            $data['cParentID'] = intval($data['cParentID']);
+            $data['cParentID'] = (int) ($data['cParentID']);
         }
 
         parent::save($data);

--- a/concrete/blocks/topic_list/edit.php
+++ b/concrete/blocks/topic_list/edit.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/topic_list/form.php
+++ b/concrete/blocks/topic_list/form.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $topics = $topics ?? [];
 $title = $title ?? t('Topics');
 $titleFormat = $titleFormat ?? 'h5';
@@ -9,7 +9,7 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
 /** @var \Concrete\Core\Tree\Type\Topic[] $trees */
 /** @var \Concrete\Core\Form\Service\Form $form */
 /** @var \Concrete\Core\Form\Service\Widget\PageSelector $form_page_selector */
-/** @var \Concrete\Block\TopicList\Controller $controller  */
+/** @var \Concrete\Block\TopicList\Controller $controller */
 /** @var \Concrete\Core\Entity\Attribute\Key\PageKey[] $attributeKeys */
 ?>
 <fieldset>
@@ -17,10 +17,10 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
         <label class="control-label form-label" for="modeSelect"><?=t('Mode')?></label>
         <select class="form-select" name="mode" id="modeSelect">
             <option value="S" <?php if ($mode == 'S') {
-    ?>selected<?php 
+    ?>selected<?php
 } ?>><?=t('Search – Display a list of all topics for use on a search sidebar.')?></option>
             <option value="P" <?php if ($mode == 'P') {
-    ?>selected<?php 
+    ?>selected<?php
 } ?>><?=t('Page – Display a list of topics for the current page.')?></option>
         </select>
     </div>
@@ -30,10 +30,10 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
             <?php foreach ($trees as $stree) {
     ?>
                 <option value="<?=$stree->getTreeID()?>" <?php if ($tree->getTreeID() == $stree->getTreeID()) {
-    ?>selected<?php 
+    ?>selected<?php
 }
     ?>><?=$stree->getTreeDisplayName()?></option>
-            <?php 
+            <?php
 } ?>
         </select>
     </div>
@@ -44,10 +44,10 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
             <?php foreach ($attributeKeys as $attributeKey) {
     ?>
                 <option value="<?=$attributeKey->getAttributeKeyHandle()?>" <?php if ($attributeKey->getAttributeKeyHandle() == $topicAttributeKeyHandle) {
-    ?>selected<?php 
+    ?>selected<?php
 }
     ?>><?=$attributeKey->getAttributeKeyDisplayName()?></option>
-            <?php 
+            <?php
 } ?>
         </select>
     </div>
@@ -55,8 +55,8 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
     <div class='form-group'>
         <label for='title' class="control-label form-label"><?=t('Results Page')?>:</label>
         <div class="form-check">
-            <input class="form-check-input" id="ccm-search-block-external-target" <?php if (intval($cParentID) > 0) {
-    ?>checked<?php 
+            <input class="form-check-input" id="ccm-search-block-external-target" <?php if ((int) $cParentID > 0) {
+    ?>checked<?php
 } ?> name="externalTarget" type="checkbox" value="1" />
             <label for="ccm-search-block-external-target" class="form-check-label">
                 <?=t('Post Results to a Different Page')?>
@@ -70,10 +70,10 @@ $topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("title", t('Title')); ?>
+        <?php echo $form->label('title', t('Title')); ?>
 	    <div class="input-group">
 		    <?php echo $form->text('title', $title); ?>
-			<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat, array('style' => 'width:105px;flex-grow:0;', 'class' => 'form-select')); ?>
+			<?php echo $form->select('titleFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $titleFormat, ['style' => 'width:105px;flex-grow:0;', 'class' => 'form-select']); ?>
 		</div>
 	</div>
 

--- a/concrete/blocks/topic_list/form.php
+++ b/concrete/blocks/topic_list/form.php
@@ -1,4 +1,17 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+$topics = $topics ?? [];
+$title = $title ?? t('Topics');
+$titleFormat = $titleFormat ?? 'h5';
+$mode = $mode ?? 'S';
+$tree = $tree ?? null;
+$cParentID = $cParentID ?? null;
+$topicAttributeKeyHandle = $topicAttributeKeyHandle ?? null;
+/** @var \Concrete\Core\Tree\Type\Topic[] $trees */
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var \Concrete\Core\Form\Service\Widget\PageSelector $form_page_selector */
+/** @var \Concrete\Block\TopicList\Controller $controller  */
+/** @var \Concrete\Core\Entity\Attribute\Key\PageKey[] $attributeKeys */
+?>
 <fieldset>
     <div class="form-group">
         <label class="control-label form-label" for="modeSelect"><?=t('Mode')?></label>
@@ -51,7 +64,7 @@
         </div>
         <div id="ccm-search-block-external-target-page">
         <?php
-        echo Loader::helper('form/page_selector')->selectPage('cParentID', $cParentID);
+        echo $form_page_selector->selectPage('cParentID', $cParentID);
         ?>
         </div>
     </div>

--- a/concrete/blocks/topic_list/templates/flat_filter.php
+++ b/concrete/blocks/topic_list/templates/flat_filter.php
@@ -1,10 +1,10 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied.");
+<?php  defined('C5_EXECUTE') or die('Access Denied.');
 $topics = $topics ?? [];
 $title = $title ?? t('Topics');
 $titleFormat = $titleFormat ?? 'h5';
 $mode = $mode ?? 'S';
 $tree = $tree ?? null;
-/** @var \Concrete\Block\TopicList\Controller $controller  */
+/** @var \Concrete\Block\TopicList\Controller $controller */
 /** @var \Concrete\Core\Block\View\BlockView $view */
 if (!isset($selectedTopicID)) {
     $selectedTopicID = null;
@@ -21,7 +21,7 @@ if (is_object($tree)) {
         <ol class="breadcrumb">
             <li><a href="<?=$view->controller->getTopicLink()?>"
                 <?php if (!$selectedTopicID) {
-    ?>class="ccm-block-topic-list-topic-selected active"<?php 
+    ?>class="ccm-block-topic-list-topic-selected active"<?php
 }
         ?>><?=t('All')?></a></li>
 
@@ -31,16 +31,16 @@ if (is_object($tree)) {
                     <?php if (isset($selectedTopicID) && $selectedTopicID == $child->getTreeNodeID()) {
     ?>
                         class="ccm-block-topic-list-topic-selected active"
-                    <?php 
+                    <?php
 }
     ?> ><?=$child->getTreeNodeDisplayName()?></a></li>
-        <?php 
+        <?php
 }
         ?>
         </ol>
-    <?php 
+    <?php
     }
     ?>
     </div>
-<?php 
+<?php
 } ?>

--- a/concrete/blocks/topic_list/templates/flat_filter.php
+++ b/concrete/blocks/topic_list/templates/flat_filter.php
@@ -1,4 +1,11 @@
 <?php  defined('C5_EXECUTE') or die("Access Denied.");
+$topics = $topics ?? [];
+$title = $title ?? t('Topics');
+$titleFormat = $titleFormat ?? 'h5';
+$mode = $mode ?? 'S';
+$tree = $tree ?? null;
+/** @var \Concrete\Block\TopicList\Controller $controller  */
+/** @var \Concrete\Core\Block\View\BlockView $view */
 if (!isset($selectedTopicID)) {
     $selectedTopicID = null;
 }

--- a/concrete/blocks/topic_list/view.php
+++ b/concrete/blocks/topic_list/view.php
@@ -1,11 +1,11 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied.");
+<?php  defined('C5_EXECUTE') or die('Access Denied.');
 
 $topics = $topics ?? [];
 $title = $title ?? t('Topics');
 $titleFormat = $titleFormat ?? 'h5';
 $mode = $mode ?? 'S';
 $tree = $tree ?? null;
-/** @var \Concrete\Block\TopicList\Controller $controller  */
+/** @var \Concrete\Block\TopicList\Controller $controller */
 ?>
 
 <div class="ccm-block-topic-list">

--- a/concrete/blocks/topic_list/view.php
+++ b/concrete/blocks/topic_list/view.php
@@ -1,4 +1,12 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php  defined('C5_EXECUTE') or die("Access Denied.");
+
+$topics = $topics ?? [];
+$title = $title ?? t('Topics');
+$titleFormat = $titleFormat ?? 'h5';
+$mode = $mode ?? 'S';
+$tree = $tree ?? null;
+/** @var \Concrete\Block\TopicList\Controller $controller  */
+?>
 
 <div class="ccm-block-topic-list">
 
@@ -14,14 +22,14 @@
             if (!isset($selectedTopicID)) {
                 $selectedTopicID = null;
             }
-            $walk = function ($node) use (&$walk, &$view, $selectedTopicID) {
+            $walk = function ($node) use (&$walk, &$controller, $selectedTopicID) {
                 ?><ul class="ccm-block-topic-list-list"><?php
                 foreach ($node->getChildNodes() as $topic) {
                     if ($topic instanceof \Concrete\Core\Tree\Node\Type\Category) {
                         ?><li><?php echo $topic->getTreeNodeDisplayName(); ?>
                         <?php
                     } else {
-                        ?><li><a href="<?php echo $view->controller->getTopicLink($topic); ?>" <?php
+                        ?><li><a href="<?php echo $controller->getTopicLink($topic); ?>" <?php
                         if (isset($selectedTopicID) && $selectedTopicID == $topic->getTreeNodeID()) {
                             ?> class="ccm-block-topic-list-topic-selected"<?php
                         }
@@ -43,7 +51,7 @@
         if (isset($topics) && count($topics)) {
             ?><ul class="ccm-block-topic-list-page-topics"><?php
             foreach ($topics as $topic) {
-                ?><li><a href="<?php echo $view->controller->getTopicLink($topic); ?>"><?php echo $topic->getTreeNodeDisplayName(); ?></a></li><?php
+                ?><li><a href="<?php echo $controller->getTopicLink($topic); ?>"><?php echo $topic->getTreeNodeDisplayName(); ?></a></li><?php
             }
             ?></ul><?php
         } else {

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -9,33 +9,56 @@ use Concrete\Core\Feature\UsesFeatureInterface;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     protected $btTable = 'btYouTube';
+    /** @var string | int */
     protected $btInterfaceWidth = '400';
+    /** @var string | int */
     protected $btInterfaceHeight = '490';
+    /** @var bool */
     protected $btCacheBlockRecord = true;
+    /** @var bool */
     protected $btCacheBlockOutput = true;
+    /** @var bool */
     protected $btCacheBlockOutputOnPost = true;
+    /** @var bool */
     protected $btCacheBlockOutputForRegisteredUsers = false;
+    /** @var string | null */
+    public $videoURL;
+    /** @var string | null */
+    public $vWidth;
+    /** @var string | null */
+    public $vHeight;
+
 
     /**
-     * Used for localization. If we want to localize the name/description we have to include this.
+     * @inheritDoc
      */
     public function getBlockTypeDescription()
     {
         return t('Embeds a YouTube Video in your web page.');
     }
 
+    /**
+     * @inheritDoc
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t('YouTube Video');
     }
 
+    /**
+     * @return void
+     */
     public function edit()
     {
-        if ($this->vWidth || $this->vWidth) {
+        if ($this->vWidth || $this->vHeight) {
             $this->set('sizing', 'fixed');
         }
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getRequiredFeatures(): array
     {
         return [
@@ -43,45 +66,58 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
     }
 
+    /**
+     * @return void
+     */
     public function view()
     {
-        $url = parse_url($this->videoURL);
-        $pathParts = explode('/', rtrim($url['path'], '/'));
-        $videoID = end($pathParts);
         $playListID = '';
+        $videoID = '';
+        $query=[];
 
-        if (isset($url['query']) === true) {
-            parse_str($url['query'], $query);
-            
-            if (isset($query['list']) === true) {
-                $playListID = $query['list'];
-                $videoID = '';
-            } else {
-                $videoID = isset($query['v']) ? $query['v'] : $videoID;
-                $videoID = strtok($videoID, '?');
+        $url = parse_url($this->videoURL ?? '');
+        if (is_array($url) && isset($url['path'])) {
+            $pathParts = explode('/', rtrim($url['path'], '/'));
+            $videoID = end($pathParts);
+            if (isset($url['query']) === true) {
+                parse_str($url['query'], $query);
+
+                if (isset($query['list']) === true) {
+                    $playListID = $query['list'];
+                    $videoID = '';
+                } else {
+                    $videoID = $query['v'] ?? $videoID;
+                    $videoID = strtok($videoID, '?');
+                }
             }
         }
 
-        if ($this->noCookie) {
+
+
+        if (isset($this->noCookie)) {
             $this->set('youtubeDomain', 'www.youtube-nocookie.com');
         } else {
             $this->set('youtubeDomain', 'www.youtube.com');
         }
 
-        if (strpos($videoID, ',') !== false) {
+        if (is_string($videoID) && strpos($videoID, ',') !== false) {
             $this->set('playlist', $videoID);
         }
 
-        if ($this->startTimeEnabled == 1 && ($this->startTime === '0' || $this->startTime)) {
+        if (isset($this->startTimeEnabled) && $this->startTimeEnabled == 1 && isset($this->startTime)) {
             $this->set('startSeconds', $this->convertStringToSeconds($this->startTime));
-        } elseif (isset($query['t']) === true && empty($query['t']) === false) {
+        } elseif (!empty($query) && isset($query['t']) === true && empty($query['t']) === false) {
             $this->set('startSeconds', $this->convertStringToSeconds($query['t']));
         }
 
-        $this->set('videoID', $videoID);
+        $this->set('videoID', (string) $videoID);
         $this->set('playListID', $playListID);
     }
 
+    /**
+     * @param string $string
+     * @return false|float|int
+     */
     public function convertStringToSeconds($string)
     {
         if (preg_match_all('/(\d+)(h|m|s)/i', $string, $matches)) {
@@ -106,6 +142,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         return false;
     }
 
+    /**
+     * Run when a block is added or edited. Automatically saves block data against the block's database table. If a block needs to do more than this (save to multiple tables, upload files, etc... it should override this.
+     *
+     * @param array<string,mixed> $data
+     * @return void
+     */
     public function save($data)
     {
         $data += [

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -8,29 +8,55 @@ use Concrete\Core\Feature\UsesFeatureInterface;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    protected $btTable = 'btYouTube';
-    /** @var string | int */
-    protected $btInterfaceWidth = '400';
-    /** @var string | int */
-    protected $btInterfaceHeight = '490';
-    /** @var bool */
-    protected $btCacheBlockRecord = true;
-    /** @var bool */
-    protected $btCacheBlockOutput = true;
-    /** @var bool */
-    protected $btCacheBlockOutputOnPost = true;
-    /** @var bool */
-    protected $btCacheBlockOutputForRegisteredUsers = false;
-    /** @var string | null */
+    /**
+     * @var string|null
+     */
     public $videoURL;
-    /** @var string | null */
-    public $vWidth;
-    /** @var string | null */
-    public $vHeight;
-
 
     /**
-     * @inheritDoc
+     * @var string|null
+     */
+    public $vWidth;
+
+    /**
+     * @var string|null
+     */
+    public $vHeight;
+
+    protected $btTable = 'btYouTube';
+
+    /**
+     * @var string|int
+     */
+    protected $btInterfaceWidth = '400';
+
+    /**
+     * @var string|int
+     */
+    protected $btInterfaceHeight = '490';
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockRecord = true;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var bool
+     */
+    protected $btCacheBlockOutputForRegisteredUsers = false;
+
+    /**
+     * {@inheritdoc}
      */
     public function getBlockTypeDescription()
     {
@@ -38,7 +64,8 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
+     *
      * @return string
      */
     public function getBlockTypeName()
@@ -57,12 +84,12 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::VIDEO
+            Features::VIDEO,
         ];
     }
 
@@ -73,7 +100,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     {
         $playListID = '';
         $videoID = '';
-        $query=[];
+        $query = [];
 
         $url = parse_url($this->videoURL ?? '');
         if (is_array($url) && isset($url['path'])) {
@@ -92,9 +119,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
         }
 
-
-
-        if (isset($this->noCookie)) {
+        if (isset($this->noCookie) && $this->noCookie) {
             $this->set('youtubeDomain', 'www.youtube-nocookie.com');
         } else {
             $this->set('youtubeDomain', 'www.youtube.com');
@@ -116,6 +141,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param string $string
+     *
      * @return false|float|int
      */
     public function convertStringToSeconds($string)
@@ -146,6 +172,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      * Run when a block is added or edited. Automatically saves block data against the block's database table. If a block needs to do more than this (save to multiple tables, upload files, etc... it should override this.
      *
      * @param array<string,mixed> $data
+     *
      * @return void
      */
     public function save($data)
@@ -174,7 +201,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             'noCookie' => false,
 
-            'lazyLoad' => false
+            'lazyLoad' => false,
         ];
 
         $args = [
@@ -200,7 +227,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             'noCookie' => $data['noCookie'] ? 1 : 0,
 
-            'lazyLoad' => $data['lazyLoad'] ? 1 : 0
+            'lazyLoad' => $data['lazyLoad'] ? 1 : 0,
         ];
         if ($args['sizing'] === 'fixed') {
             $args += [

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -5,28 +5,29 @@ defined('C5_EXECUTE') or die('Access Denied.');
 use Concrete\Core\Application\Service\UserInterface;
 use Concrete\Core\Support\Facade\Application;
 
-/** @var string $title */
-/** @var string $videoURL */
-/** @var string $vHeight */
-/** @var string $vWidth */
-/** @var string $sizing */
-/** @var bool $startTimeEnabled */
-/** @var string $startTime */
-/** @var bool $noCookie */
-/** @var bool $autoplay */
-/** @var string $color */
-/** @var int $iv_load_policy */
-/** @var bool $loopEnd */
-/** @var bool $lazyLoad */
-/** @var bool $rel */
-/** @var bool $showCaptions */
+/** @var string | null $title */
+/** @var string | null $videoURL */
+/** @var string | null $vHeight */
+/** @var string | null $vWidth */
+/** @var string | null $sizing */
+/** @var bool | null $startTimeEnabled */
+/** @var string | null $startTime */
+/** @var bool | null $noCookie */
+/** @var bool | null $autoplay */
+/** @var string | null $color  */
+/** @var int | null $iv_load_policy */
+/** @var bool | null $loopEnd */
+/** @var bool | null $lazyLoad */
+/** @var bool | null $rel */
+/** @var bool | null $showCaptions */
+/** @var Concrete\Core\Form\Service\Form $form */
 
 if (empty($vWidth)) {
-    $vWidth = 640;
+    $vWidth = '640';
 }
 
 if (empty($vHeight)) {
-    $vHeight = 360;
+    $vHeight = '360';
 }
 
 if (empty($sizing)) {
@@ -48,7 +49,7 @@ echo $ui->tabs([
     <div class="tab-pane show active" id="video" role="tabpanel">
         <div class="form-group">
             <?php echo $form->label('videoURL', t("YouTube URL")); ?>
-            <?php echo $form->text('videoURL', isset($videoURL) ? $videoURL : '', ['required' => 'required']); ?>
+            <?php echo $form->text('videoURL', $videoURL ?? '', ['required' => 'required']); ?>
         </div>
 
         <div class="form-group">
@@ -109,7 +110,7 @@ echo $ui->tabs([
                 <div class="col-xs-6">
                     <div class="form-group">
                         <div class="form-check">
-                            <?php echo $form->checkbox('controls', 1, (isset($controls) ? $controls : true)); ?>
+                            <?php echo $form->checkbox('controls', '1', ($controls ?? true)); ?>
                             <?php echo $form->label("controls", t('Show controls')); ?>
                         </div>
 
@@ -121,7 +122,7 @@ echo $ui->tabs([
                                 $additionalAttributes['disabled'] = 'disabled';
                             }
 
-                            echo $form->checkbox('modestbranding', 1, (isset($modestbranding) ? $modestbranding : true), $additionalAttributes); ?>
+                            echo $form->checkbox('modestbranding', '1', ($modestbranding ?? true), $additionalAttributes); ?>
 
                             <?php echo $form->label("modestbranding", t('Hide YouTube Logo')); ?>
                         </div>
@@ -144,37 +145,37 @@ echo $ui->tabs([
 
             <div class="form-group">
                 <div class="form-check">
-                    <?php echo $form->checkbox('rel', 1, !empty($rel)); ?>
+                    <?php echo $form->checkbox('rel', '1', !empty($rel)); ?>
                     <?php echo $form->label('rel', t('Show related videos from different channels when playback ends')); ?>
                 </div>
 
                 <div class="form-check">
-                    <?php echo $form->checkbox('iv_load_policy', 1, isset($iv_load_polict) && $iv_load_policy == 3); ?>
+                    <?php echo $form->checkbox('iv_load_policy', '1', isset($iv_load_polict) && $iv_load_policy == 3); ?>
                     <?php echo $form->label("iv_load_policy", t('Hide annotations by default')); ?>
                 </div>
 
                 <div class="form-check">
-                    <?php echo $form->checkbox('autoplay', 1, !empty($autoplay)); ?>
+                    <?php echo $form->checkbox('autoplay', '1', !empty($autoplay)); ?>
                     <?php echo $form->label("autoplay", t('Automatically play')); ?>
                 </div>
 
                 <div class="form-check">
-                    <?php echo $form->checkbox('loopEnd', 1, !empty($loopEnd)); ?>
+                    <?php echo $form->checkbox('loopEnd', '1', !empty($loopEnd)); ?>
                     <?php echo $form->label("loopEnd", t('Loop video')); ?>
                 </div>
 
                 <div class="form-check">
-                    <?php echo $form->checkbox('showCaptions', 1, !empty($showCaptions)); ?>
+                    <?php echo $form->checkbox('showCaptions', '1', !empty($showCaptions)); ?>
                     <?php echo $form->label("showCaptions", t('Show captions')); ?>
                 </div>
 
                 <div class="form-check">
-                    <?php echo $form->checkbox('startTimeEnabled', 1, !empty($startTimeEnabled)); ?>
+                    <?php echo $form->checkbox('startTimeEnabled', '1', !empty($startTimeEnabled)); ?>
                     <?php echo $form->label("startTimeEnabled", t('Start video at:')); ?>
                 </div>
 
                 <div class="form-group">
-                    <?php echo $form->text('startTime', isset($startTime) ? $startTime : null); ?>
+                    <?php echo $form->text('startTime', $startTime ?? null); ?>
                 </div>
             </div>
         </fieldset>
@@ -185,7 +186,7 @@ echo $ui->tabs([
             </legend>
 
             <div class="form-check">
-                <?php echo $form->checkbox('noCookie', 1, (isset($noCookie) ? $noCookie : false)); ?>
+                <?php echo $form->checkbox('noCookie', '1', ($noCookie ?? false)); ?>
                 <?php echo $form->label("noCookie", t('No cookie')); ?>
             </div>
         </fieldset>
@@ -196,7 +197,7 @@ echo $ui->tabs([
             </legend>
 
             <div class="form-check">
-                <?php echo $form->checkbox('lazyLoad', 1, (isset($lazyLoad) ? $lazyLoad : false)); ?>
+                <?php echo $form->checkbox('lazyLoad', '1', ($lazyLoad ?? false)); ?>
                 <?php echo $form->label("lazyLoad", t('Lazy load video')) ?>
             </div>
         </fieldset>
@@ -225,7 +226,7 @@ echo $ui->tabs([
             if ($(this).val() === 'white') {
                 $('#modestbranding').prop('disabled', 'disabled').prop('checked', false);
             } else {
-                $('#modestbranding').removeProp('disabled');
+                $('#modestbranding').removeAttr('disabled')
             }
         });
 

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -1,14 +1,21 @@
 <?php
-
-use League\Url\Url;
-
 defined('C5_EXECUTE') or die('Access Denied.');
+
+use Concrete\Core\Url\Url;
+use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Page;
+
+/** @var string $youtubeDomain */
 
 $responsiveClass = 'youtubeBlockResponsive16by9';
 $sizeDisabled = '';
 $lazyLoadAttribute = '';
 $sizeargs = null;
-if ($vWidth && $vHeight) {
+$sizing = $sizing ?? null;
+$videoID = $videoID ?? '';
+$bID = $bID ?? 0; // This should always be set but just incase
+$c = Page::getCurrentPage();
+if (isset($vWidth) && isset($vHeight)) {
     $sizeargs = 'width="' . $vWidth . '" height="' . $vHeight . '"';
     $sizeDisabled = 'style="width:' . $vWidth . 'px; height:' . $vHeight . 'px"';
     $responsiveClass = '';
@@ -27,7 +34,7 @@ if (isset($playlist)) {
     $videoID = '';
 }
 
-if ($playListID) {
+if (isset($playListID) && !empty($playListID)) {
     $params['listType'] = 'playlist';
     $params['list'] = $playListID;
 }
@@ -83,7 +90,7 @@ $source->getPath()->set(['embed', $videoID]);
 // Get rid of the `http:` at the beginning of the url
 $source = substr((string) $source, 5);
 
-if (Page::getCurrentPage()->isEditMode()) {
+if (is_object($c) && $c->isEditMode()) {
     $loc = Localization::getInstance();
     $loc->pushActiveContext(Localization::CONTEXT_UI); ?>
     <div class="ccm-edit-mode-disabled-item youtubeBlock <?php echo $responsiveClass; ?>" <?php echo $sizeDisabled; ?>>

--- a/concrete/single_pages/dashboard/pages/containers/form.php
+++ b/concrete/single_pages/dashboard/pages/containers/form.php
@@ -7,14 +7,15 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var Concrete\Core\Form\Service\Form $form
  * @var Concrete\Core\Validation\CSRF\Token $token
  * @var Concrete\Core\Entity\Page\Container[] $containers
- * @var Concrete\Core\Entity\Page\Container $container
+ * @var Concrete\Core\Entity\Page\Container|null $container
+ * @var \Concrete\Core\Page\View\PageView $view
  * @var string $tokenMessage
  */
 
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 $icons = $app->make(\Concrete\Core\Page\Container\IconRepository::class)->getIcons();
-
-if (isset($container) && $container) {
+$container = $container ?? null;
+if ($container) {
     $action = URL::to('/dashboard/pages/containers/update_container', $container->getContainerID());
     $buttonText = t('Save');
     $containerName = $container->getContainerName();

--- a/concrete/single_pages/dashboard/pages/templates/view.php
+++ b/concrete/single_pages/dashboard/pages/templates/view.php
@@ -6,6 +6,9 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var Concrete\Controller\SinglePage\Dashboard\Pages\Templates $controller
  * @var Concrete\Core\Form\Service\Form $form
  * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var \Concrete\Core\View\View $view
+ * @var array $icons
+ * @var \Concrete\Core\Entity\Page\Template[] $templates
  */
 
 if (isset($template) && is_object($template) && ($controller->getAction() == 'edit' || $controller->getAction() == 'update')) {
@@ -93,7 +96,7 @@ if (isset($template) && is_object($template) && ($controller->getAction() == 'ed
     }
 }
 
-if ($template) {
+if (isset($template)) {
         ?>
     <div class="modal fade" id="delete-template" tabindex="-1">
         <form method="post" action="<?=$view->action('delete', $template->getPageTemplateID(), $token->generate('delete_page_template')); ?>">

--- a/concrete/src/Area/Layout/Layout.php
+++ b/concrete/src/Area/Layout/Layout.php
@@ -40,7 +40,7 @@ abstract class Layout extends ConcreteObject
     /**
      * @param int $arLayoutID
      *
-     * @return CustomLayout|ThemeGridLayout|null
+     * @return \Concrete\Core\Area\Layout\PresetLayout|CustomLayout|ThemeGridLayout|null
      */
     public static function getByID($arLayoutID)
     {

--- a/concrete/src/Asset/AssetList.php
+++ b/concrete/src/Asset/AssetList.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Asset;
 
 use Concrete\Core\Foundation\ConcreteObject;
@@ -6,20 +7,23 @@ use Concrete\Core\Foundation\ConcreteObject;
 class AssetList
 {
     /**
-     * @var null|self
+     * @var array<string, array<string, Asset>> map<assetType, map<handle, Asset>> Array of assets with type, version, and handle
      */
-    private static $loc = null;
-
-    /**
-     * @var array Array of assets with type, version, and handle
-     */
-    public $assets = array();
+    public $assets = [];
 
     /**
      * @var AssetGroup[] map<handle, AssetGroup>
      */
-    public $assetGroups = array();
+    public $assetGroups = [];
 
+    /**
+     * @var self|null
+     */
+    private static $loc;
+
+    /**
+     * @return array<string, array<string, Asset>> map<assetType, map<handle, Asset>> Array of assets with type, version, and handle
+     */
     public function getRegisteredAssets()
     {
         return $this->assets;
@@ -38,7 +42,7 @@ class AssetList
      */
     public static function getInstance()
     {
-        if (null === self::$loc) {
+        if (self::$loc === null) {
             self::$loc = new self();
         }
 
@@ -49,20 +53,20 @@ class AssetList
      * @param string $assetType
      * @param string $assetHandle
      * @param string $filename
-     * @param array $args
+     * @param array<string,mixed> $args
      * @param bool $pkg
      *
      * @return Asset
      */
-    public function register($assetType, $assetHandle, $filename, $args = array(), $pkg = false)
+    public function register($assetType, $assetHandle, $filename, $args = [], $pkg = false)
     {
-        $defaults = array(
+        $defaults = [
             'position' => false,
             'local' => true,
             'version' => false,
             'combine' => -1,
             'minify' => -1, // use the asset default
-        );
+        ];
         // overwrite all the defaults with the arguments
         $args = array_merge($defaults, $args);
 
@@ -75,20 +79,24 @@ class AssetList
     }
 
     /**
-     * @param array $assets
+     * @param array<string,mixed> $assets
+     *
+     * @return void
      */
     public function registerMultiple(array $assets)
     {
         foreach ($assets as $asset_handle => $asset_types) {
-            foreach ($asset_types as $asset_type => $asset_settings) {
+            foreach ($asset_types as $asset_settings) {
                 array_splice($asset_settings, 1, 0, $asset_handle);
-                call_user_func_array(array($this, 'register'), $asset_settings);
+                call_user_func_array([$this, 'register'], $asset_settings);
             }
         }
     }
 
     /**
      * @param Asset $asset
+     *
+     * @return void
      */
     public function registerAsset(Asset $asset)
     {
@@ -108,10 +116,12 @@ class AssetList
 
     /**
      * @param string $assetGroupHandle
-     * @param array $assetHandles
+     * @param array<string,mixed> $assetHandles
      * @param bool $customClass
+     *
+     * @return void
      */
-    public function registerGroup($assetGroupHandle, $assetHandles, $customClass = false)
+    public function registerGroup(string $assetGroupHandle, array $assetHandles, bool $customClass = false)
     {
         if ($customClass) {
             $class = '\\Concrete\\Core\\Asset\\Group\\' . ConcreteObject::camelcase($assetGroupHandle) . 'AssetGroup';
@@ -127,13 +137,15 @@ class AssetList
     }
 
     /**
-     * @param array $asset_groups
+     * @param array<string, mixed> $asset_groups
+     *
+     * @return void
      */
     public function registerGroupMultiple(array $asset_groups)
     {
         foreach ($asset_groups as $group_handle => $group_setting) {
             array_unshift($group_setting, $group_handle);
-            call_user_func_array(array($this, 'registerGroup'), $group_setting);
+            call_user_func_array([$this, 'registerGroup'], $group_setting);
         }
     }
 
@@ -141,20 +153,20 @@ class AssetList
      * @param string $assetType
      * @param string $assetHandle
      *
-     * @return Asset
+     * @return Asset|null
      */
-    public function getAsset($assetType, $assetHandle)
+    public function getAsset(string $assetType, string $assetHandle)
     {
-        return isset($this->assets[$assetType][$assetHandle]) ? $this->assets[$assetType][$assetHandle] : null;
+        return $this->assets[$assetType][$assetHandle] ?? null;
     }
 
     /**
      * @param string $assetGroupHandle
      *
-     * @return \Concrete\Core\Asset\AssetGroup
+     * @return \Concrete\Core\Asset\AssetGroup|null
      */
     public function getAssetGroup($assetGroupHandle)
     {
-        return $this->assetGroups[$assetGroupHandle];
+        return $this->assetGroups[$assetGroupHandle] ?? null;
     }
 }

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -2066,11 +2066,11 @@ EOT
             if (!is_array($r1)) {
                 // Ok, no block found. So let's see if a block with the same relationID exists on the page instead.
 
-                $r2 = $db->fetchAssoc('select arHandle, bID from CollectionVersionBlocks where cID = ? and cvID = ? and cbRelationID = ?', [
+                $r2 = $db->fetchAssociative('select arHandle, bID from CollectionVersionBlocks where cID = ? and cvID = ? and cbRelationID = ?', [
                     $row['cID'], $row['cvID'], $cbRelationID,
                 ]);
 
-                if ((is_array($r2) && $r2['bID'] && $updateForkedBlocks) || (!is_array($r2['bID']) && $addBlock)) {
+                if ((is_array($r2) && $r2['bID'] && $updateForkedBlocks) || (!is_array($r2) && $addBlock)) {
                     // Ok, so either this block doesn't appear on the page at all, but addBlock set to true,
                     // or, the block appears on the page and it is forked. Either way we're going to add it to the page.
 

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1891,12 +1891,14 @@ EOT
      * Additionally, this command grabs the permissions from the original record in the CollectionVersionBlocks table, and attaches them to the new one.
      *
      * @param \Concrete\Core\Page\Collection\Collection $c The collection to add the block alias to
+     * @param int|null $displayOrder The number to display this block at. (optional)
      */
-    public function alias($c)
+    public function alias($c, int $displayOrder = null)
     {
         $app = Application::getFacadeApplication();
+        /** @var Cloner $cloner */
         $cloner = $app->make(Cloner::class);
-        $cloner->cloneBlock($this, $c);
+        $cloner->cloneBlock($this, $c, $displayOrder);
     }
 
     /**

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1891,14 +1891,13 @@ EOT
      * Additionally, this command grabs the permissions from the original record in the CollectionVersionBlocks table, and attaches them to the new one.
      *
      * @param \Concrete\Core\Page\Collection\Collection $c The collection to add the block alias to
-     * @param int|null $displayOrder The number to display this block at. (optional)
      */
-    public function alias($c, int $displayOrder = null)
+    public function alias($c)
     {
         $app = Application::getFacadeApplication();
         /** @var Cloner $cloner */
         $cloner = $app->make(Cloner::class);
-        $cloner->cloneBlock($this, $c, $displayOrder);
+        $cloner->cloneBlock($this, $c);
     }
 
     /**

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -1,11 +1,11 @@
 <?php
 namespace Concrete\Core\Block;
 
+use Concrete\Core\Area\Area;
 use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Entity\Block\BlockType\BlockType;
 use Concrete\Core\Block\View\BlockViewTemplate;
-use Concrete\Core\Controller;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Legacy\BlockRecord;
 use Concrete\Core\Page\Controller\PageController;
@@ -37,7 +37,9 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $btSupportsInlineEdit = false;
     protected $btCopyWhenPropagate = 0;
     protected $btIncludeAll = 0;
+    /** @var string | int  */
     protected $btInterfaceWidth = "400";
+    /** @var string | int  */
     protected $btInterfaceHeight = "400";
     protected $btHasRendered = false;
     protected $btCacheBlockRecord = true;
@@ -54,6 +56,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $btWrapperClass = '';
     protected $btDefaultSet;
     protected $identifier;
+    /** @var null|string  */
     protected $btTable = null;
     protected $btID;
 
@@ -253,7 +256,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
      *
      * @param int $newBlockID
      *
-     * @return BlockRecord $newInstance
+     * @return BlockRecord | null $newInstance
      */
     public function duplicate($newBID)
     {

--- a/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
+++ b/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
@@ -18,11 +18,15 @@ class AddAliasDefaultsBlockCommandHandler
                 $b = Block::getByID($command->getOriginalBlockID(), $mc, $command->getOriginalAreaHandle());
                 if ($b) {
                     $bt = $b->getBlockTypeObject();
+                    $displayOrder = $b->getBlockDisplayOrder();
                     if ($bt->isCopiedWhenPropagated()) {
-                        $b->duplicate($page, true);
+                        $b = $b->duplicate($page, true);
+                        $b->setAbsoluteBlockDisplayOrder($displayOrder);
                     } else {
-                        $b->alias($page);
+                        $b->alias($page, $displayOrder);
                     }
+
+                    $page->rescanDisplayOrder($command->getAreaHandle());
                 }
             }
         }

--- a/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
+++ b/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
@@ -18,15 +18,11 @@ class AddAliasDefaultsBlockCommandHandler
                 $b = Block::getByID($command->getOriginalBlockID(), $mc, $command->getOriginalAreaHandle());
                 if ($b) {
                     $bt = $b->getBlockTypeObject();
-                    $displayOrder = $b->getBlockDisplayOrder();
                     if ($bt->isCopiedWhenPropagated()) {
-                        $b = $b->duplicate($page, true);
-                        $b->setAbsoluteBlockDisplayOrder($displayOrder);
+                        $b->duplicate($page, true);
                     } else {
-                        $b->alias($page, $displayOrder);
+                        $b->alias($page);
                     }
-
-                    $page->rescanDisplayOrder($command->getAreaHandle());
                 }
             }
         }

--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -35,7 +35,7 @@ EOT
 
     public function handle(PhpFixer $fixer, EventDispatcher $eventDispatcher)
     {
-        class_alias('Symfony\Component\EventDispatcher\Event', 'PhpCsFixer\Event\Event');
+        class_alias('Symfony\Component\EventDispatcher\GenericEvent', 'PhpCsFixer\Event\Event');
         $action = $this->input->getArgument('action');
         switch ($action) {
             case 'fix':

--- a/concrete/src/Entity/Block/BlockType/BlockType.php
+++ b/concrete/src/Entity/Block/BlockType/BlockType.php
@@ -21,6 +21,7 @@ use Page;
 use Concrete\Core\User\User;
 use Doctrine\ORM\Mapping as ORM;
 use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Block\BlockController as BlockTypeController;
 
 /**
  * @ORM\Entity

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -356,8 +356,8 @@ class Form
      * Renders a number input field.
      *
      * @param string $key the name/id of the element
-     * @param string|array $valueOrMiscFields the value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
-     * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
+     * @param int|string|array<string,mixed> $valueOrMiscFields the value of the element or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
+     * @param array<string,mixed> $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
      * @return string
      */

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -210,7 +210,7 @@ class Form
      *
      * @param string $key The name/id of the element. It should end with '[]' if it's to return an array on submit.
      * @param string $value String value sent to server, if checkbox is checked, on submit
-     * @param string $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
+     * @param string | bool $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
      * @param array $miscFields additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
      * @return string

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -307,10 +307,11 @@ class Cloner
      *
      * @param \Concrete\Core\Block\Block $block
      * @param \Concrete\Core\Page\Collection\Collection $destinationCollection
+     * @param int|null $displayOrder The forced display order
      *
      * @return bool returns FALSE if $block is not cloned because it's already present in $destinationCollection, TRUE otherwise
      */
-    public function cloneBlock(Block $block, Collection $destinationCollection)
+    public function cloneBlock(Block $block, Collection $destinationCollection, int $displayOrder = null)
     {
         $bID = $block->getBlockID();
         $aHandle = $block->getAreaHandle();
@@ -323,7 +324,7 @@ class Cloner
         if ($already !== false) {
             return false;
         }
-        $newBlockDisplayOrder = (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
+        $newBlockDisplayOrder = $displayOrder ?? (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
         $sourceCollection = $block->getBlockCollectionID() ? $block->getBlockCollectionObject() : null;
         if ($sourceCollection) {
             $this->copyBlocks(

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -307,11 +307,10 @@ class Cloner
      *
      * @param \Concrete\Core\Block\Block $block
      * @param \Concrete\Core\Page\Collection\Collection $destinationCollection
-     * @param int|null $displayOrder The forced display order
      *
      * @return bool returns FALSE if $block is not cloned because it's already present in $destinationCollection, TRUE otherwise
      */
-    public function cloneBlock(Block $block, Collection $destinationCollection, int $displayOrder = null)
+    public function cloneBlock(Block $block, Collection $destinationCollection)
     {
         $bID = $block->getBlockID();
         $aHandle = $block->getAreaHandle();
@@ -324,7 +323,7 @@ class Cloner
         if ($already !== false) {
             return false;
         }
-        $newBlockDisplayOrder = $displayOrder ?? (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
+        $newBlockDisplayOrder = (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
         $sourceCollection = $block->getBlockCollectionID() ? $block->getBlockCollectionObject() : null;
         if ($sourceCollection) {
             $this->copyBlocks(

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DateTimeCorePageProperty.php
@@ -31,7 +31,7 @@ class DateTimeCorePageProperty extends CorePageProperty
         
         $val = $this->getRequestValue();
         
-        if ($val['date_time_dt'] && $val['date_time_h'] && $val['date_time_m']) {
+        if (isset($val['date_time_dt']) && isset($val['date_time_h']) && isset($val['date_time_m'])) {
             $datetime = $val['date_time_dt'] . ' ' . $val['date_time_h'] . ':' . $val['date_time_m'] . ':00';
         } else {
             $datetime = $this->getPageTypeComposerControlDraftValue();

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php
@@ -35,7 +35,7 @@ class DescriptionCorePageProperty extends CorePageProperty
     {
         $e = Core::make('helper/validation/error');
         $val = $this->getRequestValue();
-        if ($val['description']) {
+        if (isset($val['description'])) {
             $description = $val['description'];
         } else {
             $description = $this->getPageTypeComposerControlDraftValue();
@@ -54,7 +54,7 @@ class DescriptionCorePageProperty extends CorePageProperty
     public function getRequestValue($args = false)
     {
         $data = parent::getRequestValue($args);
-        $data['description'] = Core::make('helper/security')->sanitizeString($data['description']);
+        $data['description'] = Core::make('helper/security')->sanitizeString($data['description'] ?? '');
 
         return $data;
     }

--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -36,7 +36,7 @@ class UrlSlugCorePageProperty extends CorePageProperty
     {
         $e = Loader::helper('validation/error');
         $val = $this->getRequestValue();
-        if ($val['url_slug']) {
+        if (isset($val['url_slug'])) {
             $urlSlug = $val['url_slug'];
         } else {
             $urlSlug = $this->getPageTypeComposerControlDraftValue();

--- a/concrete/src/Support/CodingStyle/PhpFixer.php
+++ b/concrete/src/Support/CodingStyle/PhpFixer.php
@@ -98,7 +98,7 @@ class PhpFixer
             $this->runner->addStep($this->options, $paths, $flags);
         }
 
-        $progressOutput = new ProcessOutput($output, $this->runner->getEventDispatcher(), null, $this->runner->calculateNumberOfFiles());
+        $progressOutput = new ProcessOutput($output, $this->runner->getEventDispatcher()->getEventDispatcher(), null, $this->runner->calculateNumberOfFiles());
         $counters = [];
         $counter = function (FixerFileProcessedEvent $e) use (&$counters) {
             $status = $e->getStatus();

--- a/concrete/src/Support/CodingStyle/PhpFixerRunner.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerRunner.php
@@ -150,7 +150,7 @@ class PhpFixerRunner
             $finder,
             $fixers,
             new Differ(),
-            $this->eventDispatcher,
+            $this->eventDispatcher->getEventDispatcher(),
             $this->errorManager,
             $linter,
             $dryRun,

--- a/concrete/src/Support/Facade/Url.php
+++ b/concrete/src/Support/Facade/Url.php
@@ -26,7 +26,7 @@ class Url extends Facade
      * \Url::to($page_object = \Page::getByPath('blog'), 'action')
      *     http://example.com/blog/action/
      *
-     * @return \League\URL\URLInterface
+     * @return \League\Url\UrlInterface
      */
     public static function to(/* ... */)
     {
@@ -36,7 +36,7 @@ class Url extends Facade
     /**
      * This method is only here as a legacy decorator, use url::to.
      *
-     * @return \League\URL\URLInterface
+     * @return \League\Url\UrlInterface
      *
      * @deprecated
      */
@@ -55,7 +55,7 @@ class Url extends Facade
     /**
      * This method is only here as a legacy decorator, use `\URL::to($page)`.
      *
-     * @return \League\URL\URLInterface
+     * @return \League\Url\UrlInterface
      *
      * @deprecated
      */


### PR DESCRIPTION
This PR fixes various warnings in php 8 and above, it also fixes the c5:phpcs command
Since php8 changed a lot of the internal warnings to Type/Value errors and considers any warning an error by default its best to fix these when found.

This is the current ones I've found and fixed, I also updated concrete/src/block/block.php to use the latest database commands and removed if statements that aren't need. 

Also all core_area_layout,youtube block and page title block files now pass PHPStan level 6 
https://phpstan.org/user-guide/rule-levels

Fixes #10141
~~Also fixes an issue with updating child blocks from page defaults with forked blocks~~
