### PR TITLE
[v9] Implement #10172 - Force Display Order from page types

### DIFF
--- a/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
+++ b/concrete/src/Block/Command/AddAliasDefaultsBlockCommandHandler.php
@@ -3,7 +3,6 @@
 namespace Concrete\Core\Block\Command;
 
 use Concrete\Core\Block\Block;
-use Concrete\Core\Block\Command\DeleteBlockCommand;
 use Concrete\Core\Page\Page;
 
 class AddAliasDefaultsBlockCommandHandler
@@ -18,11 +17,17 @@ class AddAliasDefaultsBlockCommandHandler
                 $b = Block::getByID($command->getOriginalBlockID(), $mc, $command->getOriginalAreaHandle());
                 if ($b) {
                     $bt = $b->getBlockTypeObject();
-                    if ($bt->isCopiedWhenPropagated()) {
-                        $b->duplicate($page, true);
-                    } else {
-                        $b->alias($page);
+                    $displayOrder = null;
+                    if ($command->getForceDisplayOrder()) {
+                        $displayOrder = $b->getBlockDisplayOrder();
                     }
+                    if ($bt->isCopiedWhenPropagated()) {
+                        $b = $b->duplicate($page, true);
+                        if ($displayOrder) $b->setAbsoluteBlockDisplayOrder($displayOrder);
+                    } else {
+                        $b->alias($page, $displayOrder);
+                    }
+                    if ($displayOrder) $page->rescanDisplayOrderFromBlock($b, $command->getAreaHandle(), 0);
                 }
             }
         }

--- a/concrete/src/Block/Command/DefaultsBlockCommand.php
+++ b/concrete/src/Block/Command/DefaultsBlockCommand.php
@@ -24,6 +24,9 @@ abstract class DefaultsBlockCommand extends BlockCommand
      */
     protected $originalAreaHandle;
 
+    /** @var bool */
+    protected $forceDisplayOrder;
+
     public function __construct(
         int $originalBlockID,
         int $originalPageID,
@@ -32,7 +35,8 @@ abstract class DefaultsBlockCommand extends BlockCommand
         int $blockID,
         int $pageID,
         int $collectionVersionID,
-        string $areaHandle
+        string $areaHandle,
+        bool $forceDisplayOrder = false
     ) {
         parent::__construct($blockID, $pageID, $collectionVersionID, $areaHandle);
         $this
@@ -40,6 +44,7 @@ abstract class DefaultsBlockCommand extends BlockCommand
             ->setOriginalPageID($originalPageID)
             ->setOriginalCollectionVersionID($originalCollectionVersionID)
             ->setOriginalAreaHandle($originalAreaHandle)
+            ->setForceDisplayOrder($forceDisplayOrder)
         ;
     }
 
@@ -102,4 +107,25 @@ abstract class DefaultsBlockCommand extends BlockCommand
 
         return $this;
     }
+
+    /**
+     * @return bool
+     */
+    public function getForceDisplayOrder(): bool
+    {
+        return $this->forceDisplayOrder;
+    }
+
+    /**
+     * @param bool $forceDisplayOrder
+     * @return $this
+     */
+    public function setForceDisplayOrder(bool $forceDisplayOrder): self
+    {
+        $this->forceDisplayOrder = $forceDisplayOrder;
+
+        return $this;
+    }
+
+
 }

--- a/concrete/src/Block/Command/ForceDefaultDisplayOrderBlockCommand.php
+++ b/concrete/src/Block/Command/ForceDefaultDisplayOrderBlockCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Concrete\Core\Block\Command;
+
+
+class ForceDefaultDisplayOrderBlockCommand extends DefaultsBlockCommand
+{
+
+}

--- a/concrete/src/Block/Command/ForceDefaultDisplayOrderBlockCommandHandler.php
+++ b/concrete/src/Block/Command/ForceDefaultDisplayOrderBlockCommandHandler.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by: Derek Cameron <info@derekcameron.com>
+ * Copyright: 2021 Derek Cameron
+ * Date: 2021/12/17
+ **/
+
+namespace Concrete\Core\Block\Command;
+
+
+use Concrete\Core\Block\Block;
+use Concrete\Core\Page\Page;
+
+class ForceDefaultDisplayOrderBlockCommandHandler
+{
+
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Doctrine\DBAL\Exception
+     * @return void
+     */
+    public function __invoke(ForceDefaultDisplayOrderBlockCommand $command)
+    {
+        $page = Page::getByID($command->getPageID(), $command->getCollectionVersionID());
+        if ($page && !$page->isError()) {
+            $mc = Page::getByID($command->getOriginalPageID(), $command->getOriginalCollectionVersionID());
+            if ($mc && !$mc->isError()) {
+                $b = Block::getByID($command->getOriginalBlockID(), $mc, $command->getOriginalAreaHandle());
+
+                if ($b && !$b->isError()) {
+                    $copyBlock = Block::getByID($command->getBlockID(), $page, $command->getOriginalAreaHandle());
+                    if ($copyBlock) {
+                        $copyBlock->setAbsoluteBlockDisplayOrder($b->getBlockDisplayOrder());
+                        // Rescan all the display order from this block
+                        $page->rescanDisplayOrderFromBlock($copyBlock, $command->getAreaHandle(), 0);
+                    }
+
+                }
+            }
+        }
+    }
+
+}

--- a/concrete/src/Block/Command/UpdateForkedAliasDefaultsBlockCommandHandler.php
+++ b/concrete/src/Block/Command/UpdateForkedAliasDefaultsBlockCommandHandler.php
@@ -21,7 +21,12 @@ class UpdateForkedAliasDefaultsBlockCommandHandler
                     if (is_object($forked) && !$forked->isError()) {
                         // take the current block that is in defaults, and replace the block on the page
                         // with that block.
-                        $existingDisplayOrder = $forked->getBlockDisplayOrder();
+                        if ($command->getForceDisplayOrder()) {
+                            $existingDisplayOrder = $b->getBlockDisplayOrder();
+                        } else {
+                            $existingDisplayOrder = $forked->getBlockDisplayOrder();
+                        }
+
                         $bt = $b->getBlockTypeObject();
 
                         // Now we delete the existing forked block.
@@ -35,7 +40,7 @@ class UpdateForkedAliasDefaultsBlockCommandHandler
                         }
 
                         $b->setAbsoluteBlockDisplayOrder($existingDisplayOrder);
-                        $page->rescanDisplayOrder($command->getAreaHandle());
+                        $page->rescanDisplayOrderFromBlock($b, $command->getAreaHandle(), 0);
                     }
                 }
             }

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -307,10 +307,11 @@ class Cloner
      *
      * @param \Concrete\Core\Block\Block $block
      * @param \Concrete\Core\Page\Collection\Collection $destinationCollection
+     * @param int|null $displayOrder The forced display order
      *
      * @return bool returns FALSE if $block is not cloned because it's already present in $destinationCollection, TRUE otherwise
      */
-    public function cloneBlock(Block $block, Collection $destinationCollection)
+    public function cloneBlock(Block $block, Collection $destinationCollection, int $displayOrder = null)
     {
         $bID = $block->getBlockID();
         $aHandle = $block->getAreaHandle();
@@ -323,7 +324,7 @@ class Cloner
         if ($already !== false) {
             return false;
         }
-        $newBlockDisplayOrder = (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
+        $newBlockDisplayOrder = $displayOrder ?? (int) $destinationCollection->getCollectionAreaDisplayOrder($aHandle);
         $sourceCollection = $block->getBlockCollectionID() ? $block->getBlockCollectionObject() : null;
         if ($sourceCollection) {
             $this->copyBlocks(

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -3,9 +3,10 @@
 namespace Concrete\Core\Page\Collection;
 
 use Concrete\Core\Area\Area;
-use Block;
+
 use CacheLocal;
 use CollectionVersion;
+use Concrete\Core\Block\Block;
 use Concrete\Core\Area\CustomStyle as AreaCustomStyle;
 use Concrete\Core\Area\GlobalArea;
 use Concrete\Core\Attribute\Key\CollectionKey;
@@ -1161,6 +1162,72 @@ class Collection extends ConcreteObject implements TrackableInterface
         if ($r) {
             $displayOrder = 0;
             while ($row = $r->fetch()) {
+                $qb2 = $db->createQueryBuilder();
+                $qb2->update('CollectionVersionBlocks')
+                    ->set('cbDisplayOrder', ':cbDisplayOrder')
+                    ->where('cID = :cID')
+                    ->andWhere('cvID = :cvID')
+                    ->andWhere('arHandle = :arHandle')
+                    ->andWhere('bID = :bID')
+                    ->setParameter('cbDisplayOrder', $displayOrder)
+                    ->setParameter('cID', $cID)
+                    ->setParameter('cvID', $cvID)
+                    ->setParameter('arHandle', $arHandle)
+                    ->setParameter('bID', $row['bID'])
+                    ->execute();
+                ++$displayOrder;
+            }
+        }
+    }
+
+
+    /**
+     * Fix the display order properties for all the blocks after this block in this area.
+     * This is useful for forcing a certain block order.
+     * @param Block $block the block to begin the display order rescan from
+     * @param string $arHandle the handle of the area to be processed
+     * @param int|null $fromDisplay an optional integer to override the starting number,
+     *                              i.e start from 0 even though our block is 8
+     * @return void
+     * @throws \Doctrine\DBAL\Driver\Exception|\Doctrine\DBAL\Exception
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function rescanDisplayOrderFromBlock(Block $block, string $arHandle, int $fromDisplay = null)
+    {
+        /** This block doesnt have a display order */
+        if ($block->getBlockDisplayOrder() === null) {
+            return $this->rescanDisplayOrder($arHandle);
+        }
+        $fromDisplay = $fromDisplay ?? $block->getBlockDisplayOrder();
+        $cID = $this->cID;
+        $cvID = $this->vObj->cvID;
+        $app = Application::getFacadeApplication();
+        /** @var Connection $db */
+        $db = $app->make(Connection::class);
+        $qb = $db->createQueryBuilder();
+        $r =$qb->select('bID')
+            ->from('CollectionVersionBlocks')
+            ->where('cID = :cID')
+            ->andWhere('cvID = :cvID')
+            ->andWhere('bID != :bID')
+            ->andWhere('cbDisplayOrder >= :cbDisplay')
+            ->andWhere('arHandle = :arHandle')
+            ->orderBy('cbDisplayOrder', 'asc')
+            ->setParameter('cbDisplay', $fromDisplay)
+            ->setParameter('bID', $block->getBlockID())
+            ->setParameter('cID', $cID)
+            ->setParameter('cvID', $cvID)
+            ->setParameter('arHandle', $arHandle)
+            ->execute();
+
+        if ($r) {
+            $currentDisplayOrder = $block->getBlockDisplayOrder();
+            $displayOrder = $fromDisplay;
+            while ($row = $r->fetchAssociative()) {
+                if ($displayOrder === $currentDisplayOrder) {
+                    // Skip our blocks display order
+                    $displayOrder++;
+                }
                 $qb2 = $db->createQueryBuilder();
                 $qb2->update('CollectionVersionBlocks')
                     ->set('cbDisplayOrder', ':cbDisplayOrder')

--- a/concrete/views/dialogs/block/aliasing.php
+++ b/concrete/views/dialogs/block/aliasing.php
@@ -1,5 +1,8 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
-$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
+/* @var $dh \Concrete\Core\Localization\Service\Date */
+$dh = app('helper/date');
+/** @var \Concrete\Controller\Dialog\Block\Aliasing $controller */
+$total = $total ?? 0;
 ?>
 <div class="ccm-ui">
 
@@ -23,6 +26,12 @@ $dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service
             <label class="control-label form-label"><?=t('Would you like to update forked blocks?')?></label>
             <div class="form-check"><input class="form-check-input" type="radio" name="updateForkedBlocks" id="updateForkedBlocks1" value="1"><label class="form-check-label" for="updateForkedBlocks1"> <?=t('Yes')?></label></div>
             <div class="form-check"><input class="form-check-input" type="radio" name="updateForkedBlocks" id="updateForkedBlocks2" value="0" checked><label class="form-check-label" for="updateForkedBlocks2"> <?=t('No')?></label></div>
+        </div>
+
+        <div class="form-group">
+            <label class="control-label form-label"><?=t('Would you like to force the display order of this block?')?></label>
+            <div class="form-check"><input class="form-check-input" type="radio" name="forceDisplayOrder" id="forceDisplayOrder1" value="1"><label class="form-check-label" for="forceDisplayOrder1"> <?=t('Yes')?></label></div>
+            <div class="form-check"><input class="form-check-input" type="radio" name="forceDisplayOrder" id="forceDisplayOrder2" value="0" checked><label class="form-check-label" for="forceDisplayOrder2"> <?=t('No')?></label></div>
         </div>
 
         <div data-dialog-form-element="progress-bar"></div>


### PR DESCRIPTION
This pull request plans to implement the proposal listed in #10172

It adds the following features,
 allow users/developers to set a displayOrder when using alias and clone commands
 adds a new function that rescans an area display order using a block as a truth point, so if you set that block to position 4 and rescan it will scan everything from position 4, or the optional starting point, and onwards,  and skip over position 4 as that belongs to the block passed
 add new force display order option on the setup on child pages on the pageType defaults.

https://user-images.githubusercontent.com/23059797/146513015-ebdc93c4-fe1a-4d9c-86df-466ae0a0759e.mov


