### PR TITLE
Simplify express bindings

### DIFF
--- a/concrete/src/Express/ExpressServiceProvider.php
+++ b/concrete/src/Express/ExpressServiceProvider.php
@@ -1,30 +1,31 @@
 <?php
+
 namespace Concrete\Core\Express;
 
-use Concrete\Core\Express\Entry\Formatter\EntryFormatterInterface;
-use Concrete\Core\Express\Entry\Formatter\LabelFormatter as EntryLabelFormatter;
-use Concrete\Core\Express\Formatter\FormatterInterface;
-use Concrete\Core\Express\Formatter\LabelFormatter;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
 class ExpressServiceProvider extends ServiceProvider
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Foundation\Service\Provider::register()
+     */
     public function register()
     {
-        $app = $this->app;
-        $this->app->bindShared('express/builder/association', function () use ($app) {
-            return $app->make('Concrete\Core\Express\ObjectAssociationBuilder');
-        });
-        $this->app->bindShared('express/control/type/manager', function () use ($app) {
-            return $app->make('Concrete\Core\Express\Form\Control\Type\Manager');
-        });
-        $this->app->singleton('Concrete\Core\Express\Association\Applier');
-        $this->app->singleton('express', function() use ($app) {
-           return $app->make('Concrete\Core\Express\ObjectManager');
-        });
-        $this->app->singleton('Concrete\Core\Express\Controller\Manager');
-
-        $this->app->bind(FormatterInterface::class, LabelFormatter::class);
-        $this->app->bind(EntryFormatterInterface::class, EntryLabelFormatter::class);
+        foreach([
+            Association\Applier::class => '',
+            Controller\Manager::class => '',
+            Form\Control\Type\Manager::class => 'express/control/type/manager',
+            ObjectAssociationBuilder::class => 'express/builder/association',
+            ObjectManager::class => 'express',
+        ] as $class => $alias) {
+            $this->app->singleton($class);
+            if ($alias !== '') {
+                $this->app->alias($class, $alias);
+            }
+        }
+        $this->app->bind(Formatter\FormatterInterface::class, Formatter\LabelFormatter::class);
+        $this->app->bind(Entry\Formatter\EntryFormatterInterface::class, Entry\Formatter\LabelFormatter::class);
     }
 }


### PR DESCRIPTION
The express service provider defines a few singletons (also via the deprecated `bindShared()` method, which [is an alias](https://github.com/concrete5/concrete5/blob/9.0.1/concrete/src/Application/Application.php#L505-L514) of the `singleton()` method):
- `express/builder/association`: resolves to `Concrete\Core\Express\ObjectAssociationBuilder`
- `express/control/type/manager`: resolves to `Concrete\Core\Express\Form\Control\Type\Manager`
- `express`: resolves to `Concrete\Core\Express\ObjectManager`
- `Concrete\Core\Express\Association\Applier`
- `Concrete\Core\Express\Controller\Manager`

For DI, it'd be useful to define as singletons the destination classes to (that is, for example `Concrete\Core\Express\ObjectAssociationBuilder`).