### PR TITLE
List dependencies that can provide and execute Composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
     "vendor-dir": "./concrete/vendor",
     "platform": {
       "php": "7.3"
+    },
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "mlocati/composer-patcher": true,
+      "wikimedia/composer-merge-plugin": true
     }
   },
   "replace": {


### PR DESCRIPTION
When using Composer 2.2 we have these warnings/requests:

```
composer/package-versions-deprecated
contains a Composer plugin which is currently not in your allow-plugins config.
See https://getcomposer.org/allow-plugins
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now?

mlocati/composer-patcher
contains a Composer plugin which is currently not in your allow-plugins config.
See https://getcomposer.org/allow-plugins
Do you trust "mlocati/composer-patcher" to execute code and wish to enable it now?

wikimedia/composer-merge-plugin
contains a Composer plugin which is currently not in your allow-plugins config.
See https://getcomposer.org/allow-plugins
Do you trust "wikimedia/composer-merge-plugin" to execute code and wish to enable it now?
```

Let's get rid of those warnings.

PS: see https://getcomposer.org/doc/06-config.md#allow-plugins
