### PR TITLE
Adding CSS, CSV, Javascript and HTML to view_inline

### DIFF
--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -175,7 +175,11 @@ class DownloadFile extends PageController
                 $mimeType = $approvedVersion->getMimeType();
                 if (is_string($mimeType) &&
                     (
+                        $mimeType === "text/css" ||
+                        $mimeType === "text/csv" ||
+                        $mimeType === "text/javascript" ||
                         $mimeType === "text/plain" ||
+                        $mimeType === "text/html" ||
                         (strpos($mimeType, "/") > 0 && in_array(explode("/", $mimeType)[0], ["image", "video"]))
                     )
                 ) {


### PR DESCRIPTION
I have a client who's allowing site editor to embed some CSS and JS file onto one or few pages of the site such as landing page of promotional campaign of the intranet site.

However, @bitterdev's security commit https://github.com/concrete5/concrete5/commit/6d6c7667e5ff686be761461e85a0304b43f64a80
made unable to view_inline HTML, CSS, CSV, Javascript files.

I would like to add these mimetype.

We could allow entire "text/*" mime type.
I have temporary application override to this way.

What you guys think?

Thanks,