### PR TITLE
Fix broken reports page header

### DIFF
--- a/concrete/controllers/element/dashboard/reports/forms/header.php
+++ b/concrete/controllers/element/dashboard/reports/forms/header.php
@@ -29,7 +29,7 @@ class Header extends ElementController
     public function view()
     {
         $db = \Database::connection();
-        if ($this->entity) {
+        if (is_object($this->entity) && $this->entity->getId()) {
             $this->set('entity', $this->entity);
             $this->set('exportURL', \URL::to('/dashboard/reports/forms', 'csv_export', $this->nodeId));
             $managePage = \Page::getByPath('/dashboard/system/express/entities');

--- a/concrete/controllers/single_page/dashboard/reports/forms.php
+++ b/concrete/controllers/single_page/dashboard/reports/forms.php
@@ -40,6 +40,11 @@ class Forms extends DashboardPageController
         if ($folder) {
             $factory = $this->createBreadcrumbFactory();
             $this->setBreadcrumb($factory->getBreadcrumb($this->getPageObject(), $parent));
+        } else {
+            if (!isset($this->headerMenu)) {
+                $this->headerMenu = $this->app->make(ElementManager::class)->get('dashboard/reports/forms/header', ['nodeId' => null, 'entity' => null]);
+            }
+            $this->set('headerMenu', $this->headerMenu);
         }
 
         $this->setThemeViewTemplate('full.php');


### PR DESCRIPTION
As stated in #10213 the button to access legacy form reports is nowhere to be seen.

The single \dashboard\reports\forms single page is not using the correct header elements\dashboard\reports\forms\header.php

The page's controller use the DashboardSelectableExpressEntryListTrait trait which uses the DashboardExpressEntryListTrait trait.

That trait contains a getheaderMenu() method which is sending back the express/search/menu element.

As a result, we can't add a getheaderMenu() method to the controller of the forms single page otherwise it throws an error when trying to display Express forms results.

So I added the code to the view() method instead which works.

As far as I could tell everything related to Express in elements\dashboard\reports\forms\header.php and its controller is actually not needed as this header is really only used to show the legacy button.

I didn't remove it in case you had a different idea.

In the meantime, I also fixed the file controllers\element\dashboard\reports\forms\header.php

```
public function __construct($nodeId, Entity $entity = null)
{
    parent::__construct();
    $this->entity = $entity;
    $this->nodeId = $nodeId;
}

public function view()
{
    $db = \Database::connection();
    if ($this->entity) {
        $this->set('entity', $this->entity);
        $this->set('exportURL', \URL::to('/dashboard/reports/forms', 'csv_export', $this->nodeId));
        $managePage = \Page::getByPath('/dashboard/system/express/entities');
        $permissions = new \Permissions($managePage);
        if ($permissions->canViewPage()) {
            $this->set('manageURL', \URL::to('/dashboard/system/express/entities', 'view_entity', $this->entity->getID()));
        }

    } else {
        $this->set('supportsLegacy', $db->tableExists('btFormQuestions'));
    }
}
```

$this->entity was always true if no $entity was passed to the __construct() method. Strangely enough, instead of being null it was then an Entity object with all values (id, handle...) set to null. So always true.

I fixed that to check we actually have an object ID.

That is provided this code is still needed. and I don't think it is as the express/search/menu element is used instead.