### PR TITLE
Fix broken themes list

### DIFF
--- a/concrete/single_pages/dashboard/pages/themes/view.php
+++ b/concrete/single_pages/dashboard/pages/themes/view.php
@@ -12,7 +12,7 @@
                 $thumbnail->class('card-img-top')->width(null)->height(null);
                 ?>
 
-                <div class="col">
+                <div class="col mb-4">
                     <div class="card h-100 <?php if ($activeTheme->getThemeID() == $t->getThemeID()) { ?>border-primary border<?php } ?>">
                         <?=$thumbnail ?>
                         <div class="card-body">
@@ -142,7 +142,7 @@ if (count($tArray2) > 0) {
                 $thumbnail->class('card-img-top')->width(null)->height(null);
                 ?>
 
-                    <div class="col">
+                    <div class="col mb-4">
                         <div class="card h-100">
                             <?=$thumbnail ?>
                             <div class="card-body">
@@ -151,16 +151,12 @@ if (count($tArray2) > 0) {
                                 </div>
 
                                 <p class="card-text text-secondary small"><?=$t->getThemeDisplayDescription(); ?></p>
-
-                                <p class="card-text">
-                                <form method="post" action="<?=$view->action('install')?>">
-                                    <?=$token->output('install_theme')?>
-                                    <input type="hidden" name="theme" value="<?=$t->getThemeHandle()?>">
-                                    <button type="submit" class="btn w-100 btn-block btn-secondary"><?=t('Install')?></button>
-                                </form>
-                                </p>
                             </div>
-
+                            <form class="m-3" method="post" action="<?=$view->action('install')?>">
+                                <?=$token->output('install_theme')?>
+                                <input type="hidden" name="theme" value="<?=$t->getThemeHandle()?>">
+                                <button type="submit" class="btn w-100 btn-block btn-secondary"><?=t('Install')?></button>
+                            </form>
                         </div>
                     </div>
         <?php } ?>

--- a/concrete/single_pages/dashboard/pages/themes/view.php
+++ b/concrete/single_pages/dashboard/pages/themes/view.php
@@ -163,10 +163,9 @@ if (count($tArray2) > 0) {
 
                         </div>
                     </div>
-
-                </div>
-            </div>
         <?php } ?>
+            </div>
+        </div>
 <?php } ?>
 
 <?php if ($hasThemeCustomizations) { ?>
@@ -228,4 +227,3 @@ if (Config::get('concrete.marketplace.enabled') == true) {
     </div>
     <?php
 }
-


### PR DESCRIPTION
As explained in #10217 the list of themes ready to install is broken.

2 closing </div> tags are inside the foreach loop generating the list when they should be outside of it.

![theme-list-issue](https://user-images.githubusercontent.com/1488833/148418124-8a44062c-29bb-460d-8559-2952942b11ee.png)

### Design issues

What's more, once that is fixed some design issues appear:

- Absence of vertical spacing between cards
- Misaligned "install" buttons

![theme-list-wrong-alignment](https://user-images.githubusercontent.com/1488833/148418347-021bd841-677b-4ab7-a87f-f3cc77183bcd.png)

After fixing everything the list is not broken anymore and the design of the cards is improved

![theme-list-fixed](https://user-images.githubusercontent.com/1488833/148418461-54ce0b81-074e-4a7d-a8ab-186d0c3196ae.png)

