### PR TITLE
Improve error diagnostics in GeolocationResult.php

### DIFF
--- a/concrete/src/Geolocator/GeolocationResult.php
+++ b/concrete/src/Geolocator/GeolocationResult.php
@@ -178,7 +178,7 @@ class GeolocationResult implements JsonSerializable
                         $this->errorMessage = t('An unspecified error occurred in the geolocation library');
                         break;
                     default:
-                        $this->errorMessage = t('An unexpected error occurred in the geolocation library');
+                        $this->errorMessage = t('An unexpected error occurred in the geolocation library: %s', $this->errorCode);
                 }
             } else {
                 $this->errorMessage = $message;


### PR DESCRIPTION
Whilst trying to debug another issue in the Geolocator, I found the diagnostics lacking.
Append the error code to an 'unspecified error' message.
