### PR TITLE
Prevent test of geolocator getting stuck in the busy state

### DIFF
--- a/concrete/single_pages/dashboard/system/environment/geolocation.php
+++ b/concrete/single_pages/dashboard/system/environment/geolocation.php
@@ -208,6 +208,7 @@ if (isset($geolocator)) {
         }
         $('button.geolocator-test-launcher').on('click', function(e) {
             e.stopPropagation();
+            testGeolocator.busy = false;
             var $tr = $(this).closest('tr'),
                 geolocatorId = $tr.data('geolocator-id'),
                 $dialog = $('#ccm-geolocation-test-dialog'),


### PR DESCRIPTION
Ensures busy state is cancelled before opening the test dialog. 