### PR TITLE
Translate favorite pages on the fly

### DIFF
--- a/concrete/src/Navigation/Item/PageItem.php
+++ b/concrete/src/Navigation/Item/PageItem.php
@@ -28,7 +28,7 @@ class PageItem extends Item
         if ($page) {
             $this->pageID = $page->getCollectionID();
             $this->keywords = (string)$page->getAttribute("meta_keywords");
-            parent::__construct($page->getCollectionLink(), t($page->getCollectionName()), $isActive);
+            parent::__construct($page->getCollectionLink(), $page->getCollectionName(), $isActive);
         }
         if ($this->keywords === null) {
             $this->keywords = '';
@@ -69,12 +69,24 @@ class PageItem extends Item
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Navigation\Item\Item::getName()
+     */
+    public function getName(): string
+    {
+        return t(parent::getName());
+    }
+
     public function jsonSerialize()
     {
-        $data = parent::jsonSerialize();
-        $data['pageID'] = $this->getPageID();
-        $data['keywords'] = $this->getKeywords();
-        return $data;
+        return [
+            // We need to use the parent's getName method (it's in English)
+            'name' => parent::getName(),
+            'pageID' => $this->getPageID(),
+            'keywords' => $this->getKeywords(),
+        ] + parent::jsonSerialize();
     }
 
 


### PR DESCRIPTION
We currently have a (minor) issue with favorite pages:

1. the user logs in using language A
2. a new page is added to the favorites
3. the user logs out
4. the user logs in using language B
5. the displayed names of the favorite pages are in language A, whereas they should in language B

The problem is that in point 2 we save the page name using the current language, and in point 5 we reuse that value as is.

This PR fixes this issue by always saving the page names in English, and displaying them using the current language.