### PR TITLE
Fix return value of ActiveThemeProvider::getThemeHandle()

### DIFF
--- a/concrete/src/Area/Layout/Preset/Provider/ActiveThemeProvider.php
+++ b/concrete/src/Area/Layout/Preset/Provider/ActiveThemeProvider.php
@@ -93,6 +93,6 @@ class ActiveThemeProvider implements ProviderInterface
     {
         $theme = $this->getTheme();
 
-        return $theme === null ? '' : $theme->getThemeHandle();
+        return $theme === null ? '' : (string) $theme->getThemeHandle();
     }
 }


### PR DESCRIPTION
I don't know why it may happen, but I've noticed this error:

```
Return value of
Concrete\Core\Area\Layout\Preset\Provider\ActiveThemeProvider::getThemeHandle()
must be of the type string, null returned
```

Let's fix it.