### PR TITLE
[V8] Add not implemented validateValue/validateForm methods for some attribute types

### DIFF
--- a/concrete/attributes/express/controller.php
+++ b/concrete/attributes/express/controller.php
@@ -5,6 +5,9 @@ use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Attribute\Controller as AttributeTypeController;
 use Concrete\Core\Entity\Attribute\Key\Settings\ExpressSettings;
 use Concrete\Core\Entity\Attribute\Value\Value\ExpressValue;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\ErrorList\Field\AttributeField;
 use Doctrine\ORM\Query\Expr;
 
 class Controller extends AttributeTypeController
@@ -147,6 +150,24 @@ class Controller extends AttributeTypeController
     public function getAttributeKeySettingsClass()
     {
         return ExpressSettings::class;
+    }
+
+    public function validateForm($p)
+    {
+        return $p['value'] != false;
+    }
+
+    public function validateValue()
+    {
+        /** @var ExpressValue $val */
+        $val = $this->getAttributeValue()->getValue();
+        /** @var ErrorList $error */
+        $error = $this->app->make('helper/validation/error');
+        if (count($val->getSelectedEntries()) === 0) {
+            $error->add(new FieldNotPresentError(new AttributeField($this->getAttributeKey())));
+        }
+
+        return $error;
     }
 
 }

--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -4,6 +4,9 @@ namespace Concrete\Attribute\PageSelector;
 use Concrete\Core\Attribute\Controller as AttributeTypeController;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Entity\Attribute\Value\Value\NumberValue;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\ErrorList\Field\AttributeField;
 use Concrete\Core\Page\Page;
 
 class Controller extends AttributeTypeController
@@ -87,5 +90,23 @@ class Controller extends AttributeTypeController
             $page = Page::getByID($cID, 'ACTIVE');
             $avn = $akn->addChild('value', $page->getCollectionPath());
         }
+    }
+
+    public function validateForm($p)
+    {
+        return $p['value'] != false;
+    }
+
+    public function validateValue()
+    {
+        $val = $this->getAttributeValue()->getValue();
+        /** @var ErrorList $error */
+        $error = $this->app->make('helper/validation/error');
+        $page = Page::getByID($val);
+        if (!$page || $page->isError()) {
+            $error->add(new FieldNotPresentError(new AttributeField($this->getAttributeKey())));
+        }
+
+        return $error;
     }
 }

--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -4,8 +4,12 @@ namespace Concrete\Attribute\UserSelector;
 use Concrete\Core\Attribute\Controller as AttributeTypeController;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Entity\Attribute\Value\Value\NumberValue;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\ErrorList\Field\AttributeField;
 use Concrete\Core\User\User;
 use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\UserInfoRepository;
 
 class Controller extends AttributeTypeController
 {
@@ -99,5 +103,26 @@ class Controller extends AttributeTypeController
             $user = User::getByUserID($uID);
             $avn = $akn->addChild('value', $user->getUserID());
         }
+    }
+
+    public function validateForm($p)
+    {
+        return $p['value'] != false;
+    }
+
+    public function validateValue()
+    {
+        /** @var NumberValue $val */
+        $val = $this->getAttributeValue()->getValue();
+        /** @var ErrorList $error */
+        $error = $this->app->make('helper/validation/error');
+        /** @var UserInfoRepository $repository */
+        $repository = $this->app->make(UserInfoRepository::class);
+        $user = $repository->getByID($val);
+        if (!$user) {
+            $error->add(new FieldNotPresentError(new AttributeField($this->getAttributeKey())));
+        }
+
+        return $error;
     }
 }


### PR DESCRIPTION
The required option for composer form controls doesn't work for some attribute types.
I think it's just because the core team forgot to implement validateValue/validateForm method for them.
So let's add them. I'll add another pull request for V9 later.