### PR TITLE
[9.0.1] Fixed image libraries check not running in Image Options single page

### DIFF
--- a/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -142,7 +142,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     </div>
 </form>
 <script>
-$(window).load(function() {
+$(window).on('load', function() {
     function checked($container, ok) {
         $container.html(
             ok ? '<i class="fas fa-check" style="color: green"></i>' : '<i class="fas fa-times" style="color: red"></i>'


### PR DESCRIPTION
As explained in #10250 there is a JS error stopping the checks for GD and ImageMagick libraries to run on page /dashboard/system/files/image_uploading.

![error-file-uploading](https://user-images.githubusercontent.com/1488833/150011788-e7329615-8f26-4e73-9b57-715924497c9a.png)

It's a simple matter of replacing `$(window).load()` with `$(window).on('load'`

This PR fixes the issue.

here's a screenshot with the fix in place.

![error-file-uploading-fixed](https://user-images.githubusercontent.com/1488833/150011848-735f0fcd-a2c5-44f2-b6af-fdbfe5836e73.png)

