### PR TITLE
[v9] Fix #10238 - Add doctrine/annotations as a dependency

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -45,6 +45,7 @@
     "symfony/serializer": "^5.2",
     "symfony/yaml":"^4",
     "scssphp/scssphp": "^1.4",
+    "doctrine/annotations": "^1.13.2",
     "doctrine/dbal": "^2.13.2",
     "doctrine/orm": "^2.8.5",
     "doctrine/common": "^3.1.2",


### PR DESCRIPTION
add doctrine/annotations as required dependency
see doctrine/persistence#197
and doctrine/orm#8787

Essentially doctrine no longer requires annotations however we do require it for our packages/entities so we need to require it.

No changes to composer.lock since we already have it but in the future if we upgrade it may be removed, also currently composer based installs are currently not installing this causing the error in #10238 