### PR TITLE
[9.0.1] Fix for broken area edit menu

### DIFF
--- a/concrete/elements/block_area_footer.php
+++ b/concrete/elements/block_area_footer.php
@@ -47,7 +47,7 @@ $class = 'ccm-area-footer';
                             ?><a class="dropdown-item" dialog-title="<?=t('Add Layout')?>" data-block-type-handle="<?= $areabt->getBlockTypeHandle() ?>" data-area-grid-maximum-columns="<?=$a->getAreaGridMaximumColumns()?>" data-menu-action="add-inline" href="#" data-block-type-id="<?=$areabt->getBlockTypeID()?>"><?=t("Add Layout")?></a><?php
                         }
                         if ($canEditAreaPermissions) {
-                            ?><li><div class="dropdown-divider"></div></li><?php
+                            ?><div class="dropdown-divider"></div><?php
                         }
                     }
                     if ($canEditAreaPermissions) {


### PR DESCRIPTION
As explained in #10257 the area edit menu is broken when advanced permissions are enabled and the areas are wrapped in a list and list items <li>

When advanced permissions are enabled the permissions item appears in the area edit menu. That's the culprit so without advanced permissions we can't see the problem.

The divider just before the permissions item in the menu is wrapped in a left-over <li></li> that doesn't belong to any <ul></ul> so when it ends up inside a list it breaks it.

Removing the extra <li></li> fixes the problem. Screenshots below. The third one shows the menu fixed.

![area-menu-error](https://user-images.githubusercontent.com/1488833/150407632-f4245ff9-dfed-45b8-aed4-1aa3d9ce4dec.png)

![area-menu-error2](https://user-images.githubusercontent.com/1488833/150407669-2ee9cd27-9ff0-49c6-a0e5-45c3f1ea09d3.png)

![area-menu-fix](https://user-images.githubusercontent.com/1488833/150407692-8e4a1572-6eca-4ff9-9afe-6ca92fd592af.png)

