### PR TITLE
fix(feature_link): fix the incorrect placement of the double quote on the block view

### DIFF
--- a/concrete/blocks/feature_link/view.php
+++ b/concrete/blocks/feature_link/view.php
@@ -3,7 +3,7 @@
 
 <div class="ccm-block-feature-link">
 
-    <div class="ccm-block-feature-link-text <?php if (isset($buttonColor)) { ?>border-top pt-5 border-5 border-<?=$buttonColor?>"<?php } ?>>
+    <div class="ccm-block-feature-link-text <?php if (isset($buttonColor)) { ?>border-top pt-5 border-5 border-<?=$buttonColor?><?php } ?>">
 
         <?php if ($title) { ?>
             <<?=$titleFormat?>><?=$title?></<?=$titleFormat?>>


### PR DESCRIPTION
If by any chance `$buttonColor` is unset, the `class` tag of the `<div>`  is never closed.
