### PR TITLE
[9.0.1] Fix file tracker usage issue with content block

### DIFF
--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -31,7 +31,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btSupportsInlineAdd = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
-    
+
     public function getRequiredFeatures(): array
     {
         return [
@@ -66,7 +66,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
 
         return $str;
     }
-    
+
     public function view()
     {
         $this->set('content', $this->getContent());
@@ -122,7 +122,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         if (preg_match_all('/\<concrete-picture[^>]*?fID\s*=\s*[\'"]([^\'"]*?)[\'"]/i', $this->content, $matches)) {
             list(, $ids) = $matches;
             foreach ($ids as $id) {
-                $files[] = (int) $id;
+                $files[] = $id;
             }
         }
 
@@ -135,7 +135,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
 
         return array_map(
             function ($match) {
-                return (int) (explode('_', $match)[2]);
+                return (explode('_', $match)[2]);
             },
             $matches[0]
         );

--- a/concrete/src/File/Tracker/UsageTracker.php
+++ b/concrete/src/File/Tracker/UsageTracker.php
@@ -193,9 +193,12 @@ class UsageTracker implements TrackerInterface
             foreach ($trackable->getUsedFiles() as $file) {
                 if ($file instanceof File) {
                     $file = $file->getFileID();
+                } elseif (uuid_is_valid($file)) {
+                    $fo = \Concrete\Core\File\File::getByUUID($file);
+                    $file = $fo->getFileID();
                 }
 
-                if ($file && $persist($collection, $trackable, $file)) {
+                if ($file && $persist($collection, $trackable, (int) $file)) {
                     $buffer++;
                 }
 


### PR DESCRIPTION
Fix to the issue discussed in #10267 
![usage-tracker-error](https://user-images.githubusercontent.com/1488833/150837038-8ce16c33-9d87-4c69-bc75-e093566fa353.png)

What happens is the Usage Tracker expects an integer file ID but in the content block images are identified by their UUID.

What's more the block's controller incorrectly typecast the ID as an integer turning the alphanumeric UUID into an integer.

Often it doesn't throw any error although it saves the wrong values in the Usage Tracker table.

In this case, the resulting ID ((42000000000) was too big for the table.

One thing I can't explain is the same UUID turned into 42000000000 on a live server but to a much smaller integer on my local environment. I'm not sure what PHP setting would do that.

This fix does 2 things:

- it makes sure the block's controller doesn't convert the file ID to an integer
- it adds a check in the Usage Tracker class to verify whether we have a UUID or a normal file ID
