### PR TITLE
Fix error in Edit Express Entry Detail popup

### DIFF
--- a/concrete/blocks/express_entry_detail/edit.php
+++ b/concrete/blocks/express_entry_detail/edit.php
@@ -28,8 +28,8 @@ $expressEntrySelector = $app->make(ExpressEntrySelector::class);
 $exForms = [];
 
 if (is_object($entity)) {
-    foreach ($entity->getForms() as $form) {
-        $exForms[$form->getID()] = $form->getName();
+    foreach ($entity->getForms() as $formEntity) {
+        $exForms[$formEntity->getID()] = $formEntity->getName();
     }
 }
 ?>


### PR DESCRIPTION
When editing an express block it shows `Call to undefined method DoctrineProxies\__CG__\Concrete\Core\Entity\Express\Form::label()`. The declared `$form` is being overwritten in the foreach, which was probably incorrect. Before this might have gone right, but now `$form` became an Entity this way. This commit fixes that.