### PR TITLE
[v9] Fix core blocks on php8 / Add phpdoc

### DIFF
--- a/concrete/attributes/calendar_event/form.php
+++ b/concrete/attributes/calendar_event/form.php
@@ -1,6 +1,10 @@
+<?php
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var \Concrete\Core\Attribute\View $view */
+?>
 <div class="form-group">
     <?=$form->label('calendarID', t('Calendar'))?>
-    <?=$form->select('calendarID', $calendars, $calendarID, array('data-select' => 'calendar'));?>
+    <?=$form->select('calendarID', $calendars ?? [], $calendarID ?? 0, ['data-select' => 'calendar']);?>
 </div>
 
 <div class="form-group">

--- a/concrete/blocks/accordion/add.php
+++ b/concrete/blocks/accordion/add.php
@@ -1,2 +1,3 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $view */
 $view->inc('edit.php');

--- a/concrete/blocks/accordion/edit.php
+++ b/concrete/blocks/accordion/edit.php
@@ -1,5 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
-
+/** @var \Concrete\Core\Block\View\BlockView $view */
+/** @var \Concrete\Core\Form\Service\Form $form */
 use Concrete\Core\Application\Service\UserInterface;
 use Concrete\Core\Support\Facade\Application;
 
@@ -59,12 +60,12 @@ echo $userInterface->tabs([
 
   		<div class="form-group">
   			<?php echo $form->label('initialState', t('Initial State'))?>
-  		  <?php echo $form->select('initialState', array('openfirst' => t('First Item Open'),'closed' => t('All Items Closed'),'open' => t('All Items Open')), $initialState); ?>
+  		  <?php echo $form->select('initialState', ['openfirst' => t('First Item Open'), 'closed' => t('All Items Closed'), 'open' => t('All Items Open')], $initialState ?? 'openfirst'); ?>
   	  </div>
 
   	  <div class="form-group">
   			<?php echo $form->label('itemHeadingFormat', t('Item Heading Format'))?>
-  		  <?php echo $form->select('itemHeadingFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $itemHeadingFormat); ?>
+  		  <?php echo $form->select('itemHeadingFormat', \Concrete\Core\Block\BlockController::$btTitleFormats, $itemHeadingFormat ?? 'h2'); ?>
   	  </div>
 
       <div class="form-group">
@@ -72,13 +73,13 @@ echo $userInterface->tabs([
         <?php echo $form->label('options', t('Options'))?>
 
         <div class="form-check">
-            <?php echo $form->checkbox("alwaysOpen", "1", $alwaysOpen);?>
-            <?php echo $form->label("alwaysOpen", t("Always Open (make accordion items stay open when another item is opened)"), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('alwaysOpen', '1', $alwaysOpen ?? false); ?>
+            <?php echo $form->label('alwaysOpen', t('Always Open (make accordion items stay open when another item is opened)'), ['class' => 'form-check-label']); ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox("flush", "1", $flush);?>
-            <?php echo $form->label("flush", t("Flush (render accordion edge-to-edge)"), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('flush', '1', $flush ?? false); ?>
+            <?php echo $form->label('flush', t('Flush (render accordion edge-to-edge)'), ['class' => 'form-check-label']); ?>
         </div>
       </div>
 
@@ -96,7 +97,7 @@ echo $userInterface->tabs([
                 el: 'div[data-vue=accordion-block]',
                 components: config.components,
                 data: {
-                    entries: <?=json_encode($entries)?>
+                    entries: <?=json_encode($entries ?? [])?>
                 },
                 methods: {
                     addEntry() {

--- a/concrete/blocks/accordion/view.php
+++ b/concrete/blocks/accordion/view.php
@@ -1,16 +1,23 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
-* @var $entries \Concrete\Block\Accordion\AccordionEntry[]
+ * @var \Concrete\Block\Accordion\AccordionEntry[] $entries
  */
+/** @var int $bID */
+/** @var int $bID */
 
-$i =0;
+$i = 0;
+$flush = $flush ?? false;
+$initialState = $initialState ?? null;
+$itemHeadingFormat = $itemHeadingFormat ?? 'h2';
+$alwaysOpen = $alwaysOpen ?? false;
+
 ?>
 
-<div class="accordion ccm-block-accordion<?php if($flush){echo ' accordion-flush';}?>" id="accordion<?=$bID?>">
+<div class="accordion ccm-block-accordion<?php if($flush){echo ' accordion-flush'; }?>" id="accordion<?=$bID?>">
     <?php
       foreach ($entries as $entry) {
-        $i ++;
+        $i++;
         $entryClass = '';
         if(($initialState == 'openfirst' && $i == 1) || $initialState == 'open') {
           $entryClass = ' show';
@@ -19,12 +26,12 @@ $i =0;
         <div class="accordion-item">
 
             <<?php echo $itemHeadingFormat; ?> class="accordion-header">
-                <button class="accordion-button <?php if($i != 1){echo 'collapsed';}?>" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getID()?>">
+                <button class="accordion-button <?php if($i != 1){echo 'collapsed'; }?>" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getID()?>">
                     <?=$entry->getTitle()?>
                 </button>
             </<?php echo $itemHeadingFormat; ?>>
 
-            <div id="collapse<?=$entry->getID()?>" class="accordion-collapse collapse <?php echo $entryClass;?>" <?php if(!$alwaysOpen){ echo 'data-bs-parent="#accordion' .$bID.'"';}?>>
+            <div id="collapse<?=$entry->getId()?>" class="accordion-collapse collapse <?php echo $entryClass; ?>" <?php if(!$alwaysOpen){ echo 'data-bs-parent="#accordion' . $bID . '"'; }?>>
                 <div class="accordion-body">
                     <?=$entry->getDescription()?>
                 </div>

--- a/concrete/blocks/autonav/add.php
+++ b/concrete/blocks/autonav/add.php
@@ -1,6 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $view */
 
-<?php
-$info = array();
-$view->inc('form_setup_html.php', array('info' => $info, 'c' => isset($c) ? $c : null));
-?>
+$view->inc('form_setup_html.php', ['info' => [], 'c' => $c ?? null]);

--- a/concrete/blocks/autonav/controller.php
+++ b/concrete/blocks/autonav/controller.php
@@ -2,17 +2,17 @@
 
 namespace Concrete\Block\Autonav;
 
+use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockController;
+use Concrete\Core\Block\View\BlockView;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Block\BlockType\BlockType;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
-use Core;
-use Database;
-use Page;
-use Permissions;
-use Concrete\Core\Error\UserMessageException;
-use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Http\ResponseFactoryInterface;
-use Concrete\Core\Entity\Block\BlockType\BlockType;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
 use Doctrine\ORM\EntityManagerInterface;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -25,57 +25,174 @@ defined('C5_EXECUTE') or die('Access Denied.');
  *
  * @author     Andrew Embler <andrew@concrete5.org>
  * @author     Jordan Lev
- * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
+ * @copyright  Copyright (c) 2003-2022 ConcreteCMS. (http://www.concretecms.org)
+ * @license    http://www.concretecms.org/license/     MIT License
  */
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var Page|null
+     */
     public $collection;
+
+    /**
+     * @var NavItem[]
+     */
     public $navArray = [];
+
+    /**
+     * @var int[]
+     */
     public $cParentIDArray = [];
-    public $sorted_array = [];
-    public $navSort = [];
-    public $navObjectNames = [];
+
+    /**
+     * @var string
+     */
     public $displayPages;
-    Public $displayPagesCID;
-    Public $displayPagesIncludeSelf;
-    Public $displaySubPages;
-    Public $displaySubPageLevels;
-    Public $displaySubPageLevelsNum;
-    Public $orderBy;
-    Public $displayUnavailablePages;
+
+    /**
+     * @var int|null
+     */
+    public $displayPagesCID;
+
+    /**
+     * @var int
+     */
+    public $displayPagesIncludeSelf;
+
+    /**
+     * @var string
+     */
+    public $displaySubPages;
+
+    /**
+     * @var string
+     */
+    public $displaySubPageLevels;
+
+    /**
+     * @var int
+     */
+    public $displaySubPageLevelsNum = 0;
+
+    /**
+     * @var string
+     */
+    public $orderBy;
+
+    /**
+     * @var int
+     */
+    public $displayUnavailablePages;
+
+    /**
+     * @var bool
+     */
     public $haveRetrievedSelf = false;
+
+    /**
+     * @var bool
+     */
     public $haveRetrievedSelfPlus1 = false;
+
+    /**
+     * @var bool
+     */
     public $displayUnapproved = false;
+
+    /**
+     * @var bool
+     */
     public $ignoreExcludeNav = false;
+
+    /**
+     * @var int|null
+     */
+    public $cParentID;
+
+    /**
+     * @var string[]
+     */
     protected $helpers = ['form', 'validation/token', 'form/page_selector', 'concrete/ui'];
+
+    /**
+     * @var int|null
+     */
     protected $homePageID;
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btNavigation';
+
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 700;
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 525;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockRecord = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputForRegisteredUsers = false;
+
+    /**
+     * @var int
+     */
     protected $btCacheBlockOutputLifetime = 300;
+
+    /**
+     * @var string
+     */
     protected $btWrapperClass = 'ccm-ui';
+
+    /**
+     * @var string[]
+     */
     protected $btExportPageColumns = ['displayPagesCID'];
+
+    /**
+     * @var bool
+     */
     protected $includeParentItem;
 
+    /**
+     * @var int|null
+     */
+    protected $cID;
+
+    /**
+     * Instantiates the block controller.
+     *
+     * @param BlockType $obj |Block $obj
+     */
     public function __construct($obj = null)
     {
         if (is_object($obj)) {
-            switch (strtolower(get_class($obj))) {
-                case "blocktype":
-                    // instantiating autonav on a particular collection page, instead of adding
-                    // it through the block interface
-                    $this->bID = null;
-                    break;
-                case "block": // block
-                    // standard block object
-                    $this->bID = $obj->bID;
-                    break;
+            if ($obj instanceof Block) {
+                $this->bID = $obj->bID;
+            } else {
+                $this->bID = null;
             }
         }
 
@@ -94,6 +211,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::__construct($obj);
     }
 
+    /**
+     * @return string[]
+     */
     public function getRequiredFeatures(): array
     {
         return [
@@ -101,11 +221,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
     }
 
-    // private variable $displayUnapproved, used by the dashboard
-
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Creates navigation trees and sitemaps.");
+        return t('Creates navigation trees and sitemaps.');
     }
 
     // haveRetrievedSelf is a variable that stores whether or not a particular tree walking operation has retrieved the current page. We use this
@@ -115,11 +236,17 @@ class Controller extends BlockController implements UsesFeatureInterface
     // or whether they display them, but then restrict them when the page is actually visited
     // TODO - Implement displayUnavailablePages in the btNavigation table, and in the frontend of the autonav block
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Auto-Nav");
+        return t('Auto-Nav');
     }
 
+    /**
+     * @param array<string,mixed> $args
+     */
     public function save($args)
     {
         $args['displayPagesIncludeSelf'] = isset($args['displayPagesIncludeSelf']) && $args['displayPagesIncludeSelf'] ? 1 : 0;
@@ -129,27 +256,36 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::save($args);
     }
 
-    public function getContent()
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContent(): array
     {
-        /* our templates expect a variable not an object */
+        // our templates expect a variable not an object
         $con = [];
-        foreach ($this as $key => $value) {
+        foreach (get_object_vars($this) as $key => $value) {
             $con[$key] = $value;
         }
 
         return $con;
     }
 
-    public function getChildPages($c)
+    /**
+     * @param Page $c
+     *
+     * @return Page[]
+     */
+    public function getChildPages($c): array
     {
-
-        // a quickie
-        $db = Database::connection();
-        $r = $db->query(
-                "select cID from Pages where cParentID = ? order by cDisplayOrder asc",
-                [$c->getCollectionID()]);
+        /** @var Connection $db */
+        $db = $this->app->make(Connection::class);
+        $r = $db->executeQuery(
+            'select cID from Pages where cParentID = ? order by cDisplayOrder asc',
+            [$c->getCollectionID()]
+        );
         $pages = [];
-        while ($row = $r->fetch()) {
+        $rows = $r->fetchAllAssociative();
+        foreach ($rows as $row) {
             $pages[] = Page::getByID($row['cID'], 'ACTIVE');
         }
 
@@ -169,6 +305,10 @@ class Controller extends BlockController implements UsesFeatureInterface
      * because we need to maintain the generateNav() function for backwards compatibility with
      * older custom templates... and that function unfortunately has side-effects so it cannot
      * be called more than once per request (otherwise there will be duplicate items in the nav menu).
+     *
+     * @param bool $ignore_exclude_nav
+     *
+     * @return \stdClass[]
      */
     public function getNavItems($ignore_exclude_nav = false)
     {
@@ -192,7 +332,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         while ($parentCIDnotZero) {
             $cParentID = $inspectC->getCollectionParentID();
-            if (!intval($cParentID)) {
+            if (!(int) $cParentID) {
                 $parentCIDnotZero = false;
             } else {
                 if ($cParentID != $this->homePageID) {
@@ -224,7 +364,8 @@ class Controller extends BlockController implements UsesFeatureInterface
                 } else {
                     $excluded_parent_level = 9999; //Reset to arbitrarily high number to denote that we're no longer excluding a parent
                     $exclude_children_below_level = $_c->getAttribute(
-                                                       'exclude_subpages_from_nav') ? $current_level : 9999;
+                        'exclude_subpages_from_nav'
+                    ) ? $current_level : 9999;
                     $exclude_page = false;
                 }
             }
@@ -237,7 +378,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         //Prep all data and put it into a clean structure so markup output is as simple as possible
         $navItems = [];
         $navItemCount = count($includedNavItems);
-        for ($i = 0; $i < $navItemCount; ++$i) {
+        for ($i = 0; $i < $navItemCount; $i++) {
             $ni = $includedNavItems[$i];
             $_c = $ni->getCollectionObject();
             $current_level = $ni->getLevel();
@@ -251,8 +392,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             if ($_c->getAttribute('replace_link_with_first_in_nav')) {
                 $subPage = $_c->getFirstChild(); //Note: could be a rare bug here if first child was excluded, but this is so unlikely (and can be solved by moving it in the sitemap) that it's not worth the trouble to check
                 if ($subPage instanceof Page) {
-                    $pageLink = Core::make('helper/navigation')->getLinkToCollection(
-                                      $subPage); //We could optimize by instantiating the navigation helper outside the loop, but this is such an infrequent attribute that I prefer code clarity over performance in this case
+                    $pageLink = $this->app->make('helper/navigation')->getLinkToCollection(
+                        $subPage
+                    ); //We could optimize by instantiating the navigation helper outside the loop, but this is such an infrequent attribute that I prefer code clarity over performance in this case
                 }
             }
             if (!$pageLink) {
@@ -282,7 +424,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             //Calculate if this is the last item in its level (useful for CSS classes)
             $is_last_in_level = true;
-            for ($j = $i + 1; $j < $navItemCount; ++$j) {
+            for ($j = $i + 1; $j < $navItemCount; $j++) {
                 if ($includedNavItems[$j]->getLevel() == $current_level) {
                     //we found a subsequent item at this level (before this level "ended"), so this is NOT the last in its level
                     $is_last_in_level = false;
@@ -308,7 +450,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             $navItem->url = $pageLink;
             $translate = $this->get('translate');
             $name = (isset($translate) && $translate == true) ? t($ni->getName()) : $ni->getName();
-            $text = Core::make('helper/text');
+            $text = $this->app->make('helper/text');
             $navItem->name = $text->entities($name);
             $navItem->target = $target;
             $navItem->level = $current_level + 1; //make this 1-based instead of 0-based (more human-friendly)
@@ -332,46 +474,28 @@ class Controller extends BlockController implements UsesFeatureInterface
      * This function is used by the getNavItems() method to generate the raw "pre-processed" nav items array.
      * It also must exist as a separate function to preserve backwards-compatibility with older autonav templates.
      * Warning: this function has side-effects -- if this gets called twice, items will be duplicated in the nav structure!
+     *
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return NavItem[]
      */
-    public function generateNav()
+    public function generateNav(): array
     {
         // Initialize Nav Array
         $this->navArray = [];
 
-        if (isset($this->displayPagesCID) && !Core::make('helper/validation/numbers')->integer($this->displayPagesCID)) {
+        if (isset($this->displayPagesCID) && !$this->app->make('helper/validation/numbers')->integer($this->displayPagesCID)) {
             $this->displayPagesCID = 0;
         }
 
-        $db = Database::connection();
-        // now we proceed, with information obtained either from the database, or passed manually from
-        $orderBy = "";
-        /*switch($this->orderBy) {
-        switch($this->orderBy) {
-            case 'display_asc':
-                $orderBy = "order by Collections.cDisplayOrder asc";
-                break;
-            case 'display_desc':
-                $orderBy = "order by Collections.cDisplayOrder desc";
-                break;
-            case 'chrono_asc':
-                $orderBy = "order by cvDatePublic asc";
-                break;
-            case 'chrono_desc':
-                $orderBy = "order by cvDatePublic desc";
-                break;
-            case 'alpha_desc':
-                $orderBy = "order by cvName desc";
-                break;
-            default:
-                $orderBy = "order by cvName asc";
-                break;
-        }*/
         switch ($this->orderBy) {
             case 'display_asc':
-                $orderBy = "order by Pages.cDisplayOrder asc";
+                $orderBy = 'order by Pages.cDisplayOrder asc';
                 break;
             case 'display_desc':
-                $orderBy = "order by Pages.cDisplayOrder desc";
+                $orderBy = 'order by Pages.cDisplayOrder desc';
                 break;
             default:
                 $orderBy = '';
@@ -410,34 +534,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         if ($cParentID != null) {
-
-            /*
-
-            $displayHeadPage = false;
-
-            if ($this->displayPagesIncludeSelf) {
-                $q = "select Pages.cID from Pages where Pages.cID = '{$cParentID}' and cIsTemplate = 0";
-                $r = $db->query($q);
-                if ($r) {
-                    $row = $r->fetch();
-                    $displayHeadPage = true;
-                    if ($this->displayUnapproved) {
-                        $tc1 = Page::getByID($row['cID'], "RECENT");
-                    } else {
-                        $tc1 = Page::getByID($row['cID'], "ACTIVE");
-                    }
-                    $tc1v = $tc1->getVersionObject();
-                    if (!$tc1v->isApprovedNow() && !$this->displayUnapproved) {
-                        $displayHeadPage = false;
-                    }
-                }
-            }
-
-            if ($displayHeadPage) {
-                $level++;
-            }
-            */
-
             if ($this->displaySubPages == 'relevant' || $this->displaySubPages == 'relevant_breadcrumb') {
                 $this->populateParentIDArray($this->cID);
             }
@@ -451,37 +547,21 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
             if ($shouldIncludeParentItem) {
                 if ($this->displayUnapproved) {
-                    $tc1 = Page::getByID($cParentID, "RECENT");
+                    $tc1 = Page::getByID($cParentID);
                 } else {
-                    $tc1 = Page::getByID($cParentID, "ACTIVE");
+                    $tc1 = Page::getByID($cParentID, 'ACTIVE');
                 }
                 $niRow = [];
                 $niRow['cvName'] = $tc1->getCollectionName();
                 $niRow['cID'] = $cParentID;
                 $niRow['cvDescription'] = $tc1->getCollectionDescription();
-                $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc1);
+                $niRow['cPath'] = $this->app->make('helper/navigation')->getLinkToCollection($tc1);
 
                 $ni = new NavItem($niRow, 0);
                 $ni->setCollectionObject($tc1);
 
                 array_unshift($this->navArray, $ni);
             }
-
-            /*
-            if ($displayHeadPage) {
-                $niRow = [];
-                $niRow['cvName'] = $tc1->getCollectionName();
-                $niRow['cID'] = $row['cID'];
-                $niRow['cvDescription'] = $tc1->getCollectionDescription();
-                $niRow['cPath'] = $tc1->getCollectionPath();
-
-                $ni = new NavItem($niRow, 0);
-                $level++;
-                $ni->setCollectionObject($tc1);
-
-                array_unshift($this->navArray, $ni);
-            }
-            */
         }
 
         return $this->navArray;
@@ -489,15 +569,22 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * heh. probably should've gone the simpler route and named this getGrandparentID().
+     *
+     * @return int
      */
     public function getParentParentID()
     {
         // this has to be the stupidest name of a function I've ever created. sigh
         $cParentID = Page::getCollectionParentIDFromChildID($this->cParentID);
 
-        return ($cParentID) ? $cParentID : 0;
+        return $cParentID ?: 0;
     }
 
+    /**
+     * @param int $level
+     *
+     * @return int|null
+     */
     public function getParentAtLevel($level)
     {
         // this function works in the following way
@@ -517,13 +604,15 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         if (isset($idArray[$level])) {
             return $idArray[$level];
-        } else {
-            return null;
         }
+
+            return null;
     }
 
     /** Pupulates the $cParentIDArray instance property.
-     * @param int $cID The collection id.
+     * @param int $cID the collection id
+     *
+     * @return void
      */
     public function populateParentIDArray($cID)
     {
@@ -539,6 +628,17 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
     }
 
+    /**
+     * @param int $cParentID
+     * @param string $orderBy
+     * @param int $currentLevel
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\Driver\Exception
+     *
+     * @return void
+     */
     public function getNavigationArray($cParentID, $orderBy, $currentLevel)
     {
         // Check if the parent page is excluded or if it has been set to exclude child pages
@@ -557,25 +657,27 @@ class Controller extends BlockController implements UsesFeatureInterface
             }
         }
 
-        $db = Database::connection();
-        $navSort = $this->navSort;
-        $sorted_array = $this->sorted_array;
-        $navObjectNames = $this->navObjectNames;
+        /** @var Connection $db */
+        $db = $this->app->make(Connection::class);
+        $navSort = [];
+        $sorted_array = [];
+        $navObjectNames = [];
 
         $q = "select Pages.cID from Pages where cIsTemplate = 0 and cIsActive = 1 and cParentID = '{$cParentID}' {$orderBy}";
-        $r = $db->query($q);
-        if ($r) {
-            while ($row = $r->fetch()) {
+        $rows = $db->executeQuery($q)->fetchAllAssociative();
+        if (count($rows) > 0) {
+            foreach ($rows as $row) {
                 if ($this->displaySubPages != 'relevant_breadcrumb' || (in_array(
-                            $row['cID'],
-                            $this->cParentIDArray) || $row['cID'] == $this->cID)
+                    $row['cID'],
+                    $this->cParentIDArray
+                ) || $row['cID'] == $this->cID)
                 ) {
                     /*
                     if ($this->haveRetrievedSelf) {
                         // since we've already retrieved self, and we're going through again, we set plus 1
                         $this->haveRetrievedSelfPlus1 = true;
                     } else
-                    */
+                     */
 
                     if ($this->haveRetrievedSelf && $cParentID == $this->cID) {
                         $this->haveRetrievedSelfPlus1 = true;
@@ -584,12 +686,10 @@ class Controller extends BlockController implements UsesFeatureInterface
                             $this->haveRetrievedSelf = true;
                         }
                     }
-
-                    $displayPage = true;
                     if ($this->displayUnapproved) {
-                        $tc = Page::getByID($row['cID'], "RECENT");
+                        $tc = Page::getByID($row['cID']);
                     } else {
-                        $tc = Page::getByID($row['cID'], "ACTIVE");
+                        $tc = Page::getByID($row['cID'], 'ACTIVE');
                     }
 
                     $displayPage = $this->displayPage($tc);
@@ -599,12 +699,12 @@ class Controller extends BlockController implements UsesFeatureInterface
                         $niRow['cvName'] = $tc->getCollectionName();
                         $niRow['cID'] = $row['cID'];
                         $niRow['cvDescription'] = $tc->getCollectionDescription();
-                        $niRow['cPath'] = Core::make('helper/navigation')->getLinkToCollection($tc);
+                        $niRow['cPath'] = $this->app->make('helper/navigation')->getLinkToCollection($tc);
                         $niRow['cPointerExternalLink'] = $tc->getCollectionPointerExternalLink();
                         $niRow['cPointerExternalLinkNewWindow'] = $tc->openCollectionPointerExternalLinkInNewWindow();
                         $dateKey = strtotime($tc->getCollectionDatePublic());
 
-                        $ni = new NavItem($niRow, $currentLevel);
+                        $ni = new NavItem($niRow, (int) $currentLevel);
                         $ni->setCollectionObject($tc);
                         // $this->navArray[] = $ni;
                         $navSort[$niRow['cID']] = $dateKey;
@@ -621,84 +721,53 @@ class Controller extends BlockController implements UsesFeatureInterface
             // Joshua's Huge Sorting Crap
             if ($navSort) {
                 $sortit = 0;
-                if ($this->orderBy == "chrono_asc") {
-                    asort($navSort);
-                    $sortit = 1;
-                }
-                if ($this->orderBy == "chrono_desc") {
-                    arsort($navSort);
-                    $sortit = 1;
-                }
-
-                if ($sortit) {
-                    foreach ($navSort as $sortCID => $sortdatewhocares) {
-                        // create sorted_array
-                        $this->navArray[] = $sorted_array[$sortCID];
-
-                        #############start_recursive_crap
-                        $retrieveMore = false;
-                        if ($this->displaySubPages == 'all') {
-                            if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
-                                $retrieveMore = true;
-                            }
-                        } else {
-                            if (($this->displaySubPages == "relevant" || $this->displaySubPages == "relevant_breadcrumb") && (in_array(
-                                        $sortCID,
-                                        $this->cParentIDArray) || $sortCID == $this->cID)
-                            ) {
-                                if ($this->displaySubPageLevels == "enough" && $this->haveRetrievedSelf == false) {
-                                    $retrieveMore = true;
-                                } else {
-                                    if ($this->displaySubPageLevels == "enough_plus1" && $this->haveRetrievedSelfPlus1 == false) {
-                                        $retrieveMore = true;
-                                    } else {
-                                        if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
-                                            $retrieveMore = true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if ($retrieveMore) {
-                            $this->getNavigationArray($sortCID, $orderBy, $currentLevel + 1);
-                        }
-                        #############end_recursive_crap
-                    }
-                }
-
-                $sortit = 0;
-                if ($this->orderBy == "alpha_desc") {
+                if ($this->orderBy == 'alpha_desc') {
                     $navObjectNames = array_map('strtolower', $navObjectNames);
                     arsort($navObjectNames);
                     $sortit = 1;
                 }
 
-                if ($this->orderBy == "alpha_asc") {
+                if ($this->orderBy == 'alpha_asc') {
                     $navObjectNames = array_map('strtolower', $navObjectNames);
                     asort($navObjectNames);
                     $sortit = 1;
                 }
+                $sortArray = $navObjectNames;
+                if ($this->orderBy == 'chrono_asc') {
+                    asort($navSort);
+                    $sortit = 1;
+                    $sortArray = $navSort;
+                }
+                if ($this->orderBy == 'chrono_desc') {
+                    arsort($navSort);
+                    $sortit = 1;
+                    $sortArray = $navSort;
+                }
+                if ($this->orderBy == 'display_desc' || $this->orderBy == 'display_asc') {
+                    $sortit = 1;
+                }
 
                 if ($sortit) {
-                    foreach ($navObjectNames as $sortCID => $sortnameaction) {
+                    foreach ($sortArray as $sortCID => $sortnameaction) {
                         // create sorted_array
                         $this->navArray[] = $sorted_array[$sortCID];
 
-                        #############start_recursive_crap
+                        //############start_recursive_crap
                         $retrieveMore = false;
                         if ($this->displaySubPages == 'all') {
                             if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
                                 $retrieveMore = true;
                             }
                         } else {
-                            if (($this->displaySubPages == "relevant" || $this->displaySubPages == "relevant_breadcrumb") && (in_array(
-                                        $sortCID,
-                                        $this->cParentIDArray) || $sortCID == $this->cID)
+                            if (($this->displaySubPages == 'relevant' || $this->displaySubPages == 'relevant_breadcrumb') && (in_array(
+                                $sortCID,
+                                $this->cParentIDArray
+                            ) || $sortCID == $this->cID)
                             ) {
-                                if ($this->displaySubPageLevels == "enough" && $this->haveRetrievedSelf == false) {
+                                if ($this->displaySubPageLevels == 'enough' && $this->haveRetrievedSelf == false) {
                                     $retrieveMore = true;
                                 } else {
-                                    if ($this->displaySubPageLevels == "enough_plus1" && $this->haveRetrievedSelfPlus1 == false) {
+                                    if ($this->displaySubPageLevels == 'enough_plus1' && $this->haveRetrievedSelfPlus1 == false) {
                                         $retrieveMore = true;
                                     } else {
                                         if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
@@ -711,52 +780,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                         if ($retrieveMore) {
                             $this->getNavigationArray($sortCID, $orderBy, $currentLevel + 1);
                         }
-                        #############end_recursive_crap
-                    }
-                }
-
-                $sortit = 0;
-                if ($this->orderBy == "display_desc") {
-                    $sortit = 1;
-                }
-                if ($this->orderBy == "display_asc") {
-                    $sortit = 1;
-                }
-
-                if ($sortit) {
-                    // for display order? this stuff is already sorted...
-                    foreach ($navObjectNames as $sortCID => $sortnameaction) {
-                        // create sorted_array
-                        $this->navArray[] = $sorted_array[$sortCID];
-
-                        #############start_recursive_crap
-                        $retrieveMore = false;
-                        if ($this->displaySubPages == 'all') {
-                            if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
-                                $retrieveMore = true;
-                            }
-                        } else {
-                            if (($this->displaySubPages == "relevant" || $this->displaySubPages == "relevant_breadcrumb") && (in_array(
-                                        $sortCID,
-                                        $this->cParentIDArray) || $sortCID == $this->cID)
-                            ) {
-                                if ($this->displaySubPageLevels == "enough" && $this->haveRetrievedSelf == false) {
-                                    $retrieveMore = true;
-                                } else {
-                                    if ($this->displaySubPageLevels == "enough_plus1" && $this->haveRetrievedSelfPlus1 == false) {
-                                        $retrieveMore = true;
-                                    } else {
-                                        if ($this->displaySubPageLevels == 'all' || ($this->displaySubPageLevels == 'custom' && $this->displaySubPageLevelsNum > $currentLevel)) {
-                                            $retrieveMore = true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if ($retrieveMore) {
-                            $this->getNavigationArray($sortCID, $orderBy, $currentLevel + 1);
-                        }
-                        #############end_recursive_crap
+                        //############end_recursive_crap
                     }
                 }
             }
@@ -764,28 +788,22 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
     }
 
-    protected function displayPage($tc)
-    {
-        $tcv = $tc->getVersionObject();
-        if ((!is_object($tcv)) || (!$tcv->isApprovedNow() && !$this->displayUnapproved)) {
-            return false;
-        }
-
-        if ($this->displayUnavailablePages == false) {
-            $tcp = new Permissions($tc);
-            if (!$tcp->canRead()) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
+    /**
+     * @param Page $c
+     *
+     * @return mixed
+     */
     public function excludeFromNavViaAttribute($c)
     {
         return $c->getAttribute('exclude_nav');
     }
 
+    /**
+     * @throws UserMessageException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Concrete\Core\Http\Response
+     */
     public function action_preview_pane()
     {
         $token = $this->app->make('token');
@@ -793,6 +811,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             throw new UserMessageException($token->getErrorMessage());
         }
         $bt = $this->app->make(EntityManagerInterface::class)->find(BlockType::class, $this->getBlockTypeID());
+        /** @var Controller $btc */
         $btc = $bt->getController();
         $post = $this->request->request;
         $btc->collection = $this->getCollectionObject();
@@ -826,9 +845,34 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param bool $includeParentItem
+     *
+     * @return void
      */
     public function setIncludeParentItem($includeParentItem)
     {
         $this->includeParentItem = $includeParentItem;
+    }
+
+    /**
+     * @param Page $tc
+     *
+     * @return bool
+     */
+    protected function displayPage($tc)
+    {
+        $tcv = $tc->getVersionObject();
+        if ((!is_object($tcv)) || (!$tcv->isApprovedNow() && !$this->displayUnapproved)) {
+            return false;
+        }
+
+        if ($this->displayUnavailablePages == false) {
+            $tcp = new Checker($tc);
+            /** @phpstan-ignore-next-line */
+            if (!$tcp->canRead()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/concrete/blocks/autonav/edit.php
+++ b/concrete/blocks/autonav/edit.php
@@ -1,5 +1,9 @@
 <?php
-
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Block\Autonav\Controller $controller */
+/** @var \Concrete\Core\Block\View\BlockView $view */
+/** @var \Concrete\Core\Block\Block|null $b */
+/** @var \Concrete\Core\Page\Page|null $c */
+/** @var array<string,mixed> $info */
 $info = $controller->getContent();
-$view->inc('form_setup_html.php', array('info' => $info, 'c' => $c, 'b' => $b));
+$view->inc('form_setup_html.php', ['info' => $info, 'c' => $c, 'b' => $b]);

--- a/concrete/blocks/autonav/form_setup_html.php
+++ b/concrete/blocks/autonav/form_setup_html.php
@@ -1,19 +1,18 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var Concrete\Block\Autonav\Controller $controller */
-/* @var Concrete\Core\Block\View\BlockView $view */
+/** @var Concrete\Block\Autonav\Controller $controller */
+/** @var Concrete\Core\Block\View\BlockView $view */
+/** @var Concrete\Core\Entity\Block\BlockType\BlockType $bt */
+/** @var Concrete\Core\Form\Service\Form $form */
+/** @var Concrete\Core\Validation\CSRF\Token $validation_token */
+/** @var Concrete\Core\Application\Service\UserInterface $concrete_ui */
+/** @var \Concrete\Core\Form\Service\Widget\PageSelector $form_page_selector */
+/** @var array<string, mixed>|null $info */
 
-/* @var Concrete\Core\Entity\Block\BlockType\BlockType $bt */
-/* @var Concrete\Core\Form\Service\Form $form */
-/* @var Concrete\Core\Validation\CSRF\Token $validation_token */
-/* @var array $info */
+$c = \Concrete\Core\Page\Page::getCurrentPage();
 
-$c = Page::getCurrentPage();
-
-if (!isset($info)) {
-    $info = [];
-}
+$info = $info ?? null;
 
 $info += [
     'orderBy' => null,
@@ -24,12 +23,14 @@ $info += [
     'displaySubPageLevels' => null,
     'displaySubPageLevelsNum' => null,
 ];
+
 ?>
 
-<?=$concrete_ui->tabs(array(
-    array('autonav-settings', t('Settings'), true),
-    array('autonav-preview', t('Preview'))
-)); ?>
+
+<?=$concrete_ui->tabs([
+    ['autonav-settings', t('Settings'), true],
+    ['autonav-preview', t('Preview')],
+]); ?>
 
 <div class="tab-content">
     <div class="tab-pane show active" id="autonav-settings">
@@ -70,7 +71,7 @@ $info += [
                 <div class="form-group">
                     <label><?= t('Check Page Permissions') ?></label>
                     <div class="form-check">
-                        <?= $form->checkbox('displayUnavailablePages', 1, $info['displayUnavailablePages']); ?>
+                        <?= $form->checkbox('displayUnavailablePages', '1', $info['displayUnavailablePages']); ?>
                         <label for="displayUnavailablePages" class="form-check-label"><?= t('Display links that may require login.'); ?></label>
                     </div>
                 </div>

--- a/concrete/blocks/autonav/nav_item.php
+++ b/concrete/blocks/autonav/nav_item.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Page\Page;
@@ -8,24 +9,65 @@ use Concrete\Core\Page\Page;
  */
 class NavItem
 {
-    protected $level;
-    protected $isActive = false;
-    protected $_c;
+    /**
+     * @var bool|int
+     */
     public $hasChildren = false;
+
+    /**
+     * @var int|null
+     */
     public $cID;
+
+    /**
+     * @var string|null
+     */
     public $cPath;
+
+    /**
+     * @var string|null
+     */
     public $cPointerExternalLink;
+
+    /**
+     * @var string|null
+     */
     public $cPointerExternalLinkNewWindow;
+
+    /**
+     * @var string|null
+     */
     public $cvDescription;
+
+    /**
+     * @var string|null
+     */
     public $cvName;
+
+    /**
+     * @var int
+     */
+    protected $level;
+
+    /**
+     * @var bool
+     */
+    protected $isActive = false;
+
+    /**
+     * @var Page
+     */
+    protected $_c;
 
     /**
      * Instantiates an Autonav Block Item.
      *
-     * @param array $itemInfo
+     * @param array<string,mixed> $itemInfo
      * @param int $level
+     *
+     * @return void
      */
-    public function __construct($itemInfo, $level = 1)
+    public function __construct(array $itemInfo, int $level = 1)
     {
         $this->level = $level;
         if (is_array($itemInfo)) {
@@ -34,14 +76,12 @@ class NavItem
                 $this->{$key} = $value;
             }
         }
-
-        return $this;
     }
 
     /**
      * Returns the number of children below this current nav item.
      *
-     * @return int
+     * @return int|bool
      */
     public function hasChildren()
     {
@@ -51,17 +91,19 @@ class NavItem
     /**
      * Determines whether this nav item is the current page the user is on.
      *
-     * @param \Concrete\Core\Page\Page $c The page object for the current page
+     * @param \Concrete\Core\Page\Page|null $c The page object for the current page
      *
      * @return bool
      */
-    public function isActive(&$c)
+    public function isActive($c): bool
     {
         if ($c) {
             $cID = ($c->getCollectionPointerID() > 0) ? $c->getCollectionPointerOriginalID() : $c->getCollectionID();
 
             return $cID == $this->cID;
         }
+
+        return false;
     }
 
     /**
@@ -76,8 +118,10 @@ class NavItem
 
     /**
      * Returns a target for the nav item.
+     *
+     * @return string
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         if ($this->cPointerExternalLink != '') {
             if ($this->cPointerExternalLinkNewWindow) {
@@ -85,9 +129,10 @@ class NavItem
             }
         }
 
+        /** @var Page|null $_c */
         $_c = $this->getCollectionObject();
         if (is_object($_c)) {
-            return $_c->getAttribute('nav_target');
+            return (string) $_c->getAttribute('nav_target');
         }
 
         return '';
@@ -98,7 +143,7 @@ class NavItem
      *
      * @return string $url
      */
-    public function getURL()
+    public function getURL(): string
     {
         if ($this->cPointerExternalLink != '') {
             $link = $this->cPointerExternalLink;
@@ -147,6 +192,8 @@ class NavItem
      * Sets the collection Object of the navigation item to the passed object.
      *
      * @param \Concrete\Core\Page\Page $obj
+     *
+     * @return void
      */
     public function setCollectionObject(&$obj)
     {

--- a/concrete/blocks/autonav/templates/breadcrumb.php
+++ b/concrete/blocks/autonav/templates/breadcrumb.php
@@ -1,7 +1,8 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
+/** @var \Concrete\Block\Autonav\Controller $controller */
 $navItems = $controller->getNavItems(true); // Ignore exclude from nav
-$c = Page::getCurrentPage();
+$c = \Concrete\Core\Page\Page::getCurrentPage();
 
 if (count($navItems) > 0) {
     echo '<nav role="navigation" aria-label="breadcrumb">'; //opens the top-level menu
@@ -20,5 +21,5 @@ if (count($navItems) > 0) {
 } elseif (is_object($c) && $c->isEditMode()) {
     ?>
     <div class="ccm-edit-mode-disabled-item"><?=t('Empty Auto-Nav Block.')?></div>
-<?php 
+<?php
 }

--- a/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
+++ b/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
@@ -1,7 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-
-<?php View::getInstance()->requireAsset('javascript', 'jquery');
-
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('javascript', 'jquery');
+/** @var \Concrete\Block\Autonav\Controller $controller */
 $navItems = $controller->getNavItems();
 
 /**
@@ -48,9 +48,9 @@ $navItems = $controller->getNavItems();
  *    Functionality: Whatever is entered into this textbox will be outputted as an additional CSS class for that page's nav item (NOTE: you must un-comment the "$ni->attrClass" code block in the CSS section below for this to work).
  */
 
-/*** STEP 1 of 2: Determine all CSS classes (only 2 are enabled by default, but you can un-comment other ones or add your own) ***/
+// STEP 1 of 2: Determine all CSS classes (only 2 are enabled by default, but you can un-comment other ones or add your own)
 foreach ($navItems as $ni) {
-    $classes = array();
+    $classes = [];
 
     if ($ni->isCurrent) {
         //class for the page currently being viewed
@@ -67,43 +67,43 @@ foreach ($navItems as $ni) {
         //class for the first item in each menu section (first top-level item, and first item of each dropdown sub-menu)
         $classes[] = 'nav-first';
     }
-    */
+     */
 
     /*
     if ($ni->isLast) {
         //class for the last item in each menu section (last top-level item, and last item of each dropdown sub-menu)
         $classes[] = 'nav-last';
     }
-    */
+     */
 
     /*
     if ($ni->hasSubmenu) {
         //class for items that have dropdown sub-menus
         $classes[] = 'nav-dropdown';
     }
-    */
+     */
 
     /*
     if (!empty($ni->attrClass)) {
         //class that can be set by end-user via the 'nav_item_class' custom page attribute
         $classes[] = $ni->attrClass;
     }
-    */
+     */
 
     /*
     if ($ni->isHome) {
         //home page
         $classes[] = 'nav-home';
     }
-    */
+     */
 
     /*
     //unique class for every single menu item
     $classes[] = 'nav-item-' . $ni->cID;
-    */
+     */
 
     //Put all classes together into one space-separated string
-    $ni->classes = implode(" ", $classes);
+    $ni->classes = implode(' ', $classes);
 }
 
 //*** Step 2 of 2: Output menu HTML ***/
@@ -125,4 +125,3 @@ foreach ($navItems as $ni) {
 
 echo '</ul></nav>'; //closes the top-level menu
 echo '<div class="ccm-responsive-menu-launch"><i></i></div>'; // empty i tag for attaching :after or :before psuedos for things like FontAwesome icons.
-

--- a/concrete/blocks/autonav/view.php
+++ b/concrete/blocks/autonav/view.php
@@ -1,7 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Block\Autonav\Controller $controller */
 /**
- * DISPLAY PARENT PAGE OPTION
+ * DISPLAY PARENT PAGE OPTION.
  *
  * If you always want to add a parent page:
  * $controller->setIncludeParentItem(true);
@@ -16,10 +16,10 @@
  * First, let's get navigation items.
  * If you don't want to exclude any pages, you can ignore "exclude_nav" attribute by passing true.
  * This option is useful for breadcrumbs navigation.
- * E.g. $navItems = $controller->getNavItems(true);
+ * E.g. $navItems = $controller->getNavItems(true);.
  */
 $navItems = $controller->getNavItems();
-$c = Page::getCurrentPage();
+$c = \Concrete\Core\Page\Page::getCurrentPage();
 
 /**
  * The $navItems variable is an array of objects, each representing a nav menu item.
@@ -65,9 +65,9 @@ $c = Page::getCurrentPage();
  *    Functionality: Whatever is entered into this textbox will be outputted as an additional CSS class for that page's nav item (NOTE: you must un-comment the "$ni->attrClass" code block in the CSS section below for this to work).
  */
 
-/*** STEP 1 of 2: Determine all CSS classes (only 2 are enabled by default, but you can un-comment other ones or add your own) ***/
+// STEP 1 of 2: Determine all CSS classes (only 2 are enabled by default, but you can un-comment other ones or add your own)
 foreach ($navItems as $ni) {
-    $classes = array();
+    $classes = [];
 
     if ($ni->isCurrent) {
         //class for the page currently being viewed
@@ -84,43 +84,43 @@ foreach ($navItems as $ni) {
         //class for the first item in each menu section (first top-level item, and first item of each dropdown sub-menu)
         $classes[] = 'nav-first';
     }
-    */
+     */
 
     /*
     if ($ni->isLast) {
         //class for the last item in each menu section (last top-level item, and last item of each dropdown sub-menu)
         $classes[] = 'nav-last';
     }
-    */
+     */
 
     /*
     if ($ni->hasSubmenu) {
         //class for items that have dropdown sub-menus
         $classes[] = 'nav-dropdown';
     }
-    */
+     */
 
     /*
     if (!empty($ni->attrClass)) {
         //class that can be set by end-user via the 'nav_item_class' custom page attribute
         $classes[] = $ni->attrClass;
     }
-    */
+     */
 
     /*
     if ($ni->isHome) {
         //home page
         $classes[] = 'nav-home';
     }
-    */
+     */
 
     /*
     //unique class for every single menu item
     $classes[] = 'nav-item-' . $ni->cID;
-    */
+     */
 
     //Put all classes together into one space-separated string
-    $ni->classes = implode(" ", $classes);
+    $ni->classes = implode(' ', $classes);
 }
 
 //*** Step 2 of 2: Output menu HTML ***/

--- a/concrete/blocks/board/add.php
+++ b/concrete/blocks/board/add.php
@@ -1,9 +1,15 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var array<string,mixed> $boardSelect */
+/** @var int|string $boardID */
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$boardInstanceID = $boardInstanceID ?? 0;
+?>
 <div data-view="edit-board-block">
     <div class="form-group">
         <?php echo $form->label('boardID', t('Board'))?>
         <?php echo $form->select('boardID', $boardSelect, $boardID, [
-            'v-model' => 'boardID'
+            'v-model' => 'boardID',
         ])?>
     </div>
 

--- a/concrete/blocks/board/controller.php
+++ b/concrete/blocks/board/controller.php
@@ -18,27 +18,67 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController
 {
-    protected $btInterfaceWidth = 500;
-    protected $btInterfaceHeight = 500;
-    protected $btTable = 'btBoard';
-    protected $btIgnorePageThemeGridFrameworkContainer = true;
-    protected $btSupportsInlineEdit = true;
+    /**
+     * @var string[]
+     */
+    public $helpers = ['form', 'validation/token'];
 
-    public $helpers = ['form'];
-
+    /**
+     * @var int|null
+     */
     public $boardID;
+
+    /**
+     * @var int|null
+     */
     public $boardInstanceID;
 
+    /**
+     * @var int
+     */
+    protected $btInterfaceWidth = 500;
+
+    /**
+     * @var int
+     */
+    protected $btInterfaceHeight = 500;
+
+    /**
+     * @var string
+     */
+    protected $btTable = 'btBoard';
+
+    /**
+     * @var bool
+     */
+    protected $btIgnorePageThemeGridFrameworkContainer = true;
+
+    /**
+     * @var bool
+     */
+    protected $btSupportsInlineEdit = true;
+
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
         return t('Adds a Board to your website.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t('Board');
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function add()
     {
         $em = $this->app->make(EntityManager::class);
@@ -46,6 +86,7 @@ class Controller extends BlockController
         $boards = [];
         foreach ($em->getRepository(Board::class)->findAll() as $board) {
             $checker = new Checker($board);
+            /** @phpstan-ignore-next-line */
             if ($checker->canViewBoard()) {
                 $boards[] = $board;
                 $boardSelect[$board->getBoardID()] = $board->getBoardName();
@@ -56,6 +97,13 @@ class Controller extends BlockController
         $this->set('boards', $boards);
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function export(\SimpleXMLElement $blockNode)
     {
         $data = $blockNode->addChild('data');
@@ -67,13 +115,22 @@ class Controller extends BlockController
         }
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param \Concrete\Core\Page\Page $page
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return array<string, mixed>
+     */
     public function getImportData($blockNode, $page)
     {
         $args = [];
         $boardName = (string) $blockNode->data->board;
         if ($boardName) {
             $board = $this->app->make(EntityManager::class)->getRepository(Board::class)
-                ->findOneByBoardName($boardName);
+                ->findOneByBoardName($boardName)
+            ;
             if ($board) {
                 $instances = $board->getInstances();
                 if (empty($instances[0])) {
@@ -87,10 +144,15 @@ class Controller extends BlockController
                 $args['boardInstanceID'] = $instance->getBoardInstanceID();
             }
         }
+
         return $args;
     }
 
-
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return mixed
+     */
     public function action_get_instances()
     {
         $boardID = (int) $this->request->request->get('boardID');
@@ -99,25 +161,28 @@ class Controller extends BlockController
             $board = $this->app->make(EntityManager::class)->find(Board::class, $boardID);
             if ($board) {
                 $checker = new Checker($board);
+                /** @phpstan-ignore-next-line */
                 if ($checker->canViewBoard()) {
                     $instances = $board->getInstances();
                 }
             }
         }
+        /** @var JsonSerializer $serializer */
         $serializer = $this->app->make(JsonSerializer::class);
+
         return $serializer->serialize($instances, 'json');
     }
 
     /**
-     * Validate this block on save
+     * Validate this block on save.
      *
-     * @param array|string|null $args
-     *
-     * @return bool|ErrorList
+     * @param array<string, mixed>|string|null $args
      *
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      * @throws \Doctrine\ORM\TransactionRequiredException
+     *
+     * @return bool|ErrorList
      */
     public function validate($args)
     {
@@ -131,7 +196,8 @@ class Controller extends BlockController
         if (!$newInstance) {
             if ($boardInstanceId) {
                 $board = $this->app->make(EntityManager::class)
-                    ->find(Instance::class, $boardInstanceId);
+                    ->find(Instance::class, $boardInstanceId)
+                ;
             }
 
             // If we're not making a new instance and we don't have an instance here we've been given an invalid ID
@@ -143,12 +209,18 @@ class Controller extends BlockController
         return $e;
     }
 
+    /**
+     * @param array<string,mixed> $args
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public function save($args)
     {
         if (!empty($args['newInstance'])) {
             // Create a new instance for this board
             $board = $this->app->make(EntityManager::class)
-                ->find(Board::class, $args['boardID']);
+                ->find(Board::class, $args['boardID'])
+            ;
             if ($board) {
                 $command = new CreateBoardInstanceCommand();
                 $command->setBoard($board);
@@ -160,36 +232,50 @@ class Controller extends BlockController
         parent::save($args);
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return JsonResponse
+     */
     public function action_regenerate()
     {
         if ($this->boardInstanceID) {
             if ($this->app->make('token')->validate('regenerate')) {
                 $instance = $this->app->make(EntityManager::class)
-                    ->find(Instance::class, $this->boardInstanceID);
+                    ->find(Instance::class, $this->boardInstanceID)
+                ;
                 if ($instance) {
                     $board = $instance->getBoard();
                     $checker = new Checker($board);
+                    /** @phpstan-ignore-next-line */
                     if ($checker->canEditBoardContents()) {
                         $command = new RegenerateBoardInstanceCommand();
                         $command->setInstance($instance);
                         $this->app->executeCommand($command);
+
                         return new JsonResponse($instance);
-                    } else {
-                        throw new \RuntimeException(t('Access Denied.'));
                     }
+                        throw new \RuntimeException(t('Access Denied.'));
                 }
             }
             throw new \RuntimeException(t('Access Denied.'));
         }
+        throw new \RuntimeException(t('Invalid board instance.'));
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function edit()
     {
         $this->add();
 
         if ($this->boardInstanceID) {
             $instance = $this->app->make(EntityManager::class)
-                ->find(Instance::class, $this->boardInstanceID);
+                ->find(Instance::class, $this->boardInstanceID)
+            ;
             if ($instance) {
                 $renderer = $this->app->make(Renderer::class);
                 $renderer->setEnableEditing(true);
@@ -201,6 +287,11 @@ class Controller extends BlockController
         }
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         if ($this->boardInstanceID) {

--- a/concrete/blocks/board/view.php
+++ b/concrete/blocks/board/view.php
@@ -1,6 +1,10 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
 
+/** @var \Concrete\Core\Entity\Board\Instance|null $instance */
+/** @var \Concrete\Core\Board\Instance\Renderer|null $renderer */
+$renderer = $renderer ?? null;
+$instance = $instance ?? null;
 if ($renderer) {
     $renderer->render($instance);
 }

--- a/concrete/blocks/breadcrumbs/controller.php
+++ b/concrete/blocks/breadcrumbs/controller.php
@@ -12,17 +12,29 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = ['form'];
+    /** @var string[]  */
+    protected $helpers = ['form'];
+    /** @var bool */
     public $includeCurrent;
+    /** @var bool */
     public $ignoreExcludeNav;
+    /** @var bool */
     public $ignorePermission;
+    /** @var int  */
     protected $btInterfaceWidth = 500;
+    /** @var int  */
     protected $btInterfaceHeight = 300;
+    /** @var string  */
     protected $btTable = 'btBreadcrumbs';
+    /** @var bool  */
     protected $btCacheBlockRecord = true;
+    /** @var bool  */
     protected $btCacheBlockOutput = true;
+    /** @var bool  */
     protected $btCacheBlockOutputOnPost = true;
+    /** @var bool  */
     protected $btCacheBlockOutputForRegisteredUsers = true;
+    /** @var int  */
     protected $btCacheBlockOutputLifetime = 300;
 
     /**
@@ -51,6 +63,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
     }
 
+    /**
+     * @return void
+     */
     public function add()
     {
         $this->set('includeCurrent', 1);
@@ -59,6 +74,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     public function save($args)
     {
@@ -68,6 +84,10 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::save($args);
     }
 
+    /**
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public function view()
     {
         $page = Page::getCurrentPage();

--- a/concrete/blocks/breadcrumbs/form.php
+++ b/concrete/blocks/breadcrumbs/form.php
@@ -7,19 +7,19 @@ $ignorePermission = isset($ignorePermission) && $ignorePermission ? 1 : 0;
 ?>
 <div class="form-group">
     <div class="form-check form-switch">
-        <?= $form->checkbox('includeCurrent', 1, $includeCurrent) ?>
+        <?= $form->checkbox('includeCurrent', '1', $includeCurrent) ?>
         <?= $form->label('includeCurrent', t('Include Current Page in Breadcrumbs Navigation')) ?>
     </div>
 </div>
 <div class="form-group">
     <div class="form-check form-switch">
-        <?= $form->checkbox('ignorePermission', 1, $ignorePermission) ?>
+        <?= $form->checkbox('ignorePermission', '1', $ignorePermission) ?>
         <?= $form->label('ignorePermission', t('Ignore "View" permission')) ?>
     </div>
 </div>
 <div class="form-group">
     <div class="form-check form-switch">
-        <?= $form->checkbox('ignoreExcludeNav', 1, $ignoreExcludeNav, ['aria-describedby' => 'ignoreExcludeNavHelp']) ?>
+        <?= $form->checkbox('ignoreExcludeNav', '1', $ignoreExcludeNav, ['aria-describedby' => 'ignoreExcludeNavHelp']) ?>
         <?= $form->label('ignoreExcludeNav', t('Ignore "Exclude From Nav" attribute')) ?>
         <div id="ignoreExcludeNavHelp"
              class="form-text"><?= t('If "Exclude From Nav" on, pages are excluded in Auto-Nav block. Usually, Breadcrumbs Navigation should ignore it and show these pages even if other navigation excludes them.') ?></div>

--- a/concrete/blocks/breadcrumbs/view.php
+++ b/concrete/blocks/breadcrumbs/view.php
@@ -1,5 +1,5 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
-/** @var \Concrete\Core\Navigation\Breadcrumb\PageBreadcrumb $breadcrumb */
+/** @var \Concrete\Core\Navigation\Breadcrumb\PageBreadcrumb|null $breadcrumb */
 $breadcrumb = $breadcrumb ?? null;
 if ($breadcrumb && count($breadcrumb->getItems()) > 0) {
     ?>

--- a/concrete/blocks/calendar/controller.php
+++ b/concrete/blocks/calendar/controller.php
@@ -10,8 +10,8 @@ use Concrete\Core\Calendar\Event\EventOccurrenceList;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Html\Object\HeadLink;
-use Core;
-use Page;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Support\Facade\Url;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Controller extends BlockController implements UsesFeatureInterface
@@ -68,32 +68,64 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public $lightboxProperties;
 
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 500;
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 475;
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btCalendar';
 
+    /**
+     * @var \Concrete\Core\Entity\Attribute\Key\EventKey[]
+     */
+    protected $eventAttributes;
+
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockTypeDescription()
     {
         return t('Displays a month view calendar on a page.');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockTypeName()
     {
         return t('Calendar');
     }
 
+    /**
+     * @return void
+     */
     public function on_start()
     {
+        /** @phpstan-ignore-next-line  */
         $this->eventAttributes = EventKey::getList();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::CALENDAR
+            Features::CALENDAR,
         ];
     }
 
+    /**
+     * @return void
+     */
     public function loadData()
     {
         $viewTypes = [
@@ -119,15 +151,24 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('lightboxProperties', $lightboxProperties);
 
         // topics
+        /** @phpstan-ignore-next-line  */
         $keys = EventKey::getList(['atHandle' => 'topics']);
         $this->set('attributeKeys', array_filter($keys, function ($ak) {
-            return 'topics' == $ak->getAttributeTypeHandle();
+            return $ak->getAttributeTypeHandle() == 'topics';
         }));
     }
 
+    /**
+     * @param int $bID
+     *
+     * @throws \Concrete\Core\Attribute\Exception\InvalidAttributeException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return JsonResponse|void
+     */
     public function action_get_events($bID)
     {
-        $service = \Core::make('date');
+        $service = $this->app->make('date');
 
         if ($bID == $this->bID) {
             $start = $this->request->query->get('start');
@@ -161,7 +202,6 @@ class Controller extends BlockController implements UsesFeatureInterface
                 } else {
                     $obj->start = $service->formatCustom('Y-m-d H:i:s', $occurrence->getStart());
                     $obj->end = $service->formatCustom('Y-m-d H:i:s', $occurrence->getEnd());
-
                 }
                 $obj->backgroundColor = $background;
                 $obj->borderColor = $background;
@@ -172,12 +212,14 @@ class Controller extends BlockController implements UsesFeatureInterface
                 }
                 $data[] = $obj;
             }
-            $js = new JsonResponse($data);
 
-            return $js;
+            return new JsonResponse($data);
         }
     }
 
+    /**
+     * @return void
+     */
     public function add()
     {
         $this->loadData();
@@ -188,20 +230,31 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('viewTypesOrder', ['month_' . t('Month'), 'basicWeek_' . t('Week'), 'basicDay_' . t('Day')]);
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Concrete\Core\Entity\Calendar\Calendar|null
+     */
     public function getCalendar()
     {
         if ($this->calendarAttributeKeyHandle) {
-            $site = \Core::make('site')->getSite();
+            $site = $this->app->make('site')->getSite();
             $calendar = $site->getAttribute($this->calendarAttributeKeyHandle);
             if (is_object($calendar)) {
                 return $calendar;
             }
         }
         if ($this->caID) {
+            /** @phpstan-ignore-next-line */
             return Calendar::getByID($this->caID);
         }
+
+        return null;
     }
 
+    /**
+     * @return array<string,string>
+     */
     public function getSelectedLightboxProperties()
     {
         return (array) json_decode($this->lightboxProperties);
@@ -214,7 +267,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      * - "month" is the view type
      * - "Month" is the view type display name
      *
-     * @param array $viewTypesOrder
+     * @param string[] $viewTypesOrder
      *
      * @return string
      */
@@ -225,13 +278,17 @@ class Controller extends BlockController implements UsesFeatureInterface
         foreach ($viewTypesOrder as $test) {
             $viewType = explode('_', $test);
             $viewTypeArray[$i] = $viewType[0];
-            ++$i;
+            $i++;
         }
-        $viewTypeString = implode(',', $viewTypeArray);
 
-        return $viewTypeString;
+        return implode(',', $viewTypeArray);
     }
 
+    /**
+     * @param string $key
+     *
+     * @return string|null
+     */
     public function getPropertyTitle($key)
     {
         switch ($key) {
@@ -248,8 +305,18 @@ class Controller extends BlockController implements UsesFeatureInterface
                 }
                 break;
         }
+
+        return null;
     }
 
+    /**
+     * @param string $key
+     * @param \Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence $occurrence
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return string
+     */
     public function getPropertyValue($key, $occurrence)
     {
         $event = $occurrence->getEvent();
@@ -284,22 +351,31 @@ class Controller extends BlockController implements UsesFeatureInterface
                     break;
             }
         }
+
+        return '';
     }
 
+    /**
+     * @return void
+     */
     public function composer()
     {
         $this->edit();
     }
 
+    /**
+     * @return void
+     */
     public function edit()
     {
         $this->loadData();
         $this->set('viewTypesSelected', (array) json_decode($this->viewTypes));
         $this->set('viewTypesOrder', (array) json_decode($this->viewTypesOrder));
         $this->set('lightboxPropertiesSelected', $this->getSelectedLightboxProperties());
+        /** @phpstan-ignore-next-line  */
         $calendars = array_filter(Calendar::getList(), function ($calendar) {
-            $p = new \Permissions($calendar);
-
+            $p = new Checker($calendar);
+            /** @phpstan-ignore-next-line */
             return $p->canViewCalendarInEditInterface();
         });
         $calendarSelect = ['' => t('** Select a Calendar')];
@@ -309,6 +385,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('calendars', $calendarSelect);
     }
 
+    /**
+     * @return bool
+     */
     public function supportsLightbox()
     {
         $props = $this->getSelectedLightboxProperties();
@@ -316,29 +395,18 @@ class Controller extends BlockController implements UsesFeatureInterface
         return count($props) > 0;
     }
 
-    /*
-    public function validate($args)
-    {
-        $calendar = Calendar::getByID($args['caID']);
-        $e = \Core::make('error');
-        if (!is_object($calendar)) {
-            $e->add(t('You must choose a valid calendar.'));
-        }
-        $p = new \Permissions($calendar);
-        if (!$p->canViewCalendarInEditInterface()) {
-            $e->add(t('You do not have access to select this calendar.'));
-        }
-        return $e;
-    }
-    */
-
+    /**
+     * @param mixed $args
+     *
+     * @return void
+     */
     public function save($args)
     {
-        if ('specific' == $args['chooseCalendar']) {
+        if ($args['chooseCalendar'] == 'specific') {
             $args['caID'] = (int) $args['caID'];
             $args['calendarAttributeKeyHandle'] = '';
         }
-        if ('site' == $args['chooseCalendar']) {
+        if ($args['chooseCalendar'] == 'site') {
             $args['caID'] = 0;
             // pass through the attribute key handle to save.
         }
@@ -372,14 +440,20 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::save($args);
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $this->loadData();
         $calendar = $this->getCalendar();
         if (is_object($calendar)) {
-            $permissions = new \Permissions($calendar);
+            $permissions = new Checker($calendar);
+            /** @phpstan-ignore-next-line */
             if ($permissions->canAccessCalendarRssFeed()) {
-                $link = new HeadLink(\URL::route(['/feed', 'calendar'], $this->getCalendar()->getID()), 'alternate', 'application/rss+xml');
+                $link = new HeadLink(Url::route(['/feed', 'calendar'], $this->getCalendar()->getID()), 'alternate', 'application/rss+xml');
                 $this->addHeaderItem($link);
             }
             $this->set('permissions', $permissions);

--- a/concrete/blocks/calendar/form.php
+++ b/concrete/blocks/calendar/form.php
@@ -7,22 +7,23 @@ use Concrete\Core\Form\Service\Widget\Color;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\View\View;
 
-/** @var int $caID */
-/** @var string $calendarAttributeKeyHandle */
-/** @var int $filterByTopicAttributeKeyID */
+/** @var int|null $caID */
+/** @var string|null $calendarAttributeKeyHandle */
+/** @var int|null $filterByTopicAttributeKeyID */
 /** @var int $filterByTopicID */
+$filterByTopicID = $filterByTopicID ?? 0;
 /** @var string $viewTypes */
 /** @var string $viewTypesOrder */
-/** @var string $defaultView */
+/** @var string|null $defaultView */
 /** @var int $navLinks */
 /** @var int $eventLimit */
-/** @var array $lightboxProperties */
-/** @var array $viewTypesSelected */
-/** @var array $viewTypesOrder */
-/** @var array $lightboxPropertiesSelected */
-/** @var array $calendars */
-/** @var array $attributeKeys */
-/** @var array $viewTypes */
+/** @var array<string,string> $lightboxProperties */
+/** @var string[] $viewTypesSelected */
+/** @var string[] $viewTypesOrder */
+/** @var array<string,string> $lightboxPropertiesSelected */
+/** @var \Concrete\Core\Entity\Calendar\Calendar[] $calendars */
+/** @var \Concrete\Core\Entity\Attribute\Key\EventKey[] $attributeKeys */
+/** @var array<string, string> $viewTypes */
 
 $app = Application::getFacadeApplication();
 /** @var Form $form */
@@ -38,8 +39,8 @@ $color = $app->make(Color::class);
 
     <?php /** @noinspection PhpUnhandledExceptionInspection */
     View::element('calendar/block/data_source', [
-        'caID' => isset($caID) ? $caID : null,
-        'calendarAttributeKeyHandle' => isset($calendarAttributeKeyHandle) ? $calendarAttributeKeyHandle : null
+        'caID' => $caID ?? null,
+        'calendarAttributeKeyHandle' => $calendarAttributeKeyHandle ?? null,
     ]) ?>
 </fieldset>
 
@@ -50,20 +51,26 @@ $color = $app->make(Color::class);
 
     <div data-section="customize-results">
         <div class="form-group">
-            <?php echo $form->label("viewTypes", t("View Types")); ?>
+            <?php echo $form->label('viewTypes', t('View Types')); ?>
 
             <?php if ($viewTypes) { ?>
-                <?php foreach ($viewTypes as $key => $name) { ?>
+
+                <?php
+                /**
+                 * @var string $key
+                 * @var string $name
+                 */
+                foreach ($viewTypes as $key => $name) { ?>
                     <div class="form-check">
-                        <?php echo $form->checkbox('viewTypes[]', $key, in_array($key, $viewTypesSelected), ["name" => "viewTypes[]", "id" => "viewTypes_" . $key]); ?>
-                        <?php echo $form->label("viewTypes_" . $key, $name, ["class" => "form-check-label"]); ?>
+                        <?php echo $form->checkbox('viewTypes[]', $key, in_array($key, $viewTypesSelected), ['name' => 'viewTypes[]', 'id' => 'viewTypes_' . $key]); ?>
+                        <?php echo $form->label('viewTypes_' . $key, $name, ['class' => 'form-check-label']); ?>
                     </div>
                 <?php } ?>
             <?php } ?>
         </div>
 
         <div class="form-group">
-            <?php echo $form->label("", t("View Type Order")); ?>
+            <?php echo $form->label('', t('View Type Order')); ?>
 
             <p class="help-block">
                 <?php echo t('Click and drag to change view type order.'); ?>
@@ -75,7 +82,7 @@ $color = $app->make(Color::class);
                         <?php $valueNameArray = explode('_', $valueName); ?>
 
                         <li style="cursor: move" data-field-order-item="<?php echo $valueNameArray[0]; ?>">
-                            <?php echo $form->hidden("viewTypesOrder[]", $valueName); ?>
+                            <?php echo $form->hidden('viewTypesOrder[]', $valueName); ?>
                             <?php echo $valueNameArray[1]; ?>
                             <i class="ccm-item-select-list-sort ui-sortable-handle"></i>
                         </li>
@@ -87,15 +94,15 @@ $color = $app->make(Color::class);
 
     <div class="form-group">
         <?php echo $form->label('defaultView', t('Default View')); ?>
-        <?php echo $form->select('defaultView', $viewTypes, isset($defaultView) ? $defaultView : null); ?>
+        <?php echo $form->select('defaultView', $viewTypes, $defaultView ?? null); ?>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("", t("Day Heading Links")); ?>
+        <?php echo $form->label('', t('Day Heading Links')); ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('navLinks', 1, !empty($navLinks)); ?>
-            <?php echo $form->label("navLinks", t('Make day headings into links.'), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('navLinks', '1', !empty($navLinks)); ?>
+            <?php echo $form->label('navLinks', t('Make day headings into links.'), ['class' => 'form-check-label']); ?>
         </div>
     </div>
 
@@ -104,11 +111,11 @@ $color = $app->make(Color::class);
     </p>
 
     <div class="form-group">
-        <?php echo $form->label("", t("Event Limit")); ?>
+        <?php echo $form->label('', t('Event Limit')); ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('eventLimit', 1, !empty($eventLimit)); ?>
-            <?php echo $form->label("eventLimit", t('Limit the number of events displayed on a day.'), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('eventLimit', '1', !empty($eventLimit)); ?>
+            <?php echo $form->label('eventLimit', t('Limit the number of events displayed on a day.'), ['class' => 'form-check-label']); ?>
         </div>
 
         <p class="help-block">
@@ -123,7 +130,7 @@ $color = $app->make(Color::class);
     </legend>
 
     <div class="form-group">
-        <?php echo $form->label("totalToRetrieve", t("Filter by Topic Attribute")); ?>
+        <?php echo $form->label('totalToRetrieve', t('Filter by Topic Attribute')); ?>
 
         <!--suppress HtmlFormInputWithoutLabel -->
         <select class="form-select" name="filterByTopicAttributeKeyID">
@@ -132,7 +139,9 @@ $color = $app->make(Color::class);
             </option>
 
             <?php foreach ($attributeKeys as $ak) { ?>
-                <?php $attributeController = $ak->getController(); ?>
+                <?php
+                /** @var \Concrete\Attribute\Topics\Controller $attributeController */
+                $attributeController = $ak->getController(); ?>
 
                 <option value="<?php echo h($ak->getAttributeKeyID()) ?>"
                         <?php if (isset($filterByTopicAttributeKeyID) && $ak->getAttributeKeyID() == $filterByTopicAttributeKeyID) { ?>selected<?php } ?>
@@ -142,7 +151,7 @@ $color = $app->make(Color::class);
             <?php } ?>
         </select>
 
-        <?php echo $form->hidden("filterByTopicID", isset($filterByTopicID) ? $filterByTopicID : ''); ?>
+        <?php echo $form->hidden('filterByTopicID', (string) $filterByTopicID); ?>
 
         <div class="tree-view-container">
             <div class="tree-view-template"></div>
@@ -161,8 +170,8 @@ $color = $app->make(Color::class);
 
     <?php foreach ($lightboxProperties as $key => $name) { ?>
         <div class="form-check">
-            <?php echo $form->checkbox('lightboxProperties[]', $key, in_array($key, $lightboxPropertiesSelected), ["name" => "lightboxProperties[]", "id" => "lightboxProperties_" . $key]) ?>
-            <?php echo $form->label("lightboxProperties_" . $key, $name, ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('lightboxProperties[]', $key, in_array($key, $lightboxPropertiesSelected), ['name' => 'lightboxProperties[]', 'id' => 'lightboxProperties_' . $key]) ?>
+            <?php echo $form->label('lightboxProperties_' . $key, $name, ['class' => 'form-check-label']) ?>
         </div>
     <?php } ?>
 </fieldset>
@@ -182,7 +191,7 @@ $color = $app->make(Color::class);
             $('.tree-view-template').concreteTree({
                 'treeID': chosenTree,
                 'chooseNodeInForm': true,
-                'selectNodesByKey': [<?php echo isset($filterByTopicID) ? (int)$filterByTopicID : 0?>],
+                'selectNodesByKey': [<?php echo $filterByTopicID ?>],
                 'onSelect': function (nodes) {
                     if (nodes.length) {
                         $('input[name=filterByTopicID]').val(nodes[0]);

--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -1,5 +1,19 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
+/** @var \Concrete\Block\Calendar\Controller $controller */
+/** @var \Concrete\Core\Permission\Checker $permissions */
+
+/** @var string $viewTypeString */
+/** @var string $defaultView */
+/** @var \Concrete\Core\Block\View\BlockView $view */
+
+/** @var int $bID */
+$bID = $bID ?? 0;
+$eventLimit = $eventLimit ?? 0;
+$navLinks = $navLinks ?? 0;
+use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Page;
+
 if (!isset($calendar) || !is_object($calendar)) {
     $calendar = null;
 }
@@ -9,6 +23,7 @@ if ($c->isEditMode()) {
     $loc->pushActiveContext(Localization::CONTEXT_UI);
     ?><div class="ccm-edit-mode-disabled-item"><?=t('Calendar disabled in edit mode.')?></div><?php
     $loc->popActiveContext();
+    /** @phpstan-ignore-next-line */
 } elseif ($calendar !== null && $permissions->canViewCalendar()) { ?>
     <div class="ccm-block-calendar-wrapper" data-calendar="<?=$bID?>"></div>
 
@@ -18,7 +33,7 @@ if ($c->isEditMode()) {
                 header: {
                     left: 'prev,next today',
                     center: 'title',
-                    right: '<?= $viewTypeString ? $viewTypeString : ''; ?>'
+                    right: '<?= $viewTypeString ?: ''; ?>'
                 },
                 locale: <?= json_encode(Localization::activeLanguage()); ?>,
                 views: {
@@ -50,7 +65,7 @@ if ($c->isEditMode()) {
 
                 eventRender: function(event, element) {
                     <?php if ($controller->supportsLightbox()) { ?>
-                        element.attr('href', '<?=rtrim(URL::route(array('/view_event', 'calendar'), $bID))?>/' + event.id).magnificPopup({
+                        element.attr('href', '<?=rtrim(\Concrete\Core\Support\Facade\Url::route(['/view_event', 'calendar'], $bID))?>/' + event.id).magnificPopup({
                             type: 'ajax',
                             callbacks: {
                                 beforeOpen: function () {

--- a/concrete/blocks/calendar_event/add.php
+++ b/concrete/blocks/calendar_event/add.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/calendar_event/controller.php
+++ b/concrete/blocks/calendar_event/controller.php
@@ -1,36 +1,54 @@
 <?php
+
 namespace Concrete\Block\CalendarEvent;
 
 use Concrete\Core\Attribute\Key\CollectionKey;
-use Concrete\Core\Block\BlockController;
 use Concrete\Core\Attribute\Key\EventKey;
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Calendar\Calendar;
+use Concrete\Core\Calendar\CalendarServiceProvider;
 use Concrete\Core\Calendar\Event\Event;
 use Concrete\Core\Calendar\Event\EventOccurrence;
-use Concrete\Core\Calendar\CalendarServiceProvider;
 use Concrete\Core\Entity\Calendar\CalendarEvent;
-use Concrete\Core\Entity\Calendar\CalendarEventVersion;
 use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Page\Page;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
     public $helpers = ['form'];
-    /** @var int  */
+
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 550;
-    /** @var int  */
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 400;
-    /** @var string */
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btCalendarEvent';
-    /** @var string */
+
+    /**
+     * @var string
+     */
     protected $mode = 'S';
-    /** @var string */
+
+    /**
+     * @var string
+     */
     protected $calendarEventAttributeKeyHandle;
-    /** @var int|null */
+
+    /**
+     * @var int|null
+     */
     protected $eventID;
 
     /**
@@ -39,7 +57,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     public function getRequiredFeatures(): array
     {
         return [
-            Features::CALENDAR
+            Features::CALENDAR,
         ];
     }
 
@@ -48,7 +66,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function getBlockTypeDescription()
     {
-        return t("Displays a calendar event on a page.");
+        return t('Displays a calendar event on a page.');
     }
 
     /**
@@ -56,7 +74,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function getBlockTypeName()
     {
-        return t("Calendar Event");
+        return t('Calendar Event');
     }
 
     /**
@@ -101,12 +119,13 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param array<string,mixed> $data
+     *
      * @return void
      */
     public function save($data)
     {
-        $data['calendarID'] = isset($data['calendarID']) ? intval($data['calendarID']) : 0;
-        $data['eventID'] = isset($data['eventID']) ? intval($data['eventID']) : 0;
+        $data['calendarID'] = isset($data['calendarID']) ? (int) ($data['calendarID']) : 0;
+        $data['eventID'] = isset($data['eventID']) ? (int) ($data['eventID']) : 0;
 
         $data['allowExport'] = isset($data['allowExport']) && $data['allowExport'] ? 1 : 0;
         $data['displayEventName'] = isset($data['displayEventName']) && $data['displayEventName'] ? 1 : 0;
@@ -123,49 +142,28 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * @return CalendarEvent|null
-     */
-    protected function getEvent()
-    {
-        $event = null;
-        if ($this->mode == 'P') {
-            $page = Page::getCurrentPage();
-            $event = $page->getAttribute($this->calendarEventAttributeKeyHandle);
-        } else {
-            if ($this->eventID) {
-                /** @phpstan-ignore-next-line */
-                $event = Event::getByID($this->eventID);
-            }
-        }
-
-        return $event;
-    }
-
-    /**
-     * @return CalendarEventVersionOccurrence|null
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return CalendarEventVersionOccurrence|null
      */
     public function getOccurrence()
     {
         $event = $this->getEvent();
         if (is_object($event)) {
-            if ($this->request->query->has("occurrenceID")) {
+            if ($this->request->query->has('occurrenceID')) {
                 /** @var CalendarEventVersionOccurrence|null $occurrence */
                 /** @phpstan-ignore-next-line */
                 $occurrence = EventOccurrence::getByID($this->request->query->get('occurrenceID'));
                 if ($occurrence) {
-
                     if ($occurrence->getEvent() && $occurrence->getEvent()->getID() == $event->getID()) {
                         /** @phpstan-ignore-next-line */
                         if ($event->isApproved()) {
-
                             return $occurrence;
                         }
                     }
 
                     /** @phpstan-ignore-next-line */
                     if ($occurrence->getEvent() && Event::isRelatedTo($occurrence->getEvent(), $event)) {
-
                         // this is a temporary hack. We need to ultimately make this make sure that
                         // the event matches –but sometimes our events don't match because we imported them as series
                         // events and not as  occurrences of one event.
@@ -188,8 +186,10 @@ class Controller extends BlockController implements UsesFeatureInterface
                 $list->sortBy('startTime', 'desc');
                 $results = $list->getResults();
             }
+
             return $results[0];
-        } else if ($this->request->query->has('occurrenceID') && $this->mode == 'R') {
+        }
+        if ($this->request->query->has('occurrenceID') && $this->mode == 'R') {
             // request mode
             /** @phpstan-ignore-next-line */
             $occurrence = EventOccurrence::getByID($this->request->query->get('occurrenceID'));
@@ -200,18 +200,20 @@ class Controller extends BlockController implements UsesFeatureInterface
                 }
             }
         }
+
         return null;
     }
 
     /**
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
      * @return void
      */
     public function view()
     {
         $this->set('event', $this->getEvent());
 
-        $displayEventAttributes = array();
+        $displayEventAttributes = [];
         if (isset($this->displayEventAttributes)) {
             $displayEventAttributes = json_decode($this->displayEventAttributes);
         }
@@ -230,4 +232,22 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('formatter', $formatter);
     }
 
+    /**
+     * @return CalendarEvent|null
+     */
+    protected function getEvent()
+    {
+        $event = null;
+        if ($this->mode == 'P') {
+            $page = Page::getCurrentPage();
+            $event = $page->getAttribute($this->calendarEventAttributeKeyHandle);
+        } else {
+            if ($this->eventID) {
+                /** @phpstan-ignore-next-line */
+                $event = Event::getByID($this->eventID);
+            }
+        }
+
+        return $event;
+    }
 }

--- a/concrete/blocks/calendar_event/controller.php
+++ b/concrete/blocks/calendar_event/controller.php
@@ -8,19 +8,34 @@ use Concrete\Core\Calendar\Calendar;
 use Concrete\Core\Calendar\Event\Event;
 use Concrete\Core\Calendar\Event\EventOccurrence;
 use Concrete\Core\Calendar\CalendarServiceProvider;
+use Concrete\Core\Entity\Calendar\CalendarEvent;
+use Concrete\Core\Entity\Calendar\CalendarEventVersion;
+use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
+use Concrete\Core\Page\Page;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = array('form');
-
+    public $helpers = ['form'];
+    /** @var int  */
     protected $btInterfaceWidth = 550;
+    /** @var int  */
     protected $btInterfaceHeight = 400;
+    /** @var string */
     protected $btTable = 'btCalendarEvent';
+    /** @var string */
+    protected $mode = 'S';
+    /** @var string */
+    protected $calendarEventAttributeKeyHandle;
+    /** @var int|null */
+    protected $eventID;
 
+    /**
+     * {@inheritdoc}
+     */
     public function getRequiredFeatures(): array
     {
         return [
@@ -28,37 +43,52 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockTypeDescription()
     {
         return t("Displays a calendar event on a page.");
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockTypeName()
     {
         return t("Calendar Event");
     }
 
+    /**
+     * @return void
+     */
     public function add()
     {
         $this->edit();
     }
 
+    /**
+     * @return void
+     */
     public function edit()
     {
+        /** @var \Concrete\Core\Entity\Attribute\Key\EventKey[] $eventKeys */
+        /** @phpstan-ignore-next-line */
         $eventKeys = EventKey::getList();
         $calendars = ['' => t('** Choose a Calendar')];
         $calendarEventPageKeys = ['' => t('** Choose an Event')];
-
+        /** @phpstan-ignore-next-line */
         foreach (CollectionKey::getList() as $ak) {
             if ($ak->getAttributeTypeHandle() == 'calendar_event') {
                 $calendarEventPageKeys[$ak->getAttributeKeyHandle()] = $ak->getAttributeKeyDisplayName();
             }
         }
+        /** @phpstan-ignore-next-line */
         foreach (Calendar::getList() as $calendar) {
             $calendars[$calendar->getID()] = $calendar->getName();
         }
 
-        $displayEventAttributes = array();
+        $displayEventAttributes = [];
         if (isset($this->displayEventAttributes)) {
             $displayEventAttributes = json_decode($this->displayEventAttributes);
         }
@@ -69,6 +99,10 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('displayEventAttributes', $displayEventAttributes);
     }
 
+    /**
+     * @param array<string,mixed> $data
+     * @return void
+     */
     public function save($data)
     {
         $data['calendarID'] = isset($data['calendarID']) ? intval($data['calendarID']) : 0;
@@ -80,7 +114,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $data['displayEventDescription'] = isset($data['displayEventDescription']) && $data['displayEventDescription'] ? 1 : 0;
         $data['enableLinkToPage'] = isset($data['enableLinkToPage']) && $data['enableLinkToPage'] ? 1 : 0;
 
-        $attributes = array();
+        $attributes = [];
         if (isset($data['displayEventAttributes']) && is_array($data['displayEventAttributes'])) {
             $attributes = $data['displayEventAttributes'];
         }
@@ -88,14 +122,18 @@ class Controller extends BlockController implements UsesFeatureInterface
         parent::save($data);
     }
 
+    /**
+     * @return CalendarEvent|null
+     */
     protected function getEvent()
     {
         $event = null;
         if ($this->mode == 'P') {
-            $page = \Page::getCurrentPage();
+            $page = Page::getCurrentPage();
             $event = $page->getAttribute($this->calendarEventAttributeKeyHandle);
         } else {
             if ($this->eventID) {
+                /** @phpstan-ignore-next-line */
                 $event = Event::getByID($this->eventID);
             }
         }
@@ -103,26 +141,36 @@ class Controller extends BlockController implements UsesFeatureInterface
         return $event;
     }
 
+    /**
+     * @return CalendarEventVersionOccurrence|null
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public function getOccurrence()
     {
         $event = $this->getEvent();
         if (is_object($event)) {
             if ($this->request->query->has("occurrenceID")) {
+                /** @var CalendarEventVersionOccurrence|null $occurrence */
+                /** @phpstan-ignore-next-line */
                 $occurrence = EventOccurrence::getByID($this->request->query->get('occurrenceID'));
                 if ($occurrence) {
+
                     if ($occurrence->getEvent() && $occurrence->getEvent()->getID() == $event->getID()) {
+                        /** @phpstan-ignore-next-line */
                         if ($event->isApproved()) {
+
                             return $occurrence;
                         }
                     }
 
-
+                    /** @phpstan-ignore-next-line */
                     if ($occurrence->getEvent() && Event::isRelatedTo($occurrence->getEvent(), $event)) {
 
                         // this is a temporary hack. We need to ultimately make this make sure that
                         // the event matches –but sometimes our events don't match because we imported them as series
                         // events and not as  occurrences of one event.
                         // @TODO delete this code when we no longer need it and all related events are migrated into multidate events.
+                        /** @phpstan-ignore-next-line */
                         if ($event->isApproved()) {
                             return $occurrence;
                         }
@@ -143,6 +191,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             return $results[0];
         } else if ($this->request->query->has('occurrenceID') && $this->mode == 'R') {
             // request mode
+            /** @phpstan-ignore-next-line */
             $occurrence = EventOccurrence::getByID($this->request->query->get('occurrenceID'));
             if ($occurrence) {
                 $event = $occurrence->getEvent();
@@ -151,8 +200,13 @@ class Controller extends BlockController implements UsesFeatureInterface
                 }
             }
         }
+        return null;
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @return void
+     */
     public function view()
     {
         $this->set('event', $this->getEvent());

--- a/concrete/blocks/calendar_event/edit.php
+++ b/concrete/blocks/calendar_event/edit.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/calendar_event/form.php
+++ b/concrete/blocks/calendar_event/form.php
@@ -6,20 +6,20 @@ use Concrete\Core\Entity\Attribute\Key\EventKey;
 use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Support\Facade\Application;
 
-/** @var string $mode */
-/** @var string $calendarEventAttributeKeyHandle */
-/** @var int $calendarID */
-/** @var int $eventID */
-/** @var string $displayEventAttributes */
-/** @var bool $enableLinkToPage */
-/** @var bool $displayEventName */
-/** @var bool $displayEventDate */
-/** @var bool $displayEventDescription */
-/** @var array $calendarEventPageKeys */
+/** @var string|null $mode */
+/** @var string|null $calendarEventAttributeKeyHandle */
+/** @var int|null $calendarID */
+/** @var int|null $eventID */
+/** @var string|null $displayEventAttributes */
+/** @var bool|null  $enableLinkToPage */
+/** @var bool|null  $displayEventName */
+/** @var bool|null  $displayEventDate */
+/** @var bool|null  $displayEventDescription */
+/** @var array<string,string> $calendarEventPageKeys */
 /** @var EventKey[] $eventKeys */
-/** @var array $calendars */
-/** @var array $displayEventAttributes */
-/** @var bool $allowExport */
+/** @var array<string,string> $calendars */
+/** @var mixed[] $displayEventAttributes */
+/** @var bool|null $allowExport */
 
 $app = Application::getFacadeApplication();
 /** @var Form $form */
@@ -38,13 +38,13 @@ $form = $app->make(Form::class);
             "S" => t('Specific – Display details about a specific calendar event.'),
             "P" => t('Page – Display details about the event attached to a custom attribute.'),
             "R" => t('Request – Display details about an event occurrence passed through the URL request.')
-        ], $mode, ["data-select" => "mode"]); ?>
+        ], $mode ?? 'S', ["data-select" => "mode"]); ?>
     </div>
 
     <div data-group="specific">
         <div class="form-group">
             <?php echo $form->label('calendarID', t('Calendar')) ?>
-            <?php echo $form->select('calendarID', $calendars, $calendarID, ['data-select' => 'calendar']) ?>
+            <?php echo $form->select('calendarID', $calendars, $calendarID ?? '0', ['data-select' => 'calendar']) ?>
         </div>
 
         <div class="form-group">
@@ -56,7 +56,7 @@ $form = $app->make(Form::class);
     <div data-group="page">
         <div class="form-group">
             <?php echo $form->label('calendarEventAttributeKeyHandle', t('Retrieve Event from Attribute')) ?>
-            <?php echo $form->select('calendarEventAttributeKeyHandle', $calendarEventPageKeys, $calendarEventAttributeKeyHandle) ?>
+            <?php echo $form->select('calendarEventAttributeKeyHandle', $calendarEventPageKeys, $calendarEventAttributeKeyHandle ?? null) ?>
         </div>
     </div>
 </fieldset>
@@ -70,22 +70,22 @@ $form = $app->make(Form::class);
         <?php echo $form->label('', t('Core Properties')) ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventName', 1, $displayEventName) ?>
+            <?php echo $form->checkbox('displayEventName', '1', $displayEventName ?? false) ?>
             <?php echo $form->label("displayEventName", t('Name'), ["class" => "form-check-label"]) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventDate', 1, $displayEventDate) ?>
+            <?php echo $form->checkbox('displayEventDate', '1', $displayEventDate ?? false) ?>
             <?php echo $form->label("displayEventDate", t('Occurrence Date and Time'), ["class" => "form-check-label"]) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventDescription', 1, $displayEventDescription) ?>
+            <?php echo $form->checkbox('displayEventDescription', '1', $displayEventDescription ?? false) ?>
             <?php echo $form->label("displayEventDescription", t('Description'), ["class" => "form-check-label"]) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('allowExport', 1, $allowExport) ?>
+            <?php echo $form->checkbox('allowExport', '1', $allowExport ?? false) ?>
             <?php echo $form->label("allowExport", t('Allow event export'), ["class" => "form-check-label"]) ?>
         </div>
     </div>
@@ -106,7 +106,7 @@ $form = $app->make(Form::class);
             <?php echo $form->label('', t('Linking')) ?>
 
             <div class="form-check">
-                <?php echo $form->checkbox('enableLinkToPage', 1, $enableLinkToPage) ?>
+                <?php echo $form->checkbox('enableLinkToPage', '1', $enableLinkToPage ?? false) ?>
                 <?php echo $form->label("enableLinkToPage", t('Link Event Name to Detail Page'), ["class" => "form-check-label"]) ?>
             </div>
         </div>

--- a/concrete/blocks/calendar_event/form.php
+++ b/concrete/blocks/calendar_event/form.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Entity\Attribute\Key\EventKey;
 use Concrete\Core\Form\Service\Form;
@@ -11,10 +11,10 @@ use Concrete\Core\Support\Facade\Application;
 /** @var int|null $calendarID */
 /** @var int|null $eventID */
 /** @var string|null $displayEventAttributes */
-/** @var bool|null  $enableLinkToPage */
-/** @var bool|null  $displayEventName */
-/** @var bool|null  $displayEventDate */
-/** @var bool|null  $displayEventDescription */
+/** @var bool|null $enableLinkToPage */
+/** @var bool|null $displayEventName */
+/** @var bool|null $displayEventDate */
+/** @var bool|null $displayEventDescription */
 /** @var array<string,string> $calendarEventPageKeys */
 /** @var EventKey[] $eventKeys */
 /** @var array<string,string> $calendars */
@@ -35,10 +35,10 @@ $form = $app->make(Form::class);
     <div class="form-group">
         <?php echo $form->label('mode', t('Mode')); ?>
         <?php echo $form->select('mode', [
-            "S" => t('Specific – Display details about a specific calendar event.'),
-            "P" => t('Page – Display details about the event attached to a custom attribute.'),
-            "R" => t('Request – Display details about an event occurrence passed through the URL request.')
-        ], $mode ?? 'S', ["data-select" => "mode"]); ?>
+            'S' => t('Specific – Display details about a specific calendar event.'),
+            'P' => t('Page – Display details about the event attached to a custom attribute.'),
+            'R' => t('Request – Display details about an event occurrence passed through the URL request.'),
+        ], $mode ?? 'S', ['data-select' => 'mode']); ?>
     </div>
 
     <div data-group="specific">
@@ -71,22 +71,22 @@ $form = $app->make(Form::class);
 
         <div class="form-check">
             <?php echo $form->checkbox('displayEventName', '1', $displayEventName ?? false) ?>
-            <?php echo $form->label("displayEventName", t('Name'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('displayEventName', t('Name'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
             <?php echo $form->checkbox('displayEventDate', '1', $displayEventDate ?? false) ?>
-            <?php echo $form->label("displayEventDate", t('Occurrence Date and Time'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('displayEventDate', t('Occurrence Date and Time'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
             <?php echo $form->checkbox('displayEventDescription', '1', $displayEventDescription ?? false) ?>
-            <?php echo $form->label("displayEventDescription", t('Description'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('displayEventDescription', t('Description'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
             <?php echo $form->checkbox('allowExport', '1', $allowExport ?? false) ?>
-            <?php echo $form->label("allowExport", t('Allow event export'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('allowExport', t('Allow event export'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
@@ -95,8 +95,8 @@ $form = $app->make(Form::class);
 
         <?php foreach ($eventKeys as $ak) { ?>
             <div class="form-check">
-                <?php echo $form->checkbox('displayEventAttributes[]', $ak->getAttributeKeyID(), in_array($ak->getAttributeKeyID(), $displayEventAttributes), ["name" => "displayEventAttributes[]", "id" => "displayEventAttributes_" . $ak->getAttributeKeyID()]) ?>
-                <?php echo $form->label("displayEventAttributes_" . $ak->getAttributeKeyID(), $ak->getAttributeKeyDisplayName(), ["class" => "form-check-label"]) ?>
+                <?php echo $form->checkbox('displayEventAttributes[]', $ak->getAttributeKeyID(), in_array($ak->getAttributeKeyID(), $displayEventAttributes), ['name' => 'displayEventAttributes[]', 'id' => 'displayEventAttributes_' . $ak->getAttributeKeyID()]) ?>
+                <?php echo $form->label('displayEventAttributes_' . $ak->getAttributeKeyID(), $ak->getAttributeKeyDisplayName(), ['class' => 'form-check-label']) ?>
             </div>
         <?php } ?>
     </div>
@@ -107,7 +107,7 @@ $form = $app->make(Form::class);
 
             <div class="form-check">
                 <?php echo $form->checkbox('enableLinkToPage', '1', $enableLinkToPage ?? false) ?>
-                <?php echo $form->label("enableLinkToPage", t('Link Event Name to Detail Page'), ["class" => "form-check-label"]) ?>
+                <?php echo $form->label('enableLinkToPage', t('Link Event Name to Detail Page'), ['class' => 'form-check-label']) ?>
             </div>
         </div>
     </div>

--- a/concrete/blocks/calendar_event/view.php
+++ b/concrete/blocks/calendar_event/view.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Attribute\Key\EventKey;
 use Concrete\Core\Calendar\Event\Formatter\DateFormatter;
@@ -73,9 +73,9 @@ use Concrete\Core\Support\Facade\Url;
 
         <?php if ($allowExport) { ?>
             <div class="ccm-block-calendar-event-export">
-                <a href="<?php echo Url::to("/ccm/calendar/event/export")->setQuery(["eventID" => $event->getID()]); ?>"
-                   title="<?php echo h(t("Export Event")); ?>" class="btn btn-secondary">
-                    <?php echo t("Export Event"); ?>
+                <a href="<?php echo Url::to('/ccm/calendar/event/export')->setQuery(['eventID' => $event->getID()]); ?>"
+                   title="<?php echo h(t('Export Event')); ?>" class="btn btn-secondary">
+                    <?php echo t('Export Event'); ?>
                 </a>
             </div>
         <?php } ?>

--- a/concrete/blocks/calendar_event/view.php
+++ b/concrete/blocks/calendar_event/view.php
@@ -9,7 +9,7 @@ use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Support\Facade\Url;
 
 /** @var DateFormatter $formatter */
-/** @var CalendarEventVersion $event */
+/** @var CalendarEventVersion|null $event */
 /** @var CalendarEventVersionOccurrence $occurrence */
 /** @var string $mode */
 /** @var string $eventOccurrenceLink */

--- a/concrete/blocks/content/add.php
+++ b/concrete/blocks/content/add.php
@@ -1,3 +1,3 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
-echo app("editor")->outputPageInlineEditor('content');
+defined('C5_EXECUTE') or die('Access Denied.');
+echo app('editor')->outputPageInlineEditor('content');

--- a/concrete/blocks/content/add.php
+++ b/concrete/blocks/content/add.php
@@ -1,4 +1,3 @@
 <?php
-
 defined('C5_EXECUTE') or die("Access Denied.");
-echo Core::make("editor")->outputPageInlineEditor('content');
+echo app("editor")->outputPageInlineEditor('content');

--- a/concrete/blocks/content/composer.php
+++ b/concrete/blocks/content/composer.php
@@ -1,5 +1,5 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 /** @var string $label */
 /** @var string $description */
 /** @var \Concrete\Block\Content\Controller $controller */
@@ -8,9 +8,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <div class="form-group">
 	<label class="form-label" for=""><?=$label?></label>
-	<?php if ($description): ?>
+	<?php if ($description) { ?>
 	<i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
-	<?php endif; ?>
+	<?php } ?>
 	<?php
     $content = $controller->getContentEditMode();
     if ($controller->getRequest()->isPost()) {

--- a/concrete/blocks/content/composer.php
+++ b/concrete/blocks/content/composer.php
@@ -1,18 +1,22 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
+/** @var string $label */
+/** @var string $description */
+/** @var \Concrete\Block\Content\Controller $controller */
+/** @var Concrete\Core\Page\Type\Composer\Control\BlockControl $view */
 ?>
 
 <div class="form-group">
-	<label><?=$label?></label>
+	<label class="form-label" for=""><?=$label?></label>
 	<?php if ($description): ?>
 	<i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
 	<?php endif; ?>
 	<?php
     $content = $controller->getContentEditMode();
-    if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if ($controller->getRequest()->isPost()) {
         $data = $view->getRequestValue();
         $content = $data['content'];
     }
-    echo Core::make('editor')->outputPageComposerEditor($view->field('content'), $content);
+    echo app('editor')->outputPageComposerEditor($view->field('content'), $content);
     ?>
 </div>

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -21,50 +21,68 @@ use Concrete\Core\Page\Page;
  */
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     public $content;
-    /** @var string */
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btContentLocal';
-    /** @var int */
+
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 600;
-    /** @var int  */
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 465;
+
     /**
      * @var bool
      */
     protected $btCacheBlockRecord = true;
+
     /**
      * @var bool
      */
     protected $btCacheBlockOutput = true;
+
     /**
      * @var bool
      */
     protected $btCacheBlockOutputOnPost = true;
+
     /**
      * @var bool
      */
     protected $btSupportsInlineEdit = true;
+
     /**
      * @var bool
      */
     protected $btSupportsInlineAdd = true;
+
     /**
      * @var bool
      */
     protected $btCacheBlockOutputForRegisteredUsers = false;
+
     /**
      * @var int
      */
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
     /**
-     * {@inhertdoc}
+     * {@inhertdoc}.
      */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::IMAGERY
+            Features::IMAGERY,
         ];
     }
 
@@ -102,14 +120,14 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
 
     /**
      * @param string $str
+     *
      * @return array|string|string[]
      */
     public function br2nl($str)
     {
         $str = str_replace("\r\n", "\n", $str);
-        $str = str_replace("<br />\n", "\n", $str);
 
-        return $str;
+        return str_replace("<br />\n", "\n", $str);
     }
 
     /**
@@ -131,19 +149,20 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     /**
      * @param \SimpleXMLElement $blockNode
      * @param Page $page
+     *
      * @return array<string, string>
      */
     public function getImportData($blockNode, $page)
     {
         $content = $blockNode->data->record->content;
         $content = LinkAbstractor::import($content);
-        $args = ['content' => $content];
 
-        return $args;
+        return ['content' => $content];
     }
 
     /**
      * @param \SimpleXMLElement $blockNode
+     *
      * @return void
      */
     public function export(\SimpleXMLElement $blockNode)
@@ -207,10 +226,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
 
         return array_map(
             function ($match) {
-                return (explode('_', $match)[2]);
+                return explode('_', $match)[2];
             },
             $matches[0]
         );
     }
-
 }

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -7,6 +7,7 @@ use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
+use Concrete\Core\Page\Page;
 
 /**
  * The controller for the content block.
@@ -15,23 +16,51 @@ use Concrete\Core\File\Tracker\FileTrackableInterface;
  * @subpackage Content
  *
  * @author Andrew Embler <andrew@concrete5.org>
- * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
+ * @copyright  Copyright (c) 2003-2022 concreteCMS. (http://www.concretecms.org)
+ * @license    http://www.concretecms.org/license/     MIT License
  */
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
+    /** @var string */
     public $content;
+    /** @var string */
     protected $btTable = 'btContentLocal';
+    /** @var int */
     protected $btInterfaceWidth = 600;
+    /** @var int  */
     protected $btInterfaceHeight = 465;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockRecord = true;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutput = true;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputOnPost = true;
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineEdit = true;
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineAdd = true;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputForRegisteredUsers = false;
+    /**
+     * @var int
+     */
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
+    /**
+     * {@inhertdoc}
+     */
     public function getRequiredFeatures(): array
     {
         return [
@@ -39,26 +68,42 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         ];
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
         return t('HTML/WYSIWYG Editor Content.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t('Content');
     }
 
+    /**
+     * @return string
+     */
     public function getContent()
     {
         return LinkAbstractor::translateFrom($this->content);
     }
 
+    /**
+     * @return string
+     */
     public function getSearchableContent()
     {
         return $this->content;
     }
 
+    /**
+     * @param string $str
+     * @return array|string|string[]
+     */
     public function br2nl($str)
     {
         $str = str_replace("\r\n", "\n", $str);
@@ -67,16 +112,27 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         return $str;
     }
 
+    /**
+     * @return void
+     */
     public function view()
     {
         $this->set('content', $this->getContent());
     }
 
+    /**
+     * @return string
+     */
     public function getContentEditMode()
     {
         return LinkAbstractor::translateFromEditMode($this->content);
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param Page $page
+     * @return array<string, string>
+     */
     public function getImportData($blockNode, $page)
     {
         $content = $blockNode->data->record->content;
@@ -86,6 +142,10 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         return $args;
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @return void
+     */
     public function export(\SimpleXMLElement $blockNode)
     {
         $data = $blockNode->addChild('data');
@@ -99,6 +159,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         $node->appendChild($cdata);
     }
 
+    /**
+     * @param array<string,string> $args
+     */
     public function save($args)
     {
         if (isset($args['content'])) {
@@ -107,6 +170,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         parent::save($args);
     }
 
+    /**
+     * @return int[]|string[]
+     */
     public function getUsedFiles()
     {
         return array_merge(
@@ -115,6 +181,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         );
     }
 
+    /**
+     * @return int[]|string[]
+     */
     protected function getUsedFilesImages()
     {
         $files = [];
@@ -129,6 +198,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         return $files;
     }
 
+    /**
+     * @return int[]|string[]
+     */
     protected function getUsedFilesDownload()
     {
         preg_match_all('(FID_DL_\d+)', $this->content, $matches);

--- a/concrete/blocks/content/edit.php
+++ b/concrete/blocks/content/edit.php
@@ -1,5 +1,5 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 /** @var \Concrete\Block\Content\Controller $controller */
-echo app("editor")->outputPageInlineEditor('content', $controller->getContentEditMode());
+echo app('editor')->outputPageInlineEditor('content', $controller->getContentEditMode());

--- a/concrete/blocks/content/edit.php
+++ b/concrete/blocks/content/edit.php
@@ -1,5 +1,5 @@
 <?php
 
 defined('C5_EXECUTE') or die("Access Denied.");
-
-echo Core::make("editor")->outputPageInlineEditor('content', $controller->getContentEditMode());
+/** @var \Concrete\Block\Content\Controller $controller */
+echo app("editor")->outputPageInlineEditor('content', $controller->getContentEditMode());

--- a/concrete/blocks/content/scrapbook.php
+++ b/concrete/blocks/content/scrapbook.php
@@ -1,9 +1,10 @@
 <?php
 
 defined('C5_EXECUTE') or die("Access Denied.");
+/** @var \Concrete\Block\Content\Controller $controller */
 
 $content = $controller->getContent();
-$forbiddenTags = array('iframe', 'script', 'object', 'embed');
+$forbiddenTags = ['iframe', 'script', 'object', 'embed'];
 foreach ($forbiddenTags as $forbiddenTag) {
     $content = preg_replace("~<".$forbiddenTag."[^>]*>(.*)</".$forbiddenTag.">~i", "$2", $content);
     $content = preg_replace("~<".$forbiddenTag."[^>]*>~i", "", $content);

--- a/concrete/blocks/content/scrapbook.php
+++ b/concrete/blocks/content/scrapbook.php
@@ -1,12 +1,12 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 /** @var \Concrete\Block\Content\Controller $controller */
 
 $content = $controller->getContent();
 $forbiddenTags = ['iframe', 'script', 'object', 'embed'];
 foreach ($forbiddenTags as $forbiddenTag) {
-    $content = preg_replace("~<".$forbiddenTag."[^>]*>(.*)</".$forbiddenTag.">~i", "$2", $content);
-    $content = preg_replace("~<".$forbiddenTag."[^>]*>~i", "", $content);
+    $content = preg_replace('~<' . $forbiddenTag . '[^>]*>(.*)</' . $forbiddenTag . '>~i', '$2', $content);
+    $content = preg_replace('~<' . $forbiddenTag . '[^>]*>~i', '', $content);
 }
-echo ''.$content;
+echo '' . $content;

--- a/concrete/blocks/content/view.php
+++ b/concrete/blocks/content/view.php
@@ -1,13 +1,13 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-/** @var \Concrete\Block\Content\Controller $controller */
-/** @var string $content */
+    defined('C5_EXECUTE') or die('Access Denied.');
+    /** @var \Concrete\Block\Content\Controller $controller */
+    /** @var string $content */
 
     $c = \Concrete\Core\Page\Page::getCurrentPage();
     if (!$content && is_object($c) && $c->isEditMode()) {
         ?>
 		<div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div> 
-	<?php 
+	<?php
     } else {
         echo $content;
     }

--- a/concrete/blocks/content/view.php
+++ b/concrete/blocks/content/view.php
@@ -1,6 +1,9 @@
 <?php
     defined('C5_EXECUTE') or die("Access Denied.");
-    $c = Page::getCurrentPage();
+/** @var \Concrete\Block\Content\Controller $controller */
+/** @var string $content */
+
+    $c = \Concrete\Core\Page\Page::getCurrentPage();
     if (!$content && is_object($c) && $c->isEditMode()) {
         ?>
 		<div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div> 

--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -279,9 +279,10 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param \SimpleXMLElement $blockNode
+     * @param \Concrete\Core\Page\Page $page
      *
-     * @see \Concrete\Core\Block\BlockController::getImportData()
+     * @return array<string,mixed>
      */
     public function getImportData($blockNode, $page)
     {
@@ -303,6 +304,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $args['span'][] = (int) $column['span'];
                     $args['offset'][] = (int) $column['offset'];
                 }
+
                 return $args;
             case 'preset':
                 $preset = $this->resolveLayoutPreset(isset($node['preset-id']) ? (string) $node['preset-id'] : '', $page);

--- a/concrete/blocks/core_board_slot/controller.php
+++ b/concrete/blocks/core_board_slot/controller.php
@@ -1,41 +1,73 @@
 <?php
+
 namespace Concrete\Block\CoreBoardSlot;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Board\Instance\Slot\Content\ContentRenderer;
 use Concrete\Core\Entity\Board\SlotTemplate;
-use Concrete\Core\Feature\Features;
-use Concrete\Core\Feature\UsesFeatureInterface;
 use Doctrine\ORM\EntityManager;
 
 class Controller extends BlockController
 {
-    protected $btTable = 'btCoreBoardSlot';
-    protected $btIsInternal = true;
-    protected $btIgnorePageThemeGridFrameworkContainer = true;
-
+    /**
+     * @var string|null
+     */
     public $contentObjectCollection;
 
+    /**
+     * @var int|null
+     */
     public $slotTemplateID;
 
+    /**
+     * @var int|null
+     */
     public $instanceSlotID;
 
+    /**
+     * @var string
+     */
+    protected $btTable = 'btCoreBoardSlot';
+
+    /**
+     * @var bool
+     */
+    protected $btIsInternal = true;
+
+    /**
+     * @var bool
+     */
+    protected $btIgnorePageThemeGridFrameworkContainer = true;
+
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Proxy block for board slots.");
+        return t('Proxy block for board slots.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Board Slot");
+        return t('Board Slot');
     }
 
+    /**
+     * @return int|null
+     */
     public function getInstanceSlotID()
     {
         return $this->instanceSlotID;
     }
 
-
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $entityManager = $this->app->make(EntityManager::class);
@@ -46,5 +78,4 @@ class Controller extends BlockController
         $this->set('renderer', $renderer);
         $this->set('template', $template);
     }
-
 }

--- a/concrete/blocks/core_container/controller.php
+++ b/concrete/blocks/core_container/controller.php
@@ -125,6 +125,7 @@ class Controller extends BlockController
     {
         $instance = $this->getContainerInstanceObject();
         if ($instance) {
+            /** @var \Concrete\Core\Page\Page $page */
             $page = $this->getBlockObject()->getBlockCollectionObject();
             $exporter = new ContainerExporter($page);
             $exporter->export($instance, $blockNode);
@@ -217,6 +218,7 @@ class Controller extends BlockController
         $db = $this->app->make(Connection::class);
         // such a pain
         $this->containerInstanceID = $db->fetchColumn('select containerInstanceID from btCoreContainer where bID = ?', [$b->getBlockID()]);
+        /** @var \Concrete\Core\Page\Page $page */
         $page = $b->getBlockCollectionObject();
 
         $instance = $this->getContainerInstanceObject();

--- a/concrete/elements/event/form.php
+++ b/concrete/elements/event/form.php
@@ -8,12 +8,14 @@ use Concrete\Core\Calendar\Event\EventOccurrence;
 $fp = FilePermissions::getGlobal();
 $tp = new TaskPermission();
 $version = null;
+/** @var \Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence|null $occurrence */
+$occurrence = $occurrence ?? null;
 if ($occurrence) {
     $version = $occurrence->getEvent()->getRecentVersion();
     $calendar = $version->getEvent()->getCalendar();
 }
 
-$permissions = new Permissions($calendar);
+$permissions = new \Concrete\Core\Permission\Checker($calendar);
 
 $timezone = $calendar->getTimezone();
 
@@ -28,14 +30,14 @@ if (is_object($category) && $category->allowAttributeSets()) {
 }
 
 $summarySet = false;
-$tabs[] = array('event-summary', t('Summary'), true);
-$tabs[] = array('event-dates', t('Dates'));
+$tabs[] = ['event-summary', t('Summary'), true];
+$tabs[] = ['event-dates', t('Dates'), false];
 foreach ($sets as $set) {
     if ($set->getAttributeSetHandle() == 'calendar_summary') {
         $summarySet = $set;
         continue;
     }
-    $tabs[] = array('event-tab-' . $set->getAttributeSetHandle(), $set->getAttributeSetDisplayName());
+    $tabs[] = ['event-tab-' . $set->getAttributeSetHandle(), $set->getAttributeSetDisplayName(), false];
 }
 
 $repetitions = null;
@@ -63,8 +65,9 @@ if ($version) {
             <div class="tab-pane active" id="event-summary">
 
             <?php
-            /** @var EventOccurrence $occurrence */
+
             if ($occurrence) {
+
                 if ($occurrence->getRepetition()->repeats()) {
                     ?>
                     <div>
@@ -104,7 +107,7 @@ if ($version) {
                         <?= t('Description') ?>
                     </label>
 
-                    <?=Core::make('editor')->outputStandardEditor('description', $version ? $version->getDescription() : '')?>
+                    <?=app('editor')->outputStandardEditor('description', $version ? $version->getDescription() : '')?>
                 </div>
 
                 <?php if ($permissions->canEditCalendarEventMoreDetailsLocation()) { ?>
@@ -120,7 +123,7 @@ if ($version) {
                             }
                         }
                         ?>
-                        <?=Core::make("helper/form/page_selector")->selectPage('cID', $cID)?>
+                        <?=app("helper/form/page_selector")->selectPage('cID', $cID)?>
                     </div>
 
                 <?php } ?>
@@ -149,8 +152,8 @@ if ($version) {
                     ?>
                     <div class="single-occurrence-date-time" style="display:none">
                         <?php
-                        $form = \Core::make('helper/form');
-                        $dt = \Core::make('helper/form/date_time');
+                        $form = app('helper/form');
+                        $dt = app('helper/form/date_time');
 
                         $pdStartDateDateTime = new DateTime();
                         $pdStartDateDateTime->setTimestamp($occurrence->getStart());

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -451,6 +451,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         }
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param \Concrete\Core\Page\Page $page
+     * @return array<string,mixed>
+     */
     protected function getImportData($blockNode, $page)
     {
         $args = [];

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -210,7 +210,7 @@ class Form
      *
      * @param string $key The name/id of the element. It should end with '[]' if it's to return an array on submit.
      * @param string $value String value sent to server, if checkbox is checked, on submit
-     * @param string | bool $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
+     * @param string | bool | int $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
      * @param array $miscFields additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
      * @return string

--- a/concrete/src/Navigation/Breadcrumb/PageBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/PageBreadcrumb.php
@@ -16,6 +16,7 @@ class PageBreadcrumb implements BreadcrumbInterface, \Iterator
      * {@inheritdoc}
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::add()
+     * @return self
      */
     public function add(ItemInterface $item): NavigationInterface
     {
@@ -38,6 +39,7 @@ class PageBreadcrumb implements BreadcrumbInterface, \Iterator
      * {@inheritdoc}
      *
      * @see \Concrete\Core\Navigation\NavigationInterface::setItems()
+     * @return self
      */
     public function setItems(array $items): NavigationInterface
     {
@@ -49,27 +51,42 @@ class PageBreadcrumb implements BreadcrumbInterface, \Iterator
         return $this;
     }
 
+    /**
+     * @return void
+     */
     public function rewind()
     {
         reset($this->items);
     }
 
+    /**
+     * @return \Concrete\Core\Navigation\Item\ItemInterface|false
+     */
     public function current()
     {
         return current($this->items);
     }
 
+    /**
+     * @return int|string
+     */
     public function key()
     {
         return key($this->items);
     }
 
+    /**
+     * @return void
+     */
     public function next()
     {
         next($this->items);
     }
 
-    public function valid()
+    /**
+     * @return bool
+     */
+    public function valid():bool
     {
         return $this->current() !== false;
     }

--- a/concrete/views/dialogs/event/choose.php
+++ b/concrete/views/dialogs/event/choose.php
@@ -19,11 +19,19 @@
                 center: 'title',
                 right: 'month,basicWeek,basicDay'
             },
+            locale: <?= json_encode(Localization::activeLanguage()); ?>,
+            contentHeight: 'auto',
             events: {
                 url: '<?=$view->action('get_events')?>',
                 data: {
                     'caID': '<?=$calendar->getID()?>'
                 }
+            },
+            eventDataTransform: function(event) {
+                if(event.allDay) {
+                    event.end = moment(event.end).add(1, 'days')
+                }
+                return event;
             },
             eventRender: function(event, element) {
                 element.attr('href', '#'); // Just to make the pointer nice instead of a text handle.
@@ -36,10 +44,5 @@
                 });
             }
         });
-        setTimeout(function() {
-            // not sure why i need this to render off the bat but I do and I don't care to find out.
-
-            $('div[data-calendar=<?=$calendar->getID()?>]').fullCalendar('render');
-        }, 50);
     });
 </script>


### PR DESCRIPTION
In regards to #10299

this is an ongoing list of blocks that have been fixed and confirmed working in php8 and can currently pass phpstan level 6

- [x] Accordion
- [x] Autonav
- [x] Board
- [x] Breadcrumbs
- [x] calendar
- [x] calendar_event
- [x] content
- [x] core_area_layout
- [x] core_board_slot -- static analysis fixes only (can add boards)
- [x] core_container
- [ ] core_conversation
- [x] core_page_type_composer_control_output
- [ ] core_scrapbook_display
- [ ] core_stack_display
- [ ] core_theme_documentation_breadcrumb
- [ ] core_theme_documentation_toc
- [ ] date_navigation
- [ ] desktop_app_status
- [ ] desktop_concrete_latest
- [ ] desktop_draft_list
- [ ] desktop_featured_addon
- [ ] desktop_featured_theme
- [ ] desktop_latest_form
- [ ] desktop_site_activity
- [ ] desktop_waiting_for_me
- [ ] event_list
- [ ] express_entry_detail
- [ ] express_entry_list
- [ ] express_form
- [ ] external_form
- [ ] faq
- [ ] feature
- [ ] feature_link
- [ ] file
- [ ] form
- [ ] gallery
- [ ] google_map
- [ ] hero_image
- [ ] horizontal_rule
- [ ] html
- [ ] image
- [ ] image_slider
- [ ] next_previous
- [ ] page_attribute_display
- [ ] page_list
- [ ] page_title
- [ ] rss_displayer
- [ ] search
- [ ] share_this_page
- [ ] social_links
- [ ] survey
- [ ] switch_language
- [ ] tags
- [ ] testimonial
- [ ] top_navigation_bar
- [x] topic_list
- [x] video
- [ ] youtube