### PR TITLE
Fix deletion of external links in the trashcan

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2837,7 +2837,7 @@ EOT
     {
         $cID = $this->getCollectionID();
 
-        if ($this->isAliasPage()) {
+        if ($this->isAliasPage() && !$this->isExternalLink()) {
             $this->removeThisAlias();
 
             return;


### PR DESCRIPTION
When an external link page is aliased, that page become undeletable in the trashcan. It also blocks all other pages from being deleted as soon as it is the first in the queue. This commit fixes that by adding the external link check before entering an infinite loop between `$this->delete()` and `$this->removeThisAlias()`.