### PR TITLE
[9.02] Fix YouTube block responsive size class issue

### DIFF
--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -15,7 +15,7 @@ $sizing = $sizing ?? null;
 $videoID = $videoID ?? '';
 $bID = $bID ?? 0; // This should always be set but just incase
 $c = Page::getCurrentPage();
-if (isset($vWidth) && isset($vHeight)) {
+if (!empty($vWidth) && !empty($vHeight)) {
     $sizeargs = 'width="' . $vWidth . '" height="' . $vHeight . '"';
     $sizeDisabled = 'style="width:' . $vWidth . 'px; height:' . $vHeight . 'px"';
     $responsiveClass = '';


### PR DESCRIPTION
The youTube block does not properly implement its responsive classes in the view file and therefore responsive selection does not resize to fit the available width.

![screenshot-dev19 katalysis net-2022 02](https://user-images.githubusercontent.com/4235012/153403542-b0bc86ba-cc0c-465c-a5b6-e240ce737686.png)

The use of isset() to recognise width and height settings does not work and is replaced here with !empty().

