### PR TITLE
Clear old page versions in all site trees

### DIFF
--- a/concrete/jobs/remove_old_page_versions.php
+++ b/concrete/jobs/remove_old_page_versions.php
@@ -26,6 +26,7 @@ class RemoveOldPageVersions extends AbstractJob
 
         $pl = new PageList();
         $pl->ignorePermissions();
+        $pl->setSiteTreeToAll();
         $pl->setItemsPerPage(3);
         $pl->filter('p.cID', $pNum, '>=');
         $pl->sortByCollectionIDAscending();


### PR DESCRIPTION
When clearing  old page versions on a site with multiple page trees we've noticed that pages in all page trees other that ID 1 are skipped. This commit fixes that by specifically including all site trees.