### PR TITLE
[9.0.2] Fix several user search fields not retaining their selected values

### DIFF
--- a/concrete/src/Form/Service/Widget/FileFolderSelector.php
+++ b/concrete/src/Form/Service/Widget/FileFolderSelector.php
@@ -19,12 +19,12 @@ class FileFolderSelector
         $args = new \stdClass();
         $selected = 0;
 
-        if ($_SERVER['REQUEST_METHOD'] == 'POST' && $updateSelectionOnPost) {
+        if ($folder) {
+            $selected = is_object($folder) ? $folder->getTreeNodeID() : $folder;
+        } elseif ($_SERVER['REQUEST_METHOD'] == 'POST' && $updateSelectionOnPost) {
             if (isset($_POST[$field])) {
                 $selected = intval($_POST[$field]);
             }
-        } elseif ($folder) {
-            $selected = is_object($folder) ? $folder->getTreeNodeID() : $folder;
         }
 
         $rootTreeNodeID = $filesystem->getRootFolder()->getTreeNodeID();

--- a/concrete/src/User/Search/Field/Field/GroupSetField.php
+++ b/concrete/src/User/Search/Field/Field/GroupSetField.php
@@ -32,7 +32,7 @@ class GroupSetField extends AbstractField
         foreach ($gsl->get() as $gs) {
             $groupsets[$gs->getGroupSetID()] = $gs->getGroupSetDisplayName();
         }
-        $html = $form->select('gsID', $groupsets);
+        $html = $form->select('gsID', $groupsets, $this->getData('gsID'));
 
         return $html;
     }

--- a/concrete/src/User/Search/Field/Field/HomeFolderField.php
+++ b/concrete/src/User/Search/Field/Field/HomeFolderField.php
@@ -29,7 +29,7 @@ class HomeFolderField extends AbstractField
         $app = Application::getFacadeApplication();
         /** @var FileFolderSelector $fileFolderSelector */
         $fileFolderSelector = $app->make(FileFolderSelector::class);
-        return $fileFolderSelector->selectFileFolder('home_folder');
+        return $fileFolderSelector->selectFileFolder('home_folder', $this->getData('home_folder'));
     }
 
     /**

--- a/concrete/src/User/Search/Field/Field/IsActiveField.php
+++ b/concrete/src/User/Search/Field/Field/IsActiveField.php
@@ -27,7 +27,7 @@ class IsActiveField extends AbstractField
     public function renderSearchField()
     {
         $form = \Core::make('helper/form');
-        $html = $form->select('active', array('0' => t('Inactive Users'), '1' => t('Active Users')), array('style' => 'vertical-align: middle'));
+        $html = $form->select('active', array('0' => t('Inactive Users'), '1' => t('Active Users')), $this->getData('active'), array('style' => 'vertical-align: middle'));
         return $html;
 
     }

--- a/concrete/src/User/Search/Field/Field/IsValidatedField.php
+++ b/concrete/src/User/Search/Field/Field/IsValidatedField.php
@@ -26,7 +26,7 @@ class IsValidatedField extends AbstractField
     public function renderSearchField()
     {
         $form = \Core::make('helper/form');
-        $html = $form->select('validated', array('0' => t('Unvalidated Users'), '1' => t('Validated Users')), array('style' => 'vertical-align: middle'));
+        $html = $form->select('validated', array('0' => t('Unvalidated Users'), '1' => t('Validated Users')), $this->getData('validated'), array('style' => 'vertical-align: middle'));
         return $html;
     }
 


### PR DESCRIPTION
As explained in #10328 several field types in advanced user search don't retain their selected value when reloading the advanced search form.

These fields are:

- Group Set
- Home Folder
- Active
- Validated

Also, the file selector widget was always ignoring the $folder parameter, also impacting the user search.

This PR fixes the 4 field types and the file selector widget
