### PR TITLE
[V8] [Performance improvement] Cache response from application services

### DIFF
--- a/concrete/src/Application/Service/Dashboard.php
+++ b/concrete/src/Application/Service/Dashboard.php
@@ -6,8 +6,8 @@ use Core;
 use Database;
 use File;
 use Localization;
-use Page;
-use Permissions;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker as Permissions;
 use Session;
 use Concrete\Core\User\User as ConcreteUser;
 use Concrete\Core\Support\Facade\Application;
@@ -16,18 +16,32 @@ use View;
 class Dashboard
 {
     /**
+     * @var bool|null
+     */
+    protected $canRead;
+
+    /**
+     * @var bool|null
+     */
+    protected $canAccessComposer;
+
+    /**
      * Checks to see if a user has access to the C5 dashboard.
      *
      * @return bool
      */
     public function canRead()
     {
-        $c = Page::getByPath('/dashboard', 'ACTIVE');
-        if ($c && !$c->isError()) {
-            $cp = new Permissions($c);
+        if ($this->canRead === null) {
+            $c = Page::getByPath('/dashboard', 'ACTIVE');
+            if ($c && !$c->isError()) {
+                $cp = new Permissions($c);
 
-            return $cp->canViewPage();
+                $this->canRead = $cp->canViewPage();
+            }
         }
+
+        return $this->canRead;
     }
 
     /**
@@ -35,10 +49,14 @@ class Dashboard
      */
     public function canAccessComposer()
     {
-        $c = Page::getByPath('/dashboard/composer', 'ACTIVE');
-        $cp = new Permissions($c);
+        if ($this->canAccessComposer === null) {
+            $c = Page::getByPath('/dashboard/composer', 'ACTIVE');
+            $cp = new Permissions($c);
 
-        return $cp->canViewPage();
+            $this->canAccessComposer = $cp->canViewPage();
+        }
+
+        return $this->canAccessComposer;
     }
 
     /**

--- a/concrete/src/Application/Service/Dashboard/Sitemap.php
+++ b/concrete/src/Application/Service/Dashboard/Sitemap.php
@@ -39,6 +39,16 @@ class Sitemap
     protected $includeSystemPages;
 
     /**
+     * @var bool|null
+     */
+    protected $canViewSitemapPanel;
+
+    /**
+     * @var bool|null
+     */
+    protected $canRead;
+
+    /**
      * Sitemap constructor.
      *
      * @param \Concrete\Core\Application\Application $app
@@ -319,14 +329,21 @@ class Sitemap
 
     public function canViewSitemapPanel()
     {
-        $types = Type::getList();
-        foreach($types as $pt) {
-            $ptp = new \Permissions($pt);
-            if ($ptp->canAddPageType()) {
-                return true;
+        if ($this->canViewSitemapPanel === null) {
+            $types = Type::getList();
+            foreach ($types as $pt) {
+                $ptp = new Permissions($pt);
+                if ($ptp->canAddPageType()) {
+                    $this->canViewSitemapPanel = true;
+                    break;
+                }
+            }
+            if ($this->canViewSitemapPanel === null) {
+                $this->canViewSitemapPanel = $this->canRead();
             }
         }
-        return $this->canRead();
+
+        return $this->canViewSitemapPanel;
     }
 
     /**
@@ -334,8 +351,11 @@ class Sitemap
      */
     public function canRead()
     {
-        $tp = new Permissions();
+        if ($this->canRead === null) {
+            $tp = new Permissions();
+            $this->canRead = $tp->canAccessSitemap();
+        }
 
-        return $tp->canAccessSitemap();
+        return $this->canRead;
     }
 }


### PR DESCRIPTION
Let's cache response from `$app->make('helper/concrete/dashboard/sitemap')->canViewSitemapPanel()` or `$app->make('helper/concrete/dashboard/sitemap')->canRead()` because these methods are called several times per a request but should return same value.

I'm currently working on developing an intranet website for hundreds of employees with version 8, but if you think this PR is fine, I'll make another PR for V9.

