### PR TITLE
Make the config repository a singleton

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -165,7 +165,7 @@ class Application extends Container
     public function isInstalled()
     {
         if ($this->installed === null) {
-            if (!$this->isShared('config')) {
+            if (!$this->isAlias('config')) {
                 throw new Exception('Attempting to check install status before application initialization.');
             }
 

--- a/concrete/src/Config/ConfigServiceProvider.php
+++ b/concrete/src/Config/ConfigServiceProvider.php
@@ -12,10 +12,6 @@ class ConfigServiceProvider extends Provider
     {
         $this->registerFileConfig();
         $this->registerDatabaseConfig();
-
-        // Bind the concrete types
-        $this->app->bind('Concrete\Core\Config\Repository\Repository', 'config');
-        $this->app->bind('Illuminate\Config\Repository', 'Concrete\Core\Config\Repository\Repository');
     }
 
     /**
@@ -31,11 +27,13 @@ class ConfigServiceProvider extends Provider
         });
         $this->app->bindIf(SaverInterface::class, FileSaver::class);
 
-        $this->app->singleton('config', function ($app) {
+        $this->app->singleton(Repository\Repository::class, static function ($app) {
             $loader = $app->make(LoaderInterface::class);
             $saver = $app->make(SaverInterface::class);
             return new Repository\Repository($loader, $saver, $app->environment());
         });
+        $this->app->alias(Repository\Repository::class, 'config');
+        $this->app->alias(Repository\Repository::class, \Illuminate\Config\Repository::class);
     }
 
     /**


### PR DESCRIPTION
We currently have that `config` is a singleton, and `Concrete\Core\Config\Repository\Repository` is bound to that singleton.

What about switching the logic, making `Concrete\Core\Config\Repository\Repository` a singleton and `config` an alias of it? This makes resolving `Concrete\Core\Config\Repository\Repository` faster.