### PR TITLE
Fix order of translator assets

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -648,8 +648,8 @@ return [
         'core/translator' => [
             [
                 ['css', 'core/translator'],
-                ['javascript-localized', 'core/translator'],
                 ['javascript', 'core/translator'],
+                ['javascript-localized', 'core/translator'],
             ],
         ],
 


### PR DESCRIPTION
javascript-localized must be loaded after JavaScript, since the former references the ccmTranslator global object
