### PR TITLE
IP Access Control: add IpAccessControlCategory::describeTimeWindow()

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/denylist.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/denylist.php
@@ -11,7 +11,7 @@ use Punic\Comparer;
 class Denylist extends DashboardPageController
 {
     /**
-     * @var \Doctrine\Common\Persistence\ObjectRepository|null
+     * @var \Doctrine\ORM\EntityRepository|null
      */
     private $categoryRepository;
 
@@ -40,7 +40,7 @@ EOT
     }
 
     /**
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @return \Doctrine\ORM\EntityRepository
      */
     protected function getCategoryRepository()
     {

--- a/concrete/single_pages/dashboard/system/permissions/denylist.php
+++ b/concrete/single_pages/dashboard/system/permissions/denylist.php
@@ -21,6 +21,7 @@ else {
                 <th><?= t('Name') ?></th>
                 <th><?= t('Enabled') ?></th>
                 <th><?= t('Package') ?></th>
+                <th><?= t('Limit') ?></th>
             </tr>
         </thead>
         <tbody>
@@ -39,6 +40,7 @@ else {
                     }
                     ?>
                 </td>
+                <td><?= h($category->describeTimeWindow(true)) ?></td>
             </tr>
             <?php
         }

--- a/concrete/single_pages/dashboard/system/permissions/denylist.php
+++ b/concrete/single_pages/dashboard/system/permissions/denylist.php
@@ -20,8 +20,8 @@ else {
                 <th><?= t('Handle') ?></th>
                 <th><?= t('Name') ?></th>
                 <th><?= t('Enabled') ?></th>
-                <th class="d-none d-xl-table-cell"><?= t('Package') ?></th>
                 <th class="d-none d-lg-table-cell"><?= t('Limit') ?></th>
+                <th class="d-none d-xl-table-cell"><?= t('Package') ?></th>
             </tr>
         </thead>
         <tbody>
@@ -33,6 +33,7 @@ else {
                 <td><a href="<?= h($href) ?>"><code><?= h($category->getHandle()) ?></code></a></td>
                 <td><a href="<?= h($href) ?>"><?= h($category->getDisplayName()) ?></a></td>
                 <td><?= $category->isEnabled() ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-ban text-danger"></i>' ?></td>
+                <td class="d-none d-lg-table-cell"><?= h($category->describeTimeWindow(true)) ?></td>
                 <td class="d-none d-xl-table-cell">
                     <?php
                     if ($category->getPackage() !== null) {
@@ -40,7 +41,6 @@ else {
                     }
                     ?>
                 </td>
-                <td class="d-none d-lg-table-cell"><?= h($category->describeTimeWindow(true)) ?></td>
             </tr>
             <?php
         }

--- a/concrete/single_pages/dashboard/system/permissions/denylist.php
+++ b/concrete/single_pages/dashboard/system/permissions/denylist.php
@@ -20,8 +20,8 @@ else {
                 <th><?= t('Handle') ?></th>
                 <th><?= t('Name') ?></th>
                 <th><?= t('Enabled') ?></th>
-                <th><?= t('Package') ?></th>
-                <th><?= t('Limit') ?></th>
+                <th class="d-none d-xl-table-cell"><?= t('Package') ?></th>
+                <th class="d-none d-lg-table-cell"><?= t('Limit') ?></th>
             </tr>
         </thead>
         <tbody>
@@ -33,14 +33,14 @@ else {
                 <td><a href="<?= h($href) ?>"><code><?= h($category->getHandle()) ?></code></a></td>
                 <td><a href="<?= h($href) ?>"><?= h($category->getDisplayName()) ?></a></td>
                 <td><?= $category->isEnabled() ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-ban text-danger"></i>' ?></td>
-                <td>
+                <td class="d-none d-xl-table-cell">
                     <?php
                     if ($category->getPackage() !== null) {
                         echo h($category->getPackage()->getPackageName());
                     }
                     ?>
                 </td>
-                <td><?= h($category->describeTimeWindow(true)) ?></td>
+                <td class="d-none d-lg-table-cell"><?= h($category->describeTimeWindow(true)) ?></td>
             </tr>
             <?php
         }

--- a/concrete/single_pages/dashboard/system/permissions/denylist/configure.php
+++ b/concrete/single_pages/dashboard/system/permissions/denylist/configure.php
@@ -1,13 +1,17 @@
 <?php
+
+use Concrete\Core\Entity\Permission\IpAccessControlCategory;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var Concrete\Core\Page\View\PageView $view */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
-/* @var Concrete\Core\Form\Service\Form $form */
-/* @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\Denylist\Configure $controller */
-
-/* @var Concrete\Core\Entity\Permission\IpAccessControlCategory $category */
-/* @var array $units */
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\Denylist\Configure $controller
+ * @var Concrete\Core\Entity\Permission\IpAccessControlCategory $category
+ * @var array $units
+ */
 
 $view->element('dashboard/system/permissions/denylist/menu', ['category' => $category, 'type' => null]);
 ?>
@@ -20,11 +24,12 @@ $view->element('dashboard/system/permissions/denylist/menu', ['category' => $cat
                 <?= $form->checkbox('banEnabled', 1, $category->isEnabled()) ?>
             </div>
             <?php
-            list($selectedUnit, $unitValue) = $controller->splitSeconds($category->getTimeWindow());
+            $timeWindowSplitted = IpAccessControlCategory::splitTimeWindow($category->getTimeWindow());
+            [$unitValue, $selectedUnit] = $timeWindowSplitted === null ? ['', 'duration/minute'] : $timeWindowSplitted;
             ?>
             <?php
             echo t(
-            /* i18n: %1$s is the number of events, %2$s is the number of seconds/minutes/hours/days, %3$s is "seconds", "minutes", "hours" or "days" */
+                /* i18n: %1$s is the number of events, %2$s is the number of seconds/minutes/hours/days, %3$s is "seconds", "minutes", "hours" or "days" */
                 'Lock IP after %1$s events in %2$s %3$s',
                 sprintf('<div class="col-auto">%s</div>', $form->number('maxEvents', $category->getMaxEvents(), ['style' => 'width:90px', 'required' => 'required', 'min' => 1])),
                 sprintf('<div class="col-auto">%s</div>', $form->number('timeWindowValue', $unitValue, ['style' => 'width:90px', 'min' => 1])),
@@ -41,7 +46,7 @@ $view->element('dashboard/system/permissions/denylist/menu', ['category' => $cat
                 </label>
             </div>
             <?php
-            list($selectedUnit, $unitValue) = $controller->splitSeconds($category->getBanDuration() === null ? 300 : $category->getBanDuration());
+            [$unitValue, $selectedUnit] = IpAccessControlCategory::splitTimeWindow($category->getBanDuration() ?: 300);
             echo t(
                 /* i18n: %1$s is the number of seconds/minutes/hours/days, %2$s is "seconds", "minutes", "hours" or "days" */
                 'Ban IP for %1$s %2$s',

--- a/concrete/src/Entity/Permission/IpAccessControlCategory.php
+++ b/concrete/src/Entity/Permission/IpAccessControlCategory.php
@@ -451,7 +451,7 @@ class IpAccessControlCategory
 
         return t2(
             /* i18n: %1$s is a number; %2$s is a duration (like for example 2 minutes) */
-            '%1$s event every %2$s', '%1$s events every %2$s',
+            '%1$s event in %2$s', '%1$s events in %2$s',
             $this->getMaxEvents(),
             Unit::format($value, $unit, 'long')
         );


### PR DESCRIPTION
What about adding a helper method that describes the time window of IpAccessControlCategory?

Here's an example of its output (as displayed in the `dashboard/system/permissions/denylist` dashboard page when there is more than one IpAccessControlCategory):

![immagine](https://user-images.githubusercontent.com/928116/154979375-fad41547-d23b-4178-8ea8-1d0968e1553e.png)
