### PR TITLE
IP Access Control: fix sorting categories in the dashboard page

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/denylist.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/denylist.php
@@ -33,8 +33,8 @@ EOT
         );
         $categories = $this->getCategoryRepository()->findAll();
         $cmp = new Comparer();
-        usort($categories, function (IpAccessControlCategory $a, IpAccessControlCategory $b) use ($cmp) {
-            $cmp->compare($a->getDisplayName(), $b->getDisplayName());
+        usort($categories, static function (IpAccessControlCategory $a, IpAccessControlCategory $b) use ($cmp): int {
+            return $cmp->compare($a->getDisplayName(), $b->getDisplayName());
         });
         $this->set('categories', $categories);
     }


### PR DESCRIPTION
Let's fix the display order of IP Access Control Categories in the `/dashboard/system/permissions/denylist` dashboard page.