### PR TITLE
PHP8 Compatibility/PHP Doc Block Update for calendar and calendar event blocks

### DIFF
--- a/concrete/attributes/calendar_event/form.php
+++ b/concrete/attributes/calendar_event/form.php
@@ -1,6 +1,10 @@
+<?php
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var \Concrete\Core\Attribute\View $view */
+?>
 <div class="form-group">
     <?=$form->label('calendarID', t('Calendar'))?>
-    <?=$form->select('calendarID', $calendars, $calendarID, array('data-select' => 'calendar'));?>
+    <?=$form->select('calendarID', $calendars ?? [], $calendarID ?? 0, ['data-select' => 'calendar']);?>
 </div>
 
 <div class="form-group">

--- a/concrete/blocks/calendar/add.php
+++ b/concrete/blocks/calendar/add.php
@@ -1,2 +1,3 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/calendar/edit.php
+++ b/concrete/blocks/calendar/edit.php
@@ -1,2 +1,3 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/calendar/form.php
+++ b/concrete/blocks/calendar/form.php
@@ -2,32 +2,31 @@
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Form\Service\Widget\Color;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\View\View;
 
-/** @var int $caID */
-/** @var string $calendarAttributeKeyHandle */
-/** @var int $filterByTopicAttributeKeyID */
+/** @var int|null $caID */
+/** @var string|null $calendarAttributeKeyHandle */
+/** @var int|null $filterByTopicAttributeKeyID */
 /** @var int $filterByTopicID */
+$filterByTopicID = $filterByTopicID ?? 0;
 /** @var string $viewTypes */
 /** @var string $viewTypesOrder */
-/** @var string $defaultView */
+/** @var string|null $defaultView */
 /** @var int $navLinks */
 /** @var int $eventLimit */
-/** @var array $lightboxProperties */
-/** @var array $viewTypesSelected */
-/** @var array $viewTypesOrder */
-/** @var array $lightboxPropertiesSelected */
-/** @var array $calendars */
-/** @var array $attributeKeys */
-/** @var array $viewTypes */
+/** @var array<string,string> $lightboxProperties */
+/** @var string[] $viewTypesSelected */
+/** @var string[] $viewTypesOrder */
+/** @var array<string,string> $lightboxPropertiesSelected */
+/** @var Concrete\Core\Entity\Calendar\Calendar[] $calendars */
+/** @var Concrete\Core\Entity\Attribute\Key\EventKey[] $attributeKeys */
+/** @var array<string, string> $viewTypes */
+/** @var Concrete\Core\Form\Service\Form $form */
 
 $app = Application::getFacadeApplication();
-/** @var Form $form */
-$form = $app->make(Form::class);
-/** @var Color $color */
+/** @var Concrete\Core\Form\Service\Widget\Color $color */
 $color = $app->make(Color::class);
 ?>
 
@@ -38,8 +37,8 @@ $color = $app->make(Color::class);
 
     <?php /** @noinspection PhpUnhandledExceptionInspection */
     View::element('calendar/block/data_source', [
-        'caID' => isset($caID) ? $caID : null,
-        'calendarAttributeKeyHandle' => isset($calendarAttributeKeyHandle) ? $calendarAttributeKeyHandle : null
+        'caID' => $caID ?? null,
+        'calendarAttributeKeyHandle' => $calendarAttributeKeyHandle ?? null,
     ]) ?>
 </fieldset>
 
@@ -50,20 +49,24 @@ $color = $app->make(Color::class);
 
     <div data-section="customize-results">
         <div class="form-group">
-            <?php echo $form->label("viewTypes", t("View Types")); ?>
+            <?php echo $form->label('viewTypes', t('View Types')); ?>
 
-            <?php if ($viewTypes) { ?>
-                <?php foreach ($viewTypes as $key => $name) { ?>
+            <?php if ($viewTypes) {
+                /**
+                 * @var string $key
+                 * @var string $name
+                 */
+                foreach ($viewTypes as $key => $name) { ?>
                     <div class="form-check">
-                        <?php echo $form->checkbox('viewTypes[]', $key, in_array($key, $viewTypesSelected), ["name" => "viewTypes[]", "id" => "viewTypes_" . $key]); ?>
-                        <?php echo $form->label("viewTypes_" . $key, $name, ["class" => "form-check-label"]); ?>
+                        <?php echo $form->checkbox('viewTypes[]', $key, in_array($key, $viewTypesSelected), ['name' => 'viewTypes[]', 'id' => 'viewTypes_' . $key]); ?>
+                        <?php echo $form->label('viewTypes_' . $key, $name, ['class' => 'form-check-label']); ?>
                     </div>
                 <?php } ?>
             <?php } ?>
         </div>
 
         <div class="form-group">
-            <?php echo $form->label("", t("View Type Order")); ?>
+            <?php echo $form->label('', t('View Type Order')); ?>
 
             <p class="help-block">
                 <?php echo t('Click and drag to change view type order.'); ?>
@@ -75,7 +78,7 @@ $color = $app->make(Color::class);
                         <?php $valueNameArray = explode('_', $valueName); ?>
 
                         <li style="cursor: move" data-field-order-item="<?php echo $valueNameArray[0]; ?>">
-                            <?php echo $form->hidden("viewTypesOrder[]", $valueName); ?>
+                            <?php echo $form->hidden('viewTypesOrder[]', $valueName); ?>
                             <?php echo $valueNameArray[1]; ?>
                             <i class="ccm-item-select-list-sort ui-sortable-handle"></i>
                         </li>
@@ -87,15 +90,15 @@ $color = $app->make(Color::class);
 
     <div class="form-group">
         <?php echo $form->label('defaultView', t('Default View')); ?>
-        <?php echo $form->select('defaultView', $viewTypes, isset($defaultView) ? $defaultView : null); ?>
+        <?php echo $form->select('defaultView', $viewTypes, $defaultView ?? null); ?>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("", t("Day Heading Links")); ?>
+        <?php echo $form->label('', t('Day Heading Links')); ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('navLinks', 1, !empty($navLinks)); ?>
-            <?php echo $form->label("navLinks", t('Make day headings into links.'), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('navLinks', '1', !empty($navLinks)); ?>
+            <?php echo $form->label('navLinks', t('Make day headings into links.'), ['class' => 'form-check-label']); ?>
         </div>
     </div>
 
@@ -104,11 +107,11 @@ $color = $app->make(Color::class);
     </p>
 
     <div class="form-group">
-        <?php echo $form->label("", t("Event Limit")); ?>
+        <?php echo $form->label('', t('Event Limit')); ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('eventLimit', 1, !empty($eventLimit)); ?>
-            <?php echo $form->label("eventLimit", t('Limit the number of events displayed on a day.'), ["class" => "form-check-label"]); ?>
+            <?php echo $form->checkbox('eventLimit', '1', !empty($eventLimit)); ?>
+            <?php echo $form->label('eventLimit', t('Limit the number of events displayed on a day.'), ['class' => 'form-check-label']); ?>
         </div>
 
         <p class="help-block">
@@ -123,7 +126,7 @@ $color = $app->make(Color::class);
     </legend>
 
     <div class="form-group">
-        <?php echo $form->label("totalToRetrieve", t("Filter by Topic Attribute")); ?>
+        <?php echo $form->label('totalToRetrieve', t('Filter by Topic Attribute')); ?>
 
         <!--suppress HtmlFormInputWithoutLabel -->
         <select class="form-select" name="filterByTopicAttributeKeyID">
@@ -131,8 +134,9 @@ $color = $app->make(Color::class);
                 <?php echo t('** None') ?>
             </option>
 
-            <?php foreach ($attributeKeys as $ak) { ?>
-                <?php $attributeController = $ak->getController(); ?>
+            <?php foreach ($attributeKeys as $ak) {
+                /** @var \Concrete\Attribute\Topics\Controller $attributeController */
+                $attributeController = $ak->getController(); ?>
 
                 <option value="<?php echo h($ak->getAttributeKeyID()) ?>"
                         <?php if (isset($filterByTopicAttributeKeyID) && $ak->getAttributeKeyID() == $filterByTopicAttributeKeyID) { ?>selected<?php } ?>
@@ -142,7 +146,7 @@ $color = $app->make(Color::class);
             <?php } ?>
         </select>
 
-        <?php echo $form->hidden("filterByTopicID", isset($filterByTopicID) ? $filterByTopicID : ''); ?>
+        <?php echo $form->hidden('filterByTopicID', (string) $filterByTopicID); ?>
 
         <div class="tree-view-container">
             <div class="tree-view-template"></div>
@@ -161,8 +165,8 @@ $color = $app->make(Color::class);
 
     <?php foreach ($lightboxProperties as $key => $name) { ?>
         <div class="form-check">
-            <?php echo $form->checkbox('lightboxProperties[]', $key, in_array($key, $lightboxPropertiesSelected), ["name" => "lightboxProperties[]", "id" => "lightboxProperties_" . $key]) ?>
-            <?php echo $form->label("lightboxProperties_" . $key, $name, ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('lightboxProperties[]', $key, in_array($key, $lightboxPropertiesSelected), ['name' => 'lightboxProperties[]', 'id' => 'lightboxProperties_' . $key]) ?>
+            <?php echo $form->label('lightboxProperties_' . $key, $name, ['class' => 'form-check-label']) ?>
         </div>
     <?php } ?>
 </fieldset>
@@ -182,7 +186,7 @@ $color = $app->make(Color::class);
             $('.tree-view-template').concreteTree({
                 'treeID': chosenTree,
                 'chooseNodeInForm': true,
-                'selectNodesByKey': [<?php echo isset($filterByTopicID) ? (int)$filterByTopicID : 0?>],
+                'selectNodesByKey': [<?php echo $filterByTopicID ?>],
                 'onSelect': function (nodes) {
                     if (nodes.length) {
                         $('input[name=filterByTopicID]').val(nodes[0]);

--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -1,5 +1,19 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
+/** @var \Concrete\Block\Calendar\Controller $controller */
+/** @var \Concrete\Core\Permission\Checker $permissions */
+
+/** @var string $viewTypeString */
+/** @var string $defaultView */
+/** @var \Concrete\Core\Block\View\BlockView $view */
+
+/** @var int $bID */
+$bID = $bID ?? 0;
+$eventLimit = $eventLimit ?? 0;
+$navLinks = $navLinks ?? 0;
+use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Page;
+
 if (!isset($calendar) || !is_object($calendar)) {
     $calendar = null;
 }
@@ -9,6 +23,7 @@ if ($c->isEditMode()) {
     $loc->pushActiveContext(Localization::CONTEXT_UI);
     ?><div class="ccm-edit-mode-disabled-item"><?=t('Calendar disabled in edit mode.')?></div><?php
     $loc->popActiveContext();
+    /** @phpstan-ignore-next-line */
 } elseif ($calendar !== null && $permissions->canViewCalendar()) { ?>
     <div class="ccm-block-calendar-wrapper" data-calendar="<?=$bID?>"></div>
 
@@ -18,7 +33,7 @@ if ($c->isEditMode()) {
                 header: {
                     left: 'prev,next today',
                     center: 'title',
-                    right: '<?= $viewTypeString ? $viewTypeString : ''; ?>'
+                    right: '<?= $viewTypeString ?: ''; ?>'
                 },
                 locale: <?= json_encode(Localization::activeLanguage()); ?>,
                 views: {
@@ -50,7 +65,7 @@ if ($c->isEditMode()) {
 
                 eventRender: function(event, element) {
                     <?php if ($controller->supportsLightbox()) { ?>
-                        element.attr('href', '<?=rtrim(URL::route(array('/view_event', 'calendar'), $bID))?>/' + event.id).magnificPopup({
+                        element.attr('href', '<?=rtrim(\Concrete\Core\Support\Facade\Url::route(['/view_event', 'calendar'], $bID))?>/' + event.id).magnificPopup({
                             type: 'ajax',
                             callbacks: {
                                 beforeOpen: function () {

--- a/concrete/blocks/calendar_event/add.php
+++ b/concrete/blocks/calendar_event/add.php
@@ -1,4 +1,5 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/calendar_event/edit.php
+++ b/concrete/blocks/calendar_event/edit.php
@@ -1,4 +1,5 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/calendar_event/form.php
+++ b/concrete/blocks/calendar_event/form.php
@@ -1,29 +1,23 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
-use Concrete\Core\Entity\Attribute\Key\EventKey;
-use Concrete\Core\Form\Service\Form;
-use Concrete\Core\Support\Facade\Application;
+/** @var string|null $mode */
+/** @var string|null $calendarEventAttributeKeyHandle */
+/** @var int|null $calendarID */
+/** @var int|null $eventID */
+/** @var string|null $displayEventAttributes */
+/** @var bool|null $enableLinkToPage */
+/** @var bool|null $displayEventName */
+/** @var bool|null $displayEventDate */
+/** @var bool|null $displayEventDescription */
+/** @var array<string,string> $calendarEventPageKeys */
+/** @var Concrete\Core\Entity\Attribute\Key\EventKey[] $eventKeys */
+/** @var array<string,string> $calendars */
+/** @var mixed[] $displayEventAttributes */
+/** @var bool|null $allowExport */
 
-/** @var string $mode */
-/** @var string $calendarEventAttributeKeyHandle */
-/** @var int $calendarID */
-/** @var int $eventID */
-/** @var string $displayEventAttributes */
-/** @var bool $enableLinkToPage */
-/** @var bool $displayEventName */
-/** @var bool $displayEventDate */
-/** @var bool $displayEventDescription */
-/** @var array $calendarEventPageKeys */
-/** @var EventKey[] $eventKeys */
-/** @var array $calendars */
-/** @var array $displayEventAttributes */
-/** @var bool $allowExport */
-
-$app = Application::getFacadeApplication();
-/** @var Form $form */
-$form = $app->make(Form::class);
+/** @var Concrete\Core\Form\Service\Form $form */
 
 ?>
 
@@ -35,16 +29,16 @@ $form = $app->make(Form::class);
     <div class="form-group">
         <?php echo $form->label('mode', t('Mode')); ?>
         <?php echo $form->select('mode', [
-            "S" => t('Specific – Display details about a specific calendar event.'),
-            "P" => t('Page – Display details about the event attached to a custom attribute.'),
-            "R" => t('Request – Display details about an event occurrence passed through the URL request.')
-        ], $mode, ["data-select" => "mode"]); ?>
+            'S' => t('Specific – Display details about a specific calendar event.'),
+            'P' => t('Page – Display details about the event attached to a custom attribute.'),
+            'R' => t('Request – Display details about an event occurrence passed through the URL request.'),
+        ], $mode ?? 'S', ['data-select' => 'mode']); ?>
     </div>
 
     <div data-group="specific">
         <div class="form-group">
             <?php echo $form->label('calendarID', t('Calendar')) ?>
-            <?php echo $form->select('calendarID', $calendars, $calendarID, ['data-select' => 'calendar']) ?>
+            <?php echo $form->select('calendarID', $calendars, $calendarID ?? '0', ['data-select' => 'calendar']) ?>
         </div>
 
         <div class="form-group">
@@ -56,7 +50,7 @@ $form = $app->make(Form::class);
     <div data-group="page">
         <div class="form-group">
             <?php echo $form->label('calendarEventAttributeKeyHandle', t('Retrieve Event from Attribute')) ?>
-            <?php echo $form->select('calendarEventAttributeKeyHandle', $calendarEventPageKeys, $calendarEventAttributeKeyHandle) ?>
+            <?php echo $form->select('calendarEventAttributeKeyHandle', $calendarEventPageKeys, $calendarEventAttributeKeyHandle ?? null) ?>
         </div>
     </div>
 </fieldset>
@@ -70,23 +64,23 @@ $form = $app->make(Form::class);
         <?php echo $form->label('', t('Core Properties')) ?>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventName', 1, $displayEventName) ?>
-            <?php echo $form->label("displayEventName", t('Name'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('displayEventName', '1', $displayEventName ?? false) ?>
+            <?php echo $form->label('displayEventName', t('Name'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventDate', 1, $displayEventDate) ?>
-            <?php echo $form->label("displayEventDate", t('Occurrence Date and Time'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('displayEventDate', '1', $displayEventDate ?? false) ?>
+            <?php echo $form->label('displayEventDate', t('Occurrence Date and Time'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('displayEventDescription', 1, $displayEventDescription) ?>
-            <?php echo $form->label("displayEventDescription", t('Description'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('displayEventDescription', '1', $displayEventDescription ?? false) ?>
+            <?php echo $form->label('displayEventDescription', t('Description'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->checkbox('allowExport', 1, $allowExport) ?>
-            <?php echo $form->label("allowExport", t('Allow event export'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->checkbox('allowExport', '1', $allowExport ?? false) ?>
+            <?php echo $form->label('allowExport', t('Allow event export'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
@@ -95,8 +89,8 @@ $form = $app->make(Form::class);
 
         <?php foreach ($eventKeys as $ak) { ?>
             <div class="form-check">
-                <?php echo $form->checkbox('displayEventAttributes[]', $ak->getAttributeKeyID(), in_array($ak->getAttributeKeyID(), $displayEventAttributes), ["name" => "displayEventAttributes[]", "id" => "displayEventAttributes_" . $ak->getAttributeKeyID()]) ?>
-                <?php echo $form->label("displayEventAttributes_" . $ak->getAttributeKeyID(), $ak->getAttributeKeyDisplayName(), ["class" => "form-check-label"]) ?>
+                <?php echo $form->checkbox('displayEventAttributes[]', $ak->getAttributeKeyID(), in_array($ak->getAttributeKeyID(), $displayEventAttributes), ['name' => 'displayEventAttributes[]', 'id' => 'displayEventAttributes_' . $ak->getAttributeKeyID()]) ?>
+                <?php echo $form->label('displayEventAttributes_' . $ak->getAttributeKeyID(), $ak->getAttributeKeyDisplayName(), ['class' => 'form-check-label']) ?>
             </div>
         <?php } ?>
     </div>
@@ -106,8 +100,8 @@ $form = $app->make(Form::class);
             <?php echo $form->label('', t('Linking')) ?>
 
             <div class="form-check">
-                <?php echo $form->checkbox('enableLinkToPage', 1, $enableLinkToPage) ?>
-                <?php echo $form->label("enableLinkToPage", t('Link Event Name to Detail Page'), ["class" => "form-check-label"]) ?>
+                <?php echo $form->checkbox('enableLinkToPage', '1', $enableLinkToPage ?? false) ?>
+                <?php echo $form->label('enableLinkToPage', t('Link Event Name to Detail Page'), ['class' => 'form-check-label']) ?>
             </div>
         </div>
     </div>

--- a/concrete/blocks/calendar_event/view.php
+++ b/concrete/blocks/calendar_event/view.php
@@ -1,16 +1,13 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Attribute\Key\EventKey;
-use Concrete\Core\Calendar\Event\Formatter\DateFormatter;
-use Concrete\Core\Entity\Calendar\CalendarEventVersion;
-use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Support\Facade\Url;
 
-/** @var DateFormatter $formatter */
-/** @var CalendarEventVersion $event */
-/** @var CalendarEventVersionOccurrence $occurrence */
+/** @var Concrete\Core\Calendar\Event\Formatter\DateFormatter $formatter */
+/** @var Concrete\Core\Entity\Calendar\CalendarEventVersion|null $event */
+/** @var Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence $occurrence */
 /** @var string $mode */
 /** @var string $eventOccurrenceLink */
 /** @var string $calendarEventAttributeKeyHandle */
@@ -73,9 +70,9 @@ use Concrete\Core\Support\Facade\Url;
 
         <?php if ($allowExport) { ?>
             <div class="ccm-block-calendar-event-export">
-                <a href="<?php echo Url::to("/ccm/calendar/event/export")->setQuery(["eventID" => $event->getID()]); ?>"
-                   title="<?php echo h(t("Export Event")); ?>" class="btn btn-secondary">
-                    <?php echo t("Export Event"); ?>
+                <a href="<?php echo Url::to('/ccm/calendar/event/export')->setQuery(['eventID' => $event->getID()]); ?>"
+                   title="<?php echo h(t('Export Event')); ?>" class="btn btn-secondary">
+                    <?php echo t('Export Event'); ?>
                 </a>
             </div>
         <?php } ?>

--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -3,11 +3,12 @@ namespace Concrete\Controller\Dialog\Event;
 
 use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
 use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Progress\Response;
 use Concrete\Core\Workflow\Request\ApproveCalendarEventRequest;
-use Core;
 use Concrete\Core\Calendar\Calendar;
 use Concrete\Core\Entity\Calendar\CalendarEvent;
 use Concrete\Core\Entity\Calendar\CalendarEventVersionRepetition;
@@ -16,7 +17,6 @@ use Concrete\Core\Calendar\Event\EventOccurrenceService;
 use Concrete\Core\Calendar\Event\EventRepetitionService;
 use Concrete\Core\Calendar\Event\EventService;
 use Concrete\Core\Calendar\Utility\Preferences;
-use RedirectResponse;
 
 class Edit extends BackendInterfaceController
 {
@@ -31,6 +31,14 @@ class Edit extends BackendInterfaceController
      * @var EventService
      */
     protected $eventService;
+    /**
+     * @var EventRepetitionService
+     */
+    protected $eventRepetitionService;
+    /**
+     * @var EventOccurrenceService
+     */
+    protected $eventOccurrenceService;
 
     public function __construct()
     {
@@ -53,7 +61,7 @@ class Edit extends BackendInterfaceController
 
     public function edit()
     {
-        if ($this->canAccess(false)) {
+        if ($this->canAccess()) {
             $occurrence = $this->eventOccurrenceService->getByID($this->request->query->get('versionOccurrenceID'));
             if (!$occurrence) {
                 throw new \Exception(t('Invalid occurrence.'));
@@ -74,22 +82,22 @@ class Edit extends BackendInterfaceController
         }
         $calendar = $caID ? Calendar::getByID($caID) : null;
         if (is_object($calendar)) {
-            $cp = new \Permissions($calendar);
+            $cp = new Checker($calendar);
 
             return $cp->canAddCalendarEvent();
-        } else {
-            $versionOccurrenceID = $this->request->request->get('versionOccurrenceID');
-            if ($versionOccurrenceID === null) {
-                $versionOccurrenceID = $this->request->query->get('versionOccurrenceID');
-            }
-            $occurrence = $versionOccurrenceID ? $this->eventOccurrenceService->getByID($versionOccurrenceID) : null;
-            if (is_object($occurrence)) {
-                $calendar = $occurrence->getEvent()->getCalendar();
-                if (is_object($calendar)) {
-                    $cp = new \Permissions($calendar);
+        }
 
-                    return $cp->canEditCalendarEvents();
-                }
+        $versionOccurrenceID = $this->request->request->get('versionOccurrenceID');
+        if ($versionOccurrenceID === null) {
+            $versionOccurrenceID = $this->request->query->get('versionOccurrenceID');
+        }
+        $occurrence = $versionOccurrenceID ? $this->eventOccurrenceService->getByID($versionOccurrenceID) : null;
+        if (is_object($occurrence)) {
+            $calendar = $occurrence->getEvent()->getCalendar();
+            if (is_object($calendar)) {
+                $cp = new Checker($calendar);
+
+                return $cp->canEditCalendarEvents();
             }
         }
 
@@ -101,13 +109,12 @@ class Edit extends BackendInterfaceController
      */
     protected function validateRequest($calendar, $repetitions)
     {
-        $e = \Core::make('error');
+        $e = $this->app->make('error');
         if ($this->canAccess()) {
             if (!is_object($calendar)) {
                 $e->add(t('Invalid calendar.'));
             }
 
-            $datetime = \Core::make('helper/form/date_time');
             if (!count($repetitions)) {
                 $e->add(t('You must specify a valid date for this event.'));
             }
@@ -138,14 +145,14 @@ class Edit extends BackendInterfaceController
                 $eventVersionRepetitions[] = new CalendarEventVersionRepetition($eventVersion, $repetition);
             }
 
-            $permissions = new \Permissions($calendar);
+            $permissions = new Checker($calendar);
             if ($permissions->canEditCalendarEventMoreDetailsLocation()) {
                 if ($this->request->request->get('cID') !== null) {
                     $cID = intval($this->request->request->get('cID'));
                     if ($cID) {
-                        $eventPage = \Page::getByID($cID);
+                        $eventPage = Page::getByID($cID);
                         if (is_object($eventPage) && !$eventPage->isError()) {
-                            $cp = new \Permissions($eventPage);
+                            $cp = new Checker($eventPage);
                             if ($cp->canViewPage()) {
                                 $eventVersion->setRelatedPageRelationType(null);
                                 $eventVersion->setPageObject($eventPage);

--- a/concrete/elements/event/form.php
+++ b/concrete/elements/event/form.php
@@ -8,12 +8,14 @@ use Concrete\Core\Calendar\Event\EventOccurrence;
 $fp = FilePermissions::getGlobal();
 $tp = new TaskPermission();
 $version = null;
+/** @var \Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence|null $occurrence */
+$occurrence = $occurrence ?? null;
 if ($occurrence) {
     $version = $occurrence->getEvent()->getRecentVersion();
     $calendar = $version->getEvent()->getCalendar();
 }
 
-$permissions = new Permissions($calendar);
+$permissions = new \Concrete\Core\Permission\Checker($calendar);
 
 $timezone = $calendar->getTimezone();
 
@@ -28,14 +30,14 @@ if (is_object($category) && $category->allowAttributeSets()) {
 }
 
 $summarySet = false;
-$tabs[] = array('event-summary', t('Summary'), true);
-$tabs[] = array('event-dates', t('Dates'));
+$tabs[] = ['event-summary', t('Summary'), true];
+$tabs[] = ['event-dates', t('Dates'), false];
 foreach ($sets as $set) {
     if ($set->getAttributeSetHandle() == 'calendar_summary') {
         $summarySet = $set;
         continue;
     }
-    $tabs[] = array('event-tab-' . $set->getAttributeSetHandle(), $set->getAttributeSetDisplayName());
+    $tabs[] = ['event-tab-' . $set->getAttributeSetHandle(), $set->getAttributeSetDisplayName(), false];
 }
 
 $repetitions = null;
@@ -63,8 +65,9 @@ if ($version) {
             <div class="tab-pane active" id="event-summary">
 
             <?php
-            /** @var EventOccurrence $occurrence */
+
             if ($occurrence) {
+
                 if ($occurrence->getRepetition()->repeats()) {
                     ?>
                     <div>
@@ -104,7 +107,7 @@ if ($version) {
                         <?= t('Description') ?>
                     </label>
 
-                    <?=Core::make('editor')->outputStandardEditor('description', $version ? $version->getDescription() : '')?>
+                    <?=app('editor')->outputStandardEditor('description', $version ? $version->getDescription() : '')?>
                 </div>
 
                 <?php if ($permissions->canEditCalendarEventMoreDetailsLocation()) { ?>
@@ -120,7 +123,7 @@ if ($version) {
                             }
                         }
                         ?>
-                        <?=Core::make("helper/form/page_selector")->selectPage('cID', $cID)?>
+                        <?=app("helper/form/page_selector")->selectPage('cID', $cID)?>
                     </div>
 
                 <?php } ?>
@@ -149,8 +152,8 @@ if ($version) {
                     ?>
                     <div class="single-occurrence-date-time" style="display:none">
                         <?php
-                        $form = \Core::make('helper/form');
-                        $dt = \Core::make('helper/form/date_time');
+                        $form = app('helper/form');
+                        $dt = app('helper/form/date_time');
 
                         $pdStartDateDateTime = new DateTime();
                         $pdStartDateDateTime->setTimestamp($occurrence->getStart());

--- a/concrete/src/Attribute/AttributeInterface.php
+++ b/concrete/src/Attribute/AttributeInterface.php
@@ -72,6 +72,7 @@ interface AttributeInterface
      * $data is simply the POST values from the form.
      *
      * @param array $data
+     * @return \Concrete\Core\Attribute\Type|null|void
      */
     public function saveKey($data);
 

--- a/concrete/views/dialogs/event/choose.php
+++ b/concrete/views/dialogs/event/choose.php
@@ -19,11 +19,19 @@
                 center: 'title',
                 right: 'month,basicWeek,basicDay'
             },
+            locale: <?= json_encode(Localization::activeLanguage()); ?>,
+            contentHeight: 'auto',
             events: {
                 url: '<?=$view->action('get_events')?>',
                 data: {
                     'caID': '<?=$calendar->getID()?>'
                 }
+            },
+            eventDataTransform: function(event) {
+                if(event.allDay) {
+                    event.end = moment(event.end).add(1, 'days')
+                }
+                return event;
             },
             eventRender: function(event, element) {
                 element.attr('href', '#'); // Just to make the pointer nice instead of a text handle.
@@ -36,10 +44,5 @@
                 });
             }
         });
-        setTimeout(function() {
-            // not sure why i need this to render off the bat but I do and I don't care to find out.
-
-            $('div[data-calendar=<?=$calendar->getID()?>]').fullCalendar('render');
-        }, 50);
     });
 </script>


### PR DESCRIPTION
This PR is split from In regards to https://github.com/concrete5/concrete5/pull/10300 to make it easer to review

This PR fixes some issues in php8 when adding/editing the calendar and calendar event blocks
It also updates the php-doc for these blocks and updates/removes dead code comments
We also run php-cs-fixer against all these block files and phpstan level 6

This PR also fixes adding events, adding attribute events on php8