### PR TITLE
Fix a bug with having multiple image blocks with on-hover attribute set on the page

### DIFF
--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -166,14 +166,12 @@ if (is_object($f) && $f->getFileID()) {
         var images = document.getElementsByClassName('ccm-image-block-hover');
 
         for (var i = 0; i < images.length; i++) {
-            var image = images[i],
-                hoverSrc = image.getAttribute('data-hover-src'),
-                defaultSrc = image.getAttribute('data-default-src');
+            var image = images[i];
             image.onmouseover = function () {
-                this.setAttribute('src', hoverSrc);
+                this.setAttribute('src', this.getAttribute('data-hover-src'));
             };
             image.onmouseout = function () {
-                this.setAttribute('src', defaultSrc);
+                this.setAttribute('src', this.getAttribute('data-default-src'));
             };
         }
     </script>

--- a/concrete/blocks/image/view.php
+++ b/concrete/blocks/image/view.php
@@ -170,10 +170,10 @@ if (is_object($f) && $f->getFileID()) {
                 hoverSrc = image.getAttribute('data-hover-src'),
                 defaultSrc = image.getAttribute('data-default-src');
             image.onmouseover = function () {
-                image.setAttribute('src', hoverSrc);
+                this.setAttribute('src', hoverSrc);
             };
             image.onmouseout = function () {
-                image.setAttribute('src', defaultSrc);
+                this.setAttribute('src', defaultSrc);
             };
         }
     </script>


### PR DESCRIPTION
'image' in the handler function ends up referring the last element of the 'images' array. So if you have several image blocks on a single page, when hoving in and out of an image, it only changes the last element.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
