### PR TITLE
set isActive and isActiveParent for top_navigation_bar block

### DIFF
--- a/concrete/blocks/top_navigation_bar/view.php
+++ b/concrete/blocks/top_navigation_bar/view.php
@@ -60,17 +60,17 @@ $c = Page::getCurrentPage();
                              */
                             if (count($item->getChildren()) > 0) { ?>
                                 <li class="nav-item dropdown">
-                                    <a class="nav-link dropdown-toggle" data-concrete-toggle="dropdown" href="<?=$item->getUrl()?>">
+                                    <a class="nav-link dropdown-toggle<?= $item->isActive() || $item->isActiveParent() ? " active" : ""; ?>" data-concrete-toggle="dropdown" href="<?= $item->getUrl() ?>">
                                         <?=$item->getName()?>
                                     </a>
                                     <ul class="dropdown-menu">
                                         <?php foreach ($item->getChildren() as $dropdownChild) { ?>
-                                            <li><a class="dropdown-item" href="<?=$dropdownChild->getUrl()?>"><?=$dropdownChild->getName()?></a></li>
+                                            <li><a class="dropdown-item<?= $item->isActive() || $item->isActiveParent() ? " active" : ""; ?>" href="<?=$dropdownChild->getUrl()?>"><?=$dropdownChild->getName()?></a></li>
                                         <?php } ?>
                                     </ul>
                                 </li>
                             <?php } else { ?>
-                                <li class="nav-item"><a class="nav-link" href="<?=$item->getUrl()?>"><?=$item->getName()?></a></li>
+                                <li class="nav-item"><a class="nav-link<?= $item->isActive() || $item->isActiveParent() ? " active" : ""; ?>" href="<?=$item->getUrl()?>"><?=$item->getName()?></a></li>
                             <?php } ?>
                         <?php } ?>
                     </ul>


### PR DESCRIPTION
also adds bootstrap's active class in the template

this addresses #9906 

I'm not sure if there would be a more preferred way to loading the ancestors as it appears the `NavigationService->getTrailToCollection($c)` loads the entire page objects. If needed for performance considerations I could add a `getIDTrailToCollection($c)` to only returns the collection ids since that's all we need here anyway