### PR TITLE
Fix pagination factory created via DI

### DIFF
--- a/concrete/src/Search/Pagination/PaginationFactory.php
+++ b/concrete/src/Search/Pagination/PaginationFactory.php
@@ -7,7 +7,7 @@ use Concrete\Core\Search\PermissionableListItemInterface;
 use Pagerfanta\Exception\LessThan1CurrentPageException;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Pagerfanta\Pagerfanta;
-use Symfony\Component\HttpFoundation\Request;
+use Concrete\Core\Http\Request;
 
 class PaginationFactory
 {
@@ -22,7 +22,6 @@ class PaginationFactory
 
     /**
      * PaginationFactory constructor.
-     * @param PaginationProviderInterface $itemList
      */
     public function __construct(Request $request)
     {


### PR DESCRIPTION
When we create the PaginationFactory via DI, its constructor receives a `Symfony\Component\HttpFoundation\Request` instance.

Since it's not bound in the app, the DI created a new empty request instance. So, navigation never goes beyond the first page.

We should use `Concrete\Core\Http\Request` instead, which is bound in the app.