### PR TITLE
Add some query parameters to the canonical link tag

### DIFF
--- a/concrete/blocks/calendar_event/controller.php
+++ b/concrete/blocks/calendar_event/controller.php
@@ -14,6 +14,7 @@ use Concrete\Core\Entity\Calendar\CalendarEventVersionOccurrence;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Url\SeoCanonical;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
@@ -200,6 +201,15 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         return null;
+    }
+
+    public function on_start()
+    {
+        if ($this->request->query->has('occurrenceID') && $this->mode == 'R') {
+            /** @var SeoCanonical $seo */
+            $seo = $this->app->make(SeoCanonical::class);
+            $seo->addIncludedQuerystringParameter('occurrenceID');
+        }
     }
 
     /**

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -6,10 +6,13 @@ use CollectionAttributeKey;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Block\View\BlockView;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\Html\Service\Seo;
 use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Package\Offline\Exception;
 use Concrete\Core\Page\Feed;
 use Concrete\Core\Tree\Node\Node;
 use Concrete\Core\Tree\Node\Type\Topic;
@@ -267,6 +270,12 @@ class Controller extends BlockController implements UsesFeatureInterface
             } else {
                 $this->list->filterByParentID($cParentID);
             }
+        }
+
+        if ($this->paginate) {
+            /** @var SeoCanonical $seoCanonical */
+            $seoCanonical = $this->app->make(SeoCanonical::class);
+            $seoCanonical->addIncludedQuerystringParameter($this->list->getQueryPaginationPageParameter());
         }
 
         return $this->list;

--- a/concrete/config/site.php
+++ b/concrete/config/site.php
@@ -144,6 +144,7 @@ return [
                     'enabled' => true,
                     // List of querystring parameters to be included in SEO canonical URLs
                     'included_querystring_parameters' => [
+                        'ccm_paging_p',
                     ],
                 ],
                 'tracking' => [

--- a/concrete/src/Block/View/BlockView.php
+++ b/concrete/src/Block/View/BlockView.php
@@ -436,7 +436,22 @@ class BlockView extends AbstractView
 
     public function runControllerTask()
     {
-        $this->controller->on_start();
+        // First, check the block controller is already started.
+        $started = false;
+        $c = Page::getCurrentPage();
+        if (is_object($c) && is_object($this->block)) {
+            $pageController = $c->getPageController();
+            $blockController = $pageController->getBlockController($this->block);
+            if ($blockController) {
+                $this->controller = $blockController;
+                $started = true;
+            }
+        }
+
+        // If the block controller is not started yet, run on_start() of it.
+        if (!$started) {
+            $this->controller->on_start();
+        }
 
         if ($this->useBlockCache()) {
             $this->didPullFromOutputCache = true;
@@ -452,10 +467,8 @@ class BlockView extends AbstractView
             }
             $passthru = false;
             if ($method == 'view' && is_object($this->block)) {
-                $c = Page::getCurrentPage();
-                if (is_object($c)) {
-                    $cnt = $c->getController();
-                    $controller = $cnt->getPassThruBlockController($this->block);
+                if (isset($pageController)) {
+                    $controller = $pageController->getPassThruBlockController($this->block);
                     if (is_object($controller)) {
                         $passthru = true;
                         $this->controller = $controller;

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -24,6 +24,8 @@ class PageController extends Controller
     protected $parameters = array();
     protected $replacement = null;
     protected $requestValidated;
+    /** @var BlockController[] */
+    protected $blocks = [];
 
     /** @var bool A flag to track whether we've loaded sets from the session flash bags */
     private $hasCheckedSessionMessages = false;
@@ -315,6 +317,29 @@ class PageController extends Controller
         return isset($this->passThruBlocks[$bID]) ? $this->passThruBlocks[$bID] : null;
     }
 
+    /**
+     * @since 9.0.3
+     * @param Block $block
+     * @param BlockController $controller
+     * @return void
+     */
+    public function setBlockController(Block $block, BlockController $controller)
+    {
+        $this->blocks[$block->getBlockID()] = $controller;
+    }
+
+    /**
+     * @since 9.0.3
+     * @param Block $block
+     * @return BlockController|null
+     */
+    public function getBlockController(Block $block): ?BlockController
+    {
+        $bID = $block->getBlockID();
+
+        return $this->blocks[$bID] ?? null;
+    }
+
     public function validateRequest()
     {
 
@@ -324,16 +349,23 @@ class PageController extends Controller
 
         $valid = true;
 
+        $blockControllers = [];
+        $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
+        foreach ($blocks as $block) {
+            $controller = $block->getController();
+            // We have to run on_start() method of all blocks on this page instead of only ones that have valid tasks
+            $controller->on_start();
+            // We'll also reuse this controller in BlockView, so let's store it to avoid duplicate calls
+            $this->setBlockController($block, $controller);
+            $blockControllers[] = $controller;
+        }
+
         if (!$this->isValidControllerTask($this->action, $this->parameters)) {
             $valid = false;
             // we check the blocks on the page.
-            $blocks = array_merge($this->getPageObject()->getBlocks(), $this->getPageObject()->getGlobalBlocks());
-
-            foreach ($blocks as $b) {
-                $controller = $b->getController();
+            foreach ($blockControllers as $controller) {
                 list($method, $parameters) = $controller->getPassThruActionAndParameters($this->parameters);
                 if ($controller->isValidControllerTask($method, $parameters)) {
-                    $controller->on_start();
                     $response = $controller->runAction($method, $parameters);
                     if ($response instanceof Response) {
                         return $response;

--- a/concrete/src/Url/SeoCanonical.php
+++ b/concrete/src/Url/SeoCanonical.php
@@ -156,4 +156,14 @@ class SeoCanonical
     {
         $this->pathArguments = $pathArguments;
     }
+
+    /**
+     * @since 9.0.3
+     * @param string $parameter
+     * @return void
+     */
+    public function addIncludedQuerystringParameter(string $parameter)
+    {
+        $this->includedQuerystringParameters[] = $parameter;
+    }
 }


### PR DESCRIPTION
As we discussed on #10155 before, we decided to change the strategy of query parameter in the canonical link tag to allowlist instead of denylist. However, we don't allow any parameters now, so let's add them.

Google recommends pagination parameter should be included in the canonical link. See: https://developers.google.com/search/docs/advanced/ecommerce/pagination-and-incremental-page-loading#use-urls-correctly

Also event occurrence ID should be included in the canonical URL to avoid disappearing events from the search engine index.

I found another problem on working this issue. Block controller's `on_start` method is called too late to modify canonical URL. I think we should call it as earlier as possible, at least before rendering the `header_required` element. Additionally, we were calling `on_start` method twice if the block controller has a valid task. We should avoid doing it for performance reason.