### PR TITLE
[v9] Fix version panel responses

### DIFF
--- a/concrete/controllers/panel/page/versions.php
+++ b/concrete/controllers/panel/page/versions.php
@@ -17,47 +17,83 @@ use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 use Concrete\Core\Workflow\Request\ApprovePageRequest as ApprovePagePageWorkflowRequest;
 use Concrete\Core\Workflow\Request\UnapprovePageRequest;
+use Doctrine\DBAL\Types\Types;
 
 class Versions extends BackendInterfacePageController
 {
+    /**
+     * @var string
+     */
     protected $viewPath = '/panels/page/versions';
 
+    /**
+     * @return bool
+     */
     public function canAccess()
     {
         return $this->permissions->canViewPageVersions() || $this->permissions->canEditPageVersions();
     }
 
+    /**
+     * @return void
+     */
     public function view()
     {
         $r = $this->getPageVersionListResponse();
         $this->set('response', $r);
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function get_json()
     {
-        $currentPage = false;
+        $currentPage = 0;
         if ($this->request->request->has('currentPage')) {
-            $currentPage = $this->app->make('helper/security')->sanitizeInt($this->request->request->get('currentPage'));
+            $currentPage = (int) $this->app->make('helper/security')->sanitizeInt($this->request->request->get('currentPage'));
         }
         $r = $this->getPageVersionListResponse($currentPage);
 
-        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function duplicate()
     {
         if ($this->validateAction()) {
-            $this->page->loadVersionObject($this->request->request->get('cvID'));
-            $nc = $this->page->cloneVersion(t('Copy of Version: %s', $this->page->getVersionID()));
-            $v = $nc->getVersionObject();
+            $versionID = app('helper/security')->sanitizeInt($this->request->request->get('cvID'));
+            $this->page->loadVersionObject($versionID);
             $r = new PageEditVersionResponse();
-            $r->setMessage(t('Version %s copied successfully. New version is %s.', $this->request->request->get('cvID'), $v->getVersionID()));
-            $r->addCollectionVersion($v);
+            if ($this->page->getVersionID()) {
+                $nc = $this->page->cloneVersion(t('Copy of Version: %s', $this->page->getVersionID()));
+                $v = $nc->getVersionObject();
 
-            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+                $r->setMessage(t('Version %s copied successfully. New version is %s.', $versionID, $v->getVersionID()));
+                $r->addCollectionVersion($v);
+            } else {
+                $this->error->add(t('Invalid Version ID'));
+                $r->setError($this->error);
+            }
+
+        } else {
+            $this->error->add(t('You can not perform this action.'));
+            $r = new PageEditVersionResponse($this->error);
         }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function new_page()
     {
         if ($this->validateAction()) {
@@ -74,37 +110,54 @@ class Versions extends BackendInterfacePageController
             $r = new PageEditVersionResponse();
             $r->setError($e);
             if (!$e->has()) {
-                $c->loadVersionObject($_REQUEST['cvID']);
-                $nc = $c->cloneVersion(t('New Page Created From Version'));
-                $v = $nc->getVersionObject();
-                $drafts = Page::getDraftsParentPage();
-                $nc = $c->duplicate($drafts);
-                $nc->deactivate();
-                $nc->setPageToDraft();
-                $nc->move($drafts);
-                // now we delete all but the new version
-                $vls = new VersionList($nc);
-                $vls->setItemsPerPage(-1);
-                $vArray = $vls->getPage();
-                for ($i = 1; $i < count($vArray); $i++) {
-                    $cv = $vArray[$i];
-                    $cv->delete();
+                $cvID = app('helper/security')->sanitizeInt($this->request->request->get('cvID'));
+                $c->loadVersionObject($cvID);
+                if ($c->getVersionID()) {
+                    $nc = $c->cloneVersion(t('New Page Created From Version'));
+                    $v = $nc->getVersionObject();
+                    $drafts = Page::getDraftsParentPage();
+                    $nc = $c->duplicate($drafts);
+                    $nc->deactivate();
+                    $nc->setPageToDraft();
+                    $nc->move($drafts);
+                    // now we delete all but the new version
+                    $vls = new VersionList($nc);
+                    $vls->setItemsPerPage(-1);
+                    $vArray = $vls->getPage();
+                    for ($i = 1, $iMax = count($vArray); $i < $iMax; $i++) {
+                        $cv = $vArray[$i];
+                        $cv->delete();
+                    }
+                    // now, we delete the version we duped on the current page, since we don't need it anymore.
+                    $v->delete();
+                    // finally, we redirect the user to the new drafts page in composer mode.
+                    $r->setPage($nc);
+                    $r->setRedirectURL(
+                        $this->app->make(ResolverManagerInterface::class)->resolve([
+                            "/ccm/system/page/checkout/{$nc->getCollectionID()}/first/" . $this->app->make('token')->generate(),
+                        ])
+                    );
+                } else {
+                    $this->error->add(t('Invalid Version ID'));
+                    $r->setError($this->error);
                 }
-                // now, we delete the version we duped on the current page, since we don't need it anymore.
-                $v->delete();
-                // finally, we redirect the user to the new drafts page in composer mode.
-                $r->setPage($nc);
-                $r->setRedirectURL(
-                    $this->app->make(ResolverManagerInterface::class)->resolve([
-                        "/ccm/system/page/checkout/{$nc->getCollectionID()}/first/" . $this->app->make('token')->generate(),
-                    ])
-                );
             }
 
-            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
         }
+
+        $this->error->add(t('You do not have permission to create new pages of this type.'));
+        $r = new PageEditVersionResponse($this->error);
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function delete()
     {
         if ($this->validateAction()) {
@@ -114,13 +167,13 @@ class Versions extends BackendInterfacePageController
 
             $cp = new Permissions($this->page);
             if ($cp->canDeletePageVersions()) {
-                $r = new PageEditVersionResponse();
                 $r->setPage($c);
-                if (is_array($this->request->request->get('cvID'))) {
-                    foreach ($this->request->request->get('cvID') as $cvID) {
+                $cvIDs = $this->request->request->get('cvID');
+                if (is_array($cvIDs)) {
+                    foreach ($cvIDs as $cvID) {
                         $v = CollectionVersion::get($c, $cvID);
                         if (is_object($v)) {
-                            if ($versions == 1) {
+                            if ($versions === 1) {
                                 $e = $this->app->make('helper/validation/error');
                                 $e->add(t('You cannot delete all page versions.'));
                                 $r = new PageEditResponse($e);
@@ -143,95 +196,106 @@ class Versions extends BackendInterfacePageController
                         count($r->getCollectionVersions())
                     ));
                 }
-            } else {
-                $e = $this->app->make('helper/validation/error');
-                $e->add(t('You do not have permission to delete page versions.'));
-                $r = new PageEditResponse($e);
-            }
 
-            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+                return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
+            }
         }
+        $e = $this->app->make('helper/validation/error');
+        $e->add(t('You do not have permission to delete page versions.'));
+        $r = new PageEditResponse($e);
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function approve()
     {
         $c = $this->page;
         $cp = $this->permissions;
-        if ($this->validateAction()) {
-            $r = new PageEditVersionResponse();
-            if ($cp->canApprovePageVersions()) {
-                $ov = CollectionVersion::get($c, 'ACTIVE');
-                if (is_object($ov)) {
-                    $ovID = $ov->getVersionID();
-                }
-                $nvID = $this->request->request->get('cvID');
-
-                $r = new PageEditVersionResponse();
-                $r->setPage($c);
-                $u = $this->app->make(User::class);
-                $pkr = new ApprovePagePageWorkflowRequest();
-                $pkr->setRequestedPage($c);
-                $v = CollectionVersion::get($c, $_REQUEST['cvID']);
-                $pkr->setRequestedVersionID($v->getVersionID());
-                $pkr->setRequesterUserID($u->getUserID());
-                // We keep other scheduling if you click approve from versions panel
-                $pkr->setKeepOtherScheduling(true);
-                $response = $pkr->trigger();
-                if (!($response instanceof WorkflowProgressResponse)) {
-                    // we are deferred
-                    $r->setMessage(t('<strong>Request Saved.</strong> You must complete the workflow before this change is active.'));
-                } else {
-                    if (isset($ovID) && $ovID) {
-                        $r->addCollectionVersion(CollectionVersion::get($c, $ovID));
-                    }
-                    $r->addCollectionVersion(CollectionVersion::get($c, $nvID));
-                    $r->setMessage(t('Version %s approved successfully', $v->getVersionID()));
-                }
-            } else {
-                $e = $this->app->make('helper/validation/error');
-                $e->add(t('You do not have permission to approve page versions.'));
-                $r = new PageEditResponse($e);
+        if ($this->validateAction() && $cp->canApprovePageVersions()) {
+            $ov = CollectionVersion::get($c, 'ACTIVE');
+            $ovID = null;
+            if (is_object($ov)) {
+                $ovID = $ov->getVersionID();
             }
+            $nvID = app('helper/security')->sanitizeInt($this->request->request->get('cvID'));
 
-            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+            $r = new PageEditVersionResponse();
+            $r->setPage($c);
+            $u = $this->app->make(User::class);
+            $pkr = new ApprovePagePageWorkflowRequest();
+            $pkr->setRequestedPage($c);
+            $v = CollectionVersion::get($c, $nvID);
+            $pkr->setRequestedVersionID($v->getVersionID());
+            $pkr->setRequesterUserID($u->getUserID());
+            // We keep other scheduling if you click approve from versions panel
+            $pkr->setKeepOtherScheduling(true);
+            $response = $pkr->trigger();
+            if (!($response instanceof WorkflowProgressResponse)) {
+                // we are deferred
+                $r->setMessage(t('<strong>Request Saved.</strong> You must complete the workflow before this change is active.'));
+            } else {
+                if ($ovID) {
+                    $r->addCollectionVersion(CollectionVersion::get($c, $ovID));
+                }
+                $r->addCollectionVersion(CollectionVersion::get($c, $nvID));
+                $r->setMessage(t('Version %s approved successfully', $v->getVersionID()));
+            }
+        } else {
+            $e = $this->app->make('helper/validation/error');
+            $e->add(t('You do not have permission to approve page versions.'));
+            $r = new PageEditResponse($e);
         }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
     public function unapprove()
     {
         $c = $this->page;
         $cp = $this->permissions;
-        if ($this->validateAction()) {
+        if ($this->validateAction() && $cp->canApprovePageVersions()) {
+            $cvID = app('helper/security')->sanitizeInt($this->request->request->get('cvID'));
             $r = new PageEditVersionResponse();
-            if ($cp->canApprovePageVersions()) {
-                $cvID = $this->request->request->get('cvID');
-                $r = new PageEditVersionResponse();
-                $r->setPage($c);
-                $u = $this->app->make(User::class);
-                $pkr = new UnapprovePageRequest();
-                $pkr->setRequestedPage($c);
-                $v = CollectionVersion::get($c, $_REQUEST['cvID']);
-                $pkr->setRequestedVersionID($v->getVersionID());
-                $pkr->setRequesterUserID($u->getUserID());
-                $response = $pkr->trigger();
-                if (!($response instanceof WorkflowProgressResponse)) {
-                    // we are deferred
-                    $r->setMessage(t('<strong>Request Saved.</strong> You must complete the workflow before this change is active.'));
-                } else {
-                    $r->addCollectionVersion(CollectionVersion::get($c, $cvID));
-                    $r->setMessage(t('Version %s unapproved successfully', $v->getVersionID()));
-                }
+            $r->setPage($c);
+            $u = $this->app->make(User::class);
+            $pkr = new UnapprovePageRequest();
+            $pkr->setRequestedPage($c);
+            $v = CollectionVersion::get($c, $cvID);
+            $pkr->setRequestedVersionID($v->getVersionID());
+            $pkr->setRequesterUserID($u->getUserID());
+            $response = $pkr->trigger();
+            if (!($response instanceof WorkflowProgressResponse)) {
+                // we are deferred
+                $r->setMessage(t('<strong>Request Saved.</strong> You must complete the workflow before this change is active.'));
             } else {
-                $e = $this->app->make('helper/validation/error');
-                $e->add(t('You do not have permission to approve page versions.'));
-                $r = new PageEditResponse($e);
+                $r->addCollectionVersion(CollectionVersion::get($c, $cvID));
+                $r->setMessage(t('Version %s unapproved successfully', $v->getVersionID()));
             }
-
-            return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSON());
+        } else {
+            $e = $this->app->make('helper/validation/error');
+            $e->add(t('You do not have permission to approve page versions.'));
+            $r = new PageEditResponse($e);
         }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($r->getJSONObject());
     }
 
-    protected function getPageVersionListResponse($currentPage = false)
+    /**
+     * @param int $currentPage The current page of the list (int)
+     *
+     * @return PageEditVersionResponse
+     */
+    protected function getPageVersionListResponse(int $currentPage = 0): PageEditVersionResponse
     {
         $vl = new VersionList($this->page);
         $vl->setItemsPerPage(20);
@@ -240,7 +304,6 @@ class Versions extends BackendInterfacePageController
         $r = new PageEditVersionResponse();
         $r->setPage($this->page);
         $r->setVersionList($vl);
-        $cpCanDeletePageVersions = $this->permissions->canDeletePageVersions();
         foreach ($vArray as $v) {
             $r->addCollectionVersion($v);
         }
@@ -248,13 +311,20 @@ class Versions extends BackendInterfacePageController
         return $r;
     }
 
-    private function countVersions(Collection $c)
+    /**
+     * @param Collection $c
+     *
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return int
+     */
+    private function countVersions(Collection $c): int
     {
         /** @var Connection $database */
         $database = $this->app['database']->connection();
 
-        return $database->fetchOne('select count(cvID) from CollectionVersions where cID = :cID', [
+        return (int) $database->fetchOne('select count(cvID) from CollectionVersions where cID = :cID', [
             ':cID' => $c->getCollectionID(),
-        ]);
+        ], [Types::INTEGER]);
     }
 }


### PR DESCRIPTION
Prior to #10374 page responses returned a json object but they are now returning a json string. 

This means the current version panel is broken and while requests are successful the javascript no longer works. This is because of using `getJSON` instead of `getJSONObject`. JSON responses json_encode whatever is passed to it so getJSON (a string) is encoded as such.

While fixing this I also did the following

added basic PHP Doc blocks
removed some dead code 
return json responses always (no reason not to)
validate page version before attempting to copy it/creating a new page from it
add some calls to helper/security to validate cvIDs
tightened up some types