### PR TITLE
PHP8 Compatibility/PHP Doc Block Update for content/core_area_layout/core_board_slot…

### DIFF
--- a/concrete/blocks/content/add.php
+++ b/concrete/blocks/content/add.php
@@ -1,4 +1,3 @@
 <?php
-
-defined('C5_EXECUTE') or die("Access Denied.");
-echo Core::make("editor")->outputPageInlineEditor('content');
+defined('C5_EXECUTE') or die('Access Denied.');
+echo app('editor')->outputPageInlineEditor('content');

--- a/concrete/blocks/content/composer.php
+++ b/concrete/blocks/content/composer.php
@@ -1,18 +1,22 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var string $label */
+/** @var string $description */
+/** @var Concrete\Block\Content\Controller $controller */
+/** @var Concrete\Core\Page\Type\Composer\Control\BlockControl $view */
 ?>
 
 <div class="form-group">
-	<label><?=$label?></label>
-	<?php if ($description): ?>
+	<label class="form-label" for=""><?=$label?></label>
+	<?php if ($description) { ?>
 	<i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
-	<?php endif; ?>
+	<?php } ?>
 	<?php
     $content = $controller->getContentEditMode();
-    if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if ($controller->getRequest()->getMethod() === 'POST') {
         $data = $view->getRequestValue();
         $content = $data['content'];
     }
-    echo Core::make('editor')->outputPageComposerEditor($view->field('content'), $content);
+    echo app('editor')->outputPageComposerEditor($view->field('content'), $content);
     ?>
 </div>

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -7,6 +7,7 @@ use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
+use Concrete\Core\Page\Page;
 
 /**
  * The controller for the content block.
@@ -15,77 +16,153 @@ use Concrete\Core\File\Tracker\FileTrackableInterface;
  * @subpackage Content
  *
  * @author Andrew Embler <andrew@concrete5.org>
- * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
- * @license    http://www.concrete5.org/license/     MIT License
+ * @copyright  Copyright (c) 2003-2022 concreteCMS. (http://www.concretecms.org)
+ * @license    http://www.concretecms.org/license/     MIT License
  */
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
+    /**
+     * @var string
+     */
     public $content;
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btContentLocal';
+
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 600;
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 465;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockRecord = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineEdit = true;
+
+    /**
+     * @var bool
+     */
     protected $btSupportsInlineAdd = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputForRegisteredUsers = false;
+
+    /**
+     * @var int
+     */
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
+    /**
+     * {@inhertdoc}.
+     */
     public function getRequiredFeatures(): array
     {
         return [
-            Features::IMAGERY
+            Features::IMAGERY,
         ];
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
         return t('HTML/WYSIWYG Editor Content.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
         return t('Content');
     }
 
+    /**
+     * @return string
+     */
     public function getContent()
     {
         return LinkAbstractor::translateFrom($this->content);
     }
 
+    /**
+     * @return string
+     */
     public function getSearchableContent()
     {
         return $this->content;
     }
 
+    /**
+     * @param string $str
+     *
+     * @return array|string|string[]
+     */
     public function br2nl($str)
     {
-        $str = str_replace("\r\n", "\n", $str);
-        $str = str_replace("<br />\n", "\n", $str);
-
-        return $str;
+        return str_replace(["\r\n", "<br />\n", "<br />\r\n"], "\n", $str);
     }
 
+    /**
+     * @return void
+     */
     public function view()
     {
         $this->set('content', $this->getContent());
     }
 
+    /**
+     * @return string
+     */
     public function getContentEditMode()
     {
         return LinkAbstractor::translateFromEditMode($this->content);
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param Page $page
+     *
+     * @return array<string, string>
+     */
     public function getImportData($blockNode, $page)
     {
         $content = $blockNode->data->record->content;
         $content = LinkAbstractor::import($content);
-        $args = ['content' => $content];
 
-        return $args;
+        return ['content' => $content];
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     *
+     * @return void
+     */
     public function export(\SimpleXMLElement $blockNode)
     {
         $data = $blockNode->addChild('data');
@@ -99,6 +176,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         $node->appendChild($cdata);
     }
 
+    /**
+     * @param array<string,string> $args
+     */
     public function save($args)
     {
         if (isset($args['content'])) {
@@ -107,6 +187,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         parent::save($args);
     }
 
+    /**
+     * @return int[]|string[]
+     */
     public function getUsedFiles()
     {
         return array_merge(
@@ -115,6 +198,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         );
     }
 
+    /**
+     * @return int[]|string[]
+     */
     protected function getUsedFilesImages()
     {
         $files = [];
@@ -129,16 +215,18 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         return $files;
     }
 
+    /**
+     * @return int[]|string[]
+     */
     protected function getUsedFilesDownload()
     {
         preg_match_all('(FID_DL_\d+)', $this->content, $matches);
 
         return array_map(
             function ($match) {
-                return (explode('_', $match)[2]);
+                return explode('_', $match)[2];
             },
             $matches[0]
         );
     }
-
 }

--- a/concrete/blocks/content/edit.php
+++ b/concrete/blocks/content/edit.php
@@ -1,5 +1,5 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
-
-echo Core::make("editor")->outputPageInlineEditor('content', $controller->getContentEditMode());
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Block\Content\Controller $controller */
+echo app('editor')->outputPageInlineEditor('content', $controller->getContentEditMode());

--- a/concrete/blocks/content/scrapbook.php
+++ b/concrete/blocks/content/scrapbook.php
@@ -1,11 +1,12 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Block\Content\Controller $controller */
 
 $content = $controller->getContent();
-$forbiddenTags = array('iframe', 'script', 'object', 'embed');
+$forbiddenTags = ['iframe', 'script', 'object', 'embed'];
 foreach ($forbiddenTags as $forbiddenTag) {
-    $content = preg_replace("~<".$forbiddenTag."[^>]*>(.*)</".$forbiddenTag.">~i", "$2", $content);
-    $content = preg_replace("~<".$forbiddenTag."[^>]*>~i", "", $content);
+    $content = preg_replace('~<' . $forbiddenTag . '[^>]*>(.*)</' . $forbiddenTag . '>~i', '$2', $content);
+    $content = preg_replace('~<' . $forbiddenTag . '[^>]*>~i', '', $content);
 }
-echo ''.$content;
+echo '' . $content;

--- a/concrete/blocks/content/view.php
+++ b/concrete/blocks/content/view.php
@@ -1,10 +1,13 @@
 <?php
-    defined('C5_EXECUTE') or die("Access Denied.");
-    $c = Page::getCurrentPage();
+    defined('C5_EXECUTE') or die('Access Denied.');
+    /** @var \Concrete\Block\Content\Controller $controller */
+    /** @var string $content */
+
+    $c = \Concrete\Core\Page\Page::getCurrentPage();
     if (!$content && is_object($c) && $c->isEditMode()) {
         ?>
 		<div class="ccm-edit-mode-disabled-item"><?=t('Empty Content Block.')?></div> 
-	<?php 
+	<?php
     } else {
         echo $content;
     }

--- a/concrete/blocks/core_area_layout/add.php
+++ b/concrete/blocks/core_area_layout/add.php
@@ -1,5 +1,6 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
+    /** @var \Concrete\Core\Block\View\BlockView $this */
     $this->inc('form.php');
 ?>
 <div id="ccm-layouts-edit-mode" class="ccm-layouts-edit-mode-add"></div>

--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -281,9 +281,10 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param \SimpleXMLElement $blockNode
+     * @param \Concrete\Core\Page\Page $page
      *
-     * @see \Concrete\Core\Block\BlockController::getImportData()
+     * @return array<string,mixed>
      */
     public function getImportData($blockNode, $page)
     {
@@ -305,6 +306,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $args['span'][] = (int) $column['span'];
                     $args['offset'][] = (int) $column['offset'];
                 }
+
                 return $args;
             case 'preset':
                 $preset = $this->resolveLayoutPreset(isset($node['preset-id']) ? (string) $node['preset-id'] : '', $page);

--- a/concrete/blocks/core_area_layout/edit.php
+++ b/concrete/blocks/core_area_layout/edit.php
@@ -1,6 +1,6 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
-
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $minColumns = 1;
 $columnsNum = $columnsNum ?? 1;
 $maxColumns = $maxColumns ?? 12;

--- a/concrete/blocks/core_area_layout/edit_grid.php
+++ b/concrete/blocks/core_area_layout/edit_grid.php
@@ -11,6 +11,7 @@ $columns = $columns ?? [];
     /** @var \Concrete\Core\Block\View\BlockView $view */
     /** @var \Concrete\Core\Area\Area $a */
     /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
+    /** @var \Concrete\Core\Block\View\BlockView $this */
     $this->inc('form.php', ['b' => $b, 'a' => $a]);
 
 ?>

--- a/concrete/blocks/core_area_layout/edit_preset.php
+++ b/concrete/blocks/core_area_layout/edit_preset.php
@@ -11,6 +11,7 @@ $columns = $columns ?? [];
     /** @var \Concrete\Core\Area\Area $a */
     /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
     /** @var \Concrete\Core\Area\Layout\Formatter\FormatterInterface $formatter */
+    /** @var \Concrete\Core\Block\View\BlockView $this */
     $this->inc('form.php', ['b' => $b, 'a' => $a]);
 
 ?>

--- a/concrete/blocks/core_area_layout/form.php
+++ b/concrete/blocks/core_area_layout/form.php
@@ -1,6 +1,5 @@
 <?php
     defined('C5_EXECUTE') or die('Access Denied.');
-
     $minColumns = 1;
     $columnsNum = $columnsNum ?? 1;
     $maxColumns = $maxColumns ?? 12;
@@ -10,7 +9,7 @@
     /** @var \Concrete\Core\Block\View\BlockView $view */
     /** @var \Concrete\Core\Area\Area $a */
     /** @var \Concrete\Core\Page\Theme\GridFramework\GridFramework $themeGridFramework */
-    if ($controller->getTask() == 'add') {
+    if ($controller->getAction() === 'add') {
         $spacing = 0;
         $iscustom = false;
     }
@@ -48,10 +47,10 @@
 	</li>
 	<li data-grid-form-view="themegrid">
 		<label for="themeGridColumns"><?=t('Columns:')?></label>
-		<input type="number" name="themeGridColumns" id="themeGridColumns" style="width: 40px" <?php if ($controller->getTask() == 'add') {
+		<input type="number" name="themeGridColumns" id="themeGridColumns" style="width: 40px" <?php if ($controller->getAction() === 'add') {
     ?>  min="<?=$minColumns?>" max="<?= $themeGridMaxColumns ?? '' ?>" <?php
 } ?> value="<?=$columnsNum?>" />
-		<?php if ($controller->getTask() == 'edit') {
+		<?php if ($controller->getAction() === 'edit') {
     // we need this to actually go through the form in edit mode, for layout presets to be saveable in edit mode.?>
 			<input type="hidden" name="themeGridColumns" value="<?=$columnsNum?>" />
 		<?php
@@ -59,10 +58,10 @@
 	</li>
 	<li data-grid-form-view="custom" class="ccm-sub-toolbar-text-cell">
 		<label for="columns"><?=t('Columns:')?></label>
-		<input type="number" name="columns" id="columns" style="width: 40px" <?php if ($controller->getTask() == 'add') {
+		<input type="number" name="columns" id="columns" style="width: 40px" <?php if ($controller->getAction() === 'add') {
     ?> min="<?=$minColumns?>" max="<?=$maxColumns?>" <?php
 } ?> value="<?=$columnsNum?>" />
-		<?php if ($controller->getTask() == 'edit') {
+		<?php if ($controller->getAction() === 'edit') {
     // we need this to actually go through the form in edit mode, for layout presets to be saveable in edit mode.?>
 			<input type="hidden" name="columns" value="<?=$columnsNum?>" />
 		<?php
@@ -81,7 +80,7 @@
     ?>0<?php
 } ?>" />
 	</li>
-	<?php if ($controller->getTask() == 'edit') {
+	<?php if ($controller->getAction() === 'edit') {
     $bp = new \Concrete\Core\Permission\Checker($b);
     ?>
 
@@ -103,7 +102,7 @@
 		<button id="ccm-layouts-cancel-button" type="button" class="btn btn-mini"><?=t('Cancel')?></button>
 	</li>
 	<li class="ccm-inline-toolbar-button ccm-inline-toolbar-button-save">
-	  <button class="btn btn-primary" type="button" id="ccm-layouts-save-button"><?php if ($controller->getTask() == 'add') {
+	  <button class="btn btn-primary" type="button" id="ccm-layouts-save-button"><?php if ($controller->getAction() === 'add') {
     ?><?=t('Add Layout')?><?php
 } else {
     ?><?=t('Update Layout')?><?php
@@ -111,7 +110,7 @@
 	</li>
 </ul>
 
-	<?php if ($controller->getTask() == 'add') {
+	<?php if ($controller->getAction() === 'add') {
     ?>
 		<input name="arLayoutMaxColumns" type="hidden" value="<?=$view->getAreaObject()->getAreaGridMaximumColumns()?>" />
 	<?php
@@ -120,7 +119,7 @@
 <script type="text/javascript">
 <?php
 
-if ($controller->getTask() == 'edit') {
+if ($controller->getAction() === 'edit') {
     $editing = 'true';
 } else {
     $editing = 'false';
@@ -132,7 +131,7 @@ $(function() {
 
 
 	<?php
-    if ($controller->getTask() == 'edit') {
+    if ($controller->getAction() === 'edit') {
         ?>
 	$('#ccm-layouts-toolbar').on('click', 'a[data-menu-action=delete-layout]', function(e) {
 		var editor = new Concrete.getEditMode(),
@@ -161,7 +160,7 @@ $(function() {
 		'rowend': '<?=addslashes($themeGridFramework->getPageThemeGridFrameworkRowEndHTML())?>',
         'additionalGridColumnClasses': '<?=$themeGridFramework->getPageThemeGridFrameworkColumnAdditionalClasses()?>',
         'additionalGridColumnOffsetClasses': '<?=$themeGridFramework->getPageThemeGridFrameworkColumnOffsetAdditionalClasses()?>',
-		<?php if ($controller->getTask() == 'add') {
+		<?php if ($controller->getAction() === 'add') {
     ?>
 		'maxcolumns': '<?=$controller->getAreaObject()->getAreaGridMaximumColumns()?>',
 		<?php
@@ -174,10 +173,10 @@ $(function() {
 		'gridColumnClasses': [
 			<?php $classes = $themeGridFramework->getPageThemeGridFrameworkColumnClasses();
     ?>
-			<?php for ($i = 0; $i < count($classes); $i++) {
+			<?php for ($i = 0,$iMax = count($classes); $i < $iMax; $i++) {
     $class = $classes[$i];
     ?>
-				'<?=$class?>' <?php if (($i + 1) < count($classes)) {
+				'<?=$class?>' <?php if (($i + 1) < $iMax) {
     ?>, <?php
 }
     ?>
@@ -198,5 +197,5 @@ $(function() {
 </script>
 
 <div class="ccm-area-layout-control-bar-wrapper">
-	<div id="ccm-area-layout-active-control-bar" class="ccm-area-layout-control-bar ccm-area-layout-control-bar-<?=$controller->getTask()?>"></div>
+	<div id="ccm-area-layout-active-control-bar" class="ccm-area-layout-control-bar ccm-area-layout-control-bar-<?=$controller->getAction()?>"></div>
 </div>

--- a/concrete/blocks/core_board_slot/controller.php
+++ b/concrete/blocks/core_board_slot/controller.php
@@ -1,41 +1,73 @@
 <?php
+
 namespace Concrete\Block\CoreBoardSlot;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Board\Instance\Slot\Content\ContentRenderer;
 use Concrete\Core\Entity\Board\SlotTemplate;
-use Concrete\Core\Feature\Features;
-use Concrete\Core\Feature\UsesFeatureInterface;
 use Doctrine\ORM\EntityManager;
 
 class Controller extends BlockController
 {
-    protected $btTable = 'btCoreBoardSlot';
-    protected $btIsInternal = true;
-    protected $btIgnorePageThemeGridFrameworkContainer = true;
-
+    /**
+     * @var string|null
+     */
     public $contentObjectCollection;
 
+    /**
+     * @var int|null
+     */
     public $slotTemplateID;
 
+    /**
+     * @var int|null
+     */
     public $instanceSlotID;
 
+    /**
+     * @var string
+     */
+    protected $btTable = 'btCoreBoardSlot';
+
+    /**
+     * @var bool
+     */
+    protected $btIsInternal = true;
+
+    /**
+     * @var bool
+     */
+    protected $btIgnorePageThemeGridFrameworkContainer = true;
+
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Proxy block for board slots.");
+        return t('Proxy block for board slots.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Board Slot");
+        return t('Board Slot');
     }
 
+    /**
+     * @return int|null
+     */
     public function getInstanceSlotID()
     {
         return $this->instanceSlotID;
     }
 
-
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $entityManager = $this->app->make(EntityManager::class);
@@ -46,5 +78,4 @@ class Controller extends BlockController
         $this->set('renderer', $renderer);
         $this->set('template', $template);
     }
-
 }

--- a/concrete/blocks/core_container/controller.php
+++ b/concrete/blocks/core_container/controller.php
@@ -125,6 +125,7 @@ class Controller extends BlockController
     {
         $instance = $this->getContainerInstanceObject();
         if ($instance) {
+            /** @var \Concrete\Core\Page\Page $page */
             $page = $this->getBlockObject()->getBlockCollectionObject();
             $exporter = new ContainerExporter($page);
             $exporter->export($instance, $blockNode);
@@ -184,7 +185,7 @@ class Controller extends BlockController
                 ->fetchOne();
             if ($count < 1) {
                 // This container instance is no longer in use. So let's remove the data associated with it.
-                foreach($instance->getInstanceAreas() as $instanceArea) {
+                foreach ($instance->getInstanceAreas() as $instanceArea) {
                     $containerBlockInstance = new ContainerBlockInstance(
                         $this->getBlockObject(),
                         $instance,
@@ -192,7 +193,7 @@ class Controller extends BlockController
                     );
                     $containerArea = new ContainerArea($containerBlockInstance, $instanceArea->getContainerAreaName());
                     $subBlocks = $containerArea->getAreaBlocksArray($this->getCollectionObject());
-                    foreach($subBlocks as $subBlock) {
+                    foreach ($subBlocks as $subBlock) {
                         $subBlock->delete();
                     }
                 }
@@ -217,6 +218,7 @@ class Controller extends BlockController
         $db = $this->app->make(Connection::class);
         // such a pain
         $this->containerInstanceID = $db->fetchColumn('select containerInstanceID from btCoreContainer where bID = ?', [$b->getBlockID()]);
+        /** @var \Concrete\Core\Page\Page $page */
         $page = $b->getBlockCollectionObject();
 
         $instance = $this->getContainerInstanceObject();

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -451,6 +451,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         }
     }
 
+    /**
+     * @param \SimpleXMLElement $blockNode
+     * @param \Concrete\Core\Page\Page $page
+     * @return array<string,mixed>
+     */
     protected function getImportData($blockNode, $page)
     {
         $args = [];


### PR DESCRIPTION
… and core_container blocks

This PR is split from In regards to https://github.com/concrete5/concrete5/pull/10300 to make it easer to review

This PR adds PHP doc blocks to the content/core_area_layout/core_board_slot and core_container blocks
It also passes phpstan level 6
add small php doc block to BlockController.php getImportData (since other blocks reference it)
remove some depreciated methods, use the app helper function over Core::make
