### PR TITLE
PHP8 Compatibility/PHP Doc Block Update for Conversations

### DIFF
--- a/concrete/blocks/core_conversation/add.php
+++ b/concrete/blocks/core_conversation/add.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/core_conversation/add.php
+++ b/concrete/blocks/core_conversation/add.php
@@ -1,4 +1,5 @@
 <?php
 
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -104,6 +104,8 @@ class Controller extends BlockController implements UsesFeatureInterface
     }
 
     /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
      * @return string
      */
     public function getSearchableContent()
@@ -152,7 +154,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function duplicate_master($newBID, $newPage)
     {
-        parent::duplicate($newBID);
+        $this->duplicate($newBID);
         $db = $this->app->make('database');
         $conv = Conversation::add();
         $conv->setConversationPageObject($newPage);
@@ -322,11 +324,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         ];
         if ($values['attachmentOverridesEnabled']) {
             $conversation->setConversationAttachmentOverridesEnabled((int) ($values['attachmentOverridesEnabled']));
-            if ($values['attachmentsEnabled']) {
-                $conversation->setConversationAttachmentsEnabled(1);
-            } else {
-                $conversation->setConversationAttachmentsEnabled(0);
-            }
+            $conversation->setConversationAttachmentsEnabled($values['attachmentsEnabled'] ? 1 : 0);
         } else {
             $conversation->setConversationAttachmentOverridesEnabled(0);
         }
@@ -396,7 +394,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         /** @var PageKey $key */
         foreach ($keys as $key) {
-            if ($key->getAttributeType()->getAttributeTypeHandle() == 'rating') {
+            if ($key->getAttributeType()->getAttributeTypeHandle() === 'rating') {
                 yield $key->getAttributeKeyID() => $key->getAttributeKeyDisplayName();
             }
         }

--- a/concrete/blocks/core_conversation/edit.php
+++ b/concrete/blocks/core_conversation/edit.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/core_conversation/edit.php
+++ b/concrete/blocks/core_conversation/edit.php
@@ -1,4 +1,5 @@
 <?php
 
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -5,11 +5,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Conversation\Conversation;
 use Concrete\Core\File\Service\Application as FileApplication;
-use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Form\Service\Widget\UserSelector;
 use Concrete\Core\Support\Facade\Application;
 
-/** @var \Concrete\Block\CoreConversation\Controller $controller */
+/** @var Concrete\Block\CoreConversation\Controller $controller */
 /** @var int $cnvID */
 /** @var int $enablePosting */
 /** @var bool $paginate */
@@ -37,18 +36,18 @@ use Concrete\Core\Support\Facade\Application;
 /** @var bool|null $notificationOverridesEnabled */
 /** @var bool $subscriptionEnabled */
 /** @var \Concrete\Core\User\UserInfo[] $notificationUsers */
+/** @var Concrete\Core\Form\Service\Form $form */
 
 $app = Application::getFacadeApplication();
-/** @var Repository $config */
+/** @var Concrete\Core\Config\Repository\Repository $config */
 $config = $app->make(Repository::class);
-/** @var Form $form */
-$form = $app->make(Form::class);
-/** @var FileApplication $helperFile */
+
+/** @var Concrete\Core\File\Service\Application $helperFile */
 $helperFile = $app->make(FileApplication::class);
-/** @var UserSelector $userSelector */
+/** @var Concrete\Core\Form\Service\Widget\UserSelector $userSelector */
 $userSelector = $app->make(UserSelector::class);
 
-if ($controller->getAction() == 'add') {
+if ($controller->getAction() === 'add') {
     $enablePosting = 1;
     $paginate = 1;
     $itemsPerPage = 50;

--- a/concrete/blocks/core_conversation/form.php
+++ b/concrete/blocks/core_conversation/form.php
@@ -4,17 +4,18 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Conversation\Conversation;
+use Concrete\Core\File\Service\Application as FileApplication;
 use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Form\Service\Widget\UserSelector;
 use Concrete\Core\Support\Facade\Application;
-use \Concrete\Core\File\Service\Application as FileApplication;
 
+/** @var \Concrete\Block\CoreConversation\Controller $controller */
 /** @var int $cnvID */
 /** @var int $enablePosting */
 /** @var bool $paginate */
 /** @var int $itemsPerPage */
 /** @var string $displayMode */
-/** @var string $orderBy */
+/** @var string|null $orderBy */
 /** @var bool $enableOrdering */
 /** @var bool $enableCommentRating */
 /** @var bool $enableTopCommentReviews */
@@ -23,9 +24,9 @@ use \Concrete\Core\File\Service\Application as FileApplication;
 /** @var string $displayPostingForm */
 /** @var string $addMessageLabel */
 /** @var string $dateFormat */
-/** @var string $customDateFormat */
+/** @var string|null $customDateFormat */
 
-/** @var array $reviewAttributeKeys */
+/** @var array<string|int,string>|null $reviewAttributeKeys */
 /** @var int $maxFilesGuest */
 /** @var int $maxFilesRegistered */
 /** @var int $maxFileSizeGuest */
@@ -33,9 +34,9 @@ use \Concrete\Core\File\Service\Application as FileApplication;
 /** @var string $fileExtensions */
 /** @var bool $attachmentsEnabled */
 /** @var bool $attachmentOverridesEnabled */
-/** @var bool $notificationOverridesEnabled */
+/** @var bool|null $notificationOverridesEnabled */
 /** @var bool $subscriptionEnabled */
-/** @var array $notificationUsers */
+/** @var \Concrete\Core\User\UserInfo[] $notificationUsers */
 
 $app = Application::getFacadeApplication();
 /** @var Repository $config */
@@ -74,17 +75,17 @@ if ($controller->getAction() == 'add') {
     $maxFilesGuest = $config->get('conversations.files.guest.max');
     $maxFilesRegistered = $config->get('conversations.files.registered.max');
     $fileExtensions = implode(',', $fileAccessFileTypes);
-    $attachmentsEnabled = intval($config->get('conversations.attachments_enabled'));
+    $attachmentsEnabled = (int) ($config->get('conversations.attachments_enabled'));
     $notificationUsers = Conversation::getDefaultSubscribedUsers();
-    $subscriptionEnabled = intval($config->get('conversations.subscription_enabled'));
+    $subscriptionEnabled = (int) ($config->get('conversations.subscription_enabled'));
 }
 $fileAccessFileTypesDenylist = $config->get('conversations.files.disallowed_types');
 
 if ($fileAccessFileTypesDenylist === null) {
     $fileAccessFileTypesDenylist = $config->get('concrete.upload.extensions_denylist', $config->get('concrete.upload.extensions_blacklist'));
 }
-
-$fileAccessFileTypesDenylist = $helperFile->unserializeUploadFileExtensions($fileAccessFileTypesDenylist);
+/** @var string[]|string|false|null $fileAccessFileTypesDenylist All of the possible returns from preg_* methods */
+$fileAccessFileTypesDenylist = $helperFile->unSerializeUploadFileExtensions($fileAccessFileTypesDenylist);
 
 if (empty($dateFormat)) {
     $dateFormat = 'default';
@@ -98,46 +99,46 @@ if (empty($dateFormat)) {
     </legend>
 
     <div class="form-group">
-        <?php echo $form->label("displayMode", t('Display Mode')); ?>
+        <?php echo $form->label('displayMode', t('Display Mode')); ?>
 
         <div class="form-check">
-            <?php echo $form->radio('displayMode', 'threaded', $displayMode, ["name" => "displayMode", "id" => "displayModeThreaded"]) ?>
-            <?php echo $form->label("displayModeThreaded", t('Threaded'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('displayMode', 'threaded', $displayMode, ['name' => 'displayMode', 'id' => 'displayModeThreaded']) ?>
+            <?php echo $form->label('displayModeThreaded', t('Threaded'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('displayMode', 'flat', $displayMode, ["name" => "displayMode", "id" => "displayModeFlat"]) ?>
-            <?php echo $form->label("displayModeFlat", t('Flat'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('displayMode', 'flat', $displayMode, ['name' => 'displayMode', 'id' => 'displayModeFlat']) ?>
+            <?php echo $form->label('displayModeFlat', t('Flat'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("orderBy", t('Ordering')); ?>
-        <?php echo $form->select('orderBy', array('date_asc' => t('Earliest First'), 'date_desc' => t('Most Recent First'), 'rating' => t('Highest Rated')), $orderBy ?? '') ?>
+        <?php echo $form->label('orderBy', t('Ordering')); ?>
+        <?php echo $form->select('orderBy', ['date_asc' => t('Earliest First'), 'date_desc' => t('Most Recent First'), 'rating' => t('Highest Rated')], $orderBy ?? '') ?>
 
         <div class="form-check">
             <?php echo $form->checkbox('enableOrdering', 1, $enableOrdering) ?>
-            <?php echo $form->label("enableOrdering", t('Display Ordering Option in Page'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('enableOrdering', t('Display Ordering Option in Page'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("", t('Rating')); ?>
+        <?php echo $form->label('', t('Rating')); ?>
 
         <div class="form-check">
             <?php echo $form->checkbox('enableCommentRating', 1, $enableCommentRating) ?>
-            <?php echo $form->label("enableCommentRating", t('Enable Comment Rating'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('enableCommentRating', t('Enable Comment Rating'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
             <?php echo $form->checkbox('enableTopCommentReviews', 1, $enableTopCommentReviews) ?>
-            <?php echo $form->label("enableTopCommentReviews", t('Turn Top-Level Posts into Reviews'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('enableTopCommentReviews', t('Turn Top-Level Posts into Reviews'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <?php if (isset($reviewAttributeKeys)) { ?>
         <div class="form-group" data-unhide="[name=enableTopCommentReviews]">
-            <?php echo $form->label("reviewAggregateAttributeKey", t('Aggregate Ratings by Attribute')); ?>
+            <?php echo $form->label('reviewAggregateAttributeKey', t('Aggregate Ratings by Attribute')); ?>
 
             <?php if (count($reviewAttributeKeys) > 0) { ?>
                 <?php echo $form->select('reviewAggregateAttributeKey', $reviewAttributeKeys, $reviewAggregateAttributeKey); ?>
@@ -150,31 +151,31 @@ if (empty($dateFormat)) {
     <?php } ?>
 
     <div class="form-group">
-        <?php echo $form->label("displaySocialLinks", t('Social Sharing Links')); ?>
+        <?php echo $form->label('displaySocialLinks', t('Social Sharing Links')); ?>
 
         <div class="form-check">
             <?php echo $form->checkbox('displaySocialLinks', 1, $displaySocialLinks) ?>
-            <?php echo $form->label("displaySocialLinks", t('Display social sharing links'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('displaySocialLinks', t('Display social sharing links'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("paginate", t('Paginate Message List')); ?>
+        <?php echo $form->label('paginate', t('Paginate Message List')); ?>
 
         <div class="form-check">
-            <?php echo $form->radio('paginate', 0, $paginate, ["name" => "paginate", "id" => "paginateNo"]) ?>
-            <?php echo $form->label("paginateNo", t('No, display all messages.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('paginate', 0, $paginate, ['name' => 'paginate', 'id' => 'paginateNo']) ?>
+            <?php echo $form->label('paginateNo', t('No, display all messages.'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('paginate', 1, $paginate, ["name" => "paginate", "id" => "paginateYes"]) ?>
-            <?php echo $form->label("paginateYes", t('Yes, display only a sub-set of messages at a time.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('paginate', 1, $paginate, ['name' => 'paginate', 'id' => 'paginateYes']) ?>
+            <?php echo $form->label('paginateYes', t('Yes, display only a sub-set of messages at a time.'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group" data-row="itemsPerPage">
-        <?php echo $form->label("itemsPerPage", t('Messages Per Page')); ?>
-        <?php echo $form->text('itemsPerPage', $itemsPerPage, array('class' => 'span1')) ?>
+        <?php echo $form->label('itemsPerPage', t('Messages Per Page')); ?>
+        <?php echo $form->text('itemsPerPage', (string) $itemsPerPage, ['class' => 'span1']) ?>
     </div>
 </fieldset>
 
@@ -189,51 +190,51 @@ if (empty($dateFormat)) {
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("", t('Enable Posting')); ?>
+        <?php echo $form->label('', t('Enable Posting')); ?>
 
         <div class="form-check">
-            <?php echo $form->radio('enablePosting', 1, $enablePosting, ["name" => "enablePosting", "id" => "enablePostingYes"]) ?>
-            <?php echo $form->label("enablePostingYes", t('Yes, this conversation accepts messages and replies.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('enablePosting', 1, $enablePosting, ['name' => 'enablePosting', 'id' => 'enablePostingYes']) ?>
+            <?php echo $form->label('enablePostingYes', t('Yes, this conversation accepts messages and replies.'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('enablePosting', 0, $enablePosting, ["name" => "enablePosting", "id" => "enablePostingNo"]) ?>
-            <?php echo $form->label("enablePostingNo", t('No, posting is disabled.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('enablePosting', 0, $enablePosting, ['name' => 'enablePosting', 'id' => 'enablePostingNo']) ?>
+            <?php echo $form->label('enablePostingNo', t('No, posting is disabled.'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group">
-        <?php echo $form->label("", t('Display Posting Form')); ?>
+        <?php echo $form->label('', t('Display Posting Form')); ?>
 
         <div class="form-check">
-            <?php echo $form->radio('displayPostingForm', 'top', $displayPostingForm, ["name" => "displayPostingForm", "id" => "displayPostingFormTop"]) ?>
-            <?php echo $form->label("displayPostingFormTop", t('Top'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('displayPostingForm', 'top', $displayPostingForm, ['name' => 'displayPostingForm', 'id' => 'displayPostingFormTop']) ?>
+            <?php echo $form->label('displayPostingFormTop', t('Top'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('displayPostingForm', 'bottom', $displayPostingForm, ["name" => "displayPostingForm", "id" => "displayPostingFormBottom"]) ?>
-            <?php echo $form->label("displayPostingFormBottom", t('Bottom'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('displayPostingForm', 'bottom', $displayPostingForm, ['name' => 'displayPostingForm', 'id' => 'displayPostingFormBottom']) ?>
+            <?php echo $form->label('displayPostingFormBottom', t('Bottom'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 </fieldset>
 
 <fieldset>
     <div class="form-group">
-        <?php echo $form->label("", t('Date Format')); ?>
+        <?php echo $form->label('', t('Date Format')); ?>
 
         <div class="form-check">
-            <?php echo $form->radio('dateFormat', 'default', $dateFormat, ["name" => "dateFormat", "id" => "dateFormatDefault"]) ?>
-            <?php echo $form->label("dateFormatDefault", t('Use Site Default.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('dateFormat', 'default', $dateFormat, ['name' => 'dateFormat', 'id' => 'dateFormatDefault']) ?>
+            <?php echo $form->label('dateFormatDefault', t('Use Site Default.'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('dateFormat', 'elapsed', $dateFormat, ["name" => "dateFormat", "id" => "dateFormatElapsed"]) ?>
-            <?php echo $form->label("dateFormatElapsed", t('Time elapsed since post.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('dateFormat', 'elapsed', $dateFormat, ['name' => 'dateFormat', 'id' => 'dateFormatElapsed']) ?>
+            <?php echo $form->label('dateFormatElapsed', t('Time elapsed since post.'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-check">
-            <?php echo $form->radio('dateFormat', 'custom', $dateFormat, ["name" => "dateFormat", "id" => "dateFormatCustom"]) ?>
-            <?php echo $form->label("dateFormatCustom", t('Custom Date Format'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->radio('dateFormat', 'custom', $dateFormat, ['name' => 'dateFormat', 'id' => 'dateFormatCustom']) ?>
+            <?php echo $form->label('dateFormatCustom', t('Custom Date Format'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="form-group" data-row="customDateFormat">
@@ -259,19 +260,19 @@ if (empty($dateFormat)) {
 
         <div class="form-check">
             <?php echo $form->checkbox('attachmentOverridesEnabled', 1, $attachmentOverridesEnabled) ?>
-            <?php echo $form->label("attachmentOverridesEnabled", t('Enable Attachment Overrides'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('attachmentOverridesEnabled', t('Enable Attachment Overrides'), ['class' => 'form-check-label']) ?>
         </div>
 
         <div class="attachment-overrides">
             <div class="form-check">
                 <?php echo $form->checkbox('attachmentsEnabled', 1, $attachmentsEnabled) ?>
-                <?php echo $form->label("attachmentsEnabled", t('Enable Attachments'), ["class" => "form-check-label"]) ?>
+                <?php echo $form->label('attachmentsEnabled', t('Enable Attachments'), ['class' => 'form-check-label']) ?>
             </div>
         </div>
     </div>
 
     <div class="form-group attachment-overrides">
-        <?php echo $form->label("maxFileSizeGuest", t('Max Attachment Size for Guest Users. (MB)')); ?>
+        <?php echo $form->label('maxFileSizeGuest', t('Max Attachment Size for Guest Users. (MB)')); ?>
 
         <div class="controls">
             <?php echo $form->text('maxFileSizeGuest', $maxFileSizeGuest > 0 ? $maxFileSizeGuest : '') ?>
@@ -279,7 +280,7 @@ if (empty($dateFormat)) {
     </div>
 
     <div class="form-group attachment-overrides">
-        <?php echo $form->label("maxFileSizeRegistered", t('Max Attachment Size for Registered Users. (MB)')); ?>
+        <?php echo $form->label('maxFileSizeRegistered', t('Max Attachment Size for Registered Users. (MB)')); ?>
 
         <div class="controls">
             <?php echo $form->text('maxFileSizeRegistered', $maxFileSizeRegistered > 0 ? $maxFileSizeRegistered : '') ?>
@@ -287,7 +288,7 @@ if (empty($dateFormat)) {
     </div>
 
     <div class="form-group attachment-overrides">
-        <?php echo $form->label("maxFilesGuest", t('Max Attachments Per Message for Guest Users.')); ?>
+        <?php echo $form->label('maxFilesGuest', t('Max Attachments Per Message for Guest Users.')); ?>
 
         <div class="controls">
             <?php echo $form->text('maxFilesGuest', $maxFilesGuest > 0 ? $maxFilesGuest : '') ?>
@@ -295,7 +296,7 @@ if (empty($dateFormat)) {
     </div>
 
     <div class="form-group attachment-overrides">
-        <?php echo $form->label("maxFilesRegistered", t('Max Attachments Per Message for Registered Users.')); ?>
+        <?php echo $form->label('maxFilesRegistered', t('Max Attachments Per Message for Registered Users.')); ?>
 
         <div class="controls">
             <?php echo $form->text('maxFilesRegistered', $maxFilesRegistered > 0 ? $maxFilesRegistered : '') ?>
@@ -303,12 +304,12 @@ if (empty($dateFormat)) {
     </div>
 
     <div class="form-group attachment-overrides">
-        <?php echo $form->label("fileExtensions", t('Allowed File Extensions (Comma separated, no periods).')); ?>
+        <?php echo $form->label('fileExtensions', t('Allowed File Extensions (Comma separated, no periods).')); ?>
 
         <div class="controls">
             <?php echo $form->textarea('fileExtensions', $fileExtensions) ?>
 
-            <?php if (isset($fileAccessFileTypesDenylist) && is_array($fileAccessFileTypesDenylist) && count($fileAccessFileTypesDenylist) > 0) { ?>
+            <?php if (is_array($fileAccessFileTypesDenylist) && count($fileAccessFileTypesDenylist) > 0) { ?>
                 <div class="text-muted small">
                     <?php echo t('These file extensions will always be blocked: %s', '<code>' . implode('</code>, <code>', $fileAccessFileTypesDenylist) . '</code>') ?>
                     <br/>
@@ -327,21 +328,21 @@ if (empty($dateFormat)) {
     <div class="form-group">
         <div class="form-check">
             <?php echo $form->checkbox('notificationOverridesEnabled', 1, $notificationOverridesEnabled ?? false) ?>
-            <?php echo $form->label("notificationOverridesEnabled", t('Override Global Settings'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('notificationOverridesEnabled', t('Override Global Settings'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 
     <div class="form-group notification-overrides">
-        <?php echo $form->label("notificationUsers", t('Users To Receive Conversation Notifications')); ?>
+        <?php echo $form->label('notificationUsers', t('Users To Receive Conversation Notifications')); ?>
         <?php echo $userSelector->selectMultipleUsers('notificationUsers', $notificationUsers) ?>
     </div>
 
     <div class="form-group notification-overrides">
-        <?php echo $form->label("", t('Subscribe Option')); ?>
+        <?php echo $form->label('', t('Subscribe Option')); ?>
 
         <div class="form-check">
             <?php echo $form->checkbox('subscriptionEnabled', 1, $subscriptionEnabled) ?>
-            <?php echo $form->label("subscriptionEnabled", t('Yes, allow registered users to choose to subscribe to conversations.'), ["class" => "form-check-label"]) ?>
+            <?php echo $form->label('subscriptionEnabled', t('Yes, allow registered users to choose to subscribe to conversations.'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 </fieldset>

--- a/concrete/blocks/core_conversation/view.php
+++ b/concrete/blocks/core_conversation/view.php
@@ -1,17 +1,24 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
-
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 /** @var bool|string $paginate */
 $paginate = ($paginate ?? null) ? 'true' : 'false';
 /** @var int $itemsPerPage */
 $itemsPerPage = ($paginate === 'true') ? $itemsPerPage ?? 50 : -1;
-$blockAreaHandle = $this->block->getAreaHandle();
+/** @var \Concrete\Core\Block\Block $b */
+$blockAreaHandle = $b->getAreaHandle();
 /** @var int $maxFileSizeRegistered */
 /** @var int $maxFileSizeGuest */
 /** @var int $maxFilesRegistered */
 /** @var int $maxFilesGuest */
 /** @var int $bID */
 /** @var int $cID */
+
+$newCollectionID = null;
+if ($b->getBlockCollectionID()) {
+    // Fix for when using stacks (for sitewide conversations)
+    $newCollectionID = $b->getBlockCollectionID();
+}
 
 /** @var \Concrete\Core\User\User $u */
 $u = app(Concrete\Core\User\User::class);
@@ -56,7 +63,7 @@ if (isset($conversation) && is_object($conversation)) { ?>
         $('div[data-conversation-id=<?=$conversation->getConversationID()?>]').concreteConversation({
             cnvID: <?=$conversation->getConversationID()?>,
             blockID: <?=$bID?>,
-            cID: <?=$cID?>,
+            cID: <?=$newCollectionID ?? $cID?>,
             addMessageToken: '<?=$addMessageToken?>',
             editMessageToken: '<?=$editMessageToken?>',
             deleteMessageToken: '<?=$deleteMessageToken?>',

--- a/concrete/blocks/core_conversation/view.php
+++ b/concrete/blocks/core_conversation/view.php
@@ -1,12 +1,20 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
-
-$paginate = ($paginate) ? 'true' : 'false';
-$itemsPerPage = ($paginate) ? $itemsPerPage : -1;
+/** @var bool|string $paginate */
+$paginate = ($paginate ?? null) ? 'true' : 'false';
+/** @var int $itemsPerPage */
+$itemsPerPage = ($paginate === 'true') ? $itemsPerPage ?? 50 : -1;
 $blockAreaHandle = $this->block->getAreaHandle();
+/** @var int $maxFileSizeRegistered */
+/** @var int $maxFileSizeGuest */
+/** @var int $maxFilesRegistered */
+/** @var int $maxFilesGuest */
+/** @var int $bID */
+/** @var int $cID */
 
-$u = Core::make(Concrete\Core\User\User::class);
+/** @var \Concrete\Core\User\User $u */
+$u = app(Concrete\Core\User\User::class);
 if ($u->isRegistered()) {
     $maxFileSize = $maxFileSizeRegistered;
     $maxFiles = $maxFilesRegistered;
@@ -15,7 +23,30 @@ if ($u->isRegistered()) {
     $maxFiles = $maxFilesGuest;
 }
 
-if (is_object($conversation)) { ?>
+/** @var string $addMessageToken */
+/** @var string $editMessageToken */
+/** @var string $deleteMessageToken */
+/** @var string $flagMessageToken */
+/** @var string $displayMode */
+/** @var string $addMessageLabel */
+/** @var string $orderBy */
+/** @var string $enableOrderin */
+/** @var string $displayPostingForm */
+/** @var int $enableOrdering */
+/** @var int $enableCommentRating */
+/** @var string $dateFormat */
+/** @var string $customDateFormat */
+/** @var string $blockAreaHandle */
+/** @var string $fileExtensions */
+
+/** @var int $attachmentsEnabled */
+/** @var int $attachmentOverridesEnabled */
+/** @var int $enableTopCommentReviews */
+/** @var int $displaySocialLinks */
+/** @var string $users */
+
+/** @var \Concrete\Core\Conversation\Conversation|null $conversation */
+if (isset($conversation) && is_object($conversation)) { ?>
     <div class="ccm-conversation-wrapper" data-conversation-id="<?=$conversation->getConversationID()?>">
         <?=t('Loading Conversation')?> <i class="fas fa-spin fa-circle-o-notch"></i>
     </div>

--- a/concrete/controllers/frontend/conversations/add_message.php
+++ b/concrete/controllers/frontend/conversations/add_message.php
@@ -3,6 +3,7 @@
 namespace Concrete\Controller\Frontend\Conversations;
 
 use ArrayAccess;
+use Concrete\Block\CoreConversation\Controller;
 use Concrete\Core\Antispam\Service as AntispamService;
 use Concrete\Core\Conversation\Conversation;
 use Concrete\Core\Conversation\ConversationService;
@@ -223,6 +224,7 @@ class AddMessage extends FrontendController
 
     /**
      * @return \Concrete\Core\Entity\File\File[]
+     * @throws UserMessageException
      */
     protected function getAttachments(ArrayAccess $errors): array
     {
@@ -237,7 +239,7 @@ class AddMessage extends FrontendController
         } else {
             $blockController = $this->getBlockController();
             $u = $this->app->make(User::class);
-            $maxFiles = $u->isRegistered() ? $blockController->maxFilesRegistered : $blockController->maxFilesGuest;
+            $maxFiles = $u->isRegistered() ? $blockController->getFileSettings()['maxFilesRegistered'] : $blockController->getFileSettings()['maxFilesGuest'];
             if ($maxFiles > 0 && count($attachmentIDs) > $maxFiles) {
                 $errors[] = t('You have too many attachments.');
             } else {

--- a/concrete/controllers/frontend/conversations/message_page.php
+++ b/concrete/controllers/frontend/conversations/message_page.php
@@ -31,8 +31,15 @@ class MessagePage extends FrontendController
         $this->set('pageIndex', $this->getPageIndex());
         $this->set('displayMode', $this->getDisplayMode());
         $this->set('enablePosting', $this->isPostingEnabled());
+        $this->set('enableCommentRating', $this->isCommentRatingEnabled());
+        $this->set('displaySocialLinks', $this->shouldDisplaySocialLinks());
 
         return null;
+    }
+
+    protected function shouldDisplaySocialLinks():bool
+    {
+        return (bool) $this->request->request->get('displaySocialLinks');
     }
 
     protected function getConversationID(): ?int
@@ -87,6 +94,11 @@ class MessagePage extends FrontendController
         $itemsPerPage = $this->request->request->get('itemsPerPage');
 
         return $this->app->make(Numbers::class)->integer($itemsPerPage, 1) ? (int) $itemsPerPage : null;
+    }
+
+    protected function isCommentRatingEnabled(): bool
+    {
+        return (bool) $this->request->request->get('enableCommentRating');
     }
 
     protected function getPageIndex(): int

--- a/concrete/controllers/frontend/conversations/update_message.php
+++ b/concrete/controllers/frontend/conversations/update_message.php
@@ -190,7 +190,7 @@ class UpdateMessage extends FrontendController
     protected function dispatchEvent(Message $message): void
     {
         $event = new MessageEvent($message);
-        $dispatcher = $this->app->make(EventDispatcherInterface::class);
+        $dispatcher = $this->app->make('director');
         $dispatcher->dispatch('on_conversations_message_update', $event);
     }
 

--- a/concrete/elements/conversation/message.php
+++ b/concrete/elements/conversation/message.php
@@ -30,6 +30,7 @@ $c = Page::getByID(\Request::request('cID'));
 $cnvMessageURL = urlencode($c->getCollectionLink(true) . '#cnv' . $cnvID . 'Message' . $cnvMessageID);
 
 if ((!$message->isConversationMessageDeleted() && $message->isConversationMessageApproved()) || $message->conversationMessageHasActiveChildren()) {
+
     $author = $message->getConversationMessageAuthorObject();
     $formatter = $author->getFormatter();
     ?>

--- a/concrete/elements/conversation/message/review.php
+++ b/concrete/elements/conversation/message/review.php
@@ -3,6 +3,7 @@
  * @type int $review A number between 0 and 5
  * @type bool $starsOnly Should editing be disabled
  */
+$review = $review ?? 0;
 if (!isset($starsOnly) || !$starsOnly) {
     ?>
     <label for="review" class="float-start">

--- a/concrete/src/Antispam/Service.php
+++ b/concrete/src/Antispam/Service.php
@@ -54,7 +54,7 @@ class Service
         foreach ($additionalArgs as $key => $value) {
             $args[$key] = $value;
         }
-        if (method_exists($this->controller, 'report')) {
+        if ($this->controller && method_exists($this->controller, 'report')) {
             $this->controller->report($args);
         }
 

--- a/concrete/src/Conversation/FlagType/FlagType.php
+++ b/concrete/src/Conversation/FlagType/FlagType.php
@@ -50,7 +50,7 @@ class FlagType extends ConcreteObject
         return $bw;
     }
 
-    public static function getByhandle($handle)
+    public static function getByHandle($handle)
     {
         $db = Loader::db();
         $handle = strtolower($handle);
@@ -70,7 +70,7 @@ class FlagType extends ConcreteObject
         }
         $db = Loader::db();
         $handle = strtolower($handle);
-        if ($ft = static::getByhandle($handle)) {
+        if ($ft = static::getByHandle($handle)) {
             return $ft;
         }
         $db->execute('INSERT INTO ConversationFlaggedMessageTypes (cnvMessageFlagTypeHandle) VALUES (?)', array($handle));

--- a/concrete/src/Conversation/Message/Author.php
+++ b/concrete/src/Conversation/Message/Author.php
@@ -5,9 +5,13 @@ use Concrete\Core\User\UserInfo;
 
 class Author
 {
+    /** @var \Concrete\Core\User\UserInfo */
     protected $user;
+    /** @var string|null */
     protected $name;
+    /** @var string|null */
     protected $email;
+    /** @var string|null */
     protected $website;
 
     /**
@@ -19,7 +23,8 @@ class Author
     }
 
     /**
-     * @param mixed
+     * @param \Concrete\Core\User\User|\Concrete\Core\User\UserInfo $user
+     * @return void
      */
     public function setUser($user)
     {
@@ -33,7 +38,7 @@ class Author
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getName()
     {
@@ -41,7 +46,8 @@ class Author
     }
 
     /**
-     * @param mixed $name
+     * @param string|null $name
+     * @return void
      */
     public function setName($name)
     {
@@ -49,7 +55,7 @@ class Author
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getWebsite()
     {
@@ -57,7 +63,8 @@ class Author
     }
 
     /**
-     * @param mixed $website
+     * @param string|null $website
+     * @return void
      */
     public function setWebsite($website)
     {
@@ -65,7 +72,7 @@ class Author
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getEmail()
     {
@@ -73,7 +80,8 @@ class Author
     }
 
     /**
-     * @param mixed $email
+     * @param string|null $email
+     * @return void
      */
     public function setEmail($email)
     {
@@ -81,10 +89,10 @@ class Author
     }
 
     /**
-     *
+     * @return AuthorFormatter
      */
     public function getFormatter()
     {
-        return \Core::make(AuthorFormatter::class, [$this]);
+        return app(AuthorFormatter::class, ['author'=>$this]);
     }
 }

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -209,7 +209,7 @@ class Form
      * Generates a checkbox.
      *
      * @param string $key The name/id of the element. It should end with '[]' if it's to return an array on submit.
-     * @param string $value String value sent to server, if checkbox is checked, on submit
+     * @param string | int $value String value sent to server, if checkbox is checked, on submit
      * @param string | bool | int $isChecked "Checked" value (subject to be overridden by $_REQUEST). Checkbox is checked if value is true (string). Note that 'false' (string) evaluates to true (boolean)!
      * @param array $miscFields additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
@@ -276,8 +276,8 @@ class Form
      * Generates a radio button.
      *
      * @param string $key the name of the element (its id will start with $key but will have a progressive unique number added)
-     * @param string $value the value of the radio button
-     * @param string|array $checkedValueOrMiscFields the value of the element (if it should be initially checked) or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
+     * @param string|int $value the value of the radio button
+     * @param string|array|bool|int $checkedValueOrMiscFields the value of the element (if it should be initially checked) or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      * @param array $miscFields (used if $checkedValueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
      * @return string
@@ -447,7 +447,7 @@ class Form
      *
      * @param string $key The name of the element. If $key denotes an array, the ID will start with $key but will have a progressive unique number added; if $key does not denotes an array, the ID attribute will be $key.
      * @param array $optionValues an associative array of key => display
-     * @param string|array $valueOrMiscFields the value of the field to be selected or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
+     * @param string|array|int $valueOrMiscFields the value of the field to be selected or an array with additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      * @param array $miscFields (used if $valueOrMiscFields is not an array) Additional fields appended to the element (a hash array of attributes name => value), possibly including 'class', 'id', and 'name'
      *
      * @return $html

--- a/concrete/views/frontend/conversations/message_page.php
+++ b/concrete/views/frontend/conversations/message_page.php
@@ -12,6 +12,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var int $pageIndex
  * @var string $displayMode
  * @var bool $enablePosting
+ * @var bool $enableCommentRating
+ * @var bool $displaySocialLinks
  */
 
 // $totalPages = $messageList->getSummary()->pages;
@@ -23,6 +25,8 @@ foreach ($messageList->getPage($pageIndex) as $message) {
             'message' => $message,
             'displayMode' => $displayMode,
             'enablePosting' => $enablePosting,
+            'enableCommentRating'=> $enableCommentRating,
+            'displaySocialLinks'=> $displaySocialLinks,
         ]
     );
 }


### PR DESCRIPTION
This PR is split from In regards to https://github.com/concrete5/concrete5/pull/10300 to make it easer to review

This PR fixes some issues in php8 when adding/editing conversation blocks, it also fixes issues with the conversation dashboard pages, the conversation block not displaying correct usernames.

It also updates the FlagType::getByHandle being incorrectly named 
was `getByhandle` now `getByHandle` as everywhere it was used it was `getByHandle`

It also adds phpdoc blocks to the core_conversation block and these files now pass phpstan level 6
It also adds some phpdoc blocks the conversation/messages controller, and updates some depreciated code along with returning json responses from the methods

