### PR TITLE
Check enable_auto_update_packages once at setupPackages

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -255,8 +255,8 @@ class Application extends Container
         $entityManager = $this['Doctrine\ORM\EntityManager'];
         $configUpdater = new EntityManagerConfigUpdater($entityManager);
 
-        foreach ($this->packages as $pkg) {
-            if ($config->get('concrete.updates.enable_auto_update_packages')) {
+        if ($config->get('concrete.updates.enable_auto_update_packages')) {
+            foreach ($this->packages as $pkg) {
                 $dbPkg = \Package::getByHandle($pkg->getPackageHandle());
                 $pkgInstalledVersion = $dbPkg->getPackageVersion();
                 $pkgFileVersion = $pkg->getPackageVersion();


### PR DESCRIPTION
The function `setupPackages` loops over each package to run auto-update if that is enabled. But only checks if auto_update is enabled inside the packages loop, but takes no action when disabled. This commit fixes this behavior by checking once and start looping if enabled.

If it is intended to allow packages to disable auto_updates mid-update then this commit would break that. However, I don't think config is meant to be used as a runtime semaphore.