### PR TITLE
Forgot Password: fix rate limit logic

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -203,14 +203,13 @@ class Controller extends AuthenticationTypeController
                 /**
                  * @var $accessControlCategoryService IpAccessControlService
                  */
-                $forgotPasswordThresholdReached = false;
                 if ($accessControlCategoryService->isDenylisted()) {
                     $forgotPasswordThresholdReached = true;
                 } else {
+                    $forgotPasswordThresholdReached = $accessControlCategoryService->isThresholdReached();
                     $accessControlCategoryService->registerEvent();
-                    if ($accessControlCategoryService->isThresholdReached()) {
+                    if ($forgotPasswordThresholdReached) {
                         $accessControlCategoryService->addToDenylistForThresholdReached();
-                        $forgotPasswordThresholdReached = true;
                     }
                 }
 


### PR DESCRIPTION
We have to check if the threshold has been reached before registering the event.

Why?

For example, think at the case when we only allow 1 event every minute.

If we register the event and then we check if in the last minute we've had an event, that would always be true.