### PR TITLE
Fix accessing undefined array index

### DIFF
--- a/concrete/blocks/feature_link/controller.php
+++ b/concrete/blocks/feature_link/controller.php
@@ -168,7 +168,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $args['buttonExternalLink'] = $imageLinkType === 'external_url' ? $imageLinkValue : '';
         /** @var SanitizeService $security */
         $security = $this->app->make('helper/security');
-        $args['icon'] = $security->sanitizeString($args['icon']);
+        $args['icon'] = $security->sanitizeString($args['icon'] ?? '');
 
         parent::save($args);
     }


### PR DESCRIPTION
I have this error when installing the latest develop branch with PHP 8.1:

```
In controller.php line 171:

  [Whoops\Exception\ErrorException (2)]
  Undefined array key "icon"


Exception trace:
  at .../concrete/blocks/feature_link/controller.php:171
```
