### PR TITLE
load the home page based off the currently active site section

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -131,8 +131,9 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
 
     protected function getNavigation(): Navigation
     {
-        $al = Section::getBySectionOfSite(Page::getCurrentPage());
-        $home = \Page::getByID($al->getSiteHomePageID());
+        $section = Section::getByLocale(\Localization::getInstance()->getLocale());
+
+        $home = \Page::getByID($section->getSiteHomePageID());
         $children = $home->getCollectionChildren();
         $navigation = new Navigation();
 

--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -132,8 +132,12 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     protected function getNavigation(): Navigation
     {
         $section = Section::getByLocale(\Localization::getInstance()->getLocale());
-
-        $home = \Page::getByID($section->getSiteHomePageID());
+        if ($section instanceof Section) {
+            $home = \Page::getByID($section->getSiteHomePageID());
+        } else {
+            $site = $this->app->make('site')->getSite();
+            $home = $site->getSiteHomePageObject();
+        }
         $children = $home->getCollectionChildren();
         $navigation = new Navigation();
 

--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -11,6 +11,7 @@ use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\File\File;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Html\Service\Navigation as NavigationService;
+use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Navigation\Breadcrumb\PageBreadcrumbFactory;
 use Concrete\Core\Navigation\Item\PageItem;
 use Concrete\Core\Navigation\Navigation;
@@ -130,8 +131,8 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
 
     protected function getNavigation(): Navigation
     {
-        $site = $this->app->make('site')->getSite();
-        $home = $site->getSiteHomePageObject();
+        $al = Section::getBySectionOfSite(Page::getCurrentPage());
+        $home = \Page::getByID($al->getSiteHomePageID());
         $children = $home->getCollectionChildren();
         $navigation = new Navigation();
 


### PR DESCRIPTION
addresses #10415

are there any situations where where `Section::getBySectionOfSite(Page::getCurrentPage())` could be null and pose other issues (ie site tree not loading at all) or is the PR a reasonable way to approach this?

edit: I think I answered my own question and have added a new commit to address this. 

It would be good to consider if this will work on multi-site installs or if this needs to be tweaked to handle those scenarios