### PR TITLE
Simplify c5:exec return code

### DIFF
--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -1,35 +1,35 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
+use Exception;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Exception;
 
 class ExecCommand extends Command
 {
     protected function configure()
     {
-        $okExitCode = static::SUCCESS;
-        $errExitCode = static::FAILURE;
         $this
             ->setName('c5:exec')
             ->setDescription('Execute a PHP script within the Concrete environment')
             ->addEnvOption()
             ->addArgument('script', InputArgument::REQUIRED, 'The path of the script to be executed')
             ->addArgument('arguments', InputArgument::IS_ARRAY, 'The arguments to pass to the script')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<'EOT'
 In the included script you'll have these variables:
-- \$input: an instance of \Symfony\Component\Console\Input\InputInterface
-- \$output: an instance of \Symfony\Component\Console\Input\OutputInterface
-- \$args: an array of strings containing the arguments specified after the script to be executed 
+- $input: an instance of \Symfony\Component\Console\Input\InputInterface
+- $output: an instance of \Symfony\Component\Console\Input\OutputInterface
+- $args: an array of strings containing the arguments specified after the script to be executed 
 
-To specify the command return code, define an int variable named '\$rc'.
+To specify the command return code, the PHP script can return an integer or define an integer variable named '$rc'.
 
-Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+To pass options to the included script (via the $args variable), you can prepend them with --
+For example:
+/path/to/concrete/bin/concrete5 c5:exec your.php -- --option1 --option2=value argument1 argument2
 
 More info at http://documentation.concrete5.org/developers/appendix/cli-commands#c5-exec
 EOT
@@ -43,8 +43,11 @@ EOT
             throw new Exception(sprintf('Unable to find the file %s', $input->getArgument('script')));
         }
         $args = $input->getArgument('arguments');
-        require $input->getArgument('script');
+        $result = require $input->getArgument('script');
+        if (is_numeric($result)) {
+            return (int) $result;
+        }
 
-        return isset($rc) ? $rc : static::SUCCESS;
+        return is_numeric($rc ?? null) ? (int) $rc : static::SUCCESS;
     }
 }


### PR DESCRIPTION
The return code of the c5:exec CLI command is defined by the script, so we shouldn't describe it in the command description.

Furthermore, let's allow the included script define the return value simply by using a `return` statement instead of defining a "magic" `$rc` variable.