### PR TITLE
Avoid class::method error in marketplace update

### DIFF
--- a/concrete/src/Marketplace/RemoteItem.php
+++ b/concrete/src/Marketplace/RemoteItem.php
@@ -227,7 +227,8 @@ class RemoteItem extends ConcreteObject
         }
 
         $r = $pkg->backup();
-        if (is_object($r) && $r instanceof Error) {
+        // Can the calling code handle a return of ErrorList?
+        if (is_object($r) && ($r instanceof Error || $r instanceof ErrorList)) {
             return $r;
         }
 
@@ -237,7 +238,10 @@ class RemoteItem extends ConcreteObject
             $am = new PackageArchive($this->getHandle());
             $am->install($file, true);
         } catch (Exception $e) {
-            $pkg->restore();
+            // This is a messy fix. Better would be to restructure this method to avoid variant object type for $pkg.
+            if(is_callable([$pkg, 'restore'])){
+                $pkg->restore();
+            }
             $error = \Core::make('error');
             $error->add($e);
             return $error;


### PR DESCRIPTION
#10014 describes a whoops arising from flawed code in the error handling for errors when connecting to the marketplace
This change is untested because testing would require the initial error condition. It adds checks to avoid class::method error inside the exception handling for marketplace update.

As a fix, I don't know if the calling code to which the Error or ErrorList object is returned can handle an ErrorList (line 230)
This is a messy fix. Better would be to restructure this method to avoid variant object type for $pkg. (line 243)

This is a #10435 for v8