### PR TITLE
Move concrete5/dependency-patches to the core composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ]
   },
   "require": {
-    "wikimedia/composer-merge-plugin": "~1.3|~2.0.1",
-    "concrete5/dependency-patches": "^1.6.0"
+    "wikimedia/composer-merge-plugin": "~1.3|~2.0.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "2.19.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f41d0cba551fc2f8cff821af4c195c25",
+    "content-hash": "ccc313f986bc9469b93518130019d84c",
     "packages": [
         {
             "name": "anahkiasen/html-object",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -113,7 +113,8 @@
     "laminas/laminas-i18n": "^2.13",
     "laminas/laminas-cache-storage-adapter-memory": "^1.0",
     "tubalmartin/cssmin": "^4.1",
-    "ssddanbrown/htmldiff": "^1.0"
+    "ssddanbrown/htmldiff": "^1.0",
+    "concrete5/dependency-patches": "^1.6.0"
   },
   "replace": {
     "laminas/laminas-cache-storage-adapter-apc": "*",


### PR DESCRIPTION
That way the package will be included in composer-based installations