### PR TITLE
Let's be strict when we install/upgrade Concrete

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.display_errors true
           sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.detail debug
-          # sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.error_reporting -1
+          sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.error_reporting -1
       -
         name: Install
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -61,8 +61,8 @@ jobs:
           ln -s "$GITHUB_WORKSPACE" /app
           ccm-service start web
           SITE_NAME="$(sudo -u www-data ./concrete/bin/concrete5 c5:config get site.sites.default.name)"
-          curl -sSf -o /tmp/index.html http://localhost/
-          if ! grep -Eq "<title>.*$SITE_NAME.*</title>" /tmp/index.html; then
+          curl -sSi -o /tmp/index.html http://localhost/
+          if ! head -n1 /tmp/index.html | grep -Eq '^HTTP[^\s]* 200 ' || ! grep -Eq "<title>.*$SITE_NAME.*</title>" /tmp/index.html; then
             echo 'Wrong response from the website' >&1
             cat /tmp/index.html >&2
             exit 1

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,6 @@ jobs:
     env:
       LC_ALL: en_US.UTF-8
       CODE_COVERAGE: none
-    continue-on-error: ${{ matrix.php-version == '8.1' }}
 
     runs-on: ${{ matrix.operating-system }}
     services:
@@ -89,17 +88,10 @@ jobs:
         if: ${{ matrix.dependencies == 'locked' }}
         run: |
           composer install --no-interaction --no-progress --no-suggest
-        # Since continue on error still marks a job as failed.
-        # We also have to add continue-on-error here so it doesnt X the whole build
-        # See https://github.com/actions/toolkit/issues/399
-        continue-on-error: ${{ matrix.php-version == '8.1' }}
-
 
       - name: "Tests"
         if: env.CODE_COVERAGE == 'none'
         run: php ./concrete/vendor/phpunit/phpunit/phpunit
-        # Same as above
-        continue-on-error: ${{ matrix.php-version == '8.1' }}
 
       - name: "Tests with coverage"
         if: env.CODE_COVERAGE != 'none'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,6 +16,7 @@ jobs:
           - 9.0.1
         php-version:
           - "7.4"
+          - "8.1"
     steps:
       -
         name: Configure environment

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -60,8 +60,8 @@ jobs:
         run: |
           ccm-service start web
           SITE_NAME="$(sudo -u www-data ./concrete/bin/concrete5 c5:config get site.sites.default.name)"
-          curl -sSf -o /tmp/index.html http://localhost/
-          if ! grep -Eq "<title>.*$SITE_NAME.*</title>" /tmp/index.html; then
+          curl -sSi -o /tmp/index.html http://localhost/
+          if ! head -n1 /tmp/index.html | grep -Eq '^HTTP[^\s]* 200 ' || ! grep -Eq "<title>.*$SITE_NAME.*</title>" /tmp/index.html; then
             echo 'Wrong response from the website' >&1
             cat /tmp/index.html >&2
             exit 1

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,7 +48,7 @@ jobs:
           cd /app
           sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.display_errors true
           sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.detail debug
-          # sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.error_reporting -1
+          sudo -Hu www-data ./concrete/bin/concrete5 c5:config -g -- set concrete.debug.error_reporting -1
       -
         name: Update Concrete
         run: |

--- a/composer.lock
+++ b/composer.lock
@@ -178,16 +178,16 @@
         },
         {
             "name": "concrete5/dependency-patches",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5/dependency-patches.git",
-                "reference": "43f3a7517708c21e7bf0a047778ba6976eb66ae6"
+                "reference": "6716e26f9c7e7bcd548c0e7b7b75a56558015cee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/43f3a7517708c21e7bf0a047778ba6976eb66ae6",
-                "reference": "43f3a7517708c21e7bf0a047778ba6976eb66ae6",
+                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/6716e26f9c7e7bcd548c0e7b7b75a56558015cee",
+                "reference": "6716e26f9c7e7bcd548c0e7b7b75a56558015cee",
                 "shasum": ""
             },
             "require": {
@@ -210,7 +210,8 @@
                         "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
                     },
                     "sunra/php-simple-html-dom-parser:1.5.2": {
-                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch"
+                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
+                        "Add PHP 8.1 compability to league/url version 3.3.5": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
                     },
                     "phpunit/phpunit:4.8.36": {
                         "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
@@ -236,6 +237,9 @@
                     },
                     "lcobucci/jwt:3.4.6": {
                         "Adds php 8 compability to jwt version 3.4.6": "lcobucci/jwt/php8-compatibility.patch"
+                    },
+                    "league/url:3.3.5": {
+                        "Add PHP 8.1 compability to league/url version 3.3.5": "league/url/php8.1-compatibility.patch"
                     }
                 }
             },
@@ -253,7 +257,11 @@
             ],
             "description": "Patches required for concrete5 dependencies",
             "homepage": "https://github.com/concrete5/dependency-patches",
-            "time": "2021-10-27T20:00:13+00:00"
+            "support": {
+                "issues": "https://github.com/concrete5/dependency-patches/issues",
+                "source": "https://github.com/concrete5/dependency-patches/tree/1.7.0"
+            },
+            "time": "2022-03-15T17:06:12+00:00"
         },
         {
             "name": "concrete5/doctrine-xml",

--- a/composer.lock
+++ b/composer.lock
@@ -3860,16 +3860,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "3.1-dev"
-                },
-                "patches_applied": {
-                    "hash": "c01ee49dae3ec5d99a499583022d4223d59924fc",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.6.1",
-                            "path": "lcobucci/jwt/php8-compatibility.patch",
-                            "description": "Adds php 8 compability to jwt version 3.4.6"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -6364,18 +6354,6 @@
                 "php": ">=5.3.2"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "hash": "43699395013691839330f8406ee49fa752c163fb",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.6.1",
-                            "path": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
-                            "description": "Fix minus in regular expressions"
-                        }
-                    ]
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Sunra\\PhpSimple\\HtmlDomParser": "Src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4686,16 +4686,16 @@
         },
         {
             "name": "mlocati/composer-patcher",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/composer-patcher.git",
-                "reference": "38db5a938b33dfba6ccba5f0eb11a2fba8205b52"
+                "reference": "7b8e063adde96a7bc1c991b070937df9d36098ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/composer-patcher/zipball/38db5a938b33dfba6ccba5f0eb11a2fba8205b52",
-                "reference": "38db5a938b33dfba6ccba5f0eb11a2fba8205b52",
+                "url": "https://api.github.com/repos/mlocati/composer-patcher/zipball/7b8e063adde96a7bc1c991b070937df9d36098ad",
+                "reference": "7b8e063adde96a7bc1c991b070937df9d36098ad",
                 "shasum": ""
             },
             "require": {
@@ -4739,6 +4739,10 @@
                 "patches",
                 "plugin"
             ],
+            "support": {
+                "issues": "https://github.com/mlocati/composer-patcher/issues",
+                "source": "https://github.com/mlocati/composer-patcher/tree/1.2.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sponsors/mlocati",
@@ -4749,7 +4753,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-10-30T11:26:06+00:00"
+            "time": "2022-03-29T08:58:34+00:00"
         },
         {
             "name": "mlocati/concrete5-translation-library",

--- a/composer.lock
+++ b/composer.lock
@@ -178,16 +178,16 @@
         },
         {
             "name": "concrete5/dependency-patches",
-            "version": "1.7.0",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5/dependency-patches.git",
-                "reference": "6716e26f9c7e7bcd548c0e7b7b75a56558015cee"
+                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/6716e26f9c7e7bcd548c0e7b7b75a56558015cee",
-                "reference": "6716e26f9c7e7bcd548c0e7b7b75a56558015cee",
+                "url": "https://api.github.com/repos/concrete5/dependency-patches/zipball/ec219a55e89c2552efb7368175c65e68cd2a3de0",
+                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0",
                 "shasum": ""
             },
             "require": {
@@ -211,7 +211,7 @@
                     },
                     "sunra/php-simple-html-dom-parser:1.5.2": {
                         "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
-                        "Add PHP 8.1 compability to league/url version 3.3.5": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
+                        "Add PHP 8.1 compatibility": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
                     },
                     "phpunit/phpunit:4.8.36": {
                         "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
@@ -233,13 +233,19 @@
                         "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
                     },
                     "lcobucci/jwt:3.4.5": {
-                        "Adds php 8 compability to jwt version 3.4.5": "lcobucci/jwt/php8-compatibility.patch"
+                        "Add PHP 8 compatibility": "lcobucci/jwt/php8-compatibility.patch"
                     },
                     "lcobucci/jwt:3.4.6": {
-                        "Adds php 8 compability to jwt version 3.4.6": "lcobucci/jwt/php8-compatibility.patch"
+                        "Add PHP 8 compatibility": "lcobucci/jwt/php8-compatibility.patch"
                     },
                     "league/url:3.3.5": {
-                        "Add PHP 8.1 compability to league/url version 3.3.5": "league/url/php8.1-compatibility.patch"
+                        "Add PHP 8.1 compatibility": "league/url/php8.1-compatibility.patch"
+                    },
+                    "laminas/laminas-code:3.4.1": {
+                        "Add PHP 8.1 compatibility": "laminas/laminas-code/php8.1-compatibility.patch"
+                    },
+                    "anahkiasen/html-object:1.4.4": {
+                        "Add PHP 8.1 compatibility": "anahkiasen/html-object/php8.1-compatibility.patch"
                     }
                 }
             },
@@ -259,9 +265,9 @@
             "homepage": "https://github.com/concrete5/dependency-patches",
             "support": {
                 "issues": "https://github.com/concrete5/dependency-patches/issues",
-                "source": "https://github.com/concrete5/dependency-patches/tree/1.7.0"
+                "source": "https://github.com/concrete5/dependency-patches/tree/1.7.2"
             },
-            "time": "2022-03-15T17:06:12+00:00"
+            "time": "2022-03-31T17:52:31+00:00"
         },
         {
             "name": "concrete5/doctrine-xml",

--- a/composer.lock
+++ b/composer.lock
@@ -2683,26 +2683,26 @@
         },
         {
             "name": "imagine/imagine",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-imagine/Imagine.git",
-                "reference": "d2e18be6e930ca169e4f921ef73ebfc061bf55d8"
+                "reference": "fc3e477a15907e8f2a11c32f1aecb07101c0bd31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-imagine/Imagine/zipball/d2e18be6e930ca169e4f921ef73ebfc061bf55d8",
-                "reference": "d2e18be6e930ca169e4f921ef73ebfc061bf55d8",
+                "url": "https://api.github.com/repos/php-imagine/Imagine/zipball/fc3e477a15907e8f2a11c32f1aecb07101c0bd31",
+                "reference": "fc3e477a15907e8f2a11c32f1aecb07101c0bd31",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.2",
                 "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3"
             },
             "suggest": {
+                "ext-exif": "to read EXIF metadata",
                 "ext-gd": "to use the GD implementation",
                 "ext-gmagick": "to use the Gmagick implementation",
                 "ext-imagick": "to use the Imagick implementation"
@@ -2710,7 +2710,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.7-dev"
+                    "dev-develop": "1.x-dev"
                 }
             },
             "autoload": {
@@ -2737,7 +2737,11 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2020-11-03T22:35:03+00:00"
+            "support": {
+                "issues": "https://github.com/php-imagine/Imagine/issues",
+                "source": "https://github.com/php-imagine/Imagine/tree/1.3.1"
+            },
+            "time": "2022-03-15T15:19:48+00:00"
         },
         {
             "name": "indigophp/hash-compat",

--- a/concrete/authentication/external_concrete/controller.php
+++ b/concrete/authentication/external_concrete/controller.php
@@ -30,7 +30,7 @@ class Controller extends GenericOauth2TypeController
     protected $config;
 
     public function __construct(
-        ?\Concrete\Core\Authentication\AuthenticationType $type = null,
+        ?\Concrete\Core\Authentication\AuthenticationType $type,
         ServiceFactory $factory,
         ResolverManagerInterface $urlResolver,
         Repository $config

--- a/concrete/blocks/accordion/controller.php
+++ b/concrete/blocks/accordion/controller.php
@@ -88,6 +88,7 @@ class AccordionEntry implements \JsonSerializable
         $this->id = $id;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -205,7 +205,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     {
         $files = [];
         $matches = [];
-        if (preg_match_all('/\<concrete-picture[^>]*?fID\s*=\s*[\'"]([^\'"]*?)[\'"]/i', $this->content, $matches)) {
+        if ($this->content && preg_match_all('/\<concrete-picture[^>]*?fID\s*=\s*[\'"]([^\'"]*?)[\'"]/i', $this->content, $matches)) {
             list(, $ids) = $matches;
             foreach ($ids as $id) {
                 $files[] = $id;
@@ -220,6 +220,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
      */
     protected function getUsedFilesDownload()
     {
+        if (!$this->content) {
+            return [];
+        }
         preg_match_all('(FID_DL_\d+)', $this->content, $matches);
 
         return array_map(

--- a/concrete/bootstrap/helpers.php
+++ b/concrete/bootstrap/helpers.php
@@ -170,6 +170,7 @@ function overrideable_core_class($class, $path, $pkgHandle = null)
  */
 function camelcase($string, $leaveSlashes = false)
 {
+    $string = (string) $string;
     $return = '';
     $string = trim($string, '_-/\\');
     if (strpos($string, '/')) {

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -114,7 +114,7 @@
     "laminas/laminas-cache-storage-adapter-memory": "^1.0",
     "tubalmartin/cssmin": "^4.1",
     "ssddanbrown/htmldiff": "^1.0",
-    "concrete5/dependency-patches": "^1.6.0"
+    "concrete5/dependency-patches": "^1.7.2"
   },
   "replace": {
     "laminas/laminas-cache-storage-adapter-apc": "*",

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -25,12 +25,8 @@ $isArrangeMode = false;
 if (!isset($pageTitle) || !is_string($pageTitle) || $pageTitle === '') {
     $pageTitle = null;
 }
-if (!isset($pageDescription)) {
-    $pageDescription = null;
-}
-if (!isset($pageMetaKeywords)) {
-    $pageMetaKeywords = null;
-}
+$pageDescription = $pageDescription ?? '';
+$pageMetaKeywords = $pageMetaKeywords ?? '';
 $defaultPageTitle = $pageTitle;
 $app = Application::getFacadeApplication();
 $site = $app->make('site')->getSite();
@@ -72,16 +68,16 @@ if (is_object($c)) {
         }
     }
 
-    if (!$pageDescription) {
+    if ($pageDescription === '') {
         // we aren't getting it dynamically.
-        $pageDescription = $c->getAttribute('meta_description');
-        if (!$pageDescription) {
-            $pageDescription = $c->getCollectionDescription();
+        $pageDescription = (string) $c->getAttribute('meta_description');
+        if ($pageDescription === '') {
+            $pageDescription = (string) $c->getCollectionDescription();
         }
         $pageDescription = trim($pageDescription);
     }
-    if (!$pageMetaKeywords) {
-        $pageMetaKeywords = trim($c->getAttribute('meta_keywords'));
+    if ($pageMetaKeywords === '') {
+        $pageMetaKeywords = trim((string) $c->getAttribute('meta_keywords'));
     }
 
     // @deprecated – this is support for page level customizations custom CSS records, which are only available to
@@ -102,10 +98,10 @@ if (is_object($c)) {
 }
 $metaTags = [];
 $metaTags['charset'] = sprintf('<meta http-equiv="content-type" content="text/html; charset=%s"/>', APP_CHARSET);
-if ($pageDescription) {
+if ($pageDescription !== '') {
     $metaTags['description'] = sprintf('<meta name="description" content="%s"/>', htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET));
 }
-if ($pageMetaKeywords) {
+if ($pageMetaKeywords !== '') {
     $metaTags['keywords'] = sprintf('<meta name="keywords" content="%s"/>', htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET));
 }
 if ($c !== null && $c->getAttribute('exclude_search_index')) {

--- a/concrete/src/Application/EditResponse.php
+++ b/concrete/src/Application/EditResponse.php
@@ -288,6 +288,7 @@ class EditResponse implements JsonSerializable
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getJSONObject();

--- a/concrete/src/Application/UserInterface/ContextMenu/AbstractMenu.php
+++ b/concrete/src/Application/UserInterface/ContextMenu/AbstractMenu.php
@@ -28,6 +28,7 @@ abstract class AbstractMenu implements ModifiableMenuInterface
         $this->items->add($item);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $html = (string) $this->getMenuElement();

--- a/concrete/src/Application/UserInterface/Sitemap/JsonFormatter.php
+++ b/concrete/src/Application/UserInterface/Sitemap/JsonFormatter.php
@@ -25,6 +25,7 @@ final class JsonFormatter implements JsonSerializable
      *
      * @see JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [];

--- a/concrete/src/Application/UserInterface/Sitemap/TreeCollection/Entry/EntryJsonFormatter.php
+++ b/concrete/src/Application/UserInterface/Sitemap/TreeCollection/Entry/EntryJsonFormatter.php
@@ -11,6 +11,7 @@ final class EntryJsonFormatter implements \JsonSerializable
         $this->entry = $entry;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $response = array(

--- a/concrete/src/Application/UserInterface/Sitemap/TreeCollection/Entry/Group/GroupJsonFormatter.php
+++ b/concrete/src/Application/UserInterface/Sitemap/TreeCollection/Entry/Group/GroupJsonFormatter.php
@@ -11,6 +11,7 @@ final class GroupJsonFormatter implements \JsonSerializable
         $this->entryGroup = $entryGroup;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $response = array(

--- a/concrete/src/Application/UserInterface/Sitemap/TreeCollection/TreeCollectionJsonFormatter.php
+++ b/concrete/src/Application/UserInterface/Sitemap/TreeCollection/TreeCollectionJsonFormatter.php
@@ -26,6 +26,7 @@ final class TreeCollectionJsonFormatter implements JsonSerializable
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $response = [];

--- a/concrete/src/Attribute/Key/Component/KeySelector/KeySerializer.php
+++ b/concrete/src/Attribute/Key/Component/KeySelector/KeySerializer.php
@@ -71,6 +71,7 @@ class KeySerializer implements \JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         ob_start();

--- a/concrete/src/Attribute/Key/Component/KeySelector/ObjectSerializer.php
+++ b/concrete/src/Attribute/Key/Component/KeySelector/ObjectSerializer.php
@@ -33,6 +33,7 @@ class ObjectSerializer implements \JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [];

--- a/concrete/src/Attribute/Key/Component/KeySelector/ObjectsSerializer.php
+++ b/concrete/src/Attribute/Key/Component/KeySelector/ObjectsSerializer.php
@@ -35,6 +35,7 @@ class ObjectsSerializer implements \JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $aks = [];

--- a/concrete/src/Attribute/Key/Component/KeySelector/SetSerializer.php
+++ b/concrete/src/Attribute/Key/Component/KeySelector/SetSerializer.php
@@ -21,6 +21,7 @@ class SetSerializer implements \JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -481,7 +481,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         $inspector = \Core::make('import/value_inspector');
         if (isset($blockNode->data)) {
             foreach ($blockNode->data as $data) {
-                if (strtoupper($data['table']) != strtoupper($this->getBlockTypeDatabaseTable())) {
+                if (strtoupper((string) $data['table']) != strtoupper((string) $this->getBlockTypeDatabaseTable())) {
                     $table = (string) $data['table'];
                     if (isset($data->record)) {
                         foreach ($data->record as $record) {

--- a/concrete/src/Block/View/BlockViewTemplate.php
+++ b/concrete/src/Block/View/BlockViewTemplate.php
@@ -74,7 +74,7 @@ class BlockViewTemplate
 
     protected function computeView()
     {
-        $bFilename = $this->bFilename;
+        $bFilename = $this->bFilename ?? '';
         $obj = $this->obj;
 
         /**

--- a/concrete/src/Board/Command/GenerateBoardInstanceCommandHandler.php
+++ b/concrete/src/Board/Command/GenerateBoardInstanceCommandHandler.php
@@ -58,7 +58,7 @@ class GenerateBoardInstanceCommandHandler
         $items = $this->itemSegmenter->getBoardItemsForInstance($instance);
         $contentObjectGroups = $this->contentPopulator->createContentObjects($items);
         $boardTemplateDriver = $instance->getBoard()->getTemplate()->getDriver();
-        $slotsToPlan = $boardTemplateDriver->getTotalSlots() * 1.5; // This will give us some wiggle room
+        $slotsToPlan = (int) round($boardTemplateDriver->getTotalSlots() * 1.5); // This will give us some wiggle room
         $plannedInstance = $this->planner->plan($instance, $contentObjectGroups, 1, $slotsToPlan);
 
         $blockType = BlockType::getByHandle(BLOCK_HANDLE_BOARD_SLOT_PROXY);

--- a/concrete/src/Board/Instance/Item/Data/CalendarEventData.php
+++ b/concrete/src/Board/Instance/Item/Data/CalendarEventData.php
@@ -30,6 +30,7 @@ class CalendarEventData implements DataInterface
         return $this->occurrenceID;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['occurrenceID' => $this->occurrenceID];

--- a/concrete/src/Board/Instance/Item/Data/PageData.php
+++ b/concrete/src/Board/Instance/Item/Data/PageData.php
@@ -37,7 +37,7 @@ class PageData implements DataInterface
         $this->cID = $cID;
     }
 
-
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['cID' => $this->cID];

--- a/concrete/src/Board/Instance/Slot/Content/ObjectCollection.php
+++ b/concrete/src/Board/Instance/Slot/Content/ObjectCollection.php
@@ -29,6 +29,7 @@ class ObjectCollection implements \JsonSerializable, DenormalizableInterface
         return $this->contentObjects->toArray();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Board/Instance/Slot/Content/SummaryObject.php
+++ b/concrete/src/Board/Instance/Slot/Content/SummaryObject.php
@@ -35,6 +35,7 @@ class SummaryObject implements ObjectInterface
         return $this->summaryObject;
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Board/Instance/Slot/RenderedSlot.php
+++ b/concrete/src/Board/Instance/Slot/RenderedSlot.php
@@ -151,6 +151,7 @@ class RenderedSlot implements \JsonSerializable
         $this->boardInstanceSlotRuleID = $boardInstanceSlotRuleID;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Command/Task/Input/Definition/BooleanField.php
+++ b/concrete/src/Command/Task/Input/Definition/BooleanField.php
@@ -21,6 +21,7 @@ class BooleanField extends Field
         $command->addOption($this->getKey(), null, InputOption::VALUE_NONE, $this->getDescription());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Command/Task/Input/Definition/Definition.php
+++ b/concrete/src/Command/Task/Input/Definition/Definition.php
@@ -24,6 +24,7 @@ class Definition implements \JsonSerializable
         return $this->fields;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Command/Task/Input/Definition/Field.php
+++ b/concrete/src/Command/Task/Input/Definition/Field.php
@@ -101,6 +101,7 @@ class Field implements FieldInterface
         return $this->isRequired;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Command/Task/Input/Definition/SelectField.php
+++ b/concrete/src/Command/Task/Input/Definition/SelectField.php
@@ -49,6 +49,7 @@ class SelectField extends Field
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Command/Task/Input/Field.php
+++ b/concrete/src/Command/Task/Input/Field.php
@@ -47,6 +47,7 @@ class Field implements FieldInterface, DenormalizableInterface
         return $this->value;
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Command/Task/Input/Input.php
+++ b/concrete/src/Command/Task/Input/Input.php
@@ -51,6 +51,7 @@ class Input implements InputInterface, DenormalizableInterface
         return $this->fields;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Csv/Import/ImportResult.php
+++ b/concrete/src/Csv/Import/ImportResult.php
@@ -179,6 +179,7 @@ class ImportResult implements JsonSerializable
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $jsonErrors = $this->errors->jsonSerialize();

--- a/concrete/src/Database/Connection/Connection.php
+++ b/concrete/src/Database/Connection/Connection.php
@@ -295,7 +295,7 @@ class Connection extends \Doctrine\DBAL\Connection
             }
             $updateKeys[$key] = $field;
             if ($autoQuote) {
-                $field = $qb->expr()->literal($field);
+                $field = $qb->expr()->literal($field === null ? '' : $field);
             }
             $where->add($qb->expr()->eq($key, $field));
         }

--- a/concrete/src/Entity/Attribute/Key/Key.php
+++ b/concrete/src/Entity/Attribute/Key/Key.php
@@ -330,6 +330,7 @@ class Key implements AttributeKeyInterface, ExportableInterface, ControlInterfac
         return array();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Attribute/Set.php
+++ b/concrete/src/Entity/Attribute/Set.php
@@ -227,6 +227,7 @@ class Set implements ExportableInterface, \JsonSerializable
         $this->keys->add($setKey);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Attribute/Value/Value/SelectValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/SelectValue.php
@@ -65,6 +65,7 @@ class SelectValue extends AbstractValue implements \IteratorAggregate
         return $str;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->selectedOptions->getIterator();

--- a/concrete/src/Entity/Automation/Task.php
+++ b/concrete/src/Entity/Automation/Task.php
@@ -152,6 +152,7 @@ class Task implements \JsonSerializable, TaskInterface
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $controller = $this->getController();

--- a/concrete/src/Entity/Automation/TaskSet.php
+++ b/concrete/src/Entity/Automation/TaskSet.php
@@ -148,6 +148,7 @@ class TaskSet implements \JsonSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Board/Board.php
+++ b/concrete/src/Entity/Board/Board.php
@@ -314,6 +314,7 @@ class Board implements ObjectInterface, AssignableObjectInterface, \JsonSerializ
         $manager->setPermissionsToOverride($this);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Board/Designer/CustomElement.php
+++ b/concrete/src/Entity/Board/Designer/CustomElement.php
@@ -149,6 +149,7 @@ abstract class CustomElement implements \JsonSerializable
         return $dateTime;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Board/Designer/ItemSelectorCustomElement.php
+++ b/concrete/src/Entity/Board/Designer/ItemSelectorCustomElement.php
@@ -78,6 +78,7 @@ class ItemSelectorCustomElement extends CustomElement
         return $block;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Entity/Board/Designer/ItemSelectorCustomElementItem.php
+++ b/concrete/src/Entity/Board/Designer/ItemSelectorCustomElementItem.php
@@ -70,6 +70,7 @@ class ItemSelectorCustomElementItem implements \JsonSerializable, ItemProviderIn
         $this->element = $element;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [];

--- a/concrete/src/Entity/Board/Instance.php
+++ b/concrete/src/Entity/Board/Instance.php
@@ -241,6 +241,7 @@ class Instance implements \JsonSerializable, ObjectInterface
         $this->dateDataPoolLastUpdated = $dateDataPoolLastUpdated;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $site = $this->getSite();

--- a/concrete/src/Entity/Board/InstanceItem.php
+++ b/concrete/src/Entity/Board/InstanceItem.php
@@ -136,6 +136,7 @@ class InstanceItem implements \JsonSerializable, ItemProviderInterface
         $this->item = $item;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $file = $this->item->getRelevantThumbnail();

--- a/concrete/src/Entity/Board/InstanceSlotRule.php
+++ b/concrete/src/Entity/Board/InstanceSlotRule.php
@@ -320,6 +320,7 @@ class InstanceSlotRule implements \JsonSerializable, ObjectInterface
         $this->batchIdentifier = $batchIdentifier;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $checker = new Checker($this);

--- a/concrete/src/Entity/Board/SlotTemplate.php
+++ b/concrete/src/Entity/Board/SlotTemplate.php
@@ -152,6 +152,7 @@ class SlotTemplate implements \JsonSerializable, ProvidesTagsInterface
         $template->addAttribute('package', $this->getPackageHandle());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Board/Template.php
+++ b/concrete/src/Entity/Board/Template.php
@@ -127,6 +127,7 @@ class Template implements \JsonSerializable
         $template->addAttribute('package', $this->getPackageHandle());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Calendar/CalendarEventVersion.php
+++ b/concrete/src/Entity/Calendar/CalendarEventVersion.php
@@ -282,8 +282,9 @@ class CalendarEventVersion implements ObjectInterface, \JsonSerializable
     }
 
     /**
-     * @return \stdClass
+     * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $o = array();

--- a/concrete/src/Entity/Calendar/Summary/CalendarEventTemplate.php
+++ b/concrete/src/Entity/Calendar/Summary/CalendarEventTemplate.php
@@ -96,6 +96,7 @@ class CalendarEventTemplate implements RenderableTemplateInterface
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Entity/Command/Batch.php
+++ b/concrete/src/Entity/Command/Batch.php
@@ -94,6 +94,7 @@ class Batch implements \JsonSerializable
         return $this->id;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Command/Process.php
+++ b/concrete/src/Entity/Command/Process.php
@@ -177,6 +177,7 @@ class Process implements \JsonSerializable
         $this->exitMessage = $exitMessage;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $timezone = date_default_timezone_get();

--- a/concrete/src/Entity/Command/ScheduledTask.php
+++ b/concrete/src/Entity/Command/ScheduledTask.php
@@ -142,6 +142,7 @@ class ScheduledTask implements \JsonSerializable
         return new CronExpression($this->getCronExpression());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $timezone = date_default_timezone_get();

--- a/concrete/src/Entity/Express/Control/AttributeKeyControl.php
+++ b/concrete/src/Entity/Express/Control/AttributeKeyControl.php
@@ -50,6 +50,7 @@ class AttributeKeyControl extends Control
         return 'attribute_key';
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Entity/Express/Control/Control.php
+++ b/concrete/src/Entity/Express/Control/Control.php
@@ -125,6 +125,7 @@ abstract class Control implements \JsonSerializable, ExportableInterface, Contro
 
     abstract public function getType();
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Express/Entry.php
+++ b/concrete/src/Entity/Express/Entry.php
@@ -426,6 +426,7 @@ class Entry implements \JsonSerializable, PermissionObjectInterface, AttributeOb
     /**
      * @return array|mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $app = Application::getFacadeApplication();

--- a/concrete/src/Entity/Express/Form.php
+++ b/concrete/src/Entity/Express/Form.php
@@ -124,6 +124,7 @@ class Form implements \JsonSerializable, ExportableInterface, FormInterface
         return $controls;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/OAuth/Scope.php
+++ b/concrete/src/Entity/OAuth/Scope.php
@@ -65,6 +65,7 @@ class Scope implements ScopeEntityInterface
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIdentifier();

--- a/concrete/src/Entity/Page/Summary/PageTemplate.php
+++ b/concrete/src/Entity/Page/Summary/PageTemplate.php
@@ -100,6 +100,7 @@ class PageTemplate implements RenderableTemplateInterface
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Entity/Page/Template.php
+++ b/concrete/src/Entity/Page/Template.php
@@ -121,6 +121,7 @@ class Template implements \JsonSerializable
         return $iconImg;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Page/Theme/CustomSkin.php
+++ b/concrete/src/Entity/Page/Theme/CustomSkin.php
@@ -212,6 +212,7 @@ class CustomSkin implements \JsonSerializable, SkinInterface
         $this->customCss = $customCss;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Search/Query.php
+++ b/concrete/src/Entity/Search/Query.php
@@ -73,6 +73,7 @@ class Query implements \JsonSerializable, DenormalizableInterface
         $this->columns = $columns;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Site/Site.php
+++ b/concrete/src/Entity/Site/Site.php
@@ -478,6 +478,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
         $this->pThemeID = $pThemeID;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Entity/Summary/Template.php
+++ b/concrete/src/Entity/Summary/Template.php
@@ -214,6 +214,7 @@ class Template implements \JsonSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -516,6 +516,7 @@ class User implements UserEntityInterface, \JsonSerializable
     /**
      * @return mixed|void
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Error/ErrorList/Error/AbstractError.php
+++ b/concrete/src/Error/ErrorList/Error/AbstractError.php
@@ -84,6 +84,7 @@ abstract class AbstractError implements HtmlAwareErrorInterface
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $r = [

--- a/concrete/src/Error/ErrorList/ErrorList.php
+++ b/concrete/src/Error/ErrorList/ErrorList.php
@@ -205,6 +205,7 @@ class ErrorList implements ArrayAccess, JsonSerializable
      *
      * @return array|null
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $formatter = new JsonFormatter($this);

--- a/concrete/src/Error/ErrorList/Field/AbstractField.php
+++ b/concrete/src/Error/ErrorList/Field/AbstractField.php
@@ -9,6 +9,7 @@ abstract class AbstractField implements FieldInterface
         return $this->getDisplayName();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['element' => $this->getFieldElementName(), 'name' => $this->getDisplayName()];

--- a/concrete/src/Error/UserMessageException.php
+++ b/concrete/src/Error/UserMessageException.php
@@ -83,6 +83,7 @@ class UserMessageException extends Exception implements JsonSerializable, HtmlAw
      *
      * @see JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $result = [

--- a/concrete/src/Express/Search/Field/AssociationField.php
+++ b/concrete/src/Express/Search/Field/AssociationField.php
@@ -119,6 +119,7 @@ class AssociationField extends AbstractField
     /**
      * @return array|mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $json = parent::jsonSerialize();

--- a/concrete/src/File/Component/Chooser/ExternalFileProviderOptionTrait.php
+++ b/concrete/src/File/Component/Chooser/ExternalFileProviderOptionTrait.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 trait ExternalFileProviderOptionTrait
 {
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $user = new \Concrete\Core\User\User();

--- a/concrete/src/File/Component/Chooser/FileExtensionFilter.php
+++ b/concrete/src/File/Component/Chooser/FileExtensionFilter.php
@@ -26,6 +26,7 @@ class FileExtensionFilter implements FilterInterface
         return $this->extensions;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['filter' => 'extension', 'extensions' => $this->extensions];

--- a/concrete/src/File/Component/Chooser/FileTypeFilter.php
+++ b/concrete/src/File/Component/Chooser/FileTypeFilter.php
@@ -26,6 +26,7 @@ class FileTypeFilter implements FilterInterface
         return $this->type;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['filter' => 'type', 'type' => $this->type];

--- a/concrete/src/File/Component/Chooser/FilterCollection.php
+++ b/concrete/src/File/Component/Chooser/FilterCollection.php
@@ -22,6 +22,7 @@ class FilterCollection implements FilterCollectionInterface
         $this->filters[] = $filter;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->filters;

--- a/concrete/src/File/Component/Chooser/OptionSerializableTrait.php
+++ b/concrete/src/File/Component/Chooser/OptionSerializableTrait.php
@@ -8,6 +8,7 @@ trait OptionSerializableTrait
         return $this->getComponentKey();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/File/ExternalFileProvider/ExternalFileEntry.php
+++ b/concrete/src/File/ExternalFileProvider/ExternalFileEntry.php
@@ -149,6 +149,7 @@ class ExternalFileEntry implements \JsonSerializable
         return (string)$img;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/File/ExternalFileProvider/ExternalFileList.php
+++ b/concrete/src/File/ExternalFileProvider/ExternalFileList.php
@@ -23,6 +23,7 @@ class ExternalFileList implements JsonSerializable
         return $this->files;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getFiles();

--- a/concrete/src/File/Image/Thumbnail/AtomicThumbnailStream.php
+++ b/concrete/src/File/Image/Thumbnail/AtomicThumbnailStream.php
@@ -44,6 +44,7 @@ class AtomicThumbnailStream implements \IteratorAggregate
      * Get an iterator that outputs locked thumbnail rows
      * @return \Generator|void
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $db = $this->manager->connection();

--- a/concrete/src/File/Service/Application.php
+++ b/concrete/src/File/Service/Application.php
@@ -87,8 +87,11 @@ class Application
      */
     public function unSerializeUploadFileExtensions($types)
     {
+        if ((string) $types === '') {
+            return [];
+        }
         //split by semi-colon
-        $types = preg_split('{;}', $types, null, PREG_SPLIT_NO_EMPTY);
+        $types = preg_split('{;}', $types, -1, PREG_SPLIT_NO_EMPTY);
         $types = preg_replace('{[^a-z0-9]}i', '', $types);
 
         return $types;

--- a/concrete/src/Foundation/Repetition/AbstractRepetition.php
+++ b/concrete/src/Foundation/Repetition/AbstractRepetition.php
@@ -908,6 +908,7 @@ abstract class AbstractRepetition implements RepetitionInterface
         return $fromUTC->diff($toUTC);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $repeatPeriod = null;

--- a/concrete/src/Geolocator/GeolocationResult.php
+++ b/concrete/src/Geolocator/GeolocationResult.php
@@ -489,6 +489,7 @@ class GeolocationResult implements JsonSerializable
      *
      * @see JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Navigation/Item/FileFolderItem.php
+++ b/concrete/src/Navigation/Item/FileFolderItem.php
@@ -42,6 +42,7 @@ class FileFolderItem extends Item
         $this->folderId = $folderId;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Navigation/Item/Item.php
+++ b/concrete/src/Navigation/Item/Item.php
@@ -129,6 +129,7 @@ class Item implements ItemInterface, \JsonSerializable
         $this->isActiveParent = $isActiveParent;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Navigation/Item/PageItem.php
+++ b/concrete/src/Navigation/Item/PageItem.php
@@ -79,6 +79,7 @@ class PageItem extends Item
         return t(parent::getName());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Navigation/Item/SavedSearchItem.php
+++ b/concrete/src/Navigation/Item/SavedSearchItem.php
@@ -42,6 +42,7 @@ class SavedSearchItem extends Item
         $this->id = $id;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/Navigation/Navigation.php
+++ b/concrete/src/Navigation/Navigation.php
@@ -62,6 +62,7 @@ class Navigation implements NavigationInterface, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [];

--- a/concrete/src/Package/Dependency/DependencyException.php
+++ b/concrete/src/Package/Dependency/DependencyException.php
@@ -25,6 +25,7 @@ abstract class DependencyException extends LogicException implements ErrorInterf
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -41,7 +41,7 @@ class IndexedSearch
     public static function getSavedSearchableAreas()
     {
         $areas = Config::get('concrete.misc.search_index_area_list');
-        $areas = unserialize($areas);
+        $areas = $areas ? unserialize($areas) : [];
         if (!is_array($areas)) {
             $areas = [];
         }

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -30,8 +30,8 @@ class IndexedSearch
 
     public static function getSearchableAreaAction()
     {
-        $action = Config::get('concrete.misc.search_index_area_method');
-        if (!strlen($action)) {
+        $action = (string) Config::get('concrete.misc.search_index_area_method');
+        if ($action === '') {
             $action = 'denylist';
         }
 

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -157,7 +157,7 @@ class IndexedSearch
         if ($pageController = $c->getPageController()) {
             $searchableContent = $pageController->getSearchableContent();
 
-            if (strlen(trim($searchableContent))) {
+            if (trim((string) $searchableContent) !== '') {
                 $text .= $th->decodeEntities(
                         strip_tags(str_ireplace($tagsToSpaces, ' ', $searchableContent)),
                         ENT_QUOTES,

--- a/concrete/src/Page/Stack/Pile/PileContent.php
+++ b/concrete/src/Page/Stack/Pile/PileContent.php
@@ -136,6 +136,7 @@ class PileContent extends ConcreteObject implements \JsonSerializable
         return $modules;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $block = Block::getByID($this->getItemID());

--- a/concrete/src/Page/Theme/Color/Color.php
+++ b/concrete/src/Page/Theme/Color/Color.php
@@ -39,6 +39,7 @@ class Color implements \JsonSerializable
         return $this->variable;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['name' => $this->getName(), 'variable' => $this->getVariable()];

--- a/concrete/src/Page/Theme/Color/ColorCollection.php
+++ b/concrete/src/Page/Theme/Color/ColorCollection.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 class ColorCollection extends ArrayCollection implements \JsonSerializable
 {
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['colors' => $this->toArray()];

--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -352,6 +352,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
     /**
      * @return mixed|void
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $hasSkins = $this->hasSkins();

--- a/concrete/src/Page/Theme/ThemeRouteCollection.php
+++ b/concrete/src/Page/Theme/ThemeRouteCollection.php
@@ -41,10 +41,14 @@ class ThemeRouteCollection
      *
      * @param string $path
      *
-     * @return array
+     * @return array|false
      */
     public function getThemeByRoute($path)
     {
+        $path = (string) $path;
+        if ($path === '') {
+            return false;
+        }
         $text = new Text();
         // there's probably a more efficient way to do this
         foreach ($this->themePaths as $lp => $layout) {

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -1045,7 +1045,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         if (is_array($r) && isset($r['ptID']) && $r['ptID']) {
             $cm = new static();
             $cm->setPropertiesFromArray($r);
-            $cm->ptPublishTargetObject = unserialize($r['ptPublishTargetObject']);
+            $cm->ptPublishTargetObject = $r['ptPublishTargetObject'] ? unserialize($r['ptPublishTargetObject']) : null;
             $cache->save($item->set($cm));
 
             return $cm;

--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -119,6 +119,7 @@ class Column implements ColumnInterface
         $this->sortDirection = $this->sanitizeSortDirection($sort);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Search/Column/Set.php
+++ b/concrete/src/Search/Column/Set.php
@@ -98,6 +98,7 @@ class Set implements \JsonSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Search/Field/AbstractField.php
+++ b/concrete/src/Search/Field/AbstractField.php
@@ -44,6 +44,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @see \JsonSerializable::jsonSerialize()
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         ob_start();

--- a/concrete/src/Search/Field/AttributeKeyField.php
+++ b/concrete/src/Search/Field/AttributeKeyField.php
@@ -118,6 +118,7 @@ class AttributeKeyField extends AbstractField
     /**
      * @return array|mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $json = parent::jsonSerialize();

--- a/concrete/src/Sharing/SocialNetwork/Service.php
+++ b/concrete/src/Sharing/SocialNetwork/Service.php
@@ -58,6 +58,7 @@ class Service implements JsonSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Normalizer/ColorVariable.php
+++ b/concrete/src/StyleCustomizer/Normalizer/ColorVariable.php
@@ -86,6 +86,7 @@ class ColorVariable implements VariableInterface
         return $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Normalizer/ImageVariable.php
+++ b/concrete/src/StyleCustomizer/Normalizer/ImageVariable.php
@@ -101,6 +101,7 @@ class ImageVariable implements VariableInterface
         return sprintf("url('%s')", $this->getComputedUrl());
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Normalizer/Legacy/ImageVariable.php
+++ b/concrete/src/StyleCustomizer/Normalizer/Legacy/ImageVariable.php
@@ -12,6 +12,7 @@ class ImageVariable extends BaseImageVariable
         return "'" . $this->getComputedUrl() . "'";
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/StyleCustomizer/Normalizer/NormalizedVariableCollection.php
+++ b/concrete/src/StyleCustomizer/Normalizer/NormalizedVariableCollection.php
@@ -32,6 +32,7 @@ class NormalizedVariableCollection extends ArrayCollection implements \JsonSeria
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/concrete/src/StyleCustomizer/Normalizer/NumberVariable.php
+++ b/concrete/src/StyleCustomizer/Normalizer/NumberVariable.php
@@ -74,6 +74,7 @@ class NumberVariable implements VariableInterface
         return $this->getNumber() . $this->getUnit();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Normalizer/Variable.php
+++ b/concrete/src/StyleCustomizer/Normalizer/Variable.php
@@ -42,6 +42,7 @@ class Variable implements VariableInterface
         return $this->value;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['name' => $this->getName(), 'value' => $this->getValue()];

--- a/concrete/src/StyleCustomizer/Preset/Preset.php
+++ b/concrete/src/StyleCustomizer/Preset/Preset.php
@@ -43,6 +43,7 @@ class Preset implements PresetInterface
         return $this->identifier;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Set.php
+++ b/concrete/src/StyleCustomizer/Set.php
@@ -81,6 +81,7 @@ class Set implements \JsonSerializable
         return $this->styles;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Skin/PresetSkin.php
+++ b/concrete/src/StyleCustomizer/Skin/PresetSkin.php
@@ -43,6 +43,7 @@ class PresetSkin implements SkinInterface
         return $this->identifier;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/CustomizerVariable.php
+++ b/concrete/src/StyleCustomizer/Style/CustomizerVariable.php
@@ -55,6 +55,7 @@ class CustomizerVariable implements \JsonSerializable
         $this->value = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['variable' => $this->getVariable(), 'value' => $this->getValue()];

--- a/concrete/src/StyleCustomizer/Style/CustomizerVariableCollection.php
+++ b/concrete/src/StyleCustomizer/Style/CustomizerVariableCollection.php
@@ -16,6 +16,7 @@ class CustomizerVariableCollection extends ArrayCollection implements \JsonSeria
         return parent::add($variable);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/concrete/src/StyleCustomizer/Style/FontFamilyStyle.php
+++ b/concrete/src/StyleCustomizer/Style/FontFamilyStyle.php
@@ -46,6 +46,7 @@ class FontFamilyStyle extends Style
         return $variable;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/StyleCustomizer/Style/GroupedStyleValueList.php
+++ b/concrete/src/StyleCustomizer/Style/GroupedStyleValueList.php
@@ -12,6 +12,7 @@ class GroupedStyleValueList implements \JsonSerializable
         $this->sets[] = $set;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/GroupedStyleValueListSet.php
+++ b/concrete/src/StyleCustomizer/Style/GroupedStyleValueListSet.php
@@ -59,6 +59,7 @@ class GroupedStyleValueListSet implements \JsonSerializable
         $this->name = $name;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['name' => $this->getDisplayName('text'), 'styles' => $this->values];

--- a/concrete/src/StyleCustomizer/Style/Style.php
+++ b/concrete/src/StyleCustomizer/Style/Style.php
@@ -118,6 +118,7 @@ abstract class Style implements StyleInterface
         return $this->getVariable();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/StyleValue.php
+++ b/concrete/src/StyleCustomizer/Style/StyleValue.php
@@ -44,6 +44,7 @@ class StyleValue implements \JsonSerializable
         return $this->value;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['style' => $this->style, 'value' => $this->value];

--- a/concrete/src/StyleCustomizer/Style/TypeStyle.php
+++ b/concrete/src/StyleCustomizer/Style/TypeStyle.php
@@ -83,6 +83,7 @@ class TypeStyle extends Style
         throw new \RuntimeException(t('The TypeStyle class is a container style – it cannot convert to variables.'));
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();

--- a/concrete/src/StyleCustomizer/Style/Value/ColorValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/ColorValue.php
@@ -138,6 +138,7 @@ class ColorValue extends Value
         return (string) $this->a !== '';
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/FontFamilyValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/FontFamilyValue.php
@@ -34,6 +34,7 @@ class FontFamilyValue extends Value
         $this->fontFamily = $fontFamily;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/FontStyleValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/FontStyleValue.php
@@ -34,6 +34,7 @@ class FontStyleValue extends Value
         $this->fontStyle = $fontStyle;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/FontWeightValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/FontWeightValue.php
@@ -34,6 +34,7 @@ class FontWeightValue extends Value
         $this->fontWeight = $fontWeight;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/ImageValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/ImageValue.php
@@ -51,6 +51,7 @@ class ImageValue extends Value
     }
 
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/PresetFontsFileValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/PresetFontsFileValue.php
@@ -23,6 +23,7 @@ class PresetFontsFileValue extends Value
         return $this->value;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['value' => $this->value];

--- a/concrete/src/StyleCustomizer/Style/Value/SizeValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/SizeValue.php
@@ -79,6 +79,7 @@ class SizeValue extends Value
         return $this->unit;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/TextDecorationValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/TextDecorationValue.php
@@ -34,6 +34,7 @@ class TextDecorationValue extends Value
         $this->textDecoration = $textDecoration;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/TextTransformValue.php
+++ b/concrete/src/StyleCustomizer/Style/Value/TextTransformValue.php
@@ -34,6 +34,7 @@ class TextTransformValue extends Value
         $this->textTransform = $textTransform;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/Style/Value/ValueContainerTrait.php
+++ b/concrete/src/StyleCustomizer/Style/Value/ValueContainerTrait.php
@@ -27,6 +27,7 @@ trait ValueContainerTrait
         return $this->styleValues;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['values' => $this->styleValues];

--- a/concrete/src/StyleCustomizer/StyleList.php
+++ b/concrete/src/StyleCustomizer/StyleList.php
@@ -39,6 +39,7 @@ class StyleList implements \JsonSerializable
         return $this->sets;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/StyleCustomizer/WebFont/WebFont.php
+++ b/concrete/src/StyleCustomizer/WebFont/WebFont.php
@@ -60,6 +60,7 @@ class WebFont implements \JsonSerializable
         $this->type = $type;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['name' => $this->getName(), 'type' => $this->getType()];

--- a/concrete/src/StyleCustomizer/WebFont/WebFontCollection.php
+++ b/concrete/src/StyleCustomizer/WebFont/WebFontCollection.php
@@ -16,6 +16,7 @@ class WebFontCollection extends ArrayCollection implements \JsonSerializable
         return parent::add($font);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/concrete/src/Summary/Data/Collection.php
+++ b/concrete/src/Summary/Data/Collection.php
@@ -52,6 +52,7 @@ class Collection implements \JsonSerializable, DenormalizableInterface
         return $this->collection->get($field);
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $json = [

--- a/concrete/src/Summary/Data/Field/AbstractLazyDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/AbstractLazyDataFieldData.php
@@ -7,6 +7,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 abstract class AbstractLazyDataFieldData implements LazyDataFieldDataInterface
 {
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/AuthorDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/AuthorDataFieldData.php
@@ -59,6 +59,7 @@ class AuthorDataFieldData implements DataFieldDataInterface
         return $this->data['name'];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/DataFieldData.php
+++ b/concrete/src/Summary/Data/Field/DataFieldData.php
@@ -30,6 +30,7 @@ class DataFieldData implements DataFieldDataInterface
         return (string) $this->data;
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/DatetimeDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/DatetimeDataFieldData.php
@@ -33,6 +33,7 @@ class DatetimeDataFieldData implements DataFieldDataInterface
         return $this->dateTime;
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/ExpressEntryDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/ExpressEntryDataFieldData.php
@@ -31,6 +31,7 @@ class ExpressEntryDataFieldData implements DataFieldDataInterface
         return (string) $this->entry->getLabel();
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/ImageDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/ImageDataFieldData.php
@@ -47,6 +47,7 @@ class ImageDataFieldData implements DataFieldDataInterface
         }
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/LinkDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/LinkDataFieldData.php
@@ -33,6 +33,7 @@ class LinkDataFieldData implements DataFieldDataInterface
         return (string) $this->link;
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Summary/Data/Field/TopicsDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/TopicsDataFieldData.php
@@ -38,6 +38,7 @@ class TopicsDataFieldData implements DataFieldDataInterface
         }
     }
     
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/System/Status/QueueStatusQueue.php
+++ b/concrete/src/System/Status/QueueStatusQueue.php
@@ -40,6 +40,7 @@ class QueueStatusQueue implements \JsonSerializable
 
 
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -1083,6 +1083,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     /**
      * @return mixed|void
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/User/Group/GroupRole.php
+++ b/concrete/src/User/Group/GroupRole.php
@@ -231,6 +231,7 @@ class GroupRole extends ConcreteObject implements JsonSerializable
         return true;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/User/Group/GroupType.php
+++ b/concrete/src/User/Group/GroupType.php
@@ -256,6 +256,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         return true;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -162,13 +162,13 @@ class Text
     /**
      * A concrete5 specific version of htmlspecialchars(). Double encoding is OFF, and the character set is set to your site's.
      *
-     * @param $v
+     * @param string $v
      *
      * @return string
      */
     public function specialchars($v)
     {
-        return htmlspecialchars($v, ENT_QUOTES, APP_CHARSET, false);
+        return htmlspecialchars((string) $v, ENT_QUOTES, APP_CHARSET, false);
     }
 
     /**

--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -312,6 +312,7 @@ class Text
      */
     public function fnmatch($pattern, $string)
     {
+        $string = (string) $string;
         if (!function_exists('fnmatch')) {
             return preg_match(
                 "#^" . strtr(

--- a/concrete/src/Validation/SanitizeService.php
+++ b/concrete/src/Validation/SanitizeService.php
@@ -17,9 +17,26 @@ namespace Concrete\Core\Validation;
 
 class SanitizeService
 {
+    /**
+     * Remove everything between < and > (or from < to the end of the string).
+     *
+     * @param string|mixed $string
+     *
+     * @return string|false return false if $string is not a scalar (or not an object with a __toString method), the sanitized string otherwise
+     */
     public function sanitizeString($string)
     {
-        return filter_var($string, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+        if (is_object($string) && method_exists($string, '__toString')) {
+            $string = (string) $string;
+        } elseif (is_scalar($string) || $string === null) {
+            $string = (string) $string;
+        } else {
+            return false;
+        }
+        $string = preg_replace('/<.*?>/ms', '', $string);
+        $string = preg_replace('/<.*/ms', '', $string);
+
+        return $string;
     }
 
     public function sanitizeInt($int)

--- a/concrete/src/View/View.php
+++ b/concrete/src/View/View.php
@@ -35,7 +35,7 @@ class View extends AbstractView
 
     protected function constructView($path = false)
     {
-        $path = '/'.trim($path, '/');
+        $path = '/' . trim((string) $path, '/');
         $this->viewPath = $path;
     }
 

--- a/tests/helpers/Validation/NonStringableClass.php
+++ b/tests/helpers/Validation/NonStringableClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Concrete\TestHelpers\Validation;
+
+class NonStringableClass
+{
+    public function __toString()
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/helpers/Validation/NonStringableClass.php
+++ b/tests/helpers/Validation/NonStringableClass.php
@@ -4,8 +4,4 @@ namespace Concrete\TestHelpers\Validation;
 
 class NonStringableClass
 {
-    public function __toString()
-    {
-        return __CLASS__;
-    }
 }

--- a/tests/helpers/Validation/StringableClass.php
+++ b/tests/helpers/Validation/StringableClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Concrete\TestHelpers\Validation;
+
+class StringableClass
+{
+    public function __toString()
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/tests/Validation/SanitizeTest.php
+++ b/tests/tests/Validation/SanitizeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Concrete\Tests\Validation;
+
+use Concrete\Core\Validation\SanitizeService;
+use Concrete\Tests\TestCase;
+use Concrete\TestHelpers\Validation\StringableClass;
+use Concrete\TestHelpers\Validation\NonStringableClass;
+
+/**
+ * FILTER_SANITIZE_STRING is deprecated in PHP 8.1, so we re
+ */
+class SanitizeTest extends TestCase
+{
+    /**
+     * @var \Concrete\Core\Validation\SanitizeService
+     */
+    private static $service;
+
+    public static function setupBeforeClass(): void
+    {
+        self::$service = new SanitizeService();
+    }
+
+    /**
+     * @dataProvider provideSanitizeStringCases
+     */
+    public function testSanitizeString($value)
+    {
+        if (!defined('FILTER_SANITIZE_STRING')) {
+            self::markTestSkipped('FILTER_SANITIZE_STRING is no more available (it was deprecated since PHP 8.1');
+        }
+        $errorReporting = error_reporting();
+        error_reporting($errorReporting & ~E_DEPRECATED);
+        try {
+            // This is the old implementation of our sanitizeString
+            $expected = filter_var($value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+        } finally {
+            error_reporting($errorReporting);
+        }
+        $actual = self::$service->sanitizeString($value);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideSanitizeStringCases(): array
+    {
+        return [
+            ['plain text'],
+            ["plain text"],
+            [false],
+            [true],
+            [null],
+            [new StringableClass()],
+            [new NonStringableClass()],
+            [[]],
+            [''],
+            ['Hello world'],
+            [1],
+            [1.2],
+            ['Hello <script>world</script>'],
+            ['Hello <script>world'],
+            ['Hello <script world'],
+            ["Hello <script\nworld"],
+            ["Hello < script\nworld"],
+            ["Hello <script\n>world</\nscri\npt>"],
+            ['`x` > "y"'],
+            ["Hèllo"],
+            ['H`&llo`'],
+        ];
+    }
+}


### PR DESCRIPTION
Newer versions of PHP are more strict about coding.

For example: in old PHP versions, accessing undefined array indexes raised notices (which is less "important" than warnings).
Since PHP 8.0 we have warnings, which are more "serious" messages.
And future PHP versions may be even more strict, for example refusing to run code that access undefined array indexes.

So, in order to be as future-proof as possible, we should fix any notice/warnings (see also #4723), and run our tests in an environment as strictly possible.

So, what about, for example, testing installation and upgrades with PHP 8.1?

In order to make the tests pass we already need some fixes (which I'll add here in a second time)