### PR TITLE
PHP Doc Block Update for desktop_* blocks

### DIFF
--- a/concrete/blocks/desktop_app_status/controller.php
+++ b/concrete/blocks/desktop_app_status/controller.php
@@ -9,22 +9,47 @@ use Concrete\Core\Updater\Update;
 
 class Controller extends BlockController
 {
-    protected $btCacheBlockRecord = true;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    /**
+     * @var int
+     */
     protected $btCacheBlockOutputLifetime = 86400; // check every day
 
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Displays alerts about your Concrete site and package updates.");
+        return t('Displays alerts about your Concrete site and package updates.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Concrete Status Messages");
+        return t('Concrete Status Messages');
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $config = $this->app->make('config');
@@ -32,16 +57,17 @@ class Controller extends BlockController
         $this->set('latest_version', Update::getLatestAvailableVersionNumber());
         $updates = 0;
         $p = new Checker();
+        /** @phpstan-ignore-next-line */
         if ($p->canInstallPackages()) {
             $packageService = $this->app->make(PackageService::class);
             $localHandles = [];
             foreach ($packageService->getLocalUpgradeablePackages() as $pkg) {
-                ++$updates;
+                $updates++;
                 $localHandles[] = $pkg->getPackageHandle();
             }
             foreach ($packageService->getRemotelyUpgradeablePackages() as $pkg) {
-                if (!in_array($pkg->getPackageHandle(), $localHandles)) {
-                    ++$updates;
+                if (!in_array($pkg->getPackageHandle(), $localHandles, true)) {
+                    $updates++;
                 }
             }
         }

--- a/concrete/blocks/desktop_concrete_latest/add.php
+++ b/concrete/blocks/desktop_concrete_latest/add.php
@@ -1,7 +1,7 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 ?>
 <h2><?=t('Slot')?></h2>
 <div>
-<?=Loader::helper('form')->select('slot', array('A' => 'A', 'B' => 'B', 'C' => 'C'))?>
+<?=Loader::helper('form')->select('slot', ['A' => 'A', 'B' => 'B', 'C' => 'C'])?>
 </div>

--- a/concrete/blocks/desktop_concrete_latest/add.php
+++ b/concrete/blocks/desktop_concrete_latest/add.php
@@ -1,7 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Form\Service\Form $form */
 ?>
 <h2><?=t('Slot')?></h2>
 <div>
-<?=Loader::helper('form')->select('slot', ['A' => 'A', 'B' => 'B', 'C' => 'C'])?>
+<?=$form->select('slot', ['A' => 'A', 'B' => 'B', 'C' => 'C'])?>
 </div>

--- a/concrete/blocks/desktop_concrete_latest/controller.php
+++ b/concrete/blocks/desktop_concrete_latest/controller.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Block\DesktopConcreteLatest;
 
 use Concrete\Core\Block\BlockController;
@@ -6,29 +7,62 @@ use Concrete\Core\ConcreteCms\ActivityService;
 
 class Controller extends BlockController
 {
-    protected $btCacheBlockRecord = true;
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutput = true;
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputOnPost = true;
+
+    /**
+     * @var int
+     */
     protected $btCacheBlockOutputLifetime = 7200;
+
+    /**
+     * @var string
+     */
     protected $btTable = 'btDesktopConcreteLatest';
+
+    /**
+     * @var bool
+     */
     protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    /**
+     * @var string|null
+     */
     protected $slot;
 
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Grabs the latest information about Concrete from concretecms.com.");
+        return t('Grabs the latest information about Concrete from concretecms.com.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Desktop Latest News");
+        return t('Desktop Latest News');
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $service = $this->app->make(ActivityService::class);
         $slots = $service->getSlotContents();
-        $this->set('slot', isset($slots[$this->slot]) ? $slots[$this->slot] : null);
+        $this->set('slot', $slots[$this->slot] ?? null);
         $this->set('key', $this->slot);
     }
 }

--- a/concrete/blocks/desktop_concrete_latest/edit.php
+++ b/concrete/blocks/desktop_concrete_latest/edit.php
@@ -1,7 +1,9 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var string|null $slot */
+/** @var \Concrete\Core\Form\Service\Form $form */
 ?>
 <h2><?=t('Slot')?></h2>
 <div>
-<?=Loader::helper('form')->select('slot', array('A' => 'A', 'B' => 'B', 'C' => 'C'), $slot)?>
+<?=$form->select('slot', ['A' => 'A', 'B' => 'B', 'C' => 'C'], $slot ?? null)?>
 </div>

--- a/concrete/blocks/desktop_concrete_latest/view.php
+++ b/concrete/blocks/desktop_concrete_latest/view.php
@@ -1,9 +1,15 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/** @var Concrete\Core\ConcreteCms\ActivitySlotItem|null $slot */
+/** @var string|null $key */
+?>
 <?php if (is_object($slot)) { ?>
 <div class="ccm-block-dashboard-concrete-latest-wrapper <?php if ($key == 'C') { ?>ccm-block-dashboard-concrete-slot-c<?php } ?>">
     <div class="ccm-block-dashboard-concrete-latest">
         <?=$slot->getContent()?>
     </div>
 </div>
-<?php 
+<?php
 }

--- a/concrete/blocks/desktop_draft_list/add.php
+++ b/concrete/blocks/desktop_draft_list/add.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/desktop_draft_list/add.php
+++ b/concrete/blocks/desktop_draft_list/add.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/desktop_draft_list/edit.php
+++ b/concrete/blocks/desktop_draft_list/edit.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/desktop_draft_list/edit.php
+++ b/concrete/blocks/desktop_draft_list/edit.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/desktop_draft_list/form.php
+++ b/concrete/blocks/desktop_draft_list/form.php
@@ -1,5 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Form\Service\Form $form */
+?>
 <div class="form-group">
     <?= $form->label('draftsPerPage', t('Number of drafts per page')); ?>
-    <?= $form->number('draftsPerPage', $draftsPerPage, ['placeholder' => $defaultDraftsPerPage]); ?>
+    <?= $form->number('draftsPerPage', $draftsPerPage ?? 10, ['placeholder' => $defaultDraftsPerPage ?? 10]); ?>
 </div>

--- a/concrete/blocks/desktop_draft_list/view.php
+++ b/concrete/blocks/desktop_draft_list/view.php
@@ -1,4 +1,8 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var Concrete\Core\Block\View\BlockView $view */
+/** @var array<string, mixed> $drafts */
+/** @var Concrete\Core\Search\Pagination\Pagination<\Concrete\Core\Page\Page>|null $pagination */
+?>
 
 <div class="card ccm-block-desktop-draft-list">
     <div class="card-body">
@@ -11,8 +15,8 @@
             <?php foreach ($drafts as $draft) {
         ?>
                 <div class="draft-list-item">
-                    <a href="<?= $draft['link']; ?>">
-                        <?= t('%s created by %s on %s', $draft['name'], $draft['user'], $draft['dateAdded']); ?>
+                    <a href="<?= $draft['link']?>">
+                        <?= t('%s created by %s on %s', $draft['name'], $draft['user'], $draft['dateAdded'])?>
                     </a>
                     <?php if (!empty($draft['deleteLink'])) {
             ?>
@@ -28,7 +32,7 @@
             if ($pagination && $pagination->haveToPaginate()) {
                 $pagination->setBaseURL($view->action('reload_drafts')); ?>
                 <div class="ccm-search-results-pagination">
-                    <?= $pagination->renderDefaultView(); ?>
+                    <?= $pagination->renderDefaultView()?>
                 </div>
                 <?php
             } ?>

--- a/concrete/blocks/desktop_featured_addon/controller.php
+++ b/concrete/blocks/desktop_featured_addon/controller.php
@@ -1,40 +1,71 @@
 <?php
+
 namespace Concrete\Block\DesktopFeaturedAddon;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Marketplace\RemoteItemList as MarketplaceRemoteItemList;
 
-/**
+    /**
      * The controller for the block that displays featured add-ons in the dashboard news overlay.
      *
      * @package Blocks
      * @subpackage Dashboard Featured Add-On
      *
-     * @author Andrew Embler <andrew@concrete5.org>
-     * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
-     * @license    http://www.concrete5.org/license/     MIT License
+     * @author Andrew Embler <andrew@concretecms.org>
+     * @copyright  Copyright (c) 2003-2022 concreteCMS. (http://www.concretecms.org)
+     * @license    http://www.concretecms.org/license/     MIT License
      */
     class Controller extends BlockController
     {
-        protected $btCacheBlockRecord = true;
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutput = true;
+
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutputOnPost = true;
+
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutputForRegisteredUsers = true;
+
+        /**
+         * @var int
+         */
         protected $btCacheBlockOutputLifetime = 7200;
 
+        /**
+         * @var int
+         */
         protected $btInterfaceWidth = 300;
+
+        /**
+         * @var int
+         */
         protected $btInterfaceHeight = 100;
 
+        /**
+         * @return string
+         */
         public function getBlockTypeDescription()
         {
-            return t("Features an add-on from marketplace.concretecms.com.");
+            return t('Features an add-on from marketplace.concretecms.com.');
         }
 
+        /**
+         * @return string
+         */
         public function getBlockTypeName()
         {
-            return t("Dashboard Featured Add-On");
+            return t('Dashboard Featured Add-On');
         }
 
+        /**
+         * @return void
+         */
         public function view()
         {
             $mri = new MarketplaceRemoteItemList();

--- a/concrete/blocks/desktop_featured_addon/view.php
+++ b/concrete/blocks/desktop_featured_addon/view.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <?php if (isset($remoteItem) && is_object($remoteItem)) { ?>
 
 <div class="ccm-block-desktop-featured-addon">

--- a/concrete/blocks/desktop_featured_theme/controller.php
+++ b/concrete/blocks/desktop_featured_theme/controller.php
@@ -1,40 +1,71 @@
 <?php
+
 namespace Concrete\Block\DesktopFeaturedTheme;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Marketplace\RemoteItemList as MarketplaceRemoteItemList;
 
-/**
+    /**
      * The controller for the block that displays featured themes in the dashboard news overlay.
      *
      * @package Blocks
      * @subpackage Dashboard Featured Theme
      *
-     * @author Andrew Embler <andrew@concrete5.org>
-     * @copyright  Copyright (c) 2003-2012 Concrete5. (http://www.concrete5.org)
-     * @license    http://www.concrete5.org/license/     MIT License
+     * @author Andrew Embler <andrew@concretecms.org>
+     * @copyright  Copyright (c) 2003-2022 concreteCMS. (http://www.concretecms.org)
+     * @license    http://www.concretecms.org/license/     MIT License
      */
     class Controller extends BlockController
     {
-        protected $btCacheBlockRecord = true;
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutput = true;
+
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutputOnPost = true;
+
+        /**
+         * @var bool
+         */
         protected $btCacheBlockOutputForRegisteredUsers = true;
+
+        /**
+         * @var int
+         */
         protected $btCacheBlockOutputLifetime = 7200;
 
+        /**
+         * @var int
+         */
         protected $btInterfaceWidth = 300;
+
+        /**
+         * @var int
+         */
         protected $btInterfaceHeight = 100;
 
+        /**
+         * @return string
+         */
         public function getBlockTypeDescription()
         {
-            return t("Features a theme from marketplace.concretecms.com.");
+            return t('Features a theme from marketplace.concretecms.com.');
         }
 
+        /**
+         * @return string
+         */
         public function getBlockTypeName()
         {
-            return t("Dashboard Featured Theme");
+            return t('Dashboard Featured Theme');
         }
 
+        /**
+         * @return void
+         */
         public function view()
         {
             $mri = new MarketplaceRemoteItemList();

--- a/concrete/blocks/desktop_featured_theme/view.php
+++ b/concrete/blocks/desktop_featured_theme/view.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 <?php if (isset($remoteItem) && is_object($remoteItem)) { ?>
 
 	<div class="ccm-block-desktop-featured-theme">

--- a/concrete/blocks/desktop_latest_form/controller.php
+++ b/concrete/blocks/desktop_latest_form/controller.php
@@ -2,43 +2,61 @@
 
 namespace Concrete\Block\DesktopLatestForm;
 
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
-use Package;
-use Concrete\Core\Block\BlockController;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    protected $btCacheBlockRecord = true;
-
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Shows the latest form submission.");
+        return t('Shows the latest form submission.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Latest Form");
+        return t('Latest Form');
     }
 
+    /**
+     * @return string[]
+     */
     public function getRequiredFeatures(): array
     {
         return [Features::DESKTOP];
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     *
+     * @return void
+     */
     public function view()
     {
-        $db = \Database::connection();
-        $r = $db->query('select * from btFormAnswerSet order by created desc limit 1');
-        $row = $r->fetch();
+        /** @var Connection $db */
+        $db = app(Connection::class);
+        $r = $db->executeQuery('select * from btFormAnswerSet order by created desc limit 1');
+        $row = $r->fetchAssociative();
 
         $legacyDateCreated = $row === false ? null : strtotime($row['created']);
-
-        $entityManager = $db->getEntityManager();
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        $entityManager = app(EntityManagerInterface::class);
         $forms = $entityManager->getRepository('Concrete\Core\Entity\Express\Entity')
-            ->findExpressForms();
+            ->findExpressForms()
+        ;
 
-        $ids = array();
+        $ids = [];
         foreach ($forms as $form) {
             $ids[] = $form->getID();
         }
@@ -56,27 +74,24 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         $formDateCreated = 0;
         if (is_object($result)) {
-            $formDateCreated = \Core::make('date')->toDateTime($result->getDateCreated())->getTimestamp();
+            $formDateCreated = app('date')->toDateTime($result->getDateCreated())->getTimestamp();
         }
 
         if ($legacyDateCreated !== null && $legacyDateCreated > $formDateCreated) {
             if (is_array($row) && isset($row['questionSetId'])) {
-                $r = $db->query('select * from btForm where questionSetId = ?', array($row['questionSetId']));
-                $row2 = $r->fetch();
-                if ($row2['bID']) {
+                $r = $db->executeQuery('select * from btForm where questionSetId = ?', [$row['questionSetId']]);
+                $row2 = $r->fetchAssociative();
+                if (is_array($row2) && isset($row2['bID'])) {
                     $this->set('formName', $row2['surveyName']);
-                    $this->set('date', \Core::make('date')->formatDateTime(strtotime($row['created'])));
-                    $this->set('link', \URL::to('/dashboard/reports/forms/legacy') . '?qsid=' . $row['questionSetId']);
+                    $this->set('date', app('date')->formatDateTime(strtotime($row['created'])));
+                    $this->set('link', app(ResolverManagerInterface::class)->resolve(['/dashboard/reports/forms/legacy']) . '?qsid=' . $row['questionSetId']);
                 }
             }
         } elseif (is_object($result)) {
             $entity = $result->getEntity();
             $this->set('formName', $entity->getEntityDisplayName());
-            $this->set('date', \Core::make('date')->formatDateTime($result->getDateCreated()));
-            $this->set('link', \URL::to('/dashboard/reports/forms/view_entry', $result->getID()));
+            $this->set('date', app('date')->formatDateTime($result->getDateCreated()));
+            $this->set('link', app(ResolverManagerInterface::class)->resolve(['/dashboard/reports/forms/view_entry', $result->getID()]));
         }
-
     }
-
-
 }

--- a/concrete/blocks/desktop_latest_form/view.php
+++ b/concrete/blocks/desktop_latest_form/view.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div
     <?php if (isset($link) && $link) { ?>data-link="<?=$link?>"<?php } ?>
@@ -14,7 +14,7 @@
         <?php if (isset($formName) && $formName) { ?>
 
             <span class="ccm-block-desktop-latest-form-name"><?=$formName?></span>
-            <span class="ccm-block-desktop-latest-form-date"><?=$date?></span>
+            <span class="ccm-block-desktop-latest-form-date"><?=$date ?? ''?></span>
 
         <?php } else { ?>
             <span class="ccm-block-desktop-latest-form-name"><?=t('None')?></span>

--- a/concrete/blocks/desktop_site_activity/add.php
+++ b/concrete/blocks/desktop_site_activity/add.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/desktop_site_activity/add.php
+++ b/concrete/blocks/desktop_site_activity/add.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/desktop_site_activity/controller.php
+++ b/concrete/blocks/desktop_site_activity/controller.php
@@ -87,7 +87,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $data = $blockNode->addChild('data');
         $this->loadTypes();
         $types = $this->get('types');
-        foreach($types as $type) {
+        foreach ($types as $type) {
             $data->addChild('type', $type);
         }
     }
@@ -249,7 +249,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         $ids = [];
         $new = 0;
-        foreach($forms as $form) {
+        foreach ($forms as $form) {
             $ids[] = $form->getID();
         }
 
@@ -272,10 +272,10 @@ class Controller extends BlockController implements UsesFeatureInterface
     {
         $categories = Category::getList();
         $items = 0;
-        foreach($categories as $category) {
+        foreach ($categories as $category) {
             $list = $category->getPendingWorkflowProgressList();
             if (is_object($list)) {
-                foreach($list->get() as $it) {
+                foreach ($list->get() as $it) {
                     $wp = $it->getWorkflowProgressObject();
                     $wf = $wp->getWorkflowObject();
                     if ($wf->canApproveWorkflowProgressObject($wp)) {

--- a/concrete/blocks/desktop_site_activity/edit.php
+++ b/concrete/blocks/desktop_site_activity/edit.php
@@ -1,4 +1,4 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 $this->inc('form.php');

--- a/concrete/blocks/desktop_site_activity/edit.php
+++ b/concrete/blocks/desktop_site_activity/edit.php
@@ -1,4 +1,4 @@
 <?php
-
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $this */
 $this->inc('form.php');

--- a/concrete/blocks/desktop_site_activity/form.php
+++ b/concrete/blocks/desktop_site_activity/form.php
@@ -1,9 +1,13 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var string[]|null $types */
+$types = $types ?? [];
+?>
 <div class="form-group">
-    <?php echo $form->label('types', t('Types to Display'));?>
-    <div class="form-check"><?=$form->checkbox('types[]', 'form_submissions', in_array('form_submissions', $types))?> <?=$form->label('types_form_submissions',t('Form Submissions'), ['class'=>'form-check-label'])?></div>
-    <div class="form-check"><?=$form->checkbox('types[]', 'survey_results', in_array('survey_results', $types))?> <?=$form->label('types_survey_results',t('Survey Results'), ['class'=>'form-check-label'])?></div>
-    <div class="form-check"><?=$form->checkbox('types[]', 'signups', in_array('signups', $types))?> <?=$form->label('types_signups',t('New Users'), ['class'=>'form-check-label'])?></div>
-    <div class="form-check"><?=$form->checkbox('types[]', 'conversation_messages', in_array('conversation_messages', $types))?> <?=$form->label('types_conversation_messages',t('Conversation Messages'), ['class'=>'form-check-label'])?></div>
-    <div class="form-check"><?=$form->checkbox('types[]', 'workflow', in_array('workflow', $types))?> <?=$form->label('types_workflow',t('Workflow Approvals'), ['class'=>'form-check-label'])?></div>
+    <?php echo $form->label('types', t('Types to Display')); ?>
+    <div class="form-check"><?=$form->checkbox('types[]', 'form_submissions', in_array('form_submissions', $types))?> <?=$form->label('types_form_submissions', t('Form Submissions'), ['class' => 'form-check-label'])?></div>
+    <div class="form-check"><?=$form->checkbox('types[]', 'survey_results', in_array('survey_results', $types))?> <?=$form->label('types_survey_results', t('Survey Results'), ['class' => 'form-check-label'])?></div>
+    <div class="form-check"><?=$form->checkbox('types[]', 'signups', in_array('signups', $types))?> <?=$form->label('types_signups', t('New Users'), ['class' => 'form-check-label'])?></div>
+    <div class="form-check"><?=$form->checkbox('types[]', 'conversation_messages', in_array('conversation_messages', $types))?> <?=$form->label('types_conversation_messages', t('Conversation Messages'), ['class' => 'form-check-label'])?></div>
+    <div class="form-check"><?=$form->checkbox('types[]', 'workflow', in_array('workflow', $types))?> <?=$form->label('types_workflow', t('Workflow Approvals'), ['class' => 'form-check-label'])?></div>
 </div>

--- a/concrete/blocks/desktop_site_activity/view.php
+++ b/concrete/blocks/desktop_site_activity/view.php
@@ -1,4 +1,21 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+use Concrete\Core\Localization\Localization;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Support\Facade\Url;
+
+$types = $types ?? [];
+/** @var int|string|null $formResults */
+$formResults = $formResults ?? 0;
+/** @var int|string|null $surveyResults */
+$surveyResults = $surveyResults ?? 0;
+/** @var int|string|null $signups */
+$signups = $signups ?? 0;
+/** @var int|string|null $messages */
+$messages = $messages ?? 0;
+/** @var int|string|null $approvals */
+$approvals = $approvals ?? 0;
+
+?>
 <div class="ccm-block-desktop-site-activity">
 
     <?php
@@ -22,23 +39,23 @@
                         var results = [['<?=t('Item')?>', '<?=t('Number')?>']];
                         var slices = [];
                         <?php if (in_array('form_submissions', $types)) { ?>
-                            results.push(['<?=t('Form Results')?>', <?=intval($formResults)?>]);
+                            results.push(['<?=t('Form Results')?>', <?=(int) $formResults?>]);
                             slices.push({color: '#00d0f8'});
                         <?php } ?>
                         <?php if (in_array('survey_results', $types)) { ?>
-                            results.push(['<?=t('Survey Results')?>', <?=intval($surveyResults)?>]);
+                            results.push(['<?=t('Survey Results')?>', <?=(int) $surveyResults?>]);
                             slices.push({color: '#7c33b1'});
                         <?php } ?>
                         <?php if (in_array('signups', $types)) { ?>
-                            results.push(['<?=t('Signups')?>', <?=intval($signups)?>]);
+                            results.push(['<?=t('Signups')?>', <?=(int) $signups?>]);
                             slices.push({color: '#fed24b'});
                         <?php } ?>
                         <?php if (in_array('conversation_messages', $types)) { ?>
-                            results.push(['<?=t('Conversation Messages')?>', <?=intval($messages)?>]);
+                            results.push(['<?=t('Conversation Messages')?>', <?=(int) $messages?>]);
                             slices.push({color: '#00cc66'});
                         <?php } ?>
                         <?php if (in_array('workflow', $types)) { ?>
-                            results.push(['<?=t('Approvals')?>', <?=intval($approvals)?>]);
+                            results.push(['<?=t('Approvals')?>', <?=(int) $approvals?>]);
                             slices.push({color: '#f3ac1e'});
                         <?php } ?>
 
@@ -85,36 +102,36 @@
                 <h6><?=t('Latest')?></h6>
                 <?php if (in_array('form_submissions', $types) && $formResults) { ?>
                 <div class="ccm-block-desktop-site-activity-legend-row">
-                    <a href="<?=URL::to('/dashboard/reports/forms')?>" style="color: #00d0f8">
-                    <?=t2('%s Form', '%s Forms', intval($formResults))?>
+                    <a href="<?=Url::to('/dashboard/reports/forms')?>" style="color: #00d0f8">
+                    <?=t2('%s Form', '%s Forms', (int) $formResults)?>
                     </a>
                 </div>
                 <?php } ?>
                 <?php if (in_array('survey_results', $types) && $surveyResults) { ?>
                 <div class="ccm-block-desktop-site-activity-legend-row">
-                    <a href="<?=URL::to('/dashboard/reports/surveys')?>" style="color: #7c33b1">
-                        <?=t2('%s Vote', '%s Votes', intval($surveyResults))?>
+                    <a href="<?=Url::to('/dashboard/reports/surveys')?>" style="color: #7c33b1">
+                        <?=t2('%s Vote', '%s Votes', (int) $surveyResults)?>
                     </a>
                 </div>
                 <?php } ?>
                 <?php if (in_array('signups', $types) && $signups) { ?>
                 <div class="ccm-block-desktop-site-activity-legend-row">
-                    <a href="<?=URL::to('/dashboard/users/search')?>" style="color: #fed24b">
-                        <?=t2('%s User', '%s Users', intval($signups))?>
+                    <a href="<?=Url::to('/dashboard/users/search')?>" style="color: #fed24b">
+                        <?=t2('%s User', '%s Users', (int) $signups)?>
                     </a>
                 </div>
                 <?php } ?>
                 <?php if (in_array('conversation_messages', $types) && $messages) { ?>
                 <div class="ccm-block-desktop-site-activity-legend-row">
-                    <a href="<?=URL::to('/dashboard/conversations/messages')?>" style="color: #00cc66">
-                        <?=t2('%s Message', '%s Messages', intval($messages))?>
+                    <a href="<?=Url::to('/dashboard/conversations/messages')?>" style="color: #00cc66">
+                        <?=t2('%s Message', '%s Messages', (int) $messages)?>
                     </a>
                 </div>
                 <?php } ?>
                 <?php if (in_array('workflow', $types) && $approvals) { ?>
                     <div class="ccm-block-desktop-site-activity-legend-row">
-                        <a href="<?=URL::to('/dashboard/welcome/me')?>" style="color: #f3ac1e">
-                            <?=t2('%s Approval', '%s Approvals', intval($approvals))?>
+                        <a href="<?=Url::to('/dashboard/welcome/me')?>" style="color: #f3ac1e">
+                            <?=t2('%s Approval', '%s Approvals', (int) $approvals)?>
                         </a>
                     </div>
                 <?php } ?>

--- a/concrete/blocks/desktop_waiting_for_me/controller.php
+++ b/concrete/blocks/desktop_waiting_for_me/controller.php
@@ -1,40 +1,58 @@
 <?php
+
 namespace Concrete\Block\DesktopWaitingForMe;
 
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Block\View\BlockView;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
+use Concrete\Core\Notification\Alert\AlertList;
 use Concrete\Core\Notification\Alert\Filter\FilterListFactory;
 use Concrete\Core\User\User;
-use Concrete\Core\Workflow\Progress\Category;
-use Core;
-use Concrete\Core\Notification\Alert\AlertList;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = array('form');
-
+    /**
+     * @var int
+     */
     protected $btInterfaceWidth = 450;
+
+    /**
+     * @var int
+     */
     protected $btInterfaceHeight = 560;
 
+    /**
+     * @return array|string[]
+     */
     public function getRequiredFeatures(): array
     {
         return [Features::DESKTOP];
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeDescription()
     {
-        return t("Displays workflow actions waiting for you.");
+        return t('Displays workflow actions waiting for you.');
     }
 
+    /**
+     * @return string
+     */
     public function getBlockTypeName()
     {
-        return t("Waiting for Me");
+        return t('Waiting for Me');
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return void
+     */
     public function view()
     {
         $filterValues = ['' => t('** Show All')];
@@ -42,11 +60,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         $factory = $this->app->make(FilterListFactory::class);
         $filterList = $factory->createList();
         $filters = $filterList->getFilters();
-        foreach($filters as $filter) {
+        foreach ($filters as $filter) {
             $filterValues[$filter->getKey()] = $filter->getName();
         }
 
         $u = $this->app->make(User::class);
+        /** @var AlertList $list */
         $list = $this->app->make(AlertList::class, ['user' => $u]);
         $filter = (string) $this->request->query->get('filter');
         if ($filter !== '') {
@@ -70,6 +89,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('filter', $filter);
     }
 
+    /**
+     * @return void
+     */
     public function action_reload_results()
     {
         $b = $this->getBlockObject();
@@ -77,5 +99,4 @@ class Controller extends BlockController implements UsesFeatureInterface
         $bv->render('view');
         exit;
     }
-
 }

--- a/concrete/blocks/desktop_waiting_for_me/view.php
+++ b/concrete/blocks/desktop_waiting_for_me/view.php
@@ -1,13 +1,14 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
-/* @var Concrete\Core\Block\View\BlockView $view */
-/* @var Concrete\Core\Form\Service\Form $form */
 
-/* @var Concrete\Core\Entity\Notification\NotificationAlert[] $items */
-/* @var array $filterValues */
-/* @var string $filter */
-/* @var Concrete\Core\Validation\CSRF\Token $token */
-/* @var Concrete\Core\Search\Pagination\Pagination $pagination */
+defined('C5_EXECUTE') or die('Access Denied.');
+/** @var Concrete\Core\Block\View\BlockView $view */
+/** @var Concrete\Core\Form\Service\Form $form */
+
+/** @var Concrete\Core\Entity\Notification\NotificationAlert[] $items */
+/** @var array $filterValues */
+/** @var string $filter */
+/** @var Concrete\Core\Validation\CSRF\Token $token */
+/** @var Concrete\Core\Search\Pagination\Pagination<Concrete\Core\Entity\Notification\NotificationAlert>|null $pagination */
 ?>
 <div class="card ccm-block-desktop-waiting-for-me" data-wrapper="desktop-waiting-for-me">
 
@@ -32,7 +33,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
             foreach($items as $item) {
                 $notification = $item->getNotification();
                 /**
-                 * @var $listView \Concrete\Core\Notification\View\ListViewInterface
+                 * @var \Concrete\Core\Notification\View\ListViewInterface $listView
                  */
                 $listView = $notification->getListView();
                 $action = $listView->getFormAction();
@@ -45,17 +46,17 @@ defined('C5_EXECUTE') or die("Access Denied.");
                     <form action="<?=$action?>" method="post">
                 <?php }  ?>
 
-                    <div class="ccm-block-desktop-waiting-for-me-icon">
-                        <?php print $listView->renderIcon() ?>
-                    </div>
+                <div class="ccm-block-desktop-waiting-for-me-icon">
+                    <?php echo $listView->renderIcon() ?>
+                </div>
 
-                    <div class="ccm-block-desktop-waiting-for-me-details">
-                        <?php print $listView->renderDetails() ?>
-                    </div>
+                <div class="ccm-block-desktop-waiting-for-me-details">
+                    <?php echo $listView->renderDetails() ?>
+                </div>
 
-                    <div class="ccm-block-desktop-waiting-for-me-menu">
-                        <?php print $listView->renderMenu() ?>
-                    </div>
+                <div class="ccm-block-desktop-waiting-for-me-menu">
+                    <?php echo $listView->renderMenu() ?>
+                </div>
 
 
                 <?php if ($action) { ?>
@@ -73,18 +74,15 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
             <?php if ($pagination && $pagination->haveToPaginate()) {
                 $pagination->setBaseURL($view->action('reload_results') . '?filter=' . rawurlencode($filter));
-                ?>
 
-                <?php
-                $c = Page::getCurrentPage();
+                $c = \Concrete\Core\Page\Page::getCurrentPage();
                 $theme = $c->getController()->getTheme();
-                if (is_string($theme) && ($theme === VIEW_CORE_THEME || $theme === 'dashboard')) { ?>
-                    <?= $pagination->renderView('dashboard'); ?>
-                <?php } else { ?>
-                    <?= $pagination->renderDefaultView(); ?>
-                <?php } ?>
-
-            <?php } ?>
+                if ($theme === VIEW_CORE_THEME || $theme === 'dashboard') {
+                    echo $pagination->renderView('dashboard');
+                 } else {
+                    echo $pagination->renderDefaultView();
+                }
+            } ?>
 
         </div>
     </div>


### PR DESCRIPTION
This PR is split from In regards to https://github.com/concrete5/concrete5/pull/10300 to make it easer to review

This PR adds PHP doc blocks to all desktop_* blocks
 desktop_app_status
 desktop_concrete_latest
 desktop_draft_list
 desktop_featured_addon
 desktop_featured_theme
 desktop_latest_form
 desktop_site_activity
 desktop_waiting_for_me

It also passes phpstan level 6
remove some depreciated methods, use the app helper function over facades
ran php-cs-fixer on all the files