### PR TITLE
Fix missing none option in attribute display block

### DIFF
--- a/concrete/blocks/page_attribute_display/form.php
+++ b/concrete/blocks/page_attribute_display/form.php
@@ -84,6 +84,7 @@ echo $ui->tabs([
         <div class="form-group">
             <?php echo $form->label("delimiter", t('Delimiter for Multiple Items')); ?>
             <?php echo $form->select("delimiter", [
+                "" => t('None'),
                 "comma" => t('Comma (",")'),
                 "commaSpace" => t('Comma With Space After (", ")'),
                 "pipe" => t('Pipe ("|")'),


### PR DESCRIPTION
The core attribute display block defaults to no delimiter. But once you have set a delimiter, there was no option to clear it again!
This pull fixes that missing option.

(The option still exists on 8.5.x, but was lost when the code was refactored to use $form->select)