### PR TITLE
Switch to using Bootstrap 5 style tooltips for composer controls

### DIFF
--- a/concrete/elements/form/composer.php
+++ b/concrete/elements/form/composer.php
@@ -12,7 +12,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <?php endif; ?>
 
     <?php if ($context->getTooltip()): ?>
-        <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$context->getTooltip()?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($context->getTooltip()); ?>"></i>
     <?php endif; ?>
 
     <?php $view->renderControl()?>

--- a/concrete/elements/form/grouped/composer.php
+++ b/concrete/elements/form/grouped/composer.php
@@ -7,7 +7,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <?php } ?>
 
     <?php if ($context->getTooltip()): ?>
-        <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$context->getTooltip()?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($context->getTooltip()); ?>"></i>
     <?php endif; ?>
 
     <?php $view->renderControl()?>

--- a/concrete/elements/page_types/composer/controls/core_page_property/date_time.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/date_time.php
@@ -15,7 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<?= app('helper/form/date_time')->datetime($this->field('date_time'), $control->getPageTypeComposerControlDraftValue()) ?>

--- a/concrete/elements/page_types/composer/controls/core_page_property/description.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/description.php
@@ -15,7 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<?= $form->textarea($this->field('description'), $control->getPageTypeComposerControlDraftValue(), ['rows' => 3]) ?>

--- a/concrete/elements/page_types/composer/controls/core_page_property/name.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/name.php
@@ -19,7 +19,7 @@ $resolverManager = app(ResolverManagerInterface::class);
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<div data-composer-field="name">

--- a/concrete/elements/page_types/composer/controls/core_page_property/page_template.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/page_template.php
@@ -25,7 +25,7 @@ if (!$ptComposerPageTemplateID) {
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<div data-composer-field="page_template">

--- a/concrete/elements/page_types/composer/controls/core_page_property/publish_target.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/publish_target.php
@@ -25,7 +25,7 @@ if (is_object($parent) && $parent->isError()) {
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<div data-composer-field="name">

--- a/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
@@ -22,7 +22,7 @@ $resolverManager = app(ResolverManagerInterface::class);
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
     <div>

--- a/concrete/elements/page_types/composer/controls/core_page_property/user.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/user.php
@@ -15,7 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?=$description?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<?= app('helper/form/user_selector')->selectUser($this->field('user'), $control->getPageTypeComposerControlDraftValue()) ?>

--- a/concrete/elements/page_types/composer/controls/core_page_property/version_comment.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/version_comment.php
@@ -15,7 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php } ?>
 
 	<?php if ($description) { ?>
-	    <i class="fas fa-question-circle launch-tooltip" title="" data-original-title="<?= $description ?>"></i>
+        <i class="fas fa-question-circle launch-tooltip" data-bs-toggle="tooltip" title="<?= h($description); ?>"></i>
 	<?php } ?>
 
 	<?= $form->textarea($this->field('version_comment'), $control->getPageTypeComposerControlDraftValue(), ['rows' => 2]) ?>


### PR DESCRIPTION
refs #10462

This also wraps the output for the tooltips with the h() security helper