### PR TITLE
[V9] Fix SQL error on duplicate alias between multilingual sections

### DIFF
--- a/tests/tests/Multilingual/SectionTest.php
+++ b/tests/tests/Multilingual/SectionTest.php
@@ -4,6 +4,7 @@ namespace Concrete\Tests\Multilingual;
 use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Multilingual\Service\Detector;
+use Concrete\Core\Page\Page;
 use Concrete\TestHelpers\Page\PageTestCase;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -103,5 +104,28 @@ class SectionTest extends PageTestCase
         $oldPage->delete();
         $newPage->delete();
         $newPageInSecondLocale->delete();
+    }
+
+    public function testDuplicateAliasMultilingual()
+    {
+        $default = Section::getDefaultSection();
+        $parent = self::createPage('Parent', $default);
+        $original = self::createPage('Awesome', $parent);
+        $aliasID = $original->addCollectionAlias($default);
+        $alias = Page::getByID($aliasID);
+        $this->assertEquals($original->getCollectionID(), $alias->getCollectionPointerID());
+
+        $second = Section::getByLocale('de_CH');
+        $secondParent = $parent->duplicate($second);
+        $secondOriginal = $original->duplicate($secondParent);
+        $secondAlias = $alias->duplicate($second);
+        $this->assertEquals($secondOriginal->getCollectionID(), $secondAlias->getCollectionID());
+
+        $parent->delete();
+        $original->delete();
+        $alias->delete();
+        $secondParent->delete();
+        $secondOriginal->delete();
+        $secondAlias->delete();
     }
 }

--- a/tests/tests/Page/PageTest.php
+++ b/tests/tests/Page/PageTest.php
@@ -348,6 +348,22 @@ class PageTest extends PageTestCase
         }
     }
 
+    public function testPageAliasDuplicate()
+    {
+        extract($aliases = $this->setupAliases());
+        $aliasID = $contact->addCollectionAlias($search);
+        $alias = Page::getByID($aliasID);
+        $this->assertEquals('/search/contact-us', $alias->getCollectionPath());
+        $duplicated = $alias->duplicate($awesome);
+        $this->assertEquals('/awesome/contact-us', $duplicated->getCollectionPath());
+        $this->assertTrue($duplicated->isAliasPage());
+        $this->assertEquals($contact->getCollectionID(), $duplicated->getCollectionPointerID());
+
+        foreach ($aliases as $alias) {
+            $alias->delete();
+        }
+    }
+
     public function testPageMoveToTrashNoAliases()
     {
         \SinglePage::add(Config::get('concrete.paths.trash'));


### PR DESCRIPTION
Same as #10467 , fix #7781 for version 9

```
% composer test -- --filter testDuplicateAliasMultilingual
> phpunit '--filter' 'testDuplicateAliasMultilingual'
PHPUnit 8.5.24 #StandWithUkraine

Runtime:       PHP 7.4.27
Configuration: /path/to/phpunit.xml

E                                                                   1 / 1 (100%)

Time: 3.84 seconds, Memory: 52.50 MB

There was 1 error:

1) Concrete\Tests\Multilingual\SectionTest::testDuplicateAliasMultilingual
Doctrine\DBAL\Exception\UniqueConstraintViolationException: An exception occurred while executing 'insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)' with params ["2", 4, "de_CH", "de"]:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:74
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:182
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:159
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:2226
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1313
/path/to/concrete/src/Database/Connection/Connection.php:97
/path/to/concrete/src/Multilingual/Page/Section/Section.php:373
/path/to/concrete/src/Page/Cloner.php:147
/path/to/concrete/src/Page/Page.php:2835
/path/to/tests/tests/Multilingual/SectionTest.php:121

Caused by
Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:119
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1304
/path/to/concrete/src/Database/Connection/Connection.php:97
/path/to/concrete/src/Multilingual/Page/Section/Section.php:373
/path/to/concrete/src/Page/Cloner.php:147
/path/to/concrete/src/Page/Page.php:2835
/path/to/tests/tests/Multilingual/SectionTest.php:121

Caused by
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-4' for key 'PRIMARY'

/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:117
/path/to/concrete/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1304
/path/to/concrete/src/Database/Connection/Connection.php:97
/path/to/concrete/src/Multilingual/Page/Section/Section.php:373
/path/to/concrete/src/Page/Cloner.php:147
/path/to/concrete/src/Page/Page.php:2835
/path/to/tests/tests/Multilingual/SectionTest.php:121

ERRORS!
Tests: 1, Assertions: 1, Errors: 1.
Script phpunit handling the test event returned with error code 2
```