### PR TITLE
Use `concrete_secure` over `concrete` wherever possible

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/connect.php
+++ b/concrete/controllers/single_page/dashboard/extend/connect.php
@@ -15,7 +15,7 @@ class Connect extends DashboardPageController
         $this->set('marketplace', Marketplace::getInstance());
         $this->set('dbConfig', $this->app->make('config/database'));
         $this->set('config', $config);
-        $this->set('projectPageURL', $config->get('concrete.urls.concrete') . $config->get('concrete.urls.paths.marketplace.projects'));
+        $this->set('projectPageURL', $config->get('concrete.urls.concrete_secure') . $config->get('concrete.urls.paths.marketplace.projects'));
     }
 
     public function do_connect()

--- a/concrete/src/Marketplace/Marketplace.php
+++ b/concrete/src/Marketplace/Marketplace.php
@@ -105,7 +105,7 @@ class Marketplace implements ApplicationAwareInterface
                 $ms = '&ms=1';
             }
             $csiURL = urlencode($this->getSiteURL());
-            $url = $this->config->get('concrete.urls.concrete') . $this->config->get('concrete.urls.paths.marketplace.connect_validate') . "?csToken={$csToken}&csiURL=" . $csiURL . '&csiVersion=' . APP_VERSION . $ms;
+            $url = $this->config->get('concrete.urls.concrete_secure') . $this->config->get('concrete.urls.paths.marketplace.connect_validate') . "?csToken={$csToken}&csiURL=" . $csiURL . '&csiVersion=' . APP_VERSION . $ms;
             $vn = $this->app->make('helper/validation/numbers');
             $r = $this->get($url);
 
@@ -243,7 +243,7 @@ class Marketplace implements ApplicationAwareInterface
         // Retrieve the URL contents
         $csToken = $marketplace->databaseConfig->get('concrete.marketplace.token');
         $csiURL = urlencode($marketplace->getSiteURL());
-        $url = $marketplace->config->get('concrete.urls.concrete') . $marketplace->config->get('concrete.urls.paths.marketplace.purchases');
+        $url = $marketplace->config->get('concrete.urls.concrete_secure') . $marketplace->config->get('concrete.urls.paths.marketplace.purchases');
         $url .= "?csToken={$csToken}&csiURL=" . $csiURL . '&csiVersion=' . APP_VERSION;
         $json = $marketplace->get($url);
 
@@ -288,7 +288,7 @@ class Marketplace implements ApplicationAwareInterface
     public function getSitePageURL(): string
     {
         $token = $this->databaseConfig->get('concrete.marketplace.url_token');
-        $url = $this->config->get('concrete.urls.concrete') . $this->config->get('concrete.urls.paths.site_page');
+        $url = $this->config->get('concrete.urls.concrete_secure') . $this->config->get('concrete.urls.paths.site_page');
 
         return $url . '/' . $token;
     }
@@ -389,7 +389,7 @@ class Marketplace implements ApplicationAwareInterface
     public function generateSiteToken()
     {
         return $this->get(
-            $this->config->get('concrete.urls.concrete') .
+            $this->config->get('concrete.urls.concrete_secure') .
             $this->config->get('concrete.urls.paths.marketplace.connect_new_token')
         );
     }

--- a/concrete/src/Marketplace/RemoteItem.php
+++ b/concrete/src/Marketplace/RemoteItem.php
@@ -271,7 +271,7 @@ class RemoteItem extends ConcreteObject
         $dbConfig = \Core::make('config/database');
         $csToken = $dbConfig->get('concrete.marketplace.token');
         $csiURL = urlencode(\Core::getApplicationURL());
-        $url = Config::get('concrete.urls.concrete') . Config::get('concrete.urls.paths.marketplace.item_free_license');
+        $url = Config::get('concrete.urls.concrete_secure') . Config::get('concrete.urls.paths.marketplace.item_free_license');
         $url .= "?mpID=" . $this->mpID . "&csToken={$csToken}&csiURL=" . $csiURL . "&csiVersion=" . APP_VERSION;
         $fh->getContents($url);
     }
@@ -285,7 +285,7 @@ class RemoteItem extends ConcreteObject
         $csToken = $dbConfig->get('concrete.marketplace.token');
         $csiURL = urlencode(\Core::getApplicationURL());
 
-        $url = Config::get('concrete.urls.concrete') . Config::get('concrete.urls.paths.marketplace.item_information');
+        $url = Config::get('concrete.urls.concrete_secure') . Config::get('concrete.urls.paths.marketplace.item_information');
         $url .= "?" . $method . "=" . $identifier . "&csToken={$csToken}&csiURL=" . $csiURL . "&csiVersion=" . APP_VERSION;
         $json = $fh->getContents($url);
 

--- a/concrete/src/Marketplace/RemoteItemList.php
+++ b/concrete/src/Marketplace/RemoteItemList.php
@@ -22,7 +22,7 @@ class RemoteItemList extends ItemList
             $sets = $r->get();
         } else {
             $r->lock();
-            $url = Config::get('concrete.urls.concrete') . Config::get('concrete.urls.paths.marketplace.remote_item_list');
+            $url = Config::get('concrete.urls.concrete_secure') . Config::get('concrete.urls.paths.marketplace.remote_item_list');
             $url .= $type . '/-/get_remote_item_sets';
             if (Config::get('concrete.marketplace.log_requests')) {
                 Log::info($url);
@@ -113,7 +113,7 @@ class RemoteItemList extends ItemList
 
         $uh = Core::make('helper/url');
 
-        $url = Config::get('concrete.urls.concrete') . Config::get('concrete.urls.paths.marketplace.remote_item_list');
+        $url = Config::get('concrete.urls.concrete_secure') . Config::get('concrete.urls.paths.marketplace.remote_item_list');
         $url = $uh->buildQuery($url . $this->type . '/-/get_remote_list', $params);
         if (Config::get('concrete.marketplace.log_requests')) {
             Log::info($url);


### PR DESCRIPTION
Basically all of the communication with the marketplace happens from server to server rather than in browser these days, the only exceptions being images loaded in the browser directly from marketplace. This PR starts using `concrete_secure` for this communication leaving only the usage in `Marketplace::getMarketplaceFrame()` since this method is not actually used anywhere and secure is already used any time the site is loaded via HTTPS.
