### PR TITLE
jQuery/ FontAwesome dependencies moved from block controllers into block templates

### DIFF
--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -134,11 +134,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function registerViewAssets($outputContent = '')
     {
-        if (is_object($this->block) && $this->block->getBlockFilename() == 'parallax') {
-            $this->requireAsset('javascript', 'jquery');
-            $this->requireAsset('javascript', 'core/frontend/parallax-image');
-        }
-
         $arLayout = $this->getAreaLayoutObject();
         if (is_object($arLayout)) {
             if ($arLayout instanceof CustomAreaLayout) {

--- a/concrete/blocks/core_area_layout/templates/parallax/view.php
+++ b/concrete/blocks/core_area_layout/templates/parallax/view.php
@@ -1,4 +1,8 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('javascript', 'jquery');
+$this->requireAsset('javascript', 'core/frontend/parallax-image');
+
 $minColumns = 1;
 $columnsNum = $columnsNum ?? 1;
 $maxColumns = $maxColumns ?? 12;

--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -794,7 +794,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('results', $results);
         $this->set('hideFolders', $this->hideFolders);
 
-        $this->requireAsset('css', 'font-awesome');
         $this->set('canAddFiles', false);
         $fp = \FilePermissions::getGlobal();
 

--- a/concrete/blocks/document_library/view.php
+++ b/concrete/blocks/document_library/view.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
+<?php defined('C5_EXECUTE') or die(_("Access Denied."));
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('css', 'font-awesome');?>
 <?php
 $c = Page::getCurrentPage();
 ?>

--- a/concrete/blocks/event_list/controller.php
+++ b/concrete/blocks/event_list/controller.php
@@ -85,7 +85,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         if (!$this->totalToRetrieve) {
             $this->set('totalToRetrieve', 9);
         }
-        $this->requireAsset('font-awesome');
         $list = new EventOccurrenceList();
         $calendar = $this->getCalendarOrCalendars();
         if (is_object($calendar)) {

--- a/concrete/blocks/event_list/view.php
+++ b/concrete/blocks/event_list/view.php
@@ -1,6 +1,6 @@
-<?php
-
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('font-awesome');
 
 if (isset($calendar)) {
     $pagination = $list->getPagination();

--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -70,7 +70,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function registerViewAssets($outputContent = '')
     {
-        $this->requireAsset('css', 'font-awesome');
         if (is_object($this->block) && $this->block->getBlockFilename() == 'hover_description') {
             // this isn't great but it's the only way to do this and still make block
             // output caching available to this block.

--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -68,16 +68,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         return LinkAbstractor::translateFromEditMode($this->paragraph);
     }
 
-    public function registerViewAssets($outputContent = '')
-    {
-        if (is_object($this->block) && $this->block->getBlockFilename() == 'hover_description') {
-            // this isn't great but it's the only way to do this and still make block
-            // output caching available to this block.
-            $this->requireAsset('javascript', 'bootstrap/tooltip');
-            $this->requireAsset('css', 'bootstrap/tooltip');
-        }
-    }
-
     public function add()
     {
         $this->set('titleFormat', 'h4');

--- a/concrete/blocks/feature/view.php
+++ b/concrete/blocks/feature/view.php
@@ -1,5 +1,7 @@
-<?php  defined('C5_EXECUTE') or die("Access Denied."); ?>
-<?php
+<?php  defined('C5_EXECUTE') or die("Access Denied.");
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('css', 'font-awesome');
+
 $title = h($title);
 if ($linkURL) {
     $title = '<a href="' . $linkURL . '">' . $title . '</a>';

--- a/concrete/blocks/google_map/controller.php
+++ b/concrete/blocks/google_map/controller.php
@@ -73,8 +73,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function registerViewAssets($outputContent = '')
     {
-        $this->requireAsset('javascript', 'jquery');
-
         $c = Page::getCurrentPage();
         if (!$c->isEditMode()) {
             $this->addFooterItem(

--- a/concrete/blocks/google_map/view.php
+++ b/concrete/blocks/google_map/view.php
@@ -1,4 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('javascript', 'jquery');
 
 /**
  * @var int $width

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -288,7 +288,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('nh', $nh);
 
         if ($this->pfID) {
-            $this->requireAsset('css', 'font-awesome');
             $feed = Feed::getByID($this->pfID);
             if (is_object($feed)) {
                 $this->set('rssUrl', $feed->getFeedURL());

--- a/concrete/blocks/page_list/view.php
+++ b/concrete/blocks/page_list/view.php
@@ -7,6 +7,10 @@ $c = Page::getCurrentPage();
 $th = Core::make('helper/text');
 /** @var \Concrete\Core\Localization\Service\Date $dh */
 $dh = Core::make('helper/date');
+if(isset($rssUrl)){
+    /** @var \Concrete\Core\Block\View\BlockView $view */
+    $this->requireAsset('css', 'font-awesome');
+}
 
 if (is_object($c) && $c->isEditMode() && $controller->isBlockEmpty()) {
     ?>

--- a/concrete/blocks/share_this_page/controller.php
+++ b/concrete/blocks/share_this_page/controller.php
@@ -134,11 +134,6 @@ class Controller extends BlockController implements UsesFeatureInterface
         $db->delete('btShareThisPage', array('bID' => $this->bID));
     }
 
-    public function registerViewAssets($outputContent = '')
-    {
-        $this->requireAsset('css', 'font-awesome');
-    }
-
     public function view()
     {
         if (count($this->services) == 0) {

--- a/concrete/blocks/share_this_page/view.php
+++ b/concrete/blocks/share_this_page/view.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/* @var Concrete\Core\Block\View\BlockView $view */
+$this->requireAsset('css', 'font-awesome');?>
 
 <div class="ccm-block-share-this-page">
     <ul class="list-inline">

--- a/concrete/blocks/social_links/controller.php
+++ b/concrete/blocks/social_links/controller.php
@@ -143,9 +143,4 @@ class Controller extends BlockController implements UsesFeatureInterface
         $links = $this->getSelectedLinks();
         $this->set('links', $links);
     }
-
-    public function registerViewAssets($outputContent = '')
-    {
-        $this->requireAsset('css', 'font-awesome');
-    }
 }

--- a/concrete/blocks/social_links/view.php
+++ b/concrete/blocks/social_links/view.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+/** @var \Concrete\Core\Block\View\BlockView $view */
+$this->requireAsset('css', 'font-awesome');?>
 
 <div id="ccm-block-social-links<?php echo $bID; ?>" class="ccm-block-social-links">
     <ul class="list-inline">

--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -105,7 +105,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function view()
     {
-        $this->requireAsset('javascript', 'jquery');
         $ml = Section::getList();
         $c = \Page::getCurrentPage();
         $al = Section::getBySectionOfSite($c);

--- a/concrete/blocks/switch_language/view.php
+++ b/concrete/blocks/switch_language/view.php
@@ -3,6 +3,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 /* @var Concrete\Core\Form\Service\Form $form */
 /* @var Concrete\Core\Block\View\BlockView $view */
+$view->requireAsset('javascript', 'jquery');
 
 // The text label as configured by the user
 /* @var string $label */

--- a/concrete/themes/atomik/blocks/share_this_page/view.php
+++ b/concrete/themes/atomik/blocks/share_this_page/view.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/* @var Concrete\Core\Block\View\BlockView $view */
+$this->requireAsset('css', 'font-awesome');?>
 
 <div class="ccm-block-share-this-page">
     <h4><?=t('Share This Article')?></h4>

--- a/concrete/themes/elemental/blocks/feature/templates/hover_description/view.php
+++ b/concrete/themes/elemental/blocks/feature/templates/hover_description/view.php
@@ -1,5 +1,7 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
-
+/* @var Concrete\Core\Block\View\BlockView $view */
+$this->requireAsset('javascript', 'bootstrap/tooltip');
+$this->requireAsset('css', 'bootstrap/tooltip');
 $iconTag = $iconTag ?? '';
 ?>
 


### PR DESCRIPTION
... having these dependencies in the block type controllers forces them to be loaded even if
we create themes with block templates that don't rely on them.

This is especially severe when you look at the the jQuery dependency in the switch_language block, which is usally inserted in a global area: - This would essentially cause a site to load jQuery globaly even though the theme/ block templates might not use  it at all.
This PR solves this by moving the requireAsset calls from block controllers into template files.

Custom view templates that where created prior to this change might be affected if they also rely on these dependencies to be included by the block type.