### PR TITLE
Avoid exception when rendering thumbnail placeholders

### DIFF
--- a/concrete/src/File/Image/Thumbnail/ThumbnailPlaceholderService.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailPlaceholderService.php
@@ -84,12 +84,18 @@ class ThumbnailPlaceholderService
 
         $attributes = array_merge($attributes, $defaults);
 
+        if(empty($thumbnailType->getHeight())){
+            $thumbnailHeight = $thumbnailType->getHeight();
+        } else {
+            $thumbnailHeight = $thumbnailType->getWidth();
+        }
+
         return (string)new Element(
             "div",
             [
                 $this->getThumbnailImage(
                     $thumbnailType->getWidth(),
-                    $thumbnailType->getHeight(),
+                    $thumbnailHeight,
                     $placeholderBackgroundColor
                 ),
                 new Element(

--- a/concrete/src/File/Image/Thumbnail/ThumbnailPlaceholderService.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailPlaceholderService.php
@@ -84,7 +84,7 @@ class ThumbnailPlaceholderService
 
         $attributes = array_merge($attributes, $defaults);
 
-        if(empty($thumbnailType->getHeight())){
+        if(!empty($thumbnailType->getHeight())){
             $thumbnailHeight = $thumbnailType->getHeight();
         } else {
             $thumbnailHeight = $thumbnailType->getWidth();


### PR DESCRIPTION
This PR avoids a Exception by falling back to rendering a rectangular placeholder in case there is no height given for the thumbnail type.