### PR TITLE
Don't index if selected page, user or user group doesn't exist

### DIFF
--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -108,5 +108,14 @@ class Controller extends AttributeTypeController
         }
 
         return $error;
+    public function getSearchIndexValue()
+    {
+        if ($this->attributeValue) {
+            $cID = $this->getAttributeValue()->getValue();
+            $page = Page::getByID($cID, 'ACTIVE');
+            if (is_object($page) && !$page->isError()) {
+                return  $cID;
+            }
+        }
     }
 }

--- a/concrete/attributes/user_group/controller.php
+++ b/concrete/attributes/user_group/controller.php
@@ -245,9 +245,12 @@ class Controller extends AttributeTypeController
 
     public function getSearchIndexValue()
     {
-        $group = $this->getAttributeValue()->getValue();
-        if ($group) {
-            return $group->getGroupID();
+        $gID = $this->getAttributeValue()->getValue();
+        if ($gID) {
+            $group = Group::getByID($gID);
+            if ($group) {
+                return $group->getGroupID();
+            }
         }
     }
 

--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -31,7 +31,13 @@ class Controller extends AttributeTypeController
 
     public function getSearchIndexValue()
     {
-        return $this->attributeValue->getValue();
+        if ($this->attributeValue) {
+            $uID = $this->getAttributeValue()->getValue();
+            $user = User::getByUserID($uID);
+            if (is_object($user)) {
+                return $uID;
+            }
+        }
     }
     
     public function form()


### PR DESCRIPTION
I just noticed that page_select, user_select and group attribute type search doesn't really check for deleted pages, deleted users and deleted groups.

Let's not to index those deleted ones.

I'm sending a PR to 8.5.x branch.
If you like it, I will also have V9 version ready