### PR TITLE
[v9] Implement #10483 - add cache clear timestamp

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -411,6 +411,10 @@ return [
         'clear' => [
             'thumbnails' => false,
         ],
+        /**
+         * Timestamp of the last time that the cache was cleared, this is used when generating assets.
+         */
+        'last_cleared'=> 1648642409
     ],
 
     'design' => [

--- a/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
+++ b/concrete/controllers/single_page/dashboard/system/optimization/clearcache.php
@@ -26,6 +26,9 @@ class Clearcache extends DashboardPageController
         $config->set('concrete.cache.clear.thumbnails', $clearThumbnails);
         $config->save('concrete.cache.clear.thumbnails', $clearThumbnails);
         $this->app->clearCaches();
+        $timestamp = time();
+        $config->set('concrete.cache.last_cleared', $timestamp);
+        $config->save('concrete.cache.last_cleared', $timestamp);
         $this->flash('success', t('Cached files removed.'));
 
         return $this->buildRedirect($this->action(''));

--- a/concrete/src/Asset/Asset.php
+++ b/concrete/src/Asset/Asset.php
@@ -247,13 +247,14 @@ abstract class Asset implements AssetInterface
         }
         $result = $this->assetURL;
         if ($result && $this->isAssetLocal() && !preg_match('/\?(.*&)?' . preg_quote(static::OUTPUT_NOCACHE_PARAM, '/') . '=/', $result)) {
+            $config = app('config');
             if ($this->pkg) {
                 $noCacheValue = $this->pkg->getPackageVersion();
             } else {
-                $app = Application::getFacadeApplication();
-                $config = $app->make('config');
+
                 $noCacheValue = $config->get('concrete.version_installed') . '-' . $config->get('concrete.version_db');
             }
+            $noCacheValue .= '-' . $config->get('concrete.cache.last_cleared');
             $assetVersion = $this->getAssetVersion();
             $noCacheValue = !empty($assetVersion) ? $noCacheValue . '-' . $assetVersion : $noCacheValue;
             $noCacheValue = $this->obfuscateNoCacheValue($noCacheValue);

--- a/concrete/src/Cache/Command/ClearCacheCommandHandler.php
+++ b/concrete/src/Cache/Command/ClearCacheCommandHandler.php
@@ -102,7 +102,9 @@ class ClearCacheCommandHandler
         if ($command->doClearGlobalAreas()) {
             $this->deleteEmptyGlobalAreas();
         }
-
+        $timestamp = time();
+        $this->repository->set('concrete.cache.last_cleared', $timestamp);
+        $this->repository->save('concrete.cache.last_cleared', $timestamp);
         $this->dispatcher->dispatch('on_cache_flush_end');
     }
 

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -38,6 +38,7 @@ EOT
     {
         $cms = Core::make('app');
         $thumbnails = $input->getOption('thumbnails');
+        $config = $cms->app->make(Repository::class);
         if ($thumbnails !== null) {
             switch (strtolower($thumbnails[0])) {
                 case 'n':
@@ -49,11 +50,11 @@ EOT
                 default:
                     throw new Exception('Invalid value for the --thumbnails option: please specify Y[es] or N[o]');
             }
-            $config = $cms->app->make(Repository::class);
             $config->set('concrete.cache.clear.thumbnails', $clearThumbnails);
         }
         $output->write('Clearing the cache... ');
         $cms->clearCaches();
+        $config->set('concrete.cache.last_cleared', time());
         $output->writeln('<info>done.</info>');
 
         return static::SUCCESS;


### PR DESCRIPTION
This pull requests implements the feature suggested in #10483 which adds a `concrete.cache.last_cleared` timestamp to the ccm_nocache hash.

This should help in cases where developers edit things like block overrides css etc and clear cache but the css is still cached on users browsers due to the ccm_nocache value not changing