### PR TITLE
Move core attributes from elemental into base attribute install cif

### DIFF
--- a/concrete/config/install/base/attributes.xml
+++ b/concrete/config/install/base/attributes.xml
@@ -260,6 +260,9 @@
         <attributekey handle="exclude_sitemapxml" name="Exclude From sitemap.xml" package="" searchable="1" indexed="0" type="boolean" category="collection">
             <type checked=""/>
         </attributekey>
+        <attributekey handle="exclude_subpages_from_nav" name="Exclude Sub-Pages From Nav" package="" searchable="1" indexed="1" type="boolean" category="collection">
+            <type checked="0"/>
+        </attributekey>
         <attributekey handle="profile_private_messages_enabled" name="I would like to receive private messages." package="" searchable="1" indexed="0" type="boolean" category="user" profile-displayed="0" profile-editable="1" profile-required="0" register-editable="1" register-required="0" member-list-displayed="0">
             <type checked="1"/>
         </attributekey>
@@ -270,6 +273,7 @@
         <attributekey handle="height" name="Height" package="" searchable="1" indexed="0" type="number" category="file"/>
         <attributekey handle="account_profile_links" name="Personal Links" package="" type="social_links" category="user"/>
         <attributekey handle="duration" name="Duration" package="" searchable="1" indexed="0" type="number" category="file"/>
+        <attributekey handle="thumbnail" name="Thumbnail" package="" searchable="1" indexed="1" type="image_file" category="collection"/>
     </attributekeys>
     <attributesets>
         <attributeset handle="seo" name="SEO" package="" locked="0" category="collection">

--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -17,12 +17,6 @@
                       category="collection">
             <type mode="text"/>
         </attributekey>
-        <attributekey handle="exclude_subpages_from_nav" name="Exclude Sub-Pages From Nav" package="" searchable="1"
-                      indexed="1" type="boolean" category="collection">
-            <type checked="0"/>
-        </attributekey>
-        <attributekey handle="thumbnail" name="Thumbnail" package="" searchable="1" indexed="1" type="image_file"
-                      category="collection"/>
         <attributekey handle="blog_entry_topics" name="Blog Entry Topics" package="" searchable="1" indexed="1"
                       type="topics" category="collection">
             <tree name="Blog Entries" path="/"/>


### PR DESCRIPTION
Two attributes used by concrete's core are installed through the `elemental_full` install package. These are handles "exclude_subpages_from_nav" and "thumbnail". This seems like an oversight because if Elemental would no longer be shipped with the core that would break some core functionality. 

This PR moves the attributes out of Elemental into `concrete/config/install/base/attributes.xml`.

edit: I tried installing `elemental_blank` and in that case the two attributes are also missing.