### PR TITLE
Performance Improvement: Reduce getting theme from database

### DIFF
--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -517,9 +517,24 @@ class Theme extends ConcreteObject implements \JsonSerializable
      */
     public static function getByHandle($pThemeHandle)
     {
+        /** @var RequestCache $cache */
+        $cache = Facade::getFacadeApplication()->make('cache/request');
+        $key = '/PageTheme/handle/' . $pThemeHandle;
+        if ($cache->isEnabled()) {
+            $item = $cache->getItem($key);
+            if ($item->isHit()) {
+                return $item->get();
+            }
+        }
+
         $where = 'pThemeHandle = ?';
         $args = [$pThemeHandle];
         $pt = static::populateThemeQuery($where, $args);
+
+        if (isset($item) && $item->isMiss()) {
+            $item->set($pt);
+            $cache->save($item);
+        }
 
         return $pt;
     }


### PR DESCRIPTION
Concrete loads the current theme from database same number of times as images if the current theme supports responsive image. Let's use request cache to avoid it.

![Screen Shot 2022-04-17 at 22 24 54](https://user-images.githubusercontent.com/514294/163717500-6710bc3a-474a-441c-aafd-5a78e97dc436.png)
