### PR TITLE
Fix relative path level for CSS background images installed in the subdirectory

### DIFF
--- a/build/assets/cms.scss
+++ b/build/assets/cms.scss
@@ -77,5 +77,5 @@
 // Define where to find our concrete directory relative to where this file is built
 // This is used for things like background images in CSS (like the mobile preview, jQuery UI icons)
 // It is only a part of the CMS base, not a part of Concrete bedrock
-$concrete-path: "../../../concrete";
+$concrete-path: "../../concrete";
 @import "@concretecms/bedrock/assets/cms/scss/base";


### PR DESCRIPTION
This is reported by @hdk0016.

Andrew recently tried to fix the directly level of CSS images for Concrete site under sub directory
https://github.com/concrete5/concrete5/commit/e5b8e6ed9f857695830dd3d57a286d891b5548c1

I think you confused over the final destination.

When he tried in sub-diretory, the icons below disappeared.

![スクリーンショット 2022-04-19 17 51 49](https://user-images.githubusercontent.com/485751/163967753-8d7d835f-d34a-4a24-b610-b0d0c86dc653.png)

I think you put the path level wrong.

When he adjust the level like this..., it was fine.

Thx