### PR TITLE
Legacy form's "reply to this email address" checked state was not properly passed

### DIFF
--- a/concrete/blocks/form/auto.js
+++ b/concrete/blocks/form/auto.js
@@ -208,9 +208,9 @@ var miniSurvey = {
                         if (key_val.length == 2) {
                             if (key_val[0] == 'send_notification_from') {
                                 if (key_val[1] == 1) {
-                                    $('.send_notification_from_edit input').prop('checked', true);
+                                    $('input[name="send_notification_from_edit"]').prop('checked', true);
                                 } else {
-                                    $('.send_notification_from_edit input').prop('checked', false);
+                                    $('input[name="send_notification_from_edit"]').prop('checked', false);
                                 }
                             }
                         }


### PR DESCRIPTION
Originally reported via forum
https://forums.concretecms.org/t/9-0-2/2724/

## Bugs reproduction step

- you add a legacy form block
- you add a email address field
- you set an option `reply to this email address`
- save a block
- come back and re-edit the email address field
- The checked state of `reply to this email address` was not properly passed and the checkbox WAS NOT CHECKED.

![20220430_legacyform](https://user-images.githubusercontent.com/485751/166090123-b3058b0a-4795-4afa-b3f5-eda467d7efc1.png)

I only tested with Chrome on develop branch thought.. this PR should fix it.

Thx