### PR TITLE
Add title field for YouTube and Video block types, addressing #10507

### DIFF
--- a/concrete/blocks/video/controller.php
+++ b/concrete/blocks/video/controller.php
@@ -182,6 +182,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             'posterfID' => 0,
             'width' => 0,
             'videoSize' => 0,
+            'title' => '',
         ];
         $args = [
             'webmfID' => max(0, (int) $data['webmfID']),
@@ -189,6 +190,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             'mp4fID' => max(0, (int) $data['mp4fID']),
             'posterfID' => max(0, (int) $data['posterfID']),
             'videoSize' => max(0, (int) $data['videoSize']),
+            'title' =>  $data['title'],
         ];
         $args['width'] = $args['videoSize'] === 0 || $args['videoSize'] == 1 ? 0 : (int) $data['width'];
 

--- a/concrete/blocks/video/db.xml
+++ b/concrete/blocks/video/db.xml
@@ -28,5 +28,6 @@
         <field name="width" type="integer">
             <unsigned/>
         </field>
+        <field name="title" type="string" size="255" />
     </table>
 </schema>

--- a/concrete/blocks/video/form_setup_html.php
+++ b/concrete/blocks/video/form_setup_html.php
@@ -87,7 +87,21 @@ $width = $width ?? null;
             </span>
         </div>
     </div>
+
+
 </fieldset>
+
+
+<fieldset>
+    <legend>
+        <?php echo t('Title'); ?>
+    </legend>
+
+    <div class="form-group">
+        <?php echo $form->text('title', $title ?? ''); ?>
+    </div>
+</fieldset>
+
 
 <script>
     $(document).ready(function () {

--- a/concrete/blocks/video/view.php
+++ b/concrete/blocks/video/view.php
@@ -38,6 +38,7 @@ if (is_object($c) && $c->isEditMode()) {
     style="max-width: 100%;"
     <?php
     }?>
+    <?php echo $title ? 'title="' . h($title) . '"' : ''; ?>
     >
         <?php if ($webmURL) { ?>
         <source src="<?php echo $webmURL; ?>" type="video/webm">

--- a/concrete/blocks/youtube/form_setup_html.php
+++ b/concrete/blocks/youtube/form_setup_html.php
@@ -73,6 +73,11 @@ echo $ui->tabs([
             </div>
         </div>
 
+        <div class="form-group">
+            <?php echo $form->label('title', t("Title")); ?>
+            <?php echo $form->text('title', $title ?? ''); ?>
+        </div>
+
         <div id="fixedsizes" class="<?php echo $sizing == 'fixed' ? '' : 'd-none'; ?>">
             <div class="form-group">
                 <?php echo $form->label('YouTubeVideoWidth', t("Width"), ["class" => "form-check-label"]); ?>

--- a/concrete/blocks/youtube/view.php
+++ b/concrete/blocks/youtube/view.php
@@ -100,7 +100,7 @@ if (is_object($c) && $c->isEditMode()) {
     $loc->popActiveContext();
 } else { ?>
     <div id="youtube<?= $bID; ?>" class="youtubeBlock <?php echo $responsiveClass; ?>">
-        <iframe class="youtube-player" <?php echo $sizeargs; ?>
+        <iframe class="youtube-player" <?php echo $sizeargs; ?> <?php echo $title ? 'title="' . h($title) . '"' : ''; ?>
             src="<?= $source ?>"
             allow="autoplay" allowfullscreen <?= $lazyLoadAttribute; ?>></iframe>
     </div>


### PR DESCRIPTION
This adds a title attribute to the iframe of a YouTube embed, and the video tag in a video block.
A title tag on the iframe in particular is recommend for accessibility, and addresses issue https://github.com/concrete5/concrete5/issues/10507