### PR TITLE
Fix #10605

### DIFF
--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -262,7 +262,7 @@ class Controller extends BlockController
 
             //It should only generate a new question set id if the block is copied to a new page,
             //otherwise it will loose all of its answer sets (from all the people who've used the form on this page)
-            $questionSetCIDs = $db->fetchAll("SELECT distinct cID FROM {$this->btTable} AS f, CollectionVersionBlocks AS cvb " .
+            $questionSetCIDs = $db->fetchFirstColumn("SELECT distinct cID FROM {$this->btTable} AS f, CollectionVersionBlocks AS cvb " .
                         'WHERE f.bID=cvb.bID AND questionSetId=' . (int) ($row['questionSetId']));
 
             //this question set id is used on other pages, so make a new one for this page block


### PR DESCRIPTION
#10605 has been introduced in #8909, where [the old database `getCol` method has been mistakenly replaced by `fetchAll`](https://github.com/concrete5/concrete5/pull/8909/files#diff-7316a930598a6632d004a49e3eec09000b685c874ec852949b47aab3ed12b0a0L229) (`getCol` returns a plain array, `fetchAll` returns an array of arrays).

Close #10605