### PR TITLE
output correct class for collapsed accordion items

### DIFF
--- a/concrete/blocks/accordion/view.php
+++ b/concrete/blocks/accordion/view.php
@@ -25,7 +25,7 @@ $alwaysOpen = $alwaysOpen ?? false;
         <div class="accordion-item">
 
             <<?php echo $itemHeadingFormat; ?> class="accordion-header">
-                <button class="accordion-button <?php if($i != 1){echo 'collapsed'; }?>" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getId()?>">
+                <button class="accordion-button <?php if($entryClass !== ' show'){echo 'collapsed'; }?>" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getId()?>">
                     <?=$entry->getTitle()?>
                 </button>
             </<?php echo $itemHeadingFormat; ?>>

--- a/concrete/themes/elemental/blocks/accordion/view.php
+++ b/concrete/themes/elemental/blocks/accordion/view.php
@@ -1,7 +1,8 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
-* @var $entries \Concrete\Block\Accordion\AccordionEntry[]
+ * @var $entries \Concrete\Block\Accordion\AccordionEntry[]
+ * @var int $bID
  */
 
 $i = 0;
@@ -17,14 +18,14 @@ $alwaysOpen = $alwaysOpen ?? false;
       foreach ($entries as $entry) {
         $i ++;
         $entryClass = '';
-        if (($initialState == 'openfirst' && $i == 1) || $initialState == 'open') {
+        if (($initialState === 'openfirst' && $i == 1) || $initialState === 'open') {
           $entryClass = ' show';
         }
       ?>
         <div class="accordion-item">
 
             <<?php echo $itemHeadingFormat; ?> class="accordion-header">
-                <a href="javascript:void(0)" class="accordion-button <?php if($i != 1) {echo 'collapsed'; }?>" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getID()?>">
+                <a href="javascript:void(0)" class="accordion-button <?php if($entryClass !== ' show'){echo 'collapsed'; }?>" data-bs-toggle="collapse" data-bs-target="#collapse<?=$entry->getID()?>">
                     <?=$entry->getTitle()?>
                 </a>
             </<?php echo $itemHeadingFormat; ?>>


### PR DESCRIPTION
compares the class that is being determined a few lines up so that the logic follows the same as the 'show' class for the collapse item.

closes #10610