### PR TITLE
Fix #10628

### DIFF
--- a/concrete/src/Form/Service/Widget/Color.php
+++ b/concrete/src/Form/Service/Widget/Color.php
@@ -26,6 +26,7 @@ class Color
         $strOptions = '';
         $defaults = [
             'value' => $value,
+            'type' => 'color',
             'className' => 'ccm-widget-colorpicker',
             'showInitial' => true,
             'showInput' => true,


### PR DESCRIPTION
The upgrade to spectrum2 had the side effect of changing the color picker widget layout. This fixes back compatibility.

